### PR TITLE
Use order shipments

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/checkout/checkout_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/checkout_controller.js.coffee
@@ -7,6 +7,7 @@ Darkswarm.controller "CheckoutCtrl", ($scope, localStorageService, Checkout, Cur
   prefix = "order_#{Checkout.order.id}#{CurrentUser.id or ""}#{CurrentHub.hub.id}"
 
   for field in $scope.fieldsToBind
+    # SHIPPING_METHOD
     localStorageService.bind $scope, "Checkout.order.#{field}", Checkout.order[field], "#{prefix}_#{field}"
 
   localStorageService.bind $scope, "Checkout.ship_address_same_as_billing", true, "#{prefix}_sameasbilling"

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -30,6 +30,7 @@ Darkswarm.factory 'Checkout', (CurrentOrder, ShippingMethods, PaymentMethods, $h
             munged_order["ship_address_attributes"] = value
           when "payment_method_id"
             munged_order["payments_attributes"] = [{payment_method_id: value}]
+          # SHIPPING_METHOD
           when "shipping_method_id", "payment_method_id", "email", "special_instructions"
             munged_order[name] = value
           else
@@ -56,6 +57,7 @@ Darkswarm.factory 'Checkout', (CurrentOrder, ShippingMethods, PaymentMethods, $h
       munged_order
 
     shippingMethod: ->
+      # SHIPPING_METHOD
       ShippingMethods.shipping_methods_by_id[@order.shipping_method_id] if @order.shipping_method_id
 
     requireShipAddress: ->

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -57,6 +57,11 @@ Darkswarm.factory 'Checkout', (CurrentOrder, ShippingMethods, PaymentMethods, $h
       munged_order
 
     shippingMethod: ->
+      # Used to get the shiping method data from the passed in id.
+      #
+      # We should store the shipping method object once retrieved. Otherwise we
+      # fetch it every time we call the method, which is few times.
+      #
       # SHIPPING_METHOD
       ShippingMethods.shipping_methods_by_id[@order.shipping_method_id] if @order.shipping_method_id
 

--- a/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
@@ -1,8 +1,8 @@
 module Spree
   module Admin
     ShippingMethodsController.class_eval do
-      before_filter :do_not_destroy_referenced_shipping_methods, :only => :destroy
-      before_filter :load_hubs, only: [:new, :edit, :create, :update]
+      before_filter :do_not_destroy_referenced_shipping_methods, only: :destroy
+      before_filter :load_hubs, only: %i(new edit create update)
 
       # Sort shipping methods by distributor name
       # ! Code copied from Spree::Admin::ResourceController with two added lines
@@ -10,7 +10,7 @@ module Spree
         return parent.send(controller_name) if parent_data.present?
 
         collection = if model_class.respond_to?(:accessible_by) &&
-                         !current_ability.has_block?(params[:action], model_class)
+                        !current_ability.has_block?(params[:action], model_class)
 
                        model_class.accessible_by(current_ability, action)
 
@@ -38,14 +38,15 @@ module Spree
       # Do we really need to protect it ourselves? Does spree do this, or provide some means
       # of preserving the shipping method information for past orders?
       def do_not_destroy_referenced_shipping_methods
-        order = Order.where(:shipping_method_id => @object).first
+        order = Order.where(shipping_method_id: @object).first
         if order
           flash[:error] = "That shipping method cannot be deleted as it is referenced by an order: #{order.number}."
-          redirect_to collection_url and return
+          redirect_to(collection_url) && return
         end
       end
 
       private
+
       def load_hubs
         @hubs = Enterprise.managed_by(spree_current_user).is_distributor.sort_by!{ |d| [(@shipping_method.has_distributor? d) ? 0 : 1, d.name] }
       end

--- a/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
@@ -29,6 +29,8 @@ module Spree
         collection
       end
 
+      # SHIPPING_METHOD
+      #
       # This method was originally written because ProductDistributions referenced shipping
       # methods, and deleting a referenced shipping method would break all the reports that
       # queried it.

--- a/app/jobs/finalize_account_invoices.rb
+++ b/app/jobs/finalize_account_invoices.rb
@@ -22,6 +22,7 @@ class FinalizeAccountInvoices
     invoice_orders.select{ |order| order.present? && order.completed_at.nil? }.each{ |order| finalize(order) }
   end
 
+  # SHIPPING_METHOD
   def finalize(invoice_order)
     # TODO: When we implement per-customer and/or per-user preferences around shipping and payment methods
     # we can update these to read from those preferences

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -83,7 +83,7 @@ Spree::Order.class_eval do
   def empty_with_clear_shipping_and_payments!
     empty_without_clear_shipping_and_payments!
     payments.clear
-    update_attributes(shipping_method_id: nil)
+    shipments.destroy_all
   end
   alias_method_chain :empty!, :clear_shipping_and_payments
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -79,6 +79,7 @@ Spree::Order.class_eval do
     errors.add(:base, "Distributor or order cycle cannot supply the products in your cart") unless DistributionChangeValidator.new(self).can_change_to_distribution?(distributor, order_cycle)
   end
 
+  # SHIPPING_METHOD
   def empty_with_clear_shipping_and_payments!
     empty_without_clear_shipping_and_payments!
     payments.clear

--- a/app/serializers/api/current_order_serializer.rb
+++ b/app/serializers/api/current_order_serializer.rb
@@ -1,4 +1,5 @@
 class Api::CurrentOrderSerializer < ActiveModel::Serializer
+  # SHIPPING_METHOD
   attributes :id, :item_total, :email, :shipping_method_id,
              :display_total, :payment_method_id
 

--- a/app/serializers/api/current_order_serializer.rb
+++ b/app/serializers/api/current_order_serializer.rb
@@ -1,5 +1,4 @@
 class Api::CurrentOrderSerializer < ActiveModel::Serializer
-  # Read the shipping_method_id from shipments
   attributes :id, :item_total, :email, :shipping_method_id,
              :display_total, :payment_method_id
 
@@ -15,5 +14,10 @@ class Api::CurrentOrderSerializer < ActiveModel::Serializer
 
   def display_total
     object.display_total.money.to_f
+  end
+
+  def shipping_method_id
+    return unless object.shipments.any?
+    object.shipments.last.shipping_method_id
   end
 end

--- a/app/serializers/api/current_order_serializer.rb
+++ b/app/serializers/api/current_order_serializer.rb
@@ -1,5 +1,5 @@
 class Api::CurrentOrderSerializer < ActiveModel::Serializer
-  # SHIPPING_METHOD
+  # Read the shipping_method_id from shipments
   attributes :id, :item_total, :email, :shipping_method_id,
              :display_total, :payment_method_id
 

--- a/app/views/checkout/_shipping.html.haml
+++ b/app/views/checkout/_shipping.html.haml
@@ -15,6 +15,7 @@
 
       .small-12.columns.medium-12.columns.large-6.columns
         %label{"ng-repeat" => "method in ShippingMethods.shipping_methods"}
+          -# SHIPPING_METHOD
           %input{type: :radio,
             required: true,
             name: "order.shipping_method_id",
@@ -27,6 +28,7 @@
               ({{ method.price | localizeCurrency }})
 
         %small.error.medium.input-text{"ng-show" => "!fieldValid('order.shipping_method_id')"}
+          -# SHIPPING_METHOD
           = "{{ fieldErrors('order.shipping_method_id') }}"
 
         %label{"ng-if" => "Checkout.requireShipAddress()"}

--- a/app/views/spree/shared/_delivery_shipment_details.html.haml
+++ b/app/views/spree/shared/_delivery_shipment_details.html.haml
@@ -1,0 +1,25 @@
+.order-summary.text-small
+  %strong= shipment.shipping_method.name
+.pad
+  .text-big
+    = t :order_delivery_time
+    %strong #{order.order_cycle.pickup_time_for(order.distributor)}
+  %p.text-small.text-skinny.pre-line
+    %em= shipment.shipping_method.description.andand.html_safe || ""
+.order-summary.text-small
+  %strong
+    = t :order_delivery_address
+.pad
+  %p.text-small
+    = order.ship_address.firstname + " " + order.ship_address.lastname
+    %br
+    = order.ship_address.full_address
+    %br
+    = order.ship_address.phone
+  - if order.special_instructions.present?
+    %br
+    %p.light.small
+      %strong
+        = t :order_special_instructions
+      %br
+      = order.special_instructions

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -29,60 +29,11 @@
         = order.bill_address.phone
 
   .columns.large-6
-    - if order.shipping_method.andand.require_ship_address
-      // Delivery option
-      .order-summary.text-small
-        %strong= order.shipping_method.name
-      .pad
-        .text-big
-          = t :order_delivery_time
-          %strong #{order.order_cycle.pickup_time_for(order.distributor)}
-        %p.text-small.text-skinny.pre-line
-          %em= order.shipping_method.description.andand.html_safe || ""
-      .order-summary.text-small
-        %strong
-          = t :order_delivery_address
-      .pad
-        %p.text-small
-          = order.ship_address.firstname + " " + order.ship_address.lastname
-          %br
-          = order.ship_address.full_address
-          %br
-          = order.ship_address.phone
-        - if order.special_instructions.present?
-          %br
-          %p.light.small
-            %strong
-              = t :order_special_instructions
-            %br
-            = order.special_instructions
+    - shipment = order.shipments.last
+    - if shipment.shipping_method.andand.require_ship_address
+      = render 'spree/shared/delivery_shipment_details', order: order, shipment: shipment
     - else
-      // Collection option
-      .order-summary.text-small
-        %strong= order.shipping_method.name
-      .pad
-        .text-big
-          = t :order_pickup_time
-          %strong #{order.order_cycle.pickup_time_for(order.distributor)}
-        %p.text-small.text-skinny.pre-line
-          %em= order.shipping_method.description.andand.html_safe || ""
-
-        - if order.order_cycle.pickup_instructions_for(order.distributor).present?
-          %br
-          %p.text-small
-            %strong
-              = t :order_pickup_instructions
-            %br
-            #{order.order_cycle.pickup_instructions_for(order.distributor)}
-
-        - if order.special_instructions.present?
-          %br
-          %p.light.small
-            %strong
-              = t :order_special_instructions
-            %br
-            = order.special_instructions
-
+      = render 'spree/shared/pickup_shipment_details', order: order, shipment: shipment
 %br
 .row
   .columns.large-12

--- a/app/views/spree/shared/_pickup_shipment_details.html.haml
+++ b/app/views/spree/shared/_pickup_shipment_details.html.haml
@@ -1,0 +1,25 @@
+.order-summary.text-small
+  %strong= order.shipments.last.shipping_method.name
+.pad
+  .text-big
+    = t :order_pickup_time
+    %strong #{order.order_cycle.pickup_time_for(order.distributor)}
+  %p.text-small.text-skinny.pre-line
+    %em= order.shipments.last.shipping_method.description.andand.html_safe || ""
+
+  - if order.order_cycle.pickup_instructions_for(order.distributor).present?
+    %br
+    %p.text-small
+      %strong
+        = t :order_pickup_instructions
+      %br
+      #{order.order_cycle.pickup_instructions_for(order.distributor)}
+
+  - if order.special_instructions.present?
+    %br
+    %p.light.small
+      %strong
+        = t :order_special_instructions
+      %br
+      = order.special_instructions
+

--- a/spec/controllers/spree/admin/shipping_methods_controller_decorator_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_decorator_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Spree::Admin::ShippingMethodsController do
+  include AuthenticationWorkflow
+
+  describe '#destroy' do
+    let!(:shipping_method) { create(:shipping_method) }
+
+    before { login_as_admin }
+
+    context 'when the shipping method is in use' do
+      before { create(:order, shipping_method: shipping_method) }
+
+      it 'does not allow to destroy the shipping method' do
+        expect { delete :destroy, id: shipping_method.id }
+          .not_to change(Spree::ShippingMethod, :count)
+      end
+
+      it 'shows a flash error message' do
+        spree_delete :destroy, id: shipping_method.id
+        expect(flash[:error]).to match('That shipping method cannot be deleted')
+      end
+
+      it 'redirects to the collection url' do
+        expect(spree_delete(:destroy, id: shipping_method.id))
+          .to redirect_to('/admin/shipping_methods')
+      end
+    end
+
+    context 'when the shipping method is not in use' do
+      it 'allows to destroy the shipping method' do
+        expect { delete :destroy, id: shipping_method.id }
+          .to change(Spree::ShippingMethod, :count)
+      end
+    end
+  end
+end

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -21,6 +21,11 @@ feature "Order Management", js: true do
       quick_login_as user
     end
 
+    it 'shows the name of the shipping method' do
+      visit spree.order_path(order)
+      expect(find('#order')).to have_content(shipping_method.name)
+    end
+
     context "when the distributor doesn't allow changes to be made to orders" do
       before do
         order.distributor.update_attributes(allow_order_changes: false)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -383,18 +383,18 @@ describe Spree::Order do
   end
 
   describe "emptying the order" do
-    it "removes shipping method" do
-      subject.shipping_method = create(:shipping_method)
+    it "removes shipments" do
+      subject.shipments << create(:shipment)
       subject.save!
       subject.empty!
-      subject.shipping_method.should == nil
+      expect(subject.shipments).to be_empty
     end
 
     it "removes payments" do
       subject.payments << create(:payment)
       subject.save!
       subject.empty!
-      subject.payments.should == []
+      expect(subject.payments).to be_empty
     end
   end
 

--- a/spec/serializers/current_order_serializer_spec.rb
+++ b/spec/serializers/current_order_serializer_spec.rb
@@ -1,19 +1,21 @@
+require 'spec_helper'
+
 describe Api::CurrentOrderSerializer do
   let(:distributor) { create(:distributor_enterprise) }
   let(:oc) { create(:simple_order_cycle) }
   let(:li) { create(:line_item, variant: create(:variant)) }
   let(:order) { create(:order, line_items: [li]) }
-  let(:serializer) { Api::CurrentOrderSerializer.new(order, current_distributor: distributor, current_order_cycle: oc ).to_json }
+  let(:serializer) { Api::CurrentOrderSerializer.new(order, current_distributor: distributor, current_order_cycle: oc).to_json }
 
   it "serializers the current order" do
-    serializer.should match order.id.to_s
+    expect(serializer).to match order.id.to_s
   end
 
   it "includes line items" do
-    serializer.should match li.id.to_s
+    expect(serializer).to match li.id.to_s
   end
 
   it "includes variants of line items" do
-    serializer.should match li.variant.name
+    expect(serializer).to match li.variant.name
   end
 end

--- a/spec/serializers/current_order_serializer_spec.rb
+++ b/spec/serializers/current_order_serializer_spec.rb
@@ -18,4 +18,20 @@ describe Api::CurrentOrderSerializer do
   it "includes variants of line items" do
     expect(serializer).to match li.variant.name
   end
+
+  context 'when there is no shipment' do
+    it 'includes the shipping method of the order' do
+      expect(serializer).to match('\"shipping_method_id\":null')
+    end
+  end
+
+  context 'when there is a shipment' do
+    before { create(:shipment, order: order, shipping_method: shipping_method) }
+
+    let(:shipping_method) { create(:shipping_method) }
+
+    it 'includes the shipping method of the order' do
+      expect(serializer).to match("\"shipping_method_id\":#{shipping_method.id}")
+    end
+  end
 end


### PR DESCRIPTION
This is a work in progress to address what we agreed on in https://community.openfoodnetwork.org/t/shipping-rate-model-step7/985/2

> We have definitely abused order.shipping_method a lot, but when it comes down to it, I think we can pretty much use order.shipment.shipping_method (or equivalent) as a drop in replacement for order.shipping_method.

The goal here is exactly that: not to use `order#shipping_method` anymore and go through `order#shipments` instead.

## TODO

- [ ] Add documentation 
- [ ] Figure out how to abstract `order.shipments.last`

## How is this related to Spree upgrade?

`Order#shipping_method` is gone in Spree 2.0, so any line of code that uses it in OFN will fail. We can provide the same behaviour but being spree-2.0 compatible without having to wait for a specific spree-2.0 branch :metal: 

You can get further details in https://community.openfoodnetwork.org/t/order-model-step7/979?u=sauloperez