### PR TITLE
Uk/1560 extract text into translations

### DIFF
--- a/app/assets/javascripts/admin/business_model_configuration/controllers/business_model_configuration_controller.js.coffee
+++ b/app/assets/javascripts/admin/business_model_configuration/controllers/business_model_configuration_controller.js.coffee
@@ -14,8 +14,8 @@ angular.module("admin.businessModelConfiguration").controller "BusinessModelConf
     $scope.cappedBill()
 
   $scope.capReached = ->
-    return "No" if !$scope.cap? || Number($scope.cap) == 0
-    if $scope.bill() >= Number($scope.cap) then "Yes" else "No"
+    return t('no') if !$scope.cap? || Number($scope.cap) == 0
+    if $scope.bill() >= Number($scope.cap) then t('yes') else t('no')
 
   $scope.includedTax = ->
     return 0 if !$scope.taxRate? || Number($scope.taxRate) == 0

--- a/app/assets/javascripts/admin/customers/directives/new_customer_dialog.js.coffee
+++ b/app/assets/javascripts/admin/customers/directives/new_customer_dialog.js.coffee
@@ -21,7 +21,7 @@ angular.module("admin.customers").directive 'newCustomerDialog', ($compile, $tem
           if response.data.errors
             scope.errors.push(error) for error in response.data.errors
           else
-            scope.errors.push("Sorry! Could not create '#{scope.email}'")
+            scope.errors.push(t('js.customers.could_not_create') + " '#{scope.email}'")
       return
 
     # Compile modal template
@@ -35,4 +35,4 @@ angular.module("admin.customers").directive 'newCustomerDialog', ($compile, $tem
       if CurrentShop.shop.id
         template.dialog('open')
       else
-        alert('Please select a shop first')
+        alert(t('js.customers.select_shop'))

--- a/app/assets/javascripts/admin/enterprise_fees/directives/delete_resource.js.coffee
+++ b/app/assets/javascripts/admin/enterprise_fees/directives/delete_resource.js.coffee
@@ -2,7 +2,7 @@ angular.module('admin.enterpriseFees').directive 'spreeDeleteResource', ->
   (scope, element, attrs) ->
     if scope.enterprise_fee.id
       url = '/admin/enterprise_fees/' + scope.enterprise_fee.id
-      html = '<a href="' + url + '" class="delete-resource icon_link icon-trash no-text" data-action="remove" data-confirm="Are you sure?" url="' + url + '"></a>'
+      html = '<a href="' + url + '" class="delete-resource icon_link icon-trash no-text" data-action="remove" data-confirm="' + t('are_you_sure') + '" url="' + url + '"></a>'
       #var html = '<a href="'+url+'" class="delete-resource" data-confirm="Are you sure?"><img alt="Delete" src="/assets/admin/icons/delete.png" /> Delete</a>';
       element.append html
     return

--- a/app/assets/javascripts/admin/enterprises/controllers/enterprises_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprises_controller.js.coffee
@@ -30,27 +30,27 @@ angular.module("admin.enterprises").controller 'enterprisesCtrl', ($scope, $q, E
     $scope.producerTextFor = (enterprise) ->
       switch enterprise.is_primary_producer
         when true
-          "Producer"
+          t('js.enterprises.producer')
         else
-          "Non-Producer"
+          t('js.enterprises.non_producer')
 
     $scope.packageTextFor = (enterprise) ->
       switch enterprise.is_primary_producer
         when true
           switch enterprise.sells
             when "none"
-              "Profile"
+              t('js.profile')
             when "own"
-              "Shop"
+              t('js.shop')
             when "any"
-              "Hub"
+              t('js.hub')
             else
-              "Choose"
+              t('js.choose')
         else
           switch enterprise.sells
             when "none"
-              "Profile"
+              t('js.profile')
             when "any"
-              "Hub"
+              t('js.hub')
             else
-              "Choose"
+              t('js.choose')

--- a/app/assets/javascripts/admin/enterprises/controllers/index_panel_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/index_panel_controller.js.coffee
@@ -14,7 +14,7 @@ angular.module("admin.enterprises").controller 'indexPanelCtrl', ($scope, Enterp
       , (response) ->
         $scope.saving = false
         if response.status == 422 && response.data.errors?
-          message = 'Please resolve the following errors:\n'
+          message = t('js.resolve_errors') + ':\n'
           for attr, msg of response.data.errors
             message += "#{attr} #{msg}\n"
           alert(message)

--- a/app/assets/javascripts/admin/enterprises/services/permalink_checker.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/services/permalink_checker.js.coffee
@@ -19,16 +19,16 @@ angular.module("admin.enterprises").factory 'PermalinkChecker', ($q, $http) ->
         if data.length > @MAX_PERMALINK_LENGTH || !data.match(/^[\w-]+$/)
           deferredRequest.resolve
             permalink: permalink
-            available: "Error"
+            available: t('js.error')
         else
           deferredRequest.resolve
             permalink: data
-            available: "Available"
+            available: t('available')
       ).error (data,status) =>
         if status == 409
           deferredRequest.resolve
             permalink: data
-            available: "Unavailable"
+            available: t('js.unavailable')
         else
           # Something went wrong or request was aborted
           deferredRequest.reject()

--- a/app/assets/javascripts/admin/index_utils/services/pending_changes.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/services/pending_changes.js.coffee
@@ -21,16 +21,16 @@ angular.module("admin.indexUtils").factory "pendingChanges", ($q, resources, Sta
     submitAll: (form=null) =>
       all = []
       @errors = []
-      StatusMessage.display('progress', "Saving...")
+      StatusMessage.display('progress', t('js.saving'))
       for id, objectChanges of @pendingChanges
         for attrName, change of objectChanges
           all.push @submit(change)
       $q.all(all).then =>
         if @errors.length == 0
-          StatusMessage.display('success', "All changes saved successfully")
+          StatusMessage.display('success', t('js.all_changes_saved_successfully'))
           form.$setPristine() if form?
         else
-          StatusMessage.display('failure', "Oh no! I was unable to save your changes")
+          StatusMessage.display('failure', t('js.oh_no'))
       all
 
     submit: (change) ->

--- a/app/assets/javascripts/admin/index_utils/services/spree_api_auth.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/services/spree_api_auth.js.coffee
@@ -10,7 +10,7 @@ angular.module("admin.indexUtils").factory "SpreeApiAuth", ($q, $http, SpreeApiK
           deferred.resolve()
 
       .error (response) ->
-        error = response?.error || "You are unauthorised to access this page."
+        error = response?.error || t('js.unauthorized')
         deferred.reject(error)
 
       deferred.promise

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -51,13 +51,13 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.$watch 'bulk_order_form.$dirty', (newVal, oldVal) ->
     if newVal == true
-      StatusMessage.display 'notice', "You have unsaved changes"
+      StatusMessage.display 'notice', t('js.unsaved_changes')
 
   $scope.submit = ->
     if $scope.bulk_order_form.$valid
-      StatusMessage.display 'progress', "Saving..."
+      StatusMessage.display 'progress', t('js.saving')
       $q.all(LineItems.saveAll()).then(->
-        StatusMessage.display 'success', "All changes saved"
+        StatusMessage.display 'success', t('js.all_changes_saved')
         $scope.bulk_order_form.$setPristine()
       ).catch ->
         StatusMessage.display 'failure', t "unsaved_changes_error"

--- a/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
@@ -84,7 +84,7 @@ angular.module('admin.orderCycles')
 
     $scope.submit = ($event, destination) ->
       $event.preventDefault()
-      StatusMessage.display 'progress', "Saving..."
+      StatusMessage.display 'progress', t('js.saving')
       OrderCycle.create(destination)
 
     $scope.cancel = (destination) ->

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -87,11 +87,11 @@ angular.module('admin.orderCycles')
 
     $scope.submit = (destination) ->
       $event.preventDefault()
-      StatusMessage.display 'progress', "Saving..."
+      StatusMessage.display 'progress', t('js.saving')
 
     $scope.submit = ($event, destination) ->
       $event.preventDefault()
-      StatusMessage.display 'progress', "Saving..."
+      StatusMessage.display 'progress', t('js.saving')
       OrderCycle.update(destination, $scope.order_cycle_form)
 
     $scope.cancel = (destination) ->

--- a/app/assets/javascripts/admin/order_cycles/controllers/simple_create.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/simple_create.js.coffee
@@ -49,7 +49,7 @@ angular.module('admin.orderCycles').controller "AdminSimpleCreateOrderCycleCtrl"
 
   $scope.submit = ($event, destination) ->
     $event.preventDefault()
-    StatusMessage.display 'progress', "Saving..."
+    StatusMessage.display 'progress', t('js.saving')
     OrderCycle.mirrorIncomingToOutgoingProducts()
     OrderCycle.create(destination)
 

--- a/app/assets/javascripts/admin/order_cycles/controllers/simple_edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/simple_edit.js.coffee
@@ -42,7 +42,7 @@ angular.module('admin.orderCycles').controller "AdminSimpleEditOrderCycleCtrl", 
 
   $scope.submit = ($event, destination) ->
     $event.preventDefault()
-    StatusMessage.display 'progress', "Saving..."
+    StatusMessage.display 'progress', t('js.saving')
     OrderCycle.mirrorIncomingToOutgoingProducts()
     OrderCycle.update(destination, $scope.order_cycle_form)
 

--- a/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
@@ -165,13 +165,13 @@ angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, S
           if destination?
             $window.location = destination
           else
-            StatusMessage.display 'success', 'Your order cycle has been updated.'
+            StatusMessage.display 'success', t('js.order_cycles.update_success')
         else
           console.log('Failed to update order cycle')
 
     confirmNoDistributors: ->
       if @order_cycle.outgoing_exchanges.length == 0
-        confirm 'There are no distributors in this order cycle. This order cycle will not be visible to customers until you add one. Would you like to continue saving this order cycle?'
+        confirm t('js.order_cycles.no_distributors')
       else
         true
 

--- a/app/assets/javascripts/admin/product_import/controllers/import_options_form.js.coffee
+++ b/app/assets/javascripts/admin/product_import/controllers/import_options_form.js.coffee
@@ -1,8 +1,7 @@
 angular.module("ofn.admin").controller "ImportOptionsFormCtrl", ($scope, $rootScope, ProductImportService) ->
 
   $scope.toggleResetAbsent = () ->
-    confirmed = confirm 'This will set stock level to zero on all products for this \n' +
-      'enterprise that are not present in the uploaded file.' if $scope.resetAbsent
+    confirmed = confirm t('js.product_import.confirmation') if $scope.resetAbsent
 
     if confirmed or !$scope.resetAbsent
       ProductImportService.updateResetAbsent($scope.supplierId, $scope.resetCount, $scope.resetAbsent)

--- a/app/assets/javascripts/admin/resources/services/customers.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/customers.js.coffee
@@ -24,7 +24,7 @@ angular.module("admin.resources").factory "Customers", ($q, InfoDialog, RequestM
         if errors?
           InfoDialog.open 'error', errors[0]
         else
-          InfoDialog.open 'error', "Could not delete customer: #{customer.email}"
+          InfoDialog.open 'error', t('js.resources.could_not_delete_customer') + ": #{customer.email}"
 
     index: (params) ->
       @clear()

--- a/app/assets/javascripts/admin/services/confirm_handler.js.coffee
+++ b/app/assets/javascripts/admin/services/confirm_handler.js.coffee
@@ -1,6 +1,6 @@
 angular.module("ofn.admin").factory "ofnConfirmHandler", (pendingChanges, $compile, $q) ->
   return (scope, callback) ->
-    template = "<div id='dialog-div' style='padding: 10px'><h6>Unsaved changes currently exist, save now or ignore?</h6></div>"
+    template = "<div id='dialog-div' style='padding: 10px'><h6>" + t('js.services.unsaved_changes_message') + "</h6></div>"
     dialogDiv = $compile(template)(scope)
     return ->
       if pendingChanges.changeCount(pendingChanges.pendingChanges) > 0

--- a/app/assets/javascripts/admin/services/enterprise_relationships.js.coffee
+++ b/app/assets/javascripts/admin/services/enterprise_relationships.js.coffee
@@ -26,7 +26,7 @@ angular.module("ofn.admin").factory 'EnterpriseRelationships', ($http, enterpris
 
     permission_presentation: (permission) ->
       switch permission
-        when "add_to_order_cycle" then "add to order cycle"
-        when "manage_products" then "manage products"
-        when "edit_profile" then "edit profile"
-        when "create_variant_overrides" then "add products to inventory"
+        when "add_to_order_cycle" then t('js.services.add_to_order_cycle')
+        when "manage_products" then t('js.services.manage_products')
+        when "edit_profile" then t('js.services.edit_profile')
+        when "create_variant_overrides" then t('js.services.add_products_to_inventory')

--- a/app/assets/javascripts/admin/tag_rules/controllers/tag_rules_controller.js.coffee
+++ b/app/assets/javascripts/admin/tag_rules/controllers/tag_rules_controller.js.coffee
@@ -2,7 +2,7 @@ angular.module("admin.tagRules").controller "TagRulesCtrl", ($scope, $http, $fil
   $scope.tagGroups = enterprise.tag_groups
   $scope.defaultTagGroup = enterprise.default_tag_group
 
-  $scope.visibilityOptions = [ { id: "visible", name: "VISIBLE" }, { id: "hidden", name: "NOT VISIBLE" } ]
+  $scope.visibilityOptions = [ { id: "visible", name: t('js.tag_rules.visible')  }, { id: "hidden", name: t('js.tag_rules.not_visible') } ]
 
   $scope.updateRuleCounts = ->
     index = $scope.defaultTagGroup.rules.length

--- a/app/assets/javascripts/admin/tag_rules/directives/new_rule_dialog.js.coffee
+++ b/app/assets/javascripts/admin/tag_rules/directives/new_rule_dialog.js.coffee
@@ -9,10 +9,10 @@ angular.module("admin.tagRules").directive 'newTagRuleDialog', ($compile, $templ
 
     scope.ruleTypes = [
       # { id: "DiscountOrder", name: 'Apply a discount to orders' }
-      { id: "FilterProducts", name: 'Show or Hide variants in my shopfront' }
-      { id: "FilterShippingMethods", name: 'Show or Hide shipping methods at checkout' }
-      { id: "FilterPaymentMethods", name: 'Show or Hide payment methods at checkout' }
-      { id: "FilterOrderCycles", name: 'Show or Hide order cycles in my shopfront' }
+      { id: "FilterProducts", name: t('js.tag_rules.show_hide_variants') }
+      { id: "FilterShippingMethods", name: t('js.tag_rules.show_hide_shipping') }
+      { id: "FilterPaymentMethods", name: t('js.tag_rules.show_hide_payment') }
+      { id: "FilterOrderCycles", name: t('js.tag_rules.show_hide_order_cycles') }
     ]
 
     scope.ruleType = scope.ruleTypes[0].id

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -15,11 +15,11 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
   $scope.currentView = -> Views.currentView
 
   $scope.views = Views.setViews
-    inventory:    { name: "Inventory Products", visible: true }
-    hidden:       { name: "Hidden Products",    visible: false }
-    new:          { name: "New Products",       visible: false }
+    inventory:    { name: t('js.variant_overrides.inventory_products'), visible: true }
+    hidden:       { name: t('js.variant_overrides.hidden_products'),    visible: false }
+    new:          { name: t('js.variant_overrides.new_products'),       visible: false }
 
-  $scope.bulkActions = [ name: "Reset Stock Levels To Defaults", callback: 'resetStock' ]
+  $scope.bulkActions = [ name: t('js.variant_overrides.reset_stock_levels'), callback: 'resetStock' ]
 
   $scope.columns = Columns.columns
 
@@ -52,22 +52,22 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
 
   $scope.displayDirty = ->
     if DirtyVariantOverrides.count() > 0
-      num = if DirtyVariantOverrides.count() == 1 then "one override" else "#{DirtyVariantOverrides.count()} overrides"
-      StatusMessage.display 'notice', "Changes to #{num} remain unsaved."
+      num = if DirtyVariantOverrides.count() == 1 then t('js.variant_overrides.one_override')  else "#{DirtyVariantOverrides.count()} " + t('js.variant_overrides.overrides')
+      StatusMessage.display 'notice', t('js.variant_overrides.changes_to') + ' ' + num + ' ' + t('js.variant_overrides.remain_unsaved')
     else
       StatusMessage.clear()
 
   $scope.update = ->
     if DirtyVariantOverrides.count() == 0
-      StatusMessage.display 'alert', 'No changes to save.'
+      StatusMessage.display 'alert', t('js.variant_overrides.no_changes_to_save')
     else
-      StatusMessage.display 'progress', 'Saving...'
+      StatusMessage.display 'progress', t('js.saving')
       DirtyVariantOverrides.save()
       .success (updatedVos) ->
         DirtyVariantOverrides.clear()
         VariantOverrides.updateIds updatedVos
         $scope.variant_overrides_form.$setPristine()
-        StatusMessage.display 'success', 'Changes saved.'
+        StatusMessage.display 'success', t('js.changes_saved')
         VariantOverrides.updateData updatedVos # Refresh page data
       .error (data, status) ->
         StatusMessage.display 'failure', $scope.updateError(data, status)
@@ -75,32 +75,32 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
 
   $scope.updateError = (data, status) ->
     if status == 401
-      "I couldn't get authorisation to save those changes, so they remain unsaved."
+      t('js.variant_overrides.no_authorisation')
 
     else if status == 400 && data.errors?
       errors = []
       for field, field_errors of data.errors
         errors = errors.concat field_errors
       errors = errors.join ', '
-      "I had some trouble saving: #{errors}"
+      t('js.variant_overrides.some_trouble') + ": #{errors}"
     else
-      "Oh no! I was unable to save your changes."
+      t('js.oh_no')
 
   $scope.resetStock = ->
     if DirtyVariantOverrides.count() > 0
-      StatusMessage.display 'alert', 'Save changes first.'
+      StatusMessage.display 'alert', t('js.save_changes_first')
       $timeout ->
         $scope.displayDirty()
       , 3000 # 3 second delay
     else
       return unless $scope.hub_id?
-      StatusMessage.display 'progress', 'Changing on hand stock levels...'
+      StatusMessage.display 'progress', t('js.variant_overrides.changing_on_hand_stock')
       $http
         method: "POST"
         url: "/admin/variant_overrides/bulk_reset"
         data: { hub_id: $scope.hub_id }
       .success (updatedVos) ->
         VariantOverrides.updateData updatedVos
-        StatusMessage.display 'success', 'Stocks reset to defaults.'
+        StatusMessage.display 'success', t('js.variant_overrides.stock_reset')
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -82,7 +82,7 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
       for field, field_errors of data.errors
         errors = errors.concat field_errors
       errors = errors.join ', '
-      t('js.variant_overrides.some_trouble') + ": #{errors}"
+      t('js.variant_overrides.some_trouble', {errors: errors})
     else
       t('js.oh_no')
 

--- a/app/assets/javascripts/templates/admin/info_dialog.html.haml
+++ b/app/assets/javascripts/templates/admin/info_dialog.html.haml
@@ -6,4 +6,4 @@
       {{ message }}
   .action-buttons.text-center
     %button{ ng: { click: "close()" } }
-      OK
+      = t(:ok)

--- a/app/assets/javascripts/templates/admin/panels/exchange_distributed_products.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_distributed_products.html.haml
@@ -7,7 +7,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'setExchangeVariants(exchange, incomingExchangeVariantsFor(exchange.enterprise_id), exchange.select_all_variants)',
           'id' => 'order_cycle_outgoing_exchange_{{ $parent.$index }}_select_all_variants' }
-        Select all
+        = t('admin.select_all')
 
     .exchange-products
       -# Scope product list based on permissions the current user has to view variants in this exchange

--- a/app/assets/javascripts/templates/admin/panels/exchange_supplied_products.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_supplied_products.html.haml
@@ -7,7 +7,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'setExchangeVariants(exchange, suppliedVariants(exchange.enterprise_id), exchange.select_all_variants)',
           'id' => 'order_cycle_incoming_exchange_{{ $index }}_select_all_variants' }
-        Select all
+        = t('admin.select_all')
 
     .exchange-products
       -# No need to scope product list based on permissions, because if an incoming exchange is visible,
@@ -36,7 +36,7 @@
               'ofn-sync-distributions' => '{{ product.master_id }}',
               'id' => 'order_cycle_incoming_exchange_{{ $parent.$index }}_variants_{{ product.master_id }}',
               'ng-disabled' => '!order_cycle.editable_variants_for_incoming_exchanges.hasOwnProperty(exchange.enterprise_id) || order_cycle.editable_variants_for_incoming_exchanges[exchange.enterprise_id].indexOf(product.master_id) < 0' }
-            Obsolete master
+            = t('admin.obsolete_master')
 
         .exchange-product-variant{'ng-repeat' => 'variant in product.variants'}
           %label

--- a/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
@@ -1,5 +1,6 @@
 .row.exchange-tags
   .sixteen.columns.alpha.omega
-    %span.text-normal Tags
+    %span.text-normal
+      = t('admin.tags')
     %br
     %tags-with-translation.fullwidth{ object: 'object' }

--- a/app/assets/javascripts/templates/admin/tag_rules/filter_order_cycles_input.html.haml
+++ b/app/assets/javascripts/templates/admin/tag_rules/filter_order_cycles_input.html.haml
@@ -7,4 +7,5 @@
     id: "enterprise_tag_rules_attributes_{{tagGroup.startIndex + $index}}_preferred_matched_order_cycles_visibility",
     name: "enterprise[tag_rules_attributes][{{tagGroup.startIndex + $index}}][preferred_matched_order_cycles_visibility]",
     ng: { value: "'hidden'", if: "rule.is_default" } }
-  %span.text-normal{ ng: { if: "rule.is_default" } } not visible
+  %span.text-normal{ ng: { if: "rule.is_default" } }
+    =t(:not_visible)

--- a/app/assets/javascripts/templates/admin/tag_rules/filter_payment_methods_input.html.haml
+++ b/app/assets/javascripts/templates/admin/tag_rules/filter_payment_methods_input.html.haml
@@ -7,4 +7,5 @@
     id: "enterprise_tag_rules_attributes_{{tagGroup.startIndex + $index}}_preferred_matched_payment_methods_visibility",
     name: "enterprise[tag_rules_attributes][{{tagGroup.startIndex + $index}}][preferred_matched_payment_methods_visibility]",
     ng: { value: "'hidden'", if: "rule.is_default" } }
-  %span.text-normal{ ng: { if: "rule.is_default" } } not visible
+  %span.text-normal{ ng: { if: "rule.is_default" } }
+    = t(:not_visible)

--- a/app/assets/javascripts/templates/admin/tag_rules/filter_products_input.html.haml
+++ b/app/assets/javascripts/templates/admin/tag_rules/filter_products_input.html.haml
@@ -7,4 +7,5 @@
     id: "enterprise_tag_rules_attributes_{{tagGroup.startIndex + $index}}_preferred_matched_variants_visibility",
     name: "enterprise[tag_rules_attributes][{{tagGroup.startIndex + $index}}][preferred_matched_variants_visibility]",
     ng: { value: "'hidden'", if: "rule.is_default" } }
-  %span.text-normal{ ng: { if: "rule.is_default" } } not visible
+  %span.text-normal{ ng: { if: "rule.is_default" } }
+    = t(:not_visible)

--- a/app/assets/javascripts/templates/admin/tag_rules/filter_shipping_methods_input.html.haml
+++ b/app/assets/javascripts/templates/admin/tag_rules/filter_shipping_methods_input.html.haml
@@ -7,4 +7,6 @@
     id: "enterprise_tag_rules_attributes_{{tagGroup.startIndex + $index}}_preferred_matched_shipping_methods_visibility",
     name: "enterprise[tag_rules_attributes][{{tagGroup.startIndex + $index}}][preferred_matched_shipping_methods_visibility]",
     ng: { value: "'hidden'", if: "rule.is_default" } }
-  %span.text-normal{ ng: { if: "rule.is_default" } } not visible
+  %span.text-normal{ ng: { if: "rule.is_default" } }
+    = t(:not_visible)
+

--- a/app/assets/javascripts/templates/single_line_selectors.html.haml
+++ b/app/assets/javascripts/templates/single_line_selectors.html.haml
@@ -5,7 +5,7 @@
   %li.more
     %a.dropdown{ data: { dropdown: "{{ 'show-more-' + selectorName }}" }, ng: { class: "{active: selectedOverFlowSelectors().length > 0}" } }
       %span
-        + {{ overFlowSelectors().length }} more
+        + {{ overFlowSelectors().length }}= t(:more)
       %i.ofn-i_052-point-down
     .f-dropdown.text-right.content{ ng: { attr: { id: "{{ 'show-more-' + selectorName }}" } } }
       %ul

--- a/app/controllers/admin/accounts_and_billing_settings_controller.rb
+++ b/app/controllers/admin/accounts_and_billing_settings_controller.rb
@@ -15,11 +15,11 @@ class Admin::AccountsAndBillingSettingsController < Spree::Admin::BaseController
 
   def start_job
     if @update_account_invoices_job || @finalize_account_invoices_job
-      flash[:error] = "A task is already running, please wait until it has finished"
+      flash[:error] = I18n.t(:accounts_and_billing_task_already_running_error)
     else
       new_job = "#{params[:job][:name]}".camelize.constantize.new
       Delayed::Job.enqueue new_job
-      flash[:success] = "Task Queued"
+      flash[:success] = I18n.t(:accounts_and_billing_start_task_notice)
     end
 
     redirect_to_edit

--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -1,12 +1,12 @@
 module Admin
   class ContentsController < Spree::Admin::BaseController
     def edit
-      @preference_sections = [{name: I18n.t('contents.header'), preferences: [:logo, :logo_mobile, :logo_mobile_svg]},
-                              {name: I18n.t('contents.home_page'), preferences: [:home_hero, :home_show_stats]},
-                              {name: I18n.t('contents.producer_signup_page'), preferences: [:producer_signup_pricing_table_html, :producer_signup_case_studies_html, :producer_signup_detail_html]},
-                              {name: I18n.t('contents.hub_signup_page'), preferences: [:hub_signup_pricing_table_html, :hub_signup_case_studies_html, :hub_signup_detail_html]},
-                              {name: I18n.t('contents.group_signup_page'), preferences: [:group_signup_pricing_table_html, :group_signup_case_studies_html, :group_signup_detail_html]},
-                              {name: I18n.t('contents.footer_and_external_links'), preferences: [:footer_logo,
+      @preference_sections = [{name: I18n.t('admin.contents.edit.header'), preferences: [:logo, :logo_mobile, :logo_mobile_svg]},
+                              {name: I18n.t('admin.contents.edit.home_page'), preferences: [:home_hero, :home_show_stats]},
+                              {name: I18n.t('admin.contents.edit.producer_signup_page'), preferences: [:producer_signup_pricing_table_html, :producer_signup_case_studies_html, :producer_signup_detail_html]},
+                              {name: I18n.t('admin.contents.edit.hub_signup_page'), preferences: [:hub_signup_pricing_table_html, :hub_signup_case_studies_html, :hub_signup_detail_html]},
+                              {name: I18n.t('admin.contents.edit.group_signup_page'), preferences: [:group_signup_pricing_table_html, :group_signup_case_studies_html, :group_signup_detail_html]},
+                              {name: I18n.t('admin.contents.edit.footer_and_external_links'), preferences: [:footer_logo,
                                                              :footer_facebook_url, :footer_twitter_url, :footer_instagram_url, :footer_linkedin_url, :footer_googleplus_url, :footer_pinterest_url,
                                                              :footer_email, :community_forum_url, :footer_links_md, :footer_about_url, :footer_tos_url]}]
     end
@@ -21,7 +21,7 @@ module Admin
       # Save any uploaded images
       ContentConfig.save
 
-      flash[:success] = t(:successfully_updated, :resource => I18n.t('contents.your_content'))
+      flash[:success] = t(:successfully_updated, :resource => I18n.t('admin.contents.edit.your_content'))
 
       redirect_to main_app.edit_admin_content_path
     end

--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -1,12 +1,12 @@
 module Admin
   class ContentsController < Spree::Admin::BaseController
     def edit
-      @preference_sections = [{name: 'Header', preferences: [:logo, :logo_mobile, :logo_mobile_svg]},
-                              {name: 'Home page', preferences: [:home_hero, :home_show_stats]},
-                              {name: 'Producer signup page', preferences: [:producer_signup_pricing_table_html, :producer_signup_case_studies_html, :producer_signup_detail_html]},
-                              {name: 'Hub signup page', preferences: [:hub_signup_pricing_table_html, :hub_signup_case_studies_html, :hub_signup_detail_html]},
-                              {name: 'Group signup page', preferences: [:group_signup_pricing_table_html, :group_signup_case_studies_html, :group_signup_detail_html]},
-                              {name: 'Footer and External Links', preferences: [:footer_logo,
+      @preference_sections = [{name: I18n.t('contents.header'), preferences: [:logo, :logo_mobile, :logo_mobile_svg]},
+                              {name: I18n.t('contents.home_page'), preferences: [:home_hero, :home_show_stats]},
+                              {name: I18n.t('contents.producer_signup_page'), preferences: [:producer_signup_pricing_table_html, :producer_signup_case_studies_html, :producer_signup_detail_html]},
+                              {name: I18n.t('contents.hub_signup_page'), preferences: [:hub_signup_pricing_table_html, :hub_signup_case_studies_html, :hub_signup_detail_html]},
+                              {name: I18n.t('contents.group_signup_page'), preferences: [:group_signup_pricing_table_html, :group_signup_case_studies_html, :group_signup_detail_html]},
+                              {name: I18n.t('contents.footer_and_external_links'), preferences: [:footer_logo,
                                                              :footer_facebook_url, :footer_twitter_url, :footer_instagram_url, :footer_linkedin_url, :footer_googleplus_url, :footer_pinterest_url,
                                                              :footer_email, :community_forum_url, :footer_links_md, :footer_about_url, :footer_tos_url]}]
     end
@@ -21,7 +21,7 @@ module Admin
       # Save any uploaded images
       ContentConfig.save
 
-      flash[:success] = t(:successfully_updated, :resource => "Your content")
+      flash[:success] = t(:successfully_updated, :resource => I18n.t('contents.your_content'))
 
       redirect_to main_app.edit_admin_content_path
     end

--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -35,7 +35,7 @@ module Admin
         if params.key? :enterprise_id
           redirect_path = main_app.admin_enterprise_fees_path(enterprise_id: params[:enterprise_id])
         end
-        redirect_to redirect_path, :notice => 'Your enterprise fees have been updated.'
+        redirect_to redirect_path, :notice => I18n.t(:enterprise_fees_update_notice)
 
       else
         render :index
@@ -49,7 +49,7 @@ module Admin
       product_distribution = ProductDistribution.where(:enterprise_fee_id => @object).first
       if product_distribution
         p = product_distribution.product
-        error = "That enterprise fee cannot be deleted as it is referenced by a product distribution: #{p.id} - #{p.name}."
+        error = I18n.t(:enterprise_fees_destroy_error, id: p.id, name: p.name)
 
         respond_with(@object) do |format|
           format.html do

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -57,7 +57,7 @@ module Admin
 
     def register
       if params[:sells] == 'unspecified'
-        flash[:error] = "Please select a package"
+        flash[:error] = I18n.t(:enterprise_register_package_error)
         return render :welcome, layout: "spree/layouts/bare_admin"
       end
 
@@ -68,10 +68,10 @@ module Admin
       end
 
       if @enterprise.update_attributes(attributes)
-        flash[:success] = "Congratulations! Registration for #{@enterprise.name} is complete!"
+        flash[:success] = I18n.t(:enterprise_register_success_notice, enterprise: @enterprise.name)
         redirect_to admin_path
       else
-        flash[:error] = "Could not complete registration for #{@enterprise.name}"
+        flash[:error] = I18n.t(:enterprise_register_error, enterprise: @enterprise.name)
         render :welcome, layout: "spree/layouts/bare_admin"
       end
     end
@@ -80,19 +80,19 @@ module Admin
       @enterprise_set = EnterpriseSet.new(collection, params[:enterprise_set])
       touched_enterprises = @enterprise_set.collection.select(&:changed?)
       if @enterprise_set.save
-        flash[:success] = "Enterprises updated successfully"
+        flash[:success] = I18n.t(:enterprise_bulk_update_success_notice)
 
         # 18-3-2015: It seems that the form for this action sometimes loads bogus values for
         # the 'sells' field, and submitting that form results in a bunch of enterprises with
         # values that have mysteriously changed. This statement is here to help debug that
         # issue, and should be removed (along with its display in index.html.haml) when the
         # issue has been resolved.
-        flash[:action] = "Updated #{pluralize(touched_enterprises.count, 'enterprise')}: #{touched_enterprises.map(&:name).join(', ')}"
+        flash[:action] = "#{I18n.t(:updated)} #{pluralize(touched_enterprises.count, 'enterprise')}: #{touched_enterprises.map(&:name).join(', ')}"
 
         redirect_to main_app.admin_enterprises_path
       else
         @enterprise_set.collection.select! { |e| touched_enterprises.include? e }
-        flash[:error] = 'Update failed'
+        flash[:error] = I18n.t(:enterprise_bulk_update_error)
         render :index
       end
     end

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -76,7 +76,7 @@ module Admin
     def bulk_update
       @order_cycle_set = params[:order_cycle_set] && OrderCycleSet.new(params[:order_cycle_set])
       if @order_cycle_set.andand.save
-        redirect_to main_app.admin_order_cycles_path, :notice =>  I18n.t(:order_cycles_bulk_update_notice)
+        redirect_to main_app.admin_order_cycles_path, notice: I18n.t(:order_cycles_bulk_update_notice)
       else
         render :index
       end
@@ -85,14 +85,14 @@ module Admin
     def clone
       @order_cycle = OrderCycle.find params[:id]
       @order_cycle.clone!
-      redirect_to main_app.admin_order_cycles_path, :notice => I18n.t(:order_cycles_clone_notice, name: @order_cycle.name)
+      redirect_to main_app.admin_order_cycles_path, notice: I18n.t(:order_cycles_clone_notice, name: @order_cycle.name)
     end
 
     # Send notifications to all producers who are part of the order cycle
     def notify_producers
       Delayed::Job.enqueue OrderCycleNotificationJob.new(params[:id].to_i)
 
-      redirect_to main_app.admin_order_cycles_path, :notice => I18n.t(:order_cycles_email_to_producers_notice)
+      redirect_to main_app.admin_order_cycles_path, notice: I18n.t(:order_cycles_email_to_producers_notice)
     end
 
 
@@ -138,7 +138,7 @@ module Admin
       available_coordinators = permitted_coordinating_enterprises_for(@order_cycle).select(&:confirmed?)
       case available_coordinators.count
       when 0
-        flash[:error] =  I18n.t(:order_cycles_no_permission_to_coordinate_error)
+        flash[:error] = I18n.t(:order_cycles_no_permission_to_coordinate_error)
         redirect_to main_app.admin_order_cycles_path
       when 1
         @order_cycle.coordinator = available_coordinators.first

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -45,7 +45,7 @@ module Admin
         if @order_cycle.save
           OpenFoodNetwork::OrderCycleFormApplicator.new(@order_cycle, spree_current_user).go!
 
-          flash[:notice] = 'Your order cycle has been created.'
+          flash[:notice] = I18n.t(:order_cycles_create_notice)
           format.html { redirect_to admin_order_cycles_path }
           format.json { render :json => {:success => true} }
         else
@@ -64,7 +64,7 @@ module Admin
             # Only update apply exchange information if it is actually submmitted
             OpenFoodNetwork::OrderCycleFormApplicator.new(@order_cycle, spree_current_user).go!
           end
-          flash[:notice] = 'Your order cycle has been updated.' if params[:reloading] == '1'
+          flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
           format.html { redirect_to main_app.edit_admin_order_cycle_path(@order_cycle) }
           format.json { render :json => {:success => true}  }
         else
@@ -76,7 +76,7 @@ module Admin
     def bulk_update
       @order_cycle_set = params[:order_cycle_set] && OrderCycleSet.new(params[:order_cycle_set])
       if @order_cycle_set.andand.save
-        redirect_to main_app.admin_order_cycles_path, :notice => 'Order cycles have been updated.'
+        redirect_to main_app.admin_order_cycles_path, :notice =>  I18n.t(:order_cycles_bulk_update_notice)
       else
         render :index
       end
@@ -85,14 +85,14 @@ module Admin
     def clone
       @order_cycle = OrderCycle.find params[:id]
       @order_cycle.clone!
-      redirect_to main_app.admin_order_cycles_path, :notice => "Your order cycle #{@order_cycle.name} has been cloned."
+      redirect_to main_app.admin_order_cycles_path, :notice => I18n.t(:order_cycles_clone_notice, name: @order_cycle.name)
     end
 
     # Send notifications to all producers who are part of the order cycle
     def notify_producers
       Delayed::Job.enqueue OrderCycleNotificationJob.new(params[:id].to_i)
 
-      redirect_to main_app.admin_order_cycles_path, :notice => 'Emails to be sent to producers have been queued for sending.'
+      redirect_to main_app.admin_order_cycles_path, :notice => I18n.t(:order_cycles_email_to_producers_notice)
     end
 
 
@@ -138,12 +138,12 @@ module Admin
       available_coordinators = permitted_coordinating_enterprises_for(@order_cycle).select(&:confirmed?)
       case available_coordinators.count
       when 0
-        flash[:error] = "None of your enterprises have permission to coordinate an order cycle"
+        flash[:error] =  I18n.t(:order_cycles_no_permission_to_coordinate_error)
         redirect_to main_app.admin_order_cycles_path
       when 1
         @order_cycle.coordinator = available_coordinators.first
       else
-        flash[:error] = "You don't have permission to create an order cycle coordinated by that enterprise" if params[:coordinator_id]
+        flash[:error] = I18n.t(:order_cycles_no_permission_to_create_error) if params[:coordinator_id]
         render :set_coordinator
       end
     end
@@ -153,7 +153,7 @@ module Admin
         yield
       rescue ActiveRecord::InvalidForeignKey
         redirect_to main_app.admin_order_cycles_url
-        flash[:error] = "That order cycle has been selected by a customer and cannot be deleted. To prevent customers from accessing it, please close it instead."
+        flash[:error] = I18n.t(:order_cycles_no_permission_to_delete_error)
       end
     end
 

--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -25,7 +25,7 @@ class Admin::ProductImportController < Spree::Admin::BaseController
 
   def validate_upload_presence
     unless params[:file] || (params[:filepath] && File.exist?(params[:filepath]))
-      redirect_to '/admin/product_import', notice: 'File not found or could not be opened'
+      redirect_to '/admin/product_import', notice: I18n.t(:product_import_file_not_found_notice)
       return
     end
   end
@@ -39,7 +39,7 @@ class Admin::ProductImportController < Spree::Admin::BaseController
 
   def check_spreadsheet_has_data(importer)
     unless importer.item_count
-      redirect_to '/admin/product_import', notice: 'No data found in spreadsheet'
+      redirect_to '/admin/product_import', notice: I18n.t(:product_import_no_data_in_spreadsheet_notice)
       return
     end
   end

--- a/app/controllers/spree/admin/adjustments_controller_decorator.rb
+++ b/app/controllers/spree/admin/adjustments_controller_decorator.rb
@@ -23,7 +23,7 @@ module Spree
           @tax_rate_id = tr_yielding_matching_tax || tr_valid_for_order
 
           if tr_yielding_matching_tax.nil?
-            @adjustment.errors.add :tax_rate_id, "^Please check that the tax rate for this adjustment is correct."
+            @adjustment.errors.add :tax_rate_id, I18n.t(:adjustments_tax_rate_error)
           end
         end
       end

--- a/app/controllers/spree/admin/base_controller_decorator.rb
+++ b/app/controllers/spree/admin/base_controller_decorator.rb
@@ -51,13 +51,9 @@ Spree::Admin::BaseController.class_eval do
     distributor_names = distributors.map(&:name).join ', '
 
     if distributors.count > 1
-      "The hubs #{distributor_names} are listed in an active order cycle, " +
-        "but do not have valid shipping and payment methods. " +
-        "Until you set these up, customers will not be able to shop at these hubs."
+      I18n.t(:active_distributors_not_ready_for_checkout_message_plural, distributor_names: distributor_names)
     else
-      "The hub #{distributor_names} is listed in an active order cycle, " +
-        "but does not have valid shipping and payment methods. " +
-        "Until you set these up, customers will not be able to shop at this hub."
+      I18n.t(:active_distributors_not_ready_for_checkout_message_singular, distributor_names: distributor_names)
     end
   end
 

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -37,6 +37,37 @@ Spree::Admin::ReportsController.class_eval do
         render_to_string(partial: 'sales_tax_description', layout: false, locals: {report_types: report_types[:sales_tax]}).html_safe
 } } }
 
+  def report_types
+    {
+      orders_and_fulfillment: [
+        [I18n.t('admin.reports.supplier_totals'), :order_cycle_supplier_totals],
+        [I18n.t('admin.reports.supplier_totals_by_distributor'), :order_cycle_supplier_totals_by_distributor],
+        [I18n.t('admin.reports.totals_by_supplier'), :order_cycle_distributor_totals_by_supplier],
+        [I18n.t('admin.reports.customer_totals'), :order_cycle_customer_totals]
+      ],
+      products_and_inventory: [
+        [I18n.t('admin.reports.all_products'), :all_products],
+        [I18n.t('admin.reports.inventory'), :inventory],
+        [I18n.t('admin.reports.lettuce_share'), :lettuce_share]
+      ],
+      customers: [
+        [I18n.t('admin.reports.mailing_list'), :mailing_list],
+        [I18n.t('admin.reports.addresses'), :addresses]
+      ],
+      order_cycle_management: [
+        [I18n.t('admin.reports.payment_methods'), :payment_methods],
+        [I18n.t('admin.reports.delivery'), :delivery]
+      ],
+      sales_tax: [
+        [I18n.t('admin.reports.tax_types'), :tax_types],
+        [I18n.t('admin.reports.tax_rates'), :tax_rates]
+      ],
+      packing: [
+        [I18n.t('admin.reports.pack_by_customer'), :pack_by_customer],
+        [I18n.t('admin.reports.pack_by_supplier'), :pack_by_supplier]
+      ]
+    }
+  end
 
   # Overide spree reports list.
   def index
@@ -254,38 +285,6 @@ Spree::Admin::ReportsController.class_eval do
   end
 
   private
-  def report_types
-    {
-      orders_and_fulfillment: [
-        [I18n.t('admin.reports.supplier_totals'), :order_cycle_supplier_totals],
-        [I18n.t('admin.reports.supplier_totals_by_distributor'), :order_cycle_supplier_totals_by_distributor],
-        [I18n.t('admin.reports.totals_by_supplier'), :order_cycle_distributor_totals_by_supplier],
-        [I18n.t('admin.reports.customer_totals'), :order_cycle_customer_totals]
-      ],
-      products_and_inventory: [
-        [I18n.t('admin.reports.all_products'), :all_products],
-        [I18n.t('admin.reports.inventory'), :inventory],
-        [I18n.t('admin.reports.lettuce_share'), :lettuce_share]
-      ],
-      customers: [
-        [I18n.t('admin.reports.mailing_list'), :mailing_list],
-        [I18n.t('admin.reports.addresses'), :addresses]
-      ],
-      order_cycle_management: [
-        [I18n.t('admin.reports.payment_methods'), :payment_methods],
-        [I18n.t('admin.reports.delivery'), :delivery]
-      ],
-      sales_tax: [
-        [I18n.t('admin.reports.tax_types'), :tax_types],
-        [I18n.t('admin.reports.tax_rates'), :tax_rates]
-      ],
-      packing: [
-        [I18n.t('admin.reports.pack_by_customer'), :pack_by_customer],
-        [I18n.t('admin.reports.pack_by_supplier'), :pack_by_supplier]
-      ]
-    }
-  end
-
 
   def prepare_date_params(params)
     # -- Prepare parameters

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -144,9 +144,9 @@ Spree::Admin::ReportsController.class_eval do
     orders.select{ |order| orders_with_hidden_details.include? order }.each do |order|
       # TODO We should really be hiding customer code here too, but until we
       # have an actual association between order and customer, it's a bit tricky
-      order.bill_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-      order.ship_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-      order.assign_attributes(email: "HIDDEN")
+      order.bill_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+      order.ship_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+      order.assign_attributes(email: I18n.t('admin.reports.hidden'))
     end
 
     @report = OpenFoodNetwork::OrderAndDistributorReport.new orders

--- a/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
@@ -38,7 +38,7 @@ module Spree
       def do_not_destroy_referenced_shipping_methods
         order = Order.where(:shipping_method_id => @object).first
         if order
-          flash[:error] = "That shipping method cannot be deleted as it is referenced by an order: #{order.number}."
+          flash[:error] = I18n.t(:shipping_method_destroy_error, number: order.number)
           redirect_to collection_url and return
         end
       end

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -132,7 +132,7 @@ Spree::OrdersController.class_eval do
       distributor = Enterprise.is_distributor.find params[:order][:distributor_id]
       @order.set_distributor! distributor
 
-      flash[:notice] = 'Your hub has been selected.'
+      flash[:notice] = I18n.t(:order_choosing_hub_notice)
       redirect_to request.referer
 
     elsif params[:commit] == 'Choose Order Cycle'
@@ -140,7 +140,7 @@ Spree::OrdersController.class_eval do
       order_cycle = OrderCycle.active.find params[:order][:order_cycle_id]
       @order.set_order_cycle! order_cycle
 
-      flash[:notice] = 'Your order cycle has been selected.'
+      flash[:notice] = I18n.t(:order_choosing_hub_notice)
       redirect_to request.referer
     end
   end

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -48,7 +48,7 @@ module EnterprisesHelper
 
   def enterprise_type_name(enterprise)
     if enterprise.sells == 'none'
-      enterprise.producer_profile_only ? 'Profile' : 'Supplier Only'
+      enterprise.producer_profile_only ? I18n.t(:profile) : I18n.t(:supplier_only)
     else
       "Has Shopfront"
     end
@@ -56,7 +56,7 @@ module EnterprisesHelper
 
   def enterprise_confirm_delete_message(enterprise)
     if enterprise.supplied_products.present?
-      "This will also delete the #{pluralize enterprise.supplied_products.count, 'product'} that this enterprise supplies. Are you sure you want to continue?"
+      I18n.t(:enterprise_confirm_delete_message, product: pluralize(enterprise.supplied_products.count, 'product'))
     else
       t(:are_you_sure)
     end

--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -85,14 +85,14 @@ module OrderCyclesHelper
       disabled_message = nil
       if options[:shipping_and_payment_methods] && (e.shipping_methods.empty? || e.payment_methods.available.empty?)
         if e.shipping_methods.empty? && e.payment_methods.available.empty?
-          disabled_message = 'no shipping or payment methods'
+          disabled_message = I18n.t(:no_shipping_or_payment)
         elsif e.shipping_methods.empty?
-          disabled_message = 'no shipping methods'
+          disabled_message = I18n.t(:no_shipping)
         elsif e.payment_methods.available.empty?
-          disabled_message = 'no payment methods'
+          disabled_message = I18n.t(:no_payment)
         end
       elsif options[:confirmed] && !e.confirmed?
-        disabled_message = 'unconfirmed'
+        disabled_message = I18n.t(:unconfirmed)
       end
 
       if disabled_message

--- a/app/helpers/spree/products_helper_decorator.rb
+++ b/app/helpers/spree/products_helper_decorator.rb
@@ -15,9 +15,9 @@ module Spree
     end
 
     def product_variant_unit_options
-      [['Weight', 'weight'],
-       ['Volume', 'volume'],
-       ['Items', 'items']]
+      [[I18n.t(:weight), 'weight'],
+       [I18n.t(:volume), 'volume'],
+       [I18n.t(:items), 'items']]
     end
   end
 end

--- a/app/helpers/spree/reports_helper.rb
+++ b/app/helpers/spree/reports_helper.rb
@@ -25,8 +25,8 @@ module Spree
     end
 
     def xero_report_types
-      [['Summary', 'summary'],
-       ['Detailed', 'detailed']]
+      [[I18n.t(:summary), 'summary'],
+       [I18n.t(:detailed), 'detailed']]
     end
 
     def currency_symbol

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -10,7 +10,7 @@ class ProducerMailer < Spree::BaseMailer
     @total = total_from_line_items(line_items)
     @tax_total = tax_total_from_line_items(line_items)
 
-    subject = "[#{Spree::Config.site_name}] Order cycle report for #{producer.name}"
+    subject = "[#{Spree::Config.site_name}] #{I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)}"
 
     if has_orders? order_cycle, producer
       mail(to: @producer.email,

--- a/app/models/billable_period.rb
+++ b/app/models/billable_period.rb
@@ -25,7 +25,7 @@ class BillablePeriod < ActiveRecord::Base
   def label
     enterprise_version = enterprise.version_at(begins_at)
     category = enterprise_version.category.to_s.titleize
-    category += (trial ? " Trial" : "")
+    category += (trial ? " #{I18n.t(:trial)}" : "")
 
     "#{enterprise_version.name} (#{category})"
   end

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -17,19 +17,19 @@ class ContentConfiguration < Spree::Preferences::FileConfiguration
   has_attached_file :home_hero, default_url: "/assets/home/home.jpg"
 
   # Producer sign-up page
-  preference :producer_signup_pricing_table_html, :text, default: "(TODO: Pricing table)"
-  preference :producer_signup_case_studies_html, :text, default: "(TODO: Case studies)"
-  preference :producer_signup_detail_html, :text, default: "(TODO: Detail)"
+  preference :producer_signup_pricing_table_html, :text, default: I18n.t(:content_configuration_pricing_table)
+  preference :producer_signup_case_studies_html, :text, default: I18n.t(:content_configuration_case_studies)
+  preference :producer_signup_detail_html, :text, default: I18n.t(:content_configuration_detail)
 
   # Hubs sign-up page
-  preference :hub_signup_pricing_table_html, :text, default: "(TODO: Pricing table)"
-  preference :hub_signup_case_studies_html, :text, default: "(TODO: Case studies)"
-  preference :hub_signup_detail_html, :text, default: "(TODO: Detail)"
+  preference :hub_signup_pricing_table_html, :text, default: I18n.t(:content_configuration_pricing_table)
+  preference :hub_signup_case_studies_html, :text, default: I18n.t(:content_configuration_case_studies)
+  preference :hub_signup_detail_html, :text, default: I18n.t(:content_configuration_detail)
 
   # Groups sign-up page
-  preference :group_signup_pricing_table_html, :text, default: "(TODO: Pricing table)"
-  preference :group_signup_case_studies_html, :text, default: "(TODO: Case studies)"
-  preference :group_signup_detail_html, :text, default: "(TODO: Detail)"
+  preference :group_signup_pricing_table_html, :text, default: I18n.t(:content_configuration_pricing_table)
+  preference :group_signup_case_studies_html, :text, default: I18n.t(:content_configuration_case_studies)
+  preference :group_signup_detail_html, :text, default: I18n.t(:content_configuration_detail)
 
   # Footer
   preference :footer_logo, :file

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -41,7 +41,7 @@ class Customer < ActiveRecord::Base
 
   def check_for_orders
     return true unless orders.any?
-    errors[:base] << "Delete failed: customer has associated orders"
+    errors[:base] << I18n.t('admin.customers.destroy.has_associated_orders')
     false
   end
 end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -378,7 +378,7 @@ class Enterprise < ActiveRecord::Base
     dups = dups.where('id != ?', id) unless new_record?
 
     if dups.any?
-      errors.add :name, "has already been taken. If this is your enterprise and you would like to claim ownership, please contact the current manager of this profile at #{dups.first.owner.email}."
+      errors.add :name, I18n.t(:enterprise_name_error, email: dups.first.owner.email)
     end
   end
 
@@ -427,7 +427,7 @@ class Enterprise < ActiveRecord::Base
 
   def enforce_ownership_limit
     unless owner.can_own_more_enterprises?
-      errors.add(:owner, "^#{owner.email} is not permitted to own any more enterprises (limit is #{owner.enterprise_limit}).")
+      errors.add(:owner, I18n.t(:enterprise_owner_error, email: owner.email, enterprise_limit: owner.enterprise_limit ))
     end
   end
 

--- a/app/models/enterprise_group.rb
+++ b/app/models/enterprise_group.rb
@@ -58,23 +58,23 @@ class EnterpriseGroup < ActiveRecord::Base
   }
 
   def set_unused_address_fields
-    address.firstname = address.lastname = 'unused'
+    address.firstname = address.lastname = I18n.t(:unused)
   end
 
   def set_undefined_address_fields
-    address.phone.present? || address.phone = 'undefined'
-    address.address1.present? || address.address1 = 'undefined'
-    address.city.present? || address.city = 'undefined'
+    address.phone.present? || address.phone = I18n.t(:undefined)
+    address.address1.present? || address.address1 = I18n.t(:undefined)
+    address.city.present? || address.city = I18n.t(:undefined)
     address.state.present? || address.state = address.country.states.first
-    address.zipcode.present? || address.zipcode = 'undefined'
+    address.zipcode.present? || address.zipcode = I18n.t(:undefined)
   end
 
   def unset_undefined_address_fields
     return unless address.present?
-    address.phone.sub!(/^undefined$/, '')
-    address.address1.sub!(/^undefined$/, '')
-    address.city.sub!(/^undefined$/, '')
-    address.zipcode.sub!(/^undefined$/, '')
+    address.phone.sub!(/^#{I18n.t(:undefined)}$/, '')
+    address.address1.sub!(/^#{I18n.t(:undefined)}$/, '')
+    address.city.sub!(/^#{I18n.t(:undefined)}$/, '')
+    address.zipcode.sub!(/^#{I18n.t(:undefined)}$/, '')
   end
 
   def to_param

--- a/app/models/enterprise_role.rb
+++ b/app/models/enterprise_role.rb
@@ -3,7 +3,7 @@ class EnterpriseRole < ActiveRecord::Base
   belongs_to :enterprise
 
   validates_presence_of :user_id, :enterprise_id
-  validates_uniqueness_of :enterprise_id, scope: :user_id, message: "^That role is already present."
+  validates_uniqueness_of :enterprise_id, scope: :user_id, message: I18n.t(:enterprise_role_uniqueness_error)
 
   scope :by_user_email, joins(:user).order('spree_users.email ASC')
 end

--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -9,7 +9,7 @@ class InventoryItem < ActiveRecord::Base
   validates :variant_id, uniqueness: { scope: :enterprise_id }
   validates :enterprise_id, presence: true
   validates :variant_id, presence: true
-  validates :visible, inclusion: { in: [true, false], message: "must be true or false" }
+  validates :visible, inclusion: { in: [true, false], message: I18n.t(:inventory_item_visibility_error) }
 
   scope :visible, where(visible: true)
   scope :hidden, where(visible: false)

--- a/app/models/product_distribution.rb
+++ b/app/models/product_distribution.rb
@@ -22,6 +22,6 @@ class ProductDistribution < ActiveRecord::Base
   end
 
   def adjustment_label_for(line_item)
-    "Product distribution by #{distributor.name} for #{line_item.product.name}"
+    I18n.t(:products_distribution_adjustment_label, distributor: distributor.name, product: line_item.product.name )
   end
 end

--- a/app/models/product_importer.rb
+++ b/app/models/product_importer.rb
@@ -18,7 +18,7 @@ class ProductImporter
       @products_to_create = {}
       @variants_to_create = {}
       @variants_to_update = {}
-      
+
       @products_created = 0
       @variants_created = 0
       @variants_updated = 0
@@ -33,7 +33,7 @@ class ProductImporter
 
       init_product_importer if @sheet
     else
-      self.errors.add(:importer, 'error: no file uploaded')
+      self.errors.add(:importer, I18n.t(:product_importer_file_error))
     end
   end
 
@@ -140,7 +140,7 @@ class ProductImporter
     if accepted_mimetype
       Roo::Spreadsheet.open(@file, extension: accepted_mimetype)
     else
-      self.errors.add(:importer, 'could not process file: invalid filetype')
+      self.errors.add(:importer, I18n.t(:product_importer_spreadsheet_error))
       delete_uploaded_file
       nil
     end
@@ -212,17 +212,17 @@ class ProductImporter
     supplier_name = entry.supplier
 
     if supplier_name.blank?
-      mark_as_invalid(entry, attribute: "supplier", error: "can't be blank")
+      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_required))
       return
     end
 
     unless supplier_exists?(supplier_name)
-      mark_as_invalid(entry, attribute: "supplier", error: "\"#{supplier_name}\" not found in database")
+      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_found_in_database, name: supplier_name))
       return
     end
 
     unless permission_by_name?(supplier_name)
-      mark_as_invalid(entry, attribute: "supplier", error: "\"#{supplier_name}\": you do not have permission to manage products for this enterprise")
+      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_no_permission_for_enterprise, name: supplier_name))
       return
     end
 
@@ -237,14 +237,14 @@ class ProductImporter
     category_name = entry.category
 
     if category_name.blank?
-      mark_as_invalid(entry, attribute: "category", error: "can't be blank")
+      mark_as_invalid(entry, attribute: "category", error: I18n.t(:error_required))
       return
     end
 
     if category_exists?(category_name)
       entry.primary_taxon_id = @categories_index[category_name]
     else
-      mark_as_invalid(entry, attribute: "category", error: "\"#{category_name}\" not found in database")
+      mark_as_invalid(entry, attribute: "category", error: I18n.t(:error_not_found_in_database, name: category_name))
     end
   end
 
@@ -335,7 +335,7 @@ class ProductImporter
       end
     end
 
-    self.errors.add(:importer, "did not save any products successfully") if total_saved_count.zero?
+    self.errors.add(:importer, I18n.t(:product_importer_products_save_error)) if total_saved_count.zero?
 
     reset_absent_products
     total_saved_count

--- a/app/models/spree/classification_decorator.rb
+++ b/app/models/spree/classification_decorator.rb
@@ -13,7 +13,7 @@ Spree::Classification.class_eval do
 
   def dont_destroy_if_primary_taxon
     if product.primary_taxon == taxon
-      errors.add :base,  "Taxon #{taxon.name} is the primary taxon of #{product.name} and cannot be deleted"
+      errors.add :base,  I18n.t(:spree_classification_primary_taxon_error, taxon: taxon.name, product: product.name)
       return false
     end
   end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -76,7 +76,7 @@ Spree::Order.class_eval do
   # -- Methods
   def products_available_from_new_distribution
     # Check that the line_items in the current order are available from a newly selected distribution
-    errors.add(:base, "Distributor or order cycle cannot supply the products in your cart") unless DistributionChangeValidator.new(self).can_change_to_distribution?(distributor, order_cycle)
+    errors.add(:base, I18n.t(:spree_order_availability_error)) unless DistributionChangeValidator.new(self).can_change_to_distribution?(distributor, order_cycle)
   end
 
   def empty_with_clear_shipping_and_payments!

--- a/app/models/spree/order_populator_decorator.rb
+++ b/app/models/spree/order_populator_decorator.rb
@@ -8,7 +8,7 @@ Spree::OrderPopulator.class_eval do
     # Refactor: We may not need this validation - we can't change distribution here, so
     # this validation probably can't fail
     if !distribution_can_supply_products_in_cart(@distributor, @order_cycle)
-      errors.add(:base, "That distributor or order cycle can't supply all the products in your cart. Please choose another.")
+      errors.add(:base, I18n.t(:spree_order_populator_error))
     end
 
     if valid?
@@ -124,7 +124,7 @@ Spree::OrderPopulator.class_eval do
     if DistributionChangeValidator.new(@order).variants_available_for_distribution(@distributor, @order_cycle).include? variant
       return true
     else
-      errors.add(:base, "That product is not available from the chosen distributor or order cycle.")
+      errors.add(:base, I18n.t(:spree_order_populator_availability_error))
       return false
     end
   end

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -11,7 +11,7 @@ Spree::PaymentMethod.class_eval do
 
   after_initialize :init
 
-  validates :distributors, presence: { message: "^At least one hub must be selected" }
+  validates :distributors, presence: { message: I18n.t(:spree_distributors_error) }
 
   # -- Scopes
   scope :managed_by, lambda { |user|

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -11,7 +11,7 @@ Spree::PaymentMethod.class_eval do
 
   after_initialize :init
 
-  validates :distributors, presence: { message: I18n.t(:spree_distributors_error) }
+  validates_with DistributorsValidator
 
   # -- Scopes
   scope :managed_by, lambda { |user|

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -8,7 +8,7 @@ Spree::ShippingMethod.class_eval do
   attr_accessible :distributor_ids, :description
   attr_accessible :require_ship_address, :tag_list
 
-  validates :distributors, presence: { message: "^At least one hub must be selected" }
+  validates :distributors, presence: { message: I18n.t(:spree_distributors_error) }
 
   scope :managed_by, lambda { |user|
     if user.has_spree_role?('admin')

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -8,7 +8,7 @@ Spree::ShippingMethod.class_eval do
   attr_accessible :distributor_ids, :description
   attr_accessible :require_ship_address, :tag_list
 
-  validates :distributors, presence: { message: I18n.t(:spree_distributors_error) }
+  validates_with DistributorsValidator
 
   scope :managed_by, lambda { |user|
     if user.has_spree_role?('admin')

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -83,7 +83,7 @@ Spree.user_class.class_eval do
 
   def limit_owned_enterprises
     if owned_enterprises.size > enterprise_limit
-      errors.add(:owned_enterprises, "^#{email} is not permitted to own any more enterprises (limit is #{enterprise_limit}).")
+      errors.add(:owned_enterprises, I18n.t(:spree_user_enterprise_limit_error, email: email, enterprise_limit: enterprise_limit))
     end
   end
 

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -84,7 +84,7 @@ Spree::Variant.class_eval do
 
   def delete
     if product.variants == [self] # Only variant left on product
-      errors.add :product, "must have at least one variant"
+      errors.add :product, I18n.t(:spree_variant_product_error)
       false
     else
       transaction do

--- a/app/overrides/add_enterprise_fees_to_admin_configurations_menu.rb
+++ b/app/overrides/add_enterprise_fees_to_admin_configurations_menu.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(:virtual_path  => "spree/admin/shared/_configuration_menu",
                      :name          => "add_enterprise_fees_to_admin_configurations_menu",
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu']",
-                     :text          => "<li><%= link_to 'Enterprise Fees', main_app.admin_enterprise_fees_path %></li>",
+                     :text          => "<li><%= link_to I18n.t(:enterprise_fees), main_app.admin_enterprise_fees_path %></li>",
                      :partial       => 'enterprise_fees/admin_configurations_menu',
                      :original      => '8445a03cc903cacc832f395757ffcfaa7e99ca92')

--- a/app/overrides/replace_checkout_payment_button.rb
+++ b/app/overrides/replace_checkout_payment_button.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/checkout/_payment",
                      :replace      => "code[erb-loud]:contains('submit_tag t(:save_and_continue)')",
-                     :text         => "<%= submit_tag 'Process My Order', :class => 'continue button primary' %>",
+                     :text         => "<%= submit_tag I18n.t(:process_my_order), :class => 'continue button primary' %>",
                      :name         => "replace_checkout_payment_button",
                      :original     => 'ce2043a01931b3bc16b045302ebb0e0bb9150b67')

--- a/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
@@ -12,6 +12,6 @@
 
   .variant_unit_name{'ng-show' => 'product.variant_unit == "items"'}
     = f.field_container :variant_unit_name do
-      = f.label :variant_unit_name, 'Variant unit name'
+      = f.label :variant_unit_name, t(:spree_admin_variant_unit_name)
       = f.text_field :variant_unit_name, {placeholder: t('admin.products.unit_name_placeholder')}
       = f.error_message_on :variant_unit_name

--- a/app/overrides/spree/admin/shipping_categories/index/add_temp_controlled_td.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_categories/index/add_temp_controlled_td.html.haml.deface
@@ -1,5 +1,5 @@
 / insert_after "[data-hook='category_row'] td:first-child"
 
 %td.align-center
-  = shipping_category.temperature_controlled ? 'Yes' : 'No'
+  = shipping_category.temperature_controlled ? t(:yes) : t(:no)
   %br/

--- a/app/overrides/spree/admin/shipping_methods/_form/replace_form_fields.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/_form/replace_form_fields.html.haml.deface
@@ -8,13 +8,13 @@
     .alpha.three.columns
       = f.label :name, t(:name)
     .omega.eight.columns
-      = f.text_field :name, :class => 'fullwidth', placeholder: "eg. 'Pick-up from Primary School'"
+      = f.text_field :name, :class => 'fullwidth', placeholder: t(:spree_admin_eg_pickup_from_school)
       = error_message_on :shipping_method, :name
   .row
     .alpha.three.columns
       = f.label :description, t(:description)
     .omega.eight.columns
-      = f.text_area :description, class: 'fullwidth', rows: 2, placeholder: "eg. 'Please collect your order from 123 Imaginary St, Northcote, 3070'"
+      = f.text_area :description, class: 'fullwidth', rows: 2, placeholder: t(:spree_admin_eg_collect_your_order)
       = error_message_on :shipping_method, :description
   - if @available_zones.length == 1
     = f.hidden_field :zone_id, value: @available_zones.first.id

--- a/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
@@ -9,5 +9,5 @@
       = f.text_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}
 
     .field{"data-hook" => "unit_description"}
-      = f.label :unit_description, "Unit Description"
+      = f.label :unit_description, t(:spree_admin_unit_description)
       = f.text_field :unit_description, class: "fullwidth", placeholder: t('admin.products.unit_name_placeholder')

--- a/app/overrides/spree/admin/variants/_form/on_demand_tooltip.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/on_demand_tooltip.html.haml.deface
@@ -1,3 +1,3 @@
 / insert_bottom "[data-hook='on_demand']"
 %div{'ofn-with-tip' => t('admin.products.variants.to_order_tip')}
-  %a What's this?
+  %a= t('admin.whats_this')

--- a/app/overrides/spree/checkout/_delivery/shipping_instructions_to_delivery_instructions.html.haml.deface
+++ b/app/overrides/spree/checkout/_delivery/shipping_instructions_to_delivery_instructions.html.haml.deface
@@ -1,5 +1,5 @@
 / replace_contents '#shipping_method p#minstrs'
 
-= form.label :special_instructions, 'Delivery Instructions'
+= form.label :special_instructions, t(:delivery_instructions)
 %br/
 = form.text_area :special_instructions, :cols => 40, :rows => 7

--- a/app/overrides/spree/checkout/_delivery/shipping_method_to_delivery_method.html.haml.deface
+++ b/app/overrides/spree/checkout/_delivery/shipping_method_to_delivery_method.html.haml.deface
@@ -1,2 +1,2 @@
 / replace_contents '#shipping_method legend'
-Delivery Method
+= t(:delivery_method)

--- a/app/overrides/spree/checkout/edit/add_new_save_checkout_button.html.erb.deface
+++ b/app/overrides/spree/checkout/edit/add_new_save_checkout_button.html.erb.deface
@@ -1,11 +1,11 @@
-<!-- insert_after '[data-hook="checkout_summary_box"]'  
+<!-- insert_after '[data-hook="checkout_summary_box"]'
   sequence :before => 'add_change_distributor_form_to_checkout_address'  -->
 
 <% # Add a new 'Save and Continue/Process My Order' button under Order Summary on the checkout pages %>
 
 <div id="add_new_save_checkout_button" class="columns omega four">
-  <%= submit_tag @order.state == "payment" ? "Process My Order" : t(:save_and_continue), 
-                  :class => "continue button primary large", 
+  <%= submit_tag @order.state == "payment" ? t(:process_my_order) : t(:save_and_continue),
+                  :class => "continue button primary large",
                   :form=> "checkout_form_#{@order.state}" %>
   <script>
     //Show additional button only if form attribute is supported

--- a/app/serializers/api/admin/product_serializer.rb
+++ b/app/serializers/api/admin/product_serializer.rb
@@ -9,7 +9,7 @@ class Api::Admin::ProductSerializer < ActiveModel::Serializer
   has_one :master, serializer: Api::Admin::VariantSerializer
 
   def on_hand
-    object.on_hand.nil? ? 0 : object.on_hand.to_f.finite? ? object.on_hand : "On demand"
+    object.on_hand.nil? ? 0 : object.on_hand.to_f.finite? ? object.on_hand : I18n.t(:on_demand)
   end
 
   def price

--- a/app/serializers/api/admin/variant_serializer.rb
+++ b/app/serializers/api/admin/variant_serializer.rb
@@ -4,7 +4,7 @@ class Api::Admin::VariantSerializer < ActiveModel::Serializer
   has_many :variant_overrides
 
   def on_hand
-    object.on_hand.nil? ? 0 : ( object.on_hand.to_f.finite? ? object.on_hand : "On demand" )
+    object.on_hand.nil? ? 0 : ( object.on_hand.to_f.finite? ? object.on_hand : I18n.t(:on_demand) )
   end
 
   def price

--- a/app/validators/distributors_validator.rb
+++ b/app/validators/distributors_validator.rb
@@ -1,0 +1,6 @@
+# This is workaround only for https://github.com/openfoodfoundation/openfoodnetwork/issues/1560#issuecomment-300832051
+class DistributorsValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add(:base, I18n.t(:spree_distributors_error)) unless record.distributors.any?
+  end
+end

--- a/app/views/admin/cache_settings/show.html.haml
+++ b/app/views/admin/cache_settings/show.html.haml
@@ -13,6 +13,6 @@
       %tr
         %td= result[:distributor].name
         %td= result[:order_cycle].name
-        %td= result[:status] ? 'OK' : 'Error'
+        %td= result[:status] ? t(:ok) : t('.error')
         %td
           %pre= result[:diff].to_s(:text)

--- a/app/views/admin/enterprise_roles/_enterprise_role.html.haml
+++ b/app/views/admin/enterprise_roles/_enterprise_role.html.haml
@@ -1,5 +1,5 @@
 %td {{ enterprise_role.user_email }}
-%td= t('admin.enterprise_roles.manages')
+%td= t('.manages')
 %td {{ enterprise_role.enterprise_name }}
 %td.actions
   %a.delete-enterprise-role.icon-trash.no-text{'ng-click' => 'delete(enterprise_role)'}

--- a/app/views/admin/enterprise_roles/_enterprise_role.html.haml
+++ b/app/views/admin/enterprise_roles/_enterprise_role.html.haml
@@ -1,5 +1,5 @@
 %td {{ enterprise_role.user_email }}
-%td manages
+%td= t('admin.enterprise_roles.manages')
 %td {{ enterprise_role.enterprise_name }}
 %td.actions
   %a.delete-enterprise-role.icon-trash.no-text{'ng-click' => 'delete(enterprise_role)'}

--- a/app/views/admin/order_cycles/_exchange_supplied_products_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_supplied_products_form.html.haml
@@ -3,7 +3,7 @@
   .exchange-select-all-variants
     %label
       = check_box_tag 'order_cycle_incoming_exchange_{{ $parent.$index }}_select_all_variants', 1, 1, 'ng-model' => 'exchange.select_all_variants', 'ng-change' => 'setExchangeVariants(exchange, suppliedVariants(exchange.enterprise_id), exchange.select_all_variants)', 'id' => 'order_cycle_incoming_exchange_{{ $parent.$index }}_select_all_variants'
-      Select all
+      = t('admin.select_all')
 
   .exchange-products
     -# No need to scope product list based on permissions, because if an incoming exchange is visible,
@@ -23,7 +23,7 @@
         %label
           = check_box_tag 'order_cycle_incoming_exchange_{{ $parent.$index }}_variants_{{ product.master_id }}', 1, 1, 'ng-model' => 'exchange.variants[product.master_id]', 'ofn-sync-distributions' => '{{ product.master_id }}', 'id' => 'order_cycle_incoming_exchange_{{ $parent.$index }}_variants_{{ product.master_id }}',
           'ng-disabled' => '!order_cycle.editable_variants_for_incoming_exchanges.hasOwnProperty(exchange.enterprise_id) || order_cycle.editable_variants_for_incoming_exchanges[exchange.enterprise_id].indexOf(product.master_id) < 0'
-          Obsolete master
+          = t('admin.obsolete_master')
 
       .exchange-product-variant{'ng-repeat' => 'variant in product.variants'}
         %label

--- a/app/views/admin/order_cycles/_form.html.haml
+++ b/app/views/admin/order_cycles/_form.html.haml
@@ -37,7 +37,7 @@
       %th{ ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
         = t('.tags')
       %th= t('.delivery_details')
-      %th Fees
+      %th= t('.fees')
       %th.actions
   %tbody.panel-ctrl{ object: 'exchange', 'ng-repeat' => 'exchange in order_cycle.outgoing_exchanges'}
     = render 'exchange_form', f: f, type: 'distributor'

--- a/app/views/admin/variant_overrides/_controls.html.haml
+++ b/app/views/admin/variant_overrides/_controls.html.haml
@@ -10,6 +10,6 @@
   .four.columns.omega{ ng: { show: 'views.new.visible' } }
     %button.fullwidth{ type: 'button', ng: { click: "selectView('inventory')" } }
       %i.icon-chevron-left
-      Back to my inventory
+      = t('.back_to_my_inventory')
   .four.columns.omega{ng: { show: 'views.inventory.visible' } }
     %columns-dropdown{ action: "#{controller_name}_#{action_name}" }

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -16,7 +16,7 @@ Orders summary
   #{line_items.first.variant.sku} - #{raw(line_items.first.product.supplier.name)} - #{raw(product_and_full_name)} (QTY: #{line_items.sum(&:quantity)}) @ #{line_items.first.single_money} = #{Spree::Money.new(line_items.sum(&:total), currency: line_items.first.currency)}
 \
 \
-Total: #{@total}
+#{t :total}: #{@total}
 \
 = t :producer_mail_text_after
 

--- a/app/views/spree/admin/orders/_form/_distribution_fields.html.haml
+++ b/app/views/spree/admin/orders/_form/_distribution_fields.html.haml
@@ -4,12 +4,12 @@
   - if @order.complete?
     .alpha.six.columns
       %p
-        %b= "#{t(:distributor)}:"
+        %b= t('.distributor')
         = @order.distributor.andand.name || t(:none)
         %input{type: "hidden", id: "order_distributor_id", value: @order.distributor.andand.id}
     .omega.six.columns
       %p
-        %b= "#{t(:order_cycle)}:"
+        %b= t('.order_cycle')
         = @order.order_cycle.andand.name || t(:none)
         %input{type: "hidden", id: "order_order_cycle_id", value: @order.order_cycle.andand.id}
   - else
@@ -24,7 +24,7 @@
 
     .omega.six.columns
       .field
-        %label{ for: "order_order_cycle_id"}= t(:order_cycle)
+        %label{for: "order_order_cycle_id"}= t(:order_cycle)
         %input.ofn-select2.fullwidth{id: "order_order_cycle_id",
         type: 'number',
         name: "order[order_cycle_id]",

--- a/app/views/spree/admin/orders/invoice.html.haml
+++ b/app/views/spree/admin/orders/invoice.html.haml
@@ -4,11 +4,11 @@
   %tbody
     %tr{ valign: "top" }
       %td{ :align => "left", colspan: 3 }
-        %h6= "Issued on: #{Time.zone.now.strftime("%F")}"
+        %h6= "#{t('.issued_on')}: #{Time.zone.now.strftime("%F")}"
     %tr{ valign: "top" }
       %td{ :align => "left" }
         %h4
-          = "TAX INVOICE: "
+          = "#{t('.tax_invoice')}: "
           = "#{@order.number}"
       %td{width: "10%" }
         &nbsp;
@@ -16,10 +16,10 @@
         %h4= @order.order_cycle.andand.name
     %tr{ valign: "top" }
       %td{ :align => "left" }
-        %strong= "From: #{@order.distributor.name}"
+        %strong= "#{t('.from')}: #{@order.distributor.name}"
         - if @order.distributor.abn.present?
           %br
-          = "ABN: #{@order.distributor.abn}"
+          = "#{t(:abn)} #{@order.distributor.abn}"
         %br
         = @order.distributor.address.full_address
         %br
@@ -27,10 +27,10 @@
       %td{width: "10%" }
         &nbsp;
       %td{ :align => "right" }
-        %strong= "To: #{@order.ship_address.full_name}"
+        %strong= "#{t('.to')}: #{@order.ship_address.full_name}"
         - if @order.customer.code.present?
           %br
-          = "Code: #{@order.customer.code}"
+          = "#{t('.code')}: #{@order.customer.code}"
         %br
         = @order.ship_address.full_address
         %br

--- a/app/views/spree/admin/overview/_enterprises_header.html.haml
+++ b/app/views/spree/admin/overview/_enterprises_header.html.haml
@@ -6,5 +6,5 @@
       %a.three.columns.omega.icon-plus.button.blue.white-bottom{ href: "#{main_app.new_admin_enterprise_path}" }
         = t "spree_admin_enterprises_create_new"
   - else
-    %a{ "ofn-with-tip" => "Enterprises are Producers and/or Hubs and are the basic unit of organisation within the Open Food Network." }
+    %a{ "ofn-with-tip" => t('.ofn_with_tip') }
       = t "admin_enterprise_groups_what_s_this"

--- a/app/views/spree/admin/overview/_enterprises_hubs_tab.html.haml
+++ b/app/views/spree/admin/overview/_enterprises_hubs_tab.html.haml
@@ -22,7 +22,7 @@
             - if payment_method_count > 0
               %span.icon-ok-sign{ 'ofn-with-tip' => "#{pluralize payment_method_count, 'payment method'}" }
             - else
-              %span.icon-remove-sign{ 'ofn-with-tip' => "#{enterprise.name} has no payment methods" }
+              %span.icon-remove-sign{ 'ofn-with-tip' => t('.has_no_payment_methods', enterprise: enterprise.name) }
           - else
             &nbsp;
         %span.symbol.three.columns.centered
@@ -31,7 +31,7 @@
             - if shipping_method_count > 0
               %span.icon-ok-sign{ 'ofn-with-tip' => "#{pluralize shipping_method_count, 'shipping method'}" }
             - else
-              %span.icon-remove-sign{ 'ofn-with-tip' => "#{enterprise.name} has no shipping methods" }
+              %span.icon-remove-sign{ 'ofn-with-tip' => t('.has_no_shipping_methods', enterprise: enterprise.name) }
           - else
             &nbsp;
         %span.symbol.three.columns.centered
@@ -40,7 +40,7 @@
             - if fee_count > 0
               %span.icon-ok-sign{ 'ofn-with-tip' => "#{pluralize fee_count, 'fee'}" }
             - else
-              %span.icon-warning-sign{ 'ofn-with-tip' => "#{enterprise.name} has no enterprise fees" }
+              %span.icon-warning-sign{ 'ofn-with-tip' => t('.has_no_enterprise_fees', enterprise: enterprise.name) }
           - else
             &nbsp;
         %span.two.columns.omega.right

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -1,9 +1,9 @@
 %div.dashboard_item.seven.columns.omega#order_cycles
-  %div.header.seven.columns.alpha{ :class => "#{@order_cycle_count > 0 ? "" : "orange"}"}
+  %div.header.seven.columns.alpha{ class: @order_cycle_count > 0 ? "" : "orange"}
     %h3.four.columns.alpha
       = t "spree_admin_order_cycles"
     - if @order_cycle_count > 0
-      %a.three.columns.omega.icon-plus.button.blue{ href: "#{main_app.new_admin_order_cycle_path}" }
+      %a.three.columns.omega.icon-plus.button.blue{ href: main_app.new_admin_order_cycle_path }
         = t "spree_admin_enterprises_create_new"
     - else
       %a{ "ofn-with-tip" => t(:spree_admin_order_cycles_tip) }
@@ -15,7 +15,7 @@
           = t('.you_have_active', count: @order_cycle_count)
         %span.one.column.omega
           %span.icon-ok-sign
-      %a.seven.columns.alpha.button.bottom.blue{ href: "#{main_app.admin_order_cycles_path}" }
+      %a.seven.columns.alpha.button.bottom.blue{ href: main_app.admin_order_cycles_path }
         = t "spree_admin_enterprises_producers_manage_order_cycles"
         %span.icon-arrow-right
     - else
@@ -24,7 +24,7 @@
           = t "spree_admin_enterprises_producers_orders_cycle_text"
         %span.one.column.omega
           %span.icon-warning-sign
-      %a.seven.columns.alpha.button.bottom.orange{ href: "#{main_app.admin_order_cycles_path}" }
+      %a.seven.columns.alpha.button.bottom.orange{ href: main_app.admin_order_cycles_path }
         = t "spree_admin_enterprises_producers_manage_order_cycles"
         %span.icon-arrow-right
         = t ".manage_order_cycles"

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -1,4 +1,5 @@
 - color_class = @order_cycle_count > 0 ? "blue" : "orange"
+- icon_class = @order_cycle_count > 0 ? "icon-ok-sign" : "icon-warning-sign"
 %div.dashboard_item.seven.columns.omega#order_cycles
   %div.header.seven.columns.alpha{class: color_class}
     %h3.four.columns.alpha
@@ -10,21 +11,11 @@
       %a{ "ofn-with-tip" => t(:spree_admin_order_cycles_tip) }
         = t "admin.whats_this"
   %div.seven.columns.alpha.list
-    - if @order_cycle_count > 0
-      %div.seven.columns.alpha.list-item
-        %span.six.columns.alpha
-          = t('.you_have_active', count: @order_cycle_count)
-        %span.one.column.omega
-          %span.icon-ok-sign
-      %a.seven.columns.alpha.button.bottom{ href: main_app.admin_order_cycles_path, class: color_class }
-        = t "spree_admin_enterprises_producers_manage_order_cycles"
-        %span.icon-arrow-right
-    - else
-      %div.seven.columns.alpha.list-item{class: color_class}
-        %span.six.columns.alpha
-          = t('.you_have_active', count: @order_cycle_count)
-        %span.one.column.omega
-          %span.icon-warning-sign
-      %a.seven.columns.alpha.button.bottom{ href: main_app.admin_order_cycles_path, class: color_class }
-        = t "spree_admin_enterprises_producers_manage_order_cycles"
-        %span.icon-arrow-right
+    %div.seven.columns.alpha.list-item{class: color_class}
+      %span.six.columns.alpha
+        = t('.you_have_active', count: @order_cycle_count)
+      %span.one.column.omega
+        %span{class: icon_class}
+    %a.seven.columns.alpha.button.bottom{ href: main_app.admin_order_cycles_path, class: color_class }
+      = t "spree_admin_enterprises_producers_manage_order_cycles"
+      %span.icon-arrow-right

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -12,7 +12,7 @@
     - if @order_cycle_count > 0
       %div.seven.columns.alpha.list-item
         %span.six.columns.alpha
-          = "You have #{@order_cycle_count} active order cycle#{@order_cycle_count > 1 ? "s" : ""}."
+          = t('.you_have_active', num: @order_cycle_count, order_cycles: t('.order_cycle', count: @order_cycle_count))
         %span.one.column.omega
           %span.icon-ok-sign
       %a.seven.columns.alpha.button.bottom.blue{ href: "#{main_app.admin_order_cycles_path}" }
@@ -27,5 +27,5 @@
       %a.seven.columns.alpha.button.bottom.orange{ href: "#{main_app.admin_order_cycles_path}" }
         = t "spree_admin_enterprises_producers_manage_order_cycles"
         %span.icon-arrow-right
-        MANAGE ORDER CYCLES
+        = t ".manage_order_cycles"
         %span.icon-arrow-right

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -21,11 +21,9 @@
     - else
       %div.seven.columns.alpha.list-item.orange
         %span.six.columns.alpha
-          = t "spree_admin_enterprises_producers_orders_cycle_text"
+          = t('.you_have_active', count: @order_cycle_count)
         %span.one.column.omega
           %span.icon-warning-sign
       %a.seven.columns.alpha.button.bottom.orange{ href: main_app.admin_order_cycles_path }
         = t "spree_admin_enterprises_producers_manage_order_cycles"
-        %span.icon-arrow-right
-        = t ".manage_order_cycles"
         %span.icon-arrow-right

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -3,12 +3,12 @@
 %div.dashboard_item.seven.columns.omega#order_cycles
   %div.header.seven.columns.alpha{class: color_class}
     %h3.four.columns.alpha
-      = t "spree_admin_order_cycles"
+      = t ".order_cycles"
     - if @order_cycle_count > 0
       %a.three.columns.omega.icon-plus.button.blue{ href: main_app.new_admin_order_cycle_path }
         = t "spree_admin_enterprises_create_new"
     - else
-      %a{ "ofn-with-tip" => t(:spree_admin_order_cycles_tip) }
+      %a{ "ofn-with-tip" => t(".order_cycles_tip") }
         = t "admin.whats_this"
   %div.seven.columns.alpha.list
     %div.seven.columns.alpha.list-item{class: color_class}
@@ -17,5 +17,5 @@
       %span.one.column.omega
         %span{class: icon_class}
     %a.seven.columns.alpha.button.bottom{ href: main_app.admin_order_cycles_path, class: color_class }
-      = t "spree_admin_enterprises_producers_manage_order_cycles"
+      = t ".manage_order_cycles"
       %span.icon-arrow-right

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -12,7 +12,7 @@
     - if @order_cycle_count > 0
       %div.seven.columns.alpha.list-item
         %span.six.columns.alpha
-          = t('.you_have_active', num: @order_cycle_count, order_cycles: t('.order_cycle', count: @order_cycle_count))
+          = t('.you_have_active', count: @order_cycle_count)
         %span.one.column.omega
           %span.icon-ok-sign
       %a.seven.columns.alpha.button.bottom.blue{ href: "#{main_app.admin_order_cycles_path}" }

--- a/app/views/spree/admin/overview/_order_cycles.html.haml
+++ b/app/views/spree/admin/overview/_order_cycles.html.haml
@@ -1,5 +1,6 @@
+- color_class = @order_cycle_count > 0 ? "blue" : "orange"
 %div.dashboard_item.seven.columns.omega#order_cycles
-  %div.header.seven.columns.alpha{ class: @order_cycle_count > 0 ? "" : "orange"}
+  %div.header.seven.columns.alpha{class: color_class}
     %h3.four.columns.alpha
       = t "spree_admin_order_cycles"
     - if @order_cycle_count > 0
@@ -15,15 +16,15 @@
           = t('.you_have_active', count: @order_cycle_count)
         %span.one.column.omega
           %span.icon-ok-sign
-      %a.seven.columns.alpha.button.bottom.blue{ href: main_app.admin_order_cycles_path }
+      %a.seven.columns.alpha.button.bottom{ href: main_app.admin_order_cycles_path, class: color_class }
         = t "spree_admin_enterprises_producers_manage_order_cycles"
         %span.icon-arrow-right
     - else
-      %div.seven.columns.alpha.list-item.orange
+      %div.seven.columns.alpha.list-item{class: color_class}
         %span.six.columns.alpha
           = t('.you_have_active', count: @order_cycle_count)
         %span.one.column.omega
           %span.icon-warning-sign
-      %a.seven.columns.alpha.button.bottom.orange{ href: main_app.admin_order_cycles_path }
+      %a.seven.columns.alpha.button.bottom{ href: main_app.admin_order_cycles_path, class: color_class }
         = t "spree_admin_enterprises_producers_manage_order_cycles"
         %span.icon-arrow-right

--- a/app/views/spree/admin/products/_distributors_form.html.haml
+++ b/app/views/spree/admin/products/_distributors_form.html.haml
@@ -1,4 +1,4 @@
-%h2 Distributors
+%h2= t(:distributors)
 = f.field_container :product_distributions do
   - f.object.build_product_distributions_for_user spree_current_user
   %table

--- a/app/views/spree/admin/reports/bulk_coop.html.haml
+++ b/app/views/spree/admin/reports/bulk_coop.html.haml
@@ -3,9 +3,9 @@
 
   .row
     .four.columns.alpha
-      = label_tag nil, "#{t(:distributor)}: "
+      = label_tag nil, t(:report_distributor)
       = f.collection_select(:distributor_id_eq, @distributors, :id, :name, {:include_blank => t(:all)}, {:class => "select2 fullwidth"})
-  = label_tag nil, "#{t(:report_type)}: "
+  = label_tag nil, t(:report_type)
   %br
   = select_tag(:report_type, options_for_select([:bulk_coop_supplier_report, :bulk_coop_allocation, :bulk_coop_packing_sheets, :bulk_coop_customer_payments].map{ |e| [t(".#{e}"), e] }, @report_type))
   %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1557,7 +1557,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   spree_order_availability_error: "Distributor or order cycle cannot supply the products in your cart"
   spree_order_populator_error: "That distributor or order cycle can't supply all the products in your cart. Please choose another."
   spree_order_populator_availability_error: "That product is not available from the chosen distributor or order cycle."
-  spree_distributors_error: "^At least one hub must be selected"
+  spree_distributors_error: "At least one hub must be selected"
   spree_user_enterprise_limit_error: "^%{email} is not permitted to own any more enterprises (limit is %{enterprise_limit})."
   spree_variant_product_error: must have at least one variant
   your_profil_live: "Your profile live"
@@ -1838,11 +1838,11 @@ Please follow the instructions there to make your enterprise visible on the Open
   order_choosing_hub_notice: Your hub has been selected.
   order_cycle_selecting_notice: Your order cycle has been selected.
   adjustments_tax_rate_error: "^Please check that the tax rate for this adjustment is correct."
-  active_distributors_not_ready_for_checkout_message_singular: >
+  active_distributors_not_ready_for_checkout_message_singular: >-
     The hub %{distributor_names} is listed in an active order cycle,
     but does not have valid shipping and payment methods.
     Until you set these up, customers will not be able to shop at this hub.
-  active_distributors_not_ready_for_checkout_message_plural: >
+  active_distributors_not_ready_for_checkout_message_plural: >-
     The hubs %{distributor_names} are listed in an active order cycle,
     but do not have valid shipping and payment methods.
     Until you set these up, customers will not be able to shop at these hubs.
@@ -1856,7 +1856,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   order_cycles_create_notice: 'Your order cycle has been created.'
   order_cycles_update_notice: 'Your order cycle has been updated.'
   order_cycles_bulk_update_notice: 'Order cycles have been updated.'
-  order_cycles_clone_notice, name: "Your order cycle %{name} has been cloned."
+  order_cycles_clone_notice: "Your order cycle %{name} has been cloned."
   order_cycles_email_to_producers_notice: 'Emails to be sent to producers have been queued for sending.'
   order_cycles_no_permission_to_coordinate_error: "None of your enterprises have permission to coordinate an order cycle"
   order_cycles_no_permission_to_create_error: "You don't have permission to create an order cycle coordinated by that enterprise"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -628,6 +628,56 @@ en:
           zero: order cycle
           one: order cycle
           other: order cycles
+
+    reports:
+      supplier_totals: Order Cycle Supplier Totals
+      supplier_totals_by_distributor: Order Cycle Supplier Totals by Distributor
+      totals_by_supplier: Order Cycle Distributor Totals by Supplier
+      customer_totals: Order Cycle Customer Totals
+      all_products: All products
+      inventory: Inventory (on hand)
+      lettuce_share: LettuceShare
+      mailing_list: Mailing List
+      addresses: Addresses
+      payment_methods: Payment Methods Report
+      delivery: Delivery Report
+      tax_types: Tax Types
+      tax_rate: Tax Rates
+      pack_by_customer: Pack By Customer
+      pack_by_supplier: Pack By Supplier
+      orders_and_distributors:
+        name: Orders And Distributors
+        description: Orders with distributor details
+      bulk_coop:
+        name: Bulk Co-Op
+        description: Reports for Bulk Co-Op orders
+      payments:
+        name: Payment Reports
+        description: Reports for Payments
+      orders_and_fulfillment:
+        name: Orders & Fulfillment Reports
+      customers:
+        name: Customers
+        description: Customer details
+      products_and_inventory:
+        name: Products & Inventory
+        description:
+      sales_total:
+        name: Sales Total
+        description: Sales Total For All Orders
+      users_and_enterprises:
+        name: Users & Enterprises
+        description: Enterprise Ownership & Status
+      order_cycle_management:
+        name: Order Cycle Management
+      sales_tax:
+        name: Sales Tax
+        description: Sales Tax For Orders
+      xero_invoices:
+        name: Xero Invoices
+        description: Invoices for import into Xero
+      packing:
+        name: Packing Reports
 # Frontend views
 #
 # These keys are referenced relatively like `t('.message')` in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,7 @@ en:
   items: Items
   summary: Summary
   detailed: Detailed
+  updated: Updated
   'yes': "Yes"
   'no': "No"
   'y': 'Y'
@@ -1414,6 +1415,9 @@ Please follow the instructions there to make your enterprise visible on the Open
   registration_detail_state_error: "State required"
   registration_detail_country: "Country:"
   registration_detail_country_error: "Please select a country"
+  shipping_method_destroy_error: "That shipping method cannot be deleted as it is referenced by an order: %{number}."
+  accounts_and_billing_task_already_running_error: "A task is already running, please wait until it has finished"
+  accounts_and_billing_start_task_notice: "Task Queued"
   fees: "Fees"
   item_cost: "Item cost"
   bulk: "Bulk"
@@ -1829,7 +1833,42 @@ Please follow the instructions there to make your enterprise visible on the Open
   product_importer_file_error: "error: no file uploaded"
   product_importer_spreadsheet_error: "could not process file: invalid filetype"
   product_importer_products_save_error: did not save any products successfully
-
+  product_import_file_not_found_notice: 'File not found or could not be opened'
+  product_import_no_data_in_spreadsheet_notice: 'No data found in spreadsheet'
+  order_choosing_hub_notice: Your hub has been selected.
+  order_cycle_selecting_notice: Your order cycle has been selected.
+  adjustments_tax_rate_error: "^Please check that the tax rate for this adjustment is correct."
+  active_distributors_not_ready_for_checkout_message_singular: >
+    The hub %{distributor_names} is listed in an active order cycle,
+    but does not have valid shipping and payment methods.
+    Until you set these up, customers will not be able to shop at this hub.
+  active_distributors_not_ready_for_checkout_message_plural: >
+    The hubs %{distributor_names} are listed in an active order cycle,
+    but do not have valid shipping and payment methods.
+    Until you set these up, customers will not be able to shop at these hubs.
+  enterprise_fees_update_notice: Your enterprise fees have been updated.
+  enterprise_fees_destroy_error: "That enterprise fee cannot be deleted as it is referenced by a product distribution: #{id} - #{name}."
+  enterprise_register_package_error: "Please select a package"
+  enterprise_register_error: "Could not complete registration for %{enterprise}"
+  enterprise_register_success_notice: "Congratulations! Registration for %{enterprise} is complete!"
+  enterprise_bulk_update_success_notice: "Enterprises updated successfully"
+  enterprise_bulk_update_error: 'Update failed'
+  order_cycles_create_notice: 'Your order cycle has been created.'
+  order_cycles_update_notice: 'Your order cycle has been updated.'
+  order_cycles_bulk_update_notice: 'Order cycles have been updated.'
+  order_cycles_clone_notice, name: "Your order cycle %{name} has been cloned."
+  order_cycles_email_to_producers_notice: 'Emails to be sent to producers have been queued for sending.'
+  order_cycles_no_permission_to_coordinate_error: "None of your enterprises have permission to coordinate an order cycle"
+  order_cycles_no_permission_to_create_error: "You don't have permission to create an order cycle coordinated by that enterprise"
+  order_cycles_no_permission_to_delete_error: "That order cycle has been selected by a customer and cannot be deleted. To prevent customers from accessing it, please close it instead."
+  contents:
+    header: Header
+    home_page: Home page
+    producer_sign_up: Producer signup page
+    hub_signup_page: Hub signup page
+    group_signup_page: Group signup page
+    footer_and_external_links: Footer and External Links
+    your_content: Your content
   js:
     admin:
       modals:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,9 @@ en:
       subject: "Please confirm the email address for %{enterprise}"
     welcome:
       subject: "%{enterprise} is now on %{sitename}"
+  producer_mailer:
+    order_cycle:
+      subject: "Order cycle report for %{producer}"
   home: "OFN"
   title: Open Food Network
   welcome_to: 'Welcome to '
@@ -143,6 +146,14 @@ en:
   dashboard: Dashboard
   undefined: undefined
   unused: unused
+  admin_and_handling: Admin & Handling
+  profile: Profile
+  supplier_only: Supplier Only
+  weight: Weight
+  volume: Volume
+  items: Items
+  summary: Summary
+  detailed: Detailed
   'yes': "Yes"
   'no': "No"
   'y': 'Y'
@@ -643,10 +654,6 @@ en:
     enterprise_issues:
       create_new: Create New
       resend_email: Resend Email
-      no_shipping: no shipping methods
-      no_payment: no payment methods
-      no_shipping_or_payment: no shipping or payment methods
-      unconfirmed: unconfirmed
       has_no_payment_methods: "%{enterprise} currently has no payment methods"
       has_no_shipping_methods: "%{enterprise} currently has no shipping methods"
       email_confirmation: "Email confirmation is pending. We've sent a confirmation email to #{email}."
@@ -798,7 +805,14 @@ en:
   terms_of_service: "Terms of service"
   on_demand: On demand
   none: None
+<<<<<<< HEAD
   not_allowed: Not allowed
+=======
+  no_shipping: no shipping methods
+  no_payment: no payment methods
+  no_shipping_or_payment: no shipping or payment methods
+  unconfirmed: unconfirmed
+>>>>>>> Extract translations from mailers and helpers
 
   label_shops: "Shops"
   label_map: "Map"
@@ -1251,6 +1265,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   failed_to_create_enterprise: "Failed to create your enterprise."
   failed_to_create_enterprise_unknown: "Failed to create your enterprise.\nPlease ensure all fields are completely filled out."
   failed_to_update_enterprise_unknown: "Failed to update your enterprise.\nPlease ensure all fields are completely filled out."
+  enterprise_confirm_delete_message: "This will also delete the %{product} that this enterprise supplies. Are you sure you want to continue?"
   order_not_saved_yet: "Your order hasn't been saved yet. Give us a few seconds to finish!"
   filter_by: "Filter by"
   hide_filters: "Hide filters"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -669,7 +669,7 @@ en:
       payment_methods: Payment Methods Report
       delivery: Delivery Report
       tax_types: Tax Types
-      tax_rate: Tax Rates
+      tax_rates: Tax Rates
       pack_by_customer: Pack By Customer
       pack_by_supplier: Pack By Supplier
       orders_and_distributors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1870,6 +1870,21 @@ Please follow the instructions there to make your enterprise visible on the Open
     footer_and_external_links: Footer and External Links
     your_content: Your content
   js:
+    saving: 'Saving...'
+    changes_saved: 'Changes saved.'
+    save_changes_first: Save changes first.
+    all_changes_saved: All changes saved
+    unsaved_changes: You have unsaved changes
+    all_changes_saved_successfully: All changes saved successfully
+    oh_no: "Oh no! I was unable to save your changes."
+    unauthorized: "You are unauthorised to access this page."
+    error: Error
+    unavailable: Unavailable
+    profile: Profile
+    hub: Hub
+    shop: Shop
+    choose: Choose
+    resolve_errors: Please resolve the following errors
     admin:
       modals:
         got_it: Got it
@@ -1986,7 +2001,50 @@ Please follow the instructions there to make your enterprise visible on the Open
         in your cart have reduced. Here's what's changed:
       now_out_of_stock: is now out of stock.
       only_n_remainging: "now only has %{num} remaining."
-
+    variant_overrides:
+      inventory_products: "Inventory Products"
+      hidden_products: "Hidden Products"
+      new_products: "New Products"
+      reset_stock_levels: Reset Stock Levels To Defaults
+      changes_to: Changes to
+      one_override: one override
+      overrides: override
+      remain_unsaved: remain unsaved.
+      no_changes_to_save: No changes to save.'
+      no_authorisation: "I couldn't get authorisation to save those changes, so they remain unsaved."
+      some_trouble: I had some trouble saving
+      changing_on_hand_stock: Changing on hand stock levels...
+      stock_reset: Stocks reset to defaults.
+    tag_rules:
+      show_hide_variants: 'Show or Hide variants in my shopfront'
+      show_hide_shipping: 'Show or Hide shipping methods at checkout'
+      show_hide_payment: 'Show or Hide payment methods at checkout'
+      show_hide_order_cycles: 'Show or Hide order cycles in my shopfront'
+      visible: VISIBLE
+      not_visible: NOT VISIBLE
+    services:
+      unsaved_changes_message: Unsaved changes currently exist, save now or ignore?
+      save: SAVE
+      ignore: IGNORE
+      add_to_order_cycle: "add to order cycle"
+      manage_products: "manage products"
+      edit_profile: "edit profile"
+      add_products_to_inventory: "add products to inventory"
+    resources:
+      could_not_delete_customer: 'Could not delete customer'
+    product_import:
+      confirmation: |
+        This will set stock level to zero on all products for this
+        enterprise that are not present in the uploaded file.
+    order_cycles:
+      update_success: 'Your order cycle has been updated.'
+      no_distributors: There are no distributors in this order cycle. This order cycle will not be visible to customers until you add one. Would you like to continue saving this order cycle?'
+    enterprises:
+      producer: "Producer"
+      non_producer: "Non-Producer"
+    customers:
+      select_shop: 'Please select a shop first'
+      could_not_create: Sorry! Could not create
   producers:
     signup:
       start_free_profile: "Start with a free profile, and expand when you're ready!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,8 @@ en:
   current: Current
   available: Available
   dashboard: Dashboard
-
+  'yes': "Yes"
+  'no': "No"
   admin:
     # Common properties / models
     date: Date
@@ -206,6 +207,10 @@ en:
         finalise_user_invoices: "Finalise User Invoices"
         finalise_user_invoice_explained: "Use this button to finalize all invoices in the system for the previous calendar month. This task can be set up to run automatically once a month."
         update_user_invoices: "Update User Invoices"
+      errors:
+        accounts_distributor: must be set if you wish to create invoices for enterprise users.
+        default_payment_method: must be set if you wish to create invoices for enterprise users.
+        default_shipping_method: must be set if you wish to create invoices for enterprise users.
 
     business_model_configuration:
       edit:
@@ -628,8 +633,22 @@ en:
           zero: order cycle
           one: order cycle
           other: order cycles
-
+    enterprise_issues:
+      create_new: Create New
+      resend_email: Resend Email
+      no_shipping: no shipping methods
+      no_payment: no payment methods
+      no_shipping_or_payment: no shipping or payment methods
+      unconfirmed: unconfirmed
+      has_no_payment_methods: "%{enterprise} currently has no payment methods"
+      has_no_shipping_methods: "%{enterprise} currently has no shipping methods"
+      email_confirmation: "Email confirmation is pending. We've sent a confirmation email to #{email}."
+      not_visible: "%{enterprise} is not visible and so cannot be found on the map or in searches"
     reports:
+      hidden: HIDDEN
+      unitsize: UNITSIZE
+      total: TOTAL
+      total_items: TOTAL ITEMS
       supplier_totals: Order Cycle Supplier Totals
       supplier_totals_by_distributor: Order Cycle Supplier Totals by Distributor
       totals_by_supplier: Order Cycle Distributor Totals by Supplier
@@ -1466,7 +1485,11 @@ Please follow the instructions there to make your enterprise visible on the Open
   price: "Price"
   on_hand: "On hand"
   save_changes: "Save Changes"
+<<<<<<< HEAD
   order_saved: "Order Saved"
+=======
+  no_products: No Products
+>>>>>>> Extract translations from lib folder
   spree_admin_overview_enterprises_header: "My Enterprises"
   spree_admin_overview_enterprises_footer: "MANAGE MY ENTERPRISES"
   spree_admin_enterprises_hubs_name: "Name"
@@ -1551,11 +1574,60 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_order_cycle: "Order Cycle: "
   report_entreprises: "Enterprises: "
   report_users: "Users: "
-  report_tax_rates: "Tax rates"
-  report_tax_types: "Tax types"
-  report_header_order_number: "Order number"
-  report_header_date: "Date"
-  report_header_items: "Items"
+  report_tax_rates: Tax rates
+  report_tax_types: Tax types
+  report_tax_type: Tax type
+  report_header_tracking_name_1: Tracking Name 1
+  report_header_tracking_name_2: Tracking Name 2
+  report_header_tracking_option_1: Tracking Option 1
+  report_header_tracking_option_2: Tracking Option 2
+  report_header_branding_theme: Branding Theme
+  report_header_currency: Currency
+  report_header_order_cycle: Order Cycle
+  report_header_user: User
+  report_header_email: Email
+  report_header_status: Status
+  report_header_comments: Comments
+  report_header_contact_name: Contact Name
+  report_header_first_name: First Name
+  report_header_last_name: Last Name
+  report_header_suburb: Suburb
+  report_header_phone: Phone
+  report_header_suburb: Suburb
+  report_header_address: Address
+  report_header_billing_address: Billing Address
+  report_header_relationship: Relationship
+  report_header_hub: Hub
+  report_header_to_hub: To Hub
+  report_header_hub_code: Hub code
+  report_header_paid: Paid?
+  report_header_delivery: Delivery?
+  report_header_shipping: Shipping
+  report_header_shipping_method: Shipping Method
+  report_header_shipping_instructions: Shipping instructions
+  report_header_ship_street: Ship Street
+  report_header_ship_street_2: Ship Street 2
+  report_header_ship_city: Ship City
+  report_header_ship_postcode: Ship Postcode
+  report_header_ship_state: Ship State
+  report_header_billing_street: Billing Street
+  report_header_billing_street_2: Billing Street 2
+  report_header_billing_city: Billing City
+  report_header_billing_postcode: Billing Postcode
+  report_header_billing_region: Billing Region
+  report_header_billing_state: Billing State
+  report_header_billing_country: Billing Country
+  report_header_incoming_transport: Incoming Transport
+  report_header_special_instructions: Special instructions
+  report_header_order_number: Order number
+  report_header_invoice_number: Invoice number
+  report_header_reference: Reference
+  report_header_invoice_date: Invoice date
+  report_header_due_date: Due date
+  report_header_date: Date
+  report_header_confirmation_date: Confirmation Date
+  report_header_tags: Tags
+  report_header_items: Items
   report_header_items_total: "Items total %{currency_symbol}"
   report_header_taxable_items_total: "Taxable Items Total (%{currency_symbol})"
   report_header_sales_tax: "Sales Tax (%{currency_symbol})"
@@ -1563,10 +1635,104 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_tax_on_delivery: "Tax on Delivery (%{currency_symbol})"
   report_header_tax_on_fees: "Tax on Fees (%{currency_symbol})"
   report_header_total_tax: "Total Tax (%{currency_symbol})"
-  report_header_customer: "Customer"
-  report_header_distributor: "Distributor"
+  report_header_enterprise: Enterprise
+  report_header_customer: Customer
+  report_header_customer_code: Customer Code
+  report_header_product: Product
+  report_header_product_properties: Product Properties
+  report_header_description: Description
+  report_header_qty: Qty
+  report_header_quantity: Quantity
+  report_header_max_quantity: Max Quantity
+  report_header_variant: Variant
+  report_header_variant_value: Variant Value
+  report_header_variant_unit: Variant Unit
+  report_header_total_available: Total available
+  report_header_unallocated: Unallocated
+  report_header_max_quantity_excess: Max Quantity Excess
+  report_header_taxon: Taxon
+  report_header_taxons: Taxons
+  report_header_supplier: Supplier
+  report_header_producer: Producer
+  report_header_producer_suburb: Producer Suburb
+  report_header_unit: Unit
+  report_header_group_buy_unit_quantity: Group by unit quantity
+  report_header_cost: Cost
+  report_header_shipping_cost: Shipping Cost
+  report_header_curr_cost_per_unit: Curr. Cost per Unit
+  report_header_total_shipping_cost: Total Shipping Cost
+  report_header_payment_method: Payment Method
+  report_header_sells: Sells
+  report_header_visible: Visible
+  report_header_unit_price: Unit Price
+  report_header_price: Price
+  report_header_unit_size: Unit Size
+  report_header_pack_size: Pack Size
+  report_header_distributor: Distributor
+  report_header_distributor_address: Distributor address
+  report_header_distributor_city: Distributor city
+  report_header_distributor_postcode: Distributor postcode
+  report_header_delivery_address: Delivery Address
+  report_header_delivery_postcode: Delivery Postcode
+  report_header_bulk_unit_size: Bulk Unit Size
+  report_header_weight: Weight
+  report_header_sum_total: Sum Total
+  report_header_date_of_order: Date of Order
+  report_header_amount_owing: Amount Owing
+  report_header_amount_paid: Amount Paid
+  report_header_units_required: Units Required
+  report_header_remainder: Remainder
+  report_header_order_date: Order date
+  report_header_order_id: Order Id
+  report_header_item_name: Item name
+  report_header_inventory_item_code: Inventory Item Code
+  report_header_temp_controlled_items: Temp Controlled Items?
+  report_header_customer_name: Customer Name
+  report_header_customer_email: Customer Email
+  report_header_customer_phone: Customer Phone
+  report_header_customer_city: Customer City
+  report_header_payment_state: Payment State
+  report_header_payment_type: Payment Type
+  report_header_item_price: "Item (%{currency})"
+  report_header_item_fees_price: "Item + Fees (%{currency})"
+  report_header_admin_handling_fees: "Admin & Handling (%{currency})"
+  report_header_ship_price: "Ship (%{currency})"
+  report_header_pay_fee_price: "Pay fee (%{currency})"
+  report_header_total_price: "Total (%{currency})"
+  report_header_product_total_price: "Product Total (%{currency})"
+  report_header_shipping_total_price: "Shipping Total (%{currency})"
+  report_header_outstanding_balance_price: "Outstanding Balance (%{currency})"
+  report_header_eft_price: "EFT (%{currency})"
+  report_header_paypal_price: "PayPal (%{currency})"
+  report_header_sku: SKU
+  report_header_amount: Amount
+  report_header_unit_amount: Unit Amount
+  report_header_discount: Discount
+  report_header_account_code: Account code
+  report_header_balance: Balance
+  report_header_total: Total
+  report_header_total_cost: "Total Cost"
+  report_header_total_ordered: Total Ordered
+  report_header_total_max: Total Max
+  report_header_total_units: Total Units
+  report_header_sum_max_total: "Sum Max Total"
   report_header_total_excl_vat: "Total excl. tax (%{currency_symbol})"
   report_header_total_incl_vat: "Total incl. tax (%{currency_symbol})"
+  report_header_gst_incl: GST incl.
+  report_header_grower_and_method: Grower and growing method
+  report_header_temp_controlled: TempControlled?
+  report_header_is_producer: Producer?
+  report_header_not_confirmed: Not Confirmed
+  report_header_gst_on_income: GST on Income
+  report_header_gst_free_income: GST Free Income
+  report_header_total_untaxable_produce: Total untaxable produce (no tax)
+  report_header_total_taxable_produce: Total taxable produce (tax inclusive)
+  report_header_total_untaxable_fees: Total untaxable fees (no tax)
+  report_header_total_taxable_fees: Total taxable fees (tax inclusive)
+  report_header_delivery_shipping_cost: Delivery Shipping Cost (tax inclusive)
+  report_header_transaction_fee: Transaction Fee (no tax)
+  report_header_total_untaxable_admin: Total untaxable admin adjustments (no tax)
+  report_header_total_taxable_admin: Total taxable admin adjustments (tax inclusive)
   initial_invoice_number: "Initial invoice number:"
   invoice_date: "Invoice date:"
   due_date: "Due date:"
@@ -1601,10 +1767,11 @@ Please follow the instructions there to make your enterprise visible on the Open
   shipping_methods: "Shipping Methods"
   payment_methods: "Payment Methods"
   payment_method_fee: "Transaction fee"
-  enterprise_fees: "Enterprise Fees"
   inventory_settings: "Inventory Settings"
   tag_rules: "Tag Rules"
   shop_preferences: "Shop Preferences"
+  enterprise_fee_whole_order: Whole order
+  enterprise_fee_by: fee by
   validation_msg_relationship_already_established: "^That relationship is already established."
   validation_msg_at_least_one_hub: "^At least one hub must be selected"
   validation_msg_product_category_cant_be_blank: "^Product Category cant be blank"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,6 +295,13 @@ en:
     contents:
       edit:
         title: Content
+        header: Header
+        home_page: Home page
+        producer_signup_page: Producer signup page
+        hub_signup_page: Hub signup page
+        group_signup_page: Group signup page
+        footer_and_external_links: Footer and External Links
+        your_content: Your content
 
     enterprise_fees:
       index:
@@ -1847,14 +1854,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   order_cycles_no_permission_to_coordinate_error: "None of your enterprises have permission to coordinate an order cycle"
   order_cycles_no_permission_to_create_error: "You don't have permission to create an order cycle coordinated by that enterprise"
   order_cycles_no_permission_to_delete_error: "That order cycle has been selected by a customer and cannot be deleted. To prevent customers from accessing it, please close it instead."
-  contents:
-    header: Header
-    home_page: Home page
-    producer_signup_page: Producer signup page
-    hub_signup_page: Hub signup page
-    group_signup_page: Group signup page
-    footer_and_external_links: Footer and External Links
-    your_content: Your content
   js:
     saving: 'Saving...'
     changes_saved: 'Changes saved.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -645,8 +645,6 @@ en:
         has_no_payment_methods: "%{enterprise} has no payment methods"
         has_no_shipping_methods: "%{enterprise} has no shipping methods"
         has_no_enterprise_fees: "%{enterprise} has no enterprise fees"
-      order_cycles:
-        manage_order_cycles: MANAGE ORDER CYCLES
     enterprise_issues:
       create_new: Create New
       resend_email: Resend Email
@@ -1527,7 +1525,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   spree_admin_enterprises_tabs_producers: "PRODUCERS"
   spree_admin_enterprises_producers_manage_order_cycles: "MANAGE ORDER CYCLES"
   spree_admin_enterprises_producers_manage_products: "MANAGE PRODUCTS"
-  spree_admin_enterprises_producers_orders_cycle_text: "You don't have any active order cycles."
   spree_admin_enterprises_any_active_products_text: "You don't have any active products."
   spree_admin_enterprises_create_new_product: "CREATE A NEW PRODUCT"
   spree_admin_order_cycles: "Order Cycles"
@@ -2050,7 +2047,7 @@ Please follow the instructions there to make your enterprise visible on the Open
       overview:
         order_cycles:
           you_have_active:
-            zero: "You have no active order cycles."
+            zero: "You don't have any active order cycles."
             one: "You have one active order cycle."
             other: "You have %{count} active order cycles."
       products:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -647,11 +647,6 @@ en:
         has_no_enterprise_fees: "%{enterprise} has no enterprise fees"
       order_cycles:
         manage_order_cycles: MANAGE ORDER CYCLES
-        you_have_active: "You have %{num} active %{order_cycles}."
-        order_cycle:
-          zero: order cycle
-          one: order cycle
-          other: order cycles
     enterprise_issues:
       create_new: Create New
       resend_email: Resend Email
@@ -2052,6 +2047,12 @@ Please follow the instructions there to make your enterprise visible on the Open
         form:
           distribution_fields:
             title: Distribution
+      overview:
+        order_cycles:
+          you_have_active:
+            zero: "You have no active order cycles."
+            one: "You have one active order cycle."
+            other: "You have %{count} active order cycles."
       products:
         bulk_edit:
           header:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,8 @@ en:
   dashboard: Dashboard
   'yes': "Yes"
   'no': "No"
+  'y': 'Y'
+  'n': 'N'
   admin:
     # Common properties / models
     date: Date
@@ -1583,7 +1585,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_users: "Users: "
   report_tax_rates: Tax rates
   report_tax_types: Tax types
-  report_tax_type: Tax type
+  report_header_tax_type: Tax Type
   report_header_tracking_name_1: Tracking Name 1
   report_header_tracking_name_2: Tracking Name 2
   report_header_tracking_option_1: Tracking Option 1
@@ -1605,8 +1607,10 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_billing_address: Billing Address
   report_header_relationship: Relationship
   report_header_hub: Hub
+  report_header_hub_address: Hub Address
   report_header_to_hub: To Hub
-  report_header_hub_code: Hub code
+  report_header_hub_code: Hub Code
+  report_header_code: Code
   report_header_paid: Paid?
   report_header_delivery: Delivery?
   report_header_shipping: Shipping
@@ -1619,18 +1623,20 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_ship_state: Ship State
   report_header_billing_street: Billing Street
   report_header_billing_street_2: Billing Street 2
+  report_header_billing_street_3: Billing Street 3
+  report_header_billing_street_4: Billing Street 4
   report_header_billing_city: Billing City
   report_header_billing_postcode: Billing Postcode
   report_header_billing_region: Billing Region
   report_header_billing_state: Billing State
   report_header_billing_country: Billing Country
   report_header_incoming_transport: Incoming Transport
-  report_header_special_instructions: Special instructions
+  report_header_special_instructions: Special Instructions
   report_header_order_number: Order number
-  report_header_invoice_number: Invoice number
+  report_header_invoice_number: Invoice Number
   report_header_reference: Reference
-  report_header_invoice_date: Invoice date
-  report_header_due_date: Due date
+  report_header_invoice_date: Invoice Date
+  report_header_due_date: Due Date
   report_header_date: Date
   report_header_confirmation_date: Confirmation Date
   report_header_tags: Tags
@@ -1663,7 +1669,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_producer: Producer
   report_header_producer_suburb: Producer Suburb
   report_header_unit: Unit
-  report_header_group_buy_unit_quantity: Group by unit quantity
+  report_header_group_buy_unit_quantity: Group Buy Unit Quantity
   report_header_cost: Cost
   report_header_shipping_cost: Shipping Cost
   report_header_curr_cost_per_unit: Curr. Cost per Unit
@@ -1715,7 +1721,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_amount: Amount
   report_header_unit_amount: Unit Amount
   report_header_discount: Discount
-  report_header_account_code: Account code
+  report_header_account_code: Account Code
   report_header_balance: Balance
   report_header_total: Total
   report_header_total_cost: "Total Cost"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2041,6 +2041,8 @@ Please follow the instructions there to make your enterprise visible on the Open
         form:
           distribution_fields:
             title: Distribution
+            distributor: "Distributor:"
+            order_cycle: "Order cycle:"
       overview:
         order_cycles:
           order_cycles: "Order Cycles"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,7 @@ en:
   cancel: Cancel
   edit: Edit
   distributors: Distributors
+  distribution: Distribution
   order_cycles: Order Cycles
   enterprise_limit: Enterprise Limit
   bulk_order_management: Bulk Order Management
@@ -1458,6 +1459,9 @@ Please follow the instructions there to make your enterprise visible on the Open
   distributor: "Distributor"
   product: "Products"
   enterprise_fees: "Enterprise Fees"
+  process_my_order: "Process My Order"
+  delivery_instructions: Delivery Instructions
+  delivery_method: Delivery Method
   fee_type: "Fee Type"
   tax_category: "Tax Category"
   calculator: "Calculator"
@@ -1485,11 +1489,8 @@ Please follow the instructions there to make your enterprise visible on the Open
   price: "Price"
   on_hand: "On hand"
   save_changes: "Save Changes"
-<<<<<<< HEAD
   order_saved: "Order Saved"
-=======
   no_products: No Products
->>>>>>> Extract translations from lib folder
   spree_admin_overview_enterprises_header: "My Enterprises"
   spree_admin_overview_enterprises_footer: "MANAGE MY ENTERPRISES"
   spree_admin_enterprises_hubs_name: "Name"
@@ -1512,13 +1513,19 @@ Please follow the instructions there to make your enterprise visible on the Open
   spree_admin_enterprises_create_new_product: "CREATE A NEW PRODUCT"
   spree_admin_order_cycles: "Order Cycles"
   spree_admin_order_cycles_tip: "Order cycles determine when and where your products are available to customers."
-  dashbord: "Dashboard"
   spree_admin_single_enterprise_alert_mail_confirmation: "Please confirm the email address for"
   spree_admin_single_enterprise_alert_mail_sent: "We've sent an email to"
   spree_admin_overview_action_required: "Action Required"
   spree_admin_overview_check_your_inbox: "Please check your inbox for further instructions. Thanks!"
+  spree_admin_unit_value: Unit Value
+  spree_admin_unit_description: Unit Description
+  spree_admin_variant_unit: Variant unit
+  spree_admin_variant_unit_scale: Variant unit scale
+  spree_admin_variant_unit_name: Variant unit name
   change_package: "Change Package"
   spree_admin_single_enterprise_hint: "Hint: To allow people to find you, turn on your visibility under"
+  spree_admin_eg_pickup_from_school: "eg. 'Pick-up from Primary School'"
+  spree_admin_eg_collect_your_order: "eg. 'Please collect your order from 123 Imaginary St, Northcote, 3070'"
   your_profil_live: "Your profile live"
   on_ofn_map: "on the Open Food Network map"
   see: "See"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -657,7 +657,7 @@ en:
       resend_email: Resend Email
       has_no_payment_methods: "%{enterprise} currently has no payment methods"
       has_no_shipping_methods: "%{enterprise} currently has no shipping methods"
-      email_confirmation: "Email confirmation is pending. We've sent a confirmation email to #{email}."
+      email_confirmation: "Email confirmation is pending. We've sent a confirmation email to %{email}."
       not_visible: "%{enterprise} is not visible and so cannot be found on the map or in searches"
     reports:
       hidden: HIDDEN

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,8 @@ en:
     weight: Weight
     volume: Volume
     items: Items
+    select_all: Select all
+    obsolete_master: Obsolete master
 
     # General form elements
     quick_search: Quick Search
@@ -264,6 +266,7 @@ en:
         order_cycle: Order Cycle
         status: Status
         diff: Diff
+        error: Error
 
     contents:
       edit:
@@ -278,6 +281,8 @@ en:
         tax_category: Tax Category
         calculator: Calculator
         calculator_values: Calculator Values
+    enterprise_roles:
+      manages: manages
 
     enterprise_groups:
       index:
@@ -325,7 +330,8 @@ en:
         inventory_powertip: This is your inventory of products. To add products to your inventory, select 'New Products' from the Viewing dropdown.
         hidden_powertip: These products have been hidden from your inventory and will not be available to add to your shop. You can click 'Add' to add a product to you inventory.
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
-
+      controls:
+        back_to_my_inventory: Back to my inventory
     orders:
       bulk_management:
         tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
@@ -347,7 +353,12 @@ en:
         max_fulfilled_units: "Max Fulfilled Units"
         order_error: "Some errors must be resolved before you can update orders.\nAny fields with red borders contain errors."
         variants_without_unit_value: "WARNING: Some variants do not have a unit value"
-
+      invoice:
+        issued_on: Issued on
+        tax_invoice: TAX INVOICE
+        code: Code
+        from: From
+        to: To
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from
 
@@ -603,7 +614,20 @@ en:
         title: Invoice Settings
         invoice_style2?: Use the alternative invoice model that includes total tax breakdown per rate and tax rate info per item (not yet suitable for countries displaying prices excluding tax)
         enable_receipt_printing?: Show options for printing receipts using thermal printers in order dropdown?
-
+    overview:
+      enterprises_header:
+        ofn_with_tip: Enterprises are Producers and/or Hubs and are the basic unit of organisation within the Open Food Network.
+      enterprises_hubs_tabs:
+        has_no_payment_methods: "%{enterprise} has no payment methods"
+        has_no_shipping_methods: "%{enterprise} has no shipping methods"
+        has_no_enterprise_fees: "%{enterprise} has no enterprise fees"
+      order_cycles:
+        manage_order_cycles: MANAGE ORDER CYCLES
+        you_have_active: "You have %{num} active %{order_cycles}."
+        order_cycle:
+          zero: order cycle
+          one: order cycle
+          other: order cycles
 # Frontend views
 #
 # These keys are referenced relatively like `t('.message')` in
@@ -1325,6 +1349,8 @@ Please follow the instructions there to make your enterprise visible on the Open
   credit: "Credit"
   Paid: "Paid"
   Ready: "Ready"
+  ok: OK
+  not_visible: not visible
   you_have_no_orders_yet: "You have no orders yet"
   running_balance: "Running balance"
   outstanding_balance: "Outstanding balance"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,8 +312,6 @@ en:
         tax_category: Tax Category
         calculator: Calculator
         calculator_values: Calculator Values
-    enterprise_roles:
-      manages: manages
 
     enterprise_groups:
       index:
@@ -321,6 +319,8 @@ en:
 
     enterprise_roles:
       form:
+        manages: manages
+      enterprise_role:
         manages: manages
 
     products:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,8 @@ en:
   current: Current
   available: Available
   dashboard: Dashboard
+  undefined: undefined
+  unused: unused
   'yes': "Yes"
   'no': "No"
   'y': 'Y'
@@ -266,6 +268,8 @@ en:
         update_address: 'Update Address'
         confirm_delete: 'Sure to delete?'
         search_by_email: "Search by email/code..."
+      destroy:
+        has_associated_orders: 'Delete failed: customer has associated orders with his shop'
 
     cache_settings:
       show:
@@ -1229,6 +1233,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   products_max_quantity: Max quantity
   products_distributor: Distributor
   products_distributor_info: When you select a distributor for your order, their address and pickup times will be displayed here.
+  products_distribution_adjustment_label: "Product distribution by %{distributor} for %{product}"
 
   shop_trial_expires_in: "Your shopfront trial expires in"
   shop_trial_expired_notice: "Good news! We have decided to extend shopfront trials until further notice."
@@ -1258,6 +1263,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   error_required: "can't be blank"
   error_number: "must be number"
   error_email: "must be email address"
+  error_not_found_in_database: "%{name} not found in database"
+  error_no_permission_for_enterprise: "\"%{name}\": you do not have permission to manage products for this enterprise"
   item_handling_fees: "Item Handling Fees (included in item totals)"
   january: "January"
   february: "February"
@@ -1459,7 +1466,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   supplier: "Supplier"
   coordinator: "Coordinator"
   distributor: "Distributor"
-  product: "Products"
   enterprise_fees: "Enterprise Fees"
   process_my_order: "Process My Order"
   delivery_instructions: Delivery Instructions
@@ -1528,12 +1534,20 @@ Please follow the instructions there to make your enterprise visible on the Open
   spree_admin_single_enterprise_hint: "Hint: To allow people to find you, turn on your visibility under"
   spree_admin_eg_pickup_from_school: "eg. 'Pick-up from Primary School'"
   spree_admin_eg_collect_your_order: "eg. 'Please collect your order from 123 Imaginary St, Northcote, 3070'"
+  spree_classification_primary_taxon_error: "Taxon %{taxon} is the primary taxon of %{product} and cannot be deleted"
+  spree_order_availability_error: "Distributor or order cycle cannot supply the products in your cart"
+  spree_order_populator_error: "That distributor or order cycle can't supply all the products in your cart. Please choose another."
+  spree_order_populator_availability_error: "That product is not available from the chosen distributor or order cycle."
+  spree_distributors_error: "^At least one hub must be selected"
+  spree_user_enterprise_limit_error: "^%{email} is not permitted to own any more enterprises (limit is %{enterprise_limit})."
+  spree_variant_product_error: must have at least one variant
   your_profil_live: "Your profile live"
   on_ofn_map: "on the Open Food Network map"
   see: "See"
   live: "live"
   manage: "Manage"
   resend: "Resend"
+  trial: Trial
   add_and_manage_products: "Add & manage products"
   add_and_manage_order_cycles: "Add & manage order cycles"
   manage_order_cycles: "Manage order cycles"
@@ -1790,6 +1804,16 @@ Please follow the instructions there to make your enterprise visible on the Open
   validation_msg_product_category_cant_be_blank: "^Product Category cant be blank"
   validation_msg_tax_category_cant_be_blank: "^Tax Category can't be blank"
   validation_msg_is_associated_with_an_exising_customer: "is associated with an existing customer"
+  content_configuration_pricing_table: "(TODO: Pricing table)"
+  content_configuration_case_studies: "(TODO: Case studies)"
+  content_configuration_detail: "(TODO: Detail)"
+  enterprise_name_error: "has already been taken. If this is your enterprise and you would like to claim ownership, please contact the current manager of this profile at %{email}."
+  enterprise_owner_error: "^%{email} is not permitted to own any more enterprises (limit is %{enterprise_limit})."
+  enterprise_role_uniqueness_error: "^That role is already present."
+  inventory_item_visibility_error: must be true or false
+  product_importer_file_error: "error: no file uploaded"
+  product_importer_spreadsheet_error: "could not process file: invalid filetype"
+  product_importer_products_save_error: did not save any products successfully
 
   js:
     admin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1850,7 +1850,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   contents:
     header: Header
     home_page: Home page
-    producer_sign_up: Producer signup page
+    producer_signup_page: Producer signup page
     hub_signup_page: Hub signup page
     group_signup_page: Group signup page
     footer_and_external_links: Footer and External Links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1523,12 +1523,9 @@ Please follow the instructions there to make your enterprise visible on the Open
   spree_admin_enterprises_producers_order_cycles_title: ""
   spree_admin_enterprises_tabs_hubs: "HUBS"
   spree_admin_enterprises_tabs_producers: "PRODUCERS"
-  spree_admin_enterprises_producers_manage_order_cycles: "MANAGE ORDER CYCLES"
   spree_admin_enterprises_producers_manage_products: "MANAGE PRODUCTS"
   spree_admin_enterprises_any_active_products_text: "You don't have any active products."
   spree_admin_enterprises_create_new_product: "CREATE A NEW PRODUCT"
-  spree_admin_order_cycles: "Order Cycles"
-  spree_admin_order_cycles_tip: "Order cycles determine when and where your products are available to customers."
   spree_admin_single_enterprise_alert_mail_confirmation: "Please confirm the email address for"
   spree_admin_single_enterprise_alert_mail_sent: "We've sent an email to"
   spree_admin_overview_action_required: "Action Required"
@@ -2046,10 +2043,13 @@ Please follow the instructions there to make your enterprise visible on the Open
             title: Distribution
       overview:
         order_cycles:
+          order_cycles: "Order Cycles"
+          order_cycles_tip: "Order cycles determine when and where your products are available to customers."
           you_have_active:
             zero: "You don't have any active order cycles."
             one: "You have one active order cycle."
             other: "You have %{count} active order cycles."
+          manage_order_cycles: "MANAGE ORDER CYCLES"
       products:
         bulk_edit:
           header:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1814,7 +1814,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   tag_rules: "Tag Rules"
   shop_preferences: "Shop Preferences"
   enterprise_fee_whole_order: Whole order
-  enterprise_fee_by: fee by
+  enterprise_fee_by: "%{type} fee by %{role} %{enterprise_name}"
   validation_msg_relationship_already_established: "^That relationship is already established."
   validation_msg_at_least_one_hub: "^At least one hub must be selected"
   validation_msg_product_category_cant_be_blank: "^Product Category cant be blank"
@@ -2009,7 +2009,7 @@ Please follow the instructions there to make your enterprise visible on the Open
       remain_unsaved: remain unsaved.
       no_changes_to_save: No changes to save.'
       no_authorisation: "I couldn't get authorisation to save those changes, so they remain unsaved."
-      some_trouble: I had some trouble saving
+      some_trouble: "I had some trouble saving: %{errors}"
       changing_on_hand_stock: Changing on hand stock levels...
       stock_reset: Stocks reset to defaults.
     tag_rules:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -806,14 +806,11 @@ en:
   terms_of_service: "Terms of service"
   on_demand: On demand
   none: None
-<<<<<<< HEAD
   not_allowed: Not allowed
-=======
   no_shipping: no shipping methods
   no_payment: no payment methods
   no_shipping_or_payment: no shipping or payment methods
   unconfirmed: unconfirmed
->>>>>>> Extract translations from mailers and helpers
 
   label_shops: "Shops"
   label_map: "Map"
@@ -1847,7 +1844,7 @@ Please follow the instructions there to make your enterprise visible on the Open
     but do not have valid shipping and payment methods.
     Until you set these up, customers will not be able to shop at these hubs.
   enterprise_fees_update_notice: Your enterprise fees have been updated.
-  enterprise_fees_destroy_error: "That enterprise fee cannot be deleted as it is referenced by a product distribution: #{id} - #{name}."
+  enterprise_fees_destroy_error: "That enterprise fee cannot be deleted as it is referenced by a product distribution: %{id} - %{name}."
   enterprise_register_package_error: "Please select a package"
   enterprise_register_error: "Could not complete registration for %{enterprise}"
   enterprise_register_success_notice: "Congratulations! Registration for %{enterprise} is complete!"
@@ -2008,7 +2005,7 @@ Please follow the instructions there to make your enterprise visible on the Open
       reset_stock_levels: Reset Stock Levels To Defaults
       changes_to: Changes to
       one_override: one override
-      overrides: override
+      overrides: overrides
       remain_unsaved: remain unsaved.
       no_changes_to_save: No changes to save.'
       no_authorisation: "I couldn't get authorisation to save those changes, so they remain unsaved."

--- a/lib/open_food_network/accounts_and_billing_settings_validator.rb
+++ b/lib/open_food_network/accounts_and_billing_settings_validator.rb
@@ -20,21 +20,21 @@ module OpenFoodNetwork
 
     def ensure_accounts_distributor_set
       unless Enterprise.find_by_id(accounts_distributor_id)
-        errors.add(:accounts_distributor, "must be set if you wish to create invoices for enterprise users.")
+        errors.add(:accounts_distributor, I18n.t('admin.accounts_and_billing_settings.errors.accounts_distributor'))
       end
     end
 
     def ensure_default_payment_method_set
       unless Enterprise.find_by_id(accounts_distributor_id) &&
         Enterprise.find_by_id(accounts_distributor_id).payment_methods.find_by_id(default_accounts_payment_method_id)
-        errors.add(:default_payment_method, "must be set if you wish to create invoices for enterprise users.")
+        errors.add(:default_payment_method, I18n.t('admin.accounts_and_billing_settings.errors.default_payment_method'))
       end
     end
 
     def ensure_default_shipping_method_set
       unless Enterprise.find_by_id(accounts_distributor_id) &&
         Enterprise.find_by_id(accounts_distributor_id).shipping_methods.find_by_id(default_accounts_shipping_method_id)
-        errors.add(:default_shipping_method, "must be set if you wish to create invoices for enterprise users.")
+        errors.add(:default_shipping_method, I18n.t('admin.accounts_and_billing_settings.errors.default_shipping_method'))
       end
     end
   end

--- a/lib/open_food_network/bulk_coop_report.rb
+++ b/lib/open_food_network/bulk_coop_report.rb
@@ -19,11 +19,27 @@ module OpenFoodNetwork
       when "bulk_coop_allocation"
         @allocation_report.header
       when "bulk_coop_packing_sheets"
-        ["Customer", "Product", "Variant", "Sum Total"]
+        [I18n.t(:report_header_customer),
+          I18n.t(:report_header_product),
+          I18n.t(:report_header_variant),
+          I18n.t(:report_header_sum_total)]
       when "bulk_coop_customer_payments"
-        ["Customer", "Date of Order", "Total Cost", "Amount Owing", "Amount Paid"]
+        [I18n.t(:report_header_customer),
+          I18n.t(:report_header_date_of_order),
+          I18n.t(:report_header_total_cost),
+          I18n.t(:report_header_amount_owing),
+          I18n.t(:report_header_amount_paid)]
       else
-        ["Supplier", "Product", "Bulk Unit Size", "Variant", "Weight", "Sum Total", "Sum Max Total", "Units Required", "Remainder"]
+        [I18n.t(:report_header_supplier),
+          I18n.t(:report_header_product),
+          I18n.t(:report_header_product),
+          I18n.t(:report_header_bulk_unit_size),
+          I18n.t(:report_header_variant),
+          I18n.t(:report_header_weight),
+          I18n.t(:report_header_sum_total),
+          I18n.t(:report_header_sum_max_total),
+          I18n.t(:report_header_units_required),
+          I18n.t(:report_header_remainder)]
       end
     end
 
@@ -42,9 +58,9 @@ module OpenFoodNetwork
       line_items.select{ |li| line_items_with_hidden_details.include? li }.each do |line_item|
         # TODO We should really be hiding customer code here too, but until we
         # have an actual association between order and customer, it's a bit tricky
-        line_item.order.bill_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-        line_item.order.ship_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-        line_item.order.assign_attributes(email: "HIDDEN")
+        line_item.order.bill_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+        line_item.order.ship_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+        line_item.order.assign_attributes(email: I18n.t('admin.reports.hidden'))
       end
       line_items
     end

--- a/lib/open_food_network/cached_products_renderer.rb
+++ b/lib/open_food_network/cached_products_renderer.rb
@@ -14,11 +14,11 @@ module OpenFoodNetwork
     end
 
     def products_json
-      raise NoProducts.new("No Products") if @distributor.nil? || @order_cycle.nil?
+      raise NoProducts.new(I18n.t(:no_products)) if @distributor.nil? || @order_cycle.nil?
 
       products_json = cached_products_json
 
-      raise NoProducts.new("No Products") if products_json.nil?
+      raise NoProducts.new(I18n.t(:no_products)) if products_json.nil?
 
       products_json
     end

--- a/lib/open_food_network/customers_report.rb
+++ b/lib/open_food_network/customers_report.rb
@@ -8,9 +8,19 @@ module OpenFoodNetwork
 
     def header
       if is_mailing_list?
-        ["Email", "First Name", "Last Name", "Suburb"]
+        [I18n.t(:report_header_email),
+          I18n.t(:report_header_first_name),
+          I18n.t(:report_header_last_name),
+          I18n.t(:report_header_suburb)]
       else
-        ["First Name", "Last Name", "Billing Address", "Email", "Phone", "Hub", "Hub Address", "Shipping Method"]
+        [I18n.t(:report_header_first_name),
+          I18n.t(:report_header_last_name),
+          I18n.t(:report_header_billing_address),
+          I18n.t(:report_header_email),
+          I18n.t(:report_header_phone),
+          I18n.t(:report_header_hub),
+          I18n.t(:report_header_hub_address),
+          I18n.t(:report_header_shipping_method)]
       end
     end
 

--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -24,11 +24,11 @@ module OpenFoodNetwork
     end
 
     def order_adjustment_label
-      "Whole order - #{base_adjustment_label}"
+      "#{I18n.t(:enterprise_fee_whole_order)} - #{base_adjustment_label}"
     end
 
     def base_adjustment_label
-      "#{enterprise_fee.fee_type} fee by #{role} #{enterprise_fee.enterprise.name}"
+      "#{enterprise_fee.fee_type} #{I18n.t(:enterprise_fee_by)} #{role} #{enterprise_fee.enterprise.name}"
     end
 
     def adjustment_tax(adjustable, adjustment)

--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -28,7 +28,7 @@ module OpenFoodNetwork
     end
 
     def base_adjustment_label
-      "#{enterprise_fee.fee_type} #{I18n.t(:enterprise_fee_by)} #{role} #{enterprise_fee.enterprise.name}"
+      I18n.t(:enterprise_fee_by, type: enterprise_fee.fee_type, role: role, enterprise_name: enterprise_fee.enterprise.name)
     end
 
     def adjustment_tax(adjustable, adjustment)

--- a/lib/open_food_network/enterprise_issue_validator.rb
+++ b/lib/open_food_network/enterprise_issue_validator.rb
@@ -30,13 +30,13 @@ module OpenFoodNetwork
 
     def issues_summary(opts={})
       if    !opts[:confirmation_only] && !shipping_methods_ok? && !payment_methods_ok?
-        I18n.t('admin.enterprise_issues.no_shipping_or_payment')
+        I18n.t(:no_shipping_or_payment)
       elsif !opts[:confirmation_only] && !shipping_methods_ok?
-        I18n.t('admin.enterprise_issues.no_shipping')
+        I18n.t(:no_shipping)
       elsif !opts[:confirmation_only] && !payment_methods_ok?
-        I18n.t('admin.enterprise_issues.no_payment')
+        I18n.t(:no_payment)
       elsif !confirmed?
-         I18n.t('admin.enterprise_issues.unconfirmed')
+         I18n.t(:unconfirmed)
       end
     end
 

--- a/lib/open_food_network/enterprise_issue_validator.rb
+++ b/lib/open_food_network/enterprise_issue_validator.rb
@@ -11,18 +11,18 @@ module OpenFoodNetwork
       issues = []
 
       issues << {
-        description: "#{@enterprise.name} currently has no shipping methods.",
-        link: "<a class='button fullwidth' href='#{spree.new_admin_shipping_method_path}'>Create New</a>"
+        description: I18n.t('admin.enterprise_issues.has_no_shipping_methods', enterprise: @enterprise.name),
+        link: "<a class='button fullwidth' href='#{spree.new_admin_shipping_method_path}'>#{I18n.t('admin.enterprise_issues.create_new')}</a>"
       } unless shipping_methods_ok?
 
       issues << {
-        description: "#{@enterprise.name} currently has no payment methods.",
-        link: "<a class='button fullwidth' href='#{spree.new_admin_payment_method_path}'>Create New</a>"
+        description: I18n.t('admin.enterprise_issues.has_no_payment_methods', enterprise: @enterprise.name),
+        link: "<a class='button fullwidth' href='#{spree.new_admin_payment_method_path}'>#{I18n.t('admin.enterprise_issues.create_new')}</a>"
       } unless payment_methods_ok?
 
       issues << {
-        description: "Email confirmation is pending. We've sent a confirmation email to #{@enterprise.email}.",
-        link: "<a class='button fullwidth' href='#{enterprise_confirmation_path(enterprise: { id: @enterprise.id, email: @enterprise.email } )}' method='post'>Resend Email</a>"
+        description: I18n.t('admin.enterprise_issues.email_confirmation', email: @enterprise.email),
+        link: "<a class='button fullwidth' href='#{enterprise_confirmation_path(enterprise: { id: @enterprise.id, email: @enterprise.email } )}' method='post'>#{I18n.t('admin.enterprise_issues.resend_email')}</a>"
       } unless confirmed?
 
       issues
@@ -30,13 +30,13 @@ module OpenFoodNetwork
 
     def issues_summary(opts={})
       if    !opts[:confirmation_only] && !shipping_methods_ok? && !payment_methods_ok?
-        'no shipping or payment methods'
+        I18n.t('admin.enterprise_issues.no_shipping_or_payment')
       elsif !opts[:confirmation_only] && !shipping_methods_ok?
-        'no shipping methods'
+        I18n.t('admin.enterprise_issues.no_shipping')
       elsif !opts[:confirmation_only] && !payment_methods_ok?
-        'no payment methods'
+        I18n.t('admin.enterprise_issues.no_payment')
       elsif !confirmed?
-        'unconfirmed'
+         I18n.t('admin.enterprise_issues.unconfirmed')
       end
     end
 
@@ -44,8 +44,8 @@ module OpenFoodNetwork
       warnings = []
 
       warnings << {
-        description: "#{@enterprise.name} is not visible and so cannot be found on the map or in searches",
-        link: "<a class='button fullwidth' href='#{edit_admin_enterprise_path(@enterprise)}'>Edit</a>"
+        description: I18n.t('admin.enterprise_issues.not_visible', enterprise: @enterprise.name),
+        link: "<a class='button fullwidth' href='#{edit_admin_enterprise_path(@enterprise)}'>#{I18n.t(:edit)}</a>"
       } unless @enterprise.visible
 
       warnings

--- a/lib/open_food_network/enterprise_issue_validator.rb
+++ b/lib/open_food_network/enterprise_issue_validator.rb
@@ -36,7 +36,7 @@ module OpenFoodNetwork
       elsif !opts[:confirmation_only] && !payment_methods_ok?
         I18n.t(:no_payment)
       elsif !confirmed?
-         I18n.t(:unconfirmed)
+        I18n.t(:unconfirmed)
       end
     end
 

--- a/lib/open_food_network/group_buy_report.rb
+++ b/lib/open_food_network/group_buy_report.rb
@@ -18,13 +18,15 @@ module OpenFoodNetwork
     end
 
     def header
-      [I18n.t(:report_header_supplier),
+      [
+        I18n.t(:report_header_supplier),
         I18n.t(:report_header_product),
         I18n.t(:report_header_unit_size),
         I18n.t(:report_header_variant),
         I18n.t(:report_header_weight),
         I18n.t(:report_header_total_ordered),
-        I18n.t(:report_header_total_max)]
+        I18n.t(:report_header_total_max),
+      ]
     end
 
     def variants_and_quantities

--- a/lib/open_food_network/group_buy_report.rb
+++ b/lib/open_food_network/group_buy_report.rb
@@ -2,13 +2,13 @@ module OpenFoodNetwork
 
   GroupBuyVariantRow = Struct.new(:variant, :sum_quantities, :sum_max_quantities) do
     def to_row
-      [variant.product.supplier.name, variant.product.name, "UNITSIZE", variant.options_text, variant.weight, sum_quantities, sum_max_quantities]
+      [variant.product.supplier.name, variant.product.name, I18n.t('admin.reports.unitsize'), variant.options_text, variant.weight, sum_quantities, sum_max_quantities]
     end
   end
 
   GroupBuyProductRow = Struct.new(:product, :sum_quantities, :sum_max_quantities) do
     def to_row
-      [product.supplier.name, product.name, "UNITSIZE", "TOTAL", "", sum_quantities, sum_max_quantities]
+      [product.supplier.name, product.name, I18n.t('admin.reports.unitsize'), I18n.t('admin.reports.total'), "", sum_quantities, sum_max_quantities]
     end
   end
 
@@ -18,7 +18,13 @@ module OpenFoodNetwork
     end
 
     def header
-      ["Supplier", "Product", "Unit Size", "Variant", "Weight", "Total Ordered", "Total Max"]
+      [I18n.t(:report_header_supplier),
+        I18n.t(:report_header_product),
+        I18n.t(:report_header_unit_size),
+        I18n.t(:report_header_variant),
+        I18n.t(:report_header_weight),
+        I18n.t(:report_header_total_ordered),
+        I18n.t(:report_header_total_max)]
     end
 
     def variants_and_quantities
@@ -33,7 +39,7 @@ module OpenFoodNetwork
           variant_groups = line_items_by_product.group_by { |li| li.variant }
           variant_groups.each do |variant, line_items_by_variant|
             sum_quantities = line_items_by_variant.sum { |li| li.quantity }
-            sum_max_quantities = line_items_by_variant.sum { |li| li.max_quantity || 0 } 
+            sum_max_quantities = line_items_by_variant.sum { |li| li.max_quantity || 0 }
             variants_and_quantities << GroupBuyVariantRow.new(variant, sum_quantities, sum_max_quantities)
           end
 

--- a/lib/open_food_network/lettuce_share_report.rb
+++ b/lib/open_food_network/lettuce_share_report.rb
@@ -4,16 +4,16 @@ module OpenFoodNetwork
   class LettuceShareReport < ProductsAndInventoryReportBase
     def header
       [
-        "PRODUCT",
-        "Description",
-        "Qty",
-        "Pack Size",
-        "Unit",
-        "Unit Price",
-        "Total",
-        "GST incl.",
-        "Grower and growing method",
-        "Taxon"
+        I18n.t(:report_header_product),
+        I18n.t(:report_header_description),
+        I18n.t(:report_header_qty),
+        I18n.t(:report_header_pack_size),
+        I18n.t(:report_header_unit),
+        I18n.t(:report_header_unit_price),
+        I18n.t(:report_header_total),
+        I18n.t(:report_header_gst_incl),
+        I18n.t(:report_header_grower_and_method),
+        I18n.t(:report_header_taxon)
       ]
     end
 

--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -6,11 +6,25 @@ module OpenFoodNetwork
     end
 
     def header
-      ["Order date", "Order Id",
-       "Customer Name","Customer Email", "Customer Phone", "Customer City",
-       "SKU", "Item name", "Variant", "Quantity", "Max Quantity", "Cost", "Shipping cost",
-       "Payment method",
-       "Distributor", "Distributor address", "Distributor city", "Distributor postcode", "Shipping instructions"]
+      [I18n.t(:report_header_order_date),
+        I18n.t(:report_header_order_id),
+        I18n.t(:report_header_customer_name),
+        I18n.t(:report_header_customer_email),
+        I18n.t(:report_header_customer_phone),
+        I18n.t(:report_header_customer_city),
+        I18n.t(:report_header_sku),
+        I18n.t(:report_header_item_name),
+        I18n.t(:report_header_variant),
+        I18n.t(:report_header_quantity),
+        I18n.t(:report_header_max_quantity),
+        I18n.t(:report_header_cost),
+        I18n.t(:report_header_shipping_cost),
+        I18n.t(:report_header_payment_method),
+        I18n.t(:report_header_distributor),
+        I18n.t(:report_header_distributor_address),
+        I18n.t(:report_header_distributor_city),
+        I18n.t(:report_header_distributor_postcode),
+        I18n.t(:report_header_shipping_instructions)]
     end
 
     def table

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -10,9 +10,30 @@ module OpenFoodNetwork
 
     def header
       if is_payment_methods?
-        ["First Name", "Last Name", "Hub", "Hub Code", "Email", "Phone", "Shipping Method", "Payment Method", "Amount", "Balance"]
+        [I18n.t(:report_header_first_name),
+          I18n.t(:report_header_last_name),
+          I18n.t(:report_header_hub),
+          I18n.t(:report_header_hub_code),
+          I18n.t(:report_header_email),
+          I18n.t(:report_header_phone),
+          I18n.t(:report_header_shipping_method),
+          I18n.t(:report_header_payment_method),
+          I18n.t(:report_header_amount),
+          I18n.t(:report_header_balance)]
       else
-        ["First Name", "Last Name", "Hub", "Hub Code", "Delivery Address", "Delivery Postcode", "Phone", "Shipping Method", "Payment Method", "Amount", "Balance", "Temp Controlled Items?", "Special Instructions"]
+        [I18n.t(:report_header_first_name),
+          I18n.t(:report_header_last_name),
+          I18n.t(:report_header_hub),
+          I18n.t(:report_header_hub_code),
+          I18n.t(:report_header_delivery_address),
+          I18n.t(:report_header_delivery_postcode),
+          I18n.t(:report_header_phone),
+          I18n.t(:report_header_shipping_method),
+          I18n.t(:report_header_payment_method),
+          I18n.t(:report_header_amount),
+          I18n.t(:report_header_balance),
+          I18n.t(:report_header_temp_controlled_items),
+          I18n.t(:report_header_special_instructions)]
       end
     end
 

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -10,7 +10,8 @@ module OpenFoodNetwork
 
     def header
       if is_payment_methods?
-        [I18n.t(:report_header_first_name),
+        [
+          I18n.t(:report_header_first_name),
           I18n.t(:report_header_last_name),
           I18n.t(:report_header_hub),
           I18n.t(:report_header_hub_code),
@@ -19,9 +20,11 @@ module OpenFoodNetwork
           I18n.t(:report_header_shipping_method),
           I18n.t(:report_header_payment_method),
           I18n.t(:report_header_amount),
-          I18n.t(:report_header_balance)]
+          I18n.t(:report_header_balance),
+        ]
       else
-        [I18n.t(:report_header_first_name),
+        [
+          I18n.t(:report_header_first_name),
           I18n.t(:report_header_last_name),
           I18n.t(:report_header_hub),
           I18n.t(:report_header_hub_code),
@@ -33,7 +36,8 @@ module OpenFoodNetwork
           I18n.t(:report_header_amount),
           I18n.t(:report_header_balance),
           I18n.t(:report_header_temp_controlled_items),
-          I18n.t(:report_header_special_instructions)]
+          I18n.t(:report_header_special_instructions),
+        ]
       end
     end
 

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -10,30 +10,38 @@ module OpenFoodNetwork
 
     def header
       case params[:report_type]
+
       when "order_cycle_supplier_totals"
-        ["Producer", "Product", "Variant", "Amount", "Total Units", "Curr. Cost per Unit", "Total Cost", "Status", "Incoming Transport"]
+        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
+          I18n.t(:report_header_total_units), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
+          I18n.t(:report_header_status), I18n.t(:report_header_incoming_transport)]
       when "order_cycle_supplier_totals_by_distributor"
-        ["Producer", "Product", "Variant", "To Hub", "Amount", "Curr. Cost per Unit", "Total Cost", "Shipping Method"]
+        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
+          I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
+          I18n.t(:report_header_shipping_method)]
       when "order_cycle_distributor_totals_by_supplier"
-        ["Hub", "Producer", "Product", "Variant", "Amount", "Curr. Cost per Unit", "Total Cost", "Total Shipping Cost", "Shipping Method"]
+        [I18n.t(:report_header_hub), I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant),
+          I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
+          I18n.t(:report_header_total_shipping_cost), I18n.t(:report_header_shipping_method)]
       when "order_cycle_customer_totals"
-        ["Hub", "Customer", "Email", "Phone", "Producer", "Product", "Variant",
-                  "Amount",
-                  "Item (#{currency_symbol})",
-                  "Item + Fees (#{currency_symbol})",
-                  "Admin & Handling (#{currency_symbol})",
-                  "Ship (#{currency_symbol})",
-                  "Pay fee (#{currency_symbol})",
-                  "Total (#{currency_symbol})",
-                  "Paid?",
-                  "Shipping", "Delivery?",
-                  "Ship Street", "Ship Street 2", "Ship City", "Ship Postcode", "Ship State",
-                  "Comments", "SKU",
-                  "Order Cycle", "Payment Method", "Customer Code", "Tags",
-                  "Billing Street 1", "Billing Street 2", "Billing City", "Billing Postcode", "Billing State"
+        [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email), I18n.t(:report_header_phone),
+          I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
+          I18n.t(:report_header_item_price, currency: currency_symbol),
+          I18n.t(:report_header_item_fees_price, currency: currency_symbol),
+          I18n.t(:report_header_admin_handling_fees, currency: currency_symbol),
+          I18n.t(:report_header_ship_price, currency: currency_symbol),
+          I18n.t(:report_header_pay_fee_price, currency: currency_symbol),
+          I18n.t(:report_header_total_price, currency: currency_symbol),
+          I18n.t(:report_header_paid), I18n.t(:report_header_shipping), I18n.t(:report_header_delivery),
+          I18n.t(:report_header_ship_street), I18n.t(:report_header_ship_street_2), I18n.t(:report_header_ship_city), I18n.t(:report_header_ship_postcode), I18n.t(:report_header_ship_state),
+          I18n.t(:report_header_comments), I18n.t(:report_header_sku),
+          I18n.t(:report_header_order_cycle), I18n.t(:report_header_payment_method), I18n.t(:report_header_customer_code), I18n.t(:report_header_tags),
+          I18n.t(:report_header_billing_street), I18n.t(:report_header_billing_street_2), I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode), I18n.t(:report_header_billing_state),
          ]
       else
-        ["Producer", "Product", "Variant", "Amount", "Curr. Cost per Unit", "Total Cost", "Status", "Incoming Transport"]
+        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant),
+          I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
+          I18n.t(:report_header_status), I18n.t(:report_header_incoming_transport)]
       end
 
     end
@@ -55,9 +63,9 @@ module OpenFoodNetwork
       line_items.select{ |li| line_items_with_hidden_details.include? li }.each do |line_item|
         # TODO We should really be hiding customer code here too, but until we
         # have an actual association between order and customer, it's a bit tricky
-        line_item.order.bill_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-        line_item.order.ship_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-        line_item.order.assign_attributes(email: "HIDDEN")
+        line_item.order.bill_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+        line_item.order.ship_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+        line_item.order.assign_attributes(email: I18n.t('admin.reports.hidden'))
       end
       line_items
     end
@@ -81,7 +89,7 @@ module OpenFoodNetwork
           summary_columns: [ proc { |line_items| "" },
             proc { |line_items| "" },
             proc { |line_items| "" },
-            proc { |line_items| "TOTAL" },
+            proc { |line_items| I18n.t('admin.reports.total') },
             proc { |line_items| "" },
             proc { |line_items| "" },
             proc { |line_items| line_items.sum { |li| li.amount } },
@@ -92,7 +100,7 @@ module OpenFoodNetwork
         [ { group_by: proc { |line_item| line_item.order.distributor },
           sort_by: proc { |distributor| distributor.name },
           summary_columns: [ proc { |line_items| "" },
-            proc { |line_items| "TOTAL" },
+            proc { |line_items| I18n.t('admin.reports.total') },
             proc { |line_items| "" },
             proc { |line_items| "" },
             proc { |line_items| "" },
@@ -117,7 +125,7 @@ module OpenFoodNetwork
             proc { |line_items| "" },
             proc { |line_items| "" },
             proc { |line_items| "" },
-            proc { |line_items| "TOTAL" },
+            proc { |line_items| I18n.t('admin.reports.total') },
             proc { |line_items| "" },
 
             proc { |line_items| "" },
@@ -127,7 +135,7 @@ module OpenFoodNetwork
             proc { |line_items| line_items.map { |li| li.order }.uniq.sum { |o| o.ship_total } },
             proc { |line_items| line_items.map { |li| li.order }.uniq.sum { |o| o.payment_fee } },
             proc { |line_items| line_items.map { |li| li.order }.uniq.sum { |o| o.total } },
-            proc { |line_items| line_items.all? { |li| li.order.paid? } ? "Yes" : "No" },
+            proc { |line_items| line_items.all? { |li| li.order.paid? } ? I18n.t(:yes) : I18n.t(:no) },
 
             proc { |line_items| "" },
             proc { |line_items| "" },
@@ -178,7 +186,7 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.price },
           proc { |line_items| line_items.sum { |li| li.amount } },
           proc { |line_items| "" },
-          proc { |line_items| "incoming transport" } ]
+          proc { |line_items| I18n.t(:report_header_incoming_transport) } ]
       when "order_cycle_supplier_totals_by_distributor"
         [ proc { |line_items| line_items.first.product.supplier.name },
           proc { |line_items| line_items.first.product.name },
@@ -187,7 +195,7 @@ module OpenFoodNetwork
           proc { |line_items| line_items.sum { |li| li.quantity } },
           proc { |line_items| line_items.first.price },
           proc { |line_items| line_items.sum { |li| li.amount } },
-          proc { |line_items| "shipping method" } ]
+          proc { |line_items| I18n.t(:report_header_shipping_method) } ]
       when "order_cycle_distributor_totals_by_supplier"
         [ proc { |line_items| line_items.first.order.distributor.name },
           proc { |line_items| line_items.first.product.supplier.name },
@@ -197,7 +205,7 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.price },
           proc { |line_items| line_items.sum { |li| li.amount } },
           proc { |line_items| "" },
-          proc { |line_items| "shipping method" } ]
+          proc { |line_items| I18n.t(:report_header_shipping_method) } ]
       when "order_cycle_customer_totals"
         rsa = proc { |line_items| line_items.first.order.shipping_method.andand.require_ship_address }
         [
@@ -216,10 +224,10 @@ module OpenFoodNetwork
           proc { |line_items| "" },
           proc { |line_items| "" },
           proc { |line_items| "" },
-          proc { |line_items| line_items.all? { |li| li.order.paid? } ? "Yes" : "No" },
+          proc { |line_items| line_items.all? { |li| li.order.paid? } ? I18n.t(:yes) : I18n.t(:no) },
 
           proc { |line_items| line_items.first.order.shipping_method.andand.name },
-          proc { |line_items| rsa.call(line_items) ? 'Y' : 'N' },
+          proc { |line_items| rsa.call(line_items) ? I18n.t(:yes) : I18n.t(:no) },
 
           proc { |line_items| line_items.first.order.ship_address.andand.address1 if rsa.call(line_items) },
           proc { |line_items| line_items.first.order.ship_address.andand.address2 if rsa.call(line_items) },
@@ -248,7 +256,7 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.price },
           proc { |line_items| line_items.sum { |li| li.quantity * li.price } },
           proc { |line_items| "" },
-          proc { |line_items| "incoming transport" } ]
+          proc { |line_items| I18n.t(:report_header_incoming_transport) } ]
       end
     end
 

--- a/lib/open_food_network/packing_report.rb
+++ b/lib/open_food_network/packing_report.rb
@@ -8,9 +8,25 @@ module OpenFoodNetwork
 
     def header
       if is_by_customer?
-        ["Hub", "Code", "First Name", "Last Name", "Supplier", "Product", "Variant", "Quantity", "TempControlled?"]
+        [I18n.t(:report_header_hub),
+          I18n.t(:report_header_code),
+          I18n.t(:report_header_first_name),
+          I18n.t(:report_header_last_name),
+          I18n.t(:report_header_supplier),
+          I18n.t(:report_header_product),
+          I18n.t(:report_header_variant),
+          I18n.t(:report_header_quantity),
+          I18n.t(:report_header_temp_controlled)]
       else
-        ["Hub", "Supplier", "Code", "First Name", "Last Name", "Product", "Variant", "Quantity", "TempControlled?"]
+        [I18n.t(:report_header_hub),
+          I18n.t(:report_header_supplier),
+          I18n.t(:report_header_code),
+          I18n.t(:report_header_first_name),
+          I18n.t(:report_header_last_name),
+          I18n.t(:report_header_product),
+          I18n.t(:report_header_variant),
+          I18n.t(:report_header_quantity),
+          I18n.t(:report_header_temp_controlled)]
       end
     end
 
@@ -30,9 +46,9 @@ module OpenFoodNetwork
       line_items.select{ |li| line_items_with_hidden_details.include? li }.each do |line_item|
         # TODO We should really be hiding customer code here too, but until we
         # have an actual association between order and customer, it's a bit tricky
-        line_item.order.bill_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-        line_item.order.ship_address.andand.assign_attributes(firstname: "HIDDEN", lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
-        line_item.order.assign_attributes(email: "HIDDEN")
+        line_item.order.bill_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+        line_item.order.ship_address.andand.assign_attributes(firstname: I18n.t('admin.reports.hidden'), lastname: "", phone: "", address1: "", address2: "", city: "", zipcode: "", state: nil)
+        line_item.order.assign_attributes(email: I18n.t('admin.reports.hidden'))
       end
       line_items
     end
@@ -52,7 +68,7 @@ module OpenFoodNetwork
             proc { |line_items| "" },
             proc { |line_items| "" },
             proc { |line_items| "" },
-            proc { |line_items| "TOTAL ITEMS" },
+            proc { |line_items| I18n.t('admin.reports.total_items')},
             proc { |line_items| "" },
             proc { |line_items| line_items.sum { |li| li.quantity } },
             proc { |line_items| "" } ] },
@@ -75,7 +91,7 @@ module OpenFoodNetwork
               proc { |line_items| "" },
               proc { |line_items| "" },
               proc { |line_items| "" },
-              proc { |line_items| "TOTAL ITEMS" },
+              proc { |line_items| I18n.t('admin.reports.total_items')},
               proc { |line_items| "" },
               proc { |line_items| line_items.sum { |li| li.quantity } },
               proc { |line_items| "" } ] },

--- a/lib/open_food_network/packing_report.rb
+++ b/lib/open_food_network/packing_report.rb
@@ -8,7 +8,8 @@ module OpenFoodNetwork
 
     def header
       if is_by_customer?
-        [I18n.t(:report_header_hub),
+        [
+          I18n.t(:report_header_hub),
           I18n.t(:report_header_code),
           I18n.t(:report_header_first_name),
           I18n.t(:report_header_last_name),
@@ -16,9 +17,11 @@ module OpenFoodNetwork
           I18n.t(:report_header_product),
           I18n.t(:report_header_variant),
           I18n.t(:report_header_quantity),
-          I18n.t(:report_header_temp_controlled)]
+          I18n.t(:report_header_temp_controlled),
+        ]
       else
-        [I18n.t(:report_header_hub),
+        [
+          I18n.t(:report_header_hub),
           I18n.t(:report_header_supplier),
           I18n.t(:report_header_code),
           I18n.t(:report_header_first_name),
@@ -26,7 +29,8 @@ module OpenFoodNetwork
           I18n.t(:report_header_product),
           I18n.t(:report_header_variant),
           I18n.t(:report_header_quantity),
-          I18n.t(:report_header_temp_controlled)]
+          I18n.t(:report_header_temp_controlled),
+        ]
       end
     end
 
@@ -68,7 +72,7 @@ module OpenFoodNetwork
             proc { |line_items| "" },
             proc { |line_items| "" },
             proc { |line_items| "" },
-            proc { |line_items| I18n.t('admin.reports.total_items')},
+            proc { |line_items| I18n.t('admin.reports.total_items') },
             proc { |line_items| "" },
             proc { |line_items| line_items.sum { |li| li.quantity } },
             proc { |line_items| "" } ] },
@@ -91,7 +95,7 @@ module OpenFoodNetwork
               proc { |line_items| "" },
               proc { |line_items| "" },
               proc { |line_items| "" },
-              proc { |line_items| I18n.t('admin.reports.total_items')},
+              proc { |line_items| I18n.t('admin.reports.total_items') },
               proc { |line_items| "" },
               proc { |line_items| line_items.sum { |li| li.quantity } },
               proc { |line_items| "" } ] },

--- a/lib/open_food_network/payments_report.rb
+++ b/lib/open_food_network/payments_report.rb
@@ -9,13 +9,26 @@ module OpenFoodNetwork
     def header
       case params[:report_type]
       when "payments_by_payment_type"
-        ["Payment State", "Distributor", "Payment Type", "Total (#{currency_symbol})"]
+        I18n.t(:report_header_payment_type)
+        [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor), I18n.t(:report_header_payment_type),
+          I18n.t(:report_header_total_price, currency: currency_symbol)]
       when "itemised_payment_totals"
-        ["Payment State", "Distributor", "Product Total (#{currency_symbol})", "Shipping Total (#{currency_symbol})", "Outstanding Balance (#{currency_symbol})", "Total (#{currency_symbol})"]
+        [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor),
+          I18n.t(:report_header_product_total_price, currency: currency_symbol),
+          I18n.t(:report_header_shipping_total_price, currency: currency_symbol),
+          I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol),
+          I18n.t(:report_header_total_price, currency: currency_symbol)]
       when "payment_totals"
-        ["Payment State", "Distributor", "Product Total (#{currency_symbol})", "Shipping Total (#{currency_symbol})", "Total (#{currency_symbol})", "EFT (#{currency_symbol})", "PayPal (#{currency_symbol})", "Outstanding Balance (#{currency_symbol})"]
+        [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor),
+          I18n.t(:report_header_product_total_price, currency: currency_symbol),
+          I18n.t(:report_header_shipping_total_price, currency: currency_symbol),
+          I18n.t(:report_header_total_price, currency: currency_symbol),
+          I18n.t(:report_header_eft_price, currency: currency_symbol),
+          I18n.t(:report_header_paypal_price, currency: currency_symbol),
+          I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol)]
       else
-        ["Payment State", "Distributor", "Payment Type", "Total (#{currency_symbol})"]
+        [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor), I18n.t(:report_header_payment_type),
+          I18n.t(:report_header_total_price, currency: currency_symbol)]
       end
     end
 

--- a/lib/open_food_network/payments_report.rb
+++ b/lib/open_food_network/payments_report.rb
@@ -11,24 +11,24 @@ module OpenFoodNetwork
       when "payments_by_payment_type"
         I18n.t(:report_header_payment_type)
         [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor), I18n.t(:report_header_payment_type),
-          I18n.t(:report_header_total_price, currency: currency_symbol)]
+         I18n.t(:report_header_total_price, currency: currency_symbol)]
       when "itemised_payment_totals"
         [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor),
-          I18n.t(:report_header_product_total_price, currency: currency_symbol),
-          I18n.t(:report_header_shipping_total_price, currency: currency_symbol),
-          I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol),
-          I18n.t(:report_header_total_price, currency: currency_symbol)]
+         I18n.t(:report_header_product_total_price, currency: currency_symbol),
+         I18n.t(:report_header_shipping_total_price, currency: currency_symbol),
+         I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol),
+         I18n.t(:report_header_total_price, currency: currency_symbol)]
       when "payment_totals"
         [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor),
-          I18n.t(:report_header_product_total_price, currency: currency_symbol),
-          I18n.t(:report_header_shipping_total_price, currency: currency_symbol),
-          I18n.t(:report_header_total_price, currency: currency_symbol),
-          I18n.t(:report_header_eft_price, currency: currency_symbol),
-          I18n.t(:report_header_paypal_price, currency: currency_symbol),
-          I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol)]
+         I18n.t(:report_header_product_total_price, currency: currency_symbol),
+         I18n.t(:report_header_shipping_total_price, currency: currency_symbol),
+         I18n.t(:report_header_total_price, currency: currency_symbol),
+         I18n.t(:report_header_eft_price, currency: currency_symbol),
+         I18n.t(:report_header_paypal_price, currency: currency_symbol),
+         I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol)]
       else
         [I18n.t(:report_header_payment_state), I18n.t(:report_header_distributor), I18n.t(:report_header_payment_type),
-          I18n.t(:report_header_total_price, currency: currency_symbol)]
+         I18n.t(:report_header_total_price, currency: currency_symbol)]
       end
     end
 

--- a/lib/open_food_network/products_and_inventory_report.rb
+++ b/lib/open_food_network/products_and_inventory_report.rb
@@ -4,16 +4,16 @@ module OpenFoodNetwork
   class ProductsAndInventoryReport < ProductsAndInventoryReportBase
     def header
       [
-        "Supplier",
-        "Producer Suburb",
-        "Product",
-        "Product Properties",
-        "Taxons",
-        "Variant Value",
-        "Price",
-        "Group Buy Unit Quantity",
-        "Amount",
-        "SKU"
+        I18n.t(:report_header_supplier),
+        I18n.t(:report_header_producer_suburb),
+        I18n.t(:report_header_product),
+        I18n.t(:report_header_product_properties),
+        I18n.t(:report_header_taxons),
+        I18n.t(:report_header_variant_value),
+        I18n.t(:report_header_price),
+        I18n.t(:report_header_group_buy_unit_quantity),
+        I18n.t(:report_header_amount),
+        I18n.t(:report_header_sku)
       ]
     end
 

--- a/lib/open_food_network/reports/bulk_coop_allocation_report.rb
+++ b/lib/open_food_network/reports/bulk_coop_allocation_report.rb
@@ -2,14 +2,26 @@ require 'open_food_network/reports/bulk_coop_report'
 
 module OpenFoodNetwork::Reports
   class BulkCoopAllocationReport < BulkCoopReport
-    header "Customer", "Product", "Bulk Unit Size", "Variant", "Variant value", "Variant unit", "Weight", "Sum Total", "Total Available", "Unallocated", "Max quantity excess"
+    def header
+      [I18n.t(:report_header_customer),
+        I18n.t(:report_header_product),
+        I18n.t(:report_header_bulk_unit_size),
+        I18n.t(:report_header_variant),
+        I18n.t(:report_header_variant_value),
+        I18n.t(:report_header_variant_unit),
+        I18n.t(:report_header_weight),
+        I18n.t(:report_header_sum_total),
+        I18n.t(:report_header_total_available),
+        I18n.t(:report_header_unallocated),
+        I18n.t(:report_header_max_quantity_excess)]
+    end
 
     organise do
       group { |li| li.product }
       sort(&:name)
 
       summary_row do
-        column { |lis| "TOTAL" }
+        column { |lis| I18n.t('admin.reports.total') }
         column { |lis| product_name(lis) }
         column { |lis| group_buy_unit_size_f(lis) }
         column { |lis| "" }

--- a/lib/open_food_network/reports/bulk_coop_allocation_report.rb
+++ b/lib/open_food_network/reports/bulk_coop_allocation_report.rb
@@ -3,7 +3,8 @@ require 'open_food_network/reports/bulk_coop_report'
 module OpenFoodNetwork::Reports
   class BulkCoopAllocationReport < BulkCoopReport
     def header
-      [I18n.t(:report_header_customer),
+      [
+        I18n.t(:report_header_customer),
         I18n.t(:report_header_product),
         I18n.t(:report_header_bulk_unit_size),
         I18n.t(:report_header_variant),
@@ -13,7 +14,8 @@ module OpenFoodNetwork::Reports
         I18n.t(:report_header_sum_total),
         I18n.t(:report_header_total_available),
         I18n.t(:report_header_unallocated),
-        I18n.t(:report_header_max_quantity_excess)]
+        I18n.t(:report_header_max_quantity_excess),
+      ]
     end
 
     organise do

--- a/lib/open_food_network/reports/bulk_coop_supplier_report.rb
+++ b/lib/open_food_network/reports/bulk_coop_supplier_report.rb
@@ -2,7 +2,19 @@ require 'open_food_network/reports/bulk_coop_report'
 
 module OpenFoodNetwork::Reports
   class BulkCoopSupplierReport < BulkCoopReport
-    header "Supplier", "Product", "Bulk Unit Size", "Variant", "Variant value", "Variant unit", "Weight", "Sum Total", "Units Required", "Unallocated", "Max quantity excess"
+    def header
+      [I18n.t(:report_header_supplier),
+        I18n.t(:report_header_product),
+        I18n.t(:report_header_bulk_unit_size),
+        I18n.t(:report_header_variant),
+        I18n.t(:report_header_variant_value),
+        I18n.t(:report_header_variant_unit),
+        I18n.t(:report_header_weight),
+        I18n.t(:report_header_sum_total),
+        I18n.t(:report_header_units_required),
+        I18n.t(:report_header_unallocated),
+        I18n.t(:report_header_max_quantity_excess)]
+    end
 
     organise do
       group { |li| li.product.supplier }

--- a/lib/open_food_network/reports/bulk_coop_supplier_report.rb
+++ b/lib/open_food_network/reports/bulk_coop_supplier_report.rb
@@ -3,7 +3,8 @@ require 'open_food_network/reports/bulk_coop_report'
 module OpenFoodNetwork::Reports
   class BulkCoopSupplierReport < BulkCoopReport
     def header
-      [I18n.t(:report_header_supplier),
+      [
+        I18n.t(:report_header_supplier),
         I18n.t(:report_header_product),
         I18n.t(:report_header_bulk_unit_size),
         I18n.t(:report_header_variant),
@@ -13,7 +14,8 @@ module OpenFoodNetwork::Reports
         I18n.t(:report_header_sum_total),
         I18n.t(:report_header_units_required),
         I18n.t(:report_header_unallocated),
-        I18n.t(:report_header_max_quantity_excess)]
+        I18n.t(:report_header_max_quantity_excess),
+      ]
     end
 
     organise do

--- a/lib/open_food_network/users_and_enterprises_report.rb
+++ b/lib/open_food_network/users_and_enterprises_report.rb
@@ -10,14 +10,13 @@ module OpenFoodNetwork
     end
 
     def header
-      [
-          "User",
-          "Relationship",
-          "Enterprise",
-          "Producer?",
-          "Sells",
-          "Visible",
-          "Confirmation Date"
+      [I18n.t(:report_header_user),
+        I18n.t(:report_header_relationship),
+        I18n.t(:report_header_enterprise),
+        I18n.t(:report_header_is_producer),
+        I18n.t(:report_header_sells),
+        I18n.t(:report_header_visible),
+        I18n.t(:report_header_confirmation_date)
         ]
     end
 
@@ -81,7 +80,7 @@ module OpenFoodNetwork
     end
 
     def to_local_datetime(string)
-      return "Not Confirmed" if string.nil?
+      return I18n.t(:report_header_not_confirmed) if string.nil?
       string.to_datetime.in_time_zone.strftime "%Y-%m-%d %H:%M"
     end
   end

--- a/lib/open_food_network/users_and_enterprises_report.rb
+++ b/lib/open_food_network/users_and_enterprises_report.rb
@@ -10,14 +10,15 @@ module OpenFoodNetwork
     end
 
     def header
-      [I18n.t(:report_header_user),
+      [
+        I18n.t(:report_header_user),
         I18n.t(:report_header_relationship),
         I18n.t(:report_header_enterprise),
         I18n.t(:report_header_is_producer),
         I18n.t(:report_header_sells),
         I18n.t(:report_header_visible),
-        I18n.t(:report_header_confirmation_date)
-        ]
+        I18n.t(:report_header_confirmation_date),
+      ]
     end
 
     def table

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -12,7 +12,8 @@ module OpenFoodNetwork
     end
 
     def header
-      ["*#{I18n.t(:report_header_contact_name)}",
+      [
+        "*#{I18n.t(:report_header_contact_name)}",
         I18n.t(:report_header_email),
         I18n.t(:report_header_billing_street),
         I18n.t(:report_header_billing_street_2),
@@ -39,7 +40,8 @@ module OpenFoodNetwork
         I18n.t(:report_header_tracking_option_2),
         I18n.t(:report_header_currency),
         I18n.t(:report_header_branding_theme),
-        I18n.t(:report_header_paid)]
+        I18n.t(:report_header_paid),
+      ]
     end
 
     def search
@@ -122,26 +124,26 @@ module OpenFoodNetwork
     end
 
     def produce_summary_rows(order, invoice_number, opts)
-      [summary_row(order, I18n.t(:report_header_total_untaxable_produce),       total_untaxable_products(order), invoice_number, I18n.t(:report_header_gst_free_income),        opts),
-       summary_row(order, I18n.t(:report_header_total_taxable_produce),  total_taxable_products(order),   invoice_number, I18n.t(:report_header_gst_on_income),          opts)]
+      [summary_row(order, I18n.t(:report_header_total_untaxable_produce), total_untaxable_products(order), invoice_number, I18n.t(:report_header_gst_free_income), opts),
+       summary_row(order, I18n.t(:report_header_total_taxable_produce), total_taxable_products(order), invoice_number, I18n.t(:report_header_gst_on_income), opts)]
     end
 
     def fee_summary_rows(order, invoice_number, opts)
-      [summary_row(order, I18n.t(:report_header_total_untaxable_fees),          total_untaxable_fees(order),     invoice_number, I18n.t(:report_header_gst_free_income),        opts),
-       summary_row(order, I18n.t(:report_header_total_taxable_fees),     total_taxable_fees(order),       invoice_number, I18n.t(:report_header_gst_on_income),          opts)]
+      [summary_row(order, I18n.t(:report_header_total_untaxable_fees), total_untaxable_fees(order), invoice_number, I18n.t(:report_header_gst_free_income), opts),
+       summary_row(order, I18n.t(:report_header_total_taxable_fees), total_taxable_fees(order), invoice_number, I18n.t(:report_header_gst_on_income), opts)]
     end
 
     def shipping_summary_rows(order, invoice_number, opts)
-      [summary_row(order, I18n.t(:report_header_delivery_shipping_cost), total_shipping(order),           invoice_number, tax_on_shipping_s(order), opts)]
+      [summary_row(order, I18n.t(:report_header_delivery_shipping_cost), total_shipping(order), invoice_number, tax_on_shipping_s(order), opts)]
     end
 
     def payment_summary_rows(order, invoice_number, opts)
-      [summary_row(order, I18n.t(:report_header_transaction_fee),               total_transaction(order),        invoice_number, I18n.t(:report_header_gst_free_income), opts)]
+      [summary_row(order, I18n.t(:report_header_transaction_fee), total_transaction(order), invoice_number, I18n.t(:report_header_gst_free_income), opts)]
     end
 
     def admin_adjustment_summary_rows(order, invoice_number, opts)
-      [summary_row(order, I18n.t(:report_header_total_untaxable_admin),      total_untaxable_admin_adjustments(order), invoice_number, I18n.t(:report_header_gst_free_income), opts),
-       summary_row(order, I18n.t(:report_header_total_taxable_admin), total_taxable_admin_adjustments(order),   invoice_number, I18n.t(:report_header_gst_on_income),   opts)]
+      [summary_row(order, I18n.t(:report_header_total_untaxable_admin), total_untaxable_admin_adjustments(order), invoice_number, I18n.t(:report_header_gst_free_income), opts),
+       summary_row(order, I18n.t(:report_header_total_taxable_admin), total_taxable_admin_adjustments(order), invoice_number, I18n.t(:report_header_gst_on_income), opts)]
     end
 
     def summary_row(order, description, amount, invoice_number, tax_type, opts={})

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -12,7 +12,32 @@ module OpenFoodNetwork
     end
 
     def header
-      %w(*ContactName EmailAddress POAddressLine1 POAddressLine2 POAddressLine3 POAddressLine4 POCity PORegion POPostalCode POCountry *InvoiceNumber Reference *InvoiceDate *DueDate InventoryItemCode *Description *Quantity *UnitAmount Discount *AccountCode *TaxType TrackingName1 TrackingOption1 TrackingName2 TrackingOption2 Currency BrandingTheme Paid?)
+      ["*#{I18n.t(:report_header_contact_name)}",
+        I18n.t(:report_header_email),
+        I18n.t(:report_header_billing_street),
+        I18n.t(:report_header_billing_street_2),
+        I18n.t(:report_header_billing_city),
+        I18n.t(:report_header_billing_region),
+        I18n.t(:report_header_billing_postcode),
+        I18n.t(:report_header_billing_country),
+        "*#{I18n.t(:report_header_invoice_number)}",
+        I18n.t(:report_header_reference),
+        "*#{I18n.t(:report_header_invoice_date)}",
+        "*#{I18n.t(:report_header_due_date)}",
+        I18n.t(:report_header_inventory_item_code),
+        "*#{I18n.t(:report_header_description)}",
+        "*#{I18n.t(:report_header_quantity)}",
+        "*#{I18n.t(:report_header_unit_amount)}",
+        I18n.t(:report_header_discount),
+        "*#{I18n.t(:report_header_account_code)}",
+        "*#{I18n.t(:report_header_tax_type)}",
+        I18n.t(:report_header_tracking_name_1),
+        I18n.t(:report_header_tracking_option_1),
+        I18n.t(:report_header_tracking_name_2),
+        I18n.t(:report_header_tracking_option_2),
+        I18n.t(:report_header_currency),
+        I18n.t(:report_header_branding_theme),
+        I18n.t(:report_header_paid)]
     end
 
     def search
@@ -95,26 +120,26 @@ module OpenFoodNetwork
     end
 
     def produce_summary_rows(order, invoice_number, opts)
-      [summary_row(order, 'Total untaxable produce (no tax)',       total_untaxable_products(order), invoice_number, 'GST Free Income',        opts),
-       summary_row(order, 'Total taxable produce (tax inclusive)',  total_taxable_products(order),   invoice_number, 'GST on Income',          opts)]
+      [summary_row(order, I18n.t(:report_header_total_untaxable_produce),       total_untaxable_products(order), invoice_number, I18n.t(:report_header_gst_free_income),        opts),
+       summary_row(order, I18n.t(:report_header_total_taxable_produce),  total_taxable_products(order),   invoice_number, I18n.t(:report_header_gst_on_income),          opts)]
     end
 
     def fee_summary_rows(order, invoice_number, opts)
-      [summary_row(order, 'Total untaxable fees (no tax)',          total_untaxable_fees(order),     invoice_number, 'GST Free Income',        opts),
-       summary_row(order, 'Total taxable fees (tax inclusive)',     total_taxable_fees(order),       invoice_number, 'GST on Income',          opts)]
+      [summary_row(order, I18n.t(:report_header_total_untaxable_fees),          total_untaxable_fees(order),     invoice_number, I18n.t(:report_header_gst_free_income),        opts),
+       summary_row(order, I18n.t(:report_header_total_taxable_fees),     total_taxable_fees(order),       invoice_number, I18n.t(:report_header_gst_on_income),          opts)]
     end
 
     def shipping_summary_rows(order, invoice_number, opts)
-      [summary_row(order, 'Delivery Shipping Cost (tax inclusive)', total_shipping(order),           invoice_number, tax_on_shipping_s(order), opts)]
+      [summary_row(order, I18n.t(:report_header_delivery_shipping_cost), total_shipping(order),           invoice_number, tax_on_shipping_s(order), opts)]
     end
 
     def payment_summary_rows(order, invoice_number, opts)
-      [summary_row(order, 'Transaction Fee (no tax)',               total_transaction(order),        invoice_number, 'GST Free Income', opts)]
+      [summary_row(order, I18n.t(:report_header_transaction_fee),               total_transaction(order),        invoice_number, I18n.t(:report_header_gst_free_income), opts)]
     end
 
     def admin_adjustment_summary_rows(order, invoice_number, opts)
-      [summary_row(order, 'Total untaxable admin adjustments (no tax)',      total_untaxable_admin_adjustments(order), invoice_number, 'GST Free Income', opts),
-       summary_row(order, 'Total taxable admin adjustments (tax inclusive)', total_taxable_admin_adjustments(order),   invoice_number, 'GST on Income',   opts)]
+      [summary_row(order, I18n.t(:report_header_total_untaxable_admin),      total_untaxable_admin_adjustments(order), invoice_number, I18n.t(:report_header_gst_free_income), opts),
+       summary_row(order, I18n.t(:report_header_total_taxable_admin), total_taxable_admin_adjustments(order),   invoice_number, I18n.t(:report_header_gst_on_income),   opts)]
     end
 
     def summary_row(order, description, amount, invoice_number, tax_type, opts={})
@@ -128,8 +153,6 @@ module OpenFoodNetwork
        order.email,
        order.bill_address.andand.address1,
        order.bill_address.andand.address2,
-       '',
-       '',
        order.bill_address.andand.city,
        order.bill_address.andand.state,
        order.bill_address.andand.zipcode,
@@ -151,7 +174,7 @@ module OpenFoodNetwork
        '',
        Spree::Config.currency,
        '',
-       order.paid? ? 'Y' : 'N'
+       order.paid? ? I18n.t(:yes) : I18n.t(:no)
       ]
     end
 
@@ -200,7 +223,7 @@ module OpenFoodNetwork
 
     def tax_on_shipping_s(order)
       tax_on_shipping = order.adjustments.shipping.sum(&:included_tax) > 0
-      tax_on_shipping ? 'GST on Income' : 'GST Free Income'
+      tax_on_shipping ? I18n.t(:report_header_gst_on_income) : I18n.t(:report_header_gst_free_income)
     end
 
     def total_untaxable_admin_adjustments(order)
@@ -216,7 +239,7 @@ module OpenFoodNetwork
     end
 
     def tax_type(taxable)
-      taxable.has_tax? ? 'GST on Income' : 'GST Free Income'
+      taxable.has_tax? ? I18n.t(:report_header_gst_on_income) : I18n.t(:report_header_gst_free_income)
     end
   end
 end

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -16,6 +16,8 @@ module OpenFoodNetwork
         I18n.t(:report_header_email),
         I18n.t(:report_header_billing_street),
         I18n.t(:report_header_billing_street_2),
+        I18n.t(:report_header_billing_street_3),
+        I18n.t(:report_header_billing_street_4),
         I18n.t(:report_header_billing_city),
         I18n.t(:report_header_billing_region),
         I18n.t(:report_header_billing_postcode),
@@ -153,6 +155,8 @@ module OpenFoodNetwork
        order.email,
        order.bill_address.andand.address1,
        order.bill_address.andand.address2,
+       '',
+       '',
        order.bill_address.andand.city,
        order.bill_address.andand.state,
        order.bill_address.andand.zipcode,
@@ -174,7 +178,7 @@ module OpenFoodNetwork
        '',
        Spree::Config.currency,
        '',
-       order.paid? ? I18n.t(:yes) : I18n.t(:no)
+       order.paid? ? I18n.t(:y) : I18n.t(:n)
       ]
     end
 

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -205,7 +205,7 @@ describe Spree::Admin::ReportsController do
 
     it "assigns report types" do
       spree_get :products_and_inventory
-      assigns(:report_types).should == Spree::Admin::ReportsController::REPORT_TYPES[:products_and_inventory]
+      assigns(:report_types).should == subject.report_types[:products_and_inventory]
     end
 
     it "creates a ProductAndInventoryReport" do
@@ -223,7 +223,7 @@ describe Spree::Admin::ReportsController do
     before { login_as_admin }
 
     it "should have report types for customers" do
-      Spree::Admin::ReportsController::REPORT_TYPES[:customers].should == [
+      subject.report_types[:customers].should == [
         ["Mailing List", :mailing_list],
         ["Addresses", :addresses]
       ]
@@ -246,7 +246,7 @@ describe Spree::Admin::ReportsController do
 
     it "assigns report types" do
       spree_get :customers
-      assigns(:report_types).should == Spree::Admin::ReportsController::REPORT_TYPES[:customers]
+      assigns(:report_types).should == subject.report_types[:customers]
     end
 
     it "creates a CustomersReport" do

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -62,7 +62,7 @@ feature 'Customers' do
           within "tr#c_#{customer1.id}" do
             find("a.delete-customer").trigger('click')
           end
-          expect(page).to have_selector "#info-dialog .text", text: "Delete failed: customer has associated orders"
+          expect(page).to have_selector "#info-dialog .text", text: I18n.t('admin.customers.destroy.has_associated_orders')
           click_button "OK"
         }.to_not change{Customer.count}
 

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -127,7 +127,7 @@ feature %q{
     page.should_not have_select2 'order_order_cycle_id'
 
     page.should have_selector 'p', text: "Distributor: #{@order.distributor.name}"
-    page.should have_selector 'p', text: "Order Cycle: None"
+    page.should have_selector 'p', text: "Order cycle: None"
   end
 
   scenario "filling customer details" do

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -315,8 +315,7 @@ feature %q{
       page.should have_content "Inventory (on hand)"
       click_link 'Products & Inventory'
       page.should have_content "Supplier"
-
-      page.should have_table_row ["Supplier",             "Producer Suburb",              "Product",      "Product Properties",                               "Taxons",                     "Variant Value",  "Price",  "Group Buy Unit Quantity",         "Amount", "SKU"].map(&:upcase)
+      page.should have_table_row ["Supplier", "Producer Suburb", "Product", "Product Properties", "Taxons", "Variant Value", "Price", "Group Buy Unit Quantity", "Amount", "SKU"].map(&:upcase)
       page.should have_table_row [product1.supplier.name, product1.supplier.address.city, "Product Name", product1.properties.map(&:presentation).join(", "), product1.primary_taxon.name,  "Test",           "100.0",  product1.group_buy_unit_size.to_s, "",       "sku1"]
       page.should have_table_row [product1.supplier.name, product1.supplier.address.city, "Product Name", product1.properties.map(&:presentation).join(", "), product1.primary_taxon.name,  "Something",      "80.0",   product1.group_buy_unit_size.to_s, "",       "sku2"]
       page.should have_table_row [product2.supplier.name, product1.supplier.address.city, "Product 2",    product1.properties.map(&:presentation).join(", "), product2.primary_taxon.name,  "100g",           "99.0",   product1.group_buy_unit_size.to_s, "",       "product_sku"]
@@ -511,7 +510,9 @@ feature %q{
     end
 
     def xero_invoice_header
-      %w(*ContactName EmailAddress POAddressLine1 POAddressLine2 POAddressLine3 POAddressLine4 POCity PORegion POPostalCode POCountry *InvoiceNumber Reference *InvoiceDate *DueDate InventoryItemCode *Description *Quantity *UnitAmount Discount *AccountCode *TaxType TrackingName1 TrackingOption1 TrackingName2 TrackingOption2 Currency BrandingTheme Paid?)
+      ['*Contact Name', 'Email', 'Billing Street', 'Billing Street 2', 'Billing Street 3', 'Billing Street 4',  'Billing City', 'Billing Region', 'Billing Postcode', 'Billing Country',
+       '*Invoice Number', 'Reference', '*Invoice Date', '*Due Date', 'Inventory Item Code', '*Description', '*Quantity', '*Unit Amount', 'Discount',
+       '*Account Code', '*Tax Type', 'Tracking Name 1', 'Tracking Option 1',  'Tracking Name 2', 'Tracking Option 2', 'Currency', 'Branding Theme', 'Paid?']
     end
 
     def xero_invoice_summary_row(description, amount, tax_type, opts={})

--- a/spec/lib/open_food_network/order_and_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/order_and_distributor_report_spec.rb
@@ -28,8 +28,8 @@ module OpenFoodNetwork
         header = subject.header
         header.should == ["Order date", "Order Id",
           "Customer Name","Customer Email", "Customer Phone", "Customer City",
-          "SKU", "Item name", "Variant", "Quantity", "Max Quantity", "Cost", "Shipping cost",
-          "Payment method",
+          "SKU", "Item name", "Variant", "Quantity", "Max Quantity", "Cost", "Shipping Cost",
+          "Payment Method",
           "Distributor", "Distributor address", "Distributor city", "Distributor postcode", "Shipping instructions"]
       end
 


### PR DESCRIPTION
For issue #1560.

This task was to extract and replace it. Do not blame me for non-existent structure. As it seems that every dev followed their own way how to add translations.
I would say it is a huge tech debt and we need to fix it somehow. Any thoughts? Link to discourse -
 https://community.openfoodnetwork.org/t/workflow-to-structure-translations/932

Files  in doubt -
This might be ralated with #1561 - renders partial inside with icons `app/views/spree/admin/products/product_distributions.html.haml`
`app/overrides/spree/shared/_product_tabs/add_distributions.html.haml.deface`

Those seems are not used anymore. Can we delete it?
`app/overrides/spree/shared/_header/replace_logo_with_link_text.html.haml.deface`
`app/overrides/spree/shared/_footer/footer.html.haml.deface`
