### PR TITLE
Remove unused spec support method

### DIFF
--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -19,11 +19,6 @@ module AuthenticationWorkflow
     admin_user
   end
 
-  def stub_authorization!
-    before(:all) { Spree::Ability.register_ability(AuthorizationHelpers::Request::SuperAbility) }
-    after(:all) { Spree::Ability.remove_ability(AuthorizationHelpers::Request::SuperAbility) }
-  end
-
   def login_to_admin_section
     admin_role = Spree::Role.find_or_create_by_name!('admin')
     admin_user = create(:user,


### PR DESCRIPTION
It seems that this method is not used anymore:
```
$ git grep stub_authorization
spec/support/request/authentication_workflow.rb:  def stub_authorization!
```
It was introduced by https://github.com/openfoodfoundation/openfoodnetwork/commit/705e247eb8defe4baa16cc1780ba0b1cf8a8e86e