### PR TITLE
Require OC name, added validation on OC savebar

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
@@ -12,7 +12,7 @@ angular.module('admin.orderCycles')
     $scope.StatusMessage = StatusMessage
 
     $scope.$watch 'order_cycle_form.$dirty', (newValue) ->
-      StatusMessage.display 'notice', 'You have unsaved changes' if newValue
+      StatusMessage.display 'notice', t("admin.unsaved_changes") if newValue
 
     $scope.loaded = ->
       Enterprise.loaded && EnterpriseFee.loaded && OrderCycle.loaded

--- a/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
@@ -14,6 +14,9 @@ angular.module('admin.orderCycles')
     $scope.$watch 'order_cycle_form.$dirty', (newValue) ->
       StatusMessage.display 'notice', t("admin.unsaved_changes") if newValue
 
+    $scope.$watch 'order_cycle_form.$valid', (isValid) ->
+      StatusMessage.setValidation(isValid)
+
     $scope.loaded = ->
       Enterprise.loaded && EnterpriseFee.loaded && OrderCycle.loaded
 

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -13,7 +13,10 @@ angular.module('admin.orderCycles')
     $scope.StatusMessage = StatusMessage
 
     $scope.$watch 'order_cycle_form.$dirty', (newValue) ->
-      StatusMessage.display 'notice', 'You have unsaved changes' if newValue
+      StatusMessage.display 'notice', t("admin.unsaved_changes") if newValue
+
+    $scope.$watch 'order_cycle_form.$valid', (isValid) ->
+      StatusMessage.setValidation(isValid)
 
     $scope.loaded = ->
       Enterprise.loaded && EnterpriseFee.loaded && OrderCycle.loaded

--- a/app/assets/javascripts/admin/order_cycles/controllers/simple_create.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/simple_create.js.coffee
@@ -8,7 +8,10 @@ angular.module('admin.orderCycles').controller "AdminSimpleCreateOrderCycleCtrl"
     $scope.enterprise_fees = EnterpriseFee.index(coordinator_id: ocInstance.coordinator_id)
 
   $scope.$watch 'order_cycle_form.$dirty', (newValue) ->
-      StatusMessage.display 'notice', 'You have unsaved changes' if newValue
+      StatusMessage.display 'notice', t("admin.unsaved_changes") if newValue
+
+  $scope.$watch 'order_cycle_form.$valid', (isValid) ->
+    StatusMessage.setValidation(isValid)
 
   $scope.init = (enterprises) ->
     enterprise = enterprises[Object.keys(enterprises)[0]]

--- a/app/assets/javascripts/admin/order_cycles/controllers/simple_edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/simple_edit.js.coffee
@@ -10,7 +10,10 @@ angular.module('admin.orderCycles').controller "AdminSimpleEditOrderCycleCtrl", 
     $scope.init()
 
   $scope.$watch 'order_cycle_form.$dirty', (newValue) ->
-      StatusMessage.display 'notice', 'You have unsaved changes' if newValue
+      StatusMessage.display 'notice', t("admin.unsaved_changes") if newValue
+
+  $scope.$watch 'order_cycle_form.$valid', (isValid) ->
+    StatusMessage.setValidation(isValid)
 
   $scope.loaded = ->
     Enterprise.loaded && EnterpriseFee.loaded && OrderCycle.loaded

--- a/app/assets/javascripts/admin/utils/services/status_message.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/status_message.js.coffee
@@ -11,6 +11,14 @@ angular.module("admin.utils").factory "StatusMessage", ($timeout) ->
       text: ""
       style: {}
 
+    invalidMessage: ""
+
+    setValidation: (isValid) ->
+      if isValid
+        StatusMessage.invalidMessage = ''
+      else
+        StatusMessage.invalidMessage = t("admin.form_invalid")
+
     active: ->
       @statusMessage.text != ''
 

--- a/app/assets/javascripts/templates/admin/save_bar.html.haml
+++ b/app/assets/javascripts/templates/admin/save_bar.html.haml
@@ -1,6 +1,9 @@
 #save-bar.animate-show{ ng: { show: 'dirty || persist || StatusMessage.active()' } }
   .container
     .eight.columns.alpha
-      %h5#status-message{ ng: { style: 'StatusMessage.statusMessage.style' } }
+      %h5#status-message{ ng: { show: "StatusMessage.invalidMessage == ''", style: 'StatusMessage.statusMessage.style' } }
         {{ StatusMessage.statusMessage.text || "&nbsp;" }}
+      %h5#status-message{ ng: { show: "StatusMessage.invalidMessage !== ''" }, style: 'color: #da5354' }
+        {{ StatusMessage.invalidMessage || "&nbsp;" }}
     .eight.columns.omega.text-right{ ng: { transclude: true } }
+

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -14,7 +14,7 @@
     %td.tags.panel-toggle.text-center{ name: "tags", ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
       {{ exchange.tags.length }}
     %td.collection-details
-      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'placeholder' => 'Ready for (ie. Date / Time)', 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
+      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => 'Ready for (ie. Date / Time)', 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
       %br/
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => 'Pick-up instructions', 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
   %td.fees

--- a/app/views/admin/order_cycles/_simple_form.html.haml
+++ b/app/views/admin/order_cycles/_simple_form.html.haml
@@ -4,7 +4,7 @@
   .alpha.two.columns
     = label_tag t('.ready_for')
   .six.columns
-    = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_time', 'placeholder' => t('.ready_for_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_time', 'size' => 30
+    = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_time', 'required' => 'required', 'placeholder' => t('.ready_for_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_time', 'size' => 30
   .two.columns
     = label_tag t('.customer_instructions')
   .six.columns.omega

--- a/app/views/admin/order_cycles/edit.html.haml
+++ b/app/views/admin/order_cycles/edit.html.haml
@@ -28,8 +28,8 @@
 = form_for [main_app, :admin, @order_cycle], :url => '', :html => {:class => 'ng order_cycle', 'ng-app' => 'admin.orderCycles', 'ng-controller' => ng_controller, name: 'order_cycle_form'} do |f|
 
   %save-bar{ dirty: "order_cycle_form.$dirty", persist: "true" }
-    %input.red{ type: "button", value: t(:update), ng: { click: "submit($event, null)", disabled: "!order_cycle_form.$dirty" } }
-    %input.red{ type: "button", value: t('.update_and_close'), ng: { click: "submit($event, '#{main_app.admin_order_cycles_path}')", disabled: "!order_cycle_form.$dirty" } }
+    %input.red{ type: "button", value: t(:update), ng: { click: "submit($event, null)", disabled: "!order_cycle_form.$dirty || order_cycle_form.$invalid" } }
+    %input.red{ type: "button", value: t('.update_and_close'), ng: { click: "submit($event, '#{main_app.admin_order_cycles_path}')", disabled: "!order_cycle_form.$dirty || order_cycle_form.$invalid" } }
     %input{ type: "button", ng: { value: "order_cycle_form.$dirty ? 'Cancel' : 'Close'", click: "cancel('#{main_app.admin_order_cycles_path}')" } }
 
   - if order_cycles_simple_form

--- a/app/views/admin/order_cycles/new.html.haml
+++ b/app/views/admin/order_cycles/new.html.haml
@@ -7,7 +7,7 @@
 = form_for [main_app, :admin, @order_cycle], :url => '', :html => {:class => 'ng order_cycle', 'ng-app' => 'admin.orderCycles', 'ng-controller' => ng_controller, name: 'order_cycle_form'} do |f|
 
   %save-bar{ dirty: "order_cycle_form.$dirty", persist: "true" }
-    %input.red{ type: "button", value: t(:create), ng: { click: "submit($event, '#{main_app.admin_order_cycles_path}')", disabled: "!order_cycle_form.$dirty" } }
+    %input.red{ type: "button", value: t(:create), ng: { click: "submit($event, '#{main_app.admin_order_cycles_path}')", disabled: "!order_cycle_form.$dirty || order_cycle_form.$invalid" } }
     %input{ type: "button", ng: { value: "order_cycle_form.$dirty ? 'Cancel' : 'Close'", click: "cancel('#{main_app.admin_order_cycles_path}')" } }
 
   - if order_cycles_simple_form

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -74,6 +74,8 @@ en-GB:
     clear_all: Clear All
     start_date: "Start Date"
     end_date: "End Date"
+    unsaved_changes: "You have unsaved changes"
+    form_invalid: "Form contains missing or invalid fields"
     columns: Columns
     actions: Actions
     viewing: "Viewing: %{current_view_name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,8 @@ en:
     clear_all: Clear All
     start_date: "Start Date"
     end_date: "End Date"
+    unsaved_changes: "You have unsaved changes"
+    form_invalid: "Form contains missing or invalid fields"
 
     columns: Columns
     actions: Actions

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -350,6 +350,8 @@ feature %q{
     fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'New instructions 0'
     fill_in 'order_cycle_outgoing_exchange_1_pickup_time', with: 'New time 1'
     fill_in 'order_cycle_outgoing_exchange_1_pickup_instructions', with: 'New instructions 1'
+    fill_in 'order_cycle_outgoing_exchange_2_pickup_time', with: 'New time 2'
+    fill_in 'order_cycle_outgoing_exchange_2_pickup_instructions', with: 'New instructions 2'
 
     page.find("table.exchanges tr.distributor-#{distributor.id} td.tags").click
     within ".exchange-tags" do
@@ -615,6 +617,11 @@ feature %q{
         click_button 'Add distributor'
         select 'Permitted distributor', from: 'new_distributor_id'
         click_button 'Add distributor'
+
+        fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
+        fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
+        fill_in 'order_cycle_outgoing_exchange_1_pickup_time', with: 'pickup time 2'
+        fill_in 'order_cycle_outgoing_exchange_1_pickup_instructions', with: 'pickup instructions'
 
         # Should only have suppliers / distributors listed which the user is managing or
         # has E2E permission to add products to order cycles


### PR DESCRIPTION
Addressing #1344.

- Made order cycle display name a required field
- Created a reusable implementation for form validation when using the savebar that doesn't allow saving when the form is invalid, and displays a message
- Added some missing translation keys

![screenshot from 2017-01-04 00-47-06](https://cloud.githubusercontent.com/assets/9029026/21628462/9ae05fbc-d217-11e6-8795-b0b98188c18f.png)
