### PR TITLE
Checkout layout adjustments for mobile view

### DIFF
--- a/app/views/checkout/_payment.html.haml
+++ b/app/views/checkout/_payment.html.haml
@@ -16,7 +16,7 @@
       -# TODO render this in Angular instead of server-side
       -# The problem being how to render the partials
       .row
-        .small-6.columns
+        .small-12.medium-12.large-6.columns
           - available_payment_methods.each do |method|
             .row
               .small-12.columns
@@ -34,6 +34,6 @@
             .row{"ng-if" => "order.payment_method_id == #{method.id}"}
               .small-12.columns
                 = render partial: "spree/checkout/payment/#{method.method_type}", :locals => { :payment_method => method }
-        .small-12.columns.medium-6.columns.large-6.columns
+        .small-12.medium-12.large-6.columns
           #distributor_address.panel{"ng-show" => "Checkout.paymentMethod().description"}
             %span.pre-wrap {{ Checkout.paymentMethod().description }}

--- a/app/views/checkout/_shipping.html.haml
+++ b/app/views/checkout/_shipping.html.haml
@@ -13,7 +13,7 @@
       "ng-class" => "{valid: shipping.$valid, open: accordion.shipping}"}
       = render 'checkout/accordion_heading'
 
-      .small-12.columns.medium-6.columns.large-6.columns
+      .small-12.columns.medium-12.columns.large-6.columns
         %label{"ng-repeat" => "method in ShippingMethods.shipping_methods"}
           %input{type: :radio,
             required: true,
@@ -38,7 +38,7 @@
             %input{type: :checkbox, "ng-model" => "Checkout.default_ship_address"}
             = t :checkout_default_ship_address
 
-      .small-12.columns.medium-6.columns.large-6.columns
+      .small-12.columns.medium-12.columns.large-6.columns
         #distributor_address.panel{"ng-show" => "Checkout.shippingMethod().description"}
           %span{ style: "white-space: pre-wrap;" }{{ Checkout.shippingMethod().description }}
           %br/


### PR DESCRIPTION
Addressing #1301. Payment options now span the whole width on mobile and tablets instead of half the screen, which caused weird text folding. Also applied the same change to the shipping options as they snap to the same widths in the same way on mobiles.