### PR TITLE
Uk/1626shipping method ordering

### DIFF
--- a/app/views/checkout/_shipping.html.haml
+++ b/app/views/checkout/_shipping.html.haml
@@ -14,7 +14,7 @@
       = render 'checkout/accordion_heading'
 
       .small-12.columns.medium-12.columns.large-6.columns
-        %label{"ng-repeat" => "method in ShippingMethods.shipping_methods"}
+        %label{"ng-repeat" => "method in ShippingMethods.shipping_methods | orderBy: 'name'"}
           %input{type: :radio,
             required: true,
             name: "order.shipping_method_id",

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -224,10 +224,13 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
       it "shows all shipping methods in order by name" do
         toggle_shipping
-        shipping_methods = page.all(:xpath, '//*[@id="shipping"]/ng-form/dd/div/div[1]').map {|row| row.all('label').map(&:text)}.flatten
-        expect(shipping_methods[0]).to include(sm2.name) # Donkeys
-        expect(shipping_methods[1]).to include(sm1.name) # Frogs
-        expect(shipping_methods[2]).to include(sm3.name) # Local       
+        within '#shipping' do
+          expect(page).to have_selector "label", count: 4 # Three shipping methods + instructions label
+          labels = page.all('label').map(&:text)
+          expect(labels[0]).to start_with("Donkeys") # sm2
+          expect(labels[1]).to start_with("Frogs") # sm1
+          expect(labels[2]).to start_with("Local") # sm3
+        end
       end
 
       context "when shipping method requires an address" do

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -222,11 +222,12 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         page.should_not have_content product.tax_category.name
       end
 
-      it "shows all shipping methods" do
+      it "shows all shipping methods in order by name" do
         toggle_shipping
-        page.should have_content "Frogs"
-        page.should have_content "Donkeys"
-        page.should have_content "Local"
+        shipping_methods = page.all(:xpath, '//*[@id="shipping"]/ng-form/dd/div/div[1]').map {|row| row.all('label').map(&:text)}.flatten
+        expect(shipping_methods[0]).to include(sm2.name) # Donkeys
+        expect(shipping_methods[1]).to include(sm1.name) # Frogs
+        expect(shipping_methods[2]).to include(sm3.name) # Local       
       end
 
       context "when shipping method requires an address" do


### PR DESCRIPTION
_Based off a branch of @Duende13 that did not create a build for testing. Original PR has been code reviewed and approved. Thanks all. PR #1654_ 

#### What? Why?

Shipping methods are displayed in a random order to the user at checkout, making it confusing and difficult to be creative in displaying options. This PR ensures that shipping methods are displayed alphabetically.

#### What should we test?

On checkout, shipping methods should be displayed to the user in alphabetical and then numerical order.

#### Release notes

Shipping methods will now be displayed to the customer in alphabetical order, making it easier control how shipping method options are displayed to customers.
