### PR TITLE
Order email translation keys

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -74,7 +74,7 @@ Spree::Admin::OrdersController.class_eval do
   # This uses a new template. See mailers/spree/order_mailer_decorator.rb.
   def resend
     Spree::OrderMailer.confirm_email_for_customer(@order.id, true).deliver
-    flash[:success] = t(:order_email_resent)
+    flash[:success] = t('admin.orders.order_email_resent')
 
     respond_with(@order) { |format| format.html { redirect_to :back } }
   end
@@ -83,7 +83,7 @@ Spree::Admin::OrdersController.class_eval do
     template = if Spree::Config.invoice_style2? then "spree/admin/orders/invoice2" else "spree/admin/orders/invoice" end
     pdf = render_to_string pdf: "invoice-#{@order.number}.pdf", template: template, formats: [:html], encoding: "UTF-8"
     Spree::OrderMailer.invoice_email(@order.id, pdf).deliver
-    flash[:success] = t(:invoice_email_sent)
+    flash[:success] = t('admin.orders.invoice_email_sent')
 
     respond_with(@order) { |format| format.html { redirect_to edit_admin_order_path(@order) } }
   end

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -178,6 +178,8 @@ en-GB:
         hidden_powertip: These products have been hidden from your inventory and will not be available to add to your shop. You can click 'Add' to add a product to you inventory.
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
     orders:
+      invoice_email_sent: "Invoice email has been sent"
+      order_email_resent: "Order email has been resent"
       bulk_management:
         tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
         shared: "Shared Resource?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,8 @@ en:
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
 
     orders:
+      invoice_email_sent: "Invoice email has been sent"
+      order_email_resent: "Order email has been resent"
       bulk_management:
         tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
         shared: "Shared Resource?"


### PR DESCRIPTION
#### What? Why?

Addressing #1678. Added missing translation keys for email success flash messages.

#### What should we test?

Green success flash messages after sending or resending order invoice emails.
