### PR TITLE
Display default xero invoice dates

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -244,7 +244,9 @@ Spree::Admin::ReportsController.class_eval do
   def xero_invoices
     if request.get?
       params[:q] ||= {}
-      params[:q][:completed_at_gt] = Time.zone.now.beginning_of_month
+      params[:q][:completed_at_gt] = Time.zone.today.beginning_of_month
+      params[:invoice_date] = Time.zone.today
+      params[:due_date] = Time.zone.today + 1.month
     end
     @distributors = Enterprise.is_distributor.managed_by(spree_current_user)
     @order_cycles = OrderCycle.active_or_complete.accessible_by(spree_current_user).order('orders_close_at DESC')

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -6,8 +6,8 @@ module OpenFoodNetwork
       @opts = opts.
               reject { |k, v| v.blank? }.
               reverse_merge({report_type: 'summary',
-                             invoice_date: Date.today,
-                             due_date: 2.weeks.from_now.to_date,
+                             invoice_date: Time.zone.today,
+                             due_date: Time.zone.today + 1.month,
                              account_code: 'food sales'})
     end
 

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -530,7 +530,7 @@ feature %q{
     end
 
     def xero_invoice_row(sku, description, amount, quantity, tax_type, opts={})
-      opts.reverse_merge!({customer_name: 'Customer Name', address1: 'customer l1', city: 'customer city', state: 'Victoria', zipcode: '1234', country: country.name, invoice_number: order1.number, order_number: order1.number, invoice_date: '2015-04-26', due_date: '2015-05-10', account_code: 'food sales'})
+      opts.reverse_merge!({customer_name: 'Customer Name', address1: 'customer l1', city: 'customer city', state: 'Victoria', zipcode: '1234', country: country.name, invoice_number: order1.number, order_number: order1.number, invoice_date: '2015-04-26', due_date: '2015-05-26', account_code: 'food sales'})
 
       [opts[:customer_name], 'customer@email.com', opts[:address1], '', '', '', opts[:city], opts[:state], opts[:zipcode], opts[:country], opts[:invoice_number], opts[:order_number], opts[:invoice_date], opts[:due_date],
 

--- a/spec/lib/open_food_network/xero_invoices_report_spec.rb
+++ b/spec/lib/open_food_network/xero_invoices_report_spec.rb
@@ -11,7 +11,7 @@ module OpenFoodNetwork
 
       it "uses defaults when blank params are passed" do
         report.instance_variable_get(:@opts).should == {invoice_date: Date.civil(2015, 5, 5),
-                                                        due_date: Date.civil(2015, 5, 19),
+                                                        due_date: Date.civil(2015, 6, 5),
                                                         account_code: 'food sales',
                                                         report_type: 'summary'}
       end


### PR DESCRIPTION
fixes #682

* pre-fill the invoice_date and due_date in the xero report generation form
* increase the default period between invoice_date and due_date to 1 month in
XeroInvoiceReport

![pre filled dates](http://storage4.static.itmages.com/i/15/1213/h_1450022361_1008576_ccd571f67b.png)