### PR TITLE
Translate Enterprise Relationships tab name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1573,6 +1573,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   order_cycle: "Order Cycle"
   order_cycles: "Order Cycles"
   enterprises: "Enterprises"
+  enterprise_relationships: "Enterprise relationships"
   remove_tax: "Remove tax"
   enterprise_terms_of_service: "Enterprise Terms of Service"
   enterprises_require_tos: "Enterprises must accept Terms of Service"


### PR DESCRIPTION
#### What? Why?
We need to translate the "Enterprise relationships" tab name.

![2017-08-18-163327_1366x768_scrot](https://user-images.githubusercontent.com/748971/29463806-2dbe8132-8434-11e7-8588-0e6f002884c5.png)

#### What should we test?
That we don't break the tab name.

#### Release notes
Add translation key for Enterprise Relationships tab name.