### PR TITLE
Add CSS workaround to display repeated table head

### DIFF
--- a/app/assets/stylesheets/mail/email.css.scss
+++ b/app/assets/stylesheets/mail/email.css.scss
@@ -408,3 +408,12 @@ ul {
   display: inline-block;
   margin: 0px;
 }
+
+/*
+ * Fix overlapping table header on second page of long invoices.
+ * Problem description: https://github.com/openfoodfoundation/openfoodnetwork/issues/1738
+ * Solution: https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1770#issuecomment-73530576
+ */
+thead { display: table-header-group }
+tfoot { display: table-row-group }
+tr { page-break-inside: avoid }


### PR DESCRIPTION
Fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/1738

It adds some CSS as a workaround. We are already using the newest versions of wicked_pdf and wkhtmltopdf.

#### What should we test?

That invoice PDFs are displaying correctly with both invoice styles (see super admin setting).

#### Release notes

Long invoices are displayed correctly.
