### PR TITLE
Fix credit card checkout

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -16,7 +16,6 @@ module Spree
         adjustment.save
       else
         payment_method.create_adjustment(adjustment_label, order, self, true)
-        reload
       end
     end
 

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -16,6 +16,7 @@ module Spree
         adjustment.save
       else
         payment_method.create_adjustment(adjustment_label, order, self, true)
+        association(:adjustment).reload
       end
     end
 

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -12,7 +12,8 @@ module Spree
     def adjust_with_included_tax(order)
       adjust_without_included_tax(order)
 
-      order.reload
+      order.adjustments(:reload)
+      order.line_items(:reload)
       (order.adjustments.tax + order.price_adjustments).each do |a|
         a.set_absolute_included_tax! a.amount
       end

--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -4,30 +4,30 @@
       %legend
         = t :checkout_your_order
       %table
-        %tr
+        %tr.subtotal
           %th
             = t :checkout_cart_total
           %td.cart-total.text-right= display_checkout_subtotal(@order)
 
         - checkout_adjustments_for(current_order, exclude: [:shipping, :payment, :line_item]).reject{ |a| a.amount == 0 }.each do |adjustment|
-          %tr
+          %tr.adjustment
             %th= adjustment.label
             %td.text-right= adjustment.display_amount.to_html
 
-        %tr
+        %tr.shipping
           %th
             = t :checkout_shipping_price
-          %td.shipping.text-right {{ Checkout.shippingPrice() | localizeCurrency }}
+          %td.text-right {{ Checkout.shippingPrice() | localizeCurrency }}
 
-        %tr
+        %tr.transaction-fee
           %th
             = t :payment_method_fee
           %td.text-right {{ Checkout.paymentPrice() | localizeCurrency }}
 
-        %tr
+        %tr.total
           %th
             = t :checkout_total_price
-          %td.total.text-right {{ Checkout.cartTotal() | localizeCurrency }}
+          %td.text-right {{ Checkout.cartTotal() | localizeCurrency }}
 
       //= f.submit "Purchase", class: "button", "ofn-focus" => "accordion['payment']"
       %a.button.secondary{href: cart_url}

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -94,6 +94,7 @@ feature %q{
 
     within (".side_menu") { click_link "Users" }
     select2_search user.email, from: 'Owner'
+    expect(page).to have_no_selector '.select2-drop-mask' # Ensure select2 has finished
 
     click_link "About"
     fill_in 'enterprise_description', :with => 'Connecting farmers and eaters'

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -328,37 +328,41 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
             end
           end
 
-          context "with a credit card payment method" do
-            let!(:pm1) { create(:payment_method, distributors: [distributor], name: "Roger rabbit", type: "Spree::Gateway::Bogus") }
+          describe "credit card payments" do
+            ["Spree::Gateway::Bogus", "Spree::Gateway::BogusSimple"].each do |gateway_type|
+              context "with a credit card payment method using #{gateway_type}" do
+                let!(:pm1) { create(:payment_method, distributors: [distributor], name: "Roger rabbit", type: gateway_type) }
 
-            it "takes us to the order confirmation page when submitted with a valid credit card" do
-              toggle_payment
-              fill_in 'Card Number', with: "4111111111111111"
-              select 'February', from: 'secrets.card_month'
-              select (Date.current.year+1).to_s, from: 'secrets.card_year'
-              fill_in 'Security Code', with: '123'
+                it "takes us to the order confirmation page when submitted with a valid credit card" do
+                  toggle_payment
+                  fill_in 'Card Number', with: "4111111111111111"
+                  select 'February', from: 'secrets.card_month'
+                  select (Date.current.year+1).to_s, from: 'secrets.card_year'
+                  fill_in 'Security Code', with: '123'
 
-              place_order
-              page.should have_content "Your order has been processed successfully"
+                  place_order
+                  page.should have_content "Your order has been processed successfully"
 
-              # Order should have a payment with the correct amount
-              o = Spree::Order.complete.first
-              o.payments.first.amount.should == 11.23
-            end
+                  # Order should have a payment with the correct amount
+                  o = Spree::Order.complete.first
+                  o.payments.first.amount.should == 11.23
+                end
 
-            it "shows the payment processing failed message when submitted with an invalid credit card" do
-              toggle_payment
-              fill_in 'Card Number', with: "9999999988887777"
-              select 'February', from: 'secrets.card_month'
-              select (Date.current.year+1).to_s, from: 'secrets.card_year'
-              fill_in 'Security Code', with: '123'
+                it "shows the payment processing failed message when submitted with an invalid credit card" do
+                  toggle_payment
+                  fill_in 'Card Number', with: "9999999988887777"
+                  select 'February', from: 'secrets.card_month'
+                  select (Date.current.year+1).to_s, from: 'secrets.card_year'
+                  fill_in 'Security Code', with: '123'
 
-              place_order
-              page.should have_content "Payment could not be processed, please check the details you entered"
+                  place_order
+                  page.should have_content "Payment could not be processed, please check the details you entered"
 
-              # Does not show duplicate shipping fee
-              visit checkout_path
-              page.should have_selector "th", text: "Shipping", count: 1
+                  # Does not show duplicate shipping fee
+                  visit checkout_path
+                  page.should have_selector "th", text: "Shipping", count: 1
+                end
+              end
             end
           end
         end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-
 feature "As a consumer I want to check out my cart", js: true, retry: 3 do
   include AuthenticationWorkflow
   include ShopWorkflow
@@ -31,7 +30,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
     let(:sm2) { create(:shipping_method, require_ship_address: false, name: "Donkeys", description: "blue", calculator: Spree::Calculator::FlatRate.new(preferred_amount: 4.56)) }
     let(:sm3) { create(:shipping_method, require_ship_address: false, name: "Local", tag_list: "local") }
     let!(:pm1) { create(:payment_method, distributors: [distributor], name: "Roger rabbit", type: "Spree::PaymentMethod::Check") }
-    let!(:pm2) { create(:payment_method, distributors: [distributor]) }
+    let!(:pm2) { create(:payment_method, distributors: [distributor], calculator: Spree::Calculator::FlatRate.new(preferred_amount: 5.67)) }
     let!(:pm3) do
       Spree::Gateway::PayPalExpress.create!(name: "Paypal", environment: 'test', distributor_ids: [distributor.id]).tap do |pm|
         pm.preferred_login = 'devnull-facilitator_api1.rohanmitchell.com'
@@ -39,6 +38,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         pm.preferred_signature = 'AFcWxV21C7fd0v3bYYYRCpSSRl31AaTntNJ-AjvUJkWf4dgJIvcLsf1V'
       end
     end
+
 
     before do
       distributor.shipping_methods << sm1
@@ -325,6 +325,28 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
               o = Spree::Order.complete.first
               o.adjustments.shipping.first.amount.should == 4.56
               o.payments.first.amount.should == 10 + 1.23 + 4.56 # items + fees + shipping
+            end
+          end
+
+          context "when we are charged a payment method fee (transaction fee)" do
+            it "creates a payment including the transaction fee" do
+              # Selecting the transaction fee, it is displayed
+              expect(page).to have_selector ".transaction-fee td", text: "$0.00"
+              expect(page).to have_selector ".total", text: "$11.23"
+
+              toggle_payment
+              choose "#{pm2.name} ($5.67)"
+
+              expect(page).to have_selector ".transaction-fee td", text: "$5.67"
+              expect(page).to have_selector ".total", text: "$16.90"
+
+              place_order
+              expect(page).to have_content "Your order has been processed successfully"
+
+              # There are two orders - our order and our new cart
+              o = Spree::Order.complete.first
+              expect(o.adjustments.payment_fee.first.amount).to eq 5.67
+              expect(o.payments.first.amount).to eq(10 + 1.23 + 5.67) # items + fees + transaction
             end
           end
 


### PR DESCRIPTION
Continued from #1352:

We were seeing a bug where credit card checkouts (eg. with Pin Payments) would fail at checkout. Investigation revealed that the credit card number was being lost before it was sent to the payment gateway.

After wading through the thrice-sludgy swamps of git-bisect, I found two places where we were reloading the `Payment` or `Order`, and since the credit card is an in-memory attribute only, it was being lost.

We weren't picking this up in test because we were testing with `Spree::Gateway::Bogus`, which uses payment profiles by default, and the payment profile was being saved before the credit card number was lost. Using `Spree::Gateway::BogusSimple` exposed the bug.

To solve the problem, I removed one reload outright, and replaced the other with more targeted data refresh. I haven't confirmed that these don't break anything. Please test that payment method fees and taxes are appearing correctly on first page load.