### PR TITLE
Set log level to debug for Staging env

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -24,3 +24,5 @@ CURRENCY: AUD
 
 # see: https://developers.google.com/maps/documentation/javascript/get-api-key
 # GOOGLE_MAPS_API_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+STAGING_LOG_LEVEL: 'info'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -31,7 +31,7 @@ Openfoodnetwork::Application.configure do
   config.force_ssl = true
 
   # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = ENV['STAGING_LOG_LEVEL'] || :info
 
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new


### PR DESCRIPTION
Following a discussion about the log level for Staging env on Slack dev channel, it could be nice to be able to set up the different log level following the use of the staging environment.
My first approach was to hard-code it to debug value but it is an issue with people having a lot of traffic on their Staging servers (requiring then lograte, ...).
So I change the approach and set up a new env variable allowing to define the log level for staging, like this anybody can change it following his need.
Tell me if any issue.