### PR TITLE
Missing translations in Enterprise Registration

### DIFF
--- a/app/views/registration/steps/_contact.html.haml
+++ b/app/views/registration/steps/_contact.html.haml
@@ -12,18 +12,18 @@
         .small-12.medium-12.large-7.columns
           .row
             .small-12.columns.field
-              %label{ for: 'enterprise_contact' } {{'enterprise_contact' | t}}:
-              %input.chunky.small-12.columns{ id: 'enterprise_contact', name: 'contact', required: true, placeholder: t(:enterprise_contact_placeholder), ng: { model: 'enterprise.contact' } }
+              %label{ for: 'enterprise_contact' } {{'enterprise.registration.modal.steps.contact.contact_field' | t}}:
+              %input.chunky.small-12.columns{ id: 'enterprise_contact', name: 'contact', required: true, placeholder: "{{'enterprise.registration.modal.steps.contact.contact_field_placeholder' | t}}", ng: { model: 'enterprise.contact' } }
               %span.error.small-12.columns{ ng: { show: "contact.contact.$error.required && submitted" } }
-                {{'enterprise_contact_required' | t}}
+                {{'enterprise.registration.modal.steps.contact.contact_field_required' | t}}
           .row
             .small-12.columns.field
-              %label{ for: 'enterprise_email_address' } {{'enterprise_email_address' | t}}:
-              %input.chunky.small-12.columns{ id: 'enterprise_email_address', name: 'email_address', type: 'email', placeholder: t(:enterprise_email_placeholder), ng: { model: 'enterprise.email_address' } }
+              %label{ for: 'enterprise_email_address' } {{'enterprise.registration.modal.steps.contact.email_field' | t}}:
+              %input.chunky.small-12.columns{ id: 'enterprise_email_address', name: 'email_address', type: 'email', placeholder: "{{'enterprise.registration.modal.steps.contact.email_field_placeholder' | t}}", ng: { model: 'enterprise.email_address' } }
           .row
             .small-12.columns.field
-              %label{ for: 'enterprise_phone' } {{'enterprise_phone' | t}}:
-              %input.chunky.small-12.columns{ id: 'enterprise_phone', name: 'phone', placeholder: t(:enterprise_phone_placeholder), ng: { model: 'enterprise.phone' } }
+              %label{ for: 'enterprise_phone' } {{'enterprise.registration.modal.steps.contact.phone_field' | t}}:
+              %input.chunky.small-12.columns{ id: 'enterprise_phone', name: 'phone', placeholder: "{{'enterprise.registration.modal.steps.contact.phone_field_placeholder' | t}}", ng: { model: 'enterprise.phone' } }
         .small-12.medium-12.large-5.hide-for-small-only
 
       .row.buttons

--- a/app/views/registration/steps/_contact.html.haml
+++ b/app/views/registration/steps/_contact.html.haml
@@ -13,17 +13,17 @@
           .row
             .small-12.columns.field
               %label{ for: 'enterprise_contact' } {{'enterprise_contact' | t}}:
-              %input.chunky.small-12.columns{ id: 'enterprise_contact', name: 'contact', required: true, placeholder: "Contact Name", ng: { model: 'enterprise.contact' } }
+              %input.chunky.small-12.columns{ id: 'enterprise_contact', name: 'contact', required: true, placeholder: t(:enterprise_contact_placeholder), ng: { model: 'enterprise.contact' } }
               %span.error.small-12.columns{ ng: { show: "contact.contact.$error.required && submitted" } }
                 {{'enterprise_contact_required' | t}}
           .row
             .small-12.columns.field
               %label{ for: 'enterprise_email_address' } {{'enterprise_email_address' | t}}:
-              %input.chunky.small-12.columns{ id: 'enterprise_email_address', name: 'email_address', type: 'email', placeholder: "eg. charlie@thefarm.com", ng: { model: 'enterprise.email_address' } }
+              %input.chunky.small-12.columns{ id: 'enterprise_email_address', name: 'email_address', type: 'email', placeholder: t(:enterprise_email_placeholder), ng: { model: 'enterprise.email_address' } }
           .row
             .small-12.columns.field
               %label{ for: 'enterprise_phone' } {{'enterprise_phone' | t}}:
-              %input.chunky.small-12.columns{ id: 'enterprise_phone', name: 'phone', placeholder: "eg. (03) 1234 5678", ng: { model: 'enterprise.phone' } }
+              %input.chunky.small-12.columns{ id: 'enterprise_phone', name: 'phone', placeholder: t(:enterprise_phone_placeholder), ng: { model: 'enterprise.phone' } }
         .small-12.medium-12.large-5.hide-for-small-only
 
       .row.buttons

--- a/app/views/registration/steps/_details.html.haml
+++ b/app/views/registration/steps/_details.html.haml
@@ -4,59 +4,59 @@
     .row
       .small-12.columns
         %header
-          %h2 {{'registration_detail_headline' | t}}
-          %h5{ ng: { if: "::enterprise.type != 'own'" } } {{'registration_detail_enterprise' | t}}
-          %h5{ ng: { if: "::enterprise.type == 'own'" } } {{'registration_detail_producer' | t}}
+          %h2 {{'enterprise.registration.modal.steps.details.headline' | t}}
+          %h5{ ng: { if: "::enterprise.type != 'own'" } } {{'enterprise.registration.modal.steps.details.enterprise' | t}}
+          %h5{ ng: { if: "::enterprise.type == 'own'" } } {{'enterprise.registration.modal.steps.details.producer' | t}}
 
     %form{ name: 'details', novalidate: true, ng: { controller: "RegistrationFormCtrl", submit: "selectIfValid('contact',details)" } }
 
       .row
         .small-12.medium-9.large-12.columns.end
           .field
-            %label{ for: 'enterprise_name', ng: { if: "::enterprise.type != 'own'" } } {{'registration_detail_name_enterprise' | t}}
-            %label{ for: 'enterprise_name', ng: { if: "::enterprise.type == 'own'" } } {{'registration_detail_name_producer' | t}}
-            %input.chunky{ id: 'enterprise_name', name: 'name', placeholder: "{{'registration_detail_name_placeholder' | t}}", required: true, ng: { model: 'enterprise.name' } }
+            %label{ for: 'enterprise_name', ng: { if: "::enterprise.type != 'own'" } } {{'enterprise.registration.modal.steps.details.enterprise_name_field' | t}}
+            %label{ for: 'enterprise_name', ng: { if: "::enterprise.type == 'own'" } } {{'enterprise.registration.modal.steps.details.producer_name_field' | t}}
+            %input.chunky{ id: 'enterprise_name', name: 'name', placeholder: "{{'enterprise.registration.modal.steps.details.producer_name_field_placeholder' | t}}", required: true, ng: { model: 'enterprise.name' } }
             %span.error{ ng: { show: "details.name.$error.required && submitted" } }
-              {{'registration_detail_name_error' | t}}
+              {{'enterprise.registration.modal.steps.details.producer_name_field_error' | t}}
 
       .row
         .small-12.medium-9.large-6.columns
           .field
-            %label{ for: 'enterprise_address' } {{'registration_detail_address1' | t}}
-            %input.chunky{ id: 'enterprise_address', name: 'address1', required: true, placeholder: "{{'registration_detail_address1_placeholder' | t}}", required: true, ng: { model: 'enterprise.address.address1' } }
+            %label{ for: 'enterprise_address' } {{'enterprise.registration.modal.steps.details.address1_field' | t}}
+            %input.chunky{ id: 'enterprise_address', name: 'address1', required: true, placeholder: "{{'enterprise.registration.modal.steps.details.address1_field_placeholder' | t}}", required: true, ng: { model: 'enterprise.address.address1' } }
             %span.error{ ng: { show: "details.address1.$error.required && submitted" } }
-              {{'registration_detail_address1_error' | t}}
+              {{'enterprise.registration.modal.steps.details.address1_field_error' | t}}
           .field
-            %label{ for: 'enterprise_address2' } {{'registration_detail_address2' | t}}
+            %label{ for: 'enterprise_address2' } {{'enterprise.registration.modal.steps.details.address2_field' | t}}
             %input.chunky{ id: 'enterprise_address2', name: 'address2', required: false, placeholder: "", required: false, ng: { model: 'enterprise.address.address2' } }
 
         .small-12.medium-9.large-6.columns.end
           .row
             .small-12.medium-8.large-8.columns
               .field
-                %label{ for: 'enterprise_city' } {{'registration_detail_suburb' | t}}
-                %input.chunky{ id: 'enterprise_city', name: 'city', required: true, placeholder: "{{'registration_detail_suburb_placeholder' | t}}", ng: { model: 'enterprise.address.city' } }
+                %label{ for: 'enterprise_city' } {{'enterprise.registration.modal.steps.details.suburb_field' | t}}
+                %input.chunky{ id: 'enterprise_city', name: 'city', required: true, placeholder: "{{'enterprise.registration.modal.steps.details.suburb_field_placeholder' | t}}", ng: { model: 'enterprise.address.city' } }
                 %span.error{ ng: { show: "details.city.$error.required && submitted" } }
-                  {{'registration_detail_suburb_error' | t}}
+                  {{'enterprise.registration.modal.steps.details.suburb_field_error' | t}}
             .small-12.medium-4.large-4.columns
               .field
-                %label{ for: 'enterprise_zipcode' } {{'registration_detail_postcode' | t}}
-                %input.chunky{ id: 'enterprise_zipcode', name: 'zipcode', required: true, placeholder: "{{'registration_detail_postcode_placeholder' | t}}", ng: { model: 'enterprise.address.zipcode' } }
+                %label{ for: 'enterprise_zipcode' } {{'enterprise.registration.modal.steps.details.postcode_field' | t}}
+                %input.chunky{ id: 'enterprise_zipcode', name: 'zipcode', required: true, placeholder: "{{'enterprise.registration.modal.steps.details.postcode_field_placeholder' | t}}", ng: { model: 'enterprise.address.zipcode' } }
                 %span.error{ ng: { show: "details.zipcode.$error.required && submitted" } }
-                  {{'registration_detail_postcode_error' | t}}
+                  {{'enterprise.registration.modal.steps.details.postcode_field_error' | t}}
           .row
             .small-12.medium-4.large-4.columns
               .field
-                %label{ for: 'enterprise_state' } {{'registration_detail_state' | t}}
+                %label{ for: 'enterprise_state' } {{'enterprise.registration.modal.steps.details.state_field' | t}}
                 %select.chunky{ id: 'enterprise_state', name: 'state', ng: { model: 'enterprise.address.state_id', options: 's.id as s.abbr for s in enterprise.country.states', show: 'countryHasStates()', required: 'countryHasStates()' } }
                 %span.error{ ng: { show: "details.state.$error.required && submitted" } }
-                  {{'registration_detail_state_error' | t}}
+                  {{'enterprise.registration.modal.steps.details.state_field_error' | t}}
             .small-12.medium-8.large-8.columns
               .field
-                %label{ for: 'enterprise_country' } {{'registration_detail_country' | t}}
+                %label{ for: 'enterprise_country' } {{'enterprise.registration.modal.steps.details.country_field' | t}}
                 %select.chunky{ id: 'enterprise_country', name: 'country', required: true, ng: { init: "setDefaultCountry(#{Spree::Config[:default_country_id]})", model: 'enterprise.country', options: 'c as c.name for c in countries' } }
                 %span.error{ ng: { show: "details.country.$error.required && submitted" } }
-                  {{'registration_detail_country_error' | t}}
+                  {{'enterprise.registration.modal.steps.details.country_field_error' | t}}
 
 
       .row.buttons

--- a/app/views/registration/steps/_steps.html.haml
+++ b/app/views/registration/steps/_steps.html.haml
@@ -1,4 +1,5 @@
 %script{ type: "text/ng-template", id: "registration/steps.html" }
   .row#progress-bar
     .small-12.medium-2.columns.item{ ng: { repeat: 'step in steps', class: "{active: (currentStep() == step),'show-for-medium-up': (currentStep() != step)}" } }
-      {{ $index+1 + ". " + step }}
+      {{ $index+1 + ". " + ('enterprise.registration.modal.steps.' + step + '.title' | t) }}
+

--- a/app/views/registration/steps/_type.html.haml
+++ b/app/views/registration/steps/_type.html.haml
@@ -6,9 +6,9 @@
     .row
       .small-12.columns
         %header
-          %h2{ "ng-bind" => "'registration_type_headline' | t:{enterprise: enterprise.name}" }
+          %h2{ "ng-bind" => "'enterprise.registration.modal.steps.type.headline' | t:{enterprise: enterprise.name}" }
           %h4
-            {{'registration_type_question' | t}}
+            {{'enterprise.registration.modal.steps.type.question' | t}}
 
     %form{ name: 'type', novalidate: true, ng: { controller: "RegistrationFormCtrl", submit: "create(type)" } }
       .row#enterprise-types{ 'data-equalizer' => true, ng: { if: "::enterprise.type != 'own'" } }
@@ -17,30 +17,30 @@
             .small-12.medium-6.large-6.columns{ 'data-equalizer-watch' => true }
               %a.btnpanel#producer-panel{ href: "#", ng: { click: "enterprise.is_primary_producer = true", class: "{selected: enterprise.is_primary_producer}" } }
                 %i.ofn-i_059-producer
-                %h4 {{'registration_type_producer' | t}}
+                %h4 {{'enterprise.registration.modal.steps.type.yes_producer' | t}}
 
             .small-12.medium-6.large-6.columns{ 'data-equalizer-watch' => true }
               %a.btnpanel#hub-panel{ href: "#", ng: { click: "enterprise.is_primary_producer = false", class: "{selected: enterprise.is_primary_producer == false}" } }
                 %i.ofn-i_063-hub
-                %h4 {{'registration_type_no_producer' | t}}
+                %h4 {{'enterprise.registration.modal.steps.type.no_producer' | t}}
 
           .row
             .small-12.columns
               %input.chunky{ id: 'enterprise_is_primary_producer', name: 'is_primary_producer', hidden: true, required: true, ng: { model: 'enterprise.is_primary_producer' } }
               %span.error{ ng: { show: "type.is_primary_producer.$error.required && submitted" } }
-                {{'registration_type_error' | t}}
+                {{'enterprise.registration.modal.steps.type.producer_field_error' | t}}
           .row
             .small-12.columns
               .panel.callout
                 .left
                   %i.ofn-i_013-help
                   &nbsp;
-                %p {{'registration_type_producer_help' | t}}
+                %p {{'enterprise.registration.modal.steps.type.yes_producer_help' | t}}
               .panel.callout
                 .left
                   %i.ofn-i_013-help
                   &nbsp;
-                %p {{'registration_type_no_producer_help' | t}}
+                %p {{'enterprise.registration.modal.steps.type.no_producer_help' | t}}
 
       .row.buttons
         .small-12.columns

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1311,6 +1311,50 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   reset_password: "Reset password"
   registration_greeting: "Greetings!"
   who_is_managing_enterprise: "Who is responsible for managing %{enterprise}?"
+  enterprise:
+    registration:
+      modal:
+        steps:
+          details:
+            title: 'Details'
+            headline: "Let's Get Started"
+            enterprise: "Woot! First we need to know a little bit about your enterprise:"
+            producer: "Woot! First we need to know a little bit about your farm:"
+            enterprise_name_field: "Enterprise Name:"
+            producer_name_field: "Farm Name:"
+            producer_name_field_placeholder: "e.g. Charlie's Awesome Farm"
+            producer_name_field_error: "Please choose a unique name for your enterprise"
+            address1_field: "Address line 1:"
+            address1_field_placeholder: "e.g. 123 Cranberry Drive"
+            address1_field_error: "Please enter an address"
+            address2_field: "Address line 2:"
+            suburb_field: "Suburb:"
+            suburb_field_placeholder: "e.g. Northcote"
+            suburb_field_error: "Please enter a suburb"
+            postcode_field: "Postcode:"
+            postcode_field_placeholder: "e.g. 3070"
+            postcode_field_error: "Postcode required"
+            state_field: "State:"
+            state_field_error: "State required"
+            country_field: "Country:"
+            country_field_error: "Please select a country"
+          contact:
+            title: 'Contact'
+            contact_field: 'Primary Contact'
+            contact_field_placeholder: 'Contact Name'
+            contact_field_required: "You need to enter a primary contact."
+            email_field: 'Email address'
+            email_field_placeholder: 'eg. charlie@thefarm.com'
+            phone_field: 'Phone number'
+            phone_field_placeholder: 'eg. (03) 1234 5678'
+          type:
+            title: 'Type'
+          about:
+            title: 'About'
+          images:
+            title: 'Images'
+          social:
+            title: 'Social'
   enterprise_contact: "Primary Contact"
   enterprise_contact_placeholder: "Contact Name"
   enterprise_contact_required: "You need to enter a primary contact."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1363,6 +1363,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             title: 'Images'
           social:
             title: 'Social'
+  # TODO: Remove these once the enterprise.registration.modal keys are translated
   enterprise_contact: "Primary Contact"
   enterprise_contact_placeholder: "Contact Name"
   enterprise_contact_required: "You need to enter a primary contact."
@@ -1370,6 +1371,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   enterprise_email_placeholder: "eg. charlie@thefarm.com"
   enterprise_phone: "Phone number"
   enterprise_phone_placeholder: "eg. (03) 1234 5678"
+  # END
   back: "Back"
   continue: "Continue"
   limit_reached_headline: "Oh no!"
@@ -1441,6 +1443,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
 Please follow the instructions there to make your enterprise visible on the Open Food Network."
   registration_finished_action: "Open Food Network home"
   registration_contact_name: 'Contact Name'
+
+  # TODO: Remove these once the enterprise.registration.modal keys are translated
   registration_type_headline: "Last step to add %{enterprise}!"
   registration_type_question: "Are you a producer?"
   registration_type_producer: "Yes, I'm a producer"
@@ -1448,9 +1452,13 @@ Please follow the instructions there to make your enterprise visible on the Open
   registration_type_error: "Please choose one. Are you are producer?"
   registration_type_producer_help: "Producers make yummy things to eat and/or drink. You're a producer if you grow it, raise it, brew it, bake it, ferment it, milk it or mould it."
   registration_type_no_producer_help: "If you’re not a producer, you’re probably someone who sells and distributes food. You might be a hub, coop, buying group, retailer, wholesaler or other."
+  # END
   create_profile: "Create Profile"
   registration_images_headline: "Thanks!"
   registration_images_description: "Let's upload some pretty pictures so your profile looks great! :)"
+
+
+  # TODO: Remove these once the enterprise.registration.modal keys are translated
   registration_detail_headline: "Let's Get Started"
   registration_detail_enterprise: "Woot! First we need to know a little bit about your enterprise:"
   registration_detail_producer: "Woot! First we need to know a little bit about your farm:"
@@ -1472,6 +1480,7 @@ Please follow the instructions there to make your enterprise visible on the Open
   registration_detail_state_error: "State required"
   registration_detail_country: "Country:"
   registration_detail_country_error: "Please select a country"
+  # END
   shipping_method_destroy_error: "That shipping method cannot be deleted as it is referenced by an order: %{number}."
   accounts_and_billing_task_already_running_error: "A task is already running, please wait until it has finished"
   accounts_and_billing_start_task_notice: "Task Queued"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1312,9 +1312,12 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   registration_greeting: "Greetings!"
   who_is_managing_enterprise: "Who is responsible for managing %{enterprise}?"
   enterprise_contact: "Primary Contact"
+  enterprise_contact_placeholder: "Contact Name"
   enterprise_contact_required: "You need to enter a primary contact."
   enterprise_email_address: "Email address"
+  enterprise_email_placeholder: "eg. charlie@thefarm.com"
   enterprise_phone: "Phone number"
+  enterprise_phone_placeholder: "eg. (03) 1234 5678"
   back: "Back"
   continue: "Continue"
   limit_reached_headline: "Oh no!"
@@ -1385,6 +1388,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   registration_finished_activate_instruction_html: "We've sent a confirmation email to <strong>%{email}</strong> if it hasn't been activated before.<br/>
 Please follow the instructions there to make your enterprise visible on the Open Food Network."
   registration_finished_action: "Open Food Network home"
+  registration_contact_name: 'Contact Name'
   registration_type_headline: "Last step to add %{enterprise}!"
   registration_type_question: "Are you a producer?"
   registration_type_producer: "Yes, I'm a producer"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1349,6 +1349,14 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             phone_field_placeholder: 'eg. (03) 1234 5678'
           type:
             title: 'Type'
+            headline: "Last step to add %{enterprise}!"
+            question: "Are you a producer?"
+            yes_producer: "Yes, I'm a producer"
+            no_producer: "No, I'm not a producer"
+            producer_field_error: "Please choose one. Are you are producer?"
+            yes_producer_help: "Producers make yummy things to eat and/or drink. You're a producer if you grow it, raise it, brew it, bake it, ferment it, milk it or mould it."
+            no_producer_help: "If you’re not a producer, you’re probably someone who sells and distributes food. You might be a hub, coop, buying group, retailer, wholesaler or other."
+
           about:
             title: 'About'
           images:


### PR DESCRIPTION
#### What? Why?

The Enterprise Registration wizard was not entirely translated. This PR ensures that all the i18n keys are present (There will be some new keys to translate in Transiflex).

I also took the opportunity, to introduce decent i18n key namespacing for the Details, Contact and Type steps. There are some redundant keys, which are marked for removal after the new keys have been translated. 

#### What should we test?

- [x] Test Enterprise Registration Wizard

#### Release notes

Registration wizard is now completely translatable.

#### How is this related to the Spree upgrade?

n/a

#### Discourse thread

n/a

#### Dependencies

n/a

![](https://media.giphy.com/media/pXAvSICRT9h72/giphy.gif)