### PR TITLE
1783 embedded groups

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,7 @@ class ApplicationController < ActionController::Base
   def enable_embedded_shopfront
     whitelist = Spree::Config[:embedded_shopfronts_whitelist]
     return unless Spree::Config[:enable_embedded_shopfronts] && whitelist.present?
-    return if request.referer && URI(request.referer).scheme != 'https' && !Rails.env.test?
+    return if request.referer && URI(request.referer).scheme != 'https' && !Rails.env.test? && !Rails.env.development?
 
     response.headers.delete 'X-Frame-Options'
     response.headers['Content-Security-Policy'] = "frame-ancestors #{whitelist}"

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,6 +7,7 @@ class GroupsController < BaseController
 
   def show
     enable_embedded_shopfront
+    @hide_menu = true if @shopfront_layout == 'embedded'
     @group = EnterpriseGroup.find_by_permalink(params[:id]) || EnterpriseGroup.find(params[:id])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,6 +6,7 @@ class GroupsController < BaseController
   end
 
   def show
+    enable_embedded_shopfront
     @group = EnterpriseGroup.find_by_permalink(params[:id]) || EnterpriseGroup.find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,4 +20,10 @@ module ApplicationHelper
       super
     end
   end
+
+  def body_classes
+    classes = []
+    classes << "off-canvas" unless @hide_menu
+    classes << @shopfront_layout
+  end
 end

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -22,7 +22,7 @@
     = render "layouts/bugherd_script"
     = csrf_meta_tags
 
-  %body.off-canvas{class: @shopfront_layout, ng: {app: "Darkswarm"}}
+  %body{class: body_classes, ng: {app: "Darkswarm"}}
     / [if lte IE 8]
       = render partial: "shared/ie_warning"
       = javascript_include_tag "iehack"
@@ -39,7 +39,7 @@
 
     .off-canvas-wrap{offcanvas: true}
       .inner-wrap
-        = render "shared/menu/menu"
+        = render "shared/menu/menu" unless @hide_menu
 
         %section{ role: "main" }
           = yield

--- a/public/embedded-group-preview.html
+++ b/public/embedded-group-preview.html
@@ -1,0 +1,20 @@
+<html>
+  <head><title>Embedded Group</title></head>
+<body>
+
+  <p>
+  This is a preview page for embedded groups.
+  Choose a group to display by copying its permalink id into the URL after the question mark.
+  Example: <code>embedded-group-preview.html?flavour-crusader</code>
+  </p>
+
+  <iframe style="width:100%;min-height:35em"></iframe>
+  <script>
+    var unsafeGroupName = window.location.search.substr(1);
+    var group = unsafeGroupName.replace(/[^a-z0-9-]/g, '');
+    var iframe = document.querySelector("iframe");
+    iframe.src = "/groups/" + group + "?embedded_shopfront=true";
+  </script>
+
+</body>
+</html>

--- a/public/embedded-group-preview.html
+++ b/public/embedded-group-preview.html
@@ -1,20 +1,20 @@
 <html>
   <head><title>Embedded Group</title></head>
-<body>
+  <body>
 
-  <p>
-  This is a preview page for embedded groups.
-  Choose a group to display by copying its permalink id into the URL after the question mark.
-  Example: <code>embedded-group-preview.html?flavour-crusader</code>
-  </p>
+    <p>
+    This is a preview page for embedded groups.
+    Choose a group to display by copying its permalink id into the URL after the question mark.
+    Example: <code>embedded-group-preview.html?flavour-crusader</code>
+    </p>
 
-  <iframe style="width:100%;min-height:35em"></iframe>
-  <script>
-    var unsafeGroupName = window.location.search.substr(1);
-    var group = unsafeGroupName.replace(/[^a-z0-9-]/g, '');
-    var iframe = document.querySelector("iframe");
-    iframe.src = "/groups/" + group + "?embedded_shopfront=true";
-  </script>
+    <iframe style="width:100%;min-height:35em"></iframe>
+    <script>
+      var unsafeGroupName = window.location.search.substr(1);
+      var group = unsafeGroupName.replace(/[^a-z0-9-]/g, '');
+      var iframe = document.querySelector("iframe");
+      iframe.src = "/groups/" + group + "?embedded_shopfront=true";
+    </script>
 
-</body>
+  </body>
 </html>


### PR DESCRIPTION
#### What? Why?

First iteration of #1783.

It allows group pages to be shown in an iframe. There is a test page to preview groups at `/embedded-group-preview.html?group-name`. I have not added additional specs.

List of Sally's suggestions and what's done:

- [x] the Login (or gear symbol if already logged in) and Cart links could be removed from the header
- [ ] move the 'powered by open food network' to somewhere lower on the page (*the element got removed*)
- [ ] remove the contact details
- [ ] Remove the logo, banner and Description text fields
- [ ] Links to shops open a new window

#### What should we test?

Check that all pages display normally when not embedded.
Check that the embedded shops are displayed correctly.
Check that groups can now be embedded. It would be best to copy the iframe code into another website to test, for example: `<iframe src="/groups/flavour-crusader?embedded_shopfront=true" style="width:100%;min-height:35em"></iframe>`

#### Release notes

Group pages can be embedded on authorised websites.

