### PR TITLE
Replacing fixtures with minimal seeding

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,18 +28,6 @@ require 'spree/api/testing_support/helpers'
 require 'spree/api/testing_support/helpers_decorator'
 require 'spree/core/testing_support/authorization_helpers'
 
-if Spree::Country.first.nil?
-  Spree::Country.create!({"name"=>"Australia", "iso3"=>"AUS", "iso"=>"AU", "iso_name"=>"AUSTRALIA", "numcode"=>"36"}, :without_protection => true)
-  country = Spree::Country.find_by_name('Australia')
-  Spree::State.create!({"name"=>"Victoria", "abbr"=>"Vic", :country=>country}, :without_protection => true)
-  Spree::State.create!({"name"=>"New South Wales", "abbr"=>"NSW", :country=>country}, :without_protection => true)
-end
-
-# TODO: remove duplicate code with config/initializers/spree.rb
-Spree.config do |config|
-  config.default_country_id = Spree::Country.find_by_name('Australia').id
-end
-
 # Capybara config
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist

--- a/spec/support/seeds.rb
+++ b/spec/support/seeds.rb
@@ -1,0 +1,18 @@
+# Minimal test seeding
+# --------------------
+#
+# Countries and states are seeded once in the beginning. The database cleaner
+# leaves them there when deleting the rest (see spec/spec_helper.rb).
+# You can add more entries here if you need them for your tests.
+
+if Spree::Country.scoped.empty?
+  Spree::Country.create!({"name"=>"Australia", "iso3"=>"AUS", "iso"=>"AU", "iso_name"=>"AUSTRALIA", "numcode"=>"36"}, :without_protection => true)
+  country = Spree::Country.find_by_name('Australia')
+  Spree::State.create!({"name"=>"Victoria", "abbr"=>"Vic", :country=>country}, :without_protection => true)
+  Spree::State.create!({"name"=>"New South Wales", "abbr"=>"NSW", :country=>country}, :without_protection => true)
+end
+
+# Since the country seeding differs from other environments, the default
+# country id has to be updated here. This line can be removed as soon as the
+# default country id is replaced by something database independent.
+Spree::Config.default_country_id = Spree::Country.find_by_name('Australia').id


### PR DESCRIPTION
Removing fixtures is one step closer to solve #245. The minimal seeding is independent from the development and production seeding. It loads only a minimal set needed by the specs. The default country id is set accordingly.

Seeding:
 1 country: Australia
 2 states:  Vic, NSW
