### PR TITLE
Product descriptions formatting

### DIFF
--- a/app/assets/javascripts/admin/products/products.js.coffee
+++ b/app/assets/javascripts/admin/products/products.js.coffee
@@ -1,1 +1,1 @@
-angular.module("admin.products", ["admin.utils"])
+angular.module("admin.products", ["textAngular", "admin.utils"])

--- a/app/assets/javascripts/admin/utils/directives/textangular_strip.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/textangular_strip.js.coffee
@@ -1,0 +1,5 @@
+angular.module("admin.utils").directive "textangularStrip", () ->
+  restrict: 'CA'
+  link: (scope, element, attrs) ->
+    scope.stripFormatting = ($html) ->
+      return String($html).replace(/<[^>]+>/gm, '')

--- a/app/assets/javascripts/templates/product_modal.html.haml
+++ b/app/assets/javascripts/templates/product_modal.html.haml
@@ -16,7 +16,7 @@
 
     %div{"ng-if" => "product.description_html"}
       %hr
-      %p.text-small{"ng-bind-html" => "product.description_html"}
+      %p.text-small{"ng-bind-html" => "::product.description_html"}
       %hr
 
   .columns.small-12.large-6

--- a/app/assets/javascripts/templates/product_modal.html.haml
+++ b/app/assets/javascripts/templates/product_modal.html.haml
@@ -14,10 +14,9 @@
     .filter-shopfront.property-selectors.inline-block
       %filter-selector{ 'selector-set' => "productPropertySelectors", objects: "[product] | propertiesWithValuesOf" }
 
-    %div{"ng-if" => "product.description"}
+    %div{"ng-if" => "product.description_html"}
       %hr
-      %p.text-small{"ng-bind" => "::product.description"}
-      {{product.description}}
+      %p.text-small{"ng-bind-html" => "product.description_html"}
       %hr
 
   .columns.small-12.large-6

--- a/app/assets/javascripts/templates/product_modal.html.haml
+++ b/app/assets/javascripts/templates/product_modal.html.haml
@@ -17,6 +17,7 @@
     %div{"ng-if" => "product.description"}
       %hr
       %p.text-small{"ng-bind" => "::product.description"}
+      {{product.description}}
       %hr
 
   .columns.small-12.large-6

--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -200,6 +200,13 @@ table#listing_enterprise_groups {
 
 // textAngular wysiwyg
 text-angular {
+  .ta-toolbar {
+    border: 1px solid #cdd9e4;
+    padding: 0.4em;
+    margin-bottom: -1px;
+    background-color: #f1f1f1;
+    border-radius: 0.25em 0.25em 0 0;
+  }
   .ta-scroll-window > .ta-bind {
     max-height: 400px;
     min-height: 100px;
@@ -216,6 +223,7 @@ text-angular {
     margin-right: 8px;
     button {
       padding: 5px 10px;
+      margin-right: 0.25em;
     }
   }
 }

--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -217,6 +217,7 @@ text-angular {
   }
   .ta-scroll-window.form-control {
     min-height: 100px;
+    box-shadow: none !important;
   }
   .btn-group {
     display: inline;
@@ -224,6 +225,10 @@ text-angular {
     button {
       padding: 5px 10px;
       margin-right: 0.25em;
+    }
+    button.active:not(:hover) {
+      box-shadow: 0 0 0.7em rgba(0,0,0,0.3) inset;
+      background-color: #4583bf;
     }
   }
 }

--- a/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
@@ -1,2 +1,3 @@
 / replace "[data-hook=admin_product_form_left] code[erb-loud]:contains('f.text_area :description')"
 %text-angular{'id' => 'product_description', 'ng-model' => 'product.description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','underline','clear']]"}
+  != @product[:description].to_s.html_safe

--- a/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
@@ -1,3 +1,3 @@
 / replace "[data-hook=admin_product_form_left] code[erb-loud]:contains('f.text_area :description')"
-%text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','clear']]"}
+%text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'textangular-strip' => true, 'ta-paste' => "stripFormatting($html)", 'ta-toolbar' => "[['bold','italics','clear']]"}
   = sanitize(@product.description)

--- a/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
@@ -1,2 +1,2 @@
 / replace "[data-hook=admin_product_form_left] code[erb-loud]:contains('f.text_area :description')"
-%text-angular{'id' => 'product_description', 'ng-model' => 'product.description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['h1','h2','h3','h4','p'],['bold','italics','underline','clear']]"}
+%text-angular{'id' => 'product_description', 'ng-model' => 'product.description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','underline','clear']]"}

--- a/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
@@ -1,2 +1,2 @@
 / replace "[data-hook=admin_product_form_left] code[erb-loud]:contains('f.text_area :description')"
-<text-angular ng-model='product.description' id='product_description' name='product[description]' class='text-angular' ta-toolbar="[['bold','italics','underline','clear'],['insertLink']]"></text-angular>
+%text-angular{'id' => 'product_description', 'ng-model' => 'product.description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['h1','h2','h3','h4','p'],['bold','italics','underline','clear']]"}

--- a/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
@@ -1,0 +1,2 @@
+/ replace "[data-hook=admin_product_form_left] code[erb-loud]:contains('f.text_area :description')"
+<text-angular ng-model='product.description' id='product_description' name='product[description]' class='text-angular' ta-toolbar="[['bold','italics','underline','clear'],['insertLink']]"></text-angular>

--- a/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
@@ -1,3 +1,3 @@
 / replace "[data-hook=admin_product_form_left] code[erb-loud]:contains('f.text_area :description')"
-%text-angular{'id' => 'product_description', 'ng-model' => 'product.description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','clear']]"}
-  != @product[:description].to_s.html_safe
+%text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','clear']]"}
+  = sanitize(@product.description)

--- a/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_description_wysiwyg.html.haml.deface
@@ -1,3 +1,3 @@
 / replace "[data-hook=admin_product_form_left] code[erb-loud]:contains('f.text_area :description')"
-%text-angular{'id' => 'product_description', 'ng-model' => 'product.description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','underline','clear']]"}
+%text-angular{'id' => 'product_description', 'ng-model' => 'product.description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','clear']]"}
   != @product[:description].to_s.html_safe

--- a/app/overrides/spree/admin/products/edit/add_angular.deface
+++ b/app/overrides/spree/admin/products/edit/add_angular.deface
@@ -1,0 +1,2 @@
+add_to_attributes 'fieldset.no-border-top'
+attributes 'ng-app' => 'admin.products'

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -72,7 +72,7 @@
       = f.field_container :description do
         = f.label :product_description, t(:product_description)
         %br/
-        %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','clear']]"}
+        %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'textangular-strip' => true, 'ta-paste' => "stripFormatting($html)", 'ta-toolbar' => "[['bold','italics','clear']]"}
         = f.error_message_on :description
 .four.columns.omega{ style: "text-align: center" }
   %fieldset.no-border-bottom{ id: "image" }

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -72,7 +72,7 @@
       = f.field_container :description do
         = f.label :product_description, t(:product_description)
         %br/
-        %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','underline','clear']]"}
+        %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','clear']]"}
         = f.error_message_on :description
 .four.columns.omega{ style: "text-align: center" }
   %fieldset.no-border-bottom{ id: "image" }

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -72,7 +72,7 @@
       = f.field_container :description do
         = f.label :product_description, t(:product_description)
         %br/
-        = f.text_area :description, class: 'fullwidth', rows: 3
+        %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]"}
         = f.error_message_on :description
 .four.columns.omega{ style: "text-align: center" }
   %fieldset.no-border-bottom{ id: "image" }

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -72,7 +72,7 @@
       = f.field_container :description do
         = f.label :product_description, t(:product_description)
         %br/
-        %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]"}
+        %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', 'ta-toolbar' => "[['bold','italics','underline','clear']]"}
         = f.error_message_on :description
 .four.columns.omega{ style: "text-align: center" }
   %fieldset.no-border-bottom{ id: "image" }

--- a/app/serializers/api/product_serializer.rb
+++ b/app/serializers/api/product_serializer.rb
@@ -50,7 +50,7 @@ class Api::CachedProductSerializer < ActiveModel::Serializer
   has_one :supplier, serializer: Api::IdSerializer
 
   def description
-    strip_tags object.description
+    sanitize(object.description, options = {tags: "p, b, strong, em, i"}).html_safe
   end
 
   def properties_with_values

--- a/app/serializers/api/product_serializer.rb
+++ b/app/serializers/api/product_serializer.rb
@@ -37,7 +37,7 @@ class Api::CachedProductSerializer < ActiveModel::Serializer
   include ActionView::Helpers::SanitizeHelper
 
   attributes :id, :name, :permalink
-  attributes :on_demand, :group_buy, :notes, :description
+  attributes :on_demand, :group_buy, :notes, :description, :description_html
   attributes :properties_with_values
 
   has_many :variants, serializer: Api::VariantSerializer
@@ -49,8 +49,15 @@ class Api::CachedProductSerializer < ActiveModel::Serializer
   has_many :images, serializer: Api::ImageSerializer
   has_one :supplier, serializer: Api::IdSerializer
 
+  #return an unformatted descripton
   def description
-    sanitize(object.description, options = {tags: "p, b, strong, em, i"}).html_safe
+    strip_tags object.description
+  end
+
+  #return a sanitized html description
+  def description_html
+    d = sanitize(object.description, options = {tags: "p, b, strong, em, i"})
+    d.to_s.html_safe
   end
 
   def properties_with_values

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -35,7 +35,7 @@ feature %q{
       fill_in 'product_on_hand', with: 5
       select 'Test Tax Category', from: 'product_tax_category_id'
       select 'Test Shipping Category', from: 'product_shipping_category_id'
-      fill_in 'product_description', with: "A description..."
+      page.find("input[name='product\[description\]']", visible: false).set('A description...')
 
       click_button 'Create'
 

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -75,7 +75,8 @@ feature %q{
       check 'product_on_demand'
       select 'Test Tax Category', from: 'product_tax_category_id'
       select 'Test Shipping Category', from: 'product_shipping_category_id'
-      fill_in 'product_description', with: "In demand, and on_demand! The hottest cakes in town."
+      #fill_in 'product_description', with: "In demand, and on_demand! The hottest cakes in town."
+      page.first("input[name='product\[description\]']", visible: false).set('In demand, and on_demand! The hottest cakes in town.')
 
       click_button 'Create'
 

--- a/spec/features/consumer/shopping/products_spec.rb
+++ b/spec/features/consumer/shopping/products_spec.rb
@@ -7,7 +7,6 @@ feature "As a consumer I want to view products", js: true do
   include UIComponentHelper
 
   describe "Viewing a product" do
-
     let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
     let(:supplier) { create(:supplier_enterprise) }
     let(:oc1) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise), orders_close_at: 2.days.from_now) }
@@ -21,14 +20,12 @@ feature "As a consumer I want to view products", js: true do
     end
 
     describe "viewing HTML product descriptions" do
-
       before do
         exchange1.update_attribute :pickup_time, "monday"
         add_variant_to_order_cycle(exchange1, variant)
       end
 
       it "shows HTML product description" do
-
         product.description = "<p><b>Formatted</b> product description.</p>"
         product.save!
 
@@ -41,11 +38,9 @@ feature "As a consumer I want to view products", js: true do
         within(".reveal-modal") do
           html.should include("<p><b>Formatted</b> product description.</p>")
         end
-
       end
 
       it "does not show unsecure HTML" do
-
         product.description = "<script>alert('Dangerous!');</script><p>Safe</p>"
         product.save!
 
@@ -59,9 +54,7 @@ feature "As a consumer I want to view products", js: true do
           html.should include("<p>Safe</p>")
           html.should_not include("<script>alert('Dangerous!');</script>")
         end
-
       end
-
     end
   end
 end

--- a/spec/features/consumer/shopping/products_spec.rb
+++ b/spec/features/consumer/shopping/products_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+feature "As a consumer I want to view products", js: true do
+  include AuthenticationWorkflow
+  include WebHelper
+  include ShopWorkflow
+  include UIComponentHelper
+
+  describe "Viewing a product" do
+
+    let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
+    let(:supplier) { create(:supplier_enterprise) }
+    let(:oc1) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise), orders_close_at: 2.days.from_now) }
+    let(:product) { create(:simple_product, supplier: supplier) }
+    let(:variant) { product.variants.first }
+    let(:order) { create(:order, distributor: distributor) }
+    let(:exchange1) { oc1.exchanges.to_enterprises(distributor).outgoing.first }
+
+    before do
+      set_order order
+    end
+
+    describe "viewing HTML product descriptions" do
+
+      before do
+        exchange1.update_attribute :pickup_time, "monday"
+        add_variant_to_order_cycle(exchange1, variant)
+      end
+
+      it "shows HTML product description" do
+
+        product.description = "<p><b>Formatted</b> product description.</p>"
+        product.save!
+
+        visit shop_path
+        select "monday", :from => "order_cycle_id"
+
+        open_product_modal product
+        modal_should_be_open_for product
+
+        within(".reveal-modal") do
+          html.should include("<p><b>Formatted</b> product description.</p>")
+        end
+
+      end
+
+      it "does not show unsecure HTML" do
+
+        product.description = "<script>alert('Dangerous!');</script><p>Safe</p>"
+        product.save!
+
+        visit shop_path
+        select "monday", :from => "order_cycle_id"
+
+        open_product_modal product
+        modal_should_be_open_for product
+
+        within(".reveal-modal") do
+          html.should include("<p>Safe</p>")
+          html.should_not include("<script>alert('Dangerous!');</script>")
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
For issue #1020.

-Added WYSIWYG to product description forms on backed. 

-Modified frontend API to display formatted (properly sanitised) html for product descriptions.

-Made some UI improvements to textAngular implementation, including better visual feedback on selected options.

![screenshot from 2016-11-27 14-07-56](https://cloud.githubusercontent.com/assets/9029026/20649052/280bfb08-b4ae-11e6-8572-48066359221d.png)

New button behaviour utilising the previously unused active css class:
![screenshot from 2016-11-27 13-33-54](https://cloud.githubusercontent.com/assets/9029026/20649053/2e8224ee-b4ae-11e6-912a-23c0e69c17e5.png)
![screenshot from 2016-11-27 13-34-03](https://cloud.githubusercontent.com/assets/9029026/20649054/2ea6554e-b4ae-11e6-9b0c-34f6cc5e5af2.png)
