### PR TITLE
Reduce supplier list in order cycles

### DIFF
--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -3,6 +3,10 @@ module OrderCyclesHelper
     @current_order_cycle ||= current_order(false).andand.order_cycle
   end
 
+  def order_cycle_permitted_in(enterprises)
+    enterprises.merge(order_cycle_permitted_enterprises)
+  end
+
   def order_cycle_permitted_enterprises
     OpenFoodNetwork::Permissions.new(spree_current_user).order_cycle_enterprises
   end

--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -8,26 +8,23 @@
   - unless order_cycles_simple_index
     %td.suppliers
       - suppliers = order_cycle_permitted_in(order_cycle.suppliers)
+      - supplier_list = suppliers.map(&:name).sort.join ', '
       - if suppliers.count > 3
-        - supplier_list = suppliers.map(&:name).sort.join ', '
         %span.with-tip{'data-powertip' => supplier_list}
           = suppliers.count
           suppliers
       - else
-        - suppliers.each do |s|
-          = s.name
-        %br/
+        = supplier_list
     %td= order_cycle.coordinator.name
     %td.distributors
       - distributors = order_cycle_permitted_in(order_cycle.distributors)
+      - distributor_list = distributors.map(&:name).sort.join ', '
       - if distributors.count > 3
-        - distributor_list = distributors.map(&:name).sort.join ', '
         %span.with-tip{'data-powertip' => distributor_list}
           = distributors.count
           distributors
       - else
-        - distributors.each do |d|
-          = d.name
+        = distributor_list
         %br/
 
   %td.products

--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -7,13 +7,27 @@
 
   - unless order_cycles_simple_index
     %td.suppliers
-      - order_cycle_permitted_in(order_cycle.suppliers).each do |s|
-        = s.name
+      - suppliers = order_cycle_permitted_in(order_cycle.suppliers)
+      - if suppliers.count > 3
+        - supplier_list = suppliers.map(&:name).sort.join ', '
+        %span.with-tip{'data-powertip' => supplier_list}
+          = suppliers.count
+          suppliers
+      - else
+        - suppliers.each do |s|
+          = s.name
         %br/
     %td= order_cycle.coordinator.name
     %td.distributors
-      - order_cycle_permitted_in(order_cycle.distributors).each do |d|
-        = d.name
+      - distributors = order_cycle_permitted_in(order_cycle.distributors)
+      - if distributors.count > 3
+        - distributor_list = distributors.map(&:name).sort.join ', '
+        %span.with-tip{'data-powertip' => distributor_list}
+          = distributors.count
+          distributors
+      - else
+        - distributors.each do |d|
+          = d.name
         %br/
 
   %td.products

--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -7,12 +7,12 @@
 
   - unless order_cycles_simple_index
     %td.suppliers
-      - order_cycle.suppliers.merge(OpenFoodNetwork::Permissions.new(spree_current_user).order_cycle_enterprises).each do |s|
+      - order_cycle.suppliers.merge(order_cycle_permitted_enterprises).each do |s|
         = s.name
         %br/
     %td= order_cycle.coordinator.name
     %td.distributors
-      - order_cycle.distributors.merge(OpenFoodNetwork::Permissions.new(spree_current_user).order_cycle_enterprises).each do |d|
+      - order_cycle.distributors.merge(order_cycle_permitted_enterprises).each do |d|
         = d.name
         %br/
 

--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -7,12 +7,12 @@
 
   - unless order_cycles_simple_index
     %td.suppliers
-      - order_cycle.suppliers.merge(order_cycle_permitted_enterprises).each do |s|
+      - order_cycle_permitted_in(order_cycle.suppliers).each do |s|
         = s.name
         %br/
     %td= order_cycle.coordinator.name
     %td.distributors
-      - order_cycle.distributors.merge(order_cycle_permitted_enterprises).each do |d|
+      - order_cycle_permitted_in(order_cycle.distributors).each do |d|
         = d.name
         %br/
 

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -85,6 +85,7 @@ feature %q{
     fill_in 'order_cycle_name', with: 'Plums & Avos'
     fill_in 'order_cycle_orders_open_at', with: '2012-11-06 06:00:00'
     fill_in 'order_cycle_orders_close_at', with: '2012-11-13 17:00:00'
+    select 'My coordinator', from: 'order_cycle_coordinator_id'
 
     # And I add a coordinator fee
     click_button 'Add coordinator fee'


### PR DESCRIPTION
In order cycles summary page, when there are >3 suppliers or distributors, indicate the number of suppliers/distributors; on hover, pop up entire list of suppliers/distributors. #373
