### PR TITLE
Terms of Service URL in emails

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -42,7 +42,7 @@
               %tr
                 %td{:align => "center"}
                   %p
-                    %a{:href => "#{ URI.join(spree.root_url, "Terms-of-service.pdf").to_s }", :target => "_blank"}
+                    %a{:href => "#{ URI.join(spree.root_url, ContentConfig.footer_tos_url).to_s }", :target => "_blank"}
                       = t :terms_of_service
                     |
                     %a{:href => "#{ spree.root_url }"}


### PR DESCRIPTION
Updating email footer to read the Terms of Service url from spree-preferences. Field has a default of Terms-of-service.pdf so current functionality unchanged in the case of the field being blank.

Tested on UK staging.