### PR TITLE
Uk/1446 inventory prices

### DIFF
--- a/app/controllers/spree/admin/line_items_controller_decorator.rb
+++ b/app/controllers/spree/admin/line_items_controller_decorator.rb
@@ -19,7 +19,12 @@ Spree::Admin::LineItemsController.class_eval do
 
   def create
     variant = Spree::Variant.find(params[:line_item][:variant_id])
-    OpenFoodNetwork::ScopeVariantToHub.new(@order.distributor).scope(variant)
+    dist = if @order.distributor
+      @order.distributor
+    elsif params[:distributor_id]
+      Enterprise.find(params[:distributor_id])
+    end
+    OpenFoodNetwork::ScopeVariantToHub.new(dist).scope(variant)
 
     @line_item = @order.add_variant(variant, params[:line_item][:quantity].to_i)
 

--- a/app/overrides/spree/admin/orders/_add_product/add_distributor_to_line_item.html.haml.deface
+++ b/app/overrides/spree/admin/orders/_add_product/add_distributor_to_line_item.html.haml.deface
@@ -1,0 +1,7 @@
+/ replace '[data-hook="add_button"]'
+.two.columns.actions.omega{"data-hook" => "add-button"}
+  = link_to_with_icon 'icon-plus', t(:add), admin_order_line_items_url(@order) + '?distributor_id={{distributor_id}}'.html_safe,
+            :method => :post,
+            :id => 'add_line_item_to_order',
+            :class => 'button fullwidth',
+            'data-update' => 'order-form-wrapper'

--- a/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -133,6 +133,10 @@ describe Spree::Admin::LineItemsController do
     let!(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: [variant]) }
     let!(:order) { create(:order, distributor: distributor, order_cycle: order_cycle) }
     let(:params) { { order_id: order.number, line_item: { variant_id: variant.id, quantity: 1 } } }
+    let!(:order_without_distributor) { create(:order, distributor: nil) }
+    let!(:variant2) { create(:variant, price: 78) }
+    let!(:vo2) { create(:variant_override, hub: distributor, variant: variant2, price: 71.11) }
+    let(:params_with_distributor) { {distributor_id: distributor.id, order_id: order_without_distributor.number, line_item: { variant_id: variant2.id, quantity: 1 } } }
 
     before { login_as_admin }
 
@@ -141,6 +145,15 @@ describe Spree::Admin::LineItemsController do
 
       order.line_items(:reload).last.price.should == 11.11
     end
+
+    context "if the order has no distributor" do
+      it "uses the distributor to from the params to scope overrides" do
+        spree_post :create, params_with_distributor
+        order_without_distributor.line_items(:reload).last.price.should == 71.11
+      end
+    end
+
+
   end
 
   describe "#update" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -57,6 +57,14 @@ FactoryGirl.define do
     end
   end
 
+  factory :order_cycle_with_overrides, parent: :order_cycle do
+    after (:create) do |oc|
+      oc.variants.each do |variant|
+        create(:variant_override, variant: variant, hub: oc.coordinator, price: variant.price + 100)
+      end
+    end
+  end
+
   factory :simple_order_cycle, :class => OrderCycle do
     sequence(:name) { |n| "Order Cycle #{n}" }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -60,7 +60,7 @@ FactoryGirl.define do
   factory :order_cycle_with_overrides, parent: :order_cycle do
     after (:create) do |oc|
       oc.variants.each do |variant|
-        create(:variant_override, variant: variant, hub: oc.coordinator, price: variant.price + 100)
+        create(:variant_override, variant: variant, hub: oc.distributors.first, price: variant.price + 100)
       end
     end
   end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -315,6 +315,29 @@ feature %q{
           end
         end
       end
+
+    end
+
+    describe "when manually placing an order" do
+      let!(:order_cycle) { create(:order_cycle_with_overrides, name: "Overidden") }
+
+      before do
+        dist = order_cycle.distributors.first
+        login_to_admin_section
+        visit 'admin/orders/new'
+        select2_select dist.name, from: 'order_distributor_id'
+        page.should have_select2 'order_order_cycle_id', with_options: ['Overidden (open)']
+        select2_select order_cycle.name, from: 'order_order_cycle_id'
+      end
+
+      # Reproducing a bug, issue #1446
+      it "shows the overridden price" do
+        product = order_cycle.products.first
+        targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+        click_link 'Add'
+        page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr"  # Wait for JS
+        page.should have_content product.variants.first.variant_overrides.first.price
+      end
     end
 
     describe "when inventory_items do not exist for variants" do

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -324,7 +324,7 @@ feature %q{
       before do
         dist = order_cycle.distributors.first
         login_to_admin_section
-        visit 'admin/orders/new'
+        visit spree.new_admin_order_path 
         select2_select dist.name, from: 'order_distributor_id'
         page.should have_select2 'order_order_cycle_id', with_options: ['Overidden (open)']
         select2_select order_cycle.name, from: 'order_order_cycle_id'


### PR DESCRIPTION
Fix for #1446 - this was due to the order not having the distributor set at the point where line items are added, meaning that the variant cannot be scoped to the distributor. I set it up to pass the distributor as an extra param, which can be used if the order distributor is not found.

Please go through the rest of the order process and check that the prices are ok - I think it should be ok once the line item has been added though.