### PR TITLE
1718 show profiles

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -455,7 +455,6 @@ Layout/LeadingCommentSpace:
     - 'spec/factories.rb'
     - 'spec/features/admin/products_spec.rb'
     - 'spec/features/admin/reports_spec.rb'
-    - 'spec/features/consumer/shops_spec.rb'
     - 'spec/jobs/finalize_account_invoices_spec.rb'
     - 'spec/lib/open_food_network/order_and_distributor_report_spec.rb'
     - 'spec/lib/open_food_network/order_grouper_spec.rb'

--- a/app/assets/javascripts/darkswarm/controllers/enterprises_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/enterprises_controller.js.coffee
@@ -6,10 +6,9 @@ Darkswarm.controller "EnterprisesCtrl", ($scope, $rootScope, $timeout, $location
   $scope.openModal = EnterpriseModal.open
   $scope.activeTaxons = []
   $scope.show_profiles = false
+  $scope.show_closed = false
   $scope.filtersActive = false
   $scope.distanceMatchesShown = false
-  $scope.filterExpression = {active: true}
-
 
   $scope.$watch "query", (query)->
     Enterprises.flagMatching query
@@ -36,7 +35,7 @@ Darkswarm.controller "EnterprisesCtrl", ($scope, $rootScope, $timeout, $location
   # When filter settings change, this could change which name match is at the top, or even
   # result in no matches. This affects the reference point that the distance matches are
   # calculated from, so we need to recalculate distances.
-  $scope.$watch '[activeTaxons, activeProperties, shippingTypes, show_profiles]', ->
+  $scope.$watch '[activeTaxons, activeProperties, shippingTypes, show_profiles, show_closed]', ->
     $timeout ->
       Enterprises.calculateDistance $scope.query, $scope.firstNameMatch()
       $rootScope.$broadcast 'enterprisesChanged'
@@ -74,9 +73,9 @@ Darkswarm.controller "EnterprisesCtrl", ($scope, $rootScope, $timeout, $location
       undefined
 
   $scope.showClosedShops = ->
-    delete $scope.filterExpression['active']
+    $scope.show_closed = true
     $location.search('show_closed', '1')
 
   $scope.hideClosedShops = ->
-    $scope.filterExpression['active'] = true
+    $scope.show_closed = false
     $location.search('show_closed', null)

--- a/app/assets/javascripts/darkswarm/filters/closed_shops.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/closed_shops.js.coffee
@@ -1,0 +1,7 @@
+Darkswarm.filter 'closedShops', ->
+  (enterprises, show_closed) ->
+    enterprises ||= []
+    show_closed ?= false
+
+    enterprises.filter (enterprise) =>
+      show_closed or enterprise.active or !enterprise.is_distributor

--- a/app/views/shops/_filters.html.haml
+++ b/app/views/shops/_filters.html.haml
@@ -1,5 +1,5 @@
 - resource ||= "visibleMatches"
-- property_filters ||= "| filter:filterExpression | taxons:activeTaxons | shipping:shippingTypes | showHubProfiles:show_profiles"
+- property_filters ||= "| closedShops:show_closed | taxons:activeTaxons | shipping:shippingTypes | showHubProfiles:show_profiles"
 
 .row
   = render 'shared/components/filter_controls'

--- a/app/views/shops/_hubs.html.haml
+++ b/app/views/shops/_hubs.html.haml
@@ -28,8 +28,8 @@
         %a{href: "", "ng-click" => "showDistanceMatches()"}
           = t :hubs_distance_filter, location: "{{ nameMatchesFiltered[0].name }}"
   .more-controls
-    %a.button{href: "", ng: {click: "showClosedShops()", show: "filterExpression.active"}}
+    %a.button{href: "", ng: {click: "showClosedShops()", show: "!show_closed"}}
       = t '.show_closed_shops'
-    %a.button{href: "", ng: {click: "hideClosedShops()", show: "!filterExpression.active"}}
+    %a.button{href: "", ng: {click: "hideClosedShops()", show: "show_closed"}}
       = t '.hide_closed_shops'
     %a.button{href: main_app.map_path}= t '.show_on_map'

--- a/app/views/shops/_hubs_table.html.haml
+++ b/app/views/shops/_hubs_table.html.haml
@@ -1,5 +1,5 @@
 .active_table
-  %hub.active_table_node.row{"ng-repeat" => "hub in #{enterprises}Filtered = (#{enterprises} | filter:filterExpression | taxons:activeTaxons | properties:activeProperties:'distributed_properties' | shipping:shippingTypes | showHubProfiles:show_profiles | orderBy:['-active', '+distance', '+orders_close_at'])",
+  %hub.active_table_node.row{"ng-repeat" => "hub in #{enterprises}Filtered = (#{enterprises} | closedShops:show_closed | taxons:activeTaxons | properties:activeProperties:'distributed_properties' | shipping:shippingTypes | showHubProfiles:show_profiles | orderBy:['-active', '+distance', '+orders_close_at'])",
   "ng-class" => "{'is_profile' : hub.category == 'hub_profile', 'closed' : !open(), 'open' : open(), 'inactive' : !hub.active, 'current' : current()}",
   "ng-controller" => "HubNodeCtrl",
   id: "{{hub.hash}}"}

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -22,7 +22,7 @@ feature 'Shops', js: true do
   end
 
 
-  context "on the shops path" do
+  describe "listing shops" do
     before do
       visit shops_path
     end
@@ -37,21 +37,17 @@ feature 'Shops', js: true do
       expect(page).not_to have_content invisible_distributor.name
     end
 
-    it "should not show hubs that are not in an order cycle" do
-      create(:simple_product, distributors: [d1, d2])
-      visit shops_path
+    it "does not show hubs that are not in an order cycle" do
       expect(page).to have_no_selector 'hub.inactive'
       expect(page).to have_no_selector 'hub',   text: d2.name
     end
 
-    it "should show closed shops after clicking the button" do
-      create(:simple_product, distributors: [d1, d2])
-      visit shops_path
+    it "shows closed shops after clicking the button" do
       click_link_and_ensure("Show closed shops", -> { page.has_selector? 'hub.inactive' })
       expect(page).to have_selector 'hub.inactive', text: d2.name
     end
 
-    it "should link to the hub page" do
+    it "links to the hub page" do
       follow_active_table_node distributor.name
       expect(page).to have_current_path enterprise_shop_path(distributor)
     end
@@ -183,7 +179,6 @@ feature 'Shops', js: true do
     end
 
     it "shows closed shops" do
-      #click_link_and_ensure("Show closed shops", -> { page.has_selector? 'hub.inactive' })
       expect(page).to have_selector 'hub.inactive', text: d2.name
     end
   end

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -67,7 +67,7 @@ feature 'Shops', js: true do
       end
 
       # https://github.com/openfoodfoundation/openfoodnetwork/issues/1718
-      xit "shows profiles" do
+      it "shows profiles" do
         expect(page).to have_content profile.name
       end
     end

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -28,27 +28,27 @@ feature 'Shops', js: true do
     end
 
     it "shows hubs" do
-      page.should have_content distributor.name
+      expect(page).to have_content distributor.name
       expand_active_table_node distributor.name
-      page.should have_content "OUR PRODUCERS"
+      expect(page).to have_content "OUR PRODUCERS"
     end
 
     it "does not show invisible hubs" do
-      page.should_not have_content invisible_distributor.name
+      expect(page).not_to have_content invisible_distributor.name
     end
 
     it "should not show hubs that are not in an order cycle" do
       create(:simple_product, distributors: [d1, d2])
       visit shops_path
-      page.should have_no_selector 'hub.inactive'
-      page.should have_no_selector 'hub',   text: d2.name
+      expect(page).to have_no_selector 'hub.inactive'
+      expect(page).to have_no_selector 'hub',   text: d2.name
     end
 
     it "should show closed shops after clicking the button" do
       create(:simple_product, distributors: [d1, d2])
       visit shops_path
       click_link_and_ensure("Show closed shops", -> { page.has_selector? 'hub.inactive' })
-      page.should have_selector 'hub.inactive', text: d2.name
+      expect(page).to have_selector 'hub.inactive', text: d2.name
     end
 
     it "should link to the hub page" do
@@ -66,8 +66,8 @@ feature 'Shops', js: true do
     it "does not show hubs that are not ready for checkout" do
       visit shops_path
 
-      Enterprise.ready_for_checkout.should_not include hub
-      page.should_not have_content hub.name
+      expect(Enterprise.ready_for_checkout).not_to include hub
+      expect(page).not_to have_content hub.name
     end
   end
 
@@ -184,7 +184,7 @@ feature 'Shops', js: true do
 
     it "shows closed shops" do
       #click_link_and_ensure("Show closed shops", -> { page.has_selector? 'hub.inactive' })
-      page.should have_selector 'hub.inactive', text: d2.name
+      expect(page).to have_selector 'hub.inactive', text: d2.name
     end
   end
 

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -6,6 +6,7 @@ feature 'Shops', js: true do
 
   let!(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:invisible_distributor) { create(:distributor_enterprise, visible: false) }
+  let!(:profile) { create(:distributor_enterprise, sells: 'none') }
   let!(:d1) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:d2) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise)) }
@@ -42,6 +43,10 @@ feature 'Shops', js: true do
       expect(page).to have_no_selector 'hub',   text: d2.name
     end
 
+    it "does not show profiles" do
+      expect(page).not_to have_content profile.name
+    end
+
     it "shows closed shops after clicking the button" do
       click_link_and_ensure("Show closed shops", -> { page.has_selector? 'hub.inactive' })
       expect(page).to have_selector 'hub.inactive', text: d2.name
@@ -50,6 +55,21 @@ feature 'Shops', js: true do
     it "links to the hub page" do
       follow_active_table_node distributor.name
       expect(page).to have_current_path enterprise_shop_path(distributor)
+    end
+
+    describe "showing profiles" do
+      before do
+        check "Show profiles"
+      end
+
+      it "still shows hubs" do
+        expect(page).to have_content distributor.name
+      end
+
+      # https://github.com/openfoodfoundation/openfoodnetwork/issues/1718
+      xit "shows profiles" do
+        expect(page).to have_content profile.name
+      end
     end
   end
 

--- a/spec/javascripts/unit/darkswarm/filters/closed_shops_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/filters/closed_shops_spec.js.coffee
@@ -1,0 +1,30 @@
+describe "filtering closed shops", ->
+  enterprises = [{
+    name: "open shop"
+    active: true
+    is_distributor: true
+    }, {
+    name: "closed shop"
+    active: false
+    is_distributor: true
+    }, {
+    name: "profile"
+    active: false
+    is_distributor: false
+    }, {
+    name: "errornous entry"
+    does_not_have: "required attributes"
+    }
+  ]
+  closedShops = null
+
+  beforeEach ->
+    module 'Darkswarm'
+    inject ($filter) ->
+      closedShops = $filter('closedShops')
+
+  it "filters closed shops, but ignores profiles and invalid entries", ->
+    expect(closedShops(enterprises, false)).toEqual [enterprises[0], enterprises[2], enterprises[3]]
+
+  it "does not filter closed shops", ->
+    expect(closedShops(enterprises, true)).toEqual enterprises


### PR DESCRIPTION
#### What? Why?

The filter for closed shops was filtering profiles as well. That made it
impossible to show profiles without showing closed shops as well.
    
Replacing the filter for closed shops fixes the "show profiles" feature.
    
Fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/1718

#### What should we test?

The shops page, the producers page and the group pages.

#### Release notes

The "show profiles" feature now also works without showing closed shops.