### PR TITLE
Remove checkout flow states logic from Order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ env:
   global:
     - TZ="Australia/Melbourne"
     - TIMEZONE="Australia/Melbourne"
-    - CI_NODE_TOTAL=5
-  matrix:
-    - CI_NODE_INDEX=0
-    - CI_NODE_INDEX=1
-    - CI_NODE_INDEX=2
-    - CI_NODE_INDEX=3
-    - CI_NODE_INDEX=4 KARMA="true" GITHUB_DEPLOY="true"
 
 before_script:
   - cp config/database.travis.yml config/database.yml
@@ -41,7 +34,7 @@ before_script:
 script:
   - 'if [ "$KARMA" = "true" ]; then bundle exec rake karma:run; else echo "Skipping karma run"; fi'
   #- "KNAPSACK_GENERATE_REPORT=true bundle exec rspec spec"
-  - "bundle exec rake 'knapsack:rspec[--tag ~performance]'"
+  - "bundle exec rspec spec/features/admin/reports_spec.rb"
 
 after_success:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ env:
   global:
     - TZ="Australia/Melbourne"
     - TIMEZONE="Australia/Melbourne"
+    - CI_NODE_TOTAL=5
+  matrix:
+    - CI_NODE_INDEX=0
+    - CI_NODE_INDEX=1
+    - CI_NODE_INDEX=2
+    - CI_NODE_INDEX=3
+    - CI_NODE_INDEX=4 KARMA="true" GITHUB_DEPLOY="true"
 
 before_script:
   - cp config/database.travis.yml config/database.yml
@@ -34,7 +41,7 @@ before_script:
 script:
   - 'if [ "$KARMA" = "true" ]; then bundle exec rake karma:run; else echo "Skipping karma run"; fi'
   #- "KNAPSACK_GENERATE_REPORT=true bundle exec rspec spec"
-  - "bundle exec rspec spec/features/admin/reports_spec.rb:458"
+  - "bundle exec rake 'knapsack:rspec[--tag ~performance]'"
 
 after_success:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 script:
   - 'if [ "$KARMA" = "true" ]; then bundle exec rake karma:run; else echo "Skipping karma run"; fi'
   #- "KNAPSACK_GENERATE_REPORT=true bundle exec rspec spec"
-  - "bundle exec rspec spec/features/admin/reports_spec.rb"
+  - "bundle exec rspec spec/features/admin/reports_spec.rb:458"
 
 after_success:
   - >

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -23,6 +23,13 @@ Spree::Order.class_eval do
 
   before_save :update_shipping_fees!, if: :complete?
   before_save :update_payment_fees!, if: :complete?
+  checkout_flow do
+    go_to_state :address
+    go_to_state :delivery
+    go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
+    go_to_state :complete
+    remove_transition :from => :delivery, :to => :confirm
+  end
 
   # -- Scopes
   scope :managed_by, lambda { |user|

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -24,24 +24,6 @@ Spree::Order.class_eval do
   before_save :update_shipping_fees!, if: :complete?
   before_save :update_payment_fees!, if: :complete?
 
-  checkout_flow do
-    go_to_state :address
-    go_to_state :delivery
-    go_to_state :payment, :if => lambda { |order|
-      # Fix for #2191
-      if order.shipping_method.andand.require_ship_address and
-        if order.ship_address.andand.valid?
-          order.create_shipment!
-          order.update_totals
-        end
-      end
-      order.payment_required?
-    }
-    go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
-    go_to_state :complete
-    remove_transition :from => :delivery, :to => :confirm
-  end
-
   # -- Scopes
   scope :managed_by, lambda { |user|
     if user.has_spree_role?('admin')
@@ -292,6 +274,9 @@ Spree::Order.class_eval do
 
   private
 
+  # Because Spree makes the ship_address mandatory we set the distributor's
+  # address, as it will be picked up there, but with the customers name and
+  # phone
   def shipping_address_from_distributor
     if distributor
       # This method is confusing to conform to the vagaries of the multi-step checkout


### PR DESCRIPTION
**DISCLAIMER: this PR is just to open a discussion about the checkout flow and test whether it is actually needed for the Spree upgrade  (tests will tell us, hopefully :trollface: )**

These are our findings so far:

1 - When the shipping method does not require ship address (a pickup) we
skip the shipment creation in the payment :if callback. However, a
shipment does get created by spree in the database. Check
https://github.com/spree/spree/blob/1-3-stable/core/app/models/spree/order/checkout.rb#L82

2 - In the same payment :if callback we ensure the ship_address is valid
in order to create the shipment. This doesn't seem to bring any benefit
since ActiveRecord will run the validations before saving the models
anyway.