### PR TITLE
Sort line items by name and unit_value

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -25,6 +25,13 @@ Spree::LineItem.class_eval do
     end
   }
 
+  scope :sorted_by_name_and_unit_value,     
+      # Find line items that are from order sorted by variant name and unit value
+      joins(:variant=> :product).
+        reorder('spree_products.name asc, spree_variants.unit_value asc').
+        select('spree_line_items.*')
+  
+
   scope :supplied_by, lambda { |enterprise|
     joins(:product).
       where('spree_products.supplier_id = ?', enterprise)
@@ -85,7 +92,12 @@ Spree::LineItem.class_eval do
   end
 
   def display_name
-    variant.display_name
+    if variant.display_name.blank?
+print 'jejeje'
+      return variant.name
+    else
+      return variant.display_name
+    end
   end
 
   def unit_value

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -26,7 +26,7 @@ Spree::LineItem.class_eval do
   }
 
   # Find line items that are from order sorted by variant name and unit value
-  scope :sorted_by_name_and_unit_value, joins(:variant => :product).
+  scope :sorted_by_name_and_unit_value, joins(variant: :product).
     reorder('spree_products.name asc, spree_variants.unit_value asc').
     select('spree_line_items.*')
 

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -92,12 +92,7 @@ Spree::LineItem.class_eval do
   end
 
   def display_name
-    if variant.display_name.blank?
-print 'jejeje'
-      return variant.name
-    else
-      return variant.display_name
-    end
+    return variant.display_name
   end
 
   def unit_value

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -92,7 +92,7 @@ Spree::LineItem.class_eval do
   end
 
   def display_name
-    return variant.display_name
+    variant.display_name
   end
 
   def unit_value

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -26,10 +26,9 @@ Spree::LineItem.class_eval do
   }
 
   # Find line items that are from order sorted by variant name and unit value
-  scope :sorted_by_name_and_unit_value,     
-    joins(:variant=> :product).
+  scope :sorted_by_name_and_unit_value, joins(:variant => :product).
     reorder('spree_products.name asc, spree_variants.unit_value asc').
-    select('spree_line_items.*') 
+    select('spree_line_items.*')
 
   scope :supplied_by, lambda { |enterprise|
     joins(:product).

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -25,12 +25,11 @@ Spree::LineItem.class_eval do
     end
   }
 
+  # Find line items that are from order sorted by variant name and unit value
   scope :sorted_by_name_and_unit_value,     
-      # Find line items that are from order sorted by variant name and unit value
-      joins(:variant=> :product).
-        reorder('spree_products.name asc, spree_variants.unit_value asc').
-        select('spree_line_items.*')
-  
+    joins(:variant=> :product).
+    reorder('spree_products.name asc, spree_variants.unit_value asc').
+    select('spree_line_items.*') 
 
   scope :supplied_by, lambda { |enterprise|
     joins(:product).

--- a/app/views/spree/order_mailer/_order_summary.html.haml
+++ b/app/views/spree/order_mailer/_order_summary.html.haml
@@ -11,7 +11,7 @@
         %h4
           = t :email_order_summary_price
   %tbody
-    - @order.line_items.each do |item|
+    - @order.line_items.sorted_by_name_and_unit_value.each do |item|
       %tr
         %td
           = render 'spree/shared/line_item_name', line_item: item

--- a/app/views/spree/orders/_summary.html.haml
+++ b/app/views/spree/orders/_summary.html.haml
@@ -11,7 +11,7 @@
       %th.text-right.total
         %span= t(:total)
   %tbody{"data-hook" => ""}
-    - order.line_items.each do |item|
+    - order.line_items.sorted_by_name_and_unit_value.each do |item|
       %tr.line_item{"data-hook" => "order_details_line_item_row", class: "variant-#{item.variant.id}" }
         %td(data-hook = "order_item_description")
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -54,7 +54,7 @@ module Spree
       end
 
       it "finds line items sorted by name and unit_value" do
-        o.line_items.sorted_by_name_and_unit_value.should == [li5,li6,li4,li3]
+        expect(o.line_items.sorted_by_name_and_unit_value).to eq([li5,li6,li4,li3])
       end
     end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -14,6 +14,18 @@ module Spree
       let(:li1) { create(:line_item, order: o, product: p1) }
       let(:li2) { create(:line_item, order: o, product: p2) }
 
+      
+      let(:p3) {create(:product, name: 'Clear Honey') }
+      let(:p4) {create(:product, name: 'Apricots') }
+      let(:v1) {create(:variant, product: p3, unit_value: 500) }
+      let(:v2) {create(:variant, product: p3, unit_value: 250) }
+      let(:v3) {create(:variant, product: p4, unit_value: 500) }
+      let(:v4) {create(:variant, product: p4, unit_value: 1000) }
+      let(:li3) { create(:line_item, order: o, product: p3, variant: v1) }
+      let(:li4) { create(:line_item, order: o, product: p3, variant: v2) }
+      let(:li5) { create(:line_item, order: o, product: p4, variant: v3) }
+      let(:li6) { create(:line_item, order: o, product: p4, variant: v4) }
+
       it "finds line items for products supplied by a particular enterprise" do
         LineItem.supplied_by(s1).should == [li1]
         LineItem.supplied_by(s2).should == [li2]
@@ -39,6 +51,10 @@ module Spree
         it "finds line items without tax" do
           LineItem.without_tax.should == [li2]
         end
+      end
+
+      it "finds line items sorted by name and unit_value" do
+        o.line_items.sorted_by_name_and_unit_value.should == [li5,li6,li4,li3]
       end
     end
 


### PR DESCRIPTION
 for confirmation email and summary screen after checkout. It was done in the cart and now in emails.
Requested in issue #1663 

#### What? Why?

This change was requested to avoid annoying lists of orders without any logic. Now it comes with an alphabetic list of variants and values when name are the same.
It has been done with a scope in the line_item model to get the list of items already sorted on screen.

#### What should we test?

Create an order with two different products (Apricots and Honey, for example) and each of them with, at least, 2 different variants of unit values (Apricots 500g, Apricots 1000, Honey 1000g, Honey 500g). 
It should come a list where Aprictos 500g, is the first element and Honey 1000g the last one.

