### PR TITLE
Fix enterprise user auth

### DIFF
--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -57,6 +57,7 @@ class AbilityDecorator
 
   def add_group_management_abilities(user)
     can [:admin, :index], :overview
+    can [:admin, :sync], :analytic
     can [:admin, :index], EnterpriseGroup
     can [:read, :edit, :update], EnterpriseGroup do |group|
       user.owned_groups.include? group
@@ -69,6 +70,7 @@ class AbilityDecorator
     can [:create, :search], nil
 
     can [:admin, :index], :overview
+    can [:admin, :sync], :analytic
 
     can [:admin, :index, :read, :create, :edit, :update_positions, :destroy], ProducerProperty
 

--- a/spec/features/admin/overview_spec.rb
+++ b/spec/features/admin/overview_spec.rb
@@ -3,29 +3,16 @@ require 'spec_helper'
 feature %q{
   As a backend user
   I want to be given information about the state of my enterprises, products and order cycles
-} , js: true do
+}, js: true do
   include AuthenticationWorkflow
   include AuthorizationHelpers
   include WebHelper
 
-  stub_authorization!
-
   context "as an enterprise user" do
-    before :each do
+    before do
       @enterprise_user = create_enterprise_user
       Spree::Admin::OverviewController.any_instance.stub(:spree_current_user).and_return @enterprise_user
       quick_login_as @enterprise_user
-    end
-
-    context "with no enterprises" do
-      it "prompts the user to create a new enteprise" do
-        visit '/admin'
-        page.should have_selector ".dashboard_item#enterprises h3", text: "My Enterprises"
-        page.should have_selector ".dashboard_item#enterprises .list-item", text: "You don't have any enterprises yet"
-        page.should have_selector ".dashboard_item#enterprises .button.bottom", text: "CREATE A NEW ENTERPRISE"
-        page.should_not have_selector ".dashboard_item#products"
-        page.should_not have_selector ".dashboard_item#order_cycles"
-      end
     end
 
     context "with an enterprise" do

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -7,7 +7,7 @@ module Spree
     let!(:t2) { create(:taxon) }
 
     describe "callbacks" do
-      let!(:p2) { create(:simple_product, taxons: [t1]) }
+      let!(:p2) { create(:simple_product, taxons: [t1], primary_taxon: t2) }
 
       it "refreshes the products cache on save" do
         expect(OpenFoodNetwork::ProductsCache).to receive(:product_changed).with(p2)


### PR DESCRIPTION
When an enterprise user accesses the admin dashboard, they're getting an access denied error. I found that they were being redirected to `spree/admin/analytics#sync` by `Spree::Admin::OverviewController#check_last_jirafe_sync_time`.

I've added a spec for this scenario (which is common on production), and added permission to analytics to all users who had access to the admin dashboard.