### PR TITLE
Stripe connect

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -163,6 +163,7 @@ class CheckoutController < Spree::CheckoutController
   def restart_checkout
     return if @order.state == 'cart'
     @order.restart_checkout! # resets state to 'cart'
+    @order.update_attributes!(shipping_method_id: nil)
     @order.shipments.with_state(:pending).destroy_all
     @order.payments.with_state(:checkout).destroy_all
     @order.reload

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -376,11 +376,14 @@ Spree::Order.class_eval do
   # object_params sets the payment amount to the order total, but it does this before
   # the shipping method is set. This results in the customer not being charged for their
   # order's shipping. To fix this, we refresh the payment amount here.
-  def charge_shipping!
+  def charge_shipping_and_payment_fees!
     update_totals
     return unless payments.any?
     payments.first.update_attribute :amount, total
   end
 end
 
-Spree::Order.state_machine.after_transition to: :payment, do: :charge_shipping!
+Spree::Order.state_machine.after_transition to: :payment, do: :charge_shipping_and_payment_fees!
+Spree::Order.state_machine.event :restart_checkout do
+  transition :to => :cart, unless: :completed?
+end

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -105,7 +105,7 @@ module Spree
     # state is acheived through some trickery using an after_rollback callback on the
     # payment model. See Spree::Payment#persist_invalid
     def revoke_adjustment_eligibility
-      return unless adjustment.reload
+      return unless adjustment.try(:reload)
       return if adjustment.finalized?
       adjustment.update_attribute(:eligible, false)
       adjustment.finalize!

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -190,16 +190,69 @@ describe CheckoutController do
   describe "Paypal routing" do
     let(:payment_method) { create(:payment_method, type: "Spree::Gateway::PayPalExpress") }
     before do
-      controller.stub(:current_distributor).and_return(distributor)
-      controller.stub(:current_order_cycle).and_return(order_cycle)
-      controller.stub(:current_order).and_return(order)
+      allow(controller).to receive(:current_distributor) { distributor }
+      allow(controller).to receive(:current_order_cycle) { order_cycle }
+      allow(controller).to receive(:current_order) { order }
+      allow(controller).to receive(:restart_checkout)
     end
 
     it "should check the payment method for Paypalness if we've selected one" do
-      Spree::PaymentMethod.should_receive(:find).with(payment_method.id.to_s).and_return payment_method
-      order.stub(:update_attributes).and_return true
-      order.stub(:state).and_return "payment"
+      expect(Spree::PaymentMethod).to receive(:find).with(payment_method.id.to_s) { payment_method }
+      allow(order).to receive(:update_attributes) { true }
+      allow(order).to receive(:state) { "payment" }
       spree_post :update, order: {payments_attributes: [{payment_method_id: payment_method.id}]}
+    end
+  end
+
+  describe "#update_failed" do
+    before do
+      controller.instance_variable_set(:@order, order)
+    end
+
+    it "clears the shipping address and restarts the checkout" do
+      expect(controller).to receive(:clear_ship_address)
+      expect(controller).to receive(:restart_checkout)
+      expect(controller).to receive(:respond_to)
+      controller.send(:update_failed)
+    end
+  end
+
+  describe "#restart_checkout" do
+    let!(:shipment_pending) { create(:shipment, order: order, state: 'pending') }
+    let!(:payment_checkout) { create(:payment, order: order, state: 'checkout') }
+    let!(:payment_failed) { create(:payment, order: order, state: 'failed') }
+
+    before do
+      controller.instance_variable_set(:@order, order.reload)
+    end
+
+    context "when the order is already in the 'cart' state" do
+      it "does nothing" do
+        expect(order).to_not receive(:restart_checkout!)
+        controller.send(:restart_checkout)
+      end
+    end
+
+    context "when the order is in a subsequent state" do
+      before do
+        order.update_attribute(:state, "payment")
+      end
+
+      # NOTE: at the time of writing, it was not possible to create a shipment with a state other than
+      # 'pending' when the order has not been completed, so this is not a case that requires testing.
+      it "resets the order state, and clears incomplete shipments and payments" do
+        expect(order).to receive(:restart_checkout!).and_call_original
+        expect(order.shipments.count).to be 1
+        expect(order.adjustments.shipping.count).to be 1
+        expect(order.payments.count).to be 2
+        expect(order.adjustments.payment_fee.count).to be 2
+        controller.send(:restart_checkout)
+        expect(order.reload.state).to eq 'cart'
+        expect(order.shipments.count).to be 0
+        expect(order.adjustments.shipping.count).to be 0
+        expect(order.payments.count).to be 1
+        expect(order.adjustments.payment_fee.count).to be 1
+      end
     end
   end
 end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -223,6 +223,7 @@ describe CheckoutController do
     let!(:payment_failed) { create(:payment, order: order, state: 'failed') }
 
     before do
+      order.update_attribute(:shipping_method_id, shipment_pending.shipping_method_id)
       controller.instance_variable_set(:@order, order.reload)
     end
 
@@ -242,12 +243,14 @@ describe CheckoutController do
       # 'pending' when the order has not been completed, so this is not a case that requires testing.
       it "resets the order state, and clears incomplete shipments and payments" do
         expect(order).to receive(:restart_checkout!).and_call_original
+        expect(order.shipping_method_id).to_not be nil
         expect(order.shipments.count).to be 1
         expect(order.adjustments.shipping.count).to be 1
         expect(order.payments.count).to be 2
         expect(order.adjustments.payment_fee.count).to be 2
         controller.send(:restart_checkout)
         expect(order.reload.state).to eq 'cart'
+        expect(order.shipping_method_id).to be nil
         expect(order.shipments.count).to be 0
         expect(order.adjustments.shipping.count).to be 0
         expect(order.payments.count).to be 1

--- a/spec/requests/checkout/failed_checkout_spec.rb
+++ b/spec/requests/checkout/failed_checkout_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe "checking out an order that initially fails", type: :request do
+  include ShopWorkflow
+
+  let!(:shop) { create(:enterprise) }
+  let!(:order_cycle) { create(:simple_order_cycle) }
+  let!(:exchange) { create(:exchange, order_cycle: order_cycle, sender: order_cycle.coordinator, receiver: shop, incoming: false, pickup_time: "Monday") }
+  let!(:address) { create(:address) }
+  let!(:order) { create(:order, distributor: shop, order_cycle: order_cycle) }
+  let!(:line_item) { create(:line_item, order: order, quantity: 3, price: 5.00) }
+  let!(:payment_method) { create(:bogus_payment_method, distributor_ids: [shop.id], environment: Rails.env) }
+  let!(:check_payment_method) { create(:payment_method, distributor_ids: [shop.id], environment: Rails.env) }
+  let!(:shipping_method) { create(:shipping_method, distributor_ids: [shop.id]) }
+  let!(:shipment) { create(:shipment, order: order, shipping_method: shipping_method) }
+  let(:params) do
+    { format: :json, order: {
+      shipping_method_id: shipping_method.id,
+      payments_attributes: [{payment_method_id: payment_method.id}],
+      bill_address_attributes: address.attributes.slice("firstname", "lastname", "address1", "address2", "phone", "city", "zipcode", "state_id", "country_id"),
+      ship_address_attributes: address.attributes.slice("firstname", "lastname", "address1", "address2", "phone", "city", "zipcode", "state_id", "country_id")
+    } }
+  end
+
+  before do
+    order.reload.update_totals
+    set_order order
+  end
+
+  context "when shipping and payment fees apply" do
+    let(:calculator) { Spree::Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }
+
+    before do
+      payment_method.calculator = calculator.dup
+      payment_method.save!
+      check_payment_method.calculator = calculator.dup
+      check_payment_method.save!
+      shipping_method.calculator = calculator.dup
+      shipping_method.save!
+    end
+
+    it "clears shipments and payments before rendering the checkout" do
+      put update_checkout_path, params
+
+      # Checking out a BogusGateway without a source fails at :payment
+      # Shipments and payments should then be cleared before rendering checkout
+      expect(response.status).to be 400
+      expect(flash[:error]).to eq I18n.t(:payment_processing_failed)
+      order.reload
+      expect(order.shipments.count).to be 0
+      expect(order.payments.count).to be 0
+      expect(order.adjustment_total).to eq 0
+
+      # Add another line item to change the fee totals
+      create(:line_item, order: order, quantity: 3, price: 5.00)
+
+      # Use a check payment method, which should work
+      params[:order][:payments_attributes][0][:payment_method_id] = check_payment_method.id
+      put update_checkout_path, params
+
+      expect(response.status).to be 200
+      order.reload
+      expect(order.total).to eq 36
+      expect(order.adjustment_total).to eq 6
+      expect(order.item_total).to eq 30
+      expect(order.shipments.count).to eq 1
+      expect(order.payments.count).to eq 1
+    end
+  end
+end

--- a/spec/requests/checkout/paypal_spec.rb
+++ b/spec/requests/checkout/paypal_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "confirming an order with paypal express payment method", type: :request do
+describe "checking out an order with a paypal express payment method", type: :request do
   include ShopWorkflow
 
   let!(:address) { create(:address) }

--- a/spec/requests/checkout/stripe_connect_spec.rb
+++ b/spec/requests/checkout/stripe_connect_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Submitting Stripe Connect charge requests", type: :request do
+describe "checking out an order with a Stripe Connect payment method", type: :request do
   include ShopWorkflow
   include AuthenticationWorkflow
 


### PR DESCRIPTION
#### What? Why?

A couple of final fixes to Stripe work
- Add some logic to CheckoutController to strip incomplete shipments and payments from orders after a failed attempt to check out. This prevents incorrect shipping and payment fees from displaying in Checkout summary. Also allows correct fees to be charged if items are added or removed from cart after an initial attempt to process an order fails.

#### What should we test?

- Correct fees charged displayed and charged after > 1 failed attempts to process an order (eg. Stripe card is rejected, PayPal checkout is cancelled by the user, etc.)
- Especially test that when items are added to cart after an initial failed attempt to process an order, correct fees are still displayed and ultimately charged.

#### Release notes

N/A, part of Stripe work which is yet to be released.
