### PR TITLE
Using date and time of current timezone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,21 @@ bundler_args: --without development
 rvm:
   - "2.1.5"
 
+# Set the timezone for phantomjs with TZ
+# Set the timezone for karma with TIMEZONE
+#
 # The test cases are roughly split according to their test times.
 # It would be better to use https://github.com/ArturT/knapsack.
 env:
-  - TEST_CASES="./spec/features/admin"
-  - TEST_CASES="./spec/features/consumer ./spec/serializers ./spec/performance"
-  - TEST_CASES="./spec/models"
-  - TEST_CASES="./spec/controllers ./spec/views ./spec/jobs"
-  - TEST_CASES="./spec/requests ./spec/helpers ./spec/mailers ./spec/lib" KARMA="true" TIMEZONE="UTC"
+  global:
+    TZ="Australia/Melbourne"
+    TIMEZONE="Australia/Melbourne"
+  matrix:
+    - TEST_CASES="./spec/features/admin"
+    - TEST_CASES="./spec/features/consumer ./spec/serializers ./spec/performance"
+    - TEST_CASES="./spec/models"
+    - TEST_CASES="./spec/controllers ./spec/views ./spec/jobs"
+    - TEST_CASES="./spec/requests ./spec/helpers ./spec/mailers ./spec/lib" KARMA="true"
 
 before_script:
   - cp config/database.travis.yml config/database.yml

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -60,7 +60,7 @@ module Admin
       attributes = { sells: params[:sells], visible: true }
 
       if ['own', 'any'].include? params[:sells]
-        attributes[:shop_trial_start_date] = @enterprise.shop_trial_start_date || Time.now
+        attributes[:shop_trial_start_date] = @enterprise.shop_trial_start_date || Time.zone.now
       end
 
       if @enterprise.update_attributes(attributes)

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -317,6 +317,6 @@ Spree::Admin::ReportsController.class_eval do
   end
 
   def timestamp
-    Time.now.strftime("%Y%m%d")
+    Time.zone.now.strftime("%Y%m%d")
   end
 end

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -48,17 +48,17 @@ module EnterprisesHelper
 
   def shop_trial_in_progress?(enterprise)
     !!enterprise.shop_trial_start_date &&
-    (enterprise.shop_trial_start_date + Enterprise::SHOP_TRIAL_LENGTH.days > Time.now) &&
+    (enterprise.shop_trial_start_date + Enterprise::SHOP_TRIAL_LENGTH.days > Time.zone.now) &&
     %w(own any).include?(enterprise.sells)
   end
 
   def shop_trial_expired?(enterprise)
     !!enterprise.shop_trial_start_date &&
-    (enterprise.shop_trial_start_date + Enterprise::SHOP_TRIAL_LENGTH.days <= Time.now) &&
+    (enterprise.shop_trial_start_date + Enterprise::SHOP_TRIAL_LENGTH.days <= Time.zone.now) &&
     %w(own any).include?(enterprise.sells)
   end
 
   def remaining_trial_days(enterprise)
-    distance_of_time_in_words(Time.now, enterprise.shop_trial_start_date + Enterprise::SHOP_TRIAL_LENGTH.days)
+    distance_of_time_in_words(Time.zone.now, enterprise.shop_trial_start_date + Enterprise::SHOP_TRIAL_LENGTH.days)
   end
 end

--- a/app/models/billable_period.rb
+++ b/app/models/billable_period.rb
@@ -41,7 +41,7 @@ class BillablePeriod < ActiveRecord::Base
   end
 
   def delete
-    self.update_column(:deleted_at, Time.now)
+    self.update_column(:deleted_at, Time.zone.now)
   end
 
   def ensure_correct_adjustment_for(invoice)

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -111,12 +111,12 @@ class Enterprise < ActiveRecord::Base
   scope :supplying_variant_in, lambda { |variants| joins(:supplied_products => :variants_including_master).where('spree_variants.id IN (?)', variants).select('DISTINCT enterprises.*') }
   scope :with_supplied_active_products_on_hand, lambda {
     joins(:supplied_products)
-      .where('spree_products.deleted_at IS NULL AND spree_products.available_on <= ? AND spree_products.count_on_hand > 0', Time.now)
+      .where('spree_products.deleted_at IS NULL AND spree_products.available_on <= ? AND spree_products.count_on_hand > 0', Time.zone.now)
       .uniq
   }
   scope :with_distributed_active_products_on_hand, lambda {
     joins(:distributed_products)
-      .where('spree_products.deleted_at IS NULL AND spree_products.available_on <= ? AND spree_products.count_on_hand > 0', Time.now)
+      .where('spree_products.deleted_at IS NULL AND spree_products.available_on <= ? AND spree_products.count_on_hand > 0', Time.zone.now)
       .uniq
   }
 
@@ -140,7 +140,7 @@ class Enterprise < ActiveRecord::Base
 
   scope :active_distributors, lambda {
     with_distributed_products_outer.with_order_cycles_as_distributor_outer.
-    where('(product_distributions.product_id IS NOT NULL AND spree_products.deleted_at IS NULL AND spree_products.available_on <= ? AND spree_products.count_on_hand > 0) OR (order_cycles.id IS NOT NULL AND order_cycles.orders_open_at <= ? AND order_cycles.orders_close_at >= ?)', Time.now, Time.now, Time.now).
+    where('(product_distributions.product_id IS NOT NULL AND spree_products.deleted_at IS NULL AND spree_products.available_on <= ? AND spree_products.count_on_hand > 0) OR (order_cycles.id IS NOT NULL AND order_cycles.orders_open_at <= ? AND order_cycles.orders_close_at >= ?)', Time.zone.now, Time.zone.now, Time.zone.now).
     select('DISTINCT enterprises.*')
   }
 

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -11,11 +11,11 @@ class OrderCycle < ActiveRecord::Base
 
   validates_presence_of :name, :coordinator_id
 
-  scope :active, lambda { where('order_cycles.orders_open_at <= ? AND order_cycles.orders_close_at >= ?', Time.now, Time.now) }
-  scope :active_or_complete, lambda { where('order_cycles.orders_open_at <= ?', Time.now) }
-  scope :inactive, lambda { where('order_cycles.orders_open_at > ? OR order_cycles.orders_close_at < ?', Time.now, Time.now) }
-  scope :upcoming, lambda { where('order_cycles.orders_open_at > ?', Time.now) }
-  scope :closed, lambda { where('order_cycles.orders_close_at < ?', Time.now).order("order_cycles.orders_close_at DESC") }
+  scope :active, lambda { where('order_cycles.orders_open_at <= ? AND order_cycles.orders_close_at >= ?', Time.zone.now, Time.zone.now) }
+  scope :active_or_complete, lambda { where('order_cycles.orders_open_at <= ?', Time.zone.now) }
+  scope :inactive, lambda { where('order_cycles.orders_open_at > ? OR order_cycles.orders_close_at < ?', Time.zone.now, Time.zone.now) }
+  scope :upcoming, lambda { where('order_cycles.orders_open_at > ?', Time.zone.now) }
+  scope :closed, lambda { where('order_cycles.orders_close_at < ?', Time.zone.now).order("order_cycles.orders_close_at DESC") }
   scope :undated, where(orders_open_at: nil, orders_close_at: nil)
 
   scope :soonest_closing,      lambda { active.order('order_cycles.orders_close_at ASC') }
@@ -180,16 +180,16 @@ class OrderCycle < ActiveRecord::Base
   end
 
   def upcoming?
-    self.orders_open_at && Time.now < self.orders_open_at
+    self.orders_open_at && Time.zone.now < self.orders_open_at
   end
 
   def open?
     self.orders_open_at && self.orders_close_at &&
-      Time.now > self.orders_open_at && Time.now < self.orders_close_at
+      Time.zone.now > self.orders_open_at && Time.zone.now < self.orders_close_at
   end
 
   def closed?
-    self.orders_close_at && Time.now > self.orders_close_at
+    self.orders_close_at && Time.zone.now > self.orders_close_at
   end
 
   def exchange_for_distributor(distributor)

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -194,7 +194,7 @@ Spree::Product.class_eval do
   private
 
   def set_available_on_to_now
-    self.available_on ||= Time.now
+    self.available_on ||= Time.zone.now
   end
 
   def update_units

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -85,7 +85,7 @@ Spree::Variant.class_eval do
       false
     else
       transaction do
-        self.update_column(:deleted_at, Time.now)
+        self.update_column(:deleted_at, Time.zone.now)
         ExchangeVariant.where(variant_id: self).destroy_all
         self
       end

--- a/app/views/admin/accounts_and_billing_settings/edit.html.haml
+++ b/app/views/admin/accounts_and_billing_settings/edit.html.haml
@@ -5,7 +5,7 @@
 
 = render 'spree/shared/error_messages', target: @settings
 
--# - month_options = (0...12).map { |i| Time.now.beginning_of_month - i.months }.map{ |t| [t.strftime("%b %Y"), t.strftime("%b %Y %z")]}
+-# - month_options = (0...12).map { |i| Time.zone.now.beginning_of_month - i.months }.map{ |t| [t.strftime("%b %Y"), t.strftime("%b %Y %z")]}
 
 %fieldset.no-border-bottom
   %legend Settings
@@ -50,7 +50,7 @@
 
       - if @update_account_invoices_job
         %p.text-center
-          - if @update_account_invoices_job.run_at < Time.now
+          - if @update_account_invoices_job.run_at < Time.zone.now
             %strong In Progress
             %br
             Started at:
@@ -74,7 +74,7 @@
 
       - if @finalize_account_invoices_job
         %p.text-center
-          - if @finalize_account_invoices_job.run_at < Time.now
+          - if @finalize_account_invoices_job.run_at < Time.zone.now
             %strong In Progress
             %br
             Started at:

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -110,7 +110,7 @@
       .small-12.columns.text-center.small
         %hr
         %p.text-small
-          = "Copyright #{Date.today.year} #{@group.name}"
+          = "Copyright #{Date.current.year} #{@group.name}"
         %h2
           =link_to_service "https://www.facebook.com/", @group.facebook, title: t(:groups_contact_facebook) do
             %i.ofn-i_044-facebook

--- a/db/migrate/20140702053145_add_fields_to_distributors_shipping_methods.rb
+++ b/db/migrate/20140702053145_add_fields_to_distributors_shipping_methods.rb
@@ -9,7 +9,7 @@ class AddFieldsToDistributorsShippingMethods < ActiveRecord::Migration
     add_column :distributors_shipping_methods, :updated_at, :datetime
 
     DistributorShippingMethod.reset_column_information
-    DistributorShippingMethod.update_all created_at: Time.now, updated_at: Time.now
+    DistributorShippingMethod.update_all created_at: Time.zone.now, updated_at: Time.zone.now
 
     change_column :distributors_shipping_methods, :created_at, :datetime, null: false
     change_column :distributors_shipping_methods, :updated_at, :datetime, null: false

--- a/db/migrate/20141010043405_add_confirmable_to_enterprise.rb
+++ b/db/migrate/20141010043405_add_confirmable_to_enterprise.rb
@@ -7,7 +7,7 @@ class AddConfirmableToEnterprise < ActiveRecord::Migration
     add_index :enterprises, :confirmation_token, :unique => true
 
     # Existing enterprises are assumed to be confirmed
-    Enterprise.update_all(:confirmed_at => Time.now)
+    Enterprise.update_all(:confirmed_at => Time.zone.now)
   end
 
   def down

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -6,7 +6,7 @@ module OpenFoodNetwork
       @opts = opts.
               reject { |k, v| v.blank? }.
               reverse_merge({report_type: 'summary',
-                             invoice_date: Date.today,
+                             invoice_date: Date.current,
                              due_date: 2.weeks.from_now.to_date,
                              account_code: 'food sales'})
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -5,7 +5,7 @@ namespace :openfoodnetwork do
       input = request_months
 
       # For each order cycle which was modified within the past 3 months
-      OrderCycle.where('updated_at > ?', Date.today - input.months).each do |order_cycle|
+      OrderCycle.where('updated_at > ?', Date.current - input.months).each do |order_cycle|
         # Cycle through the incoming exchanges
         order_cycle.exchanges.incoming.each do |exchange|
           unless exchange.sender == exchange.receiver

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -315,7 +315,7 @@ module Admin
           end
 
           context "if the trial has not finished" do
-            let(:trial_start) { Date.today.to_time }
+            let(:trial_start) { Date.current.to_time }
 
             before do
               enterprise.update_attribute(:shop_trial_start_date, trial_start)
@@ -335,7 +335,7 @@ module Admin
               expect(response).to redirect_to spree.admin_path
               expect(flash[:success]).to eq "Congratulations! Registration for #{enterprise.name} is complete!"
               expect(enterprise.reload.sells).to eq 'own'
-              expect(enterprise.reload.shop_trial_start_date).to be > Time.now-(1.minute)
+              expect(enterprise.reload.shop_trial_start_date).to be > Time.zone.now-(1.minute)
             end
           end
         end
@@ -359,7 +359,7 @@ module Admin
           end
 
           context "if the trial has not finished" do
-            let(:trial_start) { Date.today.to_time }
+            let(:trial_start) { Date.current.to_time }
 
             before do
               enterprise.update_attribute(:shop_trial_start_date, trial_start)
@@ -379,7 +379,7 @@ module Admin
               expect(response).to redirect_to spree.admin_path
               expect(flash[:success]).to eq "Congratulations! Registration for #{enterprise.name} is complete!"
               expect(enterprise.reload.sells).to eq 'any'
-              expect(enterprise.reload.shop_trial_start_date).to be > Time.now-(1.minute)
+              expect(enterprise.reload.shop_trial_start_date).to be > Time.zone.now-(1.minute)
             end
           end
         end

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -102,13 +102,13 @@ module Admin
         it "updates order cycle properties" do
           spree_put :bulk_update, order_cycle_set: { collection_attributes: { '0' => {
             id: oc.id,
-            orders_open_at: Date.today - 21.days,
-            orders_close_at: Date.today + 21.days,
+            orders_open_at: Date.current - 21.days,
+            orders_close_at: Date.current + 21.days,
           } } }
 
           oc.reload
-          expect(oc.orders_open_at.to_date).to eq Date.today - 21.days
-          expect(oc.orders_close_at.to_date).to eq Date.today + 21.days
+          expect(oc.orders_open_at.to_date).to eq Date.current - 21.days
+          expect(oc.orders_close_at.to_date).to eq Date.current + 21.days
         end
 
         it "does nothing when no data is supplied" do
@@ -125,13 +125,13 @@ module Admin
         it "doesn't update order cycle properties" do
           spree_put :bulk_update, order_cycle_set: { collection_attributes: { '0' => {
             id: oc.id,
-            orders_open_at: Date.today - 21.days,
-            orders_close_at: Date.today + 21.days,
+            orders_open_at: Date.current - 21.days,
+            orders_close_at: Date.current + 21.days,
           } } }
 
           oc.reload
-          expect(oc.orders_open_at.to_date).to_not eq Date.today - 21.days
-          expect(oc.orders_close_at.to_date).to_not eq Date.today + 21.days
+          expect(oc.orders_open_at.to_date).to_not eq Date.current - 21.days
+          expect(oc.orders_close_at.to_date).to_not eq Date.current + 21.days
         end
       end
     end

--- a/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -9,8 +9,8 @@ describe Spree::Admin::LineItemsController do
     let(:line_item_attributes) { [:id, :quantity, :max_quantity, :price, :supplier, :final_weight_volume, :units_product, :units_variant, :order] }
     let!(:dist1) { FactoryGirl.create(:distributor_enterprise) }
     let!(:order1) { FactoryGirl.create(:order, state: 'complete', completed_at: 1.day.ago, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:order2) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:order3) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
+    let!(:order2) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
+    let!(:order3) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
     let!(:line_item1) { FactoryGirl.create(:line_item, order: order1) }
     let!(:line_item2) { FactoryGirl.create(:line_item, order: order2) }
     let!(:line_item3) { FactoryGirl.create(:line_item, order: order2) }
@@ -83,10 +83,10 @@ describe Spree::Admin::LineItemsController do
       let(:distributor2) { create(:distributor_enterprise) }
       let(:coordinator) { create(:distributor_enterprise) }
       let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-      let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
+      let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
       let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
       let!(:line_item2) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-      let!(:order2) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.now, distributor: distributor2, billing_address: FactoryGirl.create(:address) ) }
+      let!(:order2) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor2, billing_address: FactoryGirl.create(:address) ) }
       let!(:line_item3) { FactoryGirl.create(:line_item, order: order2, product: FactoryGirl.create(:product, supplier: supplier)) }
 
       context "producer enterprise" do
@@ -131,7 +131,7 @@ describe Spree::Admin::LineItemsController do
     let(:distributor1) { create(:distributor_enterprise) }
     let(:coordinator) { create(:distributor_enterprise) }
     let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-    let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
+    let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
     let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
     let(:params) { { format: :json, id: line_item1.id, order_id: order1.number, line_item: { quantity: 3, final_weight_volume: 3000, price: 3.00 } } }
 

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -36,9 +36,9 @@ describe Spree::Admin::OrdersController do
 
     def self.make_simple_data!
       let!(:dist1) { FactoryGirl.create(:distributor_enterprise) }
-      let!(:order1) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-      let!(:order2) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-      let!(:order3) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
+      let!(:order1) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
+      let!(:order2) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
+      let!(:order3) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
       let!(:line_item1) { FactoryGirl.create(:line_item, order: order1) }
       let!(:line_item2) { FactoryGirl.create(:line_item, order: order2) }
       let!(:line_item3) { FactoryGirl.create(:line_item, order: order2) }
@@ -95,10 +95,10 @@ describe Spree::Admin::OrdersController do
       let(:distributor2) { create(:distributor_enterprise) }
       let(:coordinator) { create(:distributor_enterprise) }
       let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-      let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
+      let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
       let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
       let!(:line_item2) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-      let!(:order2) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.now, distributor: distributor2, billing_address: FactoryGirl.create(:address) ) }
+      let!(:order2) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor2, billing_address: FactoryGirl.create(:address) ) }
       let!(:line_item3) { FactoryGirl.create(:line_item, order: order2, product: FactoryGirl.create(:product, supplier: supplier)) }
 
       context "producer enterprise" do

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -10,7 +10,7 @@ module Spree
     end
 
     def self.make_simple_data!
-      let!(:order) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.now) }
+      let!(:order) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now) }
       let!(:line_item) { FactoryGirl.create(:line_item, order: order, final_weight_volume: 500) }
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -104,7 +104,7 @@ FactoryGirl.define do
     long_description '<p>Hello, world!</p><p>This is a paragraph.</p>'
     email 'enterprise@example.com'
     address { FactoryGirl.create(:address) }
-    confirmed_at { Time.now }
+    confirmed_at { Time.zone.now }
   end
 
   factory :supplier_enterprise, :parent => :enterprise do
@@ -219,8 +219,8 @@ FactoryGirl.define do
   end
 
   factory :billable_period do
-    begins_at { Time.now.beginning_of_month }
-    ends_at { Time.now.beginning_of_month + 1.month }
+    begins_at { Time.zone.now.beginning_of_month }
+    ends_at { Time.zone.now.beginning_of_month + 1.month }
     sells { 'any' }
     trial { false }
     enterprise

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -18,8 +18,8 @@ feature %q{
     end
 
     context "displaying the list of line items" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:o3) { FactoryGirl.create(:order_with_distributor, state: 'address', completed_at: nil ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
       let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
@@ -37,8 +37,8 @@ feature %q{
     end
 
     context "displaying individual columns" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, bill_address: FactoryGirl.create(:address) ) }
-      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, bill_address: nil ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, bill_address: FactoryGirl.create(:address) ) }
+      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, bill_address: nil ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
       let!(:li2) { FactoryGirl.create(:line_item, order: o2, product: FactoryGirl.create(:product_with_option_types) ) }
 
@@ -90,7 +90,7 @@ feature %q{
     end
 
     context "tracking changes" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1, :quantity => 5 ) }
 
       before :each do
@@ -105,7 +105,7 @@ feature %q{
     end
 
     context "submitting data to the server" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1, :quantity => 5 ) }
 
       before :each do
@@ -150,7 +150,7 @@ feature %q{
 
     let!(:p1) { FactoryGirl.create(:product_with_option_types, group_buy: true, group_buy_unit_size: 5000, variant_unit: "weight", variants: [FactoryGirl.create(:variant, unit_value: 1000)] ) }
     let!(:v1) { p1.variants.first }
-    let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+    let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
     let!(:li1) { FactoryGirl.create(:line_item, order: o1, variant: v1, :quantity => 5, :final_weight_volume => 1000, price: 10.00 ) }
 
     before { v1.update_attribute(:on_hand, 100)}
@@ -227,7 +227,7 @@ feature %q{
       context "supplier filter" do
         let!(:s1) { create(:supplier_enterprise) }
         let!(:s2) { create(:supplier_enterprise) }
-        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, order_cycle: create(:simple_order_cycle) ) }
+        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, order_cycle: create(:simple_order_cycle) ) }
         let!(:li1) { FactoryGirl.create(:line_item, order: o1, product: create(:product, supplier: s1) ) }
         let!(:li2) { FactoryGirl.create(:line_item, order: o1, product: create(:product, supplier: s2) ) }
 
@@ -261,8 +261,8 @@ feature %q{
       context "distributor filter" do
         let!(:d1) { create(:distributor_enterprise) }
         let!(:d2) { create(:distributor_enterprise) }
-        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, distributor: d1, order_cycle: create(:simple_order_cycle) ) }
-        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, distributor: d2, order_cycle: create(:simple_order_cycle) ) }
+        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d1, order_cycle: create(:simple_order_cycle) ) }
+        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d2, order_cycle: create(:simple_order_cycle) ) }
         let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
         let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
 
@@ -299,8 +299,8 @@ feature %q{
         let!(:distributor) { create(:distributor_enterprise) }
         let!(:oc1) { FactoryGirl.create(:simple_order_cycle, distributors: [distributor]) }
         let!(:oc2) { FactoryGirl.create(:simple_order_cycle, distributors: [distributor]) }
-        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, order_cycle: oc1 ) }
-        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, order_cycle: oc2 ) }
+        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, order_cycle: oc1 ) }
+        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, order_cycle: oc2 ) }
         let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
         let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
 
@@ -339,8 +339,8 @@ feature %q{
         let!(:oc2) { FactoryGirl.create(:simple_order_cycle, suppliers: [s2], distributors: [d2] ) }
         let!(:p1) { FactoryGirl.create(:product, supplier: s1) }
         let!(:p2) { FactoryGirl.create(:product, supplier: s2) }
-        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, distributor: d1, order_cycle: oc1 ) }
-        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, distributor: d2, order_cycle: oc2 ) }
+        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d1, order_cycle: oc1 ) }
+        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d2, order_cycle: oc2 ) }
         let!(:li1) { FactoryGirl.create(:line_item, order: o1, product: p1 ) }
         let!(:li2) { FactoryGirl.create(:line_item, order: o2, product: p2 ) }
 
@@ -383,9 +383,9 @@ feature %q{
     end
 
     context "using quick search" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-      let!(:o3) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o3) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
       let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
       let!(:li3) { FactoryGirl.create(:line_item, order: o3 ) }
@@ -410,9 +410,9 @@ feature %q{
     end
 
     context "using date restriction controls" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: (Date.today - 8).strftime("%F %T") ) }
-      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-      let!(:o3) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: (Date.today + 2).strftime("%F %T") ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: (Date.current - 8).strftime("%F %T") ) }
+      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o3) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: (Date.current + 2).strftime("%F %T") ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1, :quantity => 1 ) }
       let!(:li2) { FactoryGirl.create(:line_item, order: o2, :quantity => 2 ) }
       let!(:li3) { FactoryGirl.create(:line_item, order: o3, :quantity => 3 ) }
@@ -422,8 +422,10 @@ feature %q{
       end
 
       it "displays date fields for filtering orders, with default values set" do
-        one_week_ago = Date.today.prev_day(7).strftime("%F")
-        tonight = Date.tomorrow.strftime("%F")
+        # use Date.current since Date.today is without timezone
+        today = Date.current
+        one_week_ago = today.prev_day(7).strftime("%F")
+        tonight = today.next_day.strftime("%F")
         expect(page).to have_field "start_date_filter", with: one_week_ago
         expect(page).to have_field "end_date_filter", with: tonight
       end
@@ -435,12 +437,12 @@ feature %q{
       end
 
       it "displays only line items whose orders meet the date restriction criteria, when changed" do
-        fill_in "start_date_filter", :with => (Date.today - 9).strftime("%F")
+        fill_in "start_date_filter", :with => (Date.current - 9).strftime("%F")
         expect(page).to have_selector "tr#li_#{li1.id}", visible: true
         expect(page).to have_selector "tr#li_#{li2.id}", visible: true
         expect(page).to_not have_selector "tr#li_#{li3.id}", visible: true
 
-        fill_in "end_date_filter", :with => (Date.today + 3).strftime("%F")
+        fill_in "end_date_filter", :with => (Date.current + 3).strftime("%F")
         expect(page).to have_selector "tr#li_#{li1.id}", visible: true
         expect(page).to have_selector "tr#li_#{li2.id}", visible: true
         expect(page).to have_selector "tr#li_#{li3.id}", visible: true
@@ -455,7 +457,7 @@ feature %q{
 
         it "shows a dialog and ignores changes when confirm dialog is accepted" do
           page.driver.accept_modal :confirm, text: "Unsaved changes exist and will be lost if you continue." do
-            fill_in "start_date_filter", :with => (Date.today - 9).strftime("%F %T")
+            fill_in "start_date_filter", :with => (Date.current - 9).strftime("%F %T")
           end
           expect(page).to have_no_selector "#save-bar"
           within("tr#li_#{li2.id} td.quantity") do
@@ -465,7 +467,7 @@ feature %q{
 
         it "shows a dialog and keeps changes when confirm dialog is rejected" do
           page.driver.dismiss_modal :confirm, text: "Unsaved changes exist and will be lost if you continue." do
-            fill_in "start_date_filter", :with => (Date.today - 9).strftime("%F %T")
+            fill_in "start_date_filter", :with => (Date.current - 9).strftime("%F %T")
           end
           expect(page).to have_selector "#save-bar"
           within("tr#li_#{li2.id} td.quantity") do
@@ -476,8 +478,8 @@ feature %q{
     end
 
     context "bulk action controls" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
       let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
 
@@ -543,8 +545,8 @@ feature %q{
 
     context "using action buttons" do
       context "using edit buttons" do
-        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
         let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
         let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
 
@@ -576,8 +578,8 @@ feature %q{
       end
 
       context "using delete buttons" do
-        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+        let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+        let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
         let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
         let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
 
@@ -597,13 +599,13 @@ feature %q{
     end
 
     context "clicking the link on variant name" do
-      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
-      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+      let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li1) { FactoryGirl.create(:line_item, order: o1 ) }
       let!(:li2) { FactoryGirl.create(:line_item, order: o2 ) }
       let!(:p3) { FactoryGirl.create(:product_with_option_types, group_buy: true, group_buy_unit_size: 5000, variant_unit: "weight", variants: [FactoryGirl.create(:variant, unit_value: 1000)] ) }
       let!(:v3) { p3.variants.first }
-      let!(:o3) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now ) }
+      let!(:o3) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li3) { FactoryGirl.create(:line_item, order: o3, variant: v3, quantity: 3, max_quantity: 6 ) }
       let!(:li4) { FactoryGirl.create(:line_item, order: o2, variant: v3, quantity: 1, max_quantity: 3 ) }
 
@@ -663,8 +665,8 @@ feature %q{
     let(:s1) { create(:supplier_enterprise, name: 'First Supplier') }
     let(:d1) { create(:distributor_enterprise, name: 'First Distributor') }
     let(:d2) { create(:distributor_enterprise, name: 'Another Distributor') }
-    let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, distributor: d1 ) }
-    let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.now, distributor: d2 ) }
+    let!(:o1) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d1 ) }
+    let!(:o2) { FactoryGirl.create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d2 ) }
     let!(:line_item_distributed) { FactoryGirl.create(:line_item, order: o1, product: create(:product, supplier: s1) ) }
     let!(:line_item_not_distributed) { FactoryGirl.create(:line_item, order: o2, product: create(:product, supplier: s1) ) }
 

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -42,8 +42,8 @@ feature %q{
     end
 
     it "displays a date input for available_on for each product, formatted to yyyy-mm-dd hh:mm:ss" do
-      p1 = FactoryGirl.create(:product, available_on: Date.today)
-      p2 = FactoryGirl.create(:product, available_on: Date.today-1)
+      p1 = FactoryGirl.create(:product, available_on: Date.current)
+      p2 = FactoryGirl.create(:product, available_on: Date.current-1)
 
       visit '/admin/products/bulk_edit'
       first("div#columns_dropdown", :text => "COLUMNS").click
@@ -237,7 +237,7 @@ feature %q{
     s2 = FactoryGirl.create(:supplier_enterprise)
     t1 = FactoryGirl.create(:taxon)
     t2 = FactoryGirl.create(:taxon)
-    p = FactoryGirl.create(:product, supplier: s1, available_on: Date.today, variant_unit: 'volume', variant_unit_scale: 1, primary_taxon: t2, sku: "OLD SKU")
+    p = FactoryGirl.create(:product, supplier: s1, available_on: Date.current, variant_unit: 'volume', variant_unit_scale: 1, primary_taxon: t2, sku: "OLD SKU")
 
     login_to_admin_section
 
@@ -305,7 +305,7 @@ feature %q{
   scenario "updating a product with variants" do
     s1 = FactoryGirl.create(:supplier_enterprise)
     s2 = FactoryGirl.create(:supplier_enterprise)
-    p = FactoryGirl.create(:product, supplier: s1, available_on: Date.today, variant_unit: 'volume', variant_unit_scale: 0.001,
+    p = FactoryGirl.create(:product, supplier: s1, available_on: Date.current, variant_unit: 'volume', variant_unit_scale: 0.001,
       price: 3.0, on_hand: 9, unit_value: 0.25, unit_description: '(bottle)' )
     v = p.variants.first
 

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -272,7 +272,7 @@ feature %q{
 
     it "handles order cycles with nil opening or closing times" do
       distributor = create(:distributor_enterprise)
-      oc = create(:simple_order_cycle, name: "My Order Cycle", distributors: [distributor], orders_open_at: Time.now, orders_close_at: nil)
+      oc = create(:simple_order_cycle, name: "My Order Cycle", distributors: [distributor], orders_open_at: Time.zone.now, orders_close_at: nil)
       o = create(:order, order_cycle: oc, distributor: distributor)
 
       login_to_admin_section

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -198,7 +198,7 @@ feature "As a consumer I want to check out my cart", js: true do
               toggle_payment
               fill_in 'Card Number', with: "4111111111111111"
               select 'February', from: 'secrets.card_month'
-              select (Date.today.year+1).to_s, from: 'secrets.card_year'
+              select (Date.current.year+1).to_s, from: 'secrets.card_year'
               fill_in 'Security Code', with: '123'
 
               place_order
@@ -213,7 +213,7 @@ feature "As a consumer I want to check out my cart", js: true do
               toggle_payment
               fill_in 'Card Number', with: "9999999988887777"
               select 'February', from: 'secrets.card_month'
-              select (Date.today.year+1).to_s, from: 'secrets.card_year'
+              select (Date.current.year+1).to_s, from: 'secrets.card_year'
               fill_in 'Security Code', with: '123'
 
               place_order

--- a/spec/models/billable_period_spec.rb
+++ b/spec/models/billable_period_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Customer, type: :model do
   describe 'ensure_correct_adjustment' do
-    let!(:start_of_july) { Time.now.beginning_of_year + 6.months }
+    let!(:start_of_july) { Time.zone.now.beginning_of_year + 6.months }
     let!(:user) { create(:user) }
     let!(:invoice) { create(:order, user: user) }
     let!(:billable_period) { create(:billable_period, owner: user, begins_at: start_of_july, ends_at: start_of_july + 12.days) }

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -302,9 +302,9 @@ describe Enterprise do
     end
 
     describe "activated" do
-      let!(:inactive_enterprise1) { create(:enterprise, sells: "unspecified", confirmed_at: Time.now) ;}
+      let!(:inactive_enterprise1) { create(:enterprise, sells: "unspecified", confirmed_at: Time.zone.now) ;}
       let!(:inactive_enterprise2) { create(:enterprise, sells: "none", confirmed_at: nil) }
-      let!(:active_enterprise) { create(:enterprise, sells: "none", confirmed_at: Time.now) }
+      let!(:active_enterprise) { create(:enterprise, sells: "none", confirmed_at: Time.zone.now) }
 
       it "finds enterprises that have a sells property other than 'unspecified' and that are confirmed" do
         activated_enterprises = Enterprise.activated
@@ -419,7 +419,7 @@ describe Enterprise do
 
       it "doesn't show distributors of deleted products" do
         d = create(:distributor_enterprise)
-        create(:product, :distributors => [d], :deleted_at => Time.now)
+        create(:product, :distributors => [d], :deleted_at => Time.zone.now)
         Enterprise.active_distributors.should be_empty
       end
 

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -191,7 +191,7 @@ describe OrderCycle do
 
       @p0 = create(:simple_product)
       @p1 = create(:simple_product)
-      @p1_v_deleted = create(:variant, product: @p1, deleted_at: Time.now)
+      @p1_v_deleted = create(:variant, product: @p1, deleted_at: Time.zone.now)
       @p2 = create(:simple_product)
       @p2_v = create(:variant, product: @p2)
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -35,7 +35,7 @@ module Spree
       it "defaults available_on to now" do
         Timecop.freeze
         product = Product.new
-        product.available_on.should == Time.now
+        product.available_on.should == Time.zone.now
       end
 
       describe "tax category" do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -14,7 +14,7 @@ module Spree
     describe "scopes" do
       it "finds non-deleted variants" do
         v_not_deleted = create(:variant)
-        v_deleted = create(:variant, deleted_at: Time.now)
+        v_deleted = create(:variant, deleted_at: Time.zone.now)
 
         Spree::Variant.not_deleted.should     include v_not_deleted
         Spree::Variant.not_deleted.should_not include v_deleted

--- a/spec/requests/shop_spec.rb
+++ b/spec/requests/shop_spec.rb
@@ -32,7 +32,7 @@ describe "Shop API" do
       v51.update_attribute(:count_on_hand, 1)
       v52.update_attribute(:count_on_hand, 0)
       v71.update_attribute(:count_on_hand, 1)
-      v71.update_attribute(:deleted_at, Time.now)
+      v71.update_attribute(:deleted_at, Time.zone.now)
       exchange = Exchange.find(oc1.exchanges.to_enterprises(distributor).outgoing.first.id)
       exchange.update_attribute :pickup_time, "frogs"
       exchange.variants << v61


### PR DESCRIPTION
Using Time.zone.now and Date.current instead of Time.now and Date.today.
This should make all specs timezone independent.

A lot of files got touched. These things should be tested for time/date issues:
* admin account and billing
* admin enterprises
* admin reports
  - xero invoices
* billable periods
* order cycles
* group page: copyright year display
