### PR TITLE
Product search indexes variant names

### DIFF
--- a/app/assets/javascripts/darkswarm/filters/filter_products.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/filter_products.js.coffee
@@ -4,5 +4,5 @@ Darkswarm.filter 'products', (Matcher) ->
     text ?= ""
     return products if text == ""
     products.filter (product) =>
-      propertiesToMatch = [product.name, product.supplier.name, product.primary_taxon.name]
+      propertiesToMatch = [product.name, product.variant_names, product.supplier.name, product.primary_taxon.name]
       Matcher.match propertiesToMatch, text

--- a/app/assets/javascripts/darkswarm/services/products.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/products.js.coffee
@@ -24,6 +24,10 @@ Darkswarm.factory 'Products', ($resource, Enterprises, Dereferencer, Taxons, Pro
         if product.variants?.length > 0
           prices = (v.price for v in product.variants)
           product.price = Math.min.apply(null, prices)
+          if product.variants.length > 1
+            angular.forEach product.variants, (item, key) ->
+              if product.name != item.name_to_display
+                product.variant_names += item.name_to_display
         product.hasVariants = product.variants?.length > 0
 
         product.primaryImage = product.images[0]?.small_url if product.images

--- a/app/assets/javascripts/darkswarm/services/products.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/products.js.coffee
@@ -19,20 +19,11 @@ Darkswarm.factory 'Products', ($resource, Enterprises, Dereferencer, Taxons, Pro
         @registerVariants()
         @loading = false
 
-    indexVariants: (product) ->
-      if product.variants.length > 1
-        variant_names = ""
-        angular.forEach product.variants, (item, key) ->
-          if product.name != item.name_to_display
-            variant_names += item.name_to_display
-      variant_names
-
     extend: ->
       for product in @products
         if product.variants?.length > 0
           prices = (v.price for v in product.variants)
           product.price = Math.min.apply(null, prices)
-          product.variant_names = @indexVariants product
         product.hasVariants = product.variants?.length > 0
         product.primaryImage = product.images[0]?.small_url if product.images
         product.primaryImageOrMissing = product.primaryImage || "/assets/noimage/small.png"
@@ -53,5 +44,7 @@ Darkswarm.factory 'Products', ($resource, Enterprises, Dereferencer, Taxons, Pro
         if product.variants
           product.variants = for variant in product.variants
             variant = Variants.register variant
+            if product.name != variant.name_to_display
+              product.variant_names += variant.name_to_display
             variant.product = product
             variant

--- a/app/assets/javascripts/darkswarm/services/products.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/products.js.coffee
@@ -19,17 +19,21 @@ Darkswarm.factory 'Products', ($resource, Enterprises, Dereferencer, Taxons, Pro
         @registerVariants()
         @loading = false
 
+    indexVariants: (product) ->
+      if product.variants.length > 1
+        variant_names = ""
+        angular.forEach product.variants, (item, key) ->
+          if product.name != item.name_to_display
+            variant_names += item.name_to_display
+      variant_names
+
     extend: ->
       for product in @products
         if product.variants?.length > 0
           prices = (v.price for v in product.variants)
           product.price = Math.min.apply(null, prices)
-          if product.variants.length > 1
-            angular.forEach product.variants, (item, key) ->
-              if product.name != item.name_to_display
-                product.variant_names += item.name_to_display
+          product.variant_names = @indexVariants product
         product.hasVariants = product.variants?.length > 0
-
         product.primaryImage = product.images[0]?.small_url if product.images
         product.primaryImageOrMissing = product.primaryImage || "/assets/noimage/small.png"
         product.largeImage = product.images[0]?.large_url if product.images

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -143,6 +143,8 @@ feature "As a consumer I want to shop with a distributor", js: true do
     describe "after selecting an order cycle with products visible" do
       let(:variant1) { create(:variant, product: product, price: 20) }
       let(:variant2) { create(:variant, product: product, price: 30, display_name: "Badgers") }
+      let(:product2) { create(:simple_product, supplier: supplier, name: "Meercats") }
+      let(:variant3) { create(:variant, product: product2, price: 40, display_name: "Ferrets") }
       let(:exchange) { Exchange.find(oc1.exchanges.to_enterprises(distributor).outgoing.first.id) }
 
       before do
@@ -150,6 +152,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
         add_variant_to_order_cycle(exchange, variant)
         add_variant_to_order_cycle(exchange, variant1)
         add_variant_to_order_cycle(exchange, variant2)
+        add_variant_to_order_cycle(exchange, variant3)
         order.order_cycle = oc1
       end
 
@@ -172,14 +175,30 @@ feature "As a consumer I want to shop with a distributor", js: true do
         page.should have_price "$43.00"
       end
 
+      it "filters search results properly" do
+        visit shop_path
+        select "frogs", :from => "order_cycle_id"
+
+        fill_in "search", with: "74576345634XXXXXX"
+        page.should have_content "Sorry, no results found"
+        page.should_not have_content product2.name
+
+        fill_in "search", with: "Meer"           # For product named "Meercats"
+        page.should have_content product2.name
+        page.should_not have_content product.name
+      end
+
       it "returns search results for products where the search term matches one of the product's variant names" do
         visit shop_path
         select "frogs", :from => "order_cycle_id"
-        fill_in "search", with: "Badg"
+
+        fill_in "search", with: "Badg"           # For variant with display_name "Badgers"
 
         within('div.pad-top') do
           page.should have_content product.name
           page.should have_content variant2.display_name
+          page.should_not have_content product2.name
+          page.should_not have_content variant3.display_name
         end
 
       end

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -142,7 +142,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
     describe "after selecting an order cycle with products visible" do
       let(:variant1) { create(:variant, product: product, price: 20) }
-      let(:variant2) { create(:variant, product: product, price: 30) }
+      let(:variant2) { create(:variant, product: product, price: 30, display_name: "Badgers") }
       let(:exchange) { Exchange.find(oc1.exchanges.to_enterprises(distributor).outgoing.first.id) }
 
       before do
@@ -171,6 +171,19 @@ feature "As a consumer I want to shop with a distributor", js: true do
         # Product price should be listed as the lesser of these
         page.should have_price "$43.00"
       end
+
+      it "search results return products where the search term matches one of the product's variant names" do
+        visit shop_path
+        select "frogs", :from => "order_cycle_id"
+        fill_in "search", with: "Badg"
+
+        within('div.pad-top') do
+          page.should have_content product.name
+          page.should have_content variant2.display_name
+        end
+
+      end
+
     end
 
     describe "group buy products" do

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -172,7 +172,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
         page.should have_price "$43.00"
       end
 
-      it "search results return products where the search term matches one of the product's variant names" do
+      it "returns search results for products where the search term matches one of the product's variant names" do
         visit shop_path
         select "frogs", :from => "order_cycle_id"
         fill_in "search", with: "Badg"


### PR DESCRIPTION
Product searches in the frontend also index variant names, addressing issue #1232.

Suggestions for a more elegant way of writing this are welcome! 

I couldn't get the product filter to match properties inside nested objects (variants are nested inside each product), so I created a new (temporary) variant_names property on the product objects as the matches are being filtered and passed any additional variant names into a concatenated string so it could be indexed by the filter.