### PR TITLE
Fix some display errors

### DIFF
--- a/app/assets/javascripts/templates/single_line_selectors.html.haml
+++ b/app/assets/javascripts/templates/single_line_selectors.html.haml
@@ -5,7 +5,7 @@
   %li.more
     %a.dropdown{ data: { dropdown: "{{ 'show-more-' + selectorName }}" }, ng: { class: "{active: selectedOverFlowSelectors().length > 0}" } }
       %span
-        + {{ overFlowSelectors().length }}= t(:more)
+        = t('js.more_items', count: "{{ overFlowSelectors().length }}")
       %i.ofn-i_052-point-down
     .f-dropdown.text-right.content{ ng: { attr: { id: "{{ 'show-more-' + selectorName }}" } } }
       %ul

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1856,6 +1856,7 @@ Please follow the instructions there to make your enterprise visible on the Open
     shop: Shop
     choose: Choose
     resolve_errors: Please resolve the following errors
+    more_items: "+ %{count} More"
     admin:
       modals:
         got_it: Got it

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1602,7 +1602,6 @@ Please follow the instructions there to make your enterprise visible on the Open
   hub_sidebar_blue: "blue"
   hub_sidebar_red: "red"
   shop_trial_in_progress: "Your shopfront trial expires in %{days}."
-  shop_trial_expired: "Good news! We have decided to extend shopfront trials until further notice (probably around March 2015)." #FIXME
   report_customers_distributor: "Distributor"
   report_customers_supplier: "Supplier"
   report_customers_cycle: "Order Cycle"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,7 +138,6 @@ en:
   enterprise_groups: Groups
   reports: Reports
   variant_overrides: Inventory
-  more: More
   spree_products: Spree Products
   all: All
   current: Current

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,12 +395,6 @@ en:
         max_fulfilled_units: "Max Fulfilled Units"
         order_error: "Some errors must be resolved before you can update orders.\nAny fields with red borders contain errors."
         variants_without_unit_value: "WARNING: Some variants do not have a unit value"
-      invoice:
-        issued_on: Issued on
-        tax_invoice: TAX INVOICE
-        code: Code
-        from: From
-        to: To
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from
 
@@ -2022,6 +2016,12 @@ Please follow the instructions there to make your enterprise visible on the Open
   spree:
     admin:
       orders:
+        invoice:
+          issued_on: Issued on
+          tax_invoice: TAX INVOICE
+          code: Code
+          from: From
+          to: To
         form:
           distribution_fields:
             title: Distribution


### PR DESCRIPTION
#### What? Why?

Recent i18n updates broke a couple of views.

#### What should we test?

The "+ 3 More" display in shop fronts. The standard view of printed order invoices.

You can switch the invoice display as admin in Settings/Invoice Settings.

A general look around if anything else is broken would be good as well.