### PR TITLE
Soft delete shipping methods and enable destroys

### DIFF
--- a/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
@@ -1,7 +1,6 @@
 module Spree
   module Admin
     ShippingMethodsController.class_eval do
-      before_filter :do_not_destroy_referenced_shipping_methods, :only => :destroy
       before_filter :load_hubs, only: [:new, :edit, :create, :update]
 
       # Sort shipping methods by distributor name
@@ -29,21 +28,8 @@ module Spree
         collection
       end
 
-      # This method was originally written because ProductDistributions referenced shipping
-      # methods, and deleting a referenced shipping method would break all the reports that
-      # queried it.
-      # This has changed, and now all we're protecting is Orders, which is a spree resource.
-      # Do we really need to protect it ourselves? Does spree do this, or provide some means
-      # of preserving the shipping method information for past orders?
-      def do_not_destroy_referenced_shipping_methods
-        order = Order.where(:shipping_method_id => @object).first
-        if order
-          flash[:error] = "That shipping method cannot be deleted as it is referenced by an order: #{order.number}."
-          redirect_to collection_url and return
-        end
-      end
-
       private
+
       def load_hubs
         @hubs = Enterprise.managed_by(spree_current_user).is_distributor.sort_by!{ |d| [(@shipping_method.has_distributor? d) ? 0 : 1, d.name] }
       end

--- a/app/models/null_shipping_method.rb
+++ b/app/models/null_shipping_method.rb
@@ -1,0 +1,11 @@
+# Represents an empty shipping method, useful when the user didn't choose
+# any but we still need to display it in the UI.
+class NullShippingMethod
+  def name
+    nil
+  end
+
+  def require_ship_address
+    nil
+  end
+end

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -3,6 +3,7 @@ require 'open_food_network/user_balance_calculator'
 module OpenFoodNetwork
   class OrderCycleManagementReport
     attr_reader :params
+
     def initialize(user, params = {})
       @params = params
       @user = user
@@ -17,7 +18,13 @@ module OpenFoodNetwork
     end
 
     def search
-      Spree::Order.complete.where("spree_orders.state != ?", :canceled).distributed_by_user(@user).managed_by(@user).search(params[:q])
+      Spree::Order
+        .eager_load(shipments: :shipping_method)
+        .complete
+        .where("spree_orders.state != ?", :canceled)
+        .distributed_by_user(@user)
+        .managed_by(@user)
+        .search(params[:q])
     end
 
     def orders
@@ -33,42 +40,59 @@ module OpenFoodNetwork
     end
 
     def filter(search_result)
-      filter_to_payment_method filter_to_shipping_method filter_to_order_cycle search_result
+      filtered_orders = filter_to_order_cycle(search_result)
+      filtered_orders = filter_to_shipping_method(filtered_orders)
+      filter_to_payment_method(filtered_orders)
     end
 
     private
 
     def payment_method_row(order)
-      ba = order.billing_address
-      [ba.firstname,
-       ba.lastname,
-       order.distributor.andand.name,
-       customer_code(order.email),
-       order.email,
-       ba.phone,
-       order.shipping_method.andand.name,
-       order.payments.first.andand.payment_method.andand.name,
-       order.payments.first.amount,
-       OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance
+      billing_address = order.billing_address
+      [
+        billing_address.firstname,
+        billing_address.lastname,
+        order.distributor.andand.name,
+        customer_code(order.email),
+        order.email,
+        billing_address.phone,
+        shipping_method_to_display(order).name,
+        order.payments.first.andand.payment_method.andand.name,
+        order.payments.first.amount,
+        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance
       ]
     end
 
     def delivery_row(order)
-      sa = order.shipping_address
-      [sa.firstname,
-       sa.lastname,
-       order.distributor.andand.name,
-       customer_code(order.email),
-       "#{sa.address1} #{sa.address2} #{sa.city}",
-       sa.zipcode,
-       sa.phone,
-       order.shipping_method.andand.name,
-       order.payments.first.andand.payment_method.andand.name,
-       order.payments.first.amount,
-       OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance,
-       has_temperature_controlled_items?(order),
-       order.special_instructions
+      shipping_address = order.shipping_address
+      [
+        shipping_address.firstname,
+        shipping_address.lastname,
+        order.distributor.andand.name,
+        customer_code(order.email),
+        "#{shipping_address.address1} #{shipping_address.address2} #{shipping_address.city}",
+        shipping_address.zipcode,
+        shipping_address.phone,
+        shipping_method_to_display(order).name,
+        order.payments.first.andand.payment_method.andand.name,
+        order.payments.first.amount,
+        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance,
+        has_temperature_controlled_items?(order),
+        order.special_instructions
       ]
+    end
+
+    # Returns the appropriate shipping method to display for the given order
+    #
+    # @param order [Spree::Order]
+    # @return [#name]
+    def shipping_method_to_display(order)
+      shipment = order.shipments.last
+      if shipment
+        shipment.shipping_method
+      else
+        NullShippingMethod.new
+      end
     end
 
     def filter_to_payment_method(orders)
@@ -81,7 +105,7 @@ module OpenFoodNetwork
 
     def filter_to_shipping_method(orders)
       if params[:shipping_method_in].present?
-        orders.joins(:shipping_method).where(shipping_method_id: params[:shipping_method_in])
+        orders.where(spree_shipments: { shipping_method_id: params[:shipping_method_in] })
       else
         orders
       end

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -50,14 +50,13 @@ feature 'shipping methods' do
     end
 
     scenario "deleting a shipping method referenced by an order" do
-      o = create(:order)
-      o.shipping_method = @sm
-      o.save!
+      order = create(:order)
+      order.shipping_method = @sm
+      order.save!
 
       visit_delete spree.admin_shipping_method_path(@sm)
 
-      page.should have_content "That shipping method cannot be deleted as it is referenced by an order: #{o.number}."
-      Spree::ShippingMethod.find(@sm.id).should_not be_nil
+      expect(@sm.reload.deleted_at).not_to be_nil
     end
   end
 

--- a/spec/models/null_shipping_method_spec.rb
+++ b/spec/models/null_shipping_method_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe NullShippingMethod do
+  describe '#name' do
+    it 'returns nil' do
+      expect(described_class.new.name).to eq(nil)
+    end
+  end
+
+  describe '#require_ship_address' do
+    it 'returns nil' do
+      expect(described_class.new.require_ship_address).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
This removes the "hack" that forbids destroying shipping methods from /admin and makes use of Spree's soft delete implementation (`deleted_at` column in `spree_shipping_methods`).

This way admins can disable a particular shipping method, so no one uses it anymore, while still showing the shipping method for past orders in reports.

## TODO
- [x] remove N+1
- [ ] Check `/admin/orders` and `/accounts`
- [ ] QA order_cycle_management and customers reports: They must work like now and shipping_methods should be deletable.

## How is this related to Spree upgrade?

You are right to ask. `app/controllers/spree/admin/shipping_methods_controller_decorator.rb` below references the column `shipping_method_id` from the `spree_orders` table and this won't be longer available in Spree 2.0 aka. step 7.

By shipping this simple change into a release before the step 7 we reduce the chance of introducing bugs and more important, we make that actual step 7 release more lightweight, which people testing will thank.