### PR TITLE
Remove zeus and guard-zeus from the bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,7 +126,6 @@ group :development do
   gem 'guard-livereload'
   gem 'rack-livereload'
   gem 'guard-rails'
-  gem 'guard-zeus'
   gem 'guard-rspec'
   gem 'parallel_tests'
   gem 'rubocop', '>= 0.49.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,9 +408,6 @@ GEM
     guard-rspec (4.0.4)
       guard (>= 2.1.1)
       rspec (~> 2.14)
-    guard-zeus (0.0.1)
-      guard
-      zeus
     haml (4.0.4)
       tilt
     highline (1.6.11)
@@ -662,8 +659,6 @@ GEM
     xml-simple (1.1.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    zeus (0.15.4)
-      method_source (>= 0.6.7)
 
 PLATFORMS
   ruby
@@ -707,7 +702,6 @@ DEPENDENCIES
   guard-livereload
   guard-rails
   guard-rspec
-  guard-zeus
   haml
   i18n (~> 0.6.11)
   immigrant
@@ -765,4 +759,4 @@ RUBY VERSION
    ruby 2.1.5p273
 
 BUNDLED WITH
-   1.15.1
+   1.15.2


### PR DESCRIPTION
#### What? Why?

Having guard-zeus specified as a dependency is problematic because it also pulls in the zeus gem as a dependency. This makes it impossible to update or switch zeus versions locally without affecting other developers.

The maintainers of zeus say that it is designed to be installed and run outside of the bundle: https://github.com/burke/zeus

#### What should we test?

I suppose it would be good if someone could pull this down and check that is doesn't break anything for them. Also, if anyone is using guard we might need to come up with a different idea.