### PR TITLE
Remove unused #within_zone? in ShippingMethod decorator

### DIFF
--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -48,14 +48,6 @@ Spree::ShippingMethod.class_eval do
   end
   alias_method_chain :available_to_order?, :distributor_check
 
-  def within_zone?(order)
-    if order.ship_address
-      zone && zone.include?(order.ship_address)
-    else
-      true # Shipping methods are available before we've selected an address
-    end
-  end
-
   def has_distributor?(distributor)
     self.distributors.include?(distributor)
   end

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -55,12 +55,6 @@ module Spree
                   distributor: create(:distributor_enterprise), currency: currency)
         sm.should_not be_available_to_order o
       end
-
-      it "is available to orders with no shipping address" do
-        o = create(:order, ship_address: nil,
-                  distributor: sm.distributors.first, currency: currency)
-        sm.should be_available_to_order o
-      end
     end
 
     describe "finding services offered by all distributors" do


### PR DESCRIPTION
This code is not used anymore 🔥 

### Test
 - Checkout without a shipping address