### PR TITLE
update wkhtmltopdf-binary and wicked_pdf gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -643,9 +643,8 @@ GEM
     whenever (0.9.2)
       activesupport (>= 2.3.4)
       chronic (>= 0.6.3)
-    wicked_pdf (0.11.0)
-      rails
-    wkhtmltopdf-binary (0.9.9.3)
+    wicked_pdf (1.1.0)
+    wkhtmltopdf-binary (0.12.3.1)
     xml-simple (1.1.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)


### PR DESCRIPTION
PR for #1511.
It seems that older versions of wicked_pdf had an issue with downloading images uploaded on aws s3 (wrong SSL version).
By updating the gem it fixes the problem and it seems to break nothing!