### PR TITLE
Fix for decimal separator in prices

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -32,7 +32,6 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     $scope.filteredProducts = []
     $scope.currentFilters = []
     $scope.limit = 15
-    $scope.productsWithUnsavedVariants = []
     $scope.query = ""
     $scope.DisplayProperties = DisplayProperties
 
@@ -114,7 +113,6 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
         display_name: null
         on_hand: null
         price: null
-      $scope.productsWithUnsavedVariants.push product
       DisplayProperties.setShowVariants product.id, true
 
 
@@ -196,7 +194,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
           filters: $scope.currentFilters
       ).success((data) ->
         DirtyProducts.clear()
-        BulkProducts.updateVariantLists(data.products, $scope.productsWithUnsavedVariants)
+        BulkProducts.updateVariantLists(data.products || [])
         $timeout -> $scope.displaySuccess()
       ).error (data, status) ->
         if status == 400 && data.errors? && data.errors.length > 0

--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -16,9 +16,9 @@ angular.module("ofn.admin").factory "BulkProducts", (PagedFetcher, dataFetcher, 
           @unpackProduct newProduct
           @insertProductAfter(product, newProduct)
 
-    updateVariantLists: (serverProducts, productsWithUnsavedVariants) ->
-      for product in productsWithUnsavedVariants
-        server_product = @findProductInList(product.id, serverProducts)
+    updateVariantLists: (serverProducts) ->
+      for server_product in serverProducts
+        product = @findProductInList(server_product.id, @products)
         product.variants = server_product.variants
         @loadVariantUnitValues product
 

--- a/app/models/calculator/flat_percent_per_item.rb
+++ b/app/models/calculator/flat_percent_per_item.rb
@@ -1,4 +1,5 @@
 require_dependency 'spree/calculator'
+require 'spree/localized_number'
 
 class Calculator::FlatPercentPerItem < Spree::Calculator
   # Spree's FlatPercentItemTotal calculator sums all amounts, and then calculates a percentage
@@ -6,10 +7,13 @@ class Calculator::FlatPercentPerItem < Spree::Calculator
   # In the cart, we display line item individual amounts rounded, so to have consistent
   # calculations we do the same internally. Here, we round adjustments at the individual
   # item level first, then multiply by the item quantity.
+  extend Spree::LocalizedNumber
 
   preference :flat_percent, :decimal, :default => 0
 
   attr_accessible :preferred_flat_percent
+
+  localize_number :preferred_flat_percent
 
   def self.description
     I18n.t(:flat_percent_per_item)

--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -1,5 +1,9 @@
+require 'spree/localized_number'
+
 module Spree
   Adjustment.class_eval do
+    extend Spree::LocalizedNumber
+
     # Deletion of metadata is handled in the database.
     # So we don't need the option `dependent: :destroy` as long as
     # AdjustmentMetadata has no destroy logic itself.
@@ -16,6 +20,8 @@ module Spree
     scope :payment_fee,     where(originator_type: 'Spree::PaymentMethod')
 
     attr_accessible :included_tax
+
+    localize_number :amount
 
     def set_included_tax!(rate)
       tax = amount - (amount / (1 + rate))
@@ -73,6 +79,5 @@ module Spree
 
       result
     end
-
   end
 end

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -42,4 +42,7 @@ Spree::AppConfiguration.class_eval do
 
   # Stripe Connect
   preference :stripe_connect_enabled, :boolean, default: false
+
+  # Number localization
+  preference :enable_localized_number?, :boolean, default: false
 end

--- a/app/models/spree/calculator/flat_percent_item_total_decorator.rb
+++ b/app/models/spree/calculator/flat_percent_item_total_decorator.rb
@@ -1,5 +1,11 @@
+require 'spree/localized_number'
+
 module Spree
   Calculator::FlatPercentItemTotal.class_eval do
+    extend Spree::LocalizedNumber
+
+    localize_number :preferred_flat_percent
+
     def compute(object)
       item_total = line_items_for(object).map(&:amount).sum
       value = item_total * BigDecimal(self.preferred_flat_percent.to_s) / 100.0

--- a/app/models/spree/calculator/flat_rate_decorator.rb
+++ b/app/models/spree/calculator/flat_rate_decorator.rb
@@ -1,0 +1,9 @@
+require 'spree/localized_number'
+
+module Spree
+  Calculator::FlatRate.class_eval do
+    extend Spree::LocalizedNumber
+
+    localize_number :preferred_amount
+  end
+end

--- a/app/models/spree/calculator/flexi_rate_decorator.rb
+++ b/app/models/spree/calculator/flexi_rate_decorator.rb
@@ -1,5 +1,12 @@
+require 'spree/localized_number'
+
 module Spree
   Calculator::FlexiRate.class_eval do
+    extend Spree::LocalizedNumber
+
+    localize_number :preferred_first_item,
+                    :preferred_additional_item
+
     def compute(object)
       sum = 0
       max = self.preferred_max_items.to_i

--- a/app/models/spree/calculator/per_item_decorator.rb
+++ b/app/models/spree/calculator/per_item_decorator.rb
@@ -1,5 +1,11 @@
+require 'spree/localized_number'
+
 module Spree
   Calculator::PerItem.class_eval do
+    extend Spree::LocalizedNumber
+
+    localize_number :preferred_amount
+
     def compute(object=nil)
       return 0 if object.nil?
       self.preferred_amount * line_items_for(object).reduce(0) do |sum, value|

--- a/app/models/spree/calculator/price_sack_decorator.rb
+++ b/app/models/spree/calculator/price_sack_decorator.rb
@@ -1,0 +1,11 @@
+require 'spree/localized_number'
+
+module Spree
+  Calculator::PriceSack.class_eval do
+    extend Spree::LocalizedNumber
+
+    localize_number :preferred_minimal_amount,
+                    :preferred_normal_amount,
+                    :preferred_discount_amount
+  end
+end

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,10 +1,16 @@
+require 'spree/localized_number'
+
 module Spree
   Payment.class_eval do
+    extend Spree::LocalizedNumber
+
     has_one :adjustment, as: :source, dependent: :destroy
 
     after_save :ensure_correct_adjustment, :update_order
 
     attr_accessible :source
+
+    localize_number :amount
 
     def ensure_correct_adjustment
       revoke_adjustment_eligibility if ['failed', 'invalid'].include?(state)

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -3,6 +3,7 @@ require 'open_food_network/variant_and_line_item_naming'
 require 'open_food_network/products_cache'
 
 Spree::Variant.class_eval do
+  extend Spree::LocalizedNumber
   # Remove method From Spree, so method from the naming module is used instead
   # This file may be double-loaded in delayed job environment, so we check before
   # removing the Spree method to prevent error.
@@ -54,6 +55,8 @@ Spree::Variant.class_eval do
     joins("LEFT OUTER JOIN (SELECT * from inventory_items WHERE enterprise_id = #{sanitize enterprise.andand.id}) AS o_inventory_items ON o_inventory_items.variant_id = spree_variants.id")
       .where("o_inventory_items.id IS NULL OR o_inventory_items.visible = (?)", true)
   }
+
+  localize_number :price, :cost_price, :weight
 
   # Define sope as class method to allow chaining with other scopes filtering id.
   # In Rails 3, merging two scopes on the same column will consider only the last scope.

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -1,4 +1,6 @@
 class VariantOverride < ActiveRecord::Base
+  extend Spree::LocalizedNumber
+
   acts_as_taggable
 
   belongs_to :hub, class_name: 'Enterprise'
@@ -16,6 +18,8 @@ class VariantOverride < ActiveRecord::Base
   scope :for_hubs, lambda { |hubs|
     where(hub_id: hubs)
   }
+
+  localize_number :price
 
   def self.indexed(hub)
     Hash[

--- a/app/overrides/spree/admin/general_settings/edit/number_localization.html.haml.deface
+++ b/app/overrides/spree/admin/general_settings/edit/number_localization.html.haml.deface
@@ -1,0 +1,7 @@
+/ insert_after "fieldset.currency"
+
+%fieldset.number_localization.no-border-bottom
+  %legend{:align => "center"}= t('admin.number_localization.number_localization_settings')
+  .field
+    = preference_field_tag(:enable_localized_number?, Spree::Config[:enable_localized_number?], type: Spree::Config.preference_type(:enable_localized_number?))
+    = label_tag(:enable_localized_number?, t('admin.number_localization.enable_localized_number')) + tag(:br)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2357,3 +2357,5 @@ Please follow the instructions there to make your enterprise visible on the Open
         total: Total
         paid?: Paid?
         view: View
+    localized_number:
+      invalid_format: has an invalid format. Please enter a number.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,10 @@ en:
       enable_embedded_shopfronts: "Enable Embedded Shopfronts"
       embedded_shopfronts_whitelist: "External Domains Whitelist"
 
+    number_localization:
+      number_localization_settings: "Number Localization Settings"
+      enable_localized_number: "Use the international thousand/decimal separator logic"
+
     business_model_configuration:
       edit:
         business_model_configuration: "Business Model"

--- a/lib/spree/localized_number.rb
+++ b/lib/spree/localized_number.rb
@@ -1,0 +1,64 @@
+module Spree
+  module LocalizedNumber
+    # This method overwrites the attribute setters of a model
+    # to make them use the LocalizedNumber parsing method.
+    # It works with ActiveRecord "normal" attributes
+    # and Preference attributes.
+    # It also adds a validation on the input format.
+    # It accepts as arguments a variable number of attribute as symbols
+    def localize_number(*attributes)
+      validate :validate_localizable_number
+
+      attributes.each do |attribute|
+        setter = "#{attribute}="
+        old_setter = instance_method(setter) if table_exists? && !column_names.include?(attribute.to_s)
+
+        define_method(setter) do |number|
+          if Spree::LocalizedNumber.valid_localizable_number?(number)
+            number = Spree::LocalizedNumber.parse(number)
+          else
+            @invalid_localized_number ||= []
+            @invalid_localized_number << attribute
+            number = nil
+          end
+
+          if has_attribute?(attribute)
+            self[attribute] = number
+          else
+            old_setter.bind(self).call(number)
+          end
+        end
+
+        define_method(:validate_localizable_number) do
+          @invalid_localized_number.andand.each do |error_attribute|
+            errors.set(error_attribute, [I18n.t('spree.localized_number.invalid_format')])
+          end
+        end
+      end
+    end
+
+    def self.valid_localizable_number?(number)
+      return true unless number.is_a?(String) || number.respond_to?(:to_d)
+      return false if number =~ /[\.,]\d{2}[\.,]/
+      true
+    end
+
+    def self.parse(number)
+      return nil if number.blank?
+      return number.to_d unless number.is_a?(String)
+
+      number = number.gsub(/[^\d.,-]/, '') # Replace all Currency Symbols, Letters and -- from the string
+
+      if number =~ /^.*[\.,]\d{1}$/        # If string ends in a single digit (e.g. ,2)
+        number += "0"                      # make it ,20 in order for the result to be in "cents"
+      end
+
+      unless number =~ /^.*[\.,]\d{2}$/    # If does not end in ,00 / .00 then
+        number += "00"                     # add trailing 00 to turn it into cents
+      end
+
+      number = number.gsub(/[\.,]/, '')    # Replace all (.) and (,) so the string result becomes in "cents"
+      number.to_d / 100                    # Let to_decimal do the rest
+    end
+  end
+end

--- a/lib/spree/localized_number.rb
+++ b/lib/spree/localized_number.rb
@@ -14,12 +14,14 @@ module Spree
         old_setter = instance_method(setter) if table_exists? && !column_names.include?(attribute.to_s)
 
         define_method(setter) do |number|
-          if Spree::LocalizedNumber.valid_localizable_number?(number)
-            number = Spree::LocalizedNumber.parse(number)
-          else
-            @invalid_localized_number ||= []
-            @invalid_localized_number << attribute
-            number = nil
+          if Spree::Config.enable_localized_number?
+            if Spree::LocalizedNumber.valid_localizable_number?(number)
+              number = Spree::LocalizedNumber.parse(number)
+            else
+              @invalid_localized_number ||= []
+              @invalid_localized_number << attribute
+              number = nil
+            end
           end
 
           if has_attribute?(attribute)
@@ -30,6 +32,8 @@ module Spree
         end
 
         define_method(:validate_localizable_number) do
+          return unless Spree::Config.enable_localized_number?
+
           @invalid_localized_number.andand.each do |error_attribute|
             errors.set(error_attribute, [I18n.t('spree.localized_number.invalid_format')])
           end

--- a/spec/lib/spree/localized_number_spec.rb
+++ b/spec/lib/spree/localized_number_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Spree::LocalizedNumber do
+  context ".parse" do
+    context "with decimal point" do
+      it "captures the proper amount for a formatted string" do
+        expect(described_class.parse('1,599.99')).to eql 1599.99
+      end
+    end
+
+    context "with decimal comma" do
+      it "captures the proper amount for a formatted string" do
+        expect(described_class.parse('1.599,99')).to eql 1599.99
+      end
+    end
+
+    context "with a numeric input" do
+      it "uses the amount as is" do
+        expect(described_class.parse(1599.99)).to eql 1599.99
+      end
+    end
+  end
+
+  context ".valid_localizable_number?" do
+    context "with a properly formatted string" do
+      it "returns true" do
+        expect(described_class.valid_localizable_number?('1.599,99')).to eql true
+      end
+    end
+
+    context "with a string having 2 digits between separators" do
+      it "returns false" do
+        expect(described_class.valid_localizable_number?('1,59.99')).to eql false
+      end
+    end
+
+    context "with a numeric input" do
+      it "returns true" do
+        expect(described_class.valid_localizable_number?(1599.99)).to eql true
+      end
+    end
+  end
+end

--- a/spec/models/calculator/flat_percent_per_item_spec.rb
+++ b/spec/models/calculator/flat_percent_per_item_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe Calculator::FlatPercentPerItem do
   let(:calculator) { Calculator::FlatPercentPerItem.new preferred_flat_percent: 20 }
 
@@ -9,5 +11,9 @@ describe Calculator::FlatPercentPerItem do
   it "rounds fractional cents before summing" do
     line_item = Spree::LineItem.new price: 0.86, quantity: 8
     expect(calculator.compute(line_item)).to eq 1.36
+  end
+
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:preferred_flat_percent]
   end
 end

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -297,5 +297,9 @@ module Spree
         end
       end
     end
+
+    context "extends LocalizedNumber" do
+      it_behaves_like "a model using the LocalizedNumber module", [:amount]
+    end
   end
 end

--- a/spec/models/spree/calculator/flat_percent_item_total_spec.rb
+++ b/spec/models/spree/calculator/flat_percent_item_total_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
- describe Spree::Calculator::FlatPercentItemTotal do
+describe Spree::Calculator::FlatPercentItemTotal do
   let(:calculator) { Spree::Calculator::FlatPercentItemTotal.new }
   let(:line_item) { instance_double(Spree::LineItem, amount: 10) }
 
@@ -8,5 +8,9 @@ require 'spec_helper'
 
   it "should compute amount correctly for a single line item" do
     calculator.compute(line_item).should == 1.0
+  end
+
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:preferred_flat_percent]
   end
 end

--- a/spec/models/spree/calculator/flat_rate_spec.rb
+++ b/spec/models/spree/calculator/flat_rate_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Spree::Calculator::FlatRate do
+  let(:calculator) { Spree::Calculator::FlatRate.new }
+
+  before { calculator.stub :preferred_amount => 10 }
+
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:preferred_amount]
+  end
+end

--- a/spec/models/spree/calculator/flexi_rate_spec.rb
+++ b/spec/models/spree/calculator/flexi_rate_spec.rb
@@ -14,4 +14,8 @@ describe Spree::Calculator::FlexiRate do
   it "allows creation of new object with all the attributes" do
     Spree::Calculator::FlexiRate.new(preferred_first_item: 1, preferred_additional_item: 1, preferred_max_items: 1)
   end
+
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:preferred_first_item, :preferred_additional_item]
+  end
 end

--- a/spec/models/spree/calculator/per_item_spec.rb
+++ b/spec/models/spree/calculator/per_item_spec.rb
@@ -9,4 +9,8 @@ describe Spree::Calculator::PerItem do
     calculator.stub(calculable: shipping_calculable)
     calculator.compute(line_item).to_f.should == 50 # 5 x 10
   end
+
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:preferred_amount]
+  end
 end

--- a/spec/models/spree/calculator/price_sack_spec.rb
+++ b/spec/models/spree/calculator/price_sack_spec.rb
@@ -14,4 +14,8 @@ describe Spree::Calculator::PriceSack do
   it "computes with a line item object" do
     calculator.compute(line_item)
   end
+
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:preferred_minimal_amount, :preferred_normal_amount, :preferred_discount_amount]
+  end
 end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -208,5 +208,9 @@ module Spree
         end
       end
     end
+
+    context "extends LocalizedNumber" do
+      it_behaves_like "a model using the LocalizedNumber module", [:amount]
+    end
   end
 end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -511,6 +511,12 @@ module Spree
         }.to change(Spree::OptionValue, :count).by(0)
       end
     end
+
+    context "extends LocalizedNumber" do
+      subject! { build(:variant) }
+
+      it_behaves_like "a model using the LocalizedNumber module", [:price, :cost_price, :weight]
+    end
   end
 
   describe "destruction" do

--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -147,4 +147,8 @@ describe VariantOverride do
       vo.reload.count_on_hand.should == 12
     end
   end
+
+  context "extends LocalizedNumber" do
+    it_behaves_like "a model using the LocalizedNumber module", [:price]
+  end
 end

--- a/spec/support/localized_number_helper.rb
+++ b/spec/support/localized_number_helper.rb
@@ -1,4 +1,12 @@
 shared_examples "a model using the LocalizedNumber module" do |attributes|
+  before do
+    Spree::Config[:enable_localized_number?] = true
+  end
+
+  after do
+    Spree::Config[:enable_localized_number?] = false
+  end
+
   attributes.each do |attribute|
     setter = "#{attribute}="
 

--- a/spec/support/localized_number_helper.rb
+++ b/spec/support/localized_number_helper.rb
@@ -1,0 +1,17 @@
+shared_examples "a model using the LocalizedNumber module" do |attributes|
+  attributes.each do |attribute|
+    setter = "#{attribute}="
+
+    it "uses the LocalizedNumber.parse method when setting #{attribute}" do
+      allow(Spree::LocalizedNumber).to receive(:parse).and_return(nil)
+      expect(Spree::LocalizedNumber).to receive(:parse).with('1.599,99')
+      subject.send(setter, '1.599,99')
+    end
+
+    it "creates an error if the input to #{attribute} is invalid" do
+      subject.send(setter, '1.59,99')
+      subject.valid?
+      expect(subject.errors[attribute]).to include(I18n.t('spree.localized_number.invalid_format'))
+    end
+  end
+end


### PR DESCRIPTION
PR for #853 
It appeared that the problem was 2 problems: improve the way Spree handles separator in prices and make it work for more than prices.
Enrico found that the latter part was [fixed](https://github.com/spree/spree/commit/b817dab4a95c1beda3f18e42f0efcd2b7e64312a) in Spree 2.3 by having the behaviour (which was in Variant _and_ Price classes) in a LocalizedNumber class, so they could also use it with variants' weights.
Apparently what's important is that it works for prices, so I simply overrode the Spree methods, with a link to the commit in Spree and tests adapted from those in Spree.
When Spree dependency gets updated we'll be able to remove both methods by overriding the one in LocalizedNumber, and using it with things like fee amounts will be way easier. 