### PR TITLE
Add shipping category to New Product Form

### DIFF
--- a/app/helpers/spree/reports_helper.rb
+++ b/app/helpers/spree/reports_helper.rb
@@ -13,14 +13,12 @@ module Spree
     #I don't like that this is done in two loops, but redundant list entries
     #  were created otherwise... 
     def report_payment_method_options(orders)
-      payment_method_list = {}
-      orders.map do |o|
-        payment_method_name = o.payments.first.payment_method.andand.name
-        payment_method_id = o.payments.first.payment_method.andand.id
-        payment_method_list[payment_method_name] = payment_method_id
+      payment_method_list = []
+      orders.map do |o| 
+        payment_method_list << o.payments.first.payment_method.andand.name
       end
-      payment_method_list.each do |key, value|
-        [ "#{value}".html_safe,  key]
+      payment_method_list.uniq.each do |pm|
+        [ "#{pm}".html_safe,  pm]
       end
     end
 

--- a/app/helpers/spree/reports_helper.rb
+++ b/app/helpers/spree/reports_helper.rb
@@ -22,7 +22,15 @@ module Spree
       end
     end
 
-    
+    def report_distribution_options(orders)
+      distribution_list = []
+      orders.map do |o| 
+        distribution_list << o.shipping_method.andand.name 
+      end
+      distribution_list.uniq.each do |pm|
+        [ "#{pm}".html_safe,  pm]
+      end
+    end    
 
   end
 end

--- a/app/helpers/spree/reports_helper.rb
+++ b/app/helpers/spree/reports_helper.rb
@@ -7,5 +7,24 @@ module Spree
         [ "#{oc.name} &nbsp; (#{orders_open_at} - #{orders_close_at})".html_safe, oc.id ]
       end
     end
+
+    #lin-d-hop
+    #Find the payment methods options for reporting. 
+    #I don't like that this is done in two loops, but redundant list entries
+    #  were created otherwise... 
+    def report_payment_method_options(orders)
+      payment_method_list = {}
+      orders.map do |o|
+        payment_method_name = o.payments.first.payment_method.andand.name
+        payment_method_id = o.payments.first.payment_method.andand.id
+        payment_method_list[payment_method_name] = payment_method_id
+      end
+      payment_method_list.each do |key, value|
+        [ "#{value}".html_safe,  key]
+      end
+    end
+
+    
+
   end
 end

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -122,7 +122,7 @@ class AbilityDecorator
     end
 
     # Reports page
-    can [:admin, :index, :customers, :group_buys, :bulk_coop, :payments, :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory], :report
+    can [:admin, :index, :customers, :orders_and_distributors, :group_buys, :bulk_coop, :payments, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management], :report
   end
 
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -66,6 +66,12 @@ Spree::Order.class_eval do
     where("state != ?", state)
   }
 
+  scope :with_payment_method_name, lambda { |payment_method_name|
+    joins(:payments => :payment_method).
+      where('spree_payment_methods.name = ?', payment_method_name).
+      select('DISTINCT spree_orders.*')
+  }
+
 
   # -- Methods
   def products_available_from_new_distribution

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -36,8 +36,10 @@
           = f.label :product_variant_unit_name, t(:unit_name)
           %input.fullwidth{ id: 'product_variant_unit_name','ng-model' => 'product.variant_unit_name', :name => 'product[variant_unit_name]', :placeholder => 'eg. bunches', :type => 'text' }
     .twelve.columns.alpha
-      .six.columns.alpha
+      .three.columns.alpha
         = render 'spree/admin/products/primary_taxon_form', f: f
+      .three.columns.alpha
+        = render 'spree/admin/products/shipping_category_form', f: f
       .three.columns
         = f.field_container :price do
           = f.label :price, t(:price)

--- a/app/views/spree/admin/products/_shipping_category_form.html.haml
+++ b/app/views/spree/admin/products/_shipping_category_form.html.haml
@@ -1,0 +1,4 @@
+= f.field_container :shipping_categories do 
+          = f.label :shipping_category_id, t(:shipping_categories)
+          = f.collection_select(:shipping_category_id, Spree::ShippingCategory.all, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth'})
+          = f.error_message_on :shipping_category_id

--- a/app/views/spree/admin/reports/_order_cycle_management_description.html.haml
+++ b/app/views/spree/admin/reports/_order_cycle_management_description.html.haml
@@ -1,0 +1,4 @@
+%ul{style: "margin-left: 12pt"}
+  - report_types.each do |report_type|
+    %li 
+      = link_to report_type[0], "#{order_cycle_management_admin_reports_url}?report_type=#{report_type[1]}"

--- a/app/views/spree/admin/reports/order_cycle_management.html.haml
+++ b/app/views/spree/admin/reports/order_cycle_management.html.haml
@@ -11,7 +11,12 @@
 
   = select_tag(:payment_method_name, 
       options_for_select(report_payment_method_options(@orders), params[:payment_method_name]), 
-      multiple: true, include_blank: true) 
+               multiple: true, include_blank: true) 
+  %br
+  %br
+  = select_tag(:distribution_name, 
+      options_for_select(report_distribution_options(@orders), params[:distribution_name]), 
+	       include_blank: true) 
   %br
   %br
   = check_box_tag :csv

--- a/app/views/spree/admin/reports/order_cycle_management.html.haml
+++ b/app/views/spree/admin/reports/order_cycle_management.html.haml
@@ -1,0 +1,38 @@
+= form_tag spree.order_cycle_management_admin_reports_url do |f|
+  %br
+  = label_tag nil, "Order Cycle: "
+  = select_tag(:order_cycle_id,
+    options_for_select(report_order_cycle_options(@order_cycles), params[:order_cycle_id]),
+              include_blank: true)
+  %br
+  %br
+  = label_tag nil, "Payment Methods (hold Ctrl to select multiple payment methods)"
+  %br
+
+  = select_tag(:payment_method_id, 
+      options_for_select(report_payment_method_options(@orders), params[:payment_method_id]), 
+      multiple: true, include_blank: true) 
+  %br
+  %br
+  = check_box_tag :csv
+  = label_tag :csv, "Download as csv"
+  %br
+  %br
+  = button t(:search)
+
+%br
+%br
+%table#listing_order_payment_methods.index
+  %thead
+    %tr{'data-hook' => "orders_header"}
+      - @report.header.each do |heading|
+        %th=heading
+  %tbody
+    - @report.table.each do |row|
+      %tr
+        - row.each do |column|
+          %td= column
+    - if @report.table.empty?
+      %tr
+        %td{:colspan => "2"}= t(:none)
+

--- a/app/views/spree/admin/reports/order_cycle_management.html.haml
+++ b/app/views/spree/admin/reports/order_cycle_management.html.haml
@@ -9,8 +9,8 @@
   = label_tag nil, "Payment Methods (hold Ctrl to select multiple payment methods)"
   %br
 
-  = select_tag(:payment_method_id, 
-      options_for_select(report_payment_method_options(@orders), params[:payment_method_id]), 
+  = select_tag(:payment_method_name, 
+      options_for_select(report_payment_method_options(@orders), params[:payment_method_name]), 
       multiple: true, include_blank: true) 
   %br
   %br

--- a/app/views/spree/order_mailer/confirm_email.text.haml
+++ b/app/views/spree/order_mailer/confirm_email.text.haml
@@ -9,7 +9,7 @@ Order for: #{@order.bill_address.full_name}
 - @order.line_items.each do |item| 
   #{item.variant.sku} #{raw(item.variant.product.supplier.name)} #{raw(item.variant.product.name)} #{raw(item.variant.options_text)} (QTY: #{item.quantity}) @ #{item.single_money} = #{item.display_amount}
 ============================================================
-Subtotal: #{number_to_currency checkout_cart_total_with_adjustments(@order)}
+Subtotal: #{spree_number_to_currency checkout_cart_total_with_adjustments(@order)}
 - checkout_adjustments_for_summary(@order, exclude: [:distribution]).each do |adjustment|
   #{raw(adjustment.label)} #{adjustment.display_amount}
 Order Total: #{@order.display_total}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ end
 
 Spree::Core::Engine.routes.prepend do
   match '/admin/reports/orders_and_distributors' => 'admin/reports#orders_and_distributors', :as => "orders_and_distributors_admin_reports",  :via  => [:get, :post]
+ match '/admin/reports/order_cycle_management' => 'admin/reports#order_cycle_management', :as => "order_cycle_management_admin_reports",  :via  => [:get, :post]
   match '/admin/reports/group_buys' => 'admin/reports#group_buys', :as => "group_buys_admin_reports",  :via  => [:get, :post]
   match '/admin/reports/bulk_coop' => 'admin/reports#bulk_coop', :as => "bulk_coop_admin_reports",  :via  => [:get, :post]
   match '/admin/reports/payments' => 'admin/reports#payments', :as => "payments_admin_reports",  :via  => [:get, :post]

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -43,9 +43,8 @@ module OpenFoodNetwork
     end
 
     def filter_to_payment_method (orders)
-      if params.has_key? (:payment_method_id)
-        orders.joins(:payments)
-          .where(:spree_payments => {:payment_method_id => params[:payment_method_id]} )
+      if params.has_key? (:payment_method_name)
+        orders.with_payment_method_name(params[:payment_method_name])
       else
         orders
       end

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -1,0 +1,65 @@
+module OpenFoodNetwork
+  class OrderCycleManagementReport
+    attr_reader :params
+    def initialize(user, params = {})
+      @params = params
+      @user = user
+    end
+
+    def header
+      ["First Name", "Last Name", "Email", "Phone", "Hub", "Payment Method", "Amount ", "Amount Paid"]
+    
+    end
+
+    def table
+      orders.map do |order|
+        ba = order.billing_address
+        da = order.distributor.andand.address
+        [ba.firstname,
+          ba.lastname,
+          order.email,
+           ba.phone,
+           order.distributor.andand.name,
+           order.payments.first.andand.payment_method.andand.name,
+	   order.payments.first.amount
+        ]       
+      end
+    end
+
+    def orders
+      filter Spree::Order
+    end
+
+    def filter(orders)
+      filter_for_user filter_active filter_to_order_cycle filter_to_payment_method orders
+    end
+  
+    def filter_for_user (orders)
+       orders.managed_by(@user).distributed_by_user(@user)
+    end	
+
+    def filter_active (orders)
+       orders.complete.where("spree_orders.state != ?", :cancelled)
+    end
+
+    def filter_to_payment_method (orders)
+      if params.has_key? (:payment_method_id)
+        orders.joins(:payments)
+          .where(:spree_payments => {:payment_method_id => params[:payment_method_id]} )
+      else
+        orders
+      end
+    end
+
+    def filter_to_order_cycle(orders)
+      if params[:order_cycle_id].to_i > 0
+        orders.where(order_cycle_id: params[:order_cycle_id])
+      else
+        orders
+      end
+    end
+
+  
+  end
+end
+

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -7,7 +7,7 @@ module OpenFoodNetwork
     end
 
     def header
-      ["First Name", "Last Name", "Email", "Phone", "Hub", "Payment Method", "Amount ", "Amount Paid"]
+      ["First Name", "Last Name", "Email", "Phone", "Hub", "Shipping Method", "Payment Method", "Amount ", "Amount Paid"]
     
     end
 
@@ -20,6 +20,7 @@ module OpenFoodNetwork
           order.email,
            ba.phone,
            order.distributor.andand.name,
+           order.shipping_method.andand.name,
            order.payments.first.andand.payment_method.andand.name,
 	   order.payments.first.amount
         ]       
@@ -31,7 +32,7 @@ module OpenFoodNetwork
     end
 
     def filter(orders)
-      filter_for_user filter_active filter_to_order_cycle filter_to_payment_method orders
+      filter_for_user filter_active filter_to_order_cycle filter_to_payment_method filter_to_distribution orders
     end
   
     def filter_for_user (orders)
@@ -45,6 +46,14 @@ module OpenFoodNetwork
     def filter_to_payment_method (orders)
       if params.has_key? (:payment_method_name)
         orders.with_payment_method_name(params[:payment_method_name])
+      else
+        orders
+      end
+    end
+
+    def filter_to_distribution (orders)
+      if params.has_key? (:distribution_name)
+        orders.joins(:shipping_method).where("spree_shipping_methods.name = ?", params[:distribution_name])
       else
         orders
       end

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -57,6 +57,22 @@ feature %q{
     end
   end
 
+  describe "Order cycle management report" do
+    before do
+      login_to_admin_section
+      click_link "Reports"
+    end
+
+    scenario "order payment method report" do
+      click_link "Order Cycle Management"
+      rows = find("table#listing_order_payment_method").all("thead tr")
+      table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
+      table.sort.should == [
+        ["First Name", "Last Name", "Email", "Phone", "Hub", "Payment Method", "Amount", "Amount Paid"]
+      ].sort
+    end
+  end
+
   scenario "orders and distributors report" do
     login_to_admin_section
     click_link 'Reports'


### PR DESCRIPTION
@RohanM @oeoeaio: Couple of questions on this PR
1) I suspect aesthetically (and logically) this will conflict with @Matt-Yorkley PR to add tax categories. Happy to redo to make it more pretty once his has been merged.

2) Do I need specs for this change? My gut feeling was no, because this is an optional category already supported in spree. Let me know if I'm wrong. 

Thanks!