### PR TITLE
Check if items in cart have been removed from OC

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -54,6 +54,9 @@ class CheckoutController < Spree::CheckoutController
       else
         update_failed
       end
+    elsif @order.errors.messages[:items_removed].present?
+      flash[:error] = @order.errors.messages[:items_removed].to_sentence
+      raise_insufficient_quantity
     else
       update_failed
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,6 +724,7 @@ en:
     already_ordered:
       cart: "cart"
       message_html: "You have an order for this order cycle already. Check the %{cart} to see the items you ordered before. You can also cancel items as long as the order cycle is open."
+    items_removed_from_order_cycle: "Items in your cart have been removed from the order cycle. Please review your order before proceeding."
   shops:
     hubs:
       show_closed_shops: "Show closed shops"

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -89,7 +89,7 @@ feature %q{
     puts d.name
     puts @distributor.name
 
-    @order.state = 'cart'; @order.completed_at = nil; @order.save
+    @order.state = 'payment'; @order.completed_at = nil; @order.save
 
     login_to_admin_section
     visit '/admin/orders'

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -16,6 +16,11 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
   let(:variant) { product.variants.first }
   let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor) }
 
+  let(:product2) { create(:taxed_product, supplier: supplier, price: 11, zone: zone, tax_rate_amount: 0.1) }
+  let(:variant2) { product2.variants.first }
+  let!(:order_cycle2) { create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor], coordinator: create(:distributor_enterprise), variants: [variant, variant2]) }
+  let(:order2) { create(:order, order_cycle: order_cycle2, distributor: distributor) }
+
   before do
     Spree::Config.shipment_inc_vat = true
     Spree::Config.shipping_tax_rate = 0.25
@@ -61,6 +66,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         page.should have_content "An item in your cart has become unavailable"
       end
     end
+
     context 'login in as user' do
       let(:user) { create(:user) }
 
@@ -292,27 +298,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
         context "with basic details filled" do
           before do
-            toggle_shipping
-            choose sm1.name
-            toggle_payment
-            choose pm1.name
-            toggle_details
-            within "#details" do
-              fill_in "First Name", with: "Will"
-              fill_in "Last Name", with: "Marshall"
-              fill_in "Email", with: "test@test.com"
-              fill_in "Phone", with: "0468363090"
-            end
-            toggle_billing
-            within "#billing" do
-              fill_in "City", with: "Melbourne"
-              fill_in "Postcode", with: "3066"
-              fill_in "Address", with: "123 Your Face"
-              select "Australia", from: "Country"
-              select "Victoria", from: "State"
-            end
-            toggle_shipping
-            check "Shipping address same as billing address?"
+            fill_in_basic_checkout_details
           end
 
           it "takes us to the order confirmation page when submitted with 'same as billing address' checked" do
@@ -433,5 +419,60 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         end.to enqueue_job ConfirmOrderJob
       end
     end
+
+    context "when the order cycle is modified before checkout is completed" do
+      before do
+        set_order order2
+        add_product_to_cart order2, product
+        add_product_to_cart order2, product2
+
+        # Remove one of the cart items from the OC
+        order_cycle2.exchanges.each do |e|
+          e.exchange_variants.first.delete
+        end
+
+        order_cycle2.save
+      end
+
+      it "redirects to cart page with message if items have been removed from the oc" do
+        visit checkout_path
+        checkout_as_guest
+
+        expect(order_cycle2.exchanges.outgoing.first.exchange_variants.count).to eq 1
+
+        fill_in_basic_checkout_details
+
+        place_order
+
+        expect(page).to have_content 'Your shopping cart'
+        expect(page).to have_content 'Items in your cart have been removed from the order cycle. Please review your order before proceeding.'
+      end
+    end
+  end
+
+  private
+
+  def fill_in_basic_checkout_details
+    toggle_shipping
+    choose sm1.name
+    toggle_payment
+    choose pm1.name
+    toggle_details
+    within "#details" do
+      fill_in "First Name", with: "Will"
+      fill_in "Last Name", with: "Marshall"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Phone", with: "0468363090"
+    end
+    toggle_billing
+    within "#billing" do
+      fill_in "City", with: "Melbourne"
+      fill_in "Postcode", with: "3066"
+      fill_in "Address", with: "123 Your Face"
+      select "Australia", from: "Country"
+      select "Victoria", from: "State"
+    end
+    toggle_shipping
+    check "Shipping address same as billing address?"
   end
 end


### PR DESCRIPTION
#### What? Why?

Addressing the bug mentioned at the bottom of #1491 (not the bug detailed in the main description)

#### What should we test?

Checking out with a cart where  some of the items have been removed from the order cycle after the cart was created but before completion of the checkout process. 

Previous behaviour allowed the order to be completed successfully despite the items being missing from the OC, potentially causing stock management issues.

New behaviour should redirect to the cart page with the "missing" items removed from the cart, and an explanatory message.
