### PR TITLE
OFN API refactoring (WiP)

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -1,0 +1,37 @@
+# We need to have Spree's API controller for all the helper methods. But this also
+# means that ActiveModel::Serializer isn't loaded. This class works around that.
+class Api::V0::BaseController < Spree::Api::BaseController
+  include ActionController::Serialization
+
+  # Needed for ActiveModel::Serializer, and to use url helpers
+  def url_options
+    {host: request.host_with_port}
+  end
+
+  private
+
+  def render(*args, **opts)
+    if obj = opts.delete(:json)
+      data = ActiveModel::Serializer.build_json(self, obj, **opts).as_json
+      data.merge!(data.delete(:meta) || {}) unless opts[:meta_key] # meta in root by default
+      super text: data.to_json, content_type: 'application/json'
+    else
+      super *args, **opts
+    end
+  end
+
+  def render_collection(scope, **opts)
+    page = (params[:page] || 1).to_i
+    per_page = (params[:per_page] || 20).to_i # @todo default from model
+    collection = scope.page(page).per(per_page)
+    render({
+        json: collection,
+        meta: {
+          count: collection.count,
+          total_count: scope.count,
+          current_page: page,
+          pages: (scope.count * 1.0 / per_page).ceil
+        }.merge(opts[:meta]||{})
+      }.merge(opts))
+  end
+end

--- a/app/controllers/api/v0/enterprises_controller.rb
+++ b/app/controllers/api/v0/enterprises_controller.rb
@@ -1,0 +1,22 @@
+class Api::V0::EnterprisesController < Api::V0::BaseController
+
+  def index
+    @scope = collection.ransack(params[:q]).result
+    render_collection @scope, each_serializer: Api::V0::EnterpriseSerializer, root: 'enterprises'
+  end
+
+  def show
+    @object = collection.find(params[:id])
+    render json: @object, serializer: Api::V0::EnterpriseSerializer
+  end
+
+  private
+
+  # @see Admin::EnterprisesController#collection
+  def collection
+    OpenFoodNetwork::Permissions.new(current_api_user).
+      visible_enterprises.
+      includes(:address => [:country, :state]).
+      order('is_primary_producer ASC, name')
+  end
+end

--- a/app/serializers/api/v0/address_serializer.rb
+++ b/app/serializers/api/v0/address_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V0::AddressSerializer < Api::V0::RablSerializer
+  def template
+    "spree/api/addresses/show".freeze
+  end
+end

--- a/app/serializers/api/v0/enterprise_serializer.rb
+++ b/app/serializers/api/v0/enterprise_serializer.rb
@@ -1,0 +1,10 @@
+class Api::V0::EnterpriseSerializer < ActiveModel::Serializer
+  attributes :id, :url, :name, :email, :website, :category
+  attributes :description, :long_description
+
+  has_one :address
+
+  def url
+    enterprise_url(object)
+  end
+end

--- a/app/serializers/api/v0/rabl_serializer.rb
+++ b/app/serializers/api/v0/rabl_serializer.rb
@@ -1,0 +1,16 @@
+# Helper class to allow accessing Spree's RABL templates from AMS
+class Api::V0::RablSerializer
+
+  # We need to find Spree API views
+  VIEW_PATH = Spree::Api::Engine.paths["app/views"].to_a
+
+  # need to define the +template+ method
+
+  def initialize(obj, opts={})
+    @obj = obj
+  end
+
+  def serializable_hash
+    Rabl.render(@obj, template, format: 'hash', view_path: VIEW_PATH)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,11 @@ Openfoodnetwork::Application.routes.draw do
       get :managed, on: :collection
       get :accessible, on: :collection
     end
+
+    # api version 0 (leading up to v1 with spree 3)
+    namespace :v0 do
+      resources :enterprises
+    end
   end
 
   namespace :open_food_network do


### PR DESCRIPTION
Please **don't merge yet**, input asked.
Related to #280.

For consistency, it would be good to use the same JSON format in OFN API endpoints as Spree has.
To avoid breaking apps using the current API, I'd like to introduce the `v0` version (to show that it's not finalized yet). When upgraded to Spree 3, we can start using `v1` in the url (just like Spree will do).

Since Spree uses RABL to serialize things like addresses and images, it is useful to embed those from within our serializers. With our preference being AMS, this includes a way to render RABL from AMS.
- `/api/products` etc. - handled by Spree 2 (will become `/api/v1/products` in Spree 3)
- `/api/enterprises` and `/api/order_cycles` - old OFN endpoints (deprecated)
- `/api/v0/enterprises` - new OFN endpoint (more to add)

Filtering products on OFN-specific properties can be done by ransack already. Perhaps it's useful to introduce [ransack scopes](https://github.com/activerecord-hackery/ransack#authorization-whitelistingblacklisting). Where this suffices, it is more flexible than url-scopes, like `products/managed`, in the current api.

I'd like to bring this to a place where Foodsoft can access the data needed for [food cooperatives: _getting information from producers_](http://community.openfoodnetwork.org/t/connecting-food-cooperatives/444), with the approach being ready for future additions.

Would this be a good way forward?
