### PR TITLE
Fix #1611 Rephrase error message for people logging in with an existing email 

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,12 @@ en:
       spree/order:
         payment_state: Payment State
         shipment_state: Shipment State
+    errors:
+      models:
+        spree/user:
+          attributes:
+            email:
+              taken: "There's already an account for this email. Please login or reset your password."
   devise:
     failure:
       invalid: |

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -60,6 +60,13 @@ feature "Authentication", js: true, retry: 3 do
             page.should have_content "too short"
           end
 
+          scenario "Failing to sign up because email is already registered" do
+            fill_in "Email", with: user.email
+            fill_in "Choose a password", with: "foobarino"
+            click_signup_button
+            expect(page).to have_content "There's already an account for this email."
+          end
+
           scenario "Signing up successfully" do
             fill_in "Email", with: "test@foo.com"
             fill_in "Choose a password", with: "test12345"


### PR DESCRIPTION
Solving #1611 Rephrase error message for people logging in with an existing user email

Overrides default error message for sign up validation to show a more friendly error when the given email is already registered.

Before:
![screenshot from 2017-06-28 14 05 30](https://user-images.githubusercontent.com/3524483/27620201-3d24a0f8-5c0b-11e7-8440-67e5955bfdd6.png)

After:
![screenshot from 2017-06-28 14 10 39](https://user-images.githubusercontent.com/3524483/27620246-97ee374c-5c0b-11e7-8b64-107aee468502.png)
