### PR TITLE
Always execute local karma

### DIFF
--- a/lib/tasks/karma.rake
+++ b/lib/tasks/karma.rake
@@ -1,28 +1,22 @@
+ENV["RAILS_ENV"] ||= 'test'
+
 namespace :karma  do
-  task :start => :environment do |task|
-    continue_only_in_test_env task
+  task :start => :environment do |_task|
     with_tmp_config :start
   end
 
-  task :run => :environment do |task|
-    continue_only_in_test_env task
+  task :run => :environment do |_task|
     with_tmp_config :start, "--single-run"
   end
 
   private
-
-  def continue_only_in_test_env task
-    if Rails.env != 'test'
-      raise "Task must be called in test environment:\n  bundle exec rake #{task.name} RAILS_ENV=test"
-    end
-  end
 
   def with_tmp_config(command, args = nil)
     Tempfile.open('karma_unit.js', Rails.root.join('tmp') ) do |f|
       f.write unit_js(application_spec_files << i18n_file)
       f.flush
       trap('SIGINT') { puts "Killing Karma"; exit }
-      exec "karma #{command} #{f.path} #{args}"
+      exec "node_modules/.bin/karma #{command} #{f.path} #{args}"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

This ensures the dev will run the version specified in the `package.json`. Besides, it makes the rake task work like all rails tests, allowing you to pass a `RAILS_ENV`.

Doing this, the next time I need to run js unit tests I don't have to do anything other than:

```
npm install
bundle exec rake karma:run
```

- [x] update wiki: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Karma