### PR TITLE
Exclude session data when mirroring data

### DIFF
--- a/script/mirror_db.sh
+++ b/script/mirror_db.sh
@@ -18,12 +18,13 @@ else
   DB_DATABASE='openfoodnetwork'
 fi
 
+DB_OPTIONS='--exclude-table-data=sessions'
 
 # -- Mirror database
 echo "Mirroring database..."
 echo "drop database open_food_network_dev" | psql -h localhost -U ofn open_food_network_test
 echo "create database open_food_network_dev" | psql -h localhost -U ofn open_food_network_test
-ssh $1 "pg_dump -h localhost -U $DB_USER $DB_DATABASE |gzip" |gunzip |psql -h localhost -U ofn open_food_network_dev
+ssh $1 "pg_dump -h localhost -U $DB_USER $DB_DATABASE $DB_OPTIONS |gzip" |gunzip |psql -h localhost -U ofn open_food_network_dev
 
 
 # -- Disable S3

--- a/script/mirror_db.sh
+++ b/script/mirror_db.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Used to pull data from production or staging servers into local dev database
+# Useful for when you want to test a migration against production data, or see
+# the effect of codebase changes on real-life data
+
 # Usage: script/mirror_db.sh [ofn-staging1|ofn-staging2|ofn-prod]
 
 set -e


### PR DESCRIPTION
#### What? Why?

What it says on the tin: exclude session data when mirroring. This is particularly useful when there is a lot of session data on the server, and you are on a slow connection.

Probably a better long term solution would be to add a job to clean up old session data on the server, but this is a quick & dirty fix.

#### What should we test?

I have tested it, but feel free to give a try to verify