### PR TITLE
Fix i18n translation keys for New Product Page

### DIFF
--- a/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/new/replace_form.html.haml.deface
@@ -19,14 +19,14 @@
     .twelve.columns.alpha{ 'ng-controller' => 'unitsCtrl' }
       .six.columns.alpha
         = f.field_container :units do
-          = f.label :variant_unit_with_scale, :units
+          = f.label :variant_unit_with_scale, t(:units)
           %select.select2.fullwidth{ id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options' }
             %option{'value' => '', 'ng-hide' => "hasUnit(product)"}
           %input{ type: 'hidden', 'ng-value' => 'product.variant_unit', name: 'product[variant_unit]' }
           %input{ type: 'hidden', 'ng-value' => 'product.variant_unit_scale', name: 'product[variant_unit_scale]' }
       .three.columns
         = f.field_container :unit_value do
-          = f.label :product_unit_value_with_description, :value, 'ng-disabled' => "!hasUnit(product)"
+          = f.label :product_unit_value_with_description, t(:value), 'ng-disabled' => "!hasUnit(product)"
           %input.fullwidth{ id: 'product_unit_value_with_description', 'ng-model' => 'product.master.unit_value_with_description', :type => 'text', placeholder: "eg. 2", 'ng-disabled' => "!hasUnit(product)" }
           %input{ type: 'hidden', 'ng-value' => 'product.master.unit_value', name: 'product[unit_value]' }
           %input{ type: 'hidden', 'ng-value' => 'product.master.unit_description', name: 'product[unit_description]' }
@@ -87,7 +87,7 @@
     = button t('actions.create'), 'icon-ok', :submit, value: "create"
     %span.or
       = t(:or)
-    = button "Create And Add Another", 'icon-repeat', :submit, value: 'add_another'
+    = button t('actions.create_and_add_another'), 'icon-repeat', :submit, value: 'add_another'
     %span.or
       = t(:or)
     = link_to_with_icon 'icon-remove', t('actions.cancel'), bulk_edit_admin_products_path, :class => 'button'

--- a/app/views/spree/admin/products/_display_as.html.haml
+++ b/app/views/spree/admin/products/_display_as.html.haml
@@ -1,4 +1,4 @@
 .three.columns.omega{ "ng-if" => "product.variant_unit_with_scale != 'items'" }
   = f.field_container :display_as do
-    = f.label :product_display_as, t(:display_as)
+    = f.label :product_display_as, t('.display_as')
     %input#product_display_as.fullwidth{name: "product[display_as]", placeholder: "{{ placeholder_text }}", type: "text"}

--- a/app/views/spree/admin/products/_primary_taxon_form.html.haml
+++ b/app/views/spree/admin/products/_primary_taxon_form.html.haml
@@ -1,5 +1,5 @@
 = f.field_container :primary_taxon_id do
-  = f.label :primary_taxon_id, t(:product_category)
+  = f.label :primary_taxon_id, t('.product_category')
   %span.required *
   %br
   = f.collection_select(:primary_taxon_id, Spree::Taxon.all, :id, :name, {:include_blank => true}, {:class => "select2 fullwidth"})

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,7 +161,8 @@ en:
   powered_by: Powered by
   blocked_cookies_alert: "Your browser may be blocking cookies needed to use this shopfront. Click below to allow cookies and reload the page."
   allow_cookies: "Allow Cookies"
-
+  actions:
+      create_and_add_another: "Create and Add Another"
   admin:
     # Common properties / models
     date: Date
@@ -1484,6 +1485,9 @@ Please follow the instructions there to make your enterprise visible on the Open
   create: "Create"
   search: "Search"
   supplier: "Supplier"
+  product_name: "Product Name"
+  product_description: "Product Description"
+  units: "Unit Size"
   coordinator: "Coordinator"
   distributor: "Distributor"
   enterprise_fees: "Enterprise Fees"
@@ -2037,6 +2041,7 @@ Please follow the instructions there to make your enterprise visible on the Open
             other: "You have %{count} active order cycles."
           manage_order_cycles: "MANAGE ORDER CYCLES"
       products:
+        unit_name_placeholder: 'eg. bunches'
         bulk_edit:
           header:
             title: Bulk Edit Products
@@ -2044,6 +2049,11 @@ Please follow the instructions there to make your enterprise visible on the Open
             title: LOADING PRODUCTS
             no_products: "No products yet. Why don't you add some?"
             no_results: "Sorry, no results match"
+          product_name: Product Name
+        primary_taxon_form:
+          product_category: Product Category
+        display_as:
+          display_as: Display As
       reports:
         bulk_coop:
           bulk_coop_supplier_report: 'Bulk Co-op - Totals by Supplier'


### PR DESCRIPTION
Hi all
This is my first contribution to the OFN project. The new product page looks better now. 
Please @sauloperez @NickWeir63 if you like, please review this PR..
Always glad to help.
I hope all good.
Tks.
Leandro.

#### What? Why?

As reported in #1789, there are some issue with missing i18n keys and hardcoded texts which needs to be translated. I added their keys in config/locales/en.yml

#### What should we test?

Added some new i18n translations keys and fixed some hardcoded texts.

![image](https://user-images.githubusercontent.com/3020581/29998243-0ac15038-901e-11e7-8776-e9d473cbdd5e.png)

#### Release notes

Added missing translations in new product page.

#### Dependencies

#1789 