### PR TITLE
Broken Contact link in Login Shopfront

### DIFF
--- a/app/views/shop/_messages.html.haml
+++ b/app/views/shop/_messages.html.haml
@@ -10,7 +10,7 @@
              register: ('<a auth="signup">' + t('.register') + '</a>').html_safe}
         - else
           = t '.require_customer_html',
-            {contact: ('<a href="##contact">' + t('.contact') + '</a>').html_safe,
+            {contact: (link_to t(:contact), "#/contact", method: :get),
              enterprise: current_distributor.name}
 - elsif @order_cycles and @order_cycles.empty?
   - if current_distributor.preferred_shopfront_closed_message.present?

--- a/app/views/shop/_messages.html.haml
+++ b/app/views/shop/_messages.html.haml
@@ -10,7 +10,7 @@
              register: ('<a auth="signup">' + t('.register') + '</a>').html_safe}
         - else
           = t '.require_customer_html',
-            {contact: (link_to t(:contact), "#/contact", method: :get),
+            {contact: (link_to t('.contact'), "#/contact", method: :get),
              enterprise: current_distributor.name}
 - elsif @order_cycles and @order_cycles.empty?
   - if current_distributor.preferred_shopfront_closed_message.present?


### PR DESCRIPTION
Quick fix to mend the broken Contact link specified in #1180 

Feels like a bit of a hack, but it works for me. If I should really be doing this in a different way would you signpost please?

@daniellemoorhead 
@mkllnk  Would you take a look at this fix please? The bug is a problem for new users who are setting up login only shopfronts, it is resulting in new customers walking away before they start :-/
