### PR TITLE
Missing translations order cycle page

### DIFF
--- a/app/views/admin/order_cycles/_add_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_add_exchange_form.html.haml
@@ -3,4 +3,4 @@
     {{ enterprise.name }}
     = "{{ enterprise.issues_summary_#{type} ? '('+enterprise.issues_summary_#{type}+')' : '' }}"
 
-= f.submit "Add #{type}", 'ng-click' => "add#{type.capitalize}($event)", 'ng-disabled' => "!new_#{type}_id || !OrderCycle.novel#{type.capitalize}(new_#{type}_id)"
+= f.submit t(".add_#{type}"), 'ng-click' => "add#{type.capitalize}($event)", 'ng-disabled' => "!new_#{type}_id || !OrderCycle.novel#{type.capitalize}(new_#{type}_id)"

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -15,10 +15,10 @@
       {{ exchange.tags.length }}
     %td.collection-details
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
-      %span.icon-question-sign{'ofn-with-tip' => t('admin.order_cycles.edit.pickup_time_tip')}
+      %span.icon-question-sign{'ofn-with-tip' => t('.pickup_time_tip')}
       %br/
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => t('.pickup_instructions_placeholder'), 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
-      %span.icon-question-sign{'ofn-with-tip' => t('admin.order_cycles.edit.pickup_instructions_tip')}
+      %span.icon-question-sign{'ofn-with-tip' => t('.pickup_instructions_tip')}
   %td.fees
     %ol{ ng: { show: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
       %li{'ng-repeat' => 'enterprise_fee in exchange.enterprise_fees'}

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -6,7 +6,7 @@
       {{ enterpriseTotalVariants(enterprises[exchange.enterprise_id]) }}
     - else
       {{ (incomingExchangeVariantsFor(exchange.enterprise_id)).length }}
-    selected
+    = t('.selected')
   - if type == 'supplier'
     %td.receival-details
       = text_field_tag 'order_cycle_incoming_exchange_{{ $index }}_receival_instructions', '', 'id' => 'order_cycle_incoming_exchange_{{ $index }}_receival_instructions', 'placeholder' => t('.receival_instructions_placeholder'), 'ng-model' => 'exchange.receival_instructions'
@@ -28,7 +28,7 @@
 
         = link_to 'Remove', '#', {'id' => 'order_cycle_{{ exchangeDirection(exchange) }}_exchange_{{ $parent.$index }}_enterprise_fees_{{ $index }}_remove', 'ng-click' => 'removeExchangeFee($event, exchange, $index)'}
 
-    = f.submit 'Add fee', 'ng-click' => 'addExchangeFee($event, exchange)', 'ng-hide' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
+    = f.submit t('.add_fee'), 'ng-click' => 'addExchangeFee($event, exchange)', 'ng-hide' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
   %td.actions
     %a{'ng-click' => 'removeExchange($event, exchange)', :class => "icon-trash no-text remove-exchange"}
 

--- a/app/views/admin/order_cycles/edit.html.haml
+++ b/app/views/admin/order_cycles/edit.html.haml
@@ -12,7 +12,7 @@
 
   - if can? :notify_producers, @order_cycle
     %li
-      = button_to "Notify producers", main_app.notify_producers_admin_order_cycle_path, :id => 'admin_notify_producers', :confirm => t(:are_you_sure)
+      = button_to t(:notify_producers), main_app.notify_producers_admin_order_cycle_path, :id => 'admin_notify_producers', :confirm => t(:are_you_sure)
   %li
     %button#toggle_settings{ onClick: 'toggleSettings()' }
       = t('.advanced_settings')
@@ -30,7 +30,7 @@
   %save-bar{ dirty: "order_cycle_form.$dirty", persist: "true" }
     %input.red{ type: "button", value: t(:update), ng: { click: "submit($event, null)", disabled: "!order_cycle_form.$dirty || order_cycle_form.$invalid" } }
     %input.red{ type: "button", value: t('.update_and_close'), ng: { click: "submit($event, '#{main_app.admin_order_cycles_path}')", disabled: "!order_cycle_form.$dirty || order_cycle_form.$invalid" } }
-    %input{ type: "button", ng: { value: "order_cycle_form.$dirty ? 'Cancel' : 'Close'", click: "cancel('#{main_app.admin_order_cycles_path}')" } }
+    %input{ type: "button", ng: { value: "order_cycle_form.$dirty ? '#{t(:cancel)}' : '#{t(:close)}'", click: "cancel('#{main_app.admin_order_cycles_path}')" } }
 
   - if order_cycles_simple_form
     = render 'simple_form', f: f

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -602,12 +602,17 @@ en:
         advanced_settings: Advanced Settings
         update_and_close: Update and Close
         choose_products_from: 'Choose Products From:'
-        pickup_time_tip: When orders from this OC will be ready for the customer
-        pickup_instructions_tip: These instructions are shown to customers after they complete an order
       exchange_form:
+        pickup_time_tip: When orders from this OC will be ready for the customer
         pickup_instructions_placeholder: "Pick-up instructions"
+        pickup_instructions_tip: These instructions are shown to customers after they complete an order
         pickup_time_placeholder: "Ready for (ie. Date / Time)"
         receival_instructions_placeholder: "Receival instructions"
+        add_fee: 'Add fee'
+        selected: 'selected'
+      add_exchange_form:
+        add_supplier: 'Add supplier'
+        add_distributor: 'Add distributor'
       advanced_settings:
         title: Advanced Settings
         choose_product_tip: You can opt to restrict all available products (both incoming and outgoing), to only those in %{inventory}'s inventory.
@@ -1507,6 +1512,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   new_order_cycles: "New Order Cycles"
   new_order_cycle: "New Order Cycle"
   select_a_coordinator_for_your_order_cycle: "Select a coordinator for your order cycle"
+  notify_producers: 'Notify producers'
   edit_order_cycle: "Edit Order Cycle"
   roles: "Roles"
   update: "Update"


### PR DESCRIPTION
#### What? Why?

As reported in https://github.com/openfoodfoundation/openfoodnetwork/issues/1778, there are still a bunch of hardcoded copies that need to be translated. I added their keys in `config/locales/en.yml`

#### What should we test?

There should be no change in an instance that has `LOCALE: en` in its `config/application.yml`. With other languages it shows as follows until the keys are not translated in transifex:

![translations](https://user-images.githubusercontent.com/762088/29922607-98c47d20-8e56-11e7-8a09-a182882e2e92.png)

#### Release notes

Added missing translations in edit order cycle page

#### Dependencies

Issue https://github.com/openfoodfoundation/openfoodnetwork/issues/1778
