### PR TITLE
Update codeclimate version

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,7 @@
 engines:
   rubocop:
     enabled: true
+    channel: rubocop-0-48
   scss-lint:
     enabled: false
 ratings:


### PR DESCRIPTION
Supersedes #1656. Update codeclimate version to allow Rails-version-specific configurations.