### PR TITLE
Uk/1563 backend for persistent lang switching

### DIFF
--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -2,6 +2,16 @@ module I18nHelper
   private
 
   def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+    # update spree_current_user locale if logged in and set cookie locale if params
+    if params[:locale] && Rails.application.config.i18n.available_locales.include?(params[:locale])
+      spree_current_user.update_attributes!(locale: params[:locale]) if spree_current_user
+      cookies[:locale] = params[:locale]
+    end
+
+    if spree_current_user && spree_current_user.locale.nil? && cookies[:locale]
+      spree_current_user.update_attributes!(locale: params[:locale])
+    end
+
+    I18n.locale = spree_current_user.andand.locale || cookies[:locale] || I18n.default_locale
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,13 +1,12 @@
 module I18nHelper
-  private
-
   def set_locale
-    # update spree_current_user locale if logged in and set cookie locale if params
+    # Save a given locale
     if params[:locale] && Rails.application.config.i18n.available_locales.include?(params[:locale])
       spree_current_user.update_attributes!(locale: params[:locale]) if spree_current_user
       cookies[:locale] = params[:locale]
     end
 
+    # After logging in, check if the user chose a locale before
     if spree_current_user && spree_current_user.locale.nil? && cookies[:locale]
       spree_current_user.update_attributes!(locale: params[:locale])
     end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -17,7 +17,7 @@ Spree.user_class.class_eval do
   accepts_nested_attributes_for :bill_address
   accepts_nested_attributes_for :ship_address
 
-  attr_accessible :enterprise_ids, :enterprise_roles_attributes, :enterprise_limit, :bill_address_attributes, :ship_address_attributes
+  attr_accessible :enterprise_ids, :enterprise_roles_attributes, :enterprise_limit, :locale, :bill_address_attributes, :ship_address_attributes
   after_create :send_signup_confirmation
 
   validate :limit_owned_enterprises

--- a/db/migrate/20170512115519_add_locale_to_spree_users.rb
+++ b/db/migrate/20170512115519_add_locale_to_spree_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToSpreeUsers < ActiveRecord::Migration
+  def change
+    add_column :spree_users, :locale, :string, limit: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170413083148) do
+ActiveRecord::Schema.define(:version => 20170512115519) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -998,6 +998,7 @@ ActiveRecord::Schema.define(:version => 20170413083148) do
     t.datetime "reset_password_sent_at"
     t.string   "api_key",                :limit => 40
     t.integer  "enterprise_limit",                     :default => 1, :null => false
+    t.string   "locale",                 :limit => 5
   end
 
   add_index "spree_users", ["email"], :name => "email_idx_unique", :unique => true

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 feature 'Multilingual', js: true do
+  include AuthenticationWorkflow
   include WebHelper
 
   it 'has two locales available' do
@@ -9,24 +10,62 @@ feature 'Multilingual', js: true do
     expect(Rails.application.config.i18n[:available_locales]).to eq ['en', 'es']
   end
 
+  it '18n-js fallsback to default language' do # in backend it doesn't until we change enforce_available_locales to `true`
+    visit root_path
+    set_i18n_locale('it')
+    expect(get_i18n_translation('label_shops')).to eq 'Shops'
+  end
+
   it 'can switch language by params' do
     visit root_path
     expect(get_i18n_locale).to eq 'en'
     expect(get_i18n_translation('label_shops')).to eq 'Shops'
+    expect(page.driver.browser.cookies['locale']).to be_nil
     expect(page).to have_content 'Interested in getting on the Open Food Network?'
     expect(page).to have_content 'SHOPS'
 
     visit root_path(locale: 'es')
     expect(get_i18n_locale).to eq 'es'
     expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
+    expect(page.driver.browser.cookies['locale'].value).to eq 'es'
     expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
     expect(page).to have_content 'TIENDAS'
 
-    # I18n-js fallsback to 'en'
+    # it is not in the list of available of available_locales
     visit root_path(locale: 'it')
-    expect(get_i18n_locale).to eq 'it'
-    expect(get_i18n_translation('label_shops')).to eq 'Shops'
-    # This still is italian until we change enforce_available_locales to `true`
-    expect(page).to have_content 'NEGOZI'
+    expect(get_i18n_locale).to eq 'es'
+    expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
+    expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+    expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
+    expect(page).to have_content 'TIENDAS'
+  end
+
+  context 'with user' do
+    let(:user) { create(:user) }
+
+    it 'updates user locale from cookie if it is empty' do
+      visit root_path(locale: 'es')
+
+      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+      expect(user.locale).to be_nil
+      quick_login_as user
+      visit root_path
+
+      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+    end
+
+    it 'updates user locale and stays in cookie after logout' do
+      quick_login_as user
+      visit root_path(locale: 'es')
+      user.reload
+
+      expect(user.locale).to eq 'es'
+
+      logout
+
+      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+      expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
+      expect(page).to have_content 'TIENDAS'
+    end
   end
 end

--- a/spec/helpers/i18n_helper_spec.rb
+++ b/spec/helpers/i18n_helper_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe I18nHelper do
+  let(:user) { create(:user) }
+
+  context "as guest" do
+    before do
+      allow(helper).to receive(:spree_current_user) { nil }
+    end
+
+    it "sets the default locale" do
+      helper.set_locale
+      expect(I18n.locale).to eq :en
+    end
+
+    it "sets the chosen locale" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+
+    it "remembers the chosen locale" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+
+    it "ignores unavailable locales" do
+      allow(helper).to receive(:params) { {locale: "xx"} }
+      helper.set_locale
+      expect(I18n.locale).to eq :en
+    end
+
+    it "remembers the last chosen locale" do
+      allow(helper).to receive(:params) { {locale: "en"} }
+      helper.set_locale
+
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+
+    it "remembers the chosen locale after logging in" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+
+      # log in
+      allow(helper).to receive(:spree_current_user) { user }
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+
+    it "forgets the chosen locale without cookies" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+
+      # clean up cookies
+      cookies.delete :locale
+
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :en
+    end
+  end
+
+  context "logged in" do
+    before do
+      allow(helper).to receive(:spree_current_user) { user }
+    end
+
+    it "sets the default locale" do
+      helper.set_locale
+      expect(I18n.locale).to eq :en
+    end
+
+    it "sets the chosen locale" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+      expect(user.locale).to eq "es"
+    end
+
+    it "remembers the chosen locale" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+
+    it "remembers the last chosen locale" do
+      allow(helper).to receive(:params) { {locale: "en"} }
+      helper.set_locale
+
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+
+    it "remembers the chosen locale after logging out" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+
+      # log out
+      allow(helper).to receive(:spree_current_user) { nil }
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+
+    it "remembers the chosen locale on another computer" do
+      allow(helper).to receive(:params) { {locale: "es"} }
+      helper.set_locale
+      expect(cookies[:locale]).to eq "es"
+
+      # switch computer / browser or loose cookies
+      cookies.delete :locale
+
+      allow(helper).to receive(:params) { {} }
+      helper.set_locale
+      expect(I18n.locale).to eq :es
+    end
+  end
+end

--- a/spec/helpers/i18n_helper_spec.rb
+++ b/spec/helpers/i18n_helper_spec.rb
@@ -3,6 +3,16 @@ require 'spec_helper'
 describe I18nHelper do
   let(:user) { create(:user) }
 
+  # In the real world, the helper is called in every request and sets
+  # I18n.locale to the chosen locale or the default. For testing purposes we
+  # have to restore I18n.locale for unit tests that don't call the helper, but
+  # rely on translated strings.
+  around do |example|
+    locale = I18n.locale
+    example.run
+    I18n.locale = locale
+  end
+
   context "as guest" do
     before do
       allow(helper).to receive(:spree_current_user) { nil }

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -113,6 +113,10 @@ module WebHelper
     DirtyFormDialog.new(page)
   end
 
+  def set_i18n_locale(locale = 'en')
+    page.evaluate_script("I18n.locale = '#{locale}'")
+  end
+
   def get_i18n_locale
     page.evaluate_script("I18n.locale;")
   end


### PR DESCRIPTION
This is extension to PR https://github.com/openfoodfoundation/openfoodnetwork/pull/1564 and back-end to #1563, meaning that passing ?locale=en-GB would switch and persist by all requirements described in Slack #multilingual channel.

P.S. Somehow extracting login from I18nHelper#set_locale to user's model seemed too much, so left as it is to keep the logic in one file.