### PR TITLE
Add a helper to allow set/reset of Spree::Config settings in specs

### DIFF
--- a/spec/models/spree/order_populator_spec.rb
+++ b/spec/models/spree/order_populator_spec.rb
@@ -196,7 +196,9 @@ module Spree
       let(:v) { double(:variant, on_hand: 10) }
 
       context "when backorders are not allowed" do
-        before { Spree::Config.allow_backorders = false }
+        around(:each) do |example|
+          with_spree_config({ allow_backorders: false }, &example)
+        end
 
         context "when max_quantity is not provided" do
           it "returns full amount when available" do
@@ -220,10 +222,8 @@ module Spree
       end
 
       context "when backorders are allowed" do
-        around do |example|
-          Spree::Config.allow_backorders = true
-          example.run
-          Spree::Config.allow_backorders = false
+        around(:each) do |example|
+          with_spree_config({ allow_backorders: true }, &example)
         end
 
         it "does not limit quantity" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,6 +98,7 @@ RSpec.configure do |config|
   config.include Spree::UrlHelpers
   config.include Spree::CheckoutHelpers
   config.include Spree::MoneyHelper
+  config.include Spree::ConfigHelper
   config.include Spree::Core::TestingSupport::ControllerRequests, :type => :controller
   config.include Devise::TestHelpers, :type => :controller
   config.extend  Spree::Api::TestingSupport::Setup, :type => :controller

--- a/spec/support/spree/config_helper.rb
+++ b/spec/support/spree/config_helper.rb
@@ -1,0 +1,18 @@
+module Spree
+  module ConfigHelper
+    def with_spree_config(hash)
+      stored = config_slice(hash.keys)
+      Config.set(hash)
+      yield
+      Config.set(stored)
+    end
+
+    private
+
+    def config_slice(keys)
+      keys.each_with_object({}) do |key, hash|
+        hash[key] = Config[key]
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

There is a requirement to alter `Spree::Config` settings in the test suite, to allow tests to check the outcome of logic in different contexts. At the moment, we are mostly doing this using something like:

````ruby
before do
  Spree::Config.set some_setting: "some_value"
end
````

The problem with this approach is that the values of such settings appear to be cached, and they are not rolled back with the transaction when the spec has finished running. This results in the test context bleeding out and influencing other specs in the test suite that are completely unrelated. Such behaviour is particularly problematic on Travis-CI, because we run tests in parallel in 5 separate threads, so if a particular spec happens to be moved from one thread to another, this can cause it to be run in a different context, sometimes resulting is seemingly random failures.

The idea to solve this problem using stubbing was raised, but the problem with this idea is that Spree::Config settings are accessed in the codebase using both of these syntaxes (a lot of this is in the Spree repo, so we don't have control of all of it):

````ruby
Spree::Config.setting_name
Spree::Config[:setting_name]
````

Stubbing both of these before each spec looks messy and stubbing the `:[]` method is problematic anyway, because it would depend on specifying a two stubs: one with `.and_call_original` and one with a `with(:setting_name)` clause.

So the approach I have used is to create a helper with a method `with_spree_settings`, which is to be called from an `around` block, and which accepts a hash of settings that will be set and reset to their original values for each relevant spec.

If others are happy with this approach I am happy to take on the work of implementing the change throughout the rest of the test suite. Should only be half an hour or so of work.

#### What should we test?

These changes and any similar future rollout will not touch any functional part of the codebase, they will only touch the specs.

#### Related PRs

There is a fair bit of discussion [on #1550](https://github.com/openfoodfoundation/openfoodnetwork/pull/1550#pullrequestreview-46995367) about this, which prompted this PR.
