### PR TITLE
Disable scss-lint for CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ engines:
   rubocop:
     enabled: true
   scss-lint:
-    enabled: true
+    enabled: false
 ratings:
   paths:
   - app/**


### PR DESCRIPTION
Until we can tweak #1393 to enable stylelint to work with CodeClimate, disable any scss linters for the project