### PR TITLE
Product Edit UX adjustments

### DIFF
--- a/app/assets/javascripts/admin/products/controllers/edit_units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/edit_units_controller.js.coffee
@@ -1,19 +1,17 @@
 angular.module("admin.products").controller "editUnitsCtrl", ($scope, VariantUnitManager) ->
 
-  $scope.product = {
+  $scope.product =
     variant_unit: angular.element('#variant_unit').val()
     variant_unit_scale: angular.element('#variant_unit_scale').val()
-  }
 
   $scope.variant_unit_options = VariantUnitManager.variantUnitOptions()
 
-  $scope.setDropdown = () ->
-    if $scope.product.variant_unit == 'items'
-      $scope.variant_unit_with_scale = 'items'
-    else
-      $scope.variant_unit_with_scale = $scope.product.variant_unit + '_' + $scope.product.variant_unit_scale
+  if $scope.product.variant_unit == 'items'
+    $scope.variant_unit_with_scale = 'items'
+  else
+    $scope.variant_unit_with_scale = $scope.product.variant_unit + '_' + $scope.product.variant_unit_scale
 
-  $scope.setFields = () ->
+  $scope.setFields = ->
     if $scope.variant_unit_with_scale == 'items'
       variant_unit = 'items'
       variant_unit_scale = null
@@ -24,5 +22,3 @@ angular.module("admin.products").controller "editUnitsCtrl", ($scope, VariantUni
 
     $scope.product.variant_unit = variant_unit
     $scope.product.variant_unit_scale = variant_unit_scale
-
-

--- a/app/assets/javascripts/admin/products/controllers/edit_units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/edit_units_controller.js.coffee
@@ -1,0 +1,28 @@
+angular.module("admin.products").controller "editUnitsCtrl", ($scope, VariantUnitManager) ->
+
+  $scope.product = {
+    variant_unit: angular.element('#variant_unit').val()
+    variant_unit_scale: angular.element('#variant_unit_scale').val()
+  }
+
+  $scope.variant_unit_options = VariantUnitManager.variantUnitOptions()
+
+  $scope.setDropdown = () ->
+    if $scope.product.variant_unit == 'items'
+      $scope.variant_unit_with_scale = 'items'
+    else
+      $scope.variant_unit_with_scale = $scope.product.variant_unit + '_' + $scope.product.variant_unit_scale
+
+  $scope.setFields = () ->
+    if $scope.variant_unit_with_scale == 'items'
+      variant_unit = 'items'
+      variant_unit_scale = null
+    else
+      options = $scope.variant_unit_with_scale.split('_')
+      variant_unit = options[0]
+      variant_unit_scale = options[1]
+
+    $scope.product.variant_unit = variant_unit
+    $scope.product.variant_unit_scale = variant_unit_scale
+
+

--- a/app/assets/javascripts/admin/products/controllers/variant_units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/variant_units_controller.js.coffee
@@ -1,0 +1,16 @@
+angular.module("admin.products").controller "variantUnitsCtrl", ($scope, VariantUnitManager, $timeout) ->
+
+  $scope.unitName = (scale, type) ->
+    VariantUnitManager.getUnitName(scale, type)
+
+  $scope.scale = angular.element('#product_variant_unit_scale').val()
+
+  $scope.setInitialValues = () ->
+    variant_unit_value = angular.element('#variant_unit_value').val()
+    $scope.unit_value_human = variant_unit_value / $scope.scale
+    $timeout ->
+      $scope.updateValue()
+
+  $scope.updateValue = () ->
+    unit_value_human = angular.element('#unit_value_human').val()
+    $scope.unit_value = unit_value_human * $scope.scale

--- a/app/assets/javascripts/admin/products/controllers/variant_units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/variant_units_controller.js.coffee
@@ -5,12 +5,10 @@ angular.module("admin.products").controller "variantUnitsCtrl", ($scope, Variant
 
   $scope.scale = angular.element('#product_variant_unit_scale').val()
 
-  $scope.setInitialValues = () ->
-    variant_unit_value = angular.element('#variant_unit_value').val()
-    $scope.unit_value_human = variant_unit_value / $scope.scale
-    $timeout ->
-      $scope.updateValue()
-
-  $scope.updateValue = () ->
+  $scope.updateValue = ->
     unit_value_human = angular.element('#unit_value_human').val()
     $scope.unit_value = unit_value_human * $scope.scale
+
+  variant_unit_value = angular.element('#variant_unit_value').val()
+  $scope.unit_value_human = variant_unit_value / $scope.scale
+  $timeout -> $scope.updateValue()

--- a/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
@@ -1,6 +1,6 @@
 / insert_top "[data-hook='admin_product_form_right']"
 
-.variant_units_form{'ng-app' => 'admin.products', 'ng-controller' => 'editUnitsCtrl', 'ng-init' => 'setDropdown()'}
+.variant_units_form{ 'ng-app' => 'admin.products', 'ng-controller' => 'editUnitsCtrl' }
 
   = f.field_container :units do
     = f.label :variant_unit_with_scale, :units

--- a/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
@@ -1,16 +1,17 @@
 / insert_top "[data-hook='admin_product_form_right']"
 
-= f.field_container :variant_unit do
-  = f.label :variant_unit, 'Variant unit'
-  = f.select :variant_unit, product_variant_unit_options, {:include_blank => true}, {:class => "select2 fullwidth"}
-  = f.error_message_on :variant_unit
+.variant_units_form{'ng-app' => 'admin.products', 'ng-controller' => 'editUnitsCtrl', 'ng-init' => 'setDropdown()'}
 
-= f.field_container :variant_unit_scale do
-  = f.label :variant_unit_scale, 'Variant unit scale'
-  = f.text_field :variant_unit_scale
-  = f.error_message_on :variant_unit_scale
+  = f.field_container :units do
+    = f.label :variant_unit_with_scale, :units
+    %select.select2.fullwidth{ id: 'product_variant_unit_with_scale', 'ng-model' => 'variant_unit_with_scale', 'ng-change' => 'setFields()', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options' }
+      %option{'value' => ''}
 
-= f.field_container :variant_unit_name do
-  = f.label :variant_unit_name, 'Variant unit name'
-  = f.text_field :variant_unit_name
-  = f.error_message_on :variant_unit_name
+  = f.text_field :variant_unit, {'id' => 'variant_unit', 'ng-value' => 'product.variant_unit', 'hidden' => true}
+  = f.text_field :variant_unit_scale, {'id' => 'variant_unit_scale', 'ng-value' => 'product.variant_unit_scale', 'hidden' => true}
+
+  .variant_unit_name{'ng-show' => 'product.variant_unit == "items"'}
+    = f.field_container :variant_unit_name do
+      = f.label :variant_unit_name, 'Variant unit name'
+      = f.text_field :variant_unit_name, {placeholder: t('admin.products.unit_name_placeholder')}
+      = f.error_message_on :variant_unit_name

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -34,7 +34,7 @@
       .three.columns.omega{ 'ng-show' => "product.variant_unit_with_scale == 'items'" }
         = f.field_container :unit_name do
           = f.label :product_variant_unit_name, t(:unit_name)
-          %input.fullwidth{ id: 'product_variant_unit_name','ng-model' => 'product.variant_unit_name', :name => 'product[variant_unit_name]', :placeholder => 'eg. bunches', :type => 'text' }
+          %input.fullwidth{ id: 'product_variant_unit_name','ng-model' => 'product.variant_unit_name', :name => 'product[variant_unit_name]', :placeholder => t('admin.products.unit_name_placeholder'), :type => 'text' }
     .twelve.columns.alpha
       .six.columns.alpha
         = render 'spree/admin/products/primary_taxon_form', f: f

--- a/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
@@ -2,7 +2,7 @@
 
 - if product_has_variant_unit_option_type?(@product)
   - if @product.variant_unit != 'items'
-    .field{"data-hook" => "unit_value", 'ng-controller' => 'variantUnitsCtrl', 'ng-init' => 'setInitialValues()'}
+    .field{"data-hook" => "unit_value", 'ng-controller' => 'variantUnitsCtrl'}
       = f.label :unit_value, "#{t('admin.'+@product.variant_unit)} ({{unitName(#{@product.variant_unit_scale}, '#{@product.variant_unit}')}})"
       = hidden_field_tag 'product_variant_unit_scale', @product.variant_unit_scale
       = text_field_tag :unit_value_human, nil, {class: "fullwidth", 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}

--- a/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
@@ -1,9 +1,12 @@
 / insert_top "[data-hook='admin_variant_form_fields']"
 
 - if product_has_variant_unit_option_type?(@product)
-  .field{"data-hook" => "unit_value"}
-    = f.label :unit_value, "Unit Value"
-    = f.text_field :unit_value, class: "fullwidth"
+  - if @product.variant_unit != 'items'
+    .field{"data-hook" => "unit_value", 'ng-controller' => 'variantUnitsCtrl', 'ng-init' => 'setInitialValues()'}
+      = f.label :unit_value, "#{t('admin.'+@product.variant_unit)} ({{unitName(#{@product.variant_unit_scale}, '#{@product.variant_unit}')}})"
+      = hidden_field_tag 'product_variant_unit_scale', @product.variant_unit_scale
+      = text_field_tag :unit_value_human, nil, {class: "fullwidth", 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
+      = f.text_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}
 
   .field{"data-hook" => "unit_description"}
     = f.label :unit_description, "Unit Description"

--- a/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
@@ -10,4 +10,4 @@
 
     .field{"data-hook" => "unit_description"}
       = f.label :unit_description, "Unit Description"
-      = f.text_field :unit_description, class: "fullwidth"
+      = f.text_field :unit_description, class: "fullwidth", placeholder: t('admin.products.unit_name_placeholder')

--- a/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
@@ -8,6 +8,6 @@
       = text_field_tag :unit_value_human, nil, {class: "fullwidth", 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
       = f.text_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}
 
-  .field{"data-hook" => "unit_description"}
-    = f.label :unit_description, "Unit Description"
-    = f.text_field :unit_description, class: "fullwidth"
+    .field{"data-hook" => "unit_description"}
+      = f.label :unit_description, "Unit Description"
+      = f.text_field :unit_description, class: "fullwidth"

--- a/app/overrides/spree/admin/variants/_form/replace_weight.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/replace_weight.html.haml.deface
@@ -1,0 +1,14 @@
+/ replace "[data-hook='admin_variant_form_additional_fields']"
+
+.right.six.columns.omega.label-block{"data-hook" => "admin_variant_form_additional_fields"}
+  - if @product.variant_unit != 'weight'
+    .field{"data-hook" => 'weight'}
+      = f.label 'weight', t('weight')+' (kg)'
+      - value = number_with_precision(@variant.weight, :precision => 2)
+      = f.text_field 'weight', :value => value, :class => 'fullwidth'
+
+  - [:height, :width, :depth].each do |field|
+    .field{"data-hook" => field}
+      = f.label field, t(field)
+      - value = number_with_precision(@variant.send(field), :precision => 2)
+      = f.text_field field, :value => value, :class => 'fullwidth'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,9 @@ en:
     sku: SKU
     tags: Tags
     variant: Variant
+    weight: Weight
+    volume: Volume
+    items: Items
 
     # General form elements
     quick_search: Quick Search
@@ -236,6 +239,7 @@ en:
         new_button: New Enterprise Group
 
     products:
+      unit_name_placeholder: 'eg. bunches'
       bulk_edit:
         unit: Unit
         display_as: Display As

--- a/spec/features/admin/variants_spec.rb
+++ b/spec/features/admin/variants_spec.rb
@@ -16,7 +16,7 @@ feature %q{
     visit spree.admin_product_variants_path p
     click_link 'New Variant'
 
-    fill_in 'variant_unit_value', with: '1'
+    fill_in 'unit_value_human', with: '1'
     fill_in 'variant_unit_description', with: 'foo'
     click_button 'Create'
 
@@ -43,11 +43,11 @@ feature %q{
     expect(page).to_not have_selector "div[data-hook='presentation'] input"
 
     # And I should see unit value and description fields for the unit-related option value
-    page.should have_field "variant_unit_value", with: "1"
+    page.should have_field "unit_value_human", with: "1"
     page.should have_field "variant_unit_description", with: "foo"
 
     # When I update the fields and save the variant
-    fill_in "variant_unit_value", with: "123"
+    fill_in "unit_value_human", with: "123"
     fill_in "variant_unit_description", with: "bar"
     click_button 'Update'
     page.should have_content %Q(Variant "#{p.name}" has been successfully updated!)


### PR DESCRIPTION
Addressing #1452. 

Lots of little changes to the the way weights/volumes are displayed to the user in Product and Variant edit screens, to bring things in line with how the units logic actually works, and to make things clearer and more usable.

**Product edit page:**
- Now has a single dropdown for choosing units which then gets translated into the correct values behind the scenes, so user can select "Weight (kg)" instead of "weight" and having to type in "1000" for the unit scale.
- "Variant Unit Name" field is hidden unless "items" is selected as the unit, because this field actually only applies to products using "items" units. Also added a placeholder description to this field to improve clarity.

**Variant edit page**
- Now displays the currently used unit value (eg Volume, mL)
- Applies the selected scaling to the input box, so if Kg is being used, then a "2" in the box means 2 Kg. Previously "2000" would mean 2 Kg and this was not obvious. Likewise for other scales like mL (0.001), the scaling gets applied so the value the user sees actually makes sense, then this gets converted behind the scenes.
- Hides duplicate weight field when weight is used. Products that use "volume" or "items" still have a weight field, but when "weight" is selected as unit type there was 2 weight fields and one of them didn't actually save if it was changed in the UI... also it often showed a different value. This is now hidden when unit type is "weight".
- Added "Kg" to the second weight field for clarity, as it's always in Kilograms by default.
- Unit Description field is now hidden when unit type is "items", as this field only applies to products using "weight" or "volume".
