### PR TITLE
Ensure created users are associated with customers

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -19,6 +19,7 @@ Spree.user_class.class_eval do
 
   attr_accessible :enterprise_ids, :enterprise_roles_attributes, :enterprise_limit, :bill_address_attributes, :ship_address_attributes
   after_create :send_signup_confirmation
+  after_create :associate_customers
 
   validate :limit_owned_enterprises
 
@@ -47,6 +48,10 @@ Spree.user_class.class_eval do
 
   def send_signup_confirmation
     Delayed::Job.enqueue ConfirmSignupJob.new(id)
+  end
+
+  def associate_customers
+    self.customers = Customer.where(email: email)
   end
 
   def can_own_more_enterprises?

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe Spree.user_class do
   include AuthenticationWorkflow
 
@@ -70,11 +72,22 @@ describe Spree.user_class do
     end
   end
 
-  context "#create" do
+  describe "#create" do
     it "should send a signup email" do
       expect do
         create(:user)
       end.to enqueue_job ConfirmSignupJob
+    end
+
+    context "called with the the same email as existing customers" do
+      let(:email) { Faker::Internet.email }
+      let!(:c1) { create(:customer, user: nil, email: email) }
+      let!(:c2) { create(:customer, user: nil, email: email) }
+      let!(:u) { create(:user, email: email) }
+
+      it "should associate these customers with the created user" do
+        u.customers(:reload).should include c1, c2
+      end
     end
   end
 


### PR DESCRIPTION
fixes #1493

When a user is created with the same email as existing customers
Then the user is associated with these customers

So that the user can access the private shops where he has been invited
to before signup