### PR TITLE
Proof of concept: float string field

### DIFF
--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -18,6 +18,7 @@
 //= require admin/spree_auth
 //= require admin/spree_promo
 //= require admin/spree_paypal_express
+//= require ../shared/util
 //= require ../shared/ng-infinite-scroll.min.js
 //= require ../shared/ng-tags-input.min.js
 //= require angular-rails-templates

--- a/app/assets/javascripts/shared/util.js.coffee
+++ b/app/assets/javascripts/shared/util.js.coffee
@@ -1,13 +1,16 @@
 window.string_to_float = (string) ->
   # Replace all Currency Symbols, Letters and -- from the string
   string = string.replace(/[^0-9\.,]+/g, '')
+
   # If string ends in a single digit (e.g. ,2) make it ,20 in order for the result to be in "cents"
   if string.match(/[\.,]\d$/)
     string = string + '0'
-  # If does not end in ,00 / .00 then
-  # add trailing 00 to turn it into cents
+
+  # If does not end in ,00 / .00 then add trailing 00 to turn it into cents
   if !string.match(/[\.,]\d\d$/)
     string = string + '00'
+
   # Replace all Currency Symbols, Letters and -- from the string
   string = string.replace(/[\.,]/g, '')
+
   string / 100

--- a/app/assets/javascripts/shared/util.js.coffee
+++ b/app/assets/javascripts/shared/util.js.coffee
@@ -1,0 +1,13 @@
+window.string_to_float = (string) ->
+  # Replace all Currency Symbols, Letters and -- from the string
+  string = string.replace(/[^0-9\.,]+/g, '')
+  # If string ends in a single digit (e.g. ,2) make it ,20 in order for the result to be in "cents"
+  if string.match(/[\.,]\d$/)
+    string = string + '0'
+  # If does not end in ,00 / .00 then
+  # add trailing 00 to turn it into cents
+  if !string.match(/[\.,]\d\d$/)
+    string = string + '00'
+  # Replace all Currency Symbols, Letters and -- from the string
+  string = string.replace(/[\.,]/g, '')
+  string / 100

--- a/app/helpers/admin/float_string_helper.rb
+++ b/app/helpers/admin/float_string_helper.rb
@@ -1,0 +1,7 @@
+module Admin
+  module FloatStringHelper
+    def float_string_field(attribute, options={})
+      render partial: 'admin/shared/float_string_input', locals: { attribute: attribute.to_s }.merge(options)
+    end
+  end
+end

--- a/app/helpers/admin/float_string_helper.rb
+++ b/app/helpers/admin/float_string_helper.rb
@@ -1,6 +1,6 @@
 module Admin
   module FloatStringHelper
-    def float_string_field(attribute, options={})
+    def float_string_field(attribute, options = {})
       render partial: 'admin/shared/float_string_input', locals: { attribute: attribute.to_s }.merge(options)
     end
   end

--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -43,7 +43,7 @@
           = f.label :price, t(:price)
           %span.required *
           %br/
-          = f.text_field :price, class: 'fullwidth'
+          = float_string_field :price, { model: 'product', value: @product.price }
           = f.error_message_on :price
       .two.columns
         = f.field_container :on_hand do

--- a/app/views/admin/shared/_float_string_input.html.haml
+++ b/app/views/admin/shared/_float_string_input.html.haml
@@ -1,4 +1,4 @@
-%input{ type: 'text', name: "#{model}[#{attribute}_parsed]", value: value, class: "fullwidth js-#{attribute}-parsed" }
+%input{ type: 'text', name: "#{model}[#{attribute}_parsed]", id: "#{model}_#{attribute}", value: value, class: "fullwidth js-#{attribute}-parsed" }
 %input{ type: 'hidden', name: "#{model}[#{attribute}]", value: value, class: "js-#{attribute}-hidden" }
 
 :javascript

--- a/app/views/admin/shared/_float_string_input.html.haml
+++ b/app/views/admin/shared/_float_string_input.html.haml
@@ -1,0 +1,10 @@
+%input{ type: 'text', name: "#{model}[#{attribute}_parsed]", value: value, class: "fullwidth js-#{attribute}-parsed" }
+%input{ type: 'hidden', name: "#{model}[#{attribute}]", value: value, class: "js-#{attribute}-hidden" }
+
+:javascript
+  $(".js-#{attribute}-parsed").change(function () {
+    var string_price = $(this).prop('value');
+    var number_price = string_to_float(string_price);
+
+    $(".js-#{attribute}-hidden").prop('value', number_price);
+  });


### PR DESCRIPTION
Tries to fix this issue: https://github.com/openfoodfoundation/openfoodnetwork/issues/853

I'm basically using a hidden input field to store the numeric conversion of the input text field. Whenever the user types a value in the visible input, it is transformed and stored in the hidden field as a numeric value. 

http://g.recordit.co/kzHcqGD5qg.gif

This is just a proof of concept, applied to the `price` attribute in the "New product" form. 

I added a partial view that adds the hidden field and the javascript that syncs both fields, and then a Rails helper to make it easier to use that partial. 

---

Note:

With this fix, we accept any kind of format as an input but **we always display those values in the standard numeric way**, which means that it uses the dot for decimals and no thousands separator.