### PR TITLE
Set default currency for tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,9 @@ Openfoodnetwork::Application.configure do
   # Tests assume English text on the site.
   config.i18n.default_locale = "en"
 
+  # Tests assume Aus timezone.
+  config.time_zone = "Australia/Melbourne"
+
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types
@@ -53,3 +56,7 @@ end
 
 # Allows us to use _url helpers in Rspec
 Rails.application.routes.default_url_options[:host] = 'test.host'
+# Set the timezone for phantomjs with TZ
+ENV['TZ'] = Rails.application.config.time_zone
+# Set the timezone for karma with TIMEZONE
+ENV['TIMEZONE'] = Rails.application.config.time_zone

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,9 @@ RSpec.configure do |config|
   # Ensure we start with consistent config settings
   config.before(:each) { Spree::Config.products_require_tax_category = false }
 
+  # Tests assume AUD is the default currency.
+  config.before(:each) {Spree::Config.currency = "AUD" }
+
   # Helpers
   config.include Rails.application.routes.url_helpers
   config.include Spree::UrlHelpers


### PR DESCRIPTION
Addressing #1346.

Set default currency in testing environment to be AUD, because the tests are littered with hard-coded values like "$10.32".