### PR TITLE
Delete customer

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -26,6 +26,23 @@ module Admin
       end
     end
 
+    # copy of Spree::Admin::ResourceController without flash notice
+    def destroy
+      invoke_callbacks(:destroy, :before)
+      if @object.destroy
+        invoke_callbacks(:destroy, :after)
+        respond_with(@object) do |format|
+          format.html { redirect_to location_after_destroy }
+          format.js   { render partial: "spree/admin/shared/destroy" }
+        end
+      else
+        invoke_callbacks(:destroy, :fails)
+        respond_with(@object) do |format|
+          format.html { redirect_to location_after_destroy }
+        end
+      end
+    end
+
     private
 
     def collection

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -15,7 +15,6 @@ Spree.user_class.class_eval do
   accepts_nested_attributes_for :enterprise_roles, :allow_destroy => true
 
   attr_accessible :enterprise_ids, :enterprise_roles_attributes, :enterprise_limit
-  after_create :associate_customers
   after_create :send_signup_confirmation
 
   validate :limit_owned_enterprises
@@ -40,10 +39,6 @@ Spree.user_class.class_eval do
 
   def customer_of(enterprise)
     customers.of(enterprise).first
-  end
-
-  def associate_customers
-    Customer.update_all({ user_id: id }, { user_id: nil, email: email })
   end
 
   def send_signup_confirmation

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -53,23 +53,6 @@ describe Spree.user_class do
         create(:user)
       end.to enqueue_job ConfirmSignupJob
     end
-
-    it "should not create a customer" do
-      expect do
-        create(:user)
-      end.to change(Customer, :count).by(0)
-    end
-
-    describe "when a customer record exists" do
-      let!(:customer) { create(:customer, user: nil) }
-
-      it "should not create a customer" do
-        expect(customer.user).to be nil
-        user = create(:user, email: customer.email)
-        customer.reload
-        expect(customer.user).to eq user
-      end
-    end
   end
 
   describe "known_users" do


### PR DESCRIPTION
- No flash notification when deleting a customer.
- Revert associating new accounts with existing customers.

To test this:

- Place an order as a guest.
- Sign up with the same email address.
- You should not be able to see the guest order.
- Place an order as a user.
- You should be able to see your order.