### PR TITLE
Hubs display as closed when not configured for payment or shipping

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -26,6 +26,8 @@ class BaseController < ApplicationController
     @order_cycles = OrderCycle.with_distributor(@distributor).active
     .order(@distributor.preferred_shopfront_order_cycle_order)
 
+    ensure_shop_ready
+
     applicator = OpenFoodNetwork::TagRuleApplicator.new(@distributor, "FilterOrderCycles", current_customer.andand.tag_list)
     applicator.filter!(@order_cycles)
 
@@ -33,5 +35,10 @@ class BaseController < ApplicationController
     if @order_cycles.count == 1
       current_order(true).set_order_cycle! @order_cycles.first
     end
+  end
+
+  def ensure_shop_ready
+    # Don't display order cycles if shop is not ready for checkout
+    @order_cycles = {} unless @distributor.ready_for_checkout?
   end
 end

--- a/lib/open_food_network/enterprise_injection_data.rb
+++ b/lib/open_food_network/enterprise_injection_data.rb
@@ -1,7 +1,7 @@
 module OpenFoodNetwork
   class EnterpriseInjectionData
     def active_distributors
-      @active_distributors ||= Enterprise.distributors_with_active_order_cycles
+      @active_distributors ||= Enterprise.distributors_with_active_order_cycles.andand.ready_for_checkout
     end
 
     def earliest_closing_times

--- a/spec/controllers/shop_controller_spec.rb
+++ b/spec/controllers/shop_controller_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 describe ShopController do
-  let(:distributor) { create(:distributor_enterprise) }
+  let!(:pm) { create(:payment_method) }
+  let!(:sm) { create(:shipping_method) }
+  let(:distributor) { create(:distributor_enterprise, payment_methods: [pm], shipping_methods: [sm]) }
 
   it "redirects to the home page if no distributor is selected" do
     spree_get :show

--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -6,7 +6,7 @@ describe ShopsController do
   let!(:invisible_distributor) { create(:distributor_enterprise, visible: false) }
 
   before do
-    Enterprise.stub(:distributors_with_active_order_cycles) { [distributor] }
+    Enterprise.stub_chain("distributors_with_active_order_cycles.andand.ready_for_checkout") { [distributor] }
   end
 
   # Exclusion from actual rendered view handled in features/consumer/home

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -201,4 +201,3 @@ feature 'Shops', js: true do
     end
   end
 end
-

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -201,3 +201,4 @@ feature 'Shops', js: true do
     end
   end
 end
+

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -6,8 +6,8 @@ feature 'Shops', js: true do
 
   let!(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:invisible_distributor) { create(:distributor_enterprise, visible: false) }
-  let(:d1) { create(:distributor_enterprise) }
-  let(:d2) { create(:distributor_enterprise) }
+  let!(:d1) { create(:distributor_enterprise, with_payment_and_shipping: true) }
+  let!(:d2) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise)) }
   let!(:producer) { create(:supplier_enterprise) }
   let!(:er) { create(:enterprise_relationship, parent: distributor, child: producer) }
@@ -57,6 +57,20 @@ feature 'Shops', js: true do
     end
   end
 
+  describe "showing available hubs" do
+    let!(:hub) { create(:distributor_enterprise, with_payment_and_shipping: false) }
+    let!(:order_cycle) { create(:simple_order_cycle, distributors: [hub], coordinator: hub) }
+    let!(:producer) { create(:supplier_enterprise) }
+    let!(:er) { create(:enterprise_relationship, parent: hub, child: producer) }
+
+    it "does not show hubs that are not ready for checkout" do
+      visit shops_path
+
+      Enterprise.ready_for_checkout.should_not include hub
+      page.should_not have_content hub.name
+    end
+  end
+
   describe "filtering by product property" do
     let!(:order_cycle) { create(:simple_order_cycle, distributors: [d1, d2], coordinator: create(:distributor_enterprise)) }
     let!(:p1) { create(:simple_product, supplier: producer) }
@@ -92,7 +106,7 @@ feature 'Shops', js: true do
   describe "taxon badges" do
     let!(:closed_oc) { create(:closed_order_cycle, distributors: [shop], variants: [p_closed.variants.first]) }
     let!(:p_closed) { create(:simple_product, taxons: [taxon_closed]) }
-    let(:shop) { create(:distributor_enterprise) }
+    let(:shop) { create(:distributor_enterprise, with_payment_and_shipping: true) }
     let(:taxon_closed) { create(:taxon, name: 'Closed') }
 
     describe "open shops" do


### PR DESCRIPTION
Addressing issue #1343 (and duplicate issue #495 ?)

Hubs now display as closed when browsing shops in the frontend if they are not "ready for checkout", i.e. don't have payment or shipping methods properly configured.

Previously they displayed as open, allowed a user to shop and add things to the basket, but then bounced the user to the homepage with an error message and emptied the cart once the user tried to go to the checkout.

The backend already displays messages to an enterprise user if their enterprise does not have payment or shipping methods properly configured, and correctly warns that customers will not be able to shop at their hub:

![screenshot from 2016-12-20 12-37-17](https://cloud.githubusercontent.com/assets/9029026/21351471/8e88a710-c6b4-11e6-9dba-f9d97916268c.png)

Updated specs to reflect this.
