### PR TITLE
Add release notes section in github template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,11 @@ context for others to understand it]
 
 [List which features should be tested and how]
 
+#### Release notes
+
+[In case this should be present in the release notes, please write them or
+remove this section otherwise]
+
 #### How is this related to the Spree upgrade?
 
 [Any known conflicts with the Spree Upgrade? explain them or remove this section


### PR DESCRIPTION
#### What? Why?

I'm adding a new section in the Github template for pull requests so that we all add release notes to our pull requests that need it.

Hopefully, this will make it easier for Kirsten to fill in the release notes from all the pull requests included in a release. It's getting tough now with the increased number of PRs that do not fix or introduce features.