### PR TITLE
Email/confirmable users

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -11,3 +11,10 @@ Darkswarm.controller "LoginCtrl", ($scope, $http, $window, AuthenticationService
     .error (data) ->
       Loading.clear()
       $scope.errors = data.message || data.error
+      $scope.user_unconfirmed = (data.error == t('devise.failure.unconfirmed'))
+
+  $scope.resend_confirmation = ->
+    $http.post("/user/spree_user/confirmation", {spree_user: $scope.spree_user}).success (data)->
+      $scope.messages = t('devise.confirmations.send_instructions')
+    .error (data) ->
+      $scope.errors = t('devise.confirmations.failed_to_send')

--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -10,4 +10,4 @@ Darkswarm.controller "LoginCtrl", ($scope, $http, $window, AuthenticationService
         $window.location.href = $window.location.origin + $window.location.pathname  # Strips out hash fragments
     .error (data) ->
       Loading.clear()
-      $scope.errors = data.message
+      $scope.errors = data.message || data.error

--- a/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
@@ -9,9 +9,6 @@ Darkswarm.controller "SignupCtrl", ($scope, $http, $window, $location, Redirecti
 
   $scope.submit = ->
     $http.post("/user/spree_user", {spree_user: $scope.spree_user}).success (data)->
-       if Redirections.after_login
-        $window.location.href = $window.location.origin + Redirections.after_login
-       else
-        $window.location.href = $window.location.origin + $window.location.pathname  # Strips out hash fragments
+       $scope.messages = t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
     .error (data) ->
       $scope.errors = data

--- a/app/assets/javascripts/templates/login.html.haml
+++ b/app/assets/javascripts/templates/login.html.haml
@@ -4,6 +4,10 @@
       .large-12.columns
         .alert-box.alert{"ng-show" => "errors != null"}
           {{ errors }}
+          %a{ng: {show: 'user_unconfirmed', click: 'resend_confirmation()'}}
+            = t('devise.confirmations.resend_confirmation_email')
+        .alert-box.success{ng: {show: 'messages != null'}}
+          {{ messages }}
     .row
       .large-12.columns
         %label{for: "email"} {{'email' | t}}

--- a/app/assets/javascripts/templates/signup.html.haml
+++ b/app/assets/javascripts/templates/signup.html.haml
@@ -2,6 +2,10 @@
   %form{ ng: { controller: "SignupCtrl", submit: "submit()" } }
     .row
       .large-12.columns
+        .alert-box.success{ng: {show: 'messages != null'}}
+          {{ messages }}
+    .row
+      .large-12.columns
         %label{for: "email"} {{'signup_email' | t}}
         %input.title.input-text{name: "email",
           type: "email",

--- a/app/assets/stylesheets/darkswarm/modal-login.css.scss
+++ b/app/assets/stylesheets/darkswarm/modal-login.css.scss
@@ -10,4 +10,16 @@
     background: #fff;
     padding-top: 10px;
   }
+
+  .alert-box {
+    a {
+      color: white;
+      text-decoration: underline;
+
+      &:hover {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: underline;
+      }
+    }
+  }
 }

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -13,10 +13,10 @@ class UserConfirmationsController < DeviseController
 
     self.resource = resource_class.send_confirmation_instructions(resource_params)
 
-    if successfully_sent?(resource)
-      set_flash_message(:success, :confirmation_sent) if is_navigational_format?
-    else
-      set_flash_message(:error, :confirmation_not_sent) if is_navigational_format?
+    if successfully_sent?(resource) && is_navigational_format?
+      set_flash_message(:success, :confirmation_sent)
+    elsif is_navigational_format?
+      set_flash_message(:error, :confirmation_not_sent)
     end
 
     respond_with_navigational(resource){ redirect_to spree.admin_path }
@@ -26,10 +26,10 @@ class UserConfirmationsController < DeviseController
   def show
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
 
-    if resource.errors.empty?
-      set_flash_message(:success, :confirmed) if is_navigational_format?
-    else
-      set_flash_message(:error, :not_confirmed) if is_navigational_format?
+    if resource.errors.empty? && is_navigational_format?
+      set_flash_message(:success, :confirmed)
+    elsif is_navigational_format?
+      set_flash_message(:error, :not_confirmed)
     end
 
     respond_with_navigational(resource){ redirect_to login_path }

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -8,9 +8,6 @@ class UserConfirmationsController < DeviseController
 
   # POST /resource/confirmation
   def create
-    self.resource = resource_class.find_by_unconfirmed_email_with_errors(resource_params)
-    authorize! :resend_confirmation, resource
-
     self.resource = resource_class.send_confirmation_instructions(resource_params)
 
     if successfully_sent?(resource) && is_navigational_format?
@@ -19,7 +16,7 @@ class UserConfirmationsController < DeviseController
       set_flash_message(:error, :confirmation_not_sent)
     end
 
-    respond_with_navigational(resource){ redirect_to spree.admin_path }
+    respond_with_navigational(resource){ redirect_to login_path }
   end
 
   # GET /resource/confirmation?confirmation_token=abcdef

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -10,10 +10,12 @@ class UserConfirmationsController < DeviseController
   def create
     self.resource = resource_class.send_confirmation_instructions(resource_params)
 
-    if successfully_sent?(resource) && is_navigational_format?
-      set_flash_message(:success, :confirmation_sent)
-    elsif is_navigational_format?
-      set_flash_message(:error, :confirmation_not_sent)
+    if is_navigational_format?
+      if successfully_sent?(resource)
+        set_flash_message(:success, :confirmation_sent)
+      else
+        set_flash_message(:error, :confirmation_not_sent)
+      end
     end
 
     respond_with_navigational(resource){ redirect_to login_path }
@@ -23,10 +25,12 @@ class UserConfirmationsController < DeviseController
   def show
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
 
-    if resource.errors.empty? && is_navigational_format?
-      set_flash_message(:success, :confirmed)
-    elsif is_navigational_format?
-      set_flash_message(:error, :not_confirmed)
+    if is_navigational_format?
+      if resource.errors.empty?
+        set_flash_message(:success, :confirmed)
+      else
+        set_flash_message(:error, :not_confirmed)
+      end
     end
 
     respond_with_navigational(resource){ redirect_to login_path }

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -1,0 +1,37 @@
+class UserConfirmationsController < DeviseController
+  include Spree::Core::ControllerHelpers::Auth # Needed for access to current_ability, so we can authorize! actions
+
+  # GET /resource/confirmation/new
+  def new
+    build_resource({})
+  end
+
+  # POST /resource/confirmation
+  def create
+    self.resource = resource_class.find_by_unconfirmed_email_with_errors(resource_params)
+    authorize! :resend_confirmation, resource
+
+    self.resource = resource_class.send_confirmation_instructions(resource_params)
+
+    if successfully_sent?(resource)
+      set_flash_message(:success, :confirmation_sent) if is_navigational_format?
+    else
+      set_flash_message(:error, :confirmation_not_sent) if is_navigational_format?
+    end
+
+    respond_with_navigational(resource){ redirect_to spree.admin_path }
+  end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  def show
+    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+
+    if resource.errors.empty?
+      set_flash_message(:success, :confirmed) if is_navigational_format?
+    else
+      set_flash_message(:error, :not_confirmed) if is_navigational_format?
+    end
+
+    respond_with_navigational(resource){ redirect_to login_path }
+  end
+end

--- a/app/controllers/user_registrations_controller.rb
+++ b/app/controllers/user_registrations_controller.rb
@@ -6,13 +6,12 @@ class UserRegistrationsController < Spree::UserRegistrationsController
     @user = build_resource(params[:spree_user])
     if resource.save
       set_flash_message(:success, :signed_up)
-      sign_in(:spree_user, @user)
       session[:spree_user_signup] = true
       associate_user
 
       respond_to do |format|
         format.html do
-          sign_in_and_redirect(:spree_user, @user)
+          redirect_to after_sign_in_path_for(@user)
         end
         format.js do
           render json: { email: @user.email }

--- a/app/controllers/user_registrations_controller.rb
+++ b/app/controllers/user_registrations_controller.rb
@@ -5,12 +5,12 @@ class UserRegistrationsController < Spree::UserRegistrationsController
   def create
     @user = build_resource(params[:spree_user])
     if resource.save
-      set_flash_message(:success, :signed_up_but_unconfirmed)
       session[:spree_user_signup] = true
       associate_user
 
       respond_to do |format|
         format.html do
+          set_flash_message(:success, :signed_up_but_unconfirmed)
           redirect_to after_sign_in_path_for(@user)
         end
         format.js do

--- a/app/controllers/user_registrations_controller.rb
+++ b/app/controllers/user_registrations_controller.rb
@@ -5,7 +5,7 @@ class UserRegistrationsController < Spree::UserRegistrationsController
   def create
     @user = build_resource(params[:spree_user])
     if resource.save
-      set_flash_message(:success, :signed_up)
+      set_flash_message(:success, :signed_up_but_unconfirmed)
       session[:spree_user_signup] = true
       associate_user
 

--- a/app/mailers/spree/user_mailer_decorator.rb
+++ b/app/mailers/spree/user_mailer_decorator.rb
@@ -1,5 +1,4 @@
 Spree::UserMailer.class_eval do
-
   def signup_confirmation(user)
     @user = user
     mail(:to => user.email, :from => from_address,

--- a/app/mailers/spree/user_mailer_decorator.rb
+++ b/app/mailers/spree/user_mailer_decorator.rb
@@ -1,7 +1,17 @@
 Spree::UserMailer.class_eval do
+
   def signup_confirmation(user)
     @user = user
     mail(:to => user.email, :from => from_address,
          :subject => t(:welcome_to) + Spree::Config[:site_name])
+  end
+
+  def confirmation_instructions(user, token)
+    @user = user
+    @token = token
+    subject = t('spree.user_mailer.confirmation_instructions.subject')
+    mail(to: user.email,
+         from: from_address,
+         subject: subject)
   end
 end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -22,8 +22,9 @@ Spree.user_class.class_eval do
   validate :limit_owned_enterprises
 
   # We use the same options as Spree and add :confirmable
-  devise :confirmable, reconfirmable: true, confirmation_keys: [:id, :email]
+  devise :confirmable, reconfirmable: true
   handle_asynchronously :send_confirmation_instructions
+  handle_asynchronously :send_on_create_confirmation_instructions
   # TODO: Later versions of devise have a dedicated after_confirmation callback, so use that
   after_update :welcome_after_confirm, if: lambda { confirmation_token_changed? && confirmation_token.nil? }
 

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -18,9 +18,16 @@ Spree.user_class.class_eval do
   accepts_nested_attributes_for :ship_address
 
   attr_accessible :enterprise_ids, :enterprise_roles_attributes, :enterprise_limit, :bill_address_attributes, :ship_address_attributes
-  after_create :send_signup_confirmation
 
   validate :limit_owned_enterprises
+
+  # We use the same options as Spree and add :confirmable
+  devise :database_authenticatable, :token_authenticatable, :registerable, :recoverable,
+    :rememberable, :trackable, :validatable, :confirmable, :encryptable,
+    :reconfirmable => true, confirmation_keys: [ :id, :email ], :encryptor => 'authlogic_sha512'
+  handle_asynchronously :send_confirmation_instructions
+  # TODO: Later versions of devise have a dedicated after_confirmation callback, so use that
+  after_update :welcome_after_confirm, if: lambda { confirmation_token_changed? && confirmation_token.nil? }
 
   def known_users
     if admin?
@@ -43,6 +50,14 @@ Spree.user_class.class_eval do
   def customer_of(enterprise)
     return nil unless enterprise
     customers.find_by_enterprise_id(enterprise)
+  end
+
+  def welcome_after_confirm
+    # Send welcome email if we are confirming an user's email
+    # Note: this callback only runs on email confirmation
+    if confirmed? && unconfirmed_email.nil? && !unconfirmed_email_changed?
+      send_signup_confirmation
+    end
   end
 
   def send_signup_confirmation

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -22,9 +22,7 @@ Spree.user_class.class_eval do
   validate :limit_owned_enterprises
 
   # We use the same options as Spree and add :confirmable
-  devise :database_authenticatable, :token_authenticatable, :registerable, :recoverable,
-    :rememberable, :trackable, :validatable, :confirmable, :encryptable,
-    :reconfirmable => true, confirmation_keys: [ :id, :email ], :encryptor => 'authlogic_sha512'
+  devise :confirmable, reconfirmable: true, confirmation_keys: [:id, :email]
   handle_asynchronously :send_confirmation_instructions
   # TODO: Later versions of devise have a dedicated after_confirmation callback, so use that
   after_update :welcome_after_confirm, if: lambda { confirmation_token_changed? && confirmation_token.nil? }

--- a/app/views/spree/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/spree/user_mailer/confirmation_instructions.html.haml
@@ -1,0 +1,15 @@
+%h3
+  = t :email_signup_greeting
+%p.lead
+  = t :email_signup_welcome, sitename: Spree::Config[:site_name]
+%p= t :email_confirmation_activate_account
+
+%p.callout
+  = t :email_confirmation_click_link
+  %br
+  %strong
+    = link_to t(:email_confirmation_link_label), spree.spree_user_confirmation_url(:confirmation_token => @user.confirmation_token)
+
+= render 'shared/mailers/signoff'
+
+= render 'shared/mailers/social_and_contact'

--- a/app/views/spree/user_mailer/confirmation_instructions.text.erb
+++ b/app/views/spree/user_mailer/confirmation_instructions.text.erb
@@ -1,4 +1,0 @@
-<%= t('.welcome', email: @email) %>
-
-<%= t('.text') %>
-<%= @confirmation_url %>

--- a/app/views/spree/user_mailer/signup_confirmation.html.haml
+++ b/app/views/spree/user_mailer/signup_confirmation.html.haml
@@ -5,13 +5,8 @@
 
 / Heading Panel
 %p &nbsp;
-%p.callout
-  %strong
-    = t :email_signup_login
 %p
-  = t :email_signup_email
-  %strong
-    = @user.email
+  = t :email_signup_confirmed_email
 %p
   -# Remove http:// and trailing slashes from root url if they exist
   = t :email_signup_shop_html, link: link_to(spree.root_url.sub(/http:\/\//,"").sub(/\/$/,""), spree.root_url, target: '_blank')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,10 @@ en:
             email:
               taken: "There's already an account for this email. Please login or reset your password."
   devise:
+    confirmations:
+      send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
+      failed_to_send: "An error occurred whilst sending your confirmation email."
+      resend_confirmation_email: "Resend confirmation email."
     user_registrations:
       spree_user:
        signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,10 +67,14 @@ en:
             email:
               taken: "There's already an account for this email. Please login or reset your password."
   devise:
+    user_registrations:
+      spree_user:
+       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."
     failure:
       invalid: |
         Invalid email or password.
         Were you a guest last time?  Perhaps you need to create an account or reset your password.
+      unconfirmed: "You have to confirm your account before continuing."
     enterprise_confirmations:
       enterprise:
         confirmed: Thank you, your email address has been confirmed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1019,8 +1019,8 @@ en:
 
   email_signup_greeting: Hello!
   email_signup_welcome: "Welcome to %{sitename}!"
-  email_signup_confirmed_email: "Thanks for confirming you email."
-  email_signup_shop_html: "You can start shopping online now at %{link}."
+  email_signup_confirmed_email: "Thanks for confirming your email."
+  email_signup_shop_html: "You can now log in at %{link}."
   email_signup_text: "Thanks for joining the network.
   If you are a customer, we look forward to introducing you to many fantastic farmers, wonderful food hubs and delicious food!
   If you are a producer or food enterprise, we are excited to have you as a part of the network."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -976,14 +976,9 @@ en:
 %{link}"
   join_community: "Join the community"
   email_help: "If you have any difficulties, check out our FAQs, browse the forum or post a 'Support' topic and someone will help you out!"
-  email_confirmation_greeting: "Hi, %{contact}!"
-  email_confirmation_profile_created: "A profile for %{name} has been successfully created!
-To activate your Profile we need to confirm this email address."
+  email_confirmation_activate_account: "Before we can activate your new account, we need to confirm your email address."
   email_confirmation_click_link: "Please click the link below to confirm your email and to continue setting up your profile."
   email_confirmation_link_label: "Confirm this email address »"
-  email_confirmation_help_html: "After confirming your email you can access your administration account for this enterprise.
-See the %{link} to find out more about %{sitename}'s features and to start using your profile or online store."
-  email_confirmation_userguide: "User Guide"
   email_social: "Connect with Us:"
   email_contact: "Email us:"
   email_signoff: "Cheers,"
@@ -1016,8 +1011,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
 
   email_signup_greeting: Hello!
   email_signup_welcome: "Welcome to %{sitename}!"
-  email_signup_login: Your login
-  email_signup_email: Your login email is
+  email_signup_confirmed_email: "Thanks for confirming you email."
   email_signup_shop_html: "You can start shopping online now at %{link}."
   email_signup_text: "Thanks for joining the network.
   If you are a customer, we look forward to introducing you to many fantastic farmers, wonderful food hubs and delicious food!
@@ -2122,6 +2116,8 @@ Please follow the instructions there to make your enterprise visible on the Open
         issue_text: |
           If the above URL does not work try copying and pasting it into your browser.
           If you continue to have problems please feel free to contact us.
+      confirmation_instructions:
+        subject: Please confirm your OFN account
     weight: Weight (per kg)
     zipcode: Postcode
     users:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -858,11 +858,9 @@ fr:
   email_community_html: "Nous avons aussi un forum de discussion en ligne (en anglais) pour échanger avec la communauté sur des questions liées au logiciel OFN et aux défis de la gestion d'un food hub.  Nous vous invitons à y participer. Nous sommes en constante évolution et vos contributions à ce forum vont façonner les prochaines étapes. %{link}"
   join_community: "Rejoindre la communauté"
   email_help: "En cas de difficulté, consultez notre FAQ, parcourez le forum (en anglais) ou postez un message dans la section 'Support' et quelqu'un viendra vous aider!"
-  email_confirmation_greeting: "Bonjour %{contact}!"
-  email_confirmation_profile_created: "Le profil pour %{name} a été créé avec succès! Pour activer votre Profil nous devons vérifier cette adresse email."
+  email_confirmation_activate_account: "Pour activer votre compte, vous devez confirmer votre adresse email."
   email_confirmation_click_link: "Veuillez cliquer sur le lien ci-dessous pour confirmer votre email et continuer la configuration de votre compte."
   email_confirmation_link_label: "Confirmer cette adresse email »"
-  email_confirmation_help_html: "Après confirmation de votre email, vous pourrez accéder au compte d'administration de cette entreprise. Voir %{link} pour en savoir plus à propos de %{sitename} et commencer à utiliser votre profil et/ou boutique en ligne."
   email_confirmation_userguide: "Guide Utilisateur"
   email_social: "Nous suivre:"
   email_contact: "Nous écrire:"
@@ -894,8 +892,7 @@ fr:
   email_special_instructions: "Vos commentaires:"
   email_signup_greeting: Bonjour!
   email_signup_welcome: "Bienvenue sur %{sitename}!"
-  email_signup_login: Votre login
-  email_signup_email: Votre email de connexion est
+  email_signup_confirmed_email: "Merci d'avoir confirmé votre adresse email."
   email_signup_shop_html: "Vous pouvez maintenant commencer vos achats sur %{link}."
   email_signup_text: "Merci d'avoir rejoint le réseau. Si vous êtes un client, nous sommes impatients de vous faire découvrir de nombreux agriculteurs fantastiques, de merveilleux hubs de distribution et des plats délicieux! Si vous êtes un producteur ou autre entreprise alimentaire, nous sommes ravis de vous compter parmi les membres du réseau."
   email_signup_help_html: "Vos questions et feedbacks sont les bienvenus! Cliquez sur le bouton <em>Envoyer un commentaire</em> sur le site ou envoyez-nous un email à %{email}"
@@ -1960,6 +1957,8 @@ fr:
         issue_text: |
           Si le lien ne fonctionne pas, essayez de le copier - coller dans la barre d'adresse de votre navigateur.
           Si le problème persiste, n'hésitez pas à nous contacter.
+      confirmation_instructions:
+        subject: Veuillez confirmer votre compte OFN
     weight: Poids (au kg)
     zipcode: Code postal
     users:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -858,9 +858,11 @@ fr:
   email_community_html: "Nous avons aussi un forum de discussion en ligne (en anglais) pour échanger avec la communauté sur des questions liées au logiciel OFN et aux défis de la gestion d'un food hub.  Nous vous invitons à y participer. Nous sommes en constante évolution et vos contributions à ce forum vont façonner les prochaines étapes. %{link}"
   join_community: "Rejoindre la communauté"
   email_help: "En cas de difficulté, consultez notre FAQ, parcourez le forum (en anglais) ou postez un message dans la section 'Support' et quelqu'un viendra vous aider!"
-  email_confirmation_activate_account: "Pour activer votre compte, vous devez confirmer votre adresse email."
+  email_confirmation_greeting: "Bonjour %{contact}!"
+  email_confirmation_profile_created: "Le profil pour %{name} a été créé avec succès! Pour activer votre Profil nous devons vérifier cette adresse email."
   email_confirmation_click_link: "Veuillez cliquer sur le lien ci-dessous pour confirmer votre email et continuer la configuration de votre compte."
   email_confirmation_link_label: "Confirmer cette adresse email »"
+  email_confirmation_help_html: "Après confirmation de votre email, vous pourrez accéder au compte d'administration de cette entreprise. Voir %{link} pour en savoir plus à propos de %{sitename} et commencer à utiliser votre profil et/ou boutique en ligne."
   email_confirmation_userguide: "Guide Utilisateur"
   email_social: "Nous suivre:"
   email_contact: "Nous écrire:"
@@ -892,7 +894,8 @@ fr:
   email_special_instructions: "Vos commentaires:"
   email_signup_greeting: Bonjour!
   email_signup_welcome: "Bienvenue sur %{sitename}!"
-  email_signup_confirmed_email: "Merci d'avoir confirmé votre adresse email."
+  email_signup_login: Votre login
+  email_signup_email: Votre email de connexion est
   email_signup_shop_html: "Vous pouvez maintenant commencer vos achats sur %{link}."
   email_signup_text: "Merci d'avoir rejoint le réseau. Si vous êtes un client, nous sommes impatients de vous faire découvrir de nombreux agriculteurs fantastiques, de merveilleux hubs de distribution et des plats délicieux! Si vous êtes un producteur ou autre entreprise alimentaire, nous sommes ravis de vous compter parmi les membres du réseau."
   email_signup_help_html: "Vos questions et feedbacks sont les bienvenus! Cliquez sur le bouton <em>Envoyer un commentaire</em> sur le site ou envoyez-nous un email à %{email}"
@@ -1957,8 +1960,6 @@ fr:
         issue_text: |
           Si le lien ne fonctionne pas, essayez de le copier - coller dans la barre d'adresse de votre navigateur.
           Si le problème persiste, n'hésitez pas à nous contacter.
-      confirmation_instructions:
-        subject: Veuillez confirmer votre compte OFN
     weight: Poids (au kg)
     zipcode: Code postal
     users:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,7 +198,8 @@ Spree::Core::Engine.routes.draw do
              :class_name => 'Spree::User',
              :controllers => { :sessions => 'spree/user_sessions',
                                :registrations => 'user_registrations',
-                               :passwords => 'user_passwords' },
+                               :passwords => 'user_passwords',
+                               :confirmations => 'user_confirmations'},
              :skip => [:unlocks, :omniauth_callbacks],
              :path_names => { :sign_out => 'logout' },
              :path_prefix => :user

--- a/db/migrate/20170710145821_add_confirmable_to_user.rb
+++ b/db/migrate/20170710145821_add_confirmable_to_user.rb
@@ -5,6 +5,9 @@ class AddConfirmableToUser < ActiveRecord::Migration
     add_column :spree_users, :confirmation_sent_at, :datetime
     add_column :spree_users, :unconfirmed_email, :string
     add_index :spree_users, :confirmation_token, :unique => true
+
+    # Set users to confirmed if they previously confirmed their email for an enterprise
+    execute "UPDATE spree_users SET confirmed_at = enterprises.confirmed_at FROM enterprises WHERE spree_users.email = enterprises.email AND enterprises.confirmed_at IS NOT NULL"
   end
 
   def down

--- a/db/migrate/20170710145821_add_confirmable_to_user.rb
+++ b/db/migrate/20170710145821_add_confirmable_to_user.rb
@@ -6,8 +6,8 @@ class AddConfirmableToUser < ActiveRecord::Migration
     add_column :spree_users, :unconfirmed_email, :string
     add_index :spree_users, :confirmation_token, :unique => true
 
-    # Set users to confirmed if they previously confirmed their email for an enterprise
-    execute "UPDATE spree_users SET confirmed_at = enterprises.confirmed_at FROM enterprises WHERE spree_users.email = enterprises.email AND enterprises.confirmed_at IS NOT NULL"
+    # Set all current users to confirmed
+    Spree::User.update_all(confirmed_at: Time.zone.now)
   end
 
   def down

--- a/db/migrate/20170710145821_add_confirmable_to_user.rb
+++ b/db/migrate/20170710145821_add_confirmable_to_user.rb
@@ -1,0 +1,13 @@
+class AddConfirmableToUser < ActiveRecord::Migration
+  def up
+    add_column :spree_users, :confirmation_token, :string
+    add_column :spree_users, :confirmed_at, :datetime
+    add_column :spree_users, :confirmation_sent_at, :datetime
+    add_column :spree_users, :unconfirmed_email, :string
+    add_index :spree_users, :confirmation_token, :unique => true
+  end
+
+  def down
+    remove_columns :spree_users, :confirmation_token, :confirmed_at, :confirmation_sent_at, :unconfirmed_email
+  end
+end

--- a/db/migrate/20170717105219_copy_confirmed_at_from_enterprises_to_spree_users.rb
+++ b/db/migrate/20170717105219_copy_confirmed_at_from_enterprises_to_spree_users.rb
@@ -1,5 +1,0 @@
-class CopyConfirmedAtFromEnterprisesToSpreeUsers < ActiveRecord::Migration
-  def up
-    execute "UPDATE spree_users SET confirmed_at = enterprises.confirmed_at FROM enterprises WHERE spree_users.email = enterprises.email AND enterprises.confirmed_at IS NOT NULL"
-  end
-end

--- a/db/migrate/20170717105219_copy_confirmed_at_from_enterprises_to_spree_users.rb
+++ b/db/migrate/20170717105219_copy_confirmed_at_from_enterprises_to_spree_users.rb
@@ -1,0 +1,5 @@
+class CopyConfirmedAtFromEnterprisesToSpreeUsers < ActiveRecord::Migration
+  def up
+    execute "UPDATE spree_users SET confirmed_at = enterprises.confirmed_at FROM enterprises WHERE spree_users.email = enterprises.email AND enterprises.confirmed_at IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -221,8 +221,8 @@ ActiveRecord::Schema.define(:version => 20170710145821) do
     t.integer  "address_id"
     t.string   "pickup_times"
     t.string   "next_collection_at"
-    t.datetime "created_at",                                         :null => false
-    t.datetime "updated_at",                                         :null => false
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
     t.text     "distributor_info"
     t.string   "logo_file_name"
     t.string   "logo_content_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161215230219) do
+ActiveRecord::Schema.define(:version => 20170710145821) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -221,8 +221,8 @@ ActiveRecord::Schema.define(:version => 20161215230219) do
     t.integer  "address_id"
     t.string   "pickup_times"
     t.string   "next_collection_at"
-    t.datetime "created_at",                                   :null => false
-    t.datetime "updated_at",                                   :null => false
+    t.datetime "created_at",                                         :null => false
+    t.datetime "updated_at",                                         :null => false
     t.text     "distributor_info"
     t.string   "logo_file_name"
     t.string   "logo_content_type"
@@ -232,26 +232,31 @@ ActiveRecord::Schema.define(:version => 20161215230219) do
     t.string   "promo_image_content_type"
     t.integer  "promo_image_file_size"
     t.datetime "promo_image_updated_at"
-    t.boolean  "visible",                  :default => true
+    t.boolean  "visible",                        :default => true
     t.string   "facebook"
     t.string   "instagram"
     t.string   "linkedin"
-    t.integer  "owner_id",                                     :null => false
-    t.string   "sells",                    :default => "none", :null => false
+    t.integer  "owner_id",                                           :null => false
+    t.string   "sells",                          :default => "none", :null => false
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
     t.datetime "shop_trial_start_date"
-    t.boolean  "producer_profile_only",    :default => false
-    t.string   "permalink",                                    :null => false
-    t.boolean  "charges_sales_tax",        :default => false,  :null => false
+    t.boolean  "producer_profile_only",          :default => false
+    t.string   "permalink",                                          :null => false
+    t.boolean  "charges_sales_tax",              :default => false,  :null => false
     t.string   "email_address"
-    t.boolean  "require_login",            :default => false,  :null => false
-    t.boolean  "allow_guest_orders",       :default => true,   :null => false
+    t.boolean  "require_login",                  :default => false,  :null => false
+    t.boolean  "allow_guest_orders",             :default => true,   :null => false
     t.text     "invoice_text"
-    t.boolean  "display_invoice_logo",     :default => false
-    t.boolean  "allow_order_changes",      :default => false,  :null => false
+    t.boolean  "display_invoice_logo",           :default => false
+    t.boolean  "allow_order_changes",            :default => false,  :null => false
+    t.boolean  "require_phone_number",           :default => true
+    t.boolean  "require_bill_address",           :default => true
+    t.boolean  "hide_comment_box",               :default => false
+    t.boolean  "check_the_only_shipping_option", :default => false
+    t.boolean  "check_the_only_payment_method",  :default => false
   end
 
   add_index "enterprises", ["address_id"], :name => "index_enterprises_on_address_id"
@@ -997,8 +1002,13 @@ ActiveRecord::Schema.define(:version => 20161215230219) do
     t.datetime "reset_password_sent_at"
     t.string   "api_key",                :limit => 40
     t.integer  "enterprise_limit",                     :default => 1, :null => false
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
   end
 
+  add_index "spree_users", ["confirmation_token"], :name => "index_spree_users_on_confirmation_token", :unique => true
   add_index "spree_users", ["email"], :name => "email_idx_unique", :unique => true
   add_index "spree_users", ["persistence_token"], :name => "index_users_on_persistence_token"
 

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe UserConfirmationsController do
+  include AuthenticationWorkflow
+  let!(:user) { create_enterprise_user }
+  let!(:confirmed_user) { create_enterprise_user(confirmed_at: nil) }
+  let!(:unconfirmed_user) { create_enterprise_user(confirmed_at: nil) }
+  let!(:confirmed_token) { confirmed_user.confirmation_token }
+
+  before do
+    @request.env["devise.mapping"] = Devise.mappings[:spree_user]
+    confirmed_user.confirm!
+  end
+
+  context "confirming a user" do
+    context "that has already been confirmed" do
+
+      before do
+        spree_get :show, confirmation_token: confirmed_token
+      end
+
+      it "redirects the user to login" do
+        expect(response).to redirect_to login_path
+        expect(flash[:error]).to eq I18n.t('devise.user_confirmations.spree_user.not_confirmed')
+      end
+    end
+
+    context "that has not been confirmed" do
+      it "redirects the user to login" do
+        spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
+        expect(response).to redirect_to login_path
+        expect(flash[:success]).to eq I18n.t('devise.user_confirmations.spree_user.confirmed')
+      end
+
+      it "confirms the user" do
+        spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
+        expect(unconfirmed_user.reload.confirmed_at).not_to eq(nil)
+      end
+    end
+  end
+
+  context "requesting confirmation instructions to be resent" do
+    it "redirects the user to login" do
+      spree_post :create, { spree_user: { email: unconfirmed_user.email } }
+      expect(response).to redirect_to login_path
+      expect(flash[:success]).to eq I18n.t('devise.user_confirmations.spree_user.confirmation_sent')
+    end
+
+    it "sends the confirmation email" do
+      expect do
+        spree_post :create, { spree_user: { email: unconfirmed_user.email } }
+      end.to enqueue_job Delayed::PerformableMethod
+      expect(Delayed::Job.last.payload_object.method_name).to eq(:send_confirmation_instructions_without_delay)
+    end
+  end
+end

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -21,7 +21,6 @@ describe UserRegistrationsController do
       response.status.should == 200
       json = JSON.parse(response.body)
       json.should == {"email" => "test@test.com"}
-      controller.spree_current_user.email.should == "test@test.com"
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -419,12 +419,18 @@ FactoryGirl.modify do
   end
 
   factory :user do
+    confirmation_sent_at '1970-01-01 00:00:00'
+    confirmed_at '1970-01-01 00:00:01'
+
     after(:create) do |user|
       user.spree_roles.clear # Remove admin role
     end
   end
 
   factory :admin_user do
+    confirmation_sent_at '1970-01-01 00:00:00'
+    confirmed_at '1970-01-01 00:00:01'
+
     after(:create) do |user|
       user.spree_roles << Spree::Role.find_or_create_by_name!('admin')
     end

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -81,8 +81,8 @@ feature "Authentication", js: true, retry: 3 do
             expect do
               click_signup_button
               page.should have_content "Welcome! You have signed up successfully"
-            end.to enqueue_job ConfirmSignupJob
-            page.should be_logged_in_as "test@foo.com"
+            end.to enqueue_job Delayed::PerformableMethod
+            Delayed::Job.last.payload_object.method_name.should == :send_on_create_confirmation_instructions_without_delay
           end
         end
 

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -80,7 +80,7 @@ feature "Authentication", js: true, retry: 3 do
             fill_in "Confirm password", with: "test12345"
             expect do
               click_signup_button
-              page.should have_content "Welcome! You have signed up successfully"
+              page.should have_content I18n.t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
             end.to enqueue_job Delayed::PerformableMethod
             expect(Delayed::Job.last.payload_object.method_name).to eq(:send_on_create_confirmation_instructions_without_delay)
           end

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -82,7 +82,7 @@ feature "Authentication", js: true, retry: 3 do
               click_signup_button
               page.should have_content "Welcome! You have signed up successfully"
             end.to enqueue_job Delayed::PerformableMethod
-            Delayed::Job.last.payload_object.method_name.should == :send_on_create_confirmation_instructions_without_delay
+            expect(Delayed::Job.last.payload_object.method_name).to eq(:send_on_create_confirmation_instructions_without_delay)
           end
         end
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -77,7 +77,7 @@ describe Spree.user_class do
       expect do
         create(:user, confirmed_at: nil)
       end.to enqueue_job Delayed::PerformableMethod
-      Delayed::Job.last.payload_object.method_name.should == :send_on_create_confirmation_instructions_without_delay
+      expect(Delayed::Job.last.payload_object.method_name).to eq(:send_on_create_confirmation_instructions_without_delay)
     end
   end
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe Spree.user_class do
   include AuthenticationWorkflow
 
@@ -71,9 +73,18 @@ describe Spree.user_class do
   end
 
   context "#create" do
-    it "should send a signup email" do
+    it "should send a confirmation email" do
       expect do
-        create(:user)
+        create(:user, confirmed_at: nil)
+      end.to enqueue_job Delayed::PerformableMethod
+      Delayed::Job.last.payload_object.method_name.should == :send_on_create_confirmation_instructions_without_delay
+    end
+  end
+
+  context "confirming email" do
+    it "should send a welcome email" do
+      expect do
+        create(:user, confirmed_at: nil).confirm!
       end.to enqueue_job ConfirmSignupJob
     end
   end


### PR DESCRIPTION
#### What? Why?

Adds email confirmations to the user model as part of the #946 epic. Supercedes #1690. 

#### What should we test?

User signs up, confirmation email gets sent. 
Clicking the link in confirmation email confirms the user's account. 
User can then log in. 
If the user tries to log in before email is confirmed an appropriate message will show in the login modal.

#### Release notes

Users will now have to confirm their email after sign-up before they can log in.

#### Discourse thread

https://community.openfoodnetwork.org/t/confirmation-emails-registration-flow/237

#### Screenshots

After user signup with login modal:
![screenshot from 2017-08-15 14-10-19](https://user-images.githubusercontent.com/9029026/29317550-58337afc-81c4-11e7-8ea7-cf2d18232e67.png)

Attempting to log in:
![screenshot from 2017-08-15 14-09-59](https://user-images.githubusercontent.com/9029026/29317556-5fa222ac-81c4-11e7-8e7d-f2d714e43f3b.png)

After clicking resend confirmation:
![screenshot from 2017-08-15 14-05-53](https://user-images.githubusercontent.com/9029026/29317560-65eaa1a2-81c4-11e7-9dac-f330de857355.png)

