### PR TITLE
Exclude node_modules from rubocop analysis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - 'config/**/*'
     - 'script/**/*'
     - 'vendor/**/*'
+    - 'node_modules/**/*'
     - !ruby/regexp /old_and_unused\.rb$/
 
 # OFN SETTINGS


### PR DESCRIPTION
#### What? Why?

I don't need to see offences for node modules when I run rubocop locally

#### What should we test?

Nothing to test