### PR TITLE
Added tax_category dropdown to New Product Form

### DIFF
--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,0 +1,9 @@
+Spree::AppConfiguration.class_eval do
+ # This file decorates the existing preferences file defined by Spree.
+ # It allows us to add our own global configuration variables, which
+ # we can allow to be modified in the UI by adding appropriate form
+ # elements to existing or new configuration pages.
+
+ # Tax Preferences
+ preference :products_require_tax_category, :boolean, default: false
+end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -20,7 +20,8 @@ Spree::Product.class_eval do
   validates_associated :master, message: "^Price and On Hand must be valid"
   validates_presence_of :supplier
   validates :primary_taxon, presence: { message: "^Product Category can't be blank" }
-
+  validates :tax_category_id, presence: { message: "^Tax Category can't be blank" }, if: "Spree::Config.products_require_tax_category"
+  
   validates_presence_of :variant_unit, if: :has_variants?
   validates_presence_of :variant_unit_scale,
                         if: -> p { %w(weight volume).include? p.variant_unit }

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -38,6 +38,8 @@
     .twelve.columns.alpha
       .six.columns.alpha
         = render 'spree/admin/products/primary_taxon_form', f: f
+        - if Spree::TaxCategory.any?
+          = render 'spree/admin/products/tax_category_form', f: f
       .three.columns
         = f.field_container :price do
           = f.label :price, t(:price)

--- a/app/overrides/spree/admin/tax_settings/edit/add_products_require_tax_category.html.haml.deface
+++ b/app/overrides/spree/admin/tax_settings/edit/add_products_require_tax_category.html.haml.deface
@@ -1,0 +1,6 @@
+/ insert_before "[data-hook='shipment_vat']"
+
+%div.field.align-center{ "data-hook" => "products_require_tax_category" }
+  = hidden_field_tag 'preferences[products_require_tax_category]', '0'
+  = check_box_tag 'preferences[products_require_tax_category]', '1',  Spree::Config[:products_require_tax_category]
+  = label_tag nil, t(:products_require_tax_category)

--- a/app/views/spree/admin/products/_tax_category_form.html.haml
+++ b/app/views/spree/admin/products/_tax_category_form.html.haml
@@ -1,0 +1,6 @@
+= f.field_container :tax_category_id do
+  = f.label :tax_category_id, t(:tax_category)
+  *
+  %br
+  = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, {:include_blank => Spree::TaxCategory.count > 1}, {:class => "select2 fullwidth"})
+  = f.error_message_on :tax_category_id

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -175,6 +175,11 @@ FactoryGirl.define do
       order.reload
     end
   end
+  
+  factory :simple_tax_category, :class => Spree::TaxCategory do
+    name "Test Tax Category"
+    description "Test tax category description"
+  end
 end
 
 

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -16,11 +16,13 @@ feature %q{
 
   describe "creating a product" do
     scenario "assigning a important attributes", js: true do
+      tax_category = create(:simple_tax_category)
       login_to_admin_section
 
       click_link 'Products'
       click_link 'New Product'
 
+      select 'Test Tax Category', from: 'product_tax_category_id'
       select 'New supplier', from: 'product_supplier_id'
       fill_in 'product_name', with: 'A new product !!!'
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
@@ -34,6 +36,7 @@ feature %q{
 
       flash_message.should == 'Product "A new product !!!" has been successfully created!'
       product = Spree::Product.find_by_name('A new product !!!')
+      product.tax_category_id.should == tax_category.id
       product.supplier.should == @supplier
       product.variant_unit.should == 'weight'
       product.variant_unit_scale.should == 1000
@@ -117,6 +120,7 @@ feature %q{
       page.should have_selector('#product_supplier_id')
       select 'Another Supplier', :from => 'product_supplier_id'
       select taxon.name, from: "product_primary_taxon_id"
+      page.should have_select 'product_tax_category_id' if Spree::TaxCategory.any?
 
       # Should only have suppliers listed which the user can manage
       page.should have_select 'product_supplier_id', with_options: [@supplier2.name, @supplier_permitted.name]
@@ -134,6 +138,7 @@ feature %q{
 
       visit spree.edit_admin_product_path product
 
+      page.should have_select 'product_tax_category_id'
       select 'Permitted Supplier', from: 'product_supplier_id'
       click_button 'Update'
       flash_message.should == 'Product "a product" has been successfully updated!'

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -8,6 +8,28 @@ module Spree
       it { should belong_to(:primary_taxon) }
       it { should have_many(:product_distributions) }
     end
+    
+    describe "validating tax category" do
+      context "when a tax category is required" do
+        before { Spree::Config.products_require_tax_category = true }
+    
+        it "is invalid when a tax category is not provided" do
+          product = create(:product)
+          product.tax_category_id = nil
+          product.should_not be_valid
+        end
+      end
+    
+      context "when a tax category is not required" do
+        before { Spree::Config.products_require_tax_category = false }
+    
+        it "is valid when a tax category is not provided" do
+          product = create(:product)
+          product.tax_category_id = nil
+          product.should be_valid
+        end
+      end
+    end
 
     describe "validations and defaults" do
       it "is valid when created from factory" do


### PR DESCRIPTION
(Resubmitted in cleaner branch)

This relates to issue #269

-Added tax_category dropdown to New Product form to make sure it's not overlooked when adding new products
-Set up validation for the tax_category dropdown
-Checked to see if it saved the data properly
-Added an if statement with the dropdown so that if there's only one tax category for that tax zone it selects it automatically to save the user some time, otherwise it inserts blank option as default and requires selection of a specific tax category.
-Included Rob's code and Raf's suggestions
-Wrote spec files, tested, rewrote spec files