### PR TITLE
Hide forbidden admin menu items (continued)

### DIFF
--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -13,14 +13,14 @@ module Spree
       # Make it so that the Reports admin tab can be enabled/disabled through the cancan
       # :report resource, since it does not have a corresponding resource class (unlike
       # eg. Spree::Product).
-      # def klass_for_with_sym_fallback(name)
-      #   klass = klass_for_without_sym_fallback(name)
-      #   klass ||= name.singularize.to_sym
-      #   klass = :overview if klass == :dashboard
-      #   klass = Spree::Order if klass == :bulk_order_management
-      #   klass
-      # end
-      # alias_method_chain :klass_for, :sym_fallback
+      def klass_for_with_sym_fallback(name)
+        klass = klass_for_without_sym_fallback(name)
+        klass ||= name.singularize.to_sym
+        klass = :overview if klass == :dashboard
+        klass = Spree::Order if klass == :bulk_order_management
+        klass
+      end
+      alias_method_chain :klass_for, :sym_fallback
 
       # TEMP: override method until it is fixed in Spree.
       def tab_with_cancan_check(*args)

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -19,6 +19,7 @@ module Spree
         klass = :overview if klass == :dashboard
         klass = Spree::Order if klass == :bulk_order_management
         klass = EnterpriseGroup if klass == :group
+        klass = VariantOverride if klass == :Inventory
         klass
       end
       alias_method_chain :klass_for, :sym_fallback

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -1,6 +1,15 @@
 module Spree
   module Admin
     module NavigationHelper
+      # TEMP: import method until it is re-introduced into Spree.
+      def klass_for(name)
+        model_name = name.to_s
+
+        ["Spree::#{model_name.classify}", model_name.classify, model_name.gsub('_', '/').classify].find do |t|
+          t.safe_constantize
+        end.try(:safe_constantize)
+      end
+
       # Make it so that the Reports admin tab can be enabled/disabled through the cancan
       # :report resource, since it does not have a corresponding resource class (unlike
       # eg. Spree::Product).
@@ -12,6 +21,17 @@ module Spree
       #   klass
       # end
       # alias_method_chain :klass_for, :sym_fallback
+
+      # TEMP: override method until it is fixed in Spree.
+      def tab_with_cancan_check(*args)
+        options = {:label => args.first.to_s}
+        if args.last.is_a?(Hash)
+          options = options.merge(args.last)
+        end
+        return '' if klass = klass_for(options[:label]) and cannot?(:admin, klass)
+        tab_without_cancan_check(*args)
+      end
+      alias_method_chain :tab, :cancan_check
     end
   end
 end

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -18,6 +18,7 @@ module Spree
         klass ||= name.singularize.to_sym
         klass = :overview if klass == :dashboard
         klass = Spree::Order if klass == :bulk_order_management
+        klass = EnterpriseGroup if klass == :group
         klass
       end
       alias_method_chain :klass_for, :sym_fallback

--- a/spec/features/admin/authentication_spec.rb
+++ b/spec/features/admin/authentication_spec.rb
@@ -18,6 +18,7 @@ feature "Authentication", js: true do
       click_login_button
       expect(page).to have_content "DASHBOARD"
       expect(page).to have_current_path spree.admin_path
+      expect(page).to have_no_content "CONFIGURATION"
     end
   end
 

--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -105,6 +105,17 @@ feature %q{
   end
 
   context "as an enterprise user" do
+    let(:user) { create_enterprise_user }
+    let!(:enterprise) { create(:distributor_enterprise, owner: user) }
+    let!(:group) { create(:enterprise_group, name: 'My Group', owner: user) }
+
+    it "lets me access enterprise groups" do
+      quick_login_as user
+      visit spree.admin_path
+      click_link 'Groups'
+      expect(page).to have_content 'My Group'
+    end
+
     xit "should show me only enterprises I manage when creating a new enterprise group"
   end
 end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -29,7 +29,9 @@ feature %q{
                           permissions_list: [:add_to_order_cycle]) } # This er should not confer ability to create VOs for hub2
 
       it "displays a list of hub choices (ie. only those managed by the user)" do
-        visit '/admin/inventory'
+        visit spree.admin_path
+        click_link 'Products'
+        click_link 'Inventory'
 
         page.should have_select2 'hub_id', options: [hub.name] # Selects the hub automatically when only one is available
       end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -19,6 +19,14 @@ module Spree
         it "returns Spree::Order for bulk_order_management" do
           helper.klass_for('bulk_order_management').should == Spree::Order
         end
+
+        it "returns EnterpriseGroup for group" do
+          helper.klass_for('group').should == EnterpriseGroup
+        end
+
+        it "returns VariantOverride for Inventory" do
+          helper.klass_for('Inventory').should == VariantOverride
+        end
       end
     end
   end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -3,23 +3,23 @@ require 'spec_helper'
 module Spree
   module Admin
     describe NavigationHelper do
-      # describe "klass_for" do
-      #   it "returns the class when present" do
-      #     helper.klass_for('products').should == Spree::Product
-      #   end
+      describe "klass_for" do
+        it "returns the class when present" do
+          helper.klass_for('products').should == Spree::Product
+        end
 
-      #   it "returns a symbol when there's no available class" do
-      #     helper.klass_for('reports').should == :report
-      #   end
+        it "returns a symbol when there's no available class" do
+          helper.klass_for('reports').should == :report
+        end
 
-      #   it "returns :overview for the dashboard" do
-      #     helper.klass_for('dashboard').should == :overview
-      #   end
+        it "returns :overview for the dashboard" do
+          helper.klass_for('dashboard').should == :overview
+        end
 
-      #   it "returns Spree::Order for bulk_order_management" do
-      #     helper.klass_for('bulk_order_management').should == Spree::Order
-      #   end
-      # end
+        it "returns Spree::Order for bulk_order_management" do
+          helper.klass_for('bulk_order_management').should == Spree::Order
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Continued from #1246.

Addressed Sally's feedback:

- Group owner can't see Groups in blue Menu
- No Inventory in green horizontal sub-menu