### PR TITLE
Mark order cycle form as dirty when removing fees

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -68,6 +68,7 @@ angular.module('admin.orderCycles')
     $scope.removeCoordinatorFee = ($event, index) ->
       $event.preventDefault()
       OrderCycle.removeCoordinatorFee(index)
+      $scope.order_cycle_form.$dirty = true
 
     $scope.addExchangeFee = ($event, exchange) ->
       $event.preventDefault()
@@ -76,6 +77,7 @@ angular.module('admin.orderCycles')
     $scope.removeExchangeFee = ($event, exchange, index) ->
       $event.preventDefault()
       OrderCycle.removeExchangeFee(exchange, index)
+      $scope.order_cycle_form.$dirty = true
 
     $scope.removeDistributionOfVariant = (variant_id) ->
       OrderCycle.removeDistributionOfVariant(variant_id)

--- a/spec/javascripts/unit/order_cycle_spec.js.coffee
+++ b/spec/javascripts/unit/order_cycle_spec.js.coffee
@@ -300,6 +300,7 @@ describe 'OrderCycle controllers', ->
       scope.removeCoordinatorFee(event, 0)
       expect(event.preventDefault).toHaveBeenCalled()
       expect(OrderCycle.removeCoordinatorFee).toHaveBeenCalledWith(0)
+      expect(scope.order_cycle_form.$dirty).toEqual true
 
     it 'Adds exchange fees', ->
       scope.addExchangeFee(event)
@@ -310,6 +311,7 @@ describe 'OrderCycle controllers', ->
       scope.removeExchangeFee(event, 'exchange', 0)
       expect(event.preventDefault).toHaveBeenCalled()
       expect(OrderCycle.removeExchangeFee).toHaveBeenCalledWith('exchange', 0)
+      expect(scope.order_cycle_form.$dirty).toEqual true
 
     it 'Removes distribution of a variant', ->
       scope.removeDistributionOfVariant('variant')


### PR DESCRIPTION
Resolves an issue where removing coordinator/exchange fees
wasn't allowing users to save the OC.

Fixes #1165
