### PR TITLE
Untranslate report headers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1623,19 +1623,11 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_users: "Users: "
   report_tax_rates: Tax rates
   report_tax_types: Tax types
-  report_header_tax_type: Tax Type
-  report_header_tracking_name_1: Tracking Name 1
-  report_header_tracking_name_2: Tracking Name 2
-  report_header_tracking_option_1: Tracking Option 1
-  report_header_tracking_option_2: Tracking Option 2
-  report_header_branding_theme: Branding Theme
-  report_header_currency: Currency
   report_header_order_cycle: Order Cycle
   report_header_user: User
   report_header_email: Email
   report_header_status: Status
   report_header_comments: Comments
-  report_header_contact_name: Contact Name
   report_header_first_name: First Name
   report_header_last_name: Last Name
   report_header_suburb: Suburb
@@ -1665,16 +1657,10 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_billing_street_4: Billing Street 4
   report_header_billing_city: Billing City
   report_header_billing_postcode: Billing Postcode
-  report_header_billing_region: Billing Region
   report_header_billing_state: Billing State
-  report_header_billing_country: Billing Country
   report_header_incoming_transport: Incoming Transport
   report_header_special_instructions: Special Instructions
   report_header_order_number: Order number
-  report_header_invoice_number: Invoice Number
-  report_header_reference: Reference
-  report_header_invoice_date: Invoice Date
-  report_header_due_date: Due Date
   report_header_date: Date
   report_header_confirmation_date: Confirmation Date
   report_header_tags: Tags
@@ -1736,7 +1722,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_order_date: Order date
   report_header_order_id: Order Id
   report_header_item_name: Item name
-  report_header_inventory_item_code: Inventory Item Code
   report_header_temp_controlled_items: Temp Controlled Items?
   report_header_customer_name: Customer Name
   report_header_customer_email: Customer Email
@@ -1757,9 +1742,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_paypal_price: "PayPal (%{currency})"
   report_header_sku: SKU
   report_header_amount: Amount
-  report_header_unit_amount: Unit Amount
-  report_header_discount: Discount
-  report_header_account_code: Account Code
   report_header_balance: Balance
   report_header_total: Total
   report_header_total_cost: "Total Cost"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1677,8 +1677,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_customer_code: Customer Code
   report_header_product: Product
   report_header_product_properties: Product Properties
-  report_header_description: Description
-  report_header_qty: Qty
   report_header_quantity: Quantity
   report_header_max_quantity: Max Quantity
   report_header_variant: Variant
@@ -1687,7 +1685,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_total_available: Total available
   report_header_unallocated: Unallocated
   report_header_max_quantity_excess: Max Quantity Excess
-  report_header_taxon: Taxon
   report_header_taxons: Taxons
   report_header_supplier: Supplier
   report_header_producer: Producer
@@ -1701,10 +1698,8 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_payment_method: Payment Method
   report_header_sells: Sells
   report_header_visible: Visible
-  report_header_unit_price: Unit Price
   report_header_price: Price
   report_header_unit_size: Unit Size
-  report_header_pack_size: Pack Size
   report_header_distributor: Distributor
   report_header_distributor_address: Distributor address
   report_header_distributor_city: Distributor city
@@ -1743,7 +1738,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_sku: SKU
   report_header_amount: Amount
   report_header_balance: Balance
-  report_header_total: Total
   report_header_total_cost: "Total Cost"
   report_header_total_ordered: Total Ordered
   report_header_total_max: Total Max
@@ -1751,8 +1745,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   report_header_sum_max_total: "Sum Max Total"
   report_header_total_excl_vat: "Total excl. tax (%{currency_symbol})"
   report_header_total_incl_vat: "Total incl. tax (%{currency_symbol})"
-  report_header_gst_incl: GST incl.
-  report_header_grower_and_method: Grower and growing method
   report_header_temp_controlled: TempControlled?
   report_header_is_producer: Producer?
   report_header_not_confirmed: Not Confirmed

--- a/lib/open_food_network/lettuce_share_report.rb
+++ b/lib/open_food_network/lettuce_share_report.rb
@@ -3,17 +3,18 @@ require 'open_food_network/products_and_inventory_report_base'
 module OpenFoodNetwork
   class LettuceShareReport < ProductsAndInventoryReportBase
     def header
+      # NOTE: These are NOT to be translated, they need to be in this exact format to work with LettucShare
       [
-        I18n.t(:report_header_product),
-        I18n.t(:report_header_description),
-        I18n.t(:report_header_qty),
-        I18n.t(:report_header_pack_size),
-        I18n.t(:report_header_unit),
-        I18n.t(:report_header_unit_price),
-        I18n.t(:report_header_total),
-        I18n.t(:report_header_gst_incl),
-        I18n.t(:report_header_grower_and_method),
-        I18n.t(:report_header_taxon)
+        "PRODUCT",
+        "Description",
+        "Qty",
+        "Pack Size",
+        "Unit",
+        "Unit Price",
+        "Total",
+        "GST incl.",
+        "Grower and growing method",
+        "Taxon"
       ]
     end
 

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -12,36 +12,8 @@ module OpenFoodNetwork
     end
 
     def header
-      [
-        "*#{I18n.t(:report_header_contact_name)}",
-        I18n.t(:report_header_email),
-        I18n.t(:report_header_billing_street),
-        I18n.t(:report_header_billing_street_2),
-        I18n.t(:report_header_billing_street_3),
-        I18n.t(:report_header_billing_street_4),
-        I18n.t(:report_header_billing_city),
-        I18n.t(:report_header_billing_region),
-        I18n.t(:report_header_billing_postcode),
-        I18n.t(:report_header_billing_country),
-        "*#{I18n.t(:report_header_invoice_number)}",
-        I18n.t(:report_header_reference),
-        "*#{I18n.t(:report_header_invoice_date)}",
-        "*#{I18n.t(:report_header_due_date)}",
-        I18n.t(:report_header_inventory_item_code),
-        "*#{I18n.t(:report_header_description)}",
-        "*#{I18n.t(:report_header_quantity)}",
-        "*#{I18n.t(:report_header_unit_amount)}",
-        I18n.t(:report_header_discount),
-        "*#{I18n.t(:report_header_account_code)}",
-        "*#{I18n.t(:report_header_tax_type)}",
-        I18n.t(:report_header_tracking_name_1),
-        I18n.t(:report_header_tracking_option_1),
-        I18n.t(:report_header_tracking_name_2),
-        I18n.t(:report_header_tracking_option_2),
-        I18n.t(:report_header_currency),
-        I18n.t(:report_header_branding_theme),
-        I18n.t(:report_header_paid),
-      ]
+      # NOTE: These are NOT to be translated, they need to be in this exact format to work with Xero
+      %w(*ContactName EmailAddress POAddressLine1 POAddressLine2 POAddressLine3 POAddressLine4 POCity PORegion POPostalCode POCountry *InvoiceNumber Reference *InvoiceDate *DueDate InventoryItemCode *Description *Quantity *UnitAmount Discount *AccountCode *TaxType TrackingName1 TrackingOption1 TrackingName2 TrackingOption2 Currency BrandingTheme Paid?)
     end
 
     def search

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -510,9 +510,7 @@ feature %q{
     end
 
     def xero_invoice_header
-      ['*Contact Name', 'Email', 'Billing Street', 'Billing Street 2', 'Billing Street 3', 'Billing Street 4',  'Billing City', 'Billing Region', 'Billing Postcode', 'Billing Country',
-       '*Invoice Number', 'Reference', '*Invoice Date', '*Due Date', 'Inventory Item Code', '*Description', '*Quantity', '*Unit Amount', 'Discount',
-       '*Account Code', '*Tax Type', 'Tracking Name 1', 'Tracking Option 1',  'Tracking Name 2', 'Tracking Option 2', 'Currency', 'Branding Theme', 'Paid?']
+      %w(*ContactName EmailAddress POAddressLine1 POAddressLine2 POAddressLine3 POAddressLine4 POCity PORegion POPostalCode POCountry *InvoiceNumber Reference *InvoiceDate *DueDate InventoryItemCode *Description *Quantity *UnitAmount Discount *AccountCode *TaxType TrackingName1 TrackingOption1 TrackingName2 TrackingOption2 Currency BrandingTheme Paid?)
     end
 
     def xero_invoice_summary_row(description, amount, tax_type, opts={})


### PR DESCRIPTION
#### What? Why?

A couple of our reports are designed to be used to integrate with other pieces of software (Xero and Lettuceshare), so translations of these headers will break the integration.

#### What should we test?

That Xero and LettuceShare integrations still work (in particular that the headers generated by the reports are acceptable).
