### PR TITLE
Ensure on_demand set properly on new products

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -237,6 +237,7 @@ Spree::Product.class_eval do
       variant = self.master.dup
       variant.product = self
       variant.is_master = false
+      variant.on_demand = self.on_demand
       self.variants << variant
     end
   end

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -59,6 +59,33 @@ feature %q{
       product.master.options_text.should == "5kg"
     end
 
+    scenario "creating an on-demand product", js: true do
+      login_to_admin_section
+
+      click_link 'Products'
+      click_link 'New Product'
+
+      fill_in 'product_name', with: 'Hot Cakes'
+      select 'New supplier', from: 'product_supplier_id'
+      select "Weight (kg)", from: 'product_variant_unit_with_scale'
+      fill_in 'product_unit_value_with_description', with: 1
+      select taxon.name, from: "product_primary_taxon_id"
+      fill_in 'product_price', with: '1.99'
+      fill_in 'product_on_hand', with: 0
+      check 'product_on_demand'
+      select 'Test Tax Category', from: 'product_tax_category_id'
+      select 'Test Shipping Category', from: 'product_shipping_category_id'
+      fill_in 'product_description', with: "In demand, and on_demand! The hottest cakes in town."
+
+      click_button 'Create'
+
+      expect(current_path).to eq spree.bulk_edit_admin_products_path
+      product = Spree::Product.find_by_name('Hot Cakes')
+      product.variants.count.should == 1
+      variant = product.variants.first
+      variant.on_demand.should be_true
+    end
+
     scenario "making a product into a group buy product" do
       product = create(:simple_product, name: 'group buy product')
 


### PR DESCRIPTION
Addressing #1420. 

When adding a new product, the product will now correctly be set to `on_demand` if the `on_demand` checkbox was checked.