### PR TITLE
Some fixes for previous invoice PR

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -54,12 +54,9 @@ module CheckoutHelper
   end
 
   def display_adjustment_tax_rates(adjustment)
-    tax_rate = (adjustment.included_tax / (adjustment.amount - adjustment.included_tax)).round(2)
-    if tax_rate == 0 || tax_rate.infinite?
-      ""
-    else
-      number_to_percentage(tax_rate * 100, :precision => 1)
-    end
+    tax_rates = adjustment.tax_rates
+    return "" if adjustment.amount == adjustment.included_tax
+    tax_rates.map { |tr| number_to_percentage(tr.amount * 100, :precision => 1) }.join(", ")
   end
 
   def display_adjustment_amount(adjustment)

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -234,12 +234,12 @@ Spree::Order.class_eval do
 
   def tax_adjustment_totals
     tax_adjustments.each_with_object(Hash.new) do |adjustment, hash|
-      if adjustment.originator_type == "Spree::TaxRate"
-        tax_rate = adjustment.originator.amount
-      else
-        tax_rate = (adjustment.included_tax / (adjustment.amount - adjustment.included_tax)).round(2)
-      end
-      hash.update({tax_rate => adjustment.included_tax}) { |_tax_rate, amount1, amount2| amount1 + amount2 }
+      tax_rates = adjustment.tax_rates
+      tax_rates_hash = Hash[tax_rates.collect do |tax_rate|
+        tax_amount = tax_rates.one? ? adjustment.included_tax : tax_rate.compute_tax(adjustment.amount)
+        [tax_rate.amount, tax_amount]
+      end]
+      hash.update(tax_rates_hash) { |_tax_rate, amount1, amount2| amount1 + amount2 }
     end
   end
 

--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -32,20 +32,10 @@ module OpenFoodNetwork
     end
 
     def adjustment_tax(adjustable, adjustment)
-      tax_rates = rates_for(adjustable)
+      tax_rates = adjustment.tax_rates
 
       tax_rates.select(&:included_in_price).sum do |rate|
         rate.compute_tax adjustment.amount
-      end
-    end
-
-    def rates_for(adjustable)
-      case adjustable
-      when Spree::LineItem
-        tax_category = enterprise_fee.inherits_tax_category? ? adjustable.product.tax_category : enterprise_fee.tax_category
-        return tax_category ? tax_category.tax_rates.match(adjustable.order) : []
-      when Spree::Order
-        return enterprise_fee.tax_category ? enterprise_fee.tax_category.tax_rates.match(adjustable) : []
       end
     end
   end

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module Spree
   describe Adjustment do
     it "has metadata" do
@@ -277,6 +279,21 @@ module Spree
         it "sets it, rounding to two decimal places" do
           adjustment.set_included_tax! 0.25
           adjustment.included_tax.should == 10.00
+        end
+      end
+
+      describe "getting the corresponding tax rate" do
+        let!(:adjustment_with_tax)    { create(:adjustment, amount: 50, included_tax: 10) }
+        let!(:adjustment_without_tax) { create(:adjustment, amount: 50, included_tax: 0) }
+        let!(:tax_rate)               { create(:tax_rate, calculator: Spree::Calculator::DefaultTax.new, amount: 0.25) }
+        let!(:other_tax_rate)         { create(:tax_rate, calculator: Spree::Calculator::DefaultTax.new, amount: 0.3) }
+
+        it "returns nil if there is no included tax" do
+          adjustment_without_tax.find_closest_tax_rate_from_included_tax.should == nil
+        end
+
+        it "returns the most accurate tax rate" do
+          adjustment_with_tax.find_closest_tax_rate_from_included_tax.should == tax_rate
         end
       end
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -276,6 +276,50 @@ describe Spree::Order do
     end
   end
 
+  describe "getting a hash of all taxes" do
+    let(:zone)            { create(:zone_with_member) }
+    let(:coordinator)     { create(:distributor_enterprise, charges_sales_tax: true) }
+
+    let(:tax_rate10)      { create(:tax_rate, included_in_price: true, calculator: Spree::Calculator::DefaultTax.new, amount: 0.1, zone: zone) }
+    let(:tax_rate15)      { create(:tax_rate, included_in_price: true, calculator: Spree::Calculator::DefaultTax.new, amount: 0.15, zone: zone) }
+    let(:tax_rate20)      { create(:tax_rate, included_in_price: true, calculator: Spree::Calculator::DefaultTax.new, amount: 0.2, zone: zone) }
+    let(:tax_category10)  { create(:tax_category, tax_rates: [tax_rate10]) }
+    let(:tax_category15)  { create(:tax_category, tax_rates: [tax_rate15]) }
+    let(:tax_category20)  { create(:tax_category, tax_rates: [tax_rate20]) }
+
+    let(:variant)         { create(:variant, product: create(:product, tax_category: tax_category10)) }
+    let(:shipping_method) { create(:shipping_method, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 46.0)) }
+    let(:enterprise_fee)  { create(:enterprise_fee, enterprise: coordinator, tax_category: tax_category20, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 48.0)) }
+
+    let(:order_cycle)     { create(:simple_order_cycle, coordinator: coordinator, coordinator_fees: [enterprise_fee], distributors: [coordinator], variants: [variant]) }
+    let!(:order)          { create(:order, shipping_method: shipping_method, bill_address: create(:address), order_cycle: order_cycle, distributor: coordinator) }
+    let!(:line_item)      { create(:line_item, order: order, variant: variant, price: 44.0) }
+
+    before do
+      Spree::Config.shipment_inc_vat = true
+      Spree::Config.shipping_tax_rate = tax_rate15.amount
+      order.create_shipment!
+      Spree::TaxRate.adjust(order)
+      order.reload.update_distribution_charge!
+    end
+
+    it "returns a hash with all 3 taxes" do
+      order.tax_adjustment_totals.size.should == 3
+    end
+
+    it "contains tax on line_item" do
+      order.tax_adjustment_totals[tax_rate10.amount].should == 4.0
+    end
+
+    it "contains tax on shipping_fee" do
+      order.tax_adjustment_totals[tax_rate15.amount].should == 6.0
+    end
+
+    it "contains tax on enterprise_fee" do
+      order.tax_adjustment_totals[tax_rate20.amount].should == 8.0
+    end
+  end
+
   describe "setting the distributor" do
     it "sets the distributor when no order cycle is set" do
       d = create(:distributor_enterprise)


### PR DESCRIPTION
I'm trying to fix the remaining issues in the invoice.
As Rob had warned us, back-calculating the tax rate from the `included_tax` parameter of adjustments was a bad idea. Not only it' a disturbing idead conceptually, but it also gives wrong results with small amounts of tax being rounded to cents...

In the idea of still trying to display those tax rates, there are some stuff we can do that I'd like to discuss.
There are 3 kinds of adjustments that are non-tax adjustments with included tax: enterprise fees, shipping fees and adjustments added via the admin panel.

About enterprise fees, I moved the method responsible for finding tax rates to apply in the adjustment decorator, so that we can also use it afterwards.

About shipping fees, we might want to have a relation between shipping methods and tax categories, like products and enterprise fees have, what do you think?

About adjustments added via the admin panel, only way I thought was that we only allow to add another enterprise fee, but not a custom adjustment. but this removes some flexibility...

To get correct results in the meantime, I've improved the "back-calcutation" by finding the closest tax rate in database.

There are 2 other shortcomings:

Rob mentioned that I might have different tax rates on a line item and its corresponding enterprise fee. According to Myriam this would not usually happen as the fee on a line item is included in the displayed line item price, so it would be a nonsense not to have it "inherit the tax rate".

And there's the thing that these adjustments with included tax can't have excluded tax. Would it be a good thing if their corresponding taxes would only increment the already created (and displayed) tax adjustments if they're supposed to be excluded from price?