### PR TITLE
Uk/ wysiwyg line breaks issue

### DIFF
--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -203,6 +203,9 @@ text-angular {
   .ta-scroll-window > .ta-bind {
     max-height: 400px;
     min-height: 100px;
+    p {
+      margin-bottom: 1.5rem;
+    }
   }
   .ta-scroll-window.form-control {
     min-height: 100px;

--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -203,6 +203,7 @@ text-angular {
   .ta-scroll-window > .ta-bind {
     max-height: 400px;
     min-height: 100px;
+    outline: none;
     p {
       margin-bottom: 1.5rem;
     }


### PR DESCRIPTION
Changed the way text displays in the editor on the "About Us" tab in enterprise management to be visually consistent with the spacing of paragraphs on the front-end, to resolve issue #375.

Also solves line break issues with product descriptions in #1020 and any other sections that use the wysiwyg.