### PR TITLE
Fixed wrong order completion dates

### DIFF
--- a/app/overrides/spree/admin/shared/_order_tabs/replace_completed_date.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_order_tabs/replace_completed_date.html.haml.deface
@@ -1,0 +1,3 @@
+/ replace_contents 'header#order_tab_summary dl.additional-info dd#date_complete'
+
+<%= l(@order.completed? ? @order.completed_at : @order.created_at, format: "%b %d, %Y %H:%M") %>


### PR DESCRIPTION
#### What? Why?

Addressing #1672. Wrong order dates shown in edit order page.

#### What should we test?

Order dates display correctly in view/edit order. See screenshots in original issue.
