### PR TITLE
Stop using Order#shipment as it will be deprecated

### DIFF
--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -113,7 +113,7 @@ describe LineItemsController do
         item_num = order.line_items.length
         initial_fees = item_num * (shipping_fee + payment_fee)
         expect(order.adjustment_total).to eq initial_fees
-        expect(order.shipment.adjustment.included_tax).to eq 1.2
+        expect(order.shipments.last.adjustment.included_tax).to eq 1.2
 
         # Delete the item
         item = order.line_items.first
@@ -124,11 +124,11 @@ describe LineItemsController do
 
         # Check the fees again
         order.reload
-        order.shipment.reload
+        order.shipments.last.reload
         expect(order.adjustment_total).to eq initial_fees - shipping_fee - payment_fee
-        expect(order.shipment.adjustment.amount).to eq shipping_fee
+        expect(order.shipments.last.adjustment.amount).to eq shipping_fee
         expect(order.payment.adjustment.amount).to eq payment_fee
-        expect(order.shipment.adjustment.included_tax).to eq 0.6
+        expect(order.shipments.last.adjustment.included_tax).to eq 0.6
       end
     end
 


### PR DESCRIPTION
Spree 2.0 adds a deprecation warning to `Order#shipment` and Spree 2.1 removes it. So we better do not depend on it. Using it would give the wrong message that orders have a single shipment. 

By what I could find out, Spree added support for multiple shipments while keeping the `Order#shipment` method. They update the shipping method of the most recent shipment of the order if there's any. See https://github.com/spree/spree/blob/1-3-stable/core/app/models/spree/order.rb#L346