### PR TITLE
Country selection in enterprise registration

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/registration/registration_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/registration/registration_controller.js.coffee
@@ -11,5 +11,14 @@ Darkswarm.controller "RegistrationCtrl", ($scope, RegistrationService, Enterpris
   $scope.countries = availableCountries.filter (country) ->
     country.states.length > 0
 
+  $scope.countriesById = $scope.countries.reduce (obj, country) ->
+    obj[country.id] = country
+    obj
+  , {}
+
+  $scope.setDefaultCountry = (id) ->
+    country = $scope.countriesById[id]
+    $scope.enterprise.country = country if country
+
   $scope.countryHasStates = ->
     $scope.enterprise.country.states.length > 0

--- a/app/assets/javascripts/darkswarm/controllers/registration/registration_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/registration/registration_controller.js.coffee
@@ -5,7 +5,11 @@ Darkswarm.controller "RegistrationCtrl", ($scope, RegistrationService, Enterpris
 
   $scope.steps = ['details', 'contact', 'type', 'about', 'images', 'social']
 
-  $scope.countries = availableCountries
+  # Filter countries without states since the form requires a state to be selected.
+  # Consider changing the form to require a state only if a country requires them (Spree option).
+  # Invalid countries still need to be filtered (better server-side).
+  $scope.countries = availableCountries.filter (country) ->
+    country.states.length > 0
 
   $scope.countryHasStates = ->
     $scope.enterprise.country.states.length > 0

--- a/app/assets/javascripts/darkswarm/services/products.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/products.js.coffee
@@ -46,6 +46,6 @@ Darkswarm.factory 'Products', ($resource, Enterprises, Dereferencer, Taxons, Pro
           product.variants = for variant in product.variants
             variant = Variants.register variant
             if product.name != variant.name_to_display
-              product.variant_names += variant.name_to_display
+              product.variant_names += variant.name_to_display + " "
             variant.product = product
             variant

--- a/app/assets/javascripts/darkswarm/services/products.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/products.js.coffee
@@ -42,6 +42,7 @@ Darkswarm.factory 'Products', ($resource, Enterprises, Dereferencer, Taxons, Pro
     registerVariants: ->
       for product in @products
         if product.variants
+          product.variant_names = ""
           product.variants = for variant in product.variants
             variant = Variants.register variant
             if product.name != variant.name_to_display

--- a/app/views/registration/steps/_details.html.haml
+++ b/app/views/registration/steps/_details.html.haml
@@ -54,7 +54,7 @@
             .small-12.medium-8.large-8.columns
               .field
                 %label{ for: 'enterprise_country' } {{'registration_detail_country' | t}}
-                %select.chunky{ id: 'enterprise_country', name: 'country', required: true, ng: { model: 'enterprise.country', options: 'c as c.name for c in countries' } }
+                %select.chunky{ id: 'enterprise_country', name: 'country', required: true, ng: { init: "setDefaultCountry(#{Spree::Config[:default_country_id]})", model: 'enterprise.country', options: 'c as c.name for c in countries' } }
                 %span.error{ ng: { show: "details.country.$error.required && submitted" } }
                   {{'registration_detail_country_error' | t}}
 

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -48,7 +48,7 @@ feature "Registration", js: true do
       fill_in 'enterprise_address', with: '123 Abc Street'
       fill_in 'enterprise_city', with: 'Northcote'
       fill_in 'enterprise_zipcode', with: '3070'
-      expect(page).to have_select('enterprise_country', options: %w(Albania Australia Chad), selected: 'Albania')
+      expect(page).to have_select('enterprise_country', options: %w(Albania Australia), selected: 'Albania')
       select 'Australia', from: 'enterprise_country'
       select 'VIC', from: 'enterprise_state'
       perform_and_ensure(:click_button, "Continue", lambda { page.has_content? 'Who is responsible for managing My Awesome Enterprise?' })

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -6,7 +6,20 @@ feature "Registration", js: true do
 
   describe "Registering a Profile" do
     let(:user) { create(:user, password: "password", password_confirmation: "password") }
-    before { Spree::Config.enterprises_require_tos = false }
+
+    before do
+      Spree::Config.enterprises_require_tos = false
+
+      albania = Spree::Country.create!({ name: "Albania", iso3: "ALB", iso: "AL", iso_name: "ALBANIA", numcode: "8" }, without_protection: true)
+      Spree::State.create!({ name: "Berat", abbr: "BRA", country: albania }, without_protection: true)
+      Spree::Country.create!({ name: "Chad", iso3: "TCD", iso: "TD", iso_name: "CHAD", numcode: "148" }, without_protection: true)
+    end
+
+    after do
+      Spree::State.where(name: 'Berat').delete_all
+      Spree::Country.where(name: 'Albania').delete_all
+      Spree::Country.where(name: 'Chad').delete_all
+    end
 
     it "Allows a logged in user to register a profile" do
       visit registration_path
@@ -35,6 +48,7 @@ feature "Registration", js: true do
       fill_in 'enterprise_address', with: '123 Abc Street'
       fill_in 'enterprise_city', with: 'Northcote'
       fill_in 'enterprise_zipcode', with: '3070'
+      expect(page).to have_select('enterprise_country', options: %w(Albania Australia Chad), selected: 'Albania')
       select 'Australia', from: 'enterprise_country'
       select 'VIC', from: 'enterprise_state'
       perform_and_ensure(:click_button, "Continue", lambda { page.has_content? 'Who is responsible for managing My Awesome Enterprise?' })

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -48,8 +48,7 @@ feature "Registration", js: true do
       fill_in 'enterprise_address', with: '123 Abc Street'
       fill_in 'enterprise_city', with: 'Northcote'
       fill_in 'enterprise_zipcode', with: '3070'
-      expect(page).to have_select('enterprise_country', options: %w(Albania Australia), selected: 'Albania')
-      select 'Australia', from: 'enterprise_country'
+      expect(page).to have_select('enterprise_country', options: %w(Albania Australia), selected: 'Australia')
       select 'VIC', from: 'enterprise_state'
       perform_and_ensure(:click_button, "Continue", lambda { page.has_content? 'Who is responsible for managing My Awesome Enterprise?' })
 

--- a/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
@@ -86,7 +86,7 @@ describe 'Products service', ->
     product.variants = [{id: 1, name_to_display: "one"}, {id: 2, name_to_display: "two"}]
     $httpBackend.expectGET("/shop/products").respond([product])
     $httpBackend.flush()
-    expect(Products.products[0].variant_names).toEqual "onetwo"
+    expect(Products.products[0].variant_names).toEqual "one two "
 
   it "sets primaryImageOrMissing when no images are provided", ->
     $httpBackend.expectGET("/shop/products").respond([product])

--- a/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
@@ -82,6 +82,12 @@ describe 'Products service', ->
     $httpBackend.flush()
     expect(Products.products[0].variants[0]).toBe Variants.variants[1]
 
+  it "stores variant names", ->
+    product.variants = [{id: 1, name_to_display: "one"}, {id: 2, name_to_display: "two"}]
+    $httpBackend.expectGET("/shop/products").respond([product])
+    $httpBackend.flush()
+    expect(Products.products[0].variant_names).toEqual "onetwo"
+
   it "sets primaryImageOrMissing when no images are provided", ->
     $httpBackend.expectGET("/shop/products").respond([product])
     $httpBackend.flush()


### PR DESCRIPTION
Addressing #1330 and competing with #1334.

Building on work by @Matt-Yorkley with lots of copy and paste. I created new commits for a better structure. Instead of a new directive proposed by Matt, I used `ng-init` to set the default country instead. I also omitted the new file `app/assets/javascripts/templates/registration/details.html.haml`. Was that used? What do you think about my new version?

@lin-d-hop I volunteered my work on this alternative. I couldn't justify spending so much time on proposing my own solution when you had something working already. :-)