### PR TITLE
Only build master branch and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 branches:
   only:
   - master
+  - merged-pull/*
 
 # Set the timezone for phantomjs with TZ
 # Set the timezone for karma with TIMEZONE

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ bundler_args: --without development
 rvm:
   - "2.1.5"
 
+branches:
+  only:
+  - master
+
 # Set the timezone for phantomjs with TZ
 # Set the timezone for karma with TIMEZONE
 #


### PR DESCRIPTION
When we push a branch, Travis builds it. Then if we open a pull request for that branch, it builds it again.

Set Travis to build only the master branch and PRs. We should see the master branch build green every time, and a red build is in indication of an intermittent failure.