### PR TITLE
Disable create profile on submit

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/registration/registration_form_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/registration/registration_form_controller.js.coffee
@@ -1,15 +1,23 @@
 Darkswarm.controller "RegistrationFormCtrl", ($scope, RegistrationService, EnterpriseRegistrationService) ->
   $scope.submitted = false
+  $scope.isDisabled = false
 
   $scope.valid = (form) ->
     $scope.submitted = !form.$valid
     form.$valid
 
   $scope.create = (form) ->
-    EnterpriseRegistrationService.create() if $scope.valid(form)
+    $scope.disableButton()
+    EnterpriseRegistrationService.create($scope.enableButton) if $scope.valid(form)
 
   $scope.update = (nextStep, form) ->
     EnterpriseRegistrationService.update(nextStep) if $scope.valid(form)
 
   $scope.selectIfValid = (nextStep, form) ->
     RegistrationService.select(nextStep) if $scope.valid(form)
+
+  $scope.disableButton = ->
+    $scope.isDisabled = true
+
+  $scope.enableButton = ->
+    $scope.isDisabled = false

--- a/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
@@ -11,6 +11,10 @@ Darkswarm.factory "EnterpriseRegistrationService", ($http, RegistrationService, 
       for key, value of enterpriseAttributes
         @enterprise[key] = value
 
+    # Creates the enterprise and redirects to the about step on success.
+    #
+    # @param callback [Function] executed at the end of the operation both in
+    #   case of success or failure.
     create: (callback) =>
       Loading.message = t('creating') + " " + @enterprise.name
       $http(

--- a/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
@@ -11,7 +11,7 @@ Darkswarm.factory "EnterpriseRegistrationService", ($http, RegistrationService, 
       for key, value of enterpriseAttributes
         @enterprise[key] = value
 
-    create: =>
+    create: (callback) =>
       Loading.message = t('creating') + " " + @enterprise.name
       $http(
         method: "POST"
@@ -25,6 +25,7 @@ Darkswarm.factory "EnterpriseRegistrationService", ($http, RegistrationService, 
         @enterprise.id = data
         EnterpriseImageService.configure(@enterprise)
         RegistrationService.select('about')
+        callback.call()
       ).error((data) =>
         Loading.clear()
         if data?.errors?
@@ -32,6 +33,8 @@ Darkswarm.factory "EnterpriseRegistrationService", ($http, RegistrationService, 
           alert t('failed_to_create_enterprise') + "\n" + errors.join('\n')
         else
           alert(t('failed_to_create_enterprise_unknown'))
+
+        callback.call()
       )
 
     update: (step) =>

--- a/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
@@ -29,7 +29,6 @@ Darkswarm.factory "EnterpriseRegistrationService", ($http, RegistrationService, 
         @enterprise.id = data
         EnterpriseImageService.configure(@enterprise)
         RegistrationService.select('about')
-        callback.call()
       ).error((data) =>
         Loading.clear()
         if data?.errors?
@@ -37,9 +36,8 @@ Darkswarm.factory "EnterpriseRegistrationService", ($http, RegistrationService, 
           alert t('failed_to_create_enterprise') + "\n" + errors.join('\n')
         else
           alert(t('failed_to_create_enterprise_unknown'))
-
-        callback.call()
       )
+      callback.call() if callback?
 
     update: (step) =>
       Loading.message = t('updating') + " " + @enterprise.name

--- a/app/views/registration/steps/_type.html.haml
+++ b/app/views/registration/steps/_type.html.haml
@@ -45,4 +45,4 @@
       .row.buttons
         .small-12.columns
           %input.button.secondary{ type: "button", value: "{{'back' | t}}", ng: { click: "select('contact')" } }
-          %input.button.primary.right{ type: "submit", value: "{{'create_profile' | t}}" }
+          %input.button.primary.right{ ng: { disabled: 'isDisabled' }, type: "submit", value: "{{'create_profile' | t}}" }


### PR DESCRIPTION
#### What? Why?

This prevents people re-submitting the form multiple times. Although the backend validates it, we show an ugly alert message that is hard for users to understand. It's better in terms of UX/UI if we avoid that situation in the first place.

This fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/1791

#### What should we test?

The whole registration form. It should work as always but if there was some lag while creating the enterprise, you shouldn't be able to resubmit the form.

#### Dependencies

https://github.com/openfoodfoundation/openfoodnetwork/issues/1791
