### PR TITLE
Allow guest orders

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -1,4 +1,8 @@
 module CheckoutHelper
+  def guest_checkout_allowed?
+    current_order.distributor.allow_guest_orders?
+  end
+
   def checkout_adjustments_for(order, opts={})
     adjustments = order.adjustments.eligible
     exclude = opts[:exclude] || {}

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -4,6 +4,7 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
   attributes :preferred_shopfront_message, :preferred_shopfront_closed_message, :preferred_shopfront_taxon_order, :preferred_shopfront_order_cycle_order
   attributes :preferred_product_selection_from_inventory_only
   attributes :owner, :users, :tag_groups, :default_tag_group
+  attributes :require_login
 
   has_one :owner, serializer: Api::Admin::UserSerializer
   has_many :users, serializer: Api::Admin::UserSerializer

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -50,17 +50,6 @@
   .five.columns.omega
     = f.radio_button :visible, false
     = f.label :visible, "Not Visible", :value => "false"
-.row
-  .three.columns.alpha
-    %label= t '.shopfront_requires_login'
-    %div{'ofn-with-tip' => t('.shopfront_requires_login_tip')}
-      %a= t 'admin.whats_this'
-  .two.columns
-    = f.radio_button :require_login, false
-    = f.label :require_login, t('.shopfront_requires_login_false'), value: :false
-  .five.columns.omega
-    = f.radio_button :require_login, true
-    = f.label :require_login, t('.shopfront_requires_login_true'), value: :true
 .permalink{ ng: { controller: "permalinkCtrl" } }
   .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
     .three.columns.alpha

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -33,3 +33,15 @@
     .five.columns.omega
       = radio_button :enterprise, :preferred_shopfront_order_cycle_order, :orders_close_at, { 'ng-model' => 'Enterprise.preferred_shopfront_order_cycle_order' }
       = label :enterprise, :preferred_shopfront_order_cycle_order_orders_close_at, "Close Date"
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      %label= t '.shopfront_requires_login'
+      %div{'ofn-with-tip' => t('.shopfront_requires_login_tip')}
+        %a= t 'admin.whats_this'
+    .three.columns
+      = f.radio_button :require_login, false
+      = f.label :require_login, t('.shopfront_requires_login_false'), value: :false
+    .five.columns.omega
+      = f.radio_button :require_login, true
+      = f.label :require_login, t('.shopfront_requires_login_true'), value: :true

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -40,20 +40,20 @@
       %div{'ofn-with-tip' => t('.shopfront_requires_login_tip')}
         %a= t 'admin.whats_this'
     .three.columns
-      = f.radio_button :require_login, false
+      = f.radio_button :require_login, false, "ng-model" => "Enterprise.require_login", "ng-value" => "false"
       = f.label :require_login, t('.shopfront_requires_login_false'), value: :false
     .five.columns.omega
-      = f.radio_button :require_login, true
+      = f.radio_button :require_login, true, "ng-model" => "Enterprise.require_login", "ng-value" => "true"
       = f.label :require_login, t('.shopfront_requires_login_true'), value: :true
-.row
+.row{ng: {if: "!Enterprise.require_login"}}
   .alpha.eleven.columns
     .three.columns.alpha
       %label= t '.allow_guest_orders'
       %div{'ofn-with-tip' => t('.allow_guest_orders_tip')}
         %a= t 'admin.whats_this'
     .three.columns
-      = f.radio_button :allow_guest_orders, false
-      = f.label :allow_guest_orders, t('.allow_guest_orders_false'), value: :false
-    .five.columns.omega
       = f.radio_button :allow_guest_orders, true
       = f.label :allow_guest_orders, t('.allow_guest_orders_true'), value: :true
+    .five.columns.omega
+      = f.radio_button :allow_guest_orders, false
+      = f.label :allow_guest_orders, t('.allow_guest_orders_false'), value: :false

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -45,3 +45,15 @@
     .five.columns.omega
       = f.radio_button :require_login, true
       = f.label :require_login, t('.shopfront_requires_login_true'), value: :true
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      %label= t '.allow_guest_orders'
+      %div{'ofn-with-tip' => t('.allow_guest_orders_tip')}
+        %a= t 'admin.whats_this'
+    .three.columns
+      = f.radio_button :allow_guest_orders, false
+      = f.label :allow_guest_orders, t('.allow_guest_orders_false'), value: :false
+    .five.columns.omega
+      = f.radio_button :allow_guest_orders, true
+      = f.label :allow_guest_orders, t('.allow_guest_orders_true'), value: :true

--- a/app/views/checkout/_authentication.html.haml
+++ b/app/views/checkout/_authentication.html.haml
@@ -4,11 +4,16 @@
       %h3.pad-top
         = t :checkout_headline
   .row.pad-top
-    .small-5.columns.text-center
-      %button.primary.expand{"auth" => "login"}
-        = t :label_login
-    .small-2.columns.text-center
-      %p.pad-top= "-#{t :action_or}-"
-    .small-5.columns.text-center
-      %button.neutral-btn.dark.expand{"ng-click" => "enabled = true"}
-        = t :checkout_as_guest
+    -if guest_checkout_allowed?
+      .small-5.columns.text-center
+        %button.primary.expand{"auth" => "login"}
+          = t :label_login
+      .small-2.columns.text-center
+        %p.pad-top= "-#{t :action_or}-"
+      .small-5.columns.text-center
+        %button.neutral-btn.dark.expand{"ng-click" => "enabled = true"}
+          = t :checkout_as_guest
+    -else
+      .small-6.columns.small-centered
+        %button.primary.expand{"auth" => "login"}
+          = t :label_login

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,7 +196,7 @@ en:
         status: Status
         manage: Manage
       form:
-        primary_details:
+        shop_preferences:
           shopfront_requires_login: "Shopfront requires login?"
           shopfront_requires_login_tip: "Choose whether customers must login to view the shopfront."
           shopfront_requires_login_false: "Public"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,10 @@ en:
           shopfront_requires_login_tip: "Choose whether customers must login to view the shopfront."
           shopfront_requires_login_false: "Public"
           shopfront_requires_login_true: "Require customers to login"
+          allow_guest_orders: "Guest orders"
+          allow_guest_orders_tip: "Allow checkout as guest or require a registered user."
+          allow_guest_orders_false: "Require login to order"
+          allow_guest_orders_true: "Allow checkout as guest"
 
   home:
     hubs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,14 +197,14 @@ en:
         manage: Manage
       form:
         shop_preferences:
-          shopfront_requires_login: "Shopfront requires login?"
-          shopfront_requires_login_tip: "Choose whether customers must login to view the shopfront."
+          shopfront_requires_login: "Publicly visible shopfront?"
+          shopfront_requires_login_tip: "Choose whether customers must login to view the shopfront or if it's visible to everybody."
           shopfront_requires_login_false: "Public"
-          shopfront_requires_login_true: "Require customers to login"
+          shopfront_requires_login_true: "Visible to registered customers only"
           allow_guest_orders: "Guest orders"
           allow_guest_orders_tip: "Allow checkout as guest or require a registered user."
           allow_guest_orders_false: "Require login to order"
-          allow_guest_orders_true: "Allow checkout as guest"
+          allow_guest_orders_true: "Allow guest checkout"
 
   home:
     hubs:

--- a/db/migrate/20160921060442_add_allow_guest_orders_to_enterprise.rb
+++ b/db/migrate/20160921060442_add_allow_guest_orders_to_enterprise.rb
@@ -1,0 +1,5 @@
+class AddAllowGuestOrdersToEnterprise < ActiveRecord::Migration
+  def change
+    add_column :enterprises, :allow_guest_orders, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160819065331) do
+ActiveRecord::Schema.define(:version => 20160921060442) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -248,6 +248,7 @@ ActiveRecord::Schema.define(:version => 20160819065331) do
     t.boolean  "charges_sales_tax",        :default => false,  :null => false
     t.string   "email_address"
     t.boolean  "require_login",            :default => false,  :null => false
+    t.boolean  "allow_guest_orders",       :default => true,   :null => false
   end
 
   add_index "enterprises", ["address_id"], :name => "index_enterprises_on_address_id"

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -85,14 +85,12 @@ feature %q{
     page.should have_selector '.available'
     choose 'Own'
 
-    # Require login to view shopfront
+    # Require login to view shopfront or for checkout
     within(".side_menu") { click_link "Shop Preferences" }
     expect(page).to have_checked_field "enterprise_require_login_false"
-    choose "Require customers to login"
-
-    # Require login for checkout
     expect(page).to have_checked_field "enterprise_allow_guest_orders_true"
-    choose "Require login to order"
+    choose "Visible to registered customers only"
+    expect(page).to have_no_checked_field "enterprise_require_login_false"
 
     within (".side_menu") { click_link "Users" }
     select2_search user.email, from: 'Owner'
@@ -195,7 +193,6 @@ feature %q{
     page.should have_content 'This is my shopfront message.'
     page.should have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
     expect(page).to have_checked_field "enterprise_require_login_true"
-    expect(page).to have_checked_field "enterprise_allow_guest_orders_false"
   end
 
   describe "producer properties" do

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -90,6 +90,10 @@ feature %q{
     expect(page).to have_checked_field "enterprise_require_login_false"
     choose "Require customers to login"
 
+    # Require login for checkout
+    expect(page).to have_checked_field "enterprise_allow_guest_orders_true"
+    choose "Require login to order"
+
     within (".side_menu") { click_link "Users" }
     select2_search user.email, from: 'Owner'
 
@@ -191,6 +195,7 @@ feature %q{
     page.should have_content 'This is my shopfront message.'
     page.should have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
     expect(page).to have_checked_field "enterprise_require_login_true"
+    expect(page).to have_checked_field "enterprise_allow_guest_orders_false"
   end
 
   describe "producer properties" do

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -86,6 +86,7 @@ feature %q{
     choose 'Own'
 
     # Require login to view shopfront
+    within(".side_menu") { click_link "Shop Preferences" }
     expect(page).to have_checked_field "enterprise_require_login_false"
     choose "Require customers to login"
 
@@ -170,7 +171,6 @@ feature %q{
     @enterprise.reload
     expect(@enterprise.owner).to eq user
     expect(page).to have_checked_field "enterprise_visible_true"
-    expect(page).to have_checked_field "enterprise_require_login_true"
 
     click_link "Business Details"
     page.should have_checked_field "enterprise_charges_sales_tax_true"
@@ -190,6 +190,7 @@ feature %q{
     click_link "Shop Preferences"
     page.should have_content 'This is my shopfront message.'
     page.should have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
+    expect(page).to have_checked_field "enterprise_require_login_true"
   end
 
   describe "producer properties" do

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -20,4 +20,14 @@ describe CheckoutHelper do
       helper.display_checkout_tax_total(order).should == Spree::Money.new(123.45, currency: 'AUD')
     end
   end
+
+  it "knows if guests can checkout" do
+    distributor = create(:distributor_enterprise)
+    order = create(:order, distributor: distributor)
+    helper.stub(:current_order) { order }
+    expect(helper.guest_checkout_allowed?).to be true
+
+    order.distributor.allow_guest_orders = false
+    expect(helper.guest_checkout_allowed?).to be false
+  end
 end


### PR DESCRIPTION
Addressing #1160 

Also moves "shopfront requires login" setting (#901) and includes testing feedback improvements ( #1113)

Please check:

* Enterprise users can disallow guest orders.
* Guests have to login before checkout for those shops.