### PR TITLE
Fix #242 - foreign key constraint error on load_sample_data

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -32,7 +32,6 @@ namespace :openfoodnetwork do
       # -- Addresses
       unless Spree::Address.find_by_zipcode "3160"
         puts "[#{task_name}] Seeding addresses"
-        Spree::Address.delete_all
 
         FactoryGirl.create(:address, :address1 => "25 Myrtle Street", :zipcode => "3153", :city => "Bayswater")
         FactoryGirl.create(:address, :address1 => "6 Rollings Road", :zipcode => "3156", :city => "Upper Ferntree Gully")


### PR DESCRIPTION
Fixes #242 - it was just this one line causing the problem. If we wanted to erase this table, it would be necessary to delete other things first. But the sole purpose of load_sample_data is to load something into the database to test the application, so it doesn't really matter if the user already put something into it.
