### PR TITLE
Fix before_filter cop for Rails 3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,10 @@ Rails/DynamicFindBy:
 Rails/SkipsModelValidations:
   Enabled: false
 
+# Use before_filter instead of before_action. #TODO: remove when upgraded to Rails 4
+Rails/ActionFilter:
+  EnforcedStyle: filter  
+
 # Relaxed.Ruby.Style SETTINGS
 # These styles are a starting point for the conversation around conventions
 # They should be removed or tweaked and moved above as decisions are made


### PR DESCRIPTION
Rubocop complains about any use of `before_filter` and `prepend_before_filter`, suggesting it should be `before_action`. I think this was introduced in Rails 4, and doesn't work with 3.2