### PR TITLE
More intuitive logic for minimum billable turnover

### DIFF
--- a/app/assets/javascripts/admin/business_model_configuration/controllers/business_model_configuration_controller.js.coffee
+++ b/app/assets/javascripts/admin/business_model_configuration/controllers/business_model_configuration_controller.js.coffee
@@ -10,7 +10,7 @@ angular.module("admin.businessModelConfiguration").controller "BusinessModelConf
     Math.min($scope.bill(), Number($scope.cap))
 
   $scope.finalBill = ->
-    return 0 if Number($scope.turnover) <= Number($scope.min_bill_to)  
+    return 0 if Number($scope.turnover) < Number($scope.minBillableTurnover)
     $scope.cappedBill()
 
   $scope.capReached = ->

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -21,7 +21,7 @@ Spree::AppConfiguration.class_eval do
   preference :account_invoices_monthly_cap, :decimal, default: 0
   preference :account_invoices_tax_rate, :decimal, default: 0
   preference :shop_trial_length_days, :integer, default: 30
-  preference :minimum_billable_turnover, :integer, default: -1
+  preference :minimum_billable_turnover, :integer, default: 0
 
   # Monitoring
   preference :last_job_queue_heartbeat_at, :string, default: nil

--- a/app/views/admin/business_model_configuration/edit.html.haml
+++ b/app/views/admin/business_model_configuration/edit.html.haml
@@ -54,11 +54,11 @@
         .row
           .three.columns.alpha
             = f.label :minimum_billable_turnover, t(:minimum_monthly_billable_turnover)
-            %span.icon-question-sign{'ofn-with-tip' => "Minimum monthly turnover before a shopfront will be charged for using OFN. Enterprises turning over less than this amount in a month will not be charged, either as a percentage or fixed rate. When set to -1 enterprises with no turnover will be charge the fixed rate as specified."}
+            %span.icon-question-sign{'ofn-with-tip' => "Minimum monthly turnover before a shopfront will be charged for using OFN. Enterprises turning over less than this amount in a month will not be charged, either as a percentage or fixed rate."}
           .two.columns.omega
             .input-symbol.before
               %span= Spree::Money.currency_symbol
-              = f.number_field :minimum_billable_turnover, min: -1.0, class: "fullwidth", 'watch-value-as' => 'min_bill_to'
+              = f.number_field :minimum_billable_turnover, min: 0, class: "fullwidth", 'watch-value-as' => 'minBillableTurnover'
 
         .row
           .five.columns.alpha.omega.form-buttons{"data-hook" => "buttons"}

--- a/lib/open_food_network/bill_calculator.rb
+++ b/lib/open_food_network/bill_calculator.rb
@@ -1,6 +1,6 @@
 module OpenFoodNetwork
   class BillCalculator
-    attr_accessor :turnover, :fixed, :rate, :cap, :tax_rate, :min_bill_to
+    attr_accessor :turnover, :fixed, :rate, :cap, :tax_rate, :minimum_billable_turnover
 
     def initialize(opts={})
       @turnover = opts[:turnover] || 0
@@ -8,13 +8,13 @@ module OpenFoodNetwork
       @rate = opts[:rate] || Spree::Config[:account_invoices_monthly_rate]
       @cap = opts[:cap] || Spree::Config[:account_invoices_monthly_cap]
       @tax_rate = opts[:tax_rate] || Spree::Config[:account_invoices_tax_rate]
-      @min_bill_to = opts[:minimum_billable_turnover] || Spree::Config[:minimum_billable_turnover]
+      @minimum_billable_turnover = opts[:minimum_billable_turnover] || Spree::Config[:minimum_billable_turnover]
     end
 
     def bill
+      return 0 if turnover < minimum_billable_turnover
       bill = fixed + (turnover * rate)
       bill = [bill, cap].min if cap > 0
-      bill = turnover > min_bill_to ? bill : 0
       bill * (1 + tax_rate)
     end
   end

--- a/lib/open_food_network/business_model_configuration_validator.rb
+++ b/lib/open_food_network/business_model_configuration_validator.rb
@@ -12,7 +12,7 @@ module OpenFoodNetwork
     validates :account_invoices_monthly_rate, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
     validates :account_invoices_monthly_cap, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :account_invoices_tax_rate, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
-    validates :minimum_billable_turnover, presence: true, numericality: { greater_than_or_equal_to: -1 }
+    validates :minimum_billable_turnover, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
     def initialize(attr, button=nil)
       attr.each { |k,v| instance_variable_set("@#{k}", v) }

--- a/spec/controllers/admin/business_model_configuration_controller_spec.rb
+++ b/spec/controllers/admin/business_model_configuration_controller_spec.rb
@@ -11,7 +11,7 @@ describe Admin::BusinessModelConfigurationController, type: :controller do
       account_invoices_monthly_cap: 50,
       account_invoices_tax_rate: 0.1,
       shop_trial_length_days: 30,
-      minimum_billable_turnover: -1
+      minimum_billable_turnover: 0
     })
   end
 
@@ -56,7 +56,7 @@ describe Admin::BusinessModelConfigurationController, type: :controller do
           params[:settings][:account_invoices_monthly_cap] = '-1'
           params[:settings][:account_invoices_tax_rate] = '4'
           params[:settings][:shop_trial_length_days] = '-30'
-          params[:settings][:minimum_billable_turnover] = '-2'
+          params[:settings][:minimum_billable_turnover] = '-1'
           spree_get :update, params
         end
 
@@ -68,7 +68,7 @@ describe Admin::BusinessModelConfigurationController, type: :controller do
           expect(Spree::Config.account_invoices_monthly_cap).to eq 50
           expect(Spree::Config.account_invoices_tax_rate).to eq 0.1
           expect(Spree::Config.shop_trial_length_days).to eq 30
-          expect(Spree::Config.minimum_billable_turnover).to eq -1
+          expect(Spree::Config.minimum_billable_turnover).to eq 0
         end
       end
 
@@ -79,7 +79,7 @@ describe Admin::BusinessModelConfigurationController, type: :controller do
           params[:settings][:account_invoices_monthly_cap] = '30'
           params[:settings][:account_invoices_tax_rate] = '0.15'
           params[:settings][:shop_trial_length_days] = '20'
-          params[:settings][:minimum_billable_turnover] = '0'
+          params[:settings][:minimum_billable_turnover] = '10'
         end
 
         it "sets global config to the specified values" do
@@ -90,7 +90,7 @@ describe Admin::BusinessModelConfigurationController, type: :controller do
           expect(Spree::Config.account_invoices_monthly_cap).to eq 30
           expect(Spree::Config.account_invoices_tax_rate).to eq 0.15
           expect(Spree::Config.shop_trial_length_days).to eq 20
-          expect(Spree::Config.minimum_billable_turnover).to eq 0
+          expect(Spree::Config.minimum_billable_turnover).to eq 10
         end
       end
     end

--- a/spec/jobs/update_account_invoices_spec.rb
+++ b/spec/jobs/update_account_invoices_spec.rb
@@ -12,7 +12,7 @@ describe UpdateAccountInvoices do
     Spree::Config.set(:account_invoices_monthly_fixed, 5)
     Spree::Config.set(:account_invoices_monthly_rate, 0.02)
     Spree::Config.set(:account_invoices_monthly_cap, 50)
-    Spree::Config.set(:minimum_billable_turnover, -1)
+    Spree::Config.set(:minimum_billable_turnover, 0)
   end
 
   describe "units specs" do

--- a/spec/models/billable_period_spec.rb
+++ b/spec/models/billable_period_spec.rb
@@ -33,8 +33,8 @@ describe BillablePeriod, type: :model do
     context "when no tax is charged" do
       before { Spree::Config.set(:account_invoices_tax_rate, 0) }
 
-      context "when no minimum billable turnover" do
-        before { Spree::Config.set(:minimum_billable_turnover, -1) }
+      context "when minimum billable turnover is zero" do
+        before { Spree::Config.set(:minimum_billable_turnover, 0) }
 
         context "when a fixed cost is included" do
           before { Spree::Config.set(:account_invoices_monthly_fixed, 10) }
@@ -47,8 +47,8 @@ describe BillablePeriod, type: :model do
         end
       end
 
-      context "when minimum billable turnover exists" do
-        before { Spree::Config.set(:minimum_billable_turnover, 0) }
+      context "when minimum billable turnover is > zero" do
+        before { Spree::Config.set(:minimum_billable_turnover, 1) }
 
         context "when a fixed cost is included" do
           before { Spree::Config.set(:account_invoices_monthly_fixed, 10) }
@@ -65,8 +65,8 @@ describe BillablePeriod, type: :model do
     context "when tax is charged" do
       before { Spree::Config.set(:account_invoices_tax_rate, 0.1) }
 
-      context "when no minimum billable turnover" do
-        before { Spree::Config.set(:minimum_billable_turnover, -1) }
+      context "when minimum billable turnover is zero" do
+        before { Spree::Config.set(:minimum_billable_turnover, 0) }
 
         context "when a fixed cost is included" do
           before { Spree::Config.set(:account_invoices_monthly_fixed, 10) }
@@ -79,8 +79,8 @@ describe BillablePeriod, type: :model do
         end
       end
 
-      context "when minimum billable turnover exists" do
-        before { Spree::Config.set(:minimum_billable_turnover, 0) }
+      context "when minimum billable turnover is > zero" do
+        before { Spree::Config.set(:minimum_billable_turnover, 1) }
 
         context "when a fixed cost is included" do
           before { Spree::Config.set(:account_invoices_monthly_fixed, 10) }
@@ -102,7 +102,7 @@ describe BillablePeriod, type: :model do
       before { Spree::Config.set(:account_invoices_tax_rate, 0) }
 
       context "when no minimum billable turnover" do
-        before { Spree::Config.set(:minimum_billable_turnover, -1) }
+        before { Spree::Config.set(:minimum_billable_turnover, 0) }
 
         context "when a fixed cost is included" do
           before { Spree::Config.set(:account_invoices_monthly_fixed, 10) }


### PR DESCRIPTION
Hi @lin-d-hop,

Thanks for this, code looks great, and I think we don't need to worry about the code climate issues too much - we are thinking that we might tweak code climate a bit to give us a bit more room to wriggle anyway. I just a have slight change that i think is not too costly in terms for desired functionality but will make configuration more intuitive.

Scenario that is affected is: when we don't want to apply a fixed charge to shops that sell exactly nothing in a given month, but we do want to charge them a fixed price if they sell anything at all.

I think this is more intuitively handled by setting minimum_billable_turnover to something like $1 is this case and using $0 to levy a fee against everyone regardless of turnover, rather than using $0 for the case when we don't want to charge a fixed price for zero turnover, and -$1 when we do.

I think this is better because:
1) We don't have to specify a non-intuitive figure of -$1 to get the desired functionality.
2) The semantics play out better. ie. minimum_billable_period is always inclusive, you are only exempt if you sell less than the amount specified, including $0.
3) The likelihood of an instance wanting to distinguish between those who sell $0 worth of produce and those who sell $1 worth of produce and to levy a fixed fee against only the latter seems remote.
4) Furthermore, even if this is the desired functionality, using a minimum billable turnover of $1 should be a perfectly acceptable way of handling this, given that the chance of a business selling between $0 and $1 worth of produce in a month is almost impossible, and inconsequential.

Let me know what you think. :)