### PR TITLE
Upgrade bundler in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ env:
     - CI_NODE_INDEX=3
     - CI_NODE_INDEX=4 KARMA="true" GITHUB_DEPLOY="true"
 
-before_install: gem install bundler
+before_install:
+  - gem install bundler
+  - gem cleanup bundler
 
 before_script:
   - cp config/database.travis.yml config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
     - CI_NODE_INDEX=3
     - CI_NODE_INDEX=4 KARMA="true" GITHUB_DEPLOY="true"
 
+before_install: gem install bundler
+
 before_script:
   - cp config/database.travis.yml config/database.yml
   - cp config/application.yml.example config/application.yml


### PR DESCRIPTION
The version used in Travis CI (1.7.6) is way too far from the one specified in our Gemfile (1.14.3). The more similar the versions in CI and our local environments are the more consistent the behaviours will be.

Ideally we should use the exact same version in the Gemfile.lock. We couldn't find a built-in way to do that in Travis CI so will give the [CodeClimate's grep engine](https://docs.codeclimate.com/v1.0/docs/grep) a try so that both bundler versions in `.travis.yml` and `Gemfile.lock` are in sync.