### PR TITLE
#1306: Add 'disabled' class to shopfront property selectors buttons ...

### DIFF
--- a/app/assets/javascripts/templates/partials/enterprise_details.html.haml
+++ b/app/assets/javascripts/templates/partials/enterprise_details.html.haml
@@ -11,7 +11,7 @@
         %span.filter-shopfront.property-selectors.pad-top
           %ul.inline-block
             %li{"ng-repeat" => "property in enterprise.supplied_properties"}
-              %a.button.tiny{"ng-bind" => "property.presentation"}
+              %a.button.tiny.disabled{"ng-bind" => "property.presentation"}
 
       .about-container.pad-top
         %img.enterprise-logo{"ng-src" => "{{::enterprise.logo}}", "ng-if" => "::enterprise.logo"}


### PR DESCRIPTION
… to prevent clickability.

#### What? Why?

This PR closes issue #1306 -
I added a `.disabled` class to the greyed out buttons, similar to the blue buttons, to prevent clickability.

#### What should we test?

This only changes the buttons in the enterprise details section; it should not affect other buttons, but it's worth making sure others are not being "disabled".