### PR TITLE
Delete fee on payment method if payment invalid

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -6,6 +6,7 @@ module CheckoutHelper
     # Remove empty tax adjustments and (optionally) shipping fees
     adjustments.reject! { |a| a.originator_type == 'Spree::TaxRate' && a.amount == 0 }
     adjustments.reject! { |a| a.originator_type == 'Spree::ShippingMethod' } if exclude.include? :shipping
+    adjustments.reject! { |a| a.originator_type == 'Spree::PaymentMethod' } if exclude.include? :payment
     adjustments.reject! { |a| a.source_type == 'Spree::LineItem' } if exclude.include? :line_item
 
     enterprise_fee_adjustments = adjustments.select { |a| a.originator_type == 'EnterpriseFee' && a.source_type != 'Spree::LineItem' }

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -5,7 +5,12 @@ module Spree
     after_save :ensure_correct_adjustment, :update_order
 
     def ensure_correct_adjustment
-      if adjustment
+      # Don't charge for invalid payments.
+      # PayPalExpress always creates a payment that is invalidated later.
+      # Unknown: What about failed payments?
+      if state == "invalid"
+        adjustment.andand.destroy
+      elsif adjustment
         adjustment.originator = payment_method
         adjustment.label = adjustment_label
         adjustment.save

--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -9,7 +9,7 @@
             = t :checkout_cart_total
           %td.cart-total.text-right= display_checkout_subtotal(@order)
 
-        - checkout_adjustments_for(current_order, exclude: [:shipping, :line_item]).reject{ |a| a.amount == 0 }.each do |adjustment|
+        - checkout_adjustments_for(current_order, exclude: [:shipping, :payment, :line_item]).reject{ |a| a.amount == 0 }.each do |adjustment|
           %tr
             %th= adjustment.label
             %td.text-right= adjustment.display_amount.to_html


### PR DESCRIPTION
PayPalExpress is always creating two payments. The first one is
invalidated and the second one succeeds. Without deleting the old fee on
the invalidated payment, the order lists the fee twice.