### PR TITLE
Do not blindly clear the whole Rails cache

### DIFF
--- a/spec/jobs/products_cache_integrity_checker_job_spec.rb
+++ b/spec/jobs/products_cache_integrity_checker_job_spec.rb
@@ -6,9 +6,10 @@ describe ProductsCacheIntegrityCheckerJob do
     let(:distributor) { create(:distributor_enterprise) }
     let(:order_cycle) { create(:simple_order_cycle) }
     let(:job) { ProductsCacheIntegrityCheckerJob.new distributor.id, order_cycle.id }
+    let(:cache_key) { "products-json-#{distributor.id}-#{order_cycle.id}" }
 
     before do
-      Rails.cache.write "products-json-#{distributor.id}-#{order_cycle.id}", "[1, 2, 3]\n"
+      Rails.cache.write(cache_key, "[1, 2, 3]\n")
       OpenFoodNetwork::ProductsRenderer.stub(:new) { double(:pr, products_json: "[1, 3]\n") }
     end
 
@@ -18,7 +19,7 @@ describe ProductsCacheIntegrityCheckerJob do
     end
 
     it "deals with nil cached_json" do
-      Rails.cache.clear
+      Rails.cache.delete(cache_key)
       expect(Bugsnag).to receive(:notify)
       run_job job
     end

--- a/spec/lib/open_food_network/cached_products_renderer_spec.rb
+++ b/spec/lib/open_food_network/cached_products_renderer_spec.rb
@@ -48,11 +48,12 @@ module OpenFoodNetwork
         end
 
         describe "when the products JSON is not cached" do
-          let(:cached_json) { Rails.cache.read "products-json-#{distributor.id}-#{order_cycle.id}" }
-          let(:cache_present) { Rails.cache.exist? "products-json-#{distributor.id}-#{order_cycle.id}" }
+          let(:cache_key) { "products-json-#{distributor.id}-#{order_cycle.id}" }
+          let(:cached_json) { Rails.cache.read(cache_key) }
+          let(:cache_present) { Rails.cache.exist?(cache_key) }
 
           before do
-            Rails.cache.clear
+            Rails.cache.delete(cache_key)
             cpr.stub(:uncached_products_json) { 'fresh products' }
           end
 

--- a/spec/performance/injection_helper_spec.rb
+++ b/spec/performance/injection_helper_spec.rb
@@ -18,7 +18,7 @@ describe InjectionHelper, type: :helper, performance: true do
     results = []
     4.times do |i|
       ActiveRecord::Base.connection.query_cache.clear
-      Rails.cache.clear
+      Rails.cache.delete_matched('api\/cached_enterprise_serializer\/enterprises')
       result = Benchmark.measure { helper.inject_enterprises }
       results << result.total if i > 0
       puts result

--- a/spec/performance/shop_controller_spec.rb
+++ b/spec/performance/shop_controller_spec.rb
@@ -14,6 +14,12 @@ describe ShopController, type: :controller, performance: true do
   describe "fetching products" do
     let(:exchange) { order_cycle.exchanges.to_enterprises(d).outgoing.first }
     let(:image) { File.open(File.expand_path('../../../app/assets/images/logo-white.png', __FILE__)) }
+    let(:cache_key_patterns) do
+      [
+        'api\/taxon_serializer\/spree\/taxons',
+        'enterprise'
+      ]
+    end
 
     before do
       11.times do
@@ -28,7 +34,7 @@ describe ShopController, type: :controller, performance: true do
     end
 
     it "returns products via json" do
-      results = multi_benchmark(3) do
+      results = multi_benchmark(3, cache_key_patterns: cache_key_patterns) do
         xhr :get, :products
         response.should be_success
       end

--- a/spec/support/performance_helper.rb
+++ b/spec/support/performance_helper.rb
@@ -1,9 +1,9 @@
 module OpenFoodNetwork
   module PerformanceHelper
-    def multi_benchmark(num_samples)
+    def multi_benchmark(num_samples, cache_key_patterns: [])
       results = (0..num_samples).map do |i|
         ActiveRecord::Base.connection.query_cache.clear
-        Rails.cache.clear
+        delete_cache_keys(cache_key_patterns)
 
         result = Benchmark.measure { yield }
 
@@ -15,6 +15,17 @@ module OpenFoodNetwork
       puts (results.sum / results.count * 1000).round 0
 
       results
+    end
+
+    # Looks for matching keys and deletes them
+    # Blindly running `Rails.cache.clear` is harmful since it alters application
+    # state outside executing spec example
+    #
+    # @param cache_key_patterns [Array<String>]
+    def delete_cache_keys(cache_key_patterns)
+      cache_key_patterns.each do |pattern|
+        Rails.cache.delete_matched(pattern)
+      end
     end
   end
 end


### PR DESCRIPTION
This is one of the causes of "random" failing specs in Travis CI that are hard to reproduce locally.

Basically using `Rails.cache.clear` in specs (and any other place IMHO) is harmful since it alters the state of the Rails application beyond the scope of the spec example.