### PR TITLE
Uk/1761 add missing i18n js partial

### DIFF
--- a/app/views/layouts/_i18n_script.html.haml
+++ b/app/views/layouts/_i18n_script.html.haml
@@ -1,4 +1,4 @@
 %script
   I18n.default_locale = "#{I18n.default_locale}";
   I18n.locale = "#{I18n.locale}";
-  I18n.fallbacks = "default_locale";
+  I18n.fallbacks = true;

--- a/app/views/layouts/registration.html.haml
+++ b/app/views/layouts/registration.html.haml
@@ -15,7 +15,7 @@
     = stylesheet_link_tag "darkswarm/all"
     = javascript_include_tag "darkswarm/all"
 
-
+    = render "layouts/i18n_script"
     = render "layouts/bugherd_script"
     = csrf_meta_tags
 


### PR DESCRIPTION
#### What? Why?

Issue - #1761
/register/auth was missing js I18n config and would fallback to 'en' local by default, but by server settings it had only 'en-GB' translations generated.

#### What should we test?

/register/auth should not show missing translations.

@jeronimo sorry to be messing about with your PR. Buildkite ain't picking it up (yet another intermittent issue I haven't looked into) so I need to merge to a branch to deploy.