### PR TITLE
Change modal redirect behaviour

### DIFF
--- a/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
@@ -25,9 +25,7 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
     isActive: Navigation.isActive
 
     close: ->
-      if location.pathname in ["/", "/checkout"]
-        Navigation.navigate "/"
-      else
+      if location.pathname in ["/register", "/register/auth"]
         Loading.message = t 'going_back_to_home_page'
         location.hash = ""
         location.pathname = "/"


### PR DESCRIPTION
This came up as part of #1557. This PR removes behaviour from login modals on the frontend that currently force a redirect to the homepage whenever a modal is closed. The behaviour is still used on the /register modal pages.