### PR TITLE
Add display flex on active table row to fix misalignment

### DIFF
--- a/app/assets/stylesheets/darkswarm/active_table.css.scss
+++ b/app/assets/stylesheets/darkswarm/active_table.css.scss
@@ -68,7 +68,11 @@
     margin-right: 0;
 
     &, & > a.row {
-      display: block;
+      display: -webkit-box;
+      display: -moz-box;
+      display: -ms-flexbox;
+      display: -webkit-flex;
+      display: flex;
     }
   }
 
@@ -96,7 +100,7 @@
 
       &:hover, &:active, &:focus {
         // color: $dark-grey
-     
+
       }
     }
 


### PR DESCRIPTION
#### What? Why?
Per #1722, the alignment in a user's Transactions table is uneven depending on the presence of a Producer's logo.  This PR uses flex and it's associated vendor prefixes to align table columns regardless of logos.

#### What should we test?
Style-only change, existing functionality tests should not be affected.

#### Discourse thread
closes #1722 