### PR TITLE
Use config to get logo in mails

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -15,7 +15,7 @@
             %table{:bgcolor => "#f2f2f2"}
               %tr
                 %td
-                  %img{:src => "#{ asset_path 'logo-color.png' }", :width => "144", :height => "50"}/
+                  %img{src: ContentConfig.footer_logo.url, width: "144", height: "50"}/
                 %td{:align => "right"}
                   %h6.collapse
                     = Spree::Config[:site_name]


### PR DESCRIPTION
Use ContentConfig.footer_logo to get localized logo file instead of
defaut AUS logo.