### PR TITLE
Reports pages improvements and i18n

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -257,12 +257,14 @@ Spree::Admin::ReportsController.class_eval do
 
     @distributors = Enterprise.is_distributor.managed_by(spree_current_user)
     @report_type = params[:report_type]
-
+    
+    currency_symbol = Money.new(1, Spree::Config[:currency]).symbol
+    
     case params[:report_type]
     when "payments_by_payment_type"
       table_items = payments
 
-      header = ["Payment State", "Distributor", "Payment Type", "Total ($)"]
+      header = ["Payment State", "Distributor", "Payment Type", "Total (#{currency_symbol})"]
 
       columns = [ proc { |payments| payments.first.order.payment_state },
         proc { |payments| payments.first.order.distributor.name },
@@ -279,7 +281,7 @@ Spree::Admin::ReportsController.class_eval do
     when "itemised_payment_totals"
       table_items = orders
 
-      header = ["Payment State", "Distributor", "Product Total ($)", "Shipping Total ($)", "Outstanding Balance ($)", "Total ($)"]
+      header = ["Payment State", "Distributor", "Product Total (#{currency_symbol})", "Shipping Total (#{currency_symbol})", "Outstanding Balance (#{currency_symbol})", "Total (#{currency_symbol})"]
 
       columns = [ proc { |orders| orders.first.payment_state },
         proc { |orders| orders.first.distributor.name },
@@ -296,7 +298,7 @@ Spree::Admin::ReportsController.class_eval do
     when "payment_totals"
       table_items = orders
 
-      header = ["Payment State", "Distributor", "Product Total ($)", "Shipping Total ($)", "Total ($)", "EFT ($)", "PayPal ($)", "Outstanding Balance ($)"]
+      header = ["Payment State", "Distributor", "Product Total (#{currency_symbol})", "Shipping Total (#{currency_symbol})", "Total (#{currency_symbol})", "EFT (#{currency_symbol})", "PayPal (#{currency_symbol})", "Outstanding Balance (#{currency_symbol})"]
 
       columns = [ proc { |orders| orders.first.payment_state },
         proc { |orders| orders.first.distributor.name },
@@ -315,7 +317,7 @@ Spree::Admin::ReportsController.class_eval do
     else
       table_items = payments
 
-      header = ["Payment State", "Distributor", "Payment Type", "Total ($)"]
+      header = ["Payment State", "Distributor", "Payment Type", "Total (#{currency_symbol})"]
 
       columns = [ proc { |payments| payments.first.order.payment_state },
         proc { |payments| payments.first.order.distributor.name },
@@ -475,7 +477,7 @@ Spree::Admin::ReportsController.class_eval do
       table_items = @line_items
       @include_blank = 'All'
 
-      header = ["Hub", "Customer", "Email", "Phone", "Producer", "Product", "Variant", "Amount", "Item ($)", "Dist ($)", "Ship ($)", "Total ($)", "Paid?",
+      header = ["Hub", "Customer", "Email", "Phone", "Producer", "Product", "Variant", "Amount", "Item (#{currency_symbol})", "Dist (#{currency_symbol})", "Ship (#{currency_symbol})", "Total (#{currency_symbol})", "Paid?",
                 "Shipping", "Delivery?", "Ship street", "Ship street 2", "Ship city", "Ship postcode", "Ship state", "Order notes"]
 
       rsa = proc { |line_items| line_items.first.order.shipping_method.andand.require_ship_address }

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -27,6 +27,7 @@ Spree::Admin::ReportsController.class_eval do
 
   # Fetches user's distributors, suppliers and order_cycles
   before_filter :load_data, only: [:customers, :products_and_inventory]
+  before_filter :set_currency_symbol
 
   # Render a partial for orders and fulfillment description
   respond_override :index => { :html => { :success => lambda {
@@ -257,14 +258,12 @@ Spree::Admin::ReportsController.class_eval do
 
     @distributors = Enterprise.is_distributor.managed_by(spree_current_user)
     @report_type = params[:report_type]
-    
-    currency_symbol = Money.new(1, Spree::Config[:currency]).symbol
-    
+
     case params[:report_type]
     when "payments_by_payment_type"
       table_items = payments
 
-      header = ["Payment State", "Distributor", "Payment Type", "Total (#{currency_symbol})"]
+      header = ["Payment State", "Distributor", "Payment Type", "Total (#{@currency_symbol})"]
 
       columns = [ proc { |payments| payments.first.order.payment_state },
         proc { |payments| payments.first.order.distributor.name },
@@ -281,7 +280,7 @@ Spree::Admin::ReportsController.class_eval do
     when "itemised_payment_totals"
       table_items = orders
 
-      header = ["Payment State", "Distributor", "Product Total (#{currency_symbol})", "Shipping Total (#{currency_symbol})", "Outstanding Balance (#{currency_symbol})", "Total (#{currency_symbol})"]
+      header = ["Payment State", "Distributor", "Product Total (#{@currency_symbol})", "Shipping Total (#{@currency_symbol})", "Outstanding Balance (#{@currency_symbol})", "Total (#{@currency_symbol})"]
 
       columns = [ proc { |orders| orders.first.payment_state },
         proc { |orders| orders.first.distributor.name },
@@ -298,7 +297,7 @@ Spree::Admin::ReportsController.class_eval do
     when "payment_totals"
       table_items = orders
 
-      header = ["Payment State", "Distributor", "Product Total (#{currency_symbol})", "Shipping Total (#{currency_symbol})", "Total (#{currency_symbol})", "EFT (#{currency_symbol})", "PayPal (#{currency_symbol})", "Outstanding Balance (#{currency_symbol})"]
+      header = ["Payment State", "Distributor", "Product Total (#{@currency_symbol})", "Shipping Total (#{@currency_symbol})", "Total (#{@currency_symbol})", "EFT (#{@currency_symbol})", "PayPal (#{@currency_symbol})", "Outstanding Balance (#{@currency_symbol})"]
 
       columns = [ proc { |orders| orders.first.payment_state },
         proc { |orders| orders.first.distributor.name },
@@ -317,7 +316,7 @@ Spree::Admin::ReportsController.class_eval do
     else
       table_items = payments
 
-      header = ["Payment State", "Distributor", "Payment Type", "Total (#{currency_symbol})"]
+      header = ["Payment State", "Distributor", "Payment Type", "Total (#{@currency_symbol})"]
 
       columns = [ proc { |payments| payments.first.order.payment_state },
         proc { |payments| payments.first.order.distributor.name },
@@ -477,7 +476,7 @@ Spree::Admin::ReportsController.class_eval do
       table_items = @line_items
       @include_blank = 'All'
 
-      header = ["Hub", "Customer", "Email", "Phone", "Producer", "Product", "Variant", "Amount", "Item (#{currency_symbol})", "Dist (#{currency_symbol})", "Ship (#{currency_symbol})", "Total (#{currency_symbol})", "Paid?",
+      header = ["Hub", "Customer", "Email", "Phone", "Producer", "Product", "Variant", "Amount", "Item (#{@currency_symbol})", "Dist (#{@currency_symbol})", "Ship (#{@currency_symbol})", "Total (#{@currency_symbol})", "Paid?",
                 "Shipping", "Delivery?", "Ship street", "Ship street 2", "Ship city", "Ship postcode", "Ship state", "Order notes"]
 
       rsa = proc { |line_items| line_items.first.order.shipping_method.andand.require_ship_address }
@@ -598,6 +597,10 @@ Spree::Admin::ReportsController.class_eval do
   end
 
   private
+  
+  def set_currency_symbol
+    @currency_symbol = Spree::Money.currency_symbol
+  end
 
   def load_data
     # Load distributors either owned by the user or selling their enterprises products.

--- a/app/models/spree/money_decorator.rb
+++ b/app/models/spree/money_decorator.rb
@@ -1,0 +1,7 @@
+Spree::Money.class_eval do
+
+  # return the currency symbol (on it's own) for the current default currency 
+  def self.currency_symbol
+    Money.new(0, Spree::Config[:currency]).symbol
+  end
+end

--- a/app/views/spree/admin/reports/bulk_coop.html.haml
+++ b/app/views/spree/admin/reports/bulk_coop.html.haml
@@ -11,15 +11,18 @@
       %br
       = label_tag nil, t(:stop)
   %br
-  = label_tag nil, "Distributor: "
-  = f.collection_select(:distributor_id_eq, @distributors, :id, :name, :include_blank => 'All')
-  %br
+  %div{"class" => "row"} 
+    %div{"class" => "four columns alpha"} 
+      = label_tag nil, "Distributor: "
+      = f.collection_select(:distributor_id_eq, @distributors, :id, :name, {:include_blank => 'All'}, {:class => "select2 fullwidth"})
   = label_tag nil, "Report Type: "
+  %br
   = select_tag(:report_type, options_for_select([['Bulk Co-op - Totals by Supplier',:bulk_coop_supplier_report],['Bulk Co-op - Allocation',:bulk_coop_allocation],['Bulk Co-op - Packing Sheets',:bulk_coop_packing_sheets],['Bulk Co-op - Customer Payments',:bulk_coop_customer_payments]], @report_type))
   %br
   %br
   = check_box_tag :csv
   = label_tag :csv, "Download as csv"
+  %br
   %br
   = button t(:search)
 %br

--- a/app/views/spree/admin/reports/customers.html.haml
+++ b/app/views/spree/admin/reports/customers.html.haml
@@ -1,23 +1,24 @@
 = form_tag spree.customers_admin_reports_url do |f|
   %br
-  = label_tag nil, "Distributor: "
-  = select_tag(:distributor_id,
-    options_from_collection_for_select(@distributors, :id, :name, params[:distributor_id]),
-    :include_blank => true)
+  %div{"class" => "row"} 
+    %div{"class" => "four columns alpha"} 
+      = label_tag nil, "Distributor: "
+      = select_tag(:distributor_id,
+        options_from_collection_for_select(@distributors, :id, :name, params[:distributor_id]),
+        {:include_blank => true, :class => "select2 fullwidth"})
 
-  %br
-  = label_tag nil, "Supplier: "
-  = select_tag(:supplier_id,
-    options_from_collection_for_select(@suppliers, :id, :name, params[:supplier_id]),
-    :include_blank => true)
+    %div{"class" => "four columns"}
+      = label_tag nil, "Supplier: "
+      = select_tag(:supplier_id,
+        options_from_collection_for_select(@suppliers, :id, :name, params[:supplier_id]),
+        {:include_blank => true, :class => "select2 fullwidth"})
 
-  %br
-  = label_tag nil, "Order Cycle: "
-  = select_tag(:order_cycle_id,
-    options_for_select(report_order_cycle_options(@order_cycles), params[:order_cycle_id]),
-              include_blank: true)
+    %div{"class" => "six columns"}
+      = label_tag nil, "Order Cycle: "
+      = select_tag(:order_cycle_id,
+        options_for_select(report_order_cycle_options(@order_cycles), params[:order_cycle_id]),
+        {:include_blank => true, :class => "select2 fullwidth"})
 
-  %br
   = label_tag nil, "Report Type: "
   = select_tag(:report_type, options_for_select(@report_types, @report_type))
 

--- a/app/views/spree/admin/reports/payments.html.haml
+++ b/app/views/spree/admin/reports/payments.html.haml
@@ -11,15 +11,18 @@
       %br
       = label_tag nil, t(:stop)
   %br
-  = label_tag nil, "Distributor: "
-  = f.collection_select(:distributor_id_eq, @distributors, :id, :name, :include_blank => 'All')
-  %br
+  %div{"class" => "row"} 
+    %div{"class" => "four columns alpha"} 
+      = label_tag nil, "Distributor: "
+      = f.collection_select(:distributor_id_eq, @distributors, :id, :name, {:include_blank => 'All'}, {:class => "select2 fullwidth"})
   = label_tag nil, "Report Type: "
+  %br
   = select_tag(:report_type, options_for_select([['Payments By Type',:payments_by_payment_type],['Itemised Payment Totals',:itemised_payment_totals],['Payment Totals',:payment_totals]], @report_type))
   %br
   %br
   = check_box_tag :csv
   = label_tag :csv, "Download as csv"
+  %br
   %br
   = button t(:search)
 %br

--- a/app/views/spree/admin/reports/products_and_inventory.html.haml
+++ b/app/views/spree/admin/reports/products_and_inventory.html.haml
@@ -1,24 +1,28 @@
 = form_tag spree.products_and_inventory_admin_reports_url do |f|
   %br
-  = label_tag nil, "Distributor: "
-  = select_tag(:distributor_id,
-    options_from_collection_for_select(@distributors, :id, :name, params[:distributor_id]),
-    :include_blank => true)
+  %div{"class" => "row"} 
+    %div{"class" => "four columns alpha"} 
+      = label_tag nil, "Distributor: "
+      = select_tag(:distributor_id,
+        options_from_collection_for_select(@distributors, :id, :name, params[:distributor_id]),
+        {:include_blank => true, :class => "select2 fullwidth"})
 
-  %br
-  = label_tag nil, "Supplier: "
-  = select_tag(:supplier_id,
-    options_from_collection_for_select(@suppliers, :id, :name, params[:supplier_id]),
-    :include_blank => true)
+  
+    %div{"class" => "four columns"} 
+      = label_tag nil, "Supplier: "
+      = select_tag(:supplier_id,
+        options_from_collection_for_select(@suppliers, :id, :name, params[:supplier_id]),
+        {:include_blank => true, :class => "select2 fullwidth"})
 
-  %br
-  = label_tag nil, "Order Cycle: "
-  = select_tag(:order_cycle_id,
-    options_for_select(report_order_cycle_options(@order_cycles), params[:order_cycle_id]),
-              include_blank: true)
+  
+    %div{"class" => "six columns"} 
+      = label_tag nil, "Order Cycle: "
+      = select_tag(:order_cycle_id,
+        options_for_select(report_order_cycle_options(@order_cycles), params[:order_cycle_id]),
+        {:include_blank => true, :class => "select2 fullwidth"})
 
-  %br
   = label_tag nil, "Report Type: "
+  %br
   = select_tag(:report_type, options_for_select(@report_types, params[:report_type]))
 
   %br


### PR DESCRIPTION
-Added Spree's scrollable/searchable list functionality to a number of the dropdowns that have large amounts of options on them to make them easier to navigate/select on various /reports pages.

-Changed the hard coded dollar signs on the /reports pages to display the symbol for the currency set in the global spree settings.
