### PR TITLE
Uk/registration state display fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,9 +732,3 @@ DEPENDENCIES
   whenever
   wicked_pdf
   wkhtmltopdf-binary
-
-RUBY VERSION
-   ruby 2.1.5p273
-
-BUNDLED WITH
-   1.13.6

--- a/app/assets/javascripts/templates/registration/details.html.haml
+++ b/app/assets/javascripts/templates/registration/details.html.haml
@@ -44,13 +44,13 @@
               %span.error{ ng: { show: "details.zipcode.$error.required && submitted" } }
                 {{'registration_detail_postcode_error' | t}}
         .row
-          .small-12.medium-4.large-4.columns
+          .small-12.medium-6.large-6.columns
             .field
               %label{ for: 'enterprise_state' } {{'registration_detail_state' | t}}
-              %select.chunky{ id: 'enterprise_state', name: 'state', ng: { model: 'enterprise.address.state_id', options: 's.id as s.abbr for s in enterprise.country.states', show: 'countryHasStates()', required: 'countryHasStates()' } }
+              %select.chunky{ id: 'enterprise_state', name: 'state', ng: { model: 'enterprise.address.state_id', options: 's.id as s.label for s in enterprise.country.states', show: 'countryHasStates()', required: 'countryHasStates()' } }
               %span.error{ ng: { show: "details.state.$error.required && submitted" } }
                 {{'registration_detail_state_error' | t}}
-          .small-12.medium-8.large-8.columns
+          .small-12.medium-6.large-6.columns
             .field
               %label{ for: 'enterprise_country' } {{'registration_detail_country' | t}}
               %select.chunky{ id: 'enterprise_country', name: 'country', required: true, ng: { model: 'enterprise.country', options: 'c as c.name for c in countries' } }

--- a/app/controllers/spree/admin/states_controller_decorator.rb
+++ b/app/controllers/spree/admin/states_controller_decorator.rb
@@ -1,0 +1,12 @@
+Spree::Admin::StatesController.class_eval do
+
+  def index
+    respond_with(@collection) do |format|
+      format.html
+      format.js { render :partial => 'state_list' }
+
+    Spree::Config.set(params[:state_display])
+    end
+  end
+
+end

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -28,4 +28,7 @@ Spree::AppConfiguration.class_eval do
 
   # External services
   preference :bugherd_api_key, :string, default: nil
+
+  # State display
+  preference :state_display, :string, default: "abbr"
 end

--- a/app/overrides/spree/admin/general_settings/edit/add_display_preference_to_state.rb
+++ b/app/overrides/spree/admin/general_settings/edit/add_display_preference_to_state.rb
@@ -1,0 +1,4 @@
+  Deface::Override.new(:virtual_path => "spree/admin/general_settings/edit",
+					 :name => "add_display_preferece_to_state",
+					 :insert_before => "[data-hook='buttons']",
+					 :partial => 'spree/admin/general_settings/state_display_preference_form')

--- a/app/serializers/api/state_serializer.rb
+++ b/app/serializers/api/state_serializer.rb
@@ -1,7 +1,12 @@
 class Api::StateSerializer < ActiveModel::Serializer
-  attributes :id, :name, :abbr
+  attributes :id, :name, :abbr, :label
 
   def abbr
     object.abbr.upcase
   end
+
+  def label	
+    eval Spree::Config[:state_display]
+  end
+
 end

--- a/app/views/spree/admin/general_settings/_state_display_preference_form.html.haml
+++ b/app/views/spree/admin/general_settings/_state_display_preference_form.html.haml
@@ -1,0 +1,11 @@
+.row
+  .alpha.six.columns
+    %fieldset.security.no-border-bottom
+      %legend{:align => "center"}
+        = t(:state_settings)
+      .field
+        = label_tag :state, t(:state_display_preference)             
+        = form_tag do
+          .select2-container.fullwidth
+            = select_tag(:state_display, options_for_select(Spree::State.accessible_attributes.to_a, "abbr"))
+

--- a/spec/features/admin/state_settings_spec.rb
+++ b/spec/features/admin/state_settings_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+feature %q{
+    As an administrator
+    I want to change the way states are displayed to users
+} do
+  include AuthenticationWorkflow
+  include WebHelper
+
+	describe "state settings" do
+		scenario "changing the state display preference settings to name" do
+			login_to_admin_section
+    		visit spree.edit_admin_general_settings_path
+    		select("name", :from => 'state_display')
+    		click_button "Update"
+			page.should have_content "General Settings has been successfully updated!"
+
+            Spree::Config[:state_display].should == "name"
+
+		end
+
+		scenario "changing the state display preference settings to abbr" do
+			login_to_admin_section
+    		visit spree.edit_admin_general_settings_path
+    		select("abbr", :from => 'state_display')
+    		click_button "Update"
+            page.should have_content "General Settings has been successfully updated!"
+
+            Spree::Config[:state_display].should == "abbr"
+
+		end
+	end
+end

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -36,7 +36,6 @@ feature "Registration", js: true do
       select 'VIC', from: 'enterprise_state'
       click_and_ensure(:button, "Continue", lambda { page.has_content? 'Who is responsible for managing My Awesome Enterprise?' })
 
-
       # Filling in Contact Details
       fill_in 'enterprise_contact', with: 'Saskia Munroe'
       page.should have_field 'enterprise_email_address', with: user.email
@@ -53,7 +52,7 @@ feature "Registration", js: true do
       expect(e.sells).to eq "unspecified"
       expect(e.is_primary_producer).to eq true
       expect(e.contact).to eq "Saskia Munroe"
-
+      
       # Filling in about
       fill_in 'enterprise_description', with: 'Short description'
       fill_in 'enterprise_long_desc', with: 'Long description'


### PR DESCRIPTION
Hi @lin-d-hop, @Matt-Yorkley and @mkllnk,

New pull request for issue #1186 replacing pull request #1242 

- Moved this over to a new branch called Uk/registration state display fix so that an automatic build is created on buildkite. 

- Removed unused modification to config/locales/en.yml. This: "registration_detail_state_label: "abbr"".

- Removed unintended alteration to Gemfile.lock.

@mkllnk I've rebased this branch against master but I can't work out how to squash my commits into one coherent commit message (i'm guessing that's the rationale behind squashing commits). I had hoped this would happen as a result of rebasing but clearly there's something else that I need to do. Could you point me in the right direction?

Was there anything else that needs working on for this issue?

Thanks,