### PR TITLE
Upgrade bundler to locked version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
     - CI_NODE_INDEX=3
     - CI_NODE_INDEX=4 KARMA="true" GITHUB_DEPLOY="true"
 
+before_install:
+  - ./script/upgrade_bundler.sh
+
 before_script:
   - cp config/database.travis.yml config/database.yml
   - cp config/application.yml.example config/application.yml

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ First, check your dependencies: Ensure that you have Ruby 2.1.5 installed:
 Install the project's gem dependencies:
 
     cd openfoodnetwork
+    ./script/upgrade_bundler.sh
     bundle install
 
 Configure the site:

--- a/script/upgrade_bundler.sh
+++ b/script/upgrade_bundler.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# This shell script looks for the last used Bundler version in Gemfile.lock and
+# installs exactly that version, removing other versions.
+
+# Fail if a single command fails.
+set -e
+
+# `grep -m 1`: find the first occurrence of "BUNDLED WITH"
+# `-A`:        print the next line after "BUNDLED WITH" as well
+# `-x -F`:     find exactly that string without interpreting regex
+# `tail -n 1`: take the last line, the version line
+# `tr -d`:     delete all spaces, the indent before the version
+version="$(grep -m 1 -A 1 -x -F "BUNDLED WITH" Gemfile.lock | tail -n 1  | tr -d '[:space:]')"
+
+if [ -z "$version" ]; then
+  echo "No bundler version in Gemfile.lock."
+  exit 1
+fi
+
+current="$(bundler --version)"
+
+if [ "$current" = "Bundler version $version" ]; then
+  echo "Already up-to-date: $current"
+  exit 0
+fi
+
+gem install bundler -v "$version"
+gem cleanup bundler


### PR DESCRIPTION
#### What? Why?

Developers have different Bundler versions installed and Travis uses a much older version than most of the developers. When @sauloperez encountered different test results locally and in Travis, suggested PR #1641. Instead of updating to the latest version of Bundler, this pull request provides a script to install the version specified in `Gemfile.lock`. This change proposes to use it in Travis. Developers can also benefit from using it to get the right version.

#### What should we test?

Only Travis is affected. No user testing on a staging server required. We could think about best practices for deployment.

#### How is this related to the Spree upgrade?

Not at all.