### PR TITLE
Add spree adjustment state migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'i18n-js', '~> 3.0.0'
 gem 'nokogiri', '>= 1.6.7.1'
 
 gem 'pg'
-gem 'spree', github: 'coopdevs/spree', branch: 'spree-upgrade-step-6', ref: '6705667'
+gem 'spree', github: 'openfoodfoundation/spree', branch: 'step-6-adjustment-state-migration', ref: '48febb2'
 gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'
 gem 'spree_auth_devise', github: 'openfoodfoundation/spree_auth_devise', branch: 'spree-upgrade-intermediate'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,32 @@ GIT
       activemodel (~> 3.0)
 
 GIT
-  remote: git://github.com/coopdevs/spree.git
-  revision: 6705667ac8acd9f5f4add580a7679bc5b524325c
-  ref: 6705667
-  branch: spree-upgrade-step-6
+  remote: git://github.com/jeremydurham/custom-err-msg.git
+  revision: 3a8ec9dddc7a5b0aab7c69a6060596de300c68f4
+  specs:
+    custom_error_message (1.1.1)
+
+GIT
+  remote: git://github.com/openfoodfoundation/better_spree_paypal_express.git
+  revision: 8d95f4544c682634812becaf50999fba0cd04df0
+  branch: spree-upgrade-intermediate
+  specs:
+    spree_paypal_express (2.0.3)
+      paypal-sdk-merchant (= 1.106.1)
+      spree_core (~> 1.3.99)
+
+GIT
+  remote: git://github.com/openfoodfoundation/ofn-qz.git
+  revision: 024680ccea429b2e5428d7b964fa67c52add34ec
+  specs:
+    ofn-qz (0.1.0)
+      railties (~> 3.1)
+
+GIT
+  remote: git://github.com/openfoodfoundation/spree.git
+  revision: 48febb250a3b1eb2d42812b27b93457e89cde589
+  ref: 48febb2
+  branch: step-6-adjustment-state-migration
   specs:
     spree (1.3.99)
       spree_api (= 1.3.99)
@@ -67,28 +89,6 @@ GIT
       stringex (~> 1.3.2)
     spree_sample (1.3.99)
       spree_core (= 1.3.99)
-
-GIT
-  remote: git://github.com/jeremydurham/custom-err-msg.git
-  revision: 3a8ec9dddc7a5b0aab7c69a6060596de300c68f4
-  specs:
-    custom_error_message (1.1.1)
-
-GIT
-  remote: git://github.com/openfoodfoundation/better_spree_paypal_express.git
-  revision: 8d95f4544c682634812becaf50999fba0cd04df0
-  branch: spree-upgrade-intermediate
-  specs:
-    spree_paypal_express (2.0.3)
-      paypal-sdk-merchant (= 1.106.1)
-      spree_core (~> 1.3.99)
-
-GIT
-  remote: git://github.com/openfoodfoundation/ofn-qz.git
-  revision: 024680ccea429b2e5428d7b964fa67c52add34ec
-  specs:
-    ofn-qz (0.1.0)
-      railties (~> 3.1)
 
 GIT
   remote: git://github.com/openfoodfoundation/spree_auth_devise.git

--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -6,8 +6,6 @@ module Spree
     has_one :metadata, class_name: 'AdjustmentMetadata'
     belongs_to :tax_rate, foreign_key: 'originator_id', conditions: "spree_adjustments.originator_type = 'Spree::TaxRate'"
 
-    before_validation :initialize_state
-
     scope :enterprise_fee,  where(originator_type: 'EnterpriseFee')
     scope :billable_period, where(source_type: 'BillablePeriod')
     scope :admin,           where(source_type: nil, originator_type: nil)
@@ -76,15 +74,5 @@ module Spree
       result
     end
 
-    private
-
-    # Required after Spree Upgrade Step 6, as existing adjustments did not have
-    # a state, and so failed validation. New adjustments are not affected.
-    def initialize_state
-      return unless state.nil?
-      # (static: true) only updates state when not already set
-      # use (static: :force) to force initialization
-      initialize_state_machines(static: true)
-    end
   end
 end

--- a/db/migrate/20170921065259_update_adjustment_states.spree.rb
+++ b/db/migrate/20170921065259_update_adjustment_states.spree.rb
@@ -1,0 +1,17 @@
+# This migration comes from spree (originally 20130417120035)
+class UpdateAdjustmentStates < ActiveRecord::Migration
+  def up
+    Spree::Order.complete.find_each do |order|
+      order.adjustments.update_all(:state => 'closed')
+    end
+
+    Spree::Shipment.shipped.includes(:adjustment).find_each do |shipment|
+      shipment.adjustment.update_column(:state, 'finalized') if shipment.adjustment
+    end
+
+    Spree::Adjustment.where(:state => nil).update_all(:state => 'open')
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170512115519) do
+ActiveRecord::Schema.define(:version => 20170921065259) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false


### PR DESCRIPTION
#### What? Why?

This is a better fix for #1826. The original fix (#1827) was a quick hack to prevent users from seeing errors. This fix uses Spree migrations to solve to problem, and reverts the original solution.

#### What should we test?

Make sure that older adjustments on orders can be updated without crashing.

#### Release notes

No release notes, as the bug that caused #1826 should never make it into a release without this fix.

#### How is this related to the Spree upgrade?

The issue was caused by the spree-upgrade, so this is one of the final fixes needed to allow us to release the upgrade. 