### PR TITLE
Simplifying Product Edit Screen

### DIFF
--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -132,7 +132,7 @@ class AbilityDecorator
   def add_product_management_abilities(user)
     # Enterprise User can only access products that they are a supplier for
     can [:create], Spree::Product
-    can [:admin, :read, :update, :product_distributions, :bulk_edit, :bulk_update, :clone, :delete, :destroy], Spree::Product do |product|
+    can [:admin, :read, :update, :product_distributions, :seo, :group_buy_options, :bulk_edit, :bulk_update, :clone, :delete, :destroy], Spree::Product do |product|
       OpenFoodNetwork::Permissions.new(user).managed_product_enterprises.include? product.supplier
     end
 

--- a/app/overrides/add_group_buy_to_admin_product_edit.rb
+++ b/app/overrides/add_group_buy_to_admin_product_edit.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/admin/products/_form",
-                     :insert_top   => "[data-hook='admin_product_form_right']",
-                     :partial      => "spree/admin/products/group_buy_form",
-                     :name         => "add_group_buy_to_admin_product_edit",
-                     :original     => '0c0e8d714989e48ee246a8253fb2b362f108621a')

--- a/app/overrides/spree/admin/products/_form/add_notes_field.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_notes_field.html.haml.deface
@@ -1,6 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_form_additional_fields']"
-
-= f.field_container :notes do
-  = f.label :notes, t(:notes)
-  = f.text_area :notes, { :class => 'fullwidth', rows: 5 }
-  = f.error_message_on :notes

--- a/app/overrides/spree/admin/products/_form/add_primary_taxon_field.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_primary_taxon_field.html.haml.deface
@@ -1,3 +1,3 @@
-/ insert_top "[data-hook='admin_product_form_right']"
+/ insert_after "div[class='variant_units_form']"
 
 = render 'spree/admin/products/primary_taxon_form', f: f

--- a/app/overrides/spree/admin/products/_form/add_supplier.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/add_supplier.html.haml.deface
@@ -1,5 +1,4 @@
-/ insert_top "[data-hook='admin_product_form_right']"
-
+/ insert_before "code[erb-loud]:contains('f.field_container :price')"
 = f.field_container :supplier do
   = f.label :supplier, t(:spree_admin_supplier)
   %br

--- a/app/overrides/spree/admin/products/_form/remove_available_on.deface
+++ b/app/overrides/spree/admin/products/_form/remove_available_on.deface
@@ -1,0 +1,2 @@
+remove "code[erb-loud]:contains('f.label :available_on')"
+closing_selector("code[erb-loud]:contains('f.text_field :available_on')")

--- a/app/overrides/spree/admin/products/_form/remove_cost_currency.deface
+++ b/app/overrides/spree/admin/products/_form/remove_cost_currency.deface
@@ -1,0 +1,2 @@
+remove "code[erb-loud]:contains('f.field_container :cost_currency')"
+closing_selector("code[erb-silent]:contains('end')")

--- a/app/overrides/spree/admin/products/_form/remove_cost_price.deface
+++ b/app/overrides/spree/admin/products/_form/remove_cost_price.deface
@@ -1,0 +1,2 @@
+remove "code[erb-loud]:contains('f.field_container :cost_price')"
+closing_selector("code[erb-silent]:contains('end')")

--- a/app/overrides/spree/admin/products/_form/remove_meta_description.deface
+++ b/app/overrides/spree/admin/products/_form/remove_meta_description.deface
@@ -1,0 +1,1 @@
+remove "div[data-hook='admin_product_form_meta']"

--- a/app/overrides/spree/admin/products/_form/remove_option_types_and_taxons.deface
+++ b/app/overrides/spree/admin/products/_form/remove_option_types_and_taxons.deface
@@ -1,0 +1,1 @@
+remove "div[class='twelve columns alpha omega']"

--- a/app/overrides/spree/admin/products/_form/replace_master_price_label.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/replace_master_price_label.html.haml.deface
@@ -1,0 +1,2 @@
+/ replace "[data-hook=admin_product_form_right] code[erb-loud]:contains('f.label :price')"
+= f.label :price, raw(t(:price) + content_tag(:span, ' *', :class => 'required'))

--- a/app/overrides/spree/admin/products/_form/replace_taxons_div.html.haml.deface
+++ b/app/overrides/spree/admin/products/_form/replace_taxons_div.html.haml.deface
@@ -1,0 +1,5 @@
+/ insert_bottom "[data-hook=admin_product_form_left]"
+= f.field_container :taxons do 
+  = f.label :taxon_ids, t(:taxons) 
+  %br
+  = f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',')

--- a/app/overrides/spree/admin/shared/_product_tabs/add_group_buy.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_group_buy.html.haml.deface
@@ -1,0 +1,5 @@
+/ insert_bottom "[data-hook='admin_product_tabs']"
+
+- klass = current == 'Group Buy Options' ? 'active' : ''
+%li{:class => klass}
+  = link_to_with_icon 'icon-tasks', 'Group Buy Options', group_buy_options_admin_product_url(@product)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
@@ -1,0 +1,5 @@
+/ insert_bottom "[data-hook='admin_product_tabs']"
+
+- klass = current == 'SEO' ? 'active' : ''
+%li{:class => klass}
+  = link_to_with_icon 'icon-tasks', 'SEO', seo_admin_product_url(@product)

--- a/app/views/spree/admin/products/_group_buy_form.html.haml
+++ b/app/views/spree/admin/products/_group_buy_form.html.haml
@@ -2,13 +2,13 @@
   = f.label :group_buy, t('.group_buy')
   %br
   .alpha.two.columns
-    = f.radio_button :group_buy, '1', checked: f.object.group_buy
     = f.label :group_buy_1, t(:yes)
+    = f.radio_button :group_buy, '1', checked: f.object.group_buy
   .alpha.two.columns
-    = f.radio_button :group_buy, '0', checked: !f.object.group_buy
     = f.label :group_buy_0, t(:no)
-%br.clear
-= f.field_container :group_buy_unit_size do
-  = f.label :group_buy_unit_size, t('.bulk_unit_size')
-  %br
-  = f.text_field :group_buy_unit_size
+    = f.radio_button :group_buy, '0', checked: !f.object.group_buy
+  %br.clear
+  = f.field_container :group_buy_unit_size do
+    = f.label :group_buy_unit_size, t('.bulk_unit_size')
+    %br
+    = f.text_field :group_buy_unit_size

--- a/app/views/spree/admin/products/_seo_form.html.haml
+++ b/app/views/spree/admin/products/_seo_form.html.haml
@@ -1,0 +1,15 @@
+.row{"data-hook" => "admin_product_meta_form"}
+  .alpha.eleven.columns
+    = f.field_container :meta_description do
+      = f.label :meta_keywords, t(:meta_keywords)
+      %br/
+      = f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6
+    = f.field_container :meta_description do
+      = f.label :meta_description, t(:meta_description)
+      %br/
+      = f.text_field :meta_description, :class => 'fullwidth', :rows => 6
+  .alpha.eleven.columns
+    = f.field_container :notes do
+      = f.label :notes, t(:notes)
+      = f.text_area :notes, { :class => 'fullwidth', rows: 5 }
+      = f.error_message_on :notes

--- a/app/views/spree/admin/products/group_buy_options.html.haml
+++ b/app/views/spree/admin/products/group_buy_options.html.haml
@@ -1,0 +1,8 @@
+= render :partial => 'spree/admin/shared/product_sub_menu'
+= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Group Buy Options' }
+= render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
+
+= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f|
+  %fieldset.no-border-top
+    = render :partial => 'group_buy_form', :locals => { :f => f }
+    = render :partial => 'spree/admin/shared/edit_resource_links'

--- a/app/views/spree/admin/products/seo.html.haml
+++ b/app/views/spree/admin/products/seo.html.haml
@@ -1,0 +1,8 @@
+= render :partial => 'spree/admin/shared/product_sub_menu'
+= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'SEO' }
+= render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
+
+= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f|
+  %fieldset.no-border-top
+    = render :partial => 'seo_form', :locals => { :f => f }
+    = render :partial => 'spree/admin/shared/edit_resource_links'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,6 +275,8 @@ Spree::Core::Engine.routes.prepend do
 
     resources :products do
       get :product_distributions, on: :member
+      get :group_buy_options, on: :member
+      get :seo, on: :member
 
       post :bulk_update, :on => :collection, :as => :bulk_update
     end

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -86,24 +86,6 @@ feature %q{
       variant = product.variants.first
       variant.on_demand.should be_true
     end
-
-    scenario "making a product into a group buy product" do
-      product = create(:simple_product, name: 'group buy product')
-
-      login_to_admin_section
-
-      visit spree.edit_admin_product_path(product)
-
-      choose 'product_group_buy_1'
-      fill_in 'product_group_buy_unit_size', with: '10'
-
-      click_button 'Update'
-
-      flash_message.should == 'Product "group buy product" has been successfully updated!'
-      product.reload
-      product.group_buy.should be_true
-      product.group_buy_unit_size.should == 10.0
-    end
   end
 
   context "as an enterprise user" do
@@ -119,15 +101,6 @@ feature %q{
              permissions_list: [:manage_products])
 
       login_to_admin_as @new_user
-    end
-
-
-    context "additional fields" do
-      it "should have a notes field" do
-        product = create(:simple_product, supplier: @supplier2)
-        visit spree.edit_admin_product_path product
-        page.should have_content "Notes"
-      end
     end
 
     context "products do not require a tax category" do
@@ -174,6 +147,22 @@ feature %q{
       product.tax_category.should == tax_category
     end
 
+    scenario "editing product group buy options" do
+      product = product = create(:simple_product, supplier: @supplier2)
+
+      visit spree.edit_admin_product_path product
+      within('#sidebar') { click_link 'Group Buy Options' }
+      choose('product_group_buy_1')
+      fill_in 'Bulk unit size', :with => '10'
+
+      click_button 'Update'
+
+      flash_message.should == "Product \"#{product.name}\" has been successfully updated!"
+      product.reload
+      product.group_buy.should be_true
+      product.group_buy_unit_size.should == 10.0
+    end
+
     scenario "editing product distributions" do
       product = create(:simple_product, supplier: @supplier2)
 
@@ -195,6 +184,20 @@ feature %q{
       product.distributors.should == [@distributors[0]]
     end
 
+    scenario "editing product SEO" do
+      product = product = create(:simple_product, supplier: @supplier2)
+      visit spree.edit_admin_product_path product
+      within('#sidebar') { click_link 'SEO' }
+      fill_in "product_meta_keywords", :with => 'Meta Keywords'
+      fill_in 'Meta Description', :with => 'Meta Description'
+      fill_in 'Notes', :with => 'Just testing Notes'
+      click_button 'Update'
+      flash_message.should == "Product \"#{product.name}\" has been successfully updated!"
+      product.reload
+      product.notes.should == 'Just testing Notes'
+      product.meta_keywords.should == 'Meta Keywords'
+      product.meta_description.should == 'Meta Description'
+    end
 
     scenario "deleting product properties", js: true do
       # Given a product with a property


### PR DESCRIPTION
#### What? Why?

Edit Product Screen has been simplified to improved the understanding and he user experience. It was decided to remove unused fields, create two new areas for not so common fields (SEO and Group buy options) and to reorder some of the fields. 

#### What should we test?
The following fields should NOT appear on the first screen of 'Product Edit' 
- Cost price
- Cost currency
- Notes
- Available on
- Option types
- Meta keywords
- Meta description

There should be two new options on the right hand side menu - SEO and Group buy options
Under the new 'SEO'  section should appear a form with the following fields and one should be able to change/edit and update:
- Meta Keywords
- Meta Description
- Notes

Under the new 'Group buy options' section should appear a form with the following fields and one should be able to change/edit and update:
- Group buy? with 2 options (Yes/NO)
- Bulk unit size


#### How is this related to the Spree upgrade?

We should to apply the same changes to the new Spree Edit Product screen once approved. It should be easier because in recent versions all the fields have been added the data-hook property which in our current version most of them lack of it.

#### Discourse thread

This issue is based on the  [discussion](https://community.openfoodnetwork.org/t/edit-product-page-ux-improvements/977)
