### PR TITLE
issue #1200. Email addresses going onto two lines on contact modal.

### DIFF
--- a/app/assets/javascripts/templates/partials/contact.html.haml
+++ b/app/assets/javascripts/templates/partials/contact.html.haml
@@ -9,5 +9,3 @@
 
     %p{"ng-if" => "enterprise.website"}
       %a{"ng-href" => "http://{{::enterprise.website | stripUrl}}", target: "_blank", "ng-bind" => "::enterprise.website | stripUrl"}
-      
-      

--- a/app/assets/javascripts/templates/partials/contact.html.haml
+++ b/app/assets/javascripts/templates/partials/contact.html.haml
@@ -9,3 +9,5 @@
 
     %p{"ng-if" => "enterprise.website"}
       %a{"ng-href" => "http://{{::enterprise.website | stripUrl}}", target: "_blank", "ng-bind" => "::enterprise.website | stripUrl"}
+      
+      

--- a/app/assets/javascripts/templates/partials/contact.html.haml
+++ b/app/assets/javascripts/templates/partials/contact.html.haml
@@ -3,9 +3,9 @@
     %p.modal-header {{'contact' | t}}
     %p{"ng-if" => "::enterprise.phone", "ng-bind" => "::enterprise.phone"}
 
-    %p.word-wrap{"ng-if" => "::enterprise.email_address"}
+    %p{"ng-if" => "::enterprise.email_address"}
       %a{"ng-href" => "{{::enterprise.email_address | stripUrl}}", target: "_blank", mailto: true}
         %span.email{"ng-bind" => "::enterprise.email_address | stripUrl"}
 
-    %p.word-wrap{"ng-if" => "enterprise.website"}
+    %p{"ng-if" => "enterprise.website"}
       %a{"ng-href" => "http://{{::enterprise.website | stripUrl}}", target: "_blank", "ng-bind" => "::enterprise.website | stripUrl"}


### PR DESCRIPTION
Remove word-wrap class from enterprise.email_address and enterprise.w…ebsite in javascripts/templates/partials/contact.html.haml.