### PR TITLE
Make feature toggle apply to mobile menu

### DIFF
--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -40,16 +40,17 @@
         %span.nav-primary
           %i.ofn-i_036-producers
           = t 'label_producers'
-    %li.li-menu
-      %a{href: "https://openfoodnetwork.org/au/connect/"}
-        %span.nav-primary
-          %i.ofn-i_035-groups
-          = t 'label_connect'
-    %li.li-menu
-      %a{href: "https://openfoodnetwork.org/au/learn/"}
-        %span.nav-primary
-          %i.ofn-i_013-help
-          = t 'label_learn'
+    - if feature? :connect_learn_homepage
+      %li.li-menu
+        %a{href: "https://openfoodnetwork.org/au/connect/"}
+          %span.nav-primary
+            %i.ofn-i_035-groups
+            = t 'label_connect'
+      %li.li-menu
+        %a{href: "https://openfoodnetwork.org/au/learn/"}
+          %span.nav-primary
+            %i.ofn-i_013-help
+            = t 'label_learn'
 
     %li
     - if spree_current_user.nil?

--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -51,6 +51,17 @@
           %span.nav-primary
             %i.ofn-i_013-help
             = t 'label_learn'
+    - else
+      %li.li-menu
+        %a{href: main_app.groups_path}
+          %span.nav-primary
+            %i.ofn-i_035-groups
+            = t 'label_groups'
+      %li.li-menu
+        %a{href: ContentConfig.footer_about_url}
+          %span.nav-primary
+            %i.ofn-i_013-help
+            = t 'label_about'
 
     %li
     - if spree_current_user.nil?


### PR DESCRIPTION
Addressing #1254.

Add the missing feature toggle to these menu items. I also discovered that when the feature toggle is disabled, the "Groups" and "About" menu items are displayed on the large menu but not the mobile menu. So I've added them to the mobile menu for symmetry.