### PR TITLE
Oeoeaio/uk/1031 insufficient stock in cart

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,6 +61,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def check_and_redirect_if_variants_not_available_in_order_cycle
+    flash.keep unless flash[:error].nil? # there are too many redirects between cart and shop, need to keep flash errors
+    unless current_order(true).variants_still_available_in_order_cycle?
+      flash[:error] = current_order.errors.full_messages.join(', ')
+      redirect_to cart_path
+    end
+  end
+
   # All render calls within the block will be performed with the specified format
   # Useful for rendering html within a JSON response, particularly if the specified
   # template or partial then goes on to render further partials without specifying

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -9,6 +9,7 @@ class CheckoutController < Spree::CheckoutController
   prepend_before_filter :require_distributor_chosen
 
   skip_before_filter :check_registration
+  before_filter :check_and_redirect_if_variants_not_available_in_order_cycle, only: %i[edit update]
 
   include OrderCyclesHelper
   include EnterprisesHelper

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -6,6 +6,7 @@ class ShopController < BaseController
   before_filter :set_order_cycles
 
   def show
+    flash.keep # too many redirects, keeping flash
     redirect_to main_app.enterprise_shop_path(current_distributor)
   end
 

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -9,6 +9,7 @@ Spree::OrdersController.class_eval do
   prepend_before_filter :require_distributor_chosen, only: :edit
   before_filter :check_hub_ready_for_checkout, only: :edit
   before_filter :check_at_least_one_line_item, only: :update
+  before_filter :check_and_redirect_if_variants_not_available_in_order_cycle, only: %i[edit update]
 
   include OrderCyclesHelper
   layout 'darkswarm'

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -79,6 +79,23 @@ Spree::Order.class_eval do
     errors.add(:base, "Distributor or order cycle cannot supply the products in your cart") unless DistributionChangeValidator.new(self).can_change_to_distribution?(distributor, order_cycle)
   end
 
+  # This method should go as validation but it is not efficient as too many tests are failing and refactoring would take too much of time
+  def variants_still_available_in_order_cycle?
+    available = true
+    if order_cycle.andand.exchanges
+      not_available_variants = line_item_variants - order_cycle.exchanges.outgoing.collect {|exchange| exchange.variants}.flatten
+
+      if not_available_variants.any?
+        not_available_variants.each do |variant|
+          errors.add(:base, I18n.t(:order_variant_not_available, name: variant.name))
+          remove_variant(variant)
+        end
+        available = false
+      end
+    end
+    available
+  end
+
   def empty_with_clear_shipping_and_payments!
     empty_without_clear_shipping_and_payments!
     payments.clear

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -83,7 +83,7 @@ Spree::Order.class_eval do
   def variants_still_available_in_order_cycle?
     available = true
     if order_cycle.andand.exchanges
-      not_available_variants = line_item_variants - order_cycle.exchanges.outgoing.collect {|exchange| exchange.variants}.flatten
+      not_available_variants = line_item_variants - order_cycle.exchanges.outgoing.collect(&:variants).flatten
 
       if not_available_variants.any?
         not_available_variants.each do |variant|

--- a/config/initializers/user_class_extensions.rb
+++ b/config/initializers/user_class_extensions.rb
@@ -4,7 +4,7 @@ Spree::Core::Engine.config.to_prepare do
 
       # Override of spree method to ignore orders associated with account_invoices
       def last_incomplete_spree_order_with_ignoring_account_invoices
-        account_invoice_order_ids = account_invoices.map(&:order_id)
+        account_invoice_order_ids = account_invoices.where('order_id IS NOT NULL').pluck(:order_id)
         return last_incomplete_spree_order_without_ignoring_account_invoices if account_invoice_order_ids.empty?
         spree_orders.incomplete.where("id NOT IN (?)", account_invoice_order_ids).order('created_at DESC').first
       end

--- a/config/initializers/user_class_extensions.rb
+++ b/config/initializers/user_class_extensions.rb
@@ -3,9 +3,12 @@ Spree::Core::Engine.config.to_prepare do
     Spree.user_class.class_eval do
 
       # Override of spree method to ignore orders associated with account_invoices
-      def last_incomplete_spree_order
-        spree_orders.incomplete.where("id NOT IN (?)", account_invoices.map(&:order_id)).order('created_at DESC').first
+      def last_incomplete_spree_order_with_ignoring_account_invoices
+        account_invoice_order_ids = account_invoices.map(&:order_id)
+        return last_incomplete_spree_order_without_ignoring_account_invoices if account_invoice_order_ids.empty?
+        spree_orders.incomplete.where("id NOT IN (?)", account_invoice_order_ids).order('created_at DESC').first
       end
+      alias_method_chain :last_incomplete_spree_order, :ignoring_account_invoices
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -835,6 +835,7 @@ en:
   order_hub_info: Hub Info
   order_back_to_store: Back To Store
   order_back_to_cart: Back To Cart
+  order_variant_not_available: "%{name} does not exist anymore"
 
   bom_tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -103,6 +103,20 @@ describe Spree.user_class do
     end
   end
 
+  describe "last incomplete spree order" do
+    let(:user) { create(:user) }
+    let!(:order) { create(:order, state: 'cart', user_id: user.id) }
+
+    it "returns any prior incomplete orders" do
+      expect(user.last_incomplete_spree_order).to eq order
+    end
+
+    it "ignores prior orders linked to an account_invoice" do
+      create :account_invoice, user: user
+      expect(user.last_incomplete_spree_order).to be_nil
+    end
+  end
+
   describe "retrieving orders for /account page" do
     let!(:u1) { create(:user) }
     let!(:u2) { create(:user) }

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -105,15 +105,21 @@ describe Spree.user_class do
 
   describe "last incomplete spree order" do
     let(:user) { create(:user) }
-    let!(:order) { create(:order, state: 'cart', user_id: user.id) }
+    let!(:order) { create(:order, state: 'cart', user: user) }
 
-    it "returns any prior incomplete orders" do
-      expect(user.last_incomplete_spree_order).to eq order
+    context "where the user has no account invoices" do
+      it "returns any prior incomplete orders" do
+        expect(user.last_incomplete_spree_order).to eq order
+      end
     end
 
-    it "ignores prior orders linked to an account_invoice" do
-      create :account_invoice, user: user
-      expect(user.last_incomplete_spree_order).to be_nil
+    context "where the user has at least one account invoice" do
+      let(:account_invoice_order) { create(:order, state: 'cart', user: user) }
+      let(:account_invoice) { create(:account_invoice, user: user, order: account_invoice_order) }
+
+      it "ignores prior orders linked to an account invoice" do
+        expect(user.last_incomplete_spree_order).to eq order
+      end
     end
   end
 

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -13,7 +13,7 @@ module ShopWorkflow
   end
 
   def set_order(order)
-    ApplicationController.any_instance.stub(:session).and_return({order_id: order.id, access_token: order.token})
+    inject_session(order_id: order.id, access_token: order.token)
   end
 
   def add_product_to_cart(order, product, quantity: 1)
@@ -47,6 +47,14 @@ module ShopWorkflow
     if oc.exchanges.from_enterprise(supplier).incoming.empty?
       create(:exchange, order_cycle: oc, incoming: true,
                         sender: supplier, receiver: oc.coordinator)
+    end
+  end
+
+  def inject_session(hash)
+    Warden.on_next_request do |proxy|
+      hash.each do |key, value|
+        proxy.raw_session[key] = value
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

This is extension to PR https://github.com/openfoodfoundation/openfoodnetwork/pull/1583 as issue has appeared:

1. a variant is in the user's cart
2. the user logs out
3. the variant is removed completely from the order cycle (not just stock reduced)
4. the user logs back in

Approach:
Validation method inside order model seemed more appropriate way but there were so many tests failing and fixing that looked like very time consuming thing so this approach has been chosen.

P.S. was not sure about naming on methods so please give better ones if you have any in mind.

#### What should we test?

Checkout process when incoming/outgoing products get unselected in admin order_cycles edit page.

#### How is this related to the Spree upgrade?

Hopefully it is not related unless later Spree versions has Orders implemented already with double check of this functionality.

#### Dependencies

Extension of https://github.com/openfoodfoundation/openfoodnetwork/pull/1583
And follow up of https://github.com/openfoodfoundation/openfoodnetwork/pull/1477