### PR TITLE
Change title when navigating to new product page

### DIFF
--- a/app/views/spree/admin/products/new.js.erb
+++ b/app/views/spree/admin/products/new.js.erb
@@ -1,0 +1,12 @@
+<%# This chunk is just a copy of Spree's core/app/views/spree/admin/products/new.js.erb %>
+$("#new_product").html('<%= escape_javascript(render :template => "spree/admin/products/new", :formats => [:html], :handlers => [:erb]) %>');
+handle_date_picker_fields();
+<% unless Rails.env.test? %>
+  $('.select2').select2();
+<% end %>
+$("#table-filter").hide();
+$("#admin_new_product").parent().hide();
+
+<%# We need to replace the page's title as well. We're navigating to a new page
+  although through ajax %>
+$('#content-header .page-title').html('<%= t('.title') %>');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2056,6 +2056,8 @@ Please follow the instructions there to make your enterprise visible on the Open
             other: "You have %{count} active order cycles."
           manage_order_cycles: "MANAGE ORDER CYCLES"
       products:
+        new:
+          title: 'New Product'
         unit_name_placeholder: 'eg. bunches'
         bulk_edit:
           header:


### PR DESCRIPTION
#### What? Why?

I'm trying to solve the missing title translation from https://github.com/openfoodfoundation/openfoodnetwork/issues/1801. It turned out to be not so simple :sweat: .

We navigate to the new product page by replacing the current page contents through an ajax call, so we also need change the section title with JS.

#### What should we test?

I'd be good to check the edit and new product pages.

#### Dependencies

https://github.com/openfoodfoundation/openfoodnetwork/issues/1801