### PR TITLE
Uk/1009 canceled orders in email

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -33,7 +33,7 @@ class ProducerMailer < Spree::BaseMailer
       joins(:order => :order_cycle, :variant => :product).
       where('order_cycles.id = ?', order_cycle).
       merge(Spree::Product.in_supplier(producer)).
-      merge(Spree::Order.complete)
+      merge(Spree::Order.by_state('complete'))
   end
 
   def total_from_line_items(line_items)

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -39,8 +39,6 @@ describe ProducerMailer do
     order.line_items << create(:line_item, variant: p5.variants.first)
     order.finalize!
     order.cancel
-    puts order.inspect
-    order.finalize!
     order.save
     order
   end

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -14,6 +14,7 @@ describe ProducerMailer do
   let(:p2) { create(:product, price: 23.45, supplier: s2) }
   let(:p3) { create(:product, price: 34.56, supplier: s1) }
   let(:p4) { create(:product, price: 45.67, supplier: s1) }
+  let(:p5) { create(:product, price: 56.78, supplier: s1) }
   let(:order_cycle) { create(:simple_order_cycle) }
   let!(:incoming_exchange) { order_cycle.exchanges.create! sender: s1, receiver: d1, incoming: true, receival_instructions: 'Outside shed.' }
 
@@ -30,6 +31,16 @@ describe ProducerMailer do
   let!(:order_incomplete) do
     order = create(:order, distributor: d1, order_cycle: order_cycle, state: 'payment')
     order.line_items << create(:line_item, variant: p3.variants.first)
+    order.save
+    order
+  end
+  let!(:order_canceled) do
+    order = create(:order, distributor: d1, order_cycle: order_cycle, state: 'complete')
+    order.line_items << create(:line_item, variant: p5.variants.first)
+    order.finalize!
+    order.cancel
+    puts order.inspect
+    order.finalize!
     order.save
     order
   end
@@ -75,8 +86,11 @@ describe ProducerMailer do
     mail.body.encoded.should_not include p3.name
   end
 
+  it "does not include canceled orders" do
+    mail.body.encoded.should_not include p5.name
+  end
+
   it "includes the total" do
-    # puts mail.text_part.body.encoded
     mail.body.encoded.should include 'Total: $50.00'
     body_as_html(mail).find("tr.total-row")
       .should have_selector("td", text: "$50.00")


### PR DESCRIPTION
Fix for issue #1009 .

This was caused by completed orders being defined by a completed_at timestamp, rather than by the state (which can change after completion - e.g. to canceled). Perhaps we should also deal with the 'resumed' state - is resuming a canceled order possible?
