### PR TITLE
Fix styling of error flash in admin section

### DIFF
--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -28,8 +28,8 @@ text-angular .ta-editor {
   left: 275px;
 }
 
-span.error, div.error {
-	color: #DA5354;
+span.error, div.error:not(.flash) {
+  color: #DA5354;
 }
 
 /* Fix conflict between Spree and elRTE's styles */


### PR DESCRIPTION
#### What? Why?

Fix for #1657, colour of the text in the error flash in the admin section is too similar to the background, so the text is barely visible.

#### What should we test?

That error messages are legible again.

#### Release notes

- Fixed styling of error messages in the admin section to make them more legible 
