### PR TITLE
Ensure that adjustment states are initialized prior to validation

### DIFF
--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -6,6 +6,8 @@ module Spree
     has_one :metadata, class_name: 'AdjustmentMetadata'
     belongs_to :tax_rate, foreign_key: 'originator_id', conditions: "spree_adjustments.originator_type = 'Spree::TaxRate'"
 
+    before_validation :initialize_state
+
     scope :enterprise_fee,  where(originator_type: 'EnterpriseFee')
     scope :billable_period, where(source_type: 'BillablePeriod')
     scope :admin,           where(source_type: nil, originator_type: nil)
@@ -74,5 +76,15 @@ module Spree
       result
     end
 
+    private
+
+    # Required after Spree Upgrade Step 6, as existing adjustments did not have
+    # a state, and so failed validation. New adjustments are not affected.
+    def initialize_state
+      return unless state.nil?
+      # (static: true) only updates state when not already set
+      # use (static: :force) to force initialization
+      initialize_state_machines(static: true)
+    end
   end
 end

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -193,9 +193,10 @@ feature "Product Import", js: true do
 
     it "returns and error if nothing was uploaded" do
       visit main_app.admin_product_import_path
+      expect(page).to have_content  'Select a spreadsheet to upload'
       click_button 'Import'
 
-      expect(page).to have_content "File not found or could not be opened"
+      expect(flash_message).to eq I18n.t(:product_import_file_not_found_notice)
     end
 
     it "handles cases where no meaningful data can be read from the file" do


### PR DESCRIPTION
Fixes #1826.

We get a `RecordInvalid` error (`state` is invalid) on adjustments when trying to update some orders from admin section. The invalid value is `nil` on all that I have seen so far, so it looks like adjustments that were created before the upgrade was performed are not being updated to have a state (which they need to have to be valid).

This fix ensures that states are initialised prior to any validation being performed on them. 

An alternative fix may be to write a migration that populates state, but this is a quick and dirty fix because this is currently affecting Aus production.

#### What? Why?

[Explain why is this change needed and the solution you propose. Provide
context for others to understand it]

#### What should we test?

Make sure that older adjustments on orders can be updated without crashing

#### Release notes

No release notes, as the bug that caused #1826 should never make it into a release without this fix.

#### How is this related to the Spree upgrade?

This issue was caused by the Spree Upgrade, for some reason the migration to add `state` to adjustments did not initialize states on existing adjustments. I am still not sure how this is supposed to work. 