### PR TITLE
Add media query to panepadding mixin

### DIFF
--- a/app/assets/stylesheets/darkswarm/mixins.scss
+++ b/app/assets/stylesheets/darkswarm/mixins.scss
@@ -15,6 +15,10 @@
 @mixin panepadding {
   padding-top: 100px;
   padding-bottom: 100px;
+
+  @media all and (max-width: 640px) {
+    padding-top: 25px;
+  }
 }
 
 @mixin paneWhiteText {


### PR DESCRIPTION
#### What? Why?

Fixes the heading padding at mobile sizes to maximize screen height. Closes issue #1311 

I created a media query for the mixin panepadding, that changes padding-top @ 640px from 100px to 25px.

Producers page
![padding-top @ 25px](http://i.imgur.com/Pa5mV79.png)

Also impacts footer:
![padding-top @ 25px](http://i.imgur.com/vrO4kEL.png)


#### What should we test?

Visual check that the change to panepadding did not negatively impact other parts of the app. 