### PR TITLE
Fix i18n translation keys for Edit Product Page

### DIFF
--- a/app/overrides/spree/admin/products/_form/add_supplier.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_supplier.html.haml.deface
@@ -1,7 +1,7 @@
 / insert_top "[data-hook='admin_product_form_right']"
 
 = f.field_container :supplier do
-  = f.label :supplier
+  = f.label :supplier, t(:spree_admin_supplier)
   %br
   = f.collection_select(:supplier_id, @producers, :id, :name, {:include_blank => true}, {:class => "select2"})
   = f.error_message_on :supplier

--- a/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_units_form.html.haml.deface
@@ -3,7 +3,7 @@
 .variant_units_form{ 'ng-app' => 'admin.products', 'ng-controller' => 'editUnitsCtrl' }
 
   = f.field_container :units do
-    = f.label :variant_unit_with_scale, :units
+    = f.label :variant_unit_with_scale, t(:spree_admin_variant_unit_scale)
     %select.select2.fullwidth{ id: 'product_variant_unit_with_scale', 'ng-model' => 'variant_unit_with_scale', 'ng-change' => 'setFields()', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options' }
       %option{'value' => ''}
 

--- a/app/views/spree/admin/products/_group_buy_form.html.haml
+++ b/app/views/spree/admin/products/_group_buy_form.html.haml
@@ -1,14 +1,14 @@
 = f.field_container :group_buy do
-  = f.label :group_buy, 'Group buy?'
+  = f.label :group_buy, t('.group_buy')
   %br
   .alpha.two.columns
-    = f.radio_button :group_buy, '1', :checked => f.object.group_buy
-    = f.label :group_buy_1, 'Yes'
+    = f.radio_button :group_buy, '1', checked: f.object.group_buy
+    = f.label :group_buy_1, t(:yes)
   .alpha.two.columns
-    = f.radio_button :group_buy, '0', :checked => !f.object.group_buy
-    = f.label :group_buy_0, 'No'
+    = f.radio_button :group_buy, '0', checked: !f.object.group_buy
+    = f.label :group_buy_0, t(:no)
 %br.clear
 = f.field_container :group_buy_unit_size do
-  = f.label :group_buy_unit_size, "Bulk unit size"
+  = f.label :group_buy_unit_size, t('.bulk_unit_size')
   %br
   = f.text_field :group_buy_unit_size

--- a/app/views/spree/admin/products/_tax_category_form.html.haml
+++ b/app/views/spree/admin/products/_tax_category_form.html.haml
@@ -2,5 +2,5 @@
   = f.label :tax_category_id, t(:tax_category)
   %span.required *
   %br
-  = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, {:include_blank => Spree::Config.products_require_tax_category ? false : 'None'}, {:class => "select2 fullwidth"})
+  = f.collection_select(:tax_category_id, Spree::TaxCategory.all, :id, :name, {:include_blank => Spree::Config.products_require_tax_category ? false : t(:none)}, {:class => "select2 fullwidth"})
   = f.error_message_on :tax_category_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,8 +161,10 @@ en:
   powered_by: Powered by
   blocked_cookies_alert: "Your browser may be blocking cookies needed to use this shopfront. Click below to allow cookies and reload the page."
   allow_cookies: "Allow Cookies"
+  none: None
+  notes: Notes
   actions:
-      create_and_add_another: "Create and Add Another"
+    create_and_add_another: "Create and Add Another"
   admin:
     # Common properties / models
     date: Date
@@ -937,6 +939,7 @@ en:
   checkout_shipping_price: Shipping
   checkout_total_price: Total
   checkout_back_to_cart: "Back to Cart"
+  cost_currency: "Cost Currency"
 
   order_paid: PAID
   order_not_paid: NOT PAID
@@ -1549,6 +1552,8 @@ Please follow the instructions there to make your enterprise visible on the Open
   spree_admin_unit_description: Unit Description
   spree_admin_variant_unit: Variant unit
   spree_admin_variant_unit_scale: Variant unit scale
+  spree_admin_supplier: Supplier
+  spree_admin_product_category: Product Category
   spree_admin_variant_unit_name: Variant unit name
   change_package: "Change Package"
   spree_admin_single_enterprise_hint: "Hint: To allow people to find you, turn on your visibility under"
@@ -2052,6 +2057,9 @@ Please follow the instructions there to make your enterprise visible on the Open
           product_name: Product Name
         primary_taxon_form:
           product_category: Product Category
+        group_buy_form:
+          group_buy: "Group Buy?"
+          bulk_unit_size: Bulk unit size
         display_as:
           display_as: Display As
       reports:

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -95,7 +95,7 @@ feature %q{
       visit spree.edit_admin_product_path(product)
 
       choose 'product_group_buy_1'
-      fill_in 'Bulk unit size', :with => '10'
+      fill_in 'product_group_buy_unit_size', with: '10'
 
       click_button 'Update'
 


### PR DESCRIPTION
Hi everyone,
The idea of this PR is too fix some missing translations on edit product page.
Always glad to help.
I hope all good.
Tks.
Leandro.

#### What? Why?

As reported in #1789, there are some issue with missing i18n keys and hardcoded texts which needs to be translated. I added their keys in config/locales/en.yml

#### What should we test?

Added some new i18n translations keys and fixed some hardcoded texts.

#### Release notes

Added missing translations in edit product page.

I realised that the `unit_weight` tag is stored in `spree_option_type` database table. So it's unlikely to have this option 'translated' in production mode as the database seeds should be specific for each language.

#### Dependencies

#1789 