### PR TITLE
Optional checkout fields (WIP)

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -17,6 +17,7 @@ class CheckoutController < Spree::CheckoutController
   end
 
   def update
+    @order.bill_address.validate_required_address unless @current_distributor.require_bill_address
     if @order.update_attributes(object_params)
       check_order_for_phantom_fees
       fire_event('spree.checkout.update')

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -2,6 +2,9 @@ Spree::Address.class_eval do
   has_one :enterprise
   belongs_to :country, class_name: "Spree::Country"
 
+  self.reset_callbacks(:validate)
+  validates :firstname, :lastname, :presence => true
+
   after_save :touch_enterprise
 
   geocoded_by :geocode_address
@@ -30,6 +33,12 @@ Spree::Address.class_eval do
     address_part2= [city, zipcode, state.andand.name]
     filtered_address = address_part2.select{ |field| !field.nil? && field != '' }
     filtered_address.compact.join(', ')
+  end
+
+  def validate_required_address
+    [:address1, :city, :zipcode, :country].each do |field|
+      errors.add(field, :blank) if send(field).blank?
+    end
   end
 
   private

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -75,3 +75,33 @@
     .five.columns.omega
       = f.radio_button :allow_order_changes, true, "ng-model" => "Enterprise.allow_order_changes", "ng-value" => "true"
       = f.label :allow_order_changes, t('.allow_order_changes_true'), value: :true
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      = f.label :require_phone_number, t('.enterprise_require_phone_number')
+    .eight.columns.omega
+      = f.check_box :require_phone_number
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      = f.label :require_bill_address, t('.enterprise_require_bill_address')
+    .eight.columns.omega
+      = f.check_box :require_bill_address
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      = f.label :hide_comment_box, t('.enterprise_hide_comment_box')
+    .eight.columns.omega
+      = f.check_box :hide_comment_box
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      = f.label :check_the_only_shipping_option, t('.enterprise_check_the_only_shipping_option')
+    .eight.columns.omega
+      = f.check_box :check_the_only_shipping_option
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      = f.label :check_the_only_payment_method, t('.enterprise_check_the_only_payment_method')
+    .eight.columns.omega
+      = f.check_box :check_the_only_payment_method

--- a/app/views/checkout/_billing.html.haml
+++ b/app/views/checkout/_billing.html.haml
@@ -22,22 +22,22 @@
       = f.fields_for :bill_address, @order.bill_address do |ba|
         .row
           .small-12.columns
-            = validated_input t(:address), "order.bill_address.address1", "ofn-focus" => "accordion['billing']"
+            = validated_input t(:address), "order.bill_address.address1", "ofn-focus" => "accordion['billing']", required: @current_distributor.require_bill_address
         .row
           .small-12.columns
             = validated_input t(:address2), "order.bill_address.address2", required: false
         .row
           .small-6.columns
-            = validated_input t(:city), "order.bill_address.city"
+            = validated_input t(:city), "order.bill_address.city", required: @current_distributor.require_bill_address
 
           .small-6.columns
-            = validated_select t(:state), "order.bill_address.state_id", checkout_state_options(:billing)
+            = validated_select t(:state), "order.bill_address.state_id", checkout_state_options(:billing), required: @current_distributor.require_bill_address
         .row
           .small-6.columns
-            = validated_input t(:postcode), "order.bill_address.zipcode"
+            = validated_input t(:postcode), "order.bill_address.zipcode", required: @current_distributor.require_bill_address
 
           .small-6.columns.right
-            = validated_select t(:country), "order.bill_address.country_id", checkout_country_options
+            = validated_select t(:country), "order.bill_address.country_id", checkout_country_options, required: @current_distributor.require_bill_address
 
       .row
         .small-12.columns.text-right

--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -24,7 +24,7 @@
           = validated_input t(:email), 'order.email', type: :email, "ofn-focus" => "accordion['details']"
 
         .small-6.columns
-          = validated_input t(:phone), 'order.bill_address.phone'
+          = validated_input t(:phone), 'order.bill_address.phone', required: @current_distributor.require_phone_number
 
       .row
         .small-12.columns.text-right

--- a/app/views/checkout/_payment.html.haml
+++ b/app/views/checkout/_payment.html.haml
@@ -24,6 +24,7 @@
                   = radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, false,
                     required: true,
                     name: "order.payment_method_id",
+                    "ng-init" => "#{available_payment_methods.length == 1 && @current_distributor.check_the_only_payment_method}?(order.payment_method_id=#{method.id}):''",
                     "ng-model" => "order.payment_method_id"
                   = method.name
                   = "(#{payment_method_price(method, @order)})"

--- a/app/views/checkout/_shipping.html.haml
+++ b/app/views/checkout/_shipping.html.haml
@@ -18,6 +18,7 @@
           %input{type: :radio,
             required: true,
             name: "order.shipping_method_id",
+            "ng-init" => "ShippingMethods.shipping_methods.length==1&&#{@current_distributor.check_the_only_shipping_option}?(order.shipping_method_id=method.id):''",
             "ng-value" => "method.id",
             "ng-model" => "order.shipping_method_id"}
             {{ method.name }}
@@ -52,7 +53,10 @@
 
       .row
         .small-12.columns
-          = f.text_area :special_instructions, label: t(:checkout_instructions), size: "60x4", "ng-model" => "order.special_instructions"
+          - if @current_distributor.hide_comment_box
+            = f.hidden_field :special_instructions
+          - else
+            = f.text_area :special_instructions, label: t(:checkout_instructions), size: "60x4", "ng-model" => "order.special_instructions"
 
       .row
         .small-12.columns.text-right

--- a/app/views/checkout/_shipping_ship_address.html.haml
+++ b/app/views/checkout/_shipping_ship_address.html.haml
@@ -1,6 +1,6 @@
 .small-12.columns
   #ship_address{"ng-if" => "Checkout.requireShipAddress()"}
-    %div.visible{"ng-if" => "!Checkout.ship_address_same_as_billing"}
+    %div.visible{"ng-show" => "!Checkout.ship_address_same_as_billing"}
       .row
         .small-6.columns
           = validated_input t(:first_name), "order.ship_address.firstname", "ofn-focus" => "accordion['shipping']"

--- a/db/migrate/20170601110911_add_checkout_customization_to_enterprises.rb
+++ b/db/migrate/20170601110911_add_checkout_customization_to_enterprises.rb
@@ -1,0 +1,9 @@
+class AddCheckoutCustomizationToEnterprises < ActiveRecord::Migration
+  def change
+    add_column :enterprises, :require_phone_number, :boolean, default: :true
+    add_column :enterprises, :require_bill_address, :boolean, default: :true
+    add_column :enterprises, :hide_comment_box, :boolean, default: :false
+    add_column :enterprises, :check_the_only_shipping_option, :boolean, default: :false
+    add_column :enterprises, :check_the_only_payment_method, :boolean, default: :false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161215230219) do
+ActiveRecord::Schema.define(:version => 20170601110911) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -221,8 +221,8 @@ ActiveRecord::Schema.define(:version => 20161215230219) do
     t.integer  "address_id"
     t.string   "pickup_times"
     t.string   "next_collection_at"
-    t.datetime "created_at",                                   :null => false
-    t.datetime "updated_at",                                   :null => false
+    t.datetime "created_at",                                         :null => false
+    t.datetime "updated_at",                                         :null => false
     t.text     "distributor_info"
     t.string   "logo_file_name"
     t.string   "logo_content_type"
@@ -232,26 +232,31 @@ ActiveRecord::Schema.define(:version => 20161215230219) do
     t.string   "promo_image_content_type"
     t.integer  "promo_image_file_size"
     t.datetime "promo_image_updated_at"
-    t.boolean  "visible",                  :default => true
+    t.boolean  "visible",                        :default => true
     t.string   "facebook"
     t.string   "instagram"
     t.string   "linkedin"
-    t.integer  "owner_id",                                     :null => false
-    t.string   "sells",                    :default => "none", :null => false
+    t.integer  "owner_id",                                           :null => false
+    t.string   "sells",                          :default => "none", :null => false
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
     t.datetime "shop_trial_start_date"
-    t.boolean  "producer_profile_only",    :default => false
-    t.string   "permalink",                                    :null => false
-    t.boolean  "charges_sales_tax",        :default => false,  :null => false
+    t.boolean  "producer_profile_only",          :default => false
+    t.string   "permalink",                                          :null => false
+    t.boolean  "charges_sales_tax",              :default => false,  :null => false
     t.string   "email_address"
-    t.boolean  "require_login",            :default => false,  :null => false
-    t.boolean  "allow_guest_orders",       :default => true,   :null => false
+    t.boolean  "require_login",                  :default => false,  :null => false
+    t.boolean  "allow_guest_orders",             :default => true,   :null => false
     t.text     "invoice_text"
-    t.boolean  "display_invoice_logo",     :default => false
-    t.boolean  "allow_order_changes",      :default => false,  :null => false
+    t.boolean  "display_invoice_logo",           :default => false
+    t.boolean  "allow_order_changes",            :default => false,  :null => false
+    t.boolean  "require_phone_number",           :default => true
+    t.boolean  "require_bill_address",           :default => true
+    t.boolean  "hide_comment_box",               :default => false
+    t.boolean  "check_the_only_shipping_option", :default => false
+    t.boolean  "check_the_only_payment_method",  :default => false
   end
 
   add_index "enterprises", ["address_id"], :name => "index_enterprises_on_address_id"


### PR DESCRIPTION
Working on issue #928, I try to make some Address fields optional at checkout. It was not simple as I thought, and I'd like some advice on the way I'm doing it.
I needed to save bill addresses without an address but still with first and last names. I thought I could (conditionaly) bypass validations on the order's bill_address, but I ran into a problem: even if the address itself has already been saved (using `#save(validate: false)`), whenever the order gets saved its associations will have their fields validated, and their errors added to the order's errors (I think this comes from the use of `accept_nested_attributes_for`).
I found that having `belongs_to :bill_address, validate: false` in Spree's Order model worked unfortunately this can't be overriden. The only way I found was to reset `validate` callbacks in the Address decorator [(here)](https://github.com/ltrls/openfoodnetwork/commit/2d3b73dea2a6cf4d1c149f8a6e3304938ca91d1e) but this removes address validations everywhere. I added a "manual" validation if the addresses are required, but I'm wondering if I should add this step each time an address is saved via user input, like when a hub edits its address. Writing this I guess I should, it's still unclear for me if I'm not missing something in all of this. any feedback is really welcome!