### PR TITLE
Reproduce line_item controller issue

### DIFF
--- a/lib/open_food_network/distribution_change_validator.rb
+++ b/lib/open_food_network/distribution_change_validator.rb
@@ -1,7 +1,7 @@
 class DistributionChangeValidator
 
-  def initialize order
-    @order = order
+  def initialize(order)
+    @order = order.reload
   end
 
   def can_change_to_distributor?(distributor)

--- a/lib/open_food_network/distribution_change_validator.rb
+++ b/lib/open_food_network/distribution_change_validator.rb
@@ -1,7 +1,7 @@
 class DistributionChangeValidator
 
   def initialize(order)
-    @order = order.reload
+    @order = order
   end
 
   def can_change_to_distributor?(distributor)

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -32,8 +32,12 @@ describe LineItemsController do
       order = create(:completed_order_with_totals)
       item = create(:line_item, order: order)
       while !order.completed? do break unless order.next! end
+      order.reload
       item
     end
+
+    let(:order) { item.order }
+    let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: [order.line_item_variants]) }
 
     before { controller.stub spree_current_user: item.order.user }
 
@@ -55,42 +59,32 @@ describe LineItemsController do
       end
 
       context "where the item's order is associated with the current user" do
-        before { item.order.update_attributes(user_id: user.id) }
+        before { order.update_attributes!(user_id: user.id) }
 
-        context "without an order cycle" do
+        context "without an order cycle or distributor" do
           it "denies deletion" do
             delete :destroy, params
             expect(response.status).to eq 403
           end
         end
 
-        context "with an order cycle" do
-          before { item.order.update_attributes(order_cycle_id: order_cycle.id) }
+        context "with an order cycle and distributor" do
+          before { order.update_attributes!(order_cycle_id: order_cycle.id, distributor_id: distributor.id) }
 
-          context "without a distributor" do
+          context "where changes are not allowed" do
             it "denies deletion" do
               delete :destroy, params
               expect(response.status).to eq 403
             end
           end
 
-          context "where the item's order has a distributor" do
-            before { item.order.update_attributes(distributor_id: distributor.id) }
-            context "where changes are not allowed" do
-              it "denies deletion" do
-                delete :destroy, params
-                expect(response.status).to eq 403
-              end
-            end
+          context "where changes are allowed" do
+            before { distributor.update_attributes!(allow_order_changes: true) }
 
-            context "where changes are allowed" do
-              before { distributor.update_attributes(allow_order_changes: true) }
-
-              it "deletes the line item" do
-                delete :destroy, params
-                expect(response.status).to eq 204
-                expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
-              end
+            it "deletes the line item" do
+              delete :destroy, params
+              expect(response.status).to eq 204
+              expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
             end
           end
         end


### PR DESCRIPTION
During the [Spree gem upgrade](https://github.com/openfoodfoundation/openfoodnetwork/pull/1524) I'm facing a broken spec:

https://travis-ci.org/openfoodfoundation/openfoodnetwork/jobs/233649570#L1126

What I found out is that even in `master` we can get the same spec failing, this PR demonstrates that:
```
  1) LineItemsController destroying a line item on a completed order with a line item id where the item's order is associated with the current user with an order cycle where the item's order has a distributor where changes are allowed deletes the line item
     Failure/Error: expect(response.status).to eq 204
       
       expected: 204
            got: 403
       
       (compared using ==)
     # ./spec/controllers/line_items_controller_spec.rb:91:in `block (8 levels) in <top (required)>'

 1/1 |=============================================== 100 ===============================================>| Time: 00:00:04 

Finished in 4.5 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/controllers/line_items_controller_spec.rb:89 # LineItemsController destroying a line item on a completed order with a line item id where the item's order is associated with the current user with an order cycle where the item's order has a distributor where changes are allowed deletes the line item
```

Any idea on what's happening?