### PR TITLE
Add noindex meta tag for invisible shops and staging environment

### DIFF
--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -7,7 +7,7 @@ class EnterprisesController < BaseController
 
   # These prepended filters are in the reverse order of execution
   prepend_before_filter :set_order_cycles, :require_distributor_chosen, :reset_order, only: :shop
-  before_filter :check_stock_levels, only: :shop
+  before_filter :check_stock_levels, :set_noindex_meta_tag, only: :shop
 
   before_filter :clean_permalink, only: :check_permalink
   before_filter :enable_embedded_shopfront
@@ -79,5 +79,9 @@ class EnterprisesController < BaseController
   def reset_order_cycle(order, distributor)
     order_cycle_options = OrderCycle.active.with_distributor(distributor)
     order.order_cycle = order_cycle_options.first if order_cycle_options.count == 1
+  end
+
+  def set_noindex_meta_tag
+    @noindex_meta_tag = true unless current_distributor.visible?
   end
 end

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -5,6 +5,8 @@
     %meta{property: "og:title", content: content_for?(:title) ? yield(:title) : t(:title)}
     %meta{property: "og:description", content: content_for?(:description) ? yield(:description) : t(:site_meta_description)}
     %meta{property: "og:image", content: content_for?(:image) ? yield(:image) : ContentConfig.logo.url}
+    - if !Rails.env.production? || @noindex_meta_tag
+      %meta{name: "robots", content: "noindex"}
     %title= content_for?(:title) ? "#{yield(:title)} - #{t(:title)}".html_safe : "#{t(:welcome_to)} #{t(:title)}"
     - if Rails.env.production?
       = favicon_link_tag


### PR DESCRIPTION
PR for #1773.
It adds the noindex tag in the layout for the whole app if the environment isn't production and for shops that have chosen to be "invisible", to prevent from being indexed by search engine bots.