### PR TITLE
Fixes #398 redirect login and signup url to homepage with login / signup panel open

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,13 @@ Openfoodnetwork::Application.routes.draw do
   root :to => 'home#index'
 
   get "/#/login", to: "home#index", as: :spree_login
+  get '/login', to: redirect('/#/login')
 
   get "/map", to: "map#index", as: :map
 
   get "/register", to: "registration#index", as: :registration
   get "/register/auth", to: "registration#authenticate", as: :registration_auth
+  get '/signup', to: redirect('/register')
 
   resource :shop, controller: "shop" do
     get :products


### PR DESCRIPTION
Hi,

I'm thinking of using a redirection to redirect the default spree login and signup page to the path with homepage with login/signup panel open.

Note: I've also take the extra steps to implement the signup redirection as well.

