### PR TITLE
Issue_1134

### DIFF
--- a/lib/open_food_network/packing_report.rb
+++ b/lib/open_food_network/packing_report.rb
@@ -83,8 +83,8 @@ module OpenFoodNetwork
           sort_by: proc { |product| product.name } },
           { group_by: proc { |line_item| line_item.full_name },
           sort_by: proc { |full_name| full_name } },
-          { group_by: proc { |line_item| line_item.order.bill_address.lastname },
-          sort_by: proc { |lastname| lastname } } ]
+          { group_by: proc { |line_item| line_item.order },
+          sort_by: proc { |order| order.bill_address.lastname } } ]
       end
     end
 


### PR DESCRIPTION
Fix to #1134 
Packing report now differentiates by order rather than last name.

Tested successfully on UK staging.