### PR TITLE
Relax rubocop Style/SymbolArray rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -143,6 +143,10 @@ Style/WordArray:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylewordarray
 
+Style/SymbolArray:
+  Enabled: false
+  StyleGuide: https://rubocop.readthedocs.io/en/latest/cops_style/#stylesymbolarray
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#lintambiguousregexpliteral


### PR DESCRIPTION
#### What? Why?

Relaxing the symbol arrays style cop to allow symbol arrays like this: `[:one, :two]` and not strictly enforce this style: `%i[one two]`. 

Current rule completely prohibits lines like this:
`before_filter :strip_new_properties, only: [:create, :update]` 
