### PR TITLE
Map search by url

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/map_osm_tiles.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_osm_tiles.js.coffee
@@ -16,6 +16,6 @@ Darkswarm.directive 'mapOsmTiles', ($timeout) ->
             x = tilesPerGlobe + x
           # Wrap y (latitude) in a like manner if you want to enable vertical infinite scroll
           'http://tile.openstreetmap.org/' + zoom + '/' + x + '/' + coord.y + '.png'
-        tileSize: new (google.maps.Size)(256, 256)
+        tileSize: new google.maps.Size(256, 256)
         name: 'OpenStreetMap'
         maxZoom: 18

--- a/app/assets/javascripts/darkswarm/directives/map_osm_tiles.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_osm_tiles.js.coffee
@@ -1,0 +1,21 @@
+Darkswarm.directive 'mapOsmTiles', ($timeout) ->
+  restrict: 'E'
+  require: '^googleMap'
+  scope: {}
+  link: (scope, elem, attrs, ctrl) ->
+    $timeout =>
+      map = ctrl.getMap()
+
+      map.mapTypes.set 'OSM', new google.maps.ImageMapType
+        getTileUrl: (coord, zoom) ->
+          # "Wrap" x (logitude) at 180th meridian properly
+          # NB: Don't touch coord.x because coord param is by reference, and changing its x property breaks something in Google's lib
+          tilesPerGlobe = 1 << zoom
+          x = coord.x % tilesPerGlobe
+          if x < 0
+            x = tilesPerGlobe + x
+          # Wrap y (latitude) in a like manner if you want to enable vertical infinite scroll
+          'http://tile.openstreetmap.org/' + zoom + '/' + x + '/' + coord.y + '.png'
+        tileSize: new (google.maps.Size)(256, 256)
+        name: 'OpenStreetMap'
+        maxZoom: 18

--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -1,23 +1,33 @@
-Darkswarm.directive 'mapSearch', ($timeout) ->
+Darkswarm.directive 'mapSearch', ($timeout, Search) ->
   # Install a basic search field in a map
   restrict: 'E'
-  require: '^googleMap'
+  require: ['^googleMap', 'ngModel']
   replace: true
-  template: '<input id="pac-input" placeholder="' + t('location_placeholder') + '"></input>'
+  template: '<input id="pac-input" ng-model="query" placeholder="' + t('location_placeholder') + '"></input>'
   scope: {}
-  link: (scope, elem, attrs, ctrl) ->
+
+  controller: ($scope) ->
+    $scope.query = Search.search()
+
+    $scope.$watch 'query', (query) ->
+      Search.search query
+
+
+  link: (scope, elem, attrs, ctrls) ->
+    [ctrl, model] = ctrls
+    scope.input = document.getElementById("pac-input")
+
     $timeout =>
       map = ctrl.getMap()
 
       searchBox = scope.createSearchBox map
       scope.bindSearchResponse map, searchBox
       scope.biasResults map, searchBox
-
+      scope.performUrlSearch map
 
     scope.createSearchBox = (map) ->
-      input = document.getElementById("pac-input")
-      map.controls[google.maps.ControlPosition.TOP_LEFT].push input
-      return new google.maps.places.SearchBox(input)
+      map.controls[google.maps.ControlPosition.TOP_LEFT].push scope.input
+      return new google.maps.places.SearchBox(scope.input)
 
     scope.bindSearchResponse = (map, searchBox) ->
       google.maps.event.addListener searchBox, "places_changed", =>
@@ -29,6 +39,12 @@ Darkswarm.directive 'mapSearch', ($timeout) ->
         map.fitBounds place.geometry.viewport
         scope.$apply ->
           model.$setViewValue elem.val()
+
+    # When the map loads, and we have a search from ?query, perform that search
+    scope.performUrlSearch = (map) ->
+      google.maps.event.addListener map, "tilesloaded", =>
+        google.maps.event.trigger(scope.input, 'focus');
+        google.maps.event.trigger(scope.input, 'keydown', {keyCode: 13});
 
     # Bias the SearchBox results towards places that are within the bounds of the
     # current map's viewport.

--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -9,28 +9,10 @@ Darkswarm.directive 'mapSearch', ($timeout) ->
     $timeout =>
       map = ctrl.getMap()
 
-      # Does this *really* belong here? It's not about search.
-      scope.useOsmTiles map
-
       searchBox = scope.createSearchBox map
       scope.respondToSearch map, searchBox
       scope.biasResults map, searchBox
 
-
-    scope.useOsmTiles = (map) ->
-      map.mapTypes.set 'OSM', new google.maps.ImageMapType
-        getTileUrl: (coord, zoom) ->
-          # "Wrap" x (logitude) at 180th meridian properly
-          # NB: Don't touch coord.x because coord param is by reference, and changing its x property breaks something in Google's lib
-          tilesPerGlobe = 1 << zoom
-          x = coord.x % tilesPerGlobe
-          if x < 0
-            x = tilesPerGlobe + x
-          # Wrap y (latitude) in a like manner if you want to enable vertical infinite scroll
-          'http://tile.openstreetmap.org/' + zoom + '/' + x + '/' + coord.y + '.png'
-        tileSize: new (google.maps.Size)(256, 256)
-        name: 'OpenStreetMap'
-        maxZoom: 18
 
     scope.createSearchBox = (map) ->
       input = document.getElementById("pac-input")

--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -10,7 +10,7 @@ Darkswarm.directive 'mapSearch', ($timeout) ->
       map = ctrl.getMap()
 
       searchBox = scope.createSearchBox map
-      scope.respondToSearch map, searchBox
+      scope.bindSearchResponse map, searchBox
       scope.biasResults map, searchBox
 
 
@@ -19,11 +19,16 @@ Darkswarm.directive 'mapSearch', ($timeout) ->
       map.controls[google.maps.ControlPosition.TOP_LEFT].push input
       return new google.maps.places.SearchBox(input)
 
-    scope.respondToSearch = (map, searchBox) ->
-      google.maps.event.addListener searchBox, "places_changed", ->
-        places = searchBox.getPlaces()
-        for place in places when place.geometry.viewport?
-          map.fitBounds place.geometry.viewport
+    scope.bindSearchResponse = (map, searchBox) ->
+      google.maps.event.addListener searchBox, "places_changed", =>
+        scope.showSearchResult map, searchBox
+
+    scope.showSearchResult = (map, searchBox) ->
+      places = searchBox.getPlaces()
+      for place in places when place.geometry.viewport?
+        map.fitBounds place.geometry.viewport
+        scope.$apply ->
+          model.$setViewValue elem.val()
 
     # Bias the SearchBox results towards places that are within the bounds of the
     # current map's viewport.

--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -29,18 +29,11 @@ Darkswarm.directive 'mapSearch', ($timeout)->
 
       google.maps.event.addListener searchBox, "places_changed", ->
         places = searchBox.getPlaces()
-        return if places.length is 0
-        # For each place, get the icon, place name, and location.
-        markers = []
-        bounds = new google.maps.LatLngBounds()
-        for place in places
-          #map.setCenter place.geometry.location
+        for place in places when place.geometry.viewport?
           map.fitBounds place.geometry.viewport
-        #map.fitBounds bounds
 
       # Bias the SearchBox results towards places that are within the bounds of the
       # current map's viewport.
       google.maps.event.addListener map, "bounds_changed", ->
         bounds = map.getBounds()
         searchBox.setBounds bounds
-

--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -1,18 +1,27 @@
-Darkswarm.directive 'mapSearch', ($timeout)->
+Darkswarm.directive 'mapSearch', ($timeout) ->
   # Install a basic search field in a map
   restrict: 'E'
   require: '^googleMap'
   replace: true
   template: '<input id="pac-input" placeholder="' + t('location_placeholder') + '"></input>'
-  link: (scope, elem, attrs, ctrl)->
+  scope: {}
+  link: (scope, elem, attrs, ctrl) ->
     $timeout =>
       map = ctrl.getMap()
 
-      # Use OSM tiles server
-      map.mapTypes.set 'OSM', new (google.maps.ImageMapType)(
+      # Does this *really* belong here? It's not about search.
+      scope.useOsmTiles map
+
+      searchBox = scope.createSearchBox map
+      scope.respondToSearch map, searchBox
+      scope.biasResults map, searchBox
+
+
+    scope.useOsmTiles = (map) ->
+      map.mapTypes.set 'OSM', new google.maps.ImageMapType
         getTileUrl: (coord, zoom) ->
           # "Wrap" x (logitude) at 180th meridian properly
-          # NB: Don't touch coord.x because coord param is by reference, and changing its x property breakes something in Google's lib
+          # NB: Don't touch coord.x because coord param is by reference, and changing its x property breaks something in Google's lib
           tilesPerGlobe = 1 << zoom
           x = coord.x % tilesPerGlobe
           if x < 0
@@ -21,19 +30,22 @@ Darkswarm.directive 'mapSearch', ($timeout)->
           'http://tile.openstreetmap.org/' + zoom + '/' + x + '/' + coord.y + '.png'
         tileSize: new (google.maps.Size)(256, 256)
         name: 'OpenStreetMap'
-        maxZoom: 18)
+        maxZoom: 18
 
-      input = (document.getElementById("pac-input"))
+    scope.createSearchBox = (map) ->
+      input = document.getElementById("pac-input")
       map.controls[google.maps.ControlPosition.TOP_LEFT].push input
-      searchBox = new google.maps.places.SearchBox((input))
+      return new google.maps.places.SearchBox(input)
 
+    scope.respondToSearch = (map, searchBox) ->
       google.maps.event.addListener searchBox, "places_changed", ->
         places = searchBox.getPlaces()
         for place in places when place.geometry.viewport?
           map.fitBounds place.geometry.viewport
 
-      # Bias the SearchBox results towards places that are within the bounds of the
-      # current map's viewport.
+    # Bias the SearchBox results towards places that are within the bounds of the
+    # current map's viewport.
+    scope.biasResults = (map, searchBox) ->
       google.maps.event.addListener map, "bounds_changed", ->
         bounds = map.getBounds()
         searchBox.setBounds bounds

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -40,6 +40,7 @@
               .map-container
                 %map{"ng-if" => "(isActive(\'/map\') && (mapShowed = true)) || mapShowed"}
                   %google-map{options: "map.additional_options", center: "map.center", zoom: "map.zoom", styles: "map.styles", draggable: "true"}
+                    %map-osm-tiles
                     %map-search
                     %markers{models: "mapMarkers", fit: "true",
                     coords: "'self'", icon: "'icon'", click: "'reveal'"}

--- a/app/views/map/index.html.haml
+++ b/app/views/map/index.html.haml
@@ -6,6 +6,7 @@
 .map-container{"fill-vertical" => true}
   %map{"ng-controller" => "MapCtrl"}
     %google-map{options: "map.additional_options", center: "map.center", zoom: "map.zoom", styles: "map.styles", draggable: "true"}
+      %map-osm-tiles
       %map-search
       %markers{models: "OfnMap.enterprises", fit: "true",
       coords: "'self'", icon: "'icon'", click: "'reveal'"}


### PR DESCRIPTION
- Extract the code to use OSM tiles from `MapSearch` into its own directive `mapOsmTiles`.
- Refactor `MapSearch` to remove cruft.
- Allow searching maps by URL.