### PR TITLE
Option allow change orders

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/edit_order_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/edit_order_controller.js.coffee
@@ -1,0 +1,10 @@
+Darkswarm.controller "EditOrderCtrl", ($scope, $resource, Cart) ->
+
+  $scope.deleteLineItem = (id) ->
+    params = {id: id}
+    success = (response) ->
+      $(".line-item-" + id).remove()
+    fail = (error) ->
+      console.log error
+
+    $resource("/line_items/:id").delete(params, success, fail)

--- a/app/assets/javascripts/darkswarm/controllers/edit_order_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/edit_order_controller.js.coffee
@@ -4,6 +4,7 @@ Darkswarm.controller "EditOrderCtrl", ($scope, $resource, Cart) ->
     params = {id: id}
     success = (response) ->
       $(".line-item-" + id).remove()
+      Cart.removeFinalisedLineItem(id)
     fail = (error) ->
       console.log error
 

--- a/app/assets/javascripts/darkswarm/controllers/order_cycle_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/order_cycle_controller.js.coffee
@@ -30,3 +30,4 @@ Darkswarm.controller "OrderCycleChangeCtrl", ($scope, $timeout, OrderCycle, Prod
     Variants.clear()
     Cart.clear()
     Products.update()
+    Cart.reloadFinalisedLineItems()

--- a/app/assets/javascripts/darkswarm/darkswarm.js.coffee
+++ b/app/assets/javascripts/darkswarm/darkswarm.js.coffee
@@ -11,8 +11,7 @@ window.Darkswarm = angular.module("Darkswarm", ["ngResource",
   'angularFileUpload',
   'angularSlideables'
   ]).config ($httpProvider, $tooltipProvider, $locationProvider, $anchorScrollProvider) ->
-  $httpProvider.defaults.headers.post['X-CSRF-Token'] = $('meta[name="csrf-token"]').attr('content')
-  $httpProvider.defaults.headers.put['X-CSRF-Token'] = $('meta[name="csrf-token"]').attr('content')
+  $httpProvider.defaults.headers['common']['X-CSRF-Token'] = $('meta[name="csrf-token"]').attr('content')
   $httpProvider.defaults.headers['common']['X-Requested-With'] = 'XMLHttpRequest'
   $httpProvider.defaults.headers.common.Accept = "application/json, text/javascript, */*"
 

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -120,6 +120,10 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       @line_items = []
       localStorageService.clearAll() # One day this will have to be moar GRANULAR
 
+    removeFinalisedLineItem: (id) =>
+      @line_items_finalised = @line_items_finalised.filter (item) ->
+        item.id != id
+
     reloadFinalisedLineItems: =>
       @line_items_finalised = []
       $resource("/line_items").query (items) =>

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -98,7 +98,7 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
         t 'order_not_saved_yet'
 
     line_items_finalised: =>
-      items = CurrentOrder.order.finalised_line_items
+      items = CurrentOrder.order?.finalised_line_items || []
       for line_item in items
         line_item.variant.line_item = line_item
         Variants.extend line_item.variant

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -97,6 +97,14 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       $(window).bind "beforeunload", ->
         t 'order_not_saved_yet'
 
+    line_items_finalised: =>
+      items = CurrentOrder.order.finalised_line_items
+      for line_item in items
+        line_item.variant.line_item = line_item
+        Variants.extend line_item.variant
+        line_item.variant.extended_name = @extendedVariantName(line_item.variant)
+      items
+
     total_item_count: =>
       @line_items.reduce (sum,li) ->
         sum = sum + li.quantity

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -102,7 +102,6 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       for line_item in items
         line_item.variant.line_item = line_item
         Variants.extend line_item.variant
-        line_item.variant.extended_name = @extendedVariantName(line_item.variant)
       items
 
     total_item_count: =>

--- a/app/assets/stylesheets/admin/enterprises.css.scss
+++ b/app/assets/stylesheets/admin/enterprises.css.scss
@@ -1,0 +1,3 @@
+form[name="enterprise_form"] div.row.warning {
+  color: #DA7F52;
+}

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,0 +1,24 @@
+class LineItemsController < Spree::BaseController
+  respond_to :json
+
+  def destroy
+    item = Spree::LineItem.find(params[:id])
+    authorize! :destroy, item
+    destroy_with_lock item
+    respond_with(item)
+  end
+
+  # Override default which just redirects
+  # See Spree::BaseController and Spree::Core::ControllerHelpers::Auth
+  def unauthorized
+    render text: '', status: 403
+  end
+
+  def destroy_with_lock(item)
+    order = item.order
+    order.with_lock do
+      item.destroy
+      order.update_distribution_charge!
+    end
+  end
+end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -30,6 +30,7 @@ class LineItemsController < BaseController
     order = item.order
     order.with_lock do
       item.destroy
+      order.update_shipping_fees!
       order.update_distribution_charge!
     end
   end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,11 +1,23 @@
-class LineItemsController < Spree::BaseController
+class LineItemsController < BaseController
   respond_to :json
+
+  def index
+    respond_with bought_items, each_serializer: Api::LineItemSerializer
+  end
 
   def destroy
     item = Spree::LineItem.find(params[:id])
     authorize! :destroy, item
     destroy_with_lock item
     respond_with(item)
+  end
+
+  private
+
+  # List all items the user already ordered in the current order cycle
+  def bought_items
+    return [] unless current_order_cycle && spree_current_user && current_distributor
+    current_order_cycle.items_bought_by_user(spree_current_user, current_distributor)
   end
 
   # Override default which just redirects

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -31,6 +31,7 @@ class LineItemsController < BaseController
     order.with_lock do
       item.destroy
       order.update_shipping_fees!
+      order.update_payment_fees!
       order.update_distribution_charge!
     end
   end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -33,6 +33,7 @@ class LineItemsController < BaseController
       order.update_shipping_fees!
       order.update_payment_fees!
       order.update_distribution_charge!
+      order.create_tax_charge!
     end
   end
 end

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -89,7 +89,11 @@ module EnterprisesHelper
     distance_of_time_in_words(Time.zone.now, enterprise.shop_trial_start_date + Spree::Config[:shop_trial_length_days].days)
   end
 
-  def show_bought_items?
+  def order_changes_allowed?
     current_order.andand.distributor.andand.allow_order_changes?
+  end
+
+  def show_bought_items?
+    order_changes_allowed? && current_order.finalised_line_items.present?
   end
 end

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -88,4 +88,8 @@ module EnterprisesHelper
   def remaining_trial_days(enterprise)
     distance_of_time_in_words(Time.zone.now, enterprise.shop_trial_start_date + Spree::Config[:shop_trial_length_days].days)
   end
+
+  def show_bought_items?
+    current_order.andand.distributor.andand.allow_order_changes? && current_order.finalised_line_items.present?
+  end
 end

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -90,6 +90,6 @@ module EnterprisesHelper
   end
 
   def show_bought_items?
-    current_order.andand.distributor.andand.allow_order_changes? && current_order.finalised_line_items.present?
+    current_order.andand.distributor.andand.allow_order_changes?
   end
 end

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -250,6 +250,18 @@ class OrderCycle < ActiveRecord::Base
     OpenFoodNetwork::ProductsCache.order_cycle_changed self
   end
 
+  def items_bought_by_user(user, distributor)
+    orders = Spree::Order.complete.where(user_id: user, order_cycle_id: self)
+    items = []
+    orders.each do |o|
+      items += o.line_items
+    end
+    scoper = OpenFoodNetwork::ScopeVariantToHub.new(distributor)
+    items.each do |li|
+      scoper.scope(li.variant)
+    end
+    items
+  end
 
   private
 

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -4,6 +4,7 @@ class AbilityDecorator
   # All abilites are allocated from this initialiser, currently in 5 chunks.
   # Spree also defines other abilities.
   def initialize(user)
+    add_shopping_abilities user
     add_base_abilities user if is_new_user? user
     add_enterprise_management_abilities user if can_manage_enterprises? user
     add_group_management_abilities user if can_manage_groups? user
@@ -48,6 +49,12 @@ class AbilityDecorator
 
   def can_manage_relationships?(user)
     can_manage_enterprises? user
+  end
+
+  def add_shopping_abilities(user)
+    can [:destroy], Spree::LineItem do |item|
+      item.andand.order.andand.order_cycle.andand.open? && item.order.user_id == user.id
+    end
   end
 
   # New users can create an enterprise, and gain other permissions from doing this.
@@ -184,6 +191,7 @@ class AbilityDecorator
     can [:admin , :for_line_items], Enterprise
     can [:admin, :index, :create], Spree::LineItem
     can [:destroy, :update], Spree::LineItem do |item|
+      order = item.order
       user.admin? || user.enterprises.include?(order.distributor) || order.order_cycle.andand.coordinated_by?(user)
     end
 

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -53,7 +53,7 @@ class AbilityDecorator
 
   def add_shopping_abilities(user)
     can [:destroy], Spree::LineItem do |item|
-      item.andand.order.andand.order_cycle.andand.open? && item.order.user_id == user.id
+      item.andand.order.andand.can_remove_items? user
     end
   end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -195,17 +195,8 @@ Spree::Order.class_eval do
 
   # Show already bought line items of this order cycle
   def finalised_line_items
-    return [] unless order_cycle && user
-    orders = self.class.complete.where(user_id: user, order_cycle_id: order_cycle)
-    items = []
-    orders.each do |o|
-      items += o.line_items
-    end
-    scoper = OpenFoodNetwork::ScopeVariantToHub.new(distributor)
-    items.each do |li|
-      scoper.scope(li.variant)
-    end
-    items
+    return [] unless order_cycle && user && distributor
+    order_cycle.items_bought_by_user(user, distributor)
   end
 
   def admin_and_handling_total

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -139,6 +139,21 @@ Spree::Order.class_eval do
     current_item
   end
 
+  # After changing line items of a completed order
+  def update_shipping_fees!
+    line_items(:reload)
+    shipments.each do |shipment|
+      next if shipment.shipped?
+      adjustment = shipment.adjustment
+      locked = adjustment.locked
+      adjustment.locked = false
+      adjustment.update!
+      adjustment.locked = locked
+      update_totals
+      save
+    end
+  end
+
   def cap_quantity_at_stock!
     line_items.each &:cap_quantity_at_stock!
   end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -145,6 +145,7 @@ Spree::Order.class_eval do
     shipments.each do |shipment|
       next if shipment.shipped?
       update_adjustment! shipment.adjustment
+      shipment.save # updates included tax
     end
     update_totals
     save

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -270,6 +270,10 @@ Spree::Order.class_eval do
     Delayed::Job.enqueue ConfirmOrderJob.new(id) unless account_invoice?
   end
 
+  def can_remove_items?(user)
+    user_id == user.id && distributor.andand.allow_order_changes? && order_cycle.andand.open?
+  end
+
   private
 
   def shipping_address_from_distributor

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -195,6 +195,21 @@ Spree::Order.class_eval do
     line_items.map(&:variant)
   end
 
+  # Show already bought line items of this order cycle
+  def finalised_line_items
+    return [] unless order_cycle && user
+    orders = self.class.complete.where(user_id: user, order_cycle_id: order_cycle)
+    items = []
+    orders.each do |o|
+      items += o.line_items
+    end
+    scoper = OpenFoodNetwork::ScopeVariantToHub.new(distributor)
+    items.each do |li|
+      scoper.scope(li.variant)
+    end
+    items
+  end
+
   def admin_and_handling_total
     adjustments.eligible.where("originator_type = ? AND source_type != ?", 'EnterpriseFee', 'Spree::LineItem').sum(&:amount)
   end

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -4,7 +4,7 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
   attributes :preferred_shopfront_message, :preferred_shopfront_closed_message, :preferred_shopfront_taxon_order, :preferred_shopfront_order_cycle_order
   attributes :preferred_product_selection_from_inventory_only
   attributes :owner, :users, :tag_groups, :default_tag_group
-  attributes :require_login
+  attributes :require_login, :allow_guest_orders, :allow_order_changes
 
   has_one :owner, serializer: Api::Admin::UserSerializer
   has_many :users, serializer: Api::Admin::UserSerializer

--- a/app/serializers/api/current_order_serializer.rb
+++ b/app/serializers/api/current_order_serializer.rb
@@ -6,6 +6,7 @@ class Api::CurrentOrderSerializer < ActiveModel::Serializer
   has_one :ship_address, serializer: Api::AddressSerializer
 
   has_many :line_items, serializer: Api::LineItemSerializer
+  has_many :finalised_line_items, serializer: Api::LineItemSerializer
 
   def payment_method_id
     object.payments.first.andand.payment_method_id

--- a/app/serializers/api/current_order_serializer.rb
+++ b/app/serializers/api/current_order_serializer.rb
@@ -1,6 +1,6 @@
 class Api::CurrentOrderSerializer < ActiveModel::Serializer
   attributes :id, :item_total, :email, :shipping_method_id,
-    :display_total, :payment_method_id
+             :display_total, :payment_method_id
 
   has_one :bill_address, serializer: Api::AddressSerializer
   has_one :ship_address, serializer: Api::AddressSerializer

--- a/app/serializers/api/variant_serializer.rb
+++ b/app/serializers/api/variant_serializer.rb
@@ -1,7 +1,6 @@
 class Api::VariantSerializer < ActiveModel::Serializer
   attributes :id, :is_master, :count_on_hand, :name_to_display, :unit_to_display
   attributes :options_text, :on_demand, :price, :fees, :price_with_fees, :product_name
-  attributes :tag_list
 
   def price
     object.price
@@ -22,5 +21,9 @@ class Api::VariantSerializer < ActiveModel::Serializer
 
   def product_name
     object.product.name
+  end
+
+  def tag_list
+    object.tag_list if object.is_a? VariantOverride
   end
 end

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -57,3 +57,15 @@
     .five.columns.omega
       = f.radio_button :allow_guest_orders, false
       = f.label :allow_guest_orders, t('.allow_guest_orders_false'), value: :false
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      %label= t '.allow_order_changes'
+      %div{'ofn-with-tip' => t('.allow_order_changes_tip')}
+        %a= t 'admin.whats_this'
+    .three.columns
+      = f.radio_button :allow_order_changes, false
+      = f.label :allow_order_changes, t('.allow_order_changes_false'), value: :false
+    .five.columns.omega
+      = f.radio_button :allow_order_changes, true
+      = f.label :allow_order_changes, t('.allow_order_changes_true'), value: :true

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -51,12 +51,18 @@
       %label= t '.allow_guest_orders'
       %div{'ofn-with-tip' => t('.allow_guest_orders_tip')}
         %a= t 'admin.whats_this'
-    .three.columns
-      = f.radio_button :allow_guest_orders, true
-      = f.label :allow_guest_orders, t('.allow_guest_orders_true'), value: :true
-    .five.columns.omega
-      = f.radio_button :allow_guest_orders, false
-      = f.label :allow_guest_orders, t('.allow_guest_orders_false'), value: :false
+    .eight.columns.omega
+      .row
+        .three.columns.alpha
+          = f.radio_button :allow_guest_orders, true, "ng-model" => "Enterprise.allow_guest_orders", "ng-value" => "true"
+          = f.label :allow_guest_orders, t('.allow_guest_orders_true'), value: :true
+        .five.columns.omega
+          = f.radio_button :allow_guest_orders, false, "ng-model" => "Enterprise.allow_guest_orders", "ng-value" => "false"
+          = f.label :allow_guest_orders, t('.allow_guest_orders_false'), value: :false
+      .row.warning{ng: {show: 'Enterprise.allow_guest_orders && Enterprise.allow_order_changes'}}
+        .eight.columns.alpha.omega
+          %i.icon-warning-sign
+          = t '.recommend_require_login'
 .row
   .alpha.eleven.columns
     .three.columns.alpha
@@ -64,8 +70,8 @@
       %div{'ofn-with-tip' => t('.allow_order_changes_tip')}
         %a= t 'admin.whats_this'
     .three.columns
-      = f.radio_button :allow_order_changes, false
+      = f.radio_button :allow_order_changes, false, "ng-model" => "Enterprise.allow_order_changes", "ng-value" => "false"
       = f.label :allow_order_changes, t('.allow_order_changes_false'), value: :false
     .five.columns.omega
-      = f.radio_button :allow_order_changes, true
+      = f.radio_button :allow_order_changes, true, "ng-model" => "Enterprise.allow_order_changes", "ng-value" => "true"
       = f.label :allow_order_changes, t('.allow_order_changes_true'), value: :true

--- a/app/views/checkout/_already_ordered.html.haml
+++ b/app/views/checkout/_already_ordered.html.haml
@@ -1,0 +1,2 @@
+%p.alert-box.info
+  = t '.message_html', cart: link_to(t('.cart'), cart_path)

--- a/app/views/checkout/_already_ordered.html.haml
+++ b/app/views/checkout/_already_ordered.html.haml
@@ -1,2 +1,2 @@
 %p.alert-box.info
-  = t '.message_html', cart: link_to(t('.cart'), cart_path)
+  = t '.message_html', cart: link_to(t('.cart'), "#{cart_path}#bought-products")

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -11,6 +11,7 @@
   = render "checkout/billing", f: f
   = render "checkout/shipping", f: f
   = render "checkout/payment", f: f
+  = render "checkout/already_ordered", f: f if show_bought_items?
   %p
     %button.button.primary{type: :submit}
       = t :checkout_send

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -49,10 +49,10 @@
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
           = t 'checkout'
       - if show_bought_items?
-        %h5{"ng-if" => "Cart.line_items_finalised().length", style: 'margin-top: 1em'}
+        %h5{"ng-if" => "Cart.line_items_finalised.length", style: 'margin-top: 1em'}
           = t '.already_ordered_products'
         %table
-          %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items_finalised()",
+          %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items_finalised",
           "id" => "cart-variant-{{ line_item.variant.id }}"}
             %td
               %small

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -48,7 +48,7 @@
           = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t(:cart_edit)}' ) }}"
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
           = t '.checkout'
-      - if show_bought_items?
+      - if order_changes_allowed?
         %h5{"ng-if" => "Cart.line_items_finalised.length", style: 'margin-top: 1em'}
           = t '.already_ordered_products'
         %table

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -48,3 +48,23 @@
           = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t(:cart_edit)}' ) }}"
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
           = t 'checkout'
+      %h5{style: 'margin-top: 1em'}
+        = t '.already_ordered_products'
+      %table
+        %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items_finalised()",
+        "ng-controller" => "LineItemCtrl", "id" => "cart-variant-{{ line_item.variant.id }}"}
+          %td
+            %small
+              %strong
+                {{ line_item.variant.extended_name }}
+          %td.text-right
+            %small
+              %span.quantity {{ line_item.quantity }}
+              %i.ofn-i_009-close
+              %span.price {{ line_item.variant.price_with_fees | localizeCurrency }}
+
+          %td
+            %small
+              \=
+              %strong
+                .total-price.right {{ line_item.total_price | localizeCurrency }}

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -48,23 +48,24 @@
           = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t(:cart_edit)}' ) }}"
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
           = t 'checkout'
-      %h5{"ng-if" => "Cart.line_items_finalised().length", style: 'margin-top: 1em'}
-        = t '.already_ordered_products'
-      %table
-        %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items_finalised()",
-        "id" => "cart-variant-{{ line_item.variant.id }}"}
-          %td
-            %small
-              %strong
-                {{ line_item.variant.extended_name }}
-          %td.text-right
-            %small
-              %span.quantity {{ line_item.quantity }}
-              %i.ofn-i_009-close
-              %span.price {{ line_item.variant.price_with_fees | localizeCurrency }}
+      - if show_bought_items?
+        %h5{"ng-if" => "Cart.line_items_finalised().length", style: 'margin-top: 1em'}
+          = t '.already_ordered_products'
+        %table
+          %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items_finalised()",
+          "id" => "cart-variant-{{ line_item.variant.id }}"}
+            %td
+              %small
+                %strong
+                  {{ line_item.variant.extended_name }}
+            %td.text-right
+              %small
+                %span.quantity {{ line_item.quantity }}
+                %i.ofn-i_009-close
+                %span.price {{ line_item.variant.price_with_fees | localizeCurrency }}
 
-          %td
-            %small
-              \=
-              %strong
-                .total-price.right {{ line_item.total_price | localizeCurrency }}
+            %td
+              %small
+                \=
+                %strong
+                  .total-price.right {{ line_item.total_price | localizeCurrency }}

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -48,7 +48,7 @@
           = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t(:cart_edit)}' ) }}"
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
           = t 'checkout'
-      %h5{style: 'margin-top: 1em'}
+      %h5{"ng-if" => "Cart.line_items_finalised().present()", style: 'margin-top: 1em'}
         = t '.already_ordered_products'
       %table
         %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items_finalised()",

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -15,7 +15,7 @@
         %a.button.secondary.tiny.add_to_cart{ href: cart_path, type: :submit, "ng-disabled" => "Cart.dirty || Cart.empty()", "ng-class" => "{ dirty: Cart.dirty }" }
           = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t(:cart_edit)}' ) }}"
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
-          = t 'checkout'
+          = t '.checkout'
       %table
         %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items", "id" => "cart-variant-{{ line_item.variant.id }}"}
           %td
@@ -47,7 +47,7 @@
         %a.button.secondary.tiny.add_to_cart{ href: cart_path, type: :submit, "ng-disabled" => "Cart.dirty || Cart.empty()", "ng-class" => "{ dirty: Cart.dirty }" }
           = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t(:cart_edit)}' ) }}"
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
-          = t 'checkout'
+          = t '.checkout'
       - if show_bought_items?
         %h5{"ng-if" => "Cart.line_items_finalised.length", style: 'margin-top: 1em'}
           = t '.already_ordered_products'

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -48,11 +48,11 @@
           = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t(:cart_edit)}' ) }}"
         %a.button.primary.tiny{href: checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
           = t 'checkout'
-      %h5{"ng-if" => "Cart.line_items_finalised().present()", style: 'margin-top: 1em'}
+      %h5{"ng-if" => "Cart.line_items_finalised().length", style: 'margin-top: 1em'}
         = t '.already_ordered_products'
       %table
         %tr.product-cart{"ng-repeat" => "line_item in Cart.line_items_finalised()",
-        "ng-controller" => "LineItemCtrl", "id" => "cart-variant-{{ line_item.variant.id }}"}
+        "id" => "cart-variant-{{ line_item.variant.id }}"}
           %td
             %small
               %strong

--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -1,4 +1,4 @@
-%div{ng: {controller: "EditOrderCtrl"}}
+%div#bought-products{ng: {controller: "EditOrderCtrl"}}
   %div
     %div
       .row

--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -1,4 +1,4 @@
-%div
+%div{ng: {controller: "EditOrderCtrl"}}
   %div
     %div
       .row
@@ -21,7 +21,7 @@
               %tbody
                 - @order.finalised_line_items.each do |line_item|
                   - variant = line_item.variant
-                  %tr.line-item{class: "variant-#{variant.id}"}
+                  %tr.line-item{class: "line-item-#{line_item.id} variant-#{variant.id}"}
                     %td.cart-item-description
 
                       %div.item-thumb-image
@@ -39,3 +39,5 @@
                       = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
 
                     %td.cart-item-delete.text-center
+                      %a.delete{ng: {click: "deleteLineItem(#{line_item.id})"}}
+                        %i.delete.ofn-i_026-trash

--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -1,0 +1,41 @@
+%div
+  %div
+    %div
+      .row
+        .row
+          .columns.large-12
+            %table{style: "width: 100%; margin-top: 2em"}
+              %col{halign: "left", valign: "middle", width: "60%"}/
+              %col{halign: "left", valign: "middle", width: "15%"}/
+              %col{halign: "center", valign: "middle", width: "10%"}/
+              %col{halign: "center", valign: "middle", width: "10%"}/
+              %col{halign: "center", valign: "middle", width: "5%"}/
+              %thead
+                %tr
+                  %th.cart-item-description-header= t('.item')
+                  %th.cart-item-price-header.text-right= t(:price)
+                  %th.text-center.cart-item-quantity-header= t(:qty)
+                  %th.cart-item-total-header.text-right= t(:total)
+                  %th.cart-item-delete-header
+
+              %tbody
+                - @order.finalised_line_items.each do |line_item|
+                  - variant = line_item.variant
+                  %tr.line-item{class: "variant-#{variant.id}"}
+                    %td.cart-item-description
+
+                      %div.item-thumb-image
+                        - if variant.images.length == 0
+                          = link_to mini_image(variant.product), variant.product
+                        - else
+                          = link_to image_tag(variant.images.first.attachment.url(:mini)), variant.product
+
+                      = render 'spree/shared/line_item_name', line_item: line_item
+                    %td.text-right.cart-item-price
+                      = line_item.single_display_amount_with_adjustments.to_html
+                    %td.text-center.cart-item-quantity
+                      = line_item.quantity
+                    %td.cart-item-total.text-right
+                      = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
+
+                    %td.cart-item-delete.text-center

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -35,6 +35,5 @@
     = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
 
   %td.cart-item-delete.text-center{"data-hook" => "cart_item_delete"}
-    {{ quantity }}
     %a.delete{href: "#", id: "delete_#{dom_id(line_item)}"}
       %i.delete.ofn-i_026-trash

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -44,4 +44,6 @@
                 = t :orders_edit_checkout
                 %i.ofn-i_007-caret-right
 
+    = render 'bought'
+
 = render partial: "shared/footer"

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -44,6 +44,6 @@
                 = t :orders_edit_checkout
                 %i.ofn-i_007-caret-right
 
-    = render 'bought'
+    = render 'bought' if @order.finalised_line_items.present?
 
 = render partial: "shared/footer"

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -44,6 +44,6 @@
                 = t :orders_edit_checkout
                 %i.ofn-i_007-caret-right
 
-    = render 'bought' if @order.finalised_line_items.present?
+    = render 'bought' if show_bought_items?
 
 = render partial: "shared/footer"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -529,6 +529,7 @@ en:
   shared:
     menu:
       cart:
+        checkout: "Checkout now"
         already_ordered_products: "Already ordered in this order cycle"
     register_call:
       selling_on_ofn: "Interested in getting on the Open Food Network?"
@@ -627,7 +628,6 @@ en:
   items: "items"
   cart_headline: "Your shopping cart"
   total: "Total"
-  checkout: "Checkout now"
   cart_updating: "Updating cart..."
   cart_empty: "Cart empty"
   cart_edit: "Edit your cart"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,6 +373,10 @@ en:
           allow_guest_orders_tip: "Allow checkout as guest or require a registered user."
           allow_guest_orders_false: "Require login to order"
           allow_guest_orders_true: "Allow guest checkout"
+          allow_order_changes: "Change orders"
+          allow_order_changes_tip: "Allow customers to change their order as long the order cycle is open."
+          allow_order_changes_false: "Placed orders cannot be changed"
+          allow_order_changes_true: "Customers can remove items from an order of an open order cycle"
           shopfront_message_placeholder: >
             An optional explanation for customers detailing how your shopfront works,
             to be displayed above the product list on your shop page.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1553,7 +1553,7 @@ Please follow the instructions there to make your enterprise visible on the Open
     zipcode: Postcode
     orders:
       bought:
-        item: "Already bought item"
+        item: "Already ordered in this order cycle"
     shipment_states:
       backorder: backorder
       partial: partial

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -527,6 +527,9 @@ en:
       hide_closed_shops: "Hide closed shops"
       show_on_map: "Show all on the map"
   shared:
+    menu:
+      cart:
+        already_ordered_products: "Already ordered in this order cycle"
     register_call:
       selling_on_ofn: "Interested in getting on the Open Food Network?"
       register: "Register here"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,7 @@ en:
           shopfront_requires_login_tip: "Choose whether customers must login to view the shopfront or if it's visible to everybody."
           shopfront_requires_login_false: "Public"
           shopfront_requires_login_true: "Visible to registered customers only"
+          recommend_require_login: "We recommend to require users to login when orders can be changed."
           allow_guest_orders: "Guest orders"
           allow_guest_orders_tip: "Allow checkout as guest or require a registered user."
           allow_guest_orders_false: "Require login to order"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,6 +521,15 @@ en:
         invoice_style2?: Use the alternative invoice model that includes total tax breakdown per rate and tax rate info per item (not yet suitable for countries displaying prices excluding tax)
         enable_receipt_printing?: Show options for printing receipts using thermal printers in order dropdown?
 
+# Frontend views
+#
+# These keys are referenced relatively like `t('.message')` in
+# app/views/checkout/_already_ordered.html.haml.
+#
+  checkout:
+    already_ordered:
+      cart: "cart"
+      message_html: "You have an order for this order cycle already. Check the %{cart} to see the items you ordered before. You can also cancel items as long as the order cycle is open."
   home:
     hubs:
       show_closed_shops: "Show closed shops"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -633,15 +633,6 @@ en:
   card_securitycode: "Security Code"
   card_expiry_date: Expiry Date
 
-  ofn_cart_headline: "Current cart for:"
-  ofn_cart_distributor: "Distributor:"
-  ofn_cart_oc: "Order cycle:"
-  ofn_cart_from: "From:"
-  ofn_cart_to: "To:"
-  ofn_cart_product: "Product:"
-  ofn_cart_quantitiy: "Quantity:"
-  ofn_cart_send: "Buy me"
-
   ie_warning_headline: "Your browser is out of date :-("
   ie_warning_text: "For the best Open Food Network experience, we strongly recommend upgrading your browser:"
   ie_warning_chrome: Download Chrome

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1551,6 +1551,9 @@ Please follow the instructions there to make your enterprise visible on the Open
       format: ! '%Y-%m-%d'
       js_format: 'yy-mm-dd'
     zipcode: Postcode
+    orders:
+      bought:
+        item: "Already bought item"
     shipment_states:
       backorder: backorder
       partial: partial

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Openfoodnetwork::Application.routes.draw do
     end
   end
 
+  resources :line_items, only: [:destroy]
+
   resources :groups, only: [:index, :show] do
     collection do
       get :signup

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Openfoodnetwork::Application.routes.draw do
     end
   end
 
-  resources :line_items, only: [:destroy]
+  resources :line_items, only: [:index, :destroy]
 
   resources :groups, only: [:index, :show] do
     collection do

--- a/db/migrate/20161012022142_add_allow_order_changes_to_enterprise.rb
+++ b/db/migrate/20161012022142_add_allow_order_changes_to_enterprise.rb
@@ -1,0 +1,5 @@
+class AddAllowOrderChangesToEnterprise < ActiveRecord::Migration
+  def change
+    add_column :enterprises, :allow_order_changes, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -251,6 +251,7 @@ ActiveRecord::Schema.define(:version => 20161215230219) do
     t.boolean  "allow_guest_orders",       :default => true,   :null => false
     t.text     "invoice_text"
     t.boolean  "display_invoice_logo",     :default => false
+    t.boolean  "allow_order_changes",      :default => false,  :null => false
   end
 
   add_index "enterprises", ["address_id"], :name => "index_enterprises_on_address_id"

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -10,11 +10,17 @@ describe LineItemsController do
     item.order.save
     item
   end
-  let(:distributor) do
-    distributor = create(:distributor_enterprise)
-    item.order.distributor = distributor
-    item.order.save
-    distributor
+
+  it "lists bought items" do
+    item.order.finalize!
+    controller.stub spree_current_user: item.order.user
+    controller.stub current_order_cycle: item_with_oc.order.order_cycle
+    controller.stub current_distributor: item_with_oc.order.distributor
+    get :index, { format: :json }
+    expect(response.status).to eq 200
+    json_response = JSON.parse(response.body)
+    expect(json_response.length).to eq 1
+    expect(json_response[0]['id']).to eq item.id
   end
 
   it "fails without line item id" do

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -68,8 +68,8 @@ describe LineItemsController do
 
     # Sanity check fees
     item_num = order.line_items.length
-    expected_fees = item_num * (shipping_fee + payment_fee)
-    expect(order.adjustment_total).to eq expected_fees
+    initial_fees = item_num * (shipping_fee + payment_fee)
+    expect(order.adjustment_total).to eq initial_fees
 
     # Delete the item
     item = order.line_items.first
@@ -80,6 +80,6 @@ describe LineItemsController do
 
     # Check the fees again
     order.reload
-    expect(order.adjustment_total).to eq expected_fees - shipping_fee
+    expect(order.adjustment_total).to eq initial_fees - shipping_fee - payment_fee
   end
 end

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe LineItemsController do
+  let(:item) { create(:line_item) }
+  let(:item_with_oc) do
+    order_cycle = create(:simple_order_cycle)
+    item.order.order_cycle = order_cycle
+    item.order.save
+    item
+  end
+
+  it "fails without line item id" do
+    expect { delete :destroy }.to raise_error
+  end
+
+  it "denies deletion without order cycle" do
+    request = { format: :json, id: item }
+    delete :destroy, request
+    expect(response.status).to be 403
+    expect { item.reload }.to_not raise_error
+  end
+
+  it "denies deletion without user" do
+    request = { format: :json, id: item_with_oc }
+    delete :destroy, request
+    expect(response.status).to be 403
+    expect { item.reload }.to_not raise_error
+  end
+
+  it "deletes the line item" do
+    controller.stub spree_current_user: item.order.user
+    request = { format: :json, id: item_with_oc }
+    delete :destroy, request
+    expect(response.status).to be 204
+    expect { item.reload }.to raise_error
+  end
+end

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -4,9 +4,17 @@ describe LineItemsController do
   let(:item) { create(:line_item) }
   let(:item_with_oc) do
     order_cycle = create(:simple_order_cycle)
+    distributor = create(:distributor_enterprise)
     item.order.order_cycle = order_cycle
+    item.order.distributor = distributor
     item.order.save
     item
+  end
+  let(:distributor) do
+    distributor = create(:distributor_enterprise)
+    item.order.distributor = distributor
+    item.order.save
+    distributor
   end
 
   it "fails without line item id" do
@@ -16,22 +24,33 @@ describe LineItemsController do
   it "denies deletion without order cycle" do
     request = { format: :json, id: item }
     delete :destroy, request
-    expect(response.status).to be 403
+    expect(response.status).to eq 403
     expect { item.reload }.to_not raise_error
   end
 
   it "denies deletion without user" do
     request = { format: :json, id: item_with_oc }
     delete :destroy, request
-    expect(response.status).to be 403
+    expect(response.status).to eq 403
     expect { item.reload }.to_not raise_error
   end
 
-  it "deletes the line item" do
+  it "denies deletion if editing is not allowed" do
     controller.stub spree_current_user: item.order.user
     request = { format: :json, id: item_with_oc }
     delete :destroy, request
-    expect(response.status).to be 204
+    expect(response.status).to eq 403
+    expect { item.reload }.to_not raise_error
+  end
+
+  it "deletes the line item if allowed" do
+    controller.stub spree_current_user: item.order.user
+    distributor = item_with_oc.order.distributor
+    distributor.allow_order_changes = true
+    distributor.save
+    request = { format: :json, id: item_with_oc }
+    delete :destroy, request
+    expect(response.status).to eq 204
     expect { item.reload }.to raise_error
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,20 @@
 require 'ffaker'
 require 'spree/core/testing_support/factories'
 
+# http://www.rubydoc.info/gems/factory_girl/file/GETTING_STARTED.md
+#
+# The spree_core gem defines factories in several files. For example:
+#
+# - lib/spree/core/testing_support/factories/calculator_factory.rb
+#   * calculator
+#   * no_amount_calculator
+#
+# - lib/spree/core/testing_support/factories/order_factory.rb
+#   * order
+#   * order_with_totals
+#   * order_with_inventory_unit_shipped
+#   * completed_order_with_totals
+#
 FactoryGirl.define do
   factory :classification, class: Spree::Classification do
   end
@@ -171,6 +185,10 @@ FactoryGirl.define do
   end
 
   sequence(:calculator_amount)
+  factory :calculator_per_item, class: Spree::Calculator::PerItem do
+    preferred_amount { generate(:calculator_amount) }
+  end
+
   factory :enterprise_fee, :class => EnterpriseFee do
     ignore { amount nil }
 
@@ -178,7 +196,7 @@ FactoryGirl.define do
     sequence(:fee_type) { |n| EnterpriseFee::FEE_TYPES[n % EnterpriseFee::FEE_TYPES.count] }
 
     enterprise { Enterprise.first || FactoryGirl.create(:supplier_enterprise) }
-    calculator { Spree::Calculator::PerItem.new(preferred_amount: amount || generate(:calculator_amount)) }
+    calculator { build(:calculator_per_item, preferred_amount: amount) }
 
     after(:create) { |ef| ef.calculator.save! }
   end
@@ -234,6 +252,27 @@ FactoryGirl.define do
     after(:create) do |order|
       create(:payment, amount: order.total - 1, order: order, state: "completed")
       order.reload
+    end
+  end
+
+  factory :completed_order_with_fees, parent: :order_with_totals_and_distribution do
+    ignore do
+      shipping_fee 3
+      payment_fee 5
+    end
+
+    shipping_method do
+      shipping_calculator = build(:calculator_per_item, preferred_amount: shipping_fee)
+      create(:shipping_method, calculator: shipping_calculator, require_ship_address: false)
+    end
+
+    after(:create) do |order, evaluator|
+      create(:line_item, order: order)
+      order.create_shipment!
+      payment_calculator = build(:calculator_per_item, preferred_amount: evaluator.payment_fee)
+      payment_method = create(:payment_method, calculator: payment_calculator)
+      create(:payment, order: order, amount: order.total, payment_method: payment_method, state: 'completed')
+      order.finalize!
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -271,7 +271,7 @@ FactoryGirl.define do
       order.create_shipment!
       payment_calculator = build(:calculator_per_item, preferred_amount: evaluator.payment_fee)
       payment_method = create(:payment_method, calculator: payment_calculator)
-      create(:payment, order: order, amount: order.total, payment_method: payment_method, state: 'completed')
+      create(:payment, order: order, amount: order.total, payment_method: payment_method, state: 'checkout')
       order.finalize!
     end
   end

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -110,6 +110,11 @@ feature "full-page cart", js: true do
         expect(page).to have_no_content item1.variant.name
         expect(page).to have_content item2.variant.name
 
+        # open the dropdown cart and check there as well
+        find('#cart').click
+        expect(page).to have_no_content item1.variant.name
+        expect(page).to have_content item2.variant.name
+
         visit spree.cart_path
         expect(page).to have_no_content item1.variant.name
         expect(page).to have_content item2.variant.name

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -94,6 +94,8 @@ feature "full-page cart", js: true do
       before do
         order.user = user
         order.save
+        order.distributor.allow_order_changes = true
+        order.distributor.save
         add_product_to_cart order, product_tax
         quick_login_as user
         visit spree.cart_path

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -113,6 +113,24 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         user.reload.bill_address.address1.should eq '123 Your Head'
         user.reload.ship_address.address1.should eq '123 Your Head'
       end
+
+      it "it doesn't tell about previous orders" do
+        expect(page).to_not have_content("You have an order for this order cycle already.")
+      end
+
+      context "with previous orders" do
+        let!(:prev_order) { create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor, user: order.user) }
+
+        before do
+          order.distributor.allow_order_changes = true
+          order.distributor.save
+        end
+
+        it "informs about previous orders" do
+          visit checkout_path
+          expect(page).to have_content("You have an order for this order cycle already.")
+        end
+      end
     end
 
     context "on the checkout page" do

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -402,7 +402,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         o.save!
       end
 
-      it "checks out successfully" do
+      it "checks out successfully", retry: 3 do
         visit checkout_path
         checkout_as_guest
         choose sm2.name

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -137,6 +137,32 @@ feature "As a consumer I want to shop with a distributor", js: true do
             end
           end
         end
+
+        context "when logged in" do
+          let!(:prev_order) { create(:completed_order_with_totals, order_cycle: oc1, distributor: distributor, user: order.user) }
+
+          before do
+            distributor.allow_order_changes = true
+            distributor.save
+            quick_login_as order.user
+            visit shop_path
+          end
+
+          it "shows previous orders if order cycle was selected already" do
+            select "frogs", from: "order_cycle_id"
+            expect(page).to have_content "Next order closing in 2 days"
+            visit shop_path
+            find("#cart").click
+            expect(page).to have_text(I18n.t("shared.menu.cart.already_ordered_products"))
+          end
+
+          it "shows previous orders after selecting an order cycle" do
+            select "frogs", from: "order_cycle_id"
+            expect(page).to have_content "Next order closing in 2 days"
+            find("#cart").click
+            expect(page).to have_text(I18n.t("shared.menu.cart.already_ordered_products"))
+          end
+        end
       end
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -630,6 +630,20 @@ describe Spree::Order do
       expect(order.line_items.length).to eq item_num - 1
       expect(order.adjustment_total).to eq expected_fees - shipping_fee
     end
+
+    it "updates transaction fees" do
+      item_num = order.line_items.length
+      initial_fees = item_num * (shipping_fee + payment_fee)
+
+      # Delete the item
+      order.line_items.first.destroy
+      order.update_payment_fees!
+
+      # Check if fees got updated
+      expect(order.adjustments.length).to eq 2
+      expect(order.line_items.length).to eq item_num - 1
+      expect(order.adjustment_total).to eq initial_fees - payment_fee
+    end
   end
 
   describe "retrieving previously ordered items" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -606,4 +606,36 @@ describe Spree::Order do
       end
     end
   end
+
+  describe "retrieving previously ordered items" do
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:order_cycle) { create(:simple_order_cycle) }
+    let!(:order) { create(:order, distributor: distributor, order_cycle: order_cycle) }
+
+    it "returns no items if nothing has been ordered" do
+      expect(order.finalised_line_items).to eq []
+    end
+
+    context "when no order has been finalised in this order cycle" do
+      let(:product) { create(:product) }
+
+      it "returns no items even though the cart contains items" do
+        order.add_variant(product.master, 1, 3)
+        expect(order.finalised_line_items).to eq []
+      end
+    end
+
+    context "when an order has been finalised in this order cycle" do
+      let!(:prev_order) { create(:completed_order_with_totals, distributor: distributor, order_cycle: order_cycle, user: order.user) }
+      let!(:prev_order2) { create(:completed_order_with_totals, distributor: distributor, order_cycle: order_cycle, user: order.user) }
+      let(:product) { create(:product) }
+
+      it "returns previous items" do
+        prev_order.add_variant(product.master, 1, 3)
+        prev_order2.reload # to get the right response from line_items
+        expect(order.finalised_line_items.length).to eq 3
+        expect(order.finalised_line_items).to match_array(prev_order.line_items + prev_order2.line_items)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a follow-up of #1141. Hopefully solving:

- #1083 Display products bought in an order cycle in the shop cart dropdown
- #1084 Display products bought in an order cycle in the edit cart page
- #1085 Allow for bought products to be removed from an order on edit cart page
- #1161 Opt-in option for enterprises to allow their customers to make changes to their current order
