### PR TITLE
Switch to using the Spree GA tracker code

### DIFF
--- a/app/overrides/spree/layouts/admin/add_analytics.html.haml.deface
+++ b/app/overrides/spree/layouts/admin/add_analytics.html.haml.deface
@@ -1,3 +1,3 @@
 / insert_bottom "[data-hook='admin_footer_scripts']"
 
-= render 'shared/analytics'
+= render 'spree/shared/google_analytics'

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -43,4 +43,4 @@
 
           #footer
     %loading
-    = render 'shared/analytics'
+    = render 'spree/shared/google_analytics'

--- a/app/views/shared/_analytics.html.haml
+++ b/app/views/shared/_analytics.html.haml
@@ -1,9 +1,0 @@
-- if Rails.env.production?
-  :javascript
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-62912229-1', 'auto');
-    ga('send', 'pageview');


### PR DESCRIPTION
Fix for #938. Would be good to test this on a staging server and verify analytics are being tracked. Would require setting up a UA code for staging as well (but with Spree trackers, that can now be done!)