### PR TITLE
Order tooltip localisation

### DIFF
--- a/app/overrides/spree/admin/orders/index/add_ship_shortcut.html.haml.deface
+++ b/app/overrides/spree/admin/orders/index/add_ship_shortcut.html.haml.deface
@@ -3,4 +3,4 @@
 
 - if order.ready_to_ship?
   - # copied from backend/app/views/spree/admin/payments/_list.html.erb
-  = link_to_with_icon "icon-road", t(:ship), fire_admin_order_url(order, :e => 'ship'), :method => :put, :no_text => true, :data => {:action => 'ship', :confirm => t(:are_you_sure)}
+  = link_to_with_icon "icon-road", t('admin.orders.index.ship'), fire_admin_order_url(order, :e => 'ship'), :method => :put, :no_text => true, :data => {:action => 'ship', :confirm => t(:are_you_sure)}

--- a/app/views/spree/admin/orders/_capture.html.haml
+++ b/app/views/spree/admin/orders/_capture.html.haml
@@ -4,4 +4,4 @@
   - if !payment.nil?
     - payment.actions.grep(/^capture$/).each do |action|
       - # copied from backend/app/views/spree/admin/payments/_list.html.erb
-      = link_to_with_icon "icon-#{action}", t(action), fire_admin_order_payment_path(order, payment, :e => action), :method => :put, :no_text => true, :data => {:action => action}
+      = link_to_with_icon "icon-#{action}", t('admin.orders.index.capture'), fire_admin_order_payment_path(order, payment, :e => action), :method => :put, :no_text => true, :data => {:action => action}

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -178,6 +178,9 @@ en-GB:
         hidden_powertip: These products have been hidden from your inventory and will not be available to add to your shop. You can click 'Add' to add a product to you inventory.
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
     orders:
+      index:
+        capture: "Mark as paid"
+        ship: "Mark as delivered"
       bulk_management:
         tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
         shared: "Shared Resource?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,9 @@ en:
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
 
     orders:
+      index:
+        capture: "Capture"
+        ship: "Ship"
       bulk_management:
         tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
         shared: "Shared Resource?"


### PR DESCRIPTION
#### What? Why?

Addressing #1676. Added localisation for order button tooltips and changed "Capture" and "Ship" buttons to "Mark as paid" and "Mark as delivered" for UK.

#### What should we test?

UK translations, see screenshots in original issue.
