### PR TITLE
Fix js currency

### DIFF
--- a/app/assets/javascripts/darkswarm/filters/localize_currency.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/localize_currency.js.coffee
@@ -3,12 +3,12 @@ Darkswarm.filter "localizeCurrency", (currencyConfig)->
   (amount) ->
     # Set country code (eg. "US").
     currency_code = if currencyConfig.display_currency then " " + currencyConfig.currency else ""
-    # Set decimal points,  2 or 0 if hide_cents.
+    # Set decimal points, 2 or 0 if hide_cents.
     decimals = if currencyConfig.hide_cents == "true" then 0 else 2
-    # Set wether the currency symbol appears first
-    sign_first =  currencyConfig.symbol_position == 'before'
+    # Set format if the currency symbol should come after the number, otherwise (default) use the locale setting.
+    format = if currencyConfig.symbol_position == "after" then "%n %u" else undefined
     # We need to use parseFloat as the amount should come in as a string.
     amount = parseFloat(amount)
 
     # Build the final price string.
-    I18n.toCurrency(amount, {precision: decimals, unit: currencyConfig.symbol, sign_first: sign_first}) + currency_code
+    I18n.toCurrency(amount, {precision: decimals, unit: currencyConfig.symbol, format: format}) + currency_code

--- a/app/assets/javascripts/darkswarm/filters/localize_currency.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/localize_currency.js.coffee
@@ -5,11 +5,10 @@ Darkswarm.filter "localizeCurrency", (currencyConfig)->
     currency_code = if currencyConfig.display_currency then " " + currencyConfig.currency else ""
     # Set decimal points,  2 or 0 if hide_cents.
     decimals = if currencyConfig.hide_cents == "true" then 0 else 2
-    # We need to use parseFloat before toFixed as the amount should come in as a string.
-    amount_fixed = parseFloat(amount).toFixed(decimals)
+    # Set wether the currency symbol appears first
+    sign_first =  currencyConfig.symbol_position == 'before'
+    # We need to use parseFloat as the amount should come in as a string.
+    amount = parseFloat(amount)
 
-    # Build the final price string. TODO use spree decimal point and spacer character settings.
-    if currencyConfig.symbol_position == 'before'
-      currencyConfig.symbol + amount_fixed + currency_code
-    else
-      amount_fixed + " " + currencyConfig.symbol + currency_code
+    # Build the final price string.
+    I18n.toCurrency(amount, {precision: decimals, unit: currencyConfig.symbol, sign_first: sign_first}) + currency_code

--- a/app/serializers/api/order_serializer.rb
+++ b/app/serializers/api/order_serializer.rb
@@ -28,10 +28,6 @@ module Api
       I18n.l(object.order_cycle.andand.orders_close_at, format: "%b %d, %Y %H:%M")
     end
 
-    def total
-      object.total.to_money.to_s
-    end
-
     def shipment_state
       object.shipment_state ? object.shipment_state : nil
     end

--- a/app/serializers/api/orders_by_distributor_serializer.rb
+++ b/app/serializers/api/orders_by_distributor_serializer.rb
@@ -4,7 +4,7 @@ module Api
     has_many :distributed_orders, serializer: Api::OrderSerializer
 
     def balance
-      object.distributed_orders.map(&:outstanding_balance).reduce(:+).to_money.to_s
+      object.distributed_orders.map(&:outstanding_balance).reduce(:+)
     end
 
     def hash

--- a/app/serializers/api/payment_serializer.rb
+++ b/app/serializers/api/payment_serializer.rb
@@ -5,10 +5,6 @@ module Api
       object.payment_method.try(:name)
     end
 
-    def amount
-      object.amount.to_money.to_s
-    end
-
     def updated_at
       I18n.l(object.updated_at, format: "%b %d, %Y %H:%M")
     end

--- a/spec/support/spree/money_helper.rb
+++ b/spec/support/spree/money_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module MoneyHelper
     def with_currency(amount, options = {})
-      Spree::Money.new(amount, {delimiter: ''}.merge(options)).to_s # Delimiter is to match js localizeCurrency
+      Spree::Money.new(amount, options).to_s
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

This PR fixes both problems raised in #1623. The issue was that serializers sent amounts of money as localized strings (`to_money.to_s`) so if the locale used a comma as decimal separator, parsing them in JS to perform operations (in the `/account` page) would fail leading either to a wrong amount (parsing stopped at the comma stripping decimals) or a NaN (not a number) error.
Here I made serializers send the amounts as unlocalized strings, and improved the `localizeCurrency` filter to use i18n-js `toCurrency` method, which as a nice "side effect" also localizes the decimal separator and spacer character.
I18n-js's `toCurrency` method uses translation values in `number.currency.format`, which are set in the rails-i18n gem.

#### What should we test?

The localizeCurrency filter is used in many places but the most notable page is the page at `/account` (see images in related issue) which now presents no error when using a locale with comma as decimal separator. In other places, amounts should also be nicely localized.