### PR TITLE
Enable iframes for embedded shopfronts

### DIFF
--- a/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
+++ b/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
@@ -1,5 +1,5 @@
 body.embedded {
-  nav.top-bar{
+  nav.top-bar {
     ul.left, ul.center, ul.right li.current_hub {
       display: none;
     }
@@ -12,6 +12,9 @@ body.embedded {
         height: 4.6875rem;
         vertical-align: top;
       }
+      li.powered-by {
+        display: inline-block;
+      }
     }
 
     &.show-for-large-up {
@@ -23,18 +26,27 @@ body.embedded {
   }
 
   footer {
-    .footer-local {
-      display: none;
-    }
-    .footer-global {
-      padding-bottom: 0;
+    display: none;
+  }
+}
 
-      .row {
-        display: none;
-      }
-      .row:first-of-type {
-        display: block;
-      }
-    }
+nav.top-bar ul.right li.powered-by {
+  display: none;
+  margin-right: 0.4rem;
+  opacity: 0.6;
+
+  img {
+    height: 1.8em;
+    margin: 0px 0.4em 0.4em 0px;
+  }
+  span, a {
+    font-family: "Oswald", sans-serif;
+    font-size: 1rem;
+    font-weight: 300;
+    color: #555;
+    padding: 0 !important;
+  }
+  a:hover {
+    color: #000;
   }
 }

--- a/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
+++ b/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
@@ -1,0 +1,40 @@
+body.embedded {
+  nav.top-bar{
+    ul.left, ul.center, ul.right li.current_hub {
+      display: none;
+    }
+
+    ul.right {
+      width: auto !important;
+      li {
+        float: left;
+        line-height: 4.6875rem;
+        height: 4.6875rem;
+        vertical-align: top;
+      }
+    }
+
+    &.show-for-large-up {
+      display: inherit !important;
+    }
+    &.show-for-medium-down {
+      display: none !important;
+    }
+  }
+
+  footer {
+    .footer-local {
+      display: none;
+    }
+    .footer-global {
+      padding-bottom: 0;
+
+      .row {
+        display: none;
+      }
+      .row:first-of-type {
+        display: block;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
+++ b/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
@@ -50,3 +50,22 @@ nav.top-bar ul.right li.powered-by {
     color: #000;
   }
 }
+
+.blocked-cookies {
+  text-align: center;
+  margin-bottom: 0 !important;
+
+  &.hidden {
+    display: none;
+  }
+
+  a.button.allow {
+    background-color: rgba(0,0,0,0.25);
+    margin-bottom: 0.4em;
+
+    &:hover {
+      background-color: rgba(0,0,0,0.35);
+    }
+  }
+
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,7 @@ class ApplicationController < ActionController::Base
   def enable_embedded_shopfront
     whitelist = Spree::Config[:embedded_shopfronts_whitelist]
     return unless Spree::Config[:enable_embedded_shopfronts] and whitelist.present?
+    return if (request.referer and URI(request.referer).scheme != 'https' and !Rails.env.test?)
 
     response.headers.delete 'X-Frame-Options'
     response.headers['Content-Security-Policy'] = "frame-ancestors #{whitelist}"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
     stored_location_for(resource_or_scope) || signed_in_root_path(resource_or_scope)
   end
 
-  def after_sign_out_path_for(resource_or_scope)
+  def after_sign_out_path_for(_resource_or_scope)
     session[:shopfront_redirect] ? session[:shopfront_redirect] : root_path
   end
 
@@ -51,8 +51,8 @@ class ApplicationController < ActionController::Base
 
   def enable_embedded_shopfront
     whitelist = Spree::Config[:embedded_shopfronts_whitelist]
-    return unless Spree::Config[:enable_embedded_shopfronts] and whitelist.present?
-    return if (request.referer and URI(request.referer).scheme != 'https' and !Rails.env.test?)
+    return unless Spree::Config[:enable_embedded_shopfronts] && whitelist.present?
+    return if request.referer && URI(request.referer).scheme != 'https' && !Rails.env.test?
 
     response.headers.delete 'X-Frame-Options'
     response.headers['Content-Security-Policy'] = "frame-ancestors #{whitelist}"
@@ -68,7 +68,7 @@ class ApplicationController < ActionController::Base
     session[:embedded_shopfront] = true
 
     # Get shopfront slug and set redirect path
-    if params[:controller] == 'enterprises' and params[:action] == 'shop' and params[:id]
+    if params[:controller] == 'enterprises' && params[:action] == 'shop' && params[:id]
       slug = params[:id]
       session[:shopfront_redirect] = '/' + slug + '/shop?embedded_shopfront=true'
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def shopfront_session
+    session[:safari_fix] = true
+    render 'shop/shopfront_session', layout: false
+  end
+
   def enable_embedded_styles
     session[:embedded_shopfront] = true
     render json: {}, status: 200

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -9,6 +9,7 @@ class CheckoutController < Spree::CheckoutController
   prepend_before_filter :require_distributor_chosen
 
   skip_before_filter :check_registration
+  before_filter :enable_embedded_shopfront
 
   include OrderCyclesHelper
   include EnterprisesHelper

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -10,6 +10,7 @@ class EnterprisesController < BaseController
   before_filter :check_stock_levels, only: :shop
 
   before_filter :clean_permalink, only: :check_permalink
+  before_filter :enable_embedded_shopfront
 
   respond_to :js, only: :permalink_checker
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,8 @@
 class HomeController < BaseController
   layout 'darkswarm'
 
+  before_filter :enable_embedded_shopfront
+
   def index
     if ContentConfig.home_show_stats
       @num_distributors = Enterprise.is_distributor.activated.visible.count

--- a/app/controllers/producers_controller.rb
+++ b/app/controllers/producers_controller.rb
@@ -1,6 +1,8 @@
 class ProducersController < BaseController
   layout 'darkswarm'
 
+  before_filter :enable_embedded_shopfront
+
   def index
   end
 end

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -2,8 +2,7 @@ require 'open_food_network/cached_products_renderer'
 
 class ShopController < BaseController
   layout "darkswarm"
-  before_filter :require_distributor_chosen
-  before_filter :set_order_cycles
+  before_filter :require_distributor_chosen, :set_order_cycles, except: :changeable_orders_alert
   before_filter :enable_embedded_shopfront
 
   def show

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -4,6 +4,7 @@ class ShopController < BaseController
   layout "darkswarm"
   before_filter :require_distributor_chosen
   before_filter :set_order_cycles
+  before_filter :enable_embedded_shopfront
 
   def show
     redirect_to main_app.enterprise_shop_path(current_distributor)

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -4,6 +4,5 @@ class ShopsController < BaseController
   before_filter :enable_embedded_shopfront
 
   def index
-    #@embeddable = "test"
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,6 +1,9 @@
 class ShopsController < BaseController
   layout 'darkswarm'
 
+  before_filter :enable_embedded_shopfront
+
   def index
+    #@embeddable = "test"
   end
 end

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -4,6 +4,8 @@ Spree::CheckoutController.class_eval do
 
   include CheckoutHelper
 
+  before_filter :enable_embedded_shopfront
+
   def edit
     flash.keep
     redirect_to main_app.checkout_path

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -4,6 +4,7 @@ Spree::OrdersController.class_eval do
   after_filter  :populate_variant_attributes, only: :populate
   before_filter :update_distribution, only: :update
   before_filter :filter_order_params, only: :update
+  before_filter :enable_embedded_shopfront
 
   prepend_before_filter :require_order_cycle, only: :edit
   prepend_before_filter :require_distributor_chosen, only: :edit

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -2,6 +2,7 @@ Spree::PaypalController.class_eval do
   include CheckoutHelper
 
   after_filter :reset_order_when_complete, only: :confirm
+  before_filter :enable_embedded_shopfront
 
   def cancel
     flash[:notice] = t('flash.cancel', :scope => 'paypal')

--- a/app/controllers/spree/users_controller_decorator.rb
+++ b/app/controllers/spree/users_controller_decorator.rb
@@ -1,3 +1,5 @@
 Spree::UsersController.class_eval do
   layout 'darkswarm'
+
+  before_filter :enable_embedded_shopfront
 end

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -4,6 +4,10 @@ Spree::AppConfiguration.class_eval do
   # we can allow to be modified in the UI by adding appropriate form
   # elements to existing or new configuration pages.
 
+  # Embedded Shopfronts
+  preference :enable_embedded_shopfronts, :boolean, default: false
+  preference :embedded_shopfronts_whitelist, :text, default: nil
+
   # Terms of Service Preferences
   preference :enterprises_require_tos, :boolean, default: false
 

--- a/app/overrides/spree/admin/general_settings/edit/embedded_shopfront_settings.html.haml.deface
+++ b/app/overrides/spree/admin/general_settings/edit/embedded_shopfront_settings.html.haml.deface
@@ -1,0 +1,11 @@
+/ insert_after "fieldset.security"
+
+%fieldset.embedded_shopfronts.no-border-bottom
+  %legend{:align => "center"}= t('admin.shopfront_settings.embedded_shopfront_settings')
+  .field
+    = preference_field_tag(:enable_embedded_shopfronts, Spree::Config[:enable_embedded_shopfronts], type: Spree::Config.preference_type(:enable_embedded_shopfronts))
+    = label_tag(:enable_embedded_shopfronts, t('admin.shopfront_settings.enable_embedded_shopfronts')) + tag(:br)
+  .field
+    = label_tag(:embedded_shopfronts_whitelist, t('admin.shopfront_settings.embedded_shopfronts_whitelist')) + tag(:br)
+    = preference_field_tag(:embedded_shopfronts_whitelist, Spree::Config[:embedded_shopfronts_whitelist], type: Spree::Config.preference_type(:embedded_shopfronts_whitelist))
+

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -8,6 +8,9 @@
 = inject_shop_enterprises
 
 %shop.darkswarm
+  - if @shopfront_layout == 'embedded'
+    = render partial: 'shop/blocked_cookies'
+
   .alert-box.changeable-orders-alert.info.animate-show{ ng: { show: "alert.visible && alert.html", cloak: true } }
     %span{ ng: { bind: { html: "alert.html" } } }
     %a.close{ ng: { click: "alert.close()" } } &times;

--- a/app/views/layouts/_shopfront_script.html.haml
+++ b/app/views/layouts/_shopfront_script.html.haml
@@ -1,0 +1,29 @@
+:javascript
+  $(document).ready(function() {
+    var in_iframe = function(){
+      try {
+        return window.self !== window.top;
+      } catch (e) {
+        return true;
+      }
+    };
+
+    var embedded_styles_active = $('body.off-canvas').hasClass('embedded');
+
+    var set_shopfront_styles = function(state) {
+      $.ajax({
+        url: '/embedded_shopfront/'+state,
+        type: 'POST'
+      });
+    };
+
+    if (in_iframe() && !embedded_styles_active){
+      $('body.off-canvas').addClass('embedded');
+      set_shopfront_styles('enable');
+    }
+
+    if (!in_iframe() && embedded_styles_active) {
+      $('body.off-canvas').removeClass('embedded');
+      set_shopfront_styles('disable');
+    }
+  });

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -21,10 +21,12 @@
     = render "layouts/bugherd_script"
     = csrf_meta_tags
 
-  %body.off-canvas{"ng-app" => "Darkswarm"}
+  %body.off-canvas{class: @shopfront_layout, ng: {app: "Darkswarm"}}
     / [if lte IE 8]
       = render partial: "shared/ie_warning"
       = javascript_include_tag "iehack"
+
+    = render "layouts/shopfront_script" if @shopfront_layout
 
     = inject_current_hub
     = inject_json "user", "current_user"

--- a/app/views/shared/menu/_large_menu.html.haml
+++ b/app/views/shared/menu/_large_menu.html.haml
@@ -37,6 +37,12 @@
               = t 'label_about'
 
     %ul.right
+      %li.powered-by
+        %img{src: '/favicon.ico'}
+        %span
+          = t 'powered_by'
+          %a{href: '/'}
+            = t 'title'
       - if spree_current_user.nil?
         = render 'shared/signed_out'
       - else

--- a/app/views/shop/_blocked_cookies.html.haml
+++ b/app/views/shop/_blocked_cookies.html.haml
@@ -1,0 +1,14 @@
+:javascript
+  $(document).ready(function() {
+    document.cookie = 'cookie_test=true';
+    if(document.cookie == '') {
+      $('.blocked-cookies').removeClass('hidden');
+    }
+  });
+
+.alert-box.blocked-cookies.hidden
+  %p= t('blocked_cookies_alert')
+
+  %a.button.allow{target: '_blank', href: "#{spree.root_url}embedded_shopfront/shopfront_session/"}
+    = t('allow_cookies')
+    

--- a/app/views/shop/shopfront_session.html.haml
+++ b/app/views/shop/shopfront_session.html.haml
@@ -1,0 +1,6 @@
+%html
+  %head
+  %body
+    :javascript
+      window.opener.location.reload(true);
+      window.close();

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -97,6 +97,10 @@ en-GB:
         update_user_invoice_explained: "Use this button to immediately update invoices for the month to date for each enterprise user in the system. This task can be set up to run automatically every night."
         auto_finalise_invoices: "Auto-finalise invoices monthly on the 2nd at 1:30am"
         auto_update_invoices: "Auto-update invoices nightly at 1:00am"
+    shopfront_settings:
+      embedded_shopfront_settings: Embedded Shopfront Settings
+      enable_embedded_shopfronts: Enable Embedded Shopfronts
+      embedded_shopfronts_whitelist: External Domains Whitelist
     business_model_configuration:
       edit:
         business_model_configuration: "Business Model"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,6 +229,11 @@ en:
         default_payment_method: must be set if you wish to create invoices for enterprise users.
         default_shipping_method: must be set if you wish to create invoices for enterprise users.
 
+    shopfront_settings:
+      embedded_shopfront_settings: Embedded Shopfront Settings
+      enable_embedded_shopfronts: Enable Embedded Shopfronts
+      embedded_shopfronts_whitelist: External Domains Whitelist
+
     business_model_configuration:
       edit:
         business_model_configuration: "Business Model"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,8 @@ en:
   'no': "No"
   'y': 'Y'
   'n': 'N'
+  powered_by: Powered by
+
   admin:
     # Common properties / models
     date: Date
@@ -230,9 +232,9 @@ en:
         default_shipping_method: must be set if you wish to create invoices for enterprise users.
 
     shopfront_settings:
-      embedded_shopfront_settings: Embedded Shopfront Settings
-      enable_embedded_shopfronts: Enable Embedded Shopfronts
-      embedded_shopfronts_whitelist: External Domains Whitelist
+      embedded_shopfront_settings: "Embedded Shopfront Settings"
+      enable_embedded_shopfronts: "Enable Embedded Shopfronts"
+      embedded_shopfronts_whitelist: "External Domains Whitelist"
 
     business_model_configuration:
       edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,8 @@ en:
   'y': 'Y'
   'n': 'N'
   powered_by: Powered by
+  blocked_cookies_alert: "Your browser may be blocking cookies needed to use this shopfront. Click below to allow cookies and reload the page."
+  allow_cookies: "Allow Cookies"
 
   admin:
     # Common properties / models

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,9 @@ Openfoodnetwork::Application.routes.draw do
   put '/checkout', :to => 'checkout#update' , :as => :update_checkout
   get '/checkout/paypal_payment/:order_id', to: 'checkout#paypal_payment', as: :paypal_payment
 
+  post 'embedded_shopfront/enable', to: 'application#enable_embedded_styles'
+  post 'embedded_shopfront/disable', to: 'application#disable_embedded_styles'
+
   resources :enterprises do
     collection do
       post :search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Openfoodnetwork::Application.routes.draw do
   put '/checkout', :to => 'checkout#update' , :as => :update_checkout
   get '/checkout/paypal_payment/:order_id', to: 'checkout#paypal_payment', as: :paypal_payment
 
+  get 'embedded_shopfront/shopfront_session', to: 'application#shopfront_session'
   post 'embedded_shopfront/enable', to: 'application#enable_embedded_styles'
   post 'embedded_shopfront/disable', to: 'application#disable_embedded_styles'
 

--- a/spec/dummy/iframe_test.html
+++ b/spec/dummy/iframe_test.html
@@ -1,0 +1,10 @@
+<html>
+<head></head>
+<body>
+
+<p>Iframe Test</p>
+
+<iframe src="http://test.com/shops" name="test_iframe" id="test_iframe" style="width:100%;min-height:30em"></iframe>
+
+</body>
+</html>

--- a/spec/dummy/iframe_test.html
+++ b/spec/dummy/iframe_test.html
@@ -2,9 +2,7 @@
 <head></head>
 <body>
 
-<p>Iframe Test</p>
-
-<iframe src="http://test.com/shops" name="test_iframe" id="test_iframe" style="width:100%;min-height:30em"></iframe>
+<iframe src="http://localhost:9999/test_enterprise/shop?embedded_shopfront=true" name="test_iframe" class="test_iframe" id="test_iframe" style="width:100%;min-height:35em"></iframe>
 
 </body>
 </html>

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 feature "Using embedded shopfront functionality", js: true do
   include AuthenticationWorkflow
   include WebHelper
+  include ShopWorkflow
+  include CheckoutWorkflow
+  include UIComponentHelper
+
+  Capybara.server_port = 9999
 
   describe "enabling embedded shopfronts" do
     before do
@@ -31,25 +36,118 @@ feature "Using embedded shopfront functionality", js: true do
     end
   end
 
-  describe "using iframes", js: true do
+  describe "using iframes" do
+    let(:distributor) { create(:distributor_enterprise, name: 'My Embedded Hub', permalink: 'test_enterprise', with_payment_and_shipping: true) }
+    let(:supplier) { create(:supplier_enterprise) }
+    let(:oc1) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise), orders_close_at: 2.days.from_now) }
+    let(:product) { create(:simple_product, name: 'Framed Apples', supplier: supplier) }
+    let(:variant) { create(:variant, product: product, price: 19.99) }
+    let(:exchange) { Exchange.find(oc1.exchanges.to_enterprises(distributor).outgoing.first.id) }
+    let(:user) { create(:user) }
+
     before do
+      add_variant_to_order_cycle(exchange, variant)
+
       Spree::Config[:enable_embedded_shopfronts] = true
+      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
+
+      page.driver.browser.js_errors = false
+      Capybara.current_session.driver.visit('spec/dummy/iframe_test.html')
     end
 
     after do
       Spree::Config[:enable_embedded_shopfronts] = false
     end
 
-    pending "displays iframe content" do
-      Capybara.current_session.driver.visit('spec/dummy/iframe_test.html')
-
-      expect(page).to have_text 'Iframe Test'
+    it "displays modified shopfront layout" do
       expect(page).to have_selector 'iframe#test_iframe'
 
       within_frame 'test_iframe' do
-        sleep 1
-        expect(page).to have_content "OFN" # currently fails...
+        within 'nav.top-bar' do
+          expect(page).to have_selector 'ul.left', visible: false
+          expect(page).to have_selector 'ul.center', visible: false
+        end
+
+        expect(page).to have_content "My Embedded Hub"
+        expect(page).to have_content "Framed Apples"
       end
     end
+
+    it "allows shopping and checkout" do
+      within_frame 'test_iframe' do
+        fill_in "variants[#{variant.id}]", with: 1
+        wait_until_enabled 'input.add_to_cart'
+
+        first("input.add_to_cart:not([disabled='disabled'])").click
+
+        expect(page).to have_text 'Your shopping cart'
+        find('a#checkout-link').click
+
+        expect(page).to have_text 'Checkout now'
+
+        click_button 'Login'
+        login_with_modal
+
+        expect(page).to have_text 'Payment'
+
+        within "#details" do
+          fill_in "First Name", with: "Some"
+          fill_in "Last Name", with: "One"
+          fill_in "Email", with: "test@example.com"
+          fill_in "Phone", with: "0456789012"
+        end
+
+        toggle_billing
+        within "#billing" do
+          fill_in "Address", with: "123 Street"
+          select "Australia", from: "Country"
+          select "Victoria", from: "State"
+          fill_in "City", with: "Melbourne"
+          fill_in "Postcode", with: "3066"
+        end
+
+        toggle_shipping
+        within "#shipping" do
+          find('input[type="radio"]').trigger 'click'
+        end
+
+        toggle_payment
+        within "#payment" do
+          find('input[type="radio"]').trigger 'click'
+        end
+
+        place_order
+
+        expect(page).to have_content "Your order has been processed successfully"
+      end
+    end
+
+    it "redirects to embedded hub on logout when embedded" do
+      within_frame 'test_iframe' do
+
+        find('ul.right li#login-link a').click
+        login_with_modal
+
+        wait_until { page.find('ul.right li.has-dropdown').value.present? }
+        logout_via_navigation
+
+        expect(page).to have_text 'My Embedded Hub'
+      end
+    end
+  end
+
+  def login_with_modal
+    expect(page).to have_selector 'div.login-modal', visible: true
+
+    within 'div.login-modal' do
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user.password
+      find('input[type="submit"]').click
+    end
+  end
+
+  def logout_via_navigation
+    first('ul.right li.has-dropdown a').click
+    find('ul.right ul.dropdown li a[title="Logout"]').click
   end
 end

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+feature "Using embedded shopfront functionality", js: true do
+  include AuthenticationWorkflow
+  include WebHelper
+
+  describe "enabling embedded shopfronts" do
+    before do
+      Spree::Config[:enable_embedded_shopfronts] = false
+    end
+
+    it "disables iframes by default" do
+      visit shops_path
+      expect(page.response_headers['X-Frame-Options']).to eq 'DENY'
+      expect(page.response_headers['Content-Security-Policy']).to eq "frame-ancestors 'none'"
+    end
+
+    it "allows iframes on certain pages when enabled in configuration" do
+      quick_login_as_admin
+
+      visit spree.edit_admin_general_settings_path
+
+      check 'enable_embedded_shopfronts'
+      fill_in 'embedded_shopfronts_whitelist', with: "test.com"
+
+      click_button 'Update'
+
+      visit shops_path
+      expect(page.response_headers['X-Frame-Options']).to be_nil
+      expect(page.response_headers['Content-Security-Policy']).to eq "frame-ancestors test.com"
+    end
+  end
+
+  describe "using iframes", js: true do
+    before do
+      Spree::Config[:enable_embedded_shopfronts] = true
+    end
+
+    after do
+      Spree::Config[:enable_embedded_shopfronts] = false
+    end
+
+    pending "displays iframe content" do
+      Capybara.current_session.driver.visit('spec/dummy/iframe_test.html')
+
+      expect(page).to have_text 'Iframe Test'
+      expect(page).to have_selector 'iframe#test_iframe'
+
+      within_frame 'test_iframe' do
+        sleep 1
+        expect(page).to have_content "OFN" # currently fails...
+      end
+    end
+  end
+end

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -33,6 +33,10 @@ feature "Using embedded shopfront functionality", js: true do
       visit shops_path
       expect(page.response_headers['X-Frame-Options']).to be_nil
       expect(page.response_headers['Content-Security-Policy']).to eq "frame-ancestors test.com"
+
+      visit spree.admin_path
+      expect(page.response_headers['X-Frame-Options']).to eq 'DENY'
+      expect(page.response_headers['Content-Security-Policy']).to eq "frame-ancestors 'none'"
     end
   end
 


### PR DESCRIPTION
Addressing #1556. Preliminary work towards Shopfront Whitelabelling that allows embedding shops in iframes on external sites.

Edit: this branch has expanded to include #1565 and #1566 (Embedded Shopfront functionality).

Functionality in this PR:

- Restricts iframe use via Rails settings (as opposed to server settings which is what we do currently)
- Allows superadmins to enable embedded shopfronts, and specify a whitelist for alowed domains, seperated by a space
- Allowed domains can use embedded shopfronts in external sites by linking to their shopfront page in an iframe and appending `?embedded_shopfront=true` in the url
- Layout is modified for embedded shopfronts with some minor whitelabelling (logo and navigation hidden, footer content mostly hidden)
- When using embedded shopfronts, logging in or out returns the user to the designated shopfront page instead of the OFN home page.
- Most of this is handled by sessions, but there is also some secondary javascript detection to ensure things are displayed properly. For instance if a user has opened a non-embedded OFN page in a separate tab/window but the session is still set to "embedded mode", the javascript will re-adjust the layout and session data accordingly. 

Testing/Implementing notes:

- For this to work the nginx server configuration for the production/staging instance will need to be modified so that the line referring to `'X-Frame-Options' = 'DENY'` is removed/commented out.
- Embedding shopfronts will only work on sites that use HTTPS.