### PR TITLE
Update from address in notification emails

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -16,7 +16,6 @@ class ProducerMailer < Spree::BaseMailer
       mail(to: @producer.email,
            from: @coordinator.email,
            subject: subject,
-           reply_to: @coordinator.email,
            cc: @coordinator.email)
     end
   end

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -44,8 +44,8 @@ describe ProducerMailer do
     ActionMailer::Base.deliveries.count.should == 1
   end
 
-  it "sets a reply-to of the enterprise email" do
-    mail.reply_to.should == [s1.email]
+  it "sets a from of the enterprise email" do
+    mail.from.should == [s1.email]
   end
 
   it "includes receival instructions" do


### PR DESCRIPTION
Quick update to the 'from' email in producer order summary emails: change to from enterprise instead of from instance.
