### PR TITLE
Email - fix password confirmation

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
@@ -1,6 +1,8 @@
 Darkswarm.controller "SignupCtrl", ($scope, $http, $window, $location, Redirections, AuthenticationService) ->
   $scope.path = "/signup"
 
+  $scope.spree_user.password_confirmation = ''
+
   $scope.errors =
     email: null
     password: null

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -67,6 +67,13 @@ feature "Authentication", js: true, retry: 3 do
             expect(page).to have_content "There's already an account for this email."
           end
 
+          scenario "Failing to sign up because password confirmation doesn't match or is blank" do
+            fill_in "Email", with: user.email
+            fill_in "Choose a password", with: "ForgotToRetype"
+            click_signup_button
+            expect(page).to have_content "doesn't match"
+          end
+
           scenario "Signing up successfully" do
             fill_in "Email", with: "test@foo.com"
             fill_in "Choose a password", with: "test12345"


### PR DESCRIPTION
Addressing #1696. Password confirm field on login modal signup tab was not working when empty.