### PR TITLE
Updating order cycle dropdown

### DIFF
--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -74,6 +74,9 @@ form.order_cycle {
       margin-bottom: 0.5em;
     }
   }
+  .icon-question-sign {
+    font-size: 18px;
+  }
   table.exchanges {
     tr td.active {
       width: 20px;

--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -113,6 +113,14 @@ form.order_cycle {
         margin-right: 2em;
       }
     }
+    .collection-details {
+      input {
+        width: 90%
+      }
+      span {
+        font-size: 1rem
+      }
+    }
   }
   .coordinator-fees {
     margin-top: 1em;

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -14,7 +14,7 @@
     %td.tags.panel-toggle.text-center{ name: "tags", ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
       {{ exchange.tags.length }}
     %td.collection-details
-      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'placeholder' => 'Ready for (ie. Date / Time)', 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
+      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'placeholder' => 'Ready for (ie. Date / Time)', 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
       %span.icon-question-sign{'ofn-with-tip' => "#{t('admin.order_cycles.edit.pickup_time_tip')}"}
       %br/
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => 'Pick-up instructions', 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -15,8 +15,10 @@
       {{ exchange.tags.length }}
     %td.collection-details
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'placeholder' => 'Ready for (ie. Date / Time)', 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
+      %span.icon-question-sign{'ofn-with-tip' => "#{t('admin.order_cycles.edit.pickup_time_tip')}"}
       %br/
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => 'Pick-up instructions', 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
+      %span.icon-question-sign{'ofn-with-tip' => "#{t('admin.order_cycles.edit.pickup_instructions_tip')}"}
   %td.fees
     %ol{ ng: { show: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
       %li{'ng-repeat' => 'enterprise_fee in exchange.enterprise_fees'}

--- a/app/views/admin/order_cycles/_simple_form.html.haml
+++ b/app/views/admin/order_cycles/_simple_form.html.haml
@@ -4,11 +4,13 @@
   .alpha.two.columns
     = label_tag t('.ready_for')
   .six.columns
-    = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_time', 'placeholder' => t('.ready_for_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_time', 'size' => 30
+    = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_time', 'placeholder' => t('.ready_for_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_time', 'size' => 30, 'maxlength' => 35
+    %span.icon-question-sign{'ofn-with-tip' => "#{t('admin.order_cycles.edit.pickup_time_tip')}"}
   .two.columns
     = label_tag t('.customer_instructions')
   .six.columns.omega
     = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_instructions', 'placeholder' => t('.customer_instructions_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_instructions', 'size' => 30
+    %span.icon-question-sign{'ofn-with-tip' => "#{t('admin.order_cycles.edit.pickup_instructions_tip')}"}
 
 = label_tag t('.products')
 %table.exchanges

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -154,9 +154,9 @@ en-GB:
         variants_without_unit_value: "WARNING: Some variants do not have a unit value"
     order_cycles:
       edit:
-        choose_products_from: "Choose Products From:"
-        pickup_time_tip: 'Display name for order cycle delivery, e.g "Monday"'
-        pickup_instructions_tip: 'Additional notes for this selection'
+        choose_products_from: 'Choose Products From:'
+        pickup_time_tip: When orders from this OC will be ready for the customer
+        pickup_instructions_tip: These instructions are shown to customers after they complete an order
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from
     enterprises:

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -155,6 +155,8 @@ en-GB:
     order_cycles:
       edit:
         choose_products_from: "Choose Products From:"
+        pickup_time_tip: 'Display name for order cycle delivery, e.g "Monday"'
+        pickup_instructions_tip: 'Additional notes for this selection'
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from
     enterprises:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,6 +222,9 @@ en:
     order_cycles:
       edit:
         choose_products_from: "Choose Products From:"
+        pickup_time_tip: 'Display name for order cycle delivery, e.g "Monday"'
+        pickup_instructions_tip: 'Additional notes for this selection'
+
 
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,13 +219,6 @@ en:
         order_error: "Some errors must be resolved before you can update orders.\nAny fields with red borders contain errors."
         variants_without_unit_value: "WARNING: Some variants do not have a unit value"
 
-    order_cycles:
-      edit:
-        choose_products_from: "Choose Products From:"
-        pickup_time_tip: 'Display name for order cycle delivery, e.g "Monday"'
-        pickup_instructions_tip: 'Additional notes for this selection'
-
-
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from
 
@@ -411,6 +404,14 @@ en:
         next_step: Next step
         choose_starting_point: 'Choose your starting point:'
     order_cycles:
+      test:
+        test: testing
+      edit:
+        advanced_settings: Advanced Settings
+        update_and_close: Update and Close
+        choose_products_from: 'Choose Products From:'
+        pickup_time_tip: When orders from this OC will be ready for the customer
+        pickup_instructions_tip: These instructions are shown to customers after they complete an order
       advanced_settings:
         title: Advanced Settings
         choose_product_tip: You can opt to restrict all available products (both incoming and outgoing), to only those in {{inventory}}'s inventory.
@@ -429,7 +430,7 @@ en:
         distributor: Distributor
         products: Products
         tags: Tags
-        delivery_detaisl: Pickup / Delivery details
+        delivery_details: Pickup / Delivery details
         debug_info: Debug information
       name_and_timing_form:
         name: Name
@@ -447,9 +448,6 @@ en:
         customer_instructions_placeholder: Pick-up or delivery notes
         products: Products
         fees: Fees
-      edit:
-        advanced_settings: Advanced Settings
-        update_and_close: Update and Close
     producer_properties:
       form:
         property: Property


### PR DESCRIPTION
Addressing #1294.

- Set max length on field for order cycle name to 35 characters
- Implemented displaying of additional notes field in frontend
- Added tooltips in backend