### PR TITLE
Fix translation of email confirmation notice

### DIFF
--- a/app/views/admin/enterprises/form/_users.html.haml
+++ b/app/views/admin/enterprises/form/_users.html.haml
@@ -4,8 +4,7 @@
 -if @enterprise.pending_any_confirmation?
   .alert-box
     - email = @enterprise.confirmed? ? @enterprise.unconfirmed_email : @enterprise.email
-    = t('.email_confirmation_text')
-    %strong= "#{email}."
+    = t('.email_confirmation_notice_html', {email: "<strong>#{email}</strong>".html_safe})
     = link_to(t('.resend'), main_app.enterprise_confirmation_path(enterprise: { id: @enterprise.id, email: email } ), method: :post)
     %a.close{ href: "#" } ×
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,7 +342,7 @@ en:
           add_new_rule: '+ Add A New Rule'
           add_new_tag: '+ Add A New Tag'
         users:
-          email_confirmation_text: Email confirmation is pending.<br />We've sent a confirmation email to
+          email_confirmation_notice_html: "Email confirmation is pending. We've sent a confirmation email to %{email}."
           resend: Resend
           owner: 'Owner'
           owner_tip: The primary user responsible for this enterprise.


### PR DESCRIPTION
The `_html` suffix was missing leading to `<br />` being displayed in
plain text. The new version also integrates the email address as a
variable in the translation.

Follow-up fix of #1338.