### PR TITLE
Bump eventmachine version to resolve openssl issue on macOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,4 +130,9 @@ group :development do
   gem 'guard-rspec'
   gem 'parallel_tests'
   gem 'rubocop', '>= 0.49.1'
+
+  # 1.0.9 fixed openssl issues on macOS https://github.com/eventmachine/eventmachine/issues/602
+  # While we don't require this gem directly, no dependents forced the upgrade to a version
+  # greater than 1.0.9, so we just required the latest available version here.
+  gem 'eventmachine', '>= 1.2.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.5.3)
     erubis (2.7.0)
-    eventmachine (1.0.8)
+    eventmachine (1.2.3)
     excon (0.45.4)
     execjs (2.6.0)
     factory_girl (3.3.0)
@@ -693,6 +693,7 @@ DEPENDENCIES
   deface!
   delayed_job_active_record
   diffy
+  eventmachine (>= 1.2.3)
   factory_girl_rails
   figaro
   foreigner


### PR DESCRIPTION
Fixed in `1.0.9` see: https://github.com/eventmachine/eventmachine/issues/602