### PR TITLE
Add tooltips in products bulk edit page

### DIFF
--- a/app/views/spree/admin/products/bulk_edit/_products_product.html.haml
+++ b/app/views/spree/admin/products/bulk_edit/_products_product.html.haml
@@ -32,8 +32,8 @@
   %td.available_on{ 'ng-show' => 'columns.available_on.visible' }
     %input{ 'ng-model' => 'product.available_on', :name => 'available_on', 'ofn-track-product' => 'available_on', 'datetimepicker' => 'product.available_on', type: "text" }
   %td.actions
-    %a{ 'ng-click' => 'editWarn(product)', :class => "edit-product icon-edit no-text" }
+    %a{ 'ng-click' => 'editWarn(product)', :class => "edit-product icon-edit no-text", 'ofn-with-tip' => t(:edit) }
   %td.actions
-    %a{ 'ng-click' => 'cloneProduct(product)', :class => "clone-product icon-copy no-text" }
+    %a{ 'ng-click' => 'cloneProduct(product)', :class => "clone-product icon-copy no-text", 'ofn-with-tip' => t(:clone) }
   %td.actions
-    %a{ 'ng-click' => 'deleteProduct(product)', :class => "delete-product icon-trash no-text" }
+    %a{ 'ng-click' => 'deleteProduct(product)', :class => "delete-product icon-trash no-text", 'ofn-with-tip' => t(:remove) }

--- a/app/views/spree/admin/products/bulk_edit/_products_variant.html.haml
+++ b/app/views/spree/admin/products/bulk_edit/_products_variant.html.haml
@@ -25,6 +25,6 @@
   %td.actions
     %a{ 'ng-click' => 'editWarn(product,variant)', :class => "edit-variant icon-edit no-text", 'ng-show' => "variantSaved(variant)", 'ofn-with-tip' => t(:edit)  }
   %td.actions
-    %span.icon-warning-sign{ 'ng-if' => 'variant.variant_overrides', 'ofn-with-tip' => "This variant has {{variant.variant_overrides.length}} override(s)" }
+    %span.icon-warning-sign{ 'ng-if' => 'variant.variant_overrides', 'ofn-with-tip' => "{{ 'spree.admin.products.bulk_edit.products_variant.variant_has_n_overrides' | t:{n: variant.variant_overrides.length} }}" }
   %td.actions
     %a{ 'ng-click' => 'deleteVariant(product,variant)', "ng-class" => '{disabled: product.variants.length < 2}', :class => "delete-variant icon-trash no-text", 'ofn-with-tip' => t(:remove)  }

--- a/app/views/spree/admin/products/bulk_edit/_products_variant.html.haml
+++ b/app/views/spree/admin/products/bulk_edit/_products_variant.html.haml
@@ -1,7 +1,7 @@
 %tr.variant{ :id => "v_{{variant.id}}", 'ng-repeat' => 'variant in product.variants', 'ng-show' => 'DisplayProperties.showVariants(product.id)', 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'" }
   %td.left-actions
     %a{ :class => "variant-item icon-caret-right", 'ng-hide' => "$last" }
-    %a{ :class => "add-variant icon-plus-sign", 'ng-click' => "addVariant(product)", 'ng-show' => "$last" }
+    %a{ :class => "add-variant icon-plus-sign", 'ng-click' => "addVariant(product)", 'ng-show' => "$last", 'ofn-with-tip' => t('.new_variant') }
   %td{ 'ng-show' => 'columns.producer.visible' }
   %td{ 'ng-show' => 'columns.sku.visible' }
     %input{ 'ng-model' => "variant.sku", :name => 'variant_sku', 'ofn-track-variant' => 'sku', :type => 'text' }

--- a/app/views/spree/admin/products/bulk_edit/_products_variant.html.haml
+++ b/app/views/spree/admin/products/bulk_edit/_products_variant.html.haml
@@ -23,8 +23,8 @@
   %td{ 'ng-show' => 'columns.inherits_properties.visible' }
   %td{ 'ng-show' => 'columns.available_on.visible' }
   %td.actions
-    %a{ 'ng-click' => 'editWarn(product,variant)', :class => "edit-variant icon-edit no-text", 'ng-show' => "variantSaved(variant)" }
+    %a{ 'ng-click' => 'editWarn(product,variant)', :class => "edit-variant icon-edit no-text", 'ng-show' => "variantSaved(variant)", 'ofn-with-tip' => t(:edit)  }
   %td.actions
     %span.icon-warning-sign{ 'ng-if' => 'variant.variant_overrides', 'ofn-with-tip' => "This variant has {{variant.variant_overrides.length}} override(s)" }
   %td.actions
-    %a{ 'ng-click' => 'deleteVariant(product,variant)', "ng-class" => '{disabled: product.variants.length < 2}', :class => "delete-variant icon-trash no-text" }
+    %a{ 'ng-click' => 'deleteVariant(product,variant)', "ng-class" => '{disabled: product.variants.length < 2}', :class => "delete-variant icon-trash no-text", 'ofn-with-tip' => t(:remove)  }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,7 @@ en:
   show_all_with_more: "Show All (%{num}  More)"
   cancel: Cancel
   edit: Edit
+  clone: Clone
   distributors: Distributors
   distribution: Distribution
   order_cycles: Order Cycles

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2229,6 +2229,7 @@ Please follow the instructions there to make your enterprise visible on the Open
             av_on: "Av. On"
           products_variant:
             variant_has_n_overrides: "This variant has %{n} override(s)"
+            new_variant: "New variant"
           product_name: Product Name
         primary_taxon_form:
           product_category: Product Category

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2227,6 +2227,8 @@ Please follow the instructions there to make your enterprise visible on the Open
             inherits_properties?: Inherits Properties?
             available_on: Available On
             av_on: "Av. On"
+          products_variant:
+            variant_has_n_overrides: "This variant has %{n} override(s)"
           product_name: Product Name
         primary_taxon_form:
           product_category: Product Category


### PR DESCRIPTION
Fixes #1804 
If someone knows a way to translate [this tooltip that has an Angular interpolation in it](https://github.com/ltrls/openfoodnetwork/blob/9b2d9303f29f0fad26ca43de9b8faf18b64e3805/app/views/spree/admin/products/bulk_edit/_products_variant.html.haml#L28) please let me know!