### PR TITLE
Add delivery and pickup

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -29,7 +29,7 @@ Spree::Order.class_eval do
     go_to_state :delivery
     go_to_state :payment, :if => lambda { |order|
       # Fix for #2191
-      if order.shipping_method.andand.require_ship_address and
+      if order.shipping_method.andand.delivery?
         if order.ship_address.andand.valid?
           order.create_shipment!
           order.update_totals

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -64,6 +64,10 @@ Spree::ShippingMethod.class_eval do
     'Shipping'
   end
 
+  def delivery?
+    require_ship_address
+  end
+
   private
 
   def touch_distributors

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -64,6 +64,11 @@ Spree::ShippingMethod.class_eval do
     'Shipping'
   end
 
+  # Checks whether the shipping method is of delivery type, meaning that it
+  # requires the user to specify a ship address at checkout. Note this is
+  # a setting we added onto the +spree_shipping_methods+ table.
+  #
+  # @return [Boolean]
   def delivery?
     require_ship_address
   end

--- a/app/views/spree/order_mailer/_shipping.html.haml
+++ b/app/views/spree/order_mailer/_shipping.html.haml
@@ -1,4 +1,4 @@
-- if @order.shipping_method.andand.require_ship_address
+- if @order.shipping_method.andand.delivery?
   / Delivery details
   %p.callout
     %strong

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -29,7 +29,7 @@
         = order.bill_address.phone
 
   .columns.large-6
-    - if order.shipping_method.andand.require_ship_address
+    - if order.shipping_method.andand.delivery?
       // Delivery option
       .order-summary.text-small
         %strong= order.shipping_method.name

--- a/lib/open_food_network/last_used_address.rb
+++ b/lib/open_food_network/last_used_address.rb
@@ -9,9 +9,9 @@ module OpenFoodNetwork
     end
 
     def last_used_ship_address
-      recent_orders.detect { |o|
-        o.ship_address && o.shipping_method.andand.require_ship_address
-       }.andand.ship_address
+      recent_orders.detect { |order|
+        order.ship_address && order.shipping_method.andand.delivery?
+      }.andand.ship_address
     end
 
 

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -207,7 +207,7 @@ module OpenFoodNetwork
           proc { |line_items| "" },
           proc { |line_items| I18n.t(:report_header_shipping_method) } ]
       when "order_cycle_customer_totals"
-        rsa = proc { |line_items| line_items.first.order.shipping_method.andand.require_ship_address }
+        rsa = proc { |line_items| line_items.first.order.shipping_method.andand.delivery? }
         [
           proc { |line_items| line_items.first.order.distributor.name },
           proc { |line_items| line_items.first.order.bill_address.firstname + " " + line_items.first.order.bill_address.lastname },

--- a/spec/lib/open_food_network/last_used_address_spec.rb
+++ b/spec/lib/open_food_network/last_used_address_spec.rb
@@ -36,11 +36,16 @@ module OpenFoodNetwork
       let(:order_without_ship_address) { double(:order, ship_address: nil) }
 
       it "returns the ship address when present" do
+        allow(delivery).to receive(:delivery?).and_return(true)
         lua.stub(:recent_orders) { [order_with_ship_address] }
         lua.last_used_ship_address.should == address
       end
 
       it "returns nil when the order doesn't require a ship address" do
+        allow(order_with_unrequired_ship_address.shipping_method)
+          .to receive(:delivery?)
+          .and_return(false)
+
         lua.stub(:recent_orders) { [order_with_unrequired_ship_address] }
         lua.last_used_ship_address.should be_nil
       end

--- a/spec/lib/open_food_network/last_used_address_spec.rb
+++ b/spec/lib/open_food_network/last_used_address_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'open_food_network/last_used_address'
 
 module OpenFoodNetwork

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -89,5 +89,17 @@ module Spree
         ShippingMethod.services[d4.id].should be_nil
       end
     end
+
+    describe '#delivery?' do
+      context 'when the shipping method requires an address' do
+        let(:shipping_method) { build(:shipping_method, require_ship_address: true) }
+        it { expect(shipping_method.delivery?).to be_true }
+      end
+
+      context 'when the shipping method does not require address' do
+        let(:shipping_method) { build(:shipping_method, require_ship_address: false) }
+        it { expect(shipping_method.delivery?).to be_false }
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

While reading the codebase we constantly find ourselves "computing" the actual meaning of `ShippingMethod#require_ship_address` in our heads to understand whether we're talking about a delivery or a pickup.

This refactor makes the intent behind all this logic a bit more obvious, which makes the spree upgrade a bit easier.

#### What should we test?

I'd say having the test suite green is enough. It's a pretty simple change.

#### How is this related to the Spree upgrade?

This is the code we read everyday working on the upgrade since `Order#shipping_method` is gone in Spree 2.0. The easier it is to understand the better.
