### PR TITLE
Fix credit card checkout

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -16,7 +16,6 @@ module Spree
         adjustment.save
       else
         payment_method.create_adjustment(adjustment_label, order, self, true)
-        reload
       end
     end
 

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -12,7 +12,8 @@ module Spree
     def adjust_with_included_tax(order)
       adjust_without_included_tax(order)
 
-      order.reload
+      order.adjustments(:reload)
+      order.line_items(:reload)
       (order.adjustments.tax + order.price_adjustments).each do |a|
         a.set_absolute_included_tax! a.amount
       end

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -94,6 +94,7 @@ feature %q{
 
     within (".side_menu") { click_link "Users" }
     select2_search user.email, from: 'Owner'
+    expect(page).to have_no_selector '.select2-drop-mask' # Ensure select2 has finished
 
     click_link "About"
     fill_in 'enterprise_description', :with => 'Connecting farmers and eaters'

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -328,37 +328,41 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
             end
           end
 
-          context "with a credit card payment method" do
-            let!(:pm1) { create(:payment_method, distributors: [distributor], name: "Roger rabbit", type: "Spree::Gateway::Bogus") }
+          describe "credit card payments" do
+            ["Spree::Gateway::Bogus", "Spree::Gateway::BogusSimple"].each do |gateway_type|
+              context "with a credit card payment method using #{gateway_type}" do
+                let!(:pm1) { create(:payment_method, distributors: [distributor], name: "Roger rabbit", type: gateway_type) }
 
-            it "takes us to the order confirmation page when submitted with a valid credit card" do
-              toggle_payment
-              fill_in 'Card Number', with: "4111111111111111"
-              select 'February', from: 'secrets.card_month'
-              select (Date.current.year+1).to_s, from: 'secrets.card_year'
-              fill_in 'Security Code', with: '123'
+                it "takes us to the order confirmation page when submitted with a valid credit card" do
+                  toggle_payment
+                  fill_in 'Card Number', with: "4111111111111111"
+                  select 'February', from: 'secrets.card_month'
+                  select (Date.current.year+1).to_s, from: 'secrets.card_year'
+                  fill_in 'Security Code', with: '123'
 
-              place_order
-              page.should have_content "Your order has been processed successfully"
+                  place_order
+                  page.should have_content "Your order has been processed successfully"
 
-              # Order should have a payment with the correct amount
-              o = Spree::Order.complete.first
-              o.payments.first.amount.should == 11.23
-            end
+                  # Order should have a payment with the correct amount
+                  o = Spree::Order.complete.first
+                  o.payments.first.amount.should == 11.23
+                end
 
-            it "shows the payment processing failed message when submitted with an invalid credit card" do
-              toggle_payment
-              fill_in 'Card Number', with: "9999999988887777"
-              select 'February', from: 'secrets.card_month'
-              select (Date.current.year+1).to_s, from: 'secrets.card_year'
-              fill_in 'Security Code', with: '123'
+                it "shows the payment processing failed message when submitted with an invalid credit card" do
+                  toggle_payment
+                  fill_in 'Card Number', with: "9999999988887777"
+                  select 'February', from: 'secrets.card_month'
+                  select (Date.current.year+1).to_s, from: 'secrets.card_year'
+                  fill_in 'Security Code', with: '123'
 
-              place_order
-              page.should have_content "Payment could not be processed, please check the details you entered"
+                  place_order
+                  page.should have_content "Payment could not be processed, please check the details you entered"
 
-              # Does not show duplicate shipping fee
-              visit checkout_path
-              page.should have_selector "th", text: "Shipping", count: 1
+                  # Does not show duplicate shipping fee
+                  visit checkout_path
+                  page.should have_selector "th", text: "Shipping", count: 1
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
We were seeing a bug where credit card checkouts (eg. with Pin Payments) would fail at checkout. Investigation revealed that the credit card number was being lost before it was sent to the payment gateway.

After wading through the thrice-sludgy swamps of git-bisect, I found two places where we were reloading the `Payment` or `Order`, and since the credit card is an in-memory attribute only, it was being lost.

We weren't picking this up in test because we were testing with `Spree::Gateway::Bogus`, which uses payment profiles by default, and the payment profile was being saved before the credit card number was lost. Using `Spree::Gateway::BogusSimple` exposed the bug.

To solve the problem, I removed one reload outright, and replaced the other with more targeted data refresh. I haven't confirmed that these don't break anything. Please test that payment method fees and taxes are appearing correctly on first page load.