### PR TITLE
Disable allow_backorders by default in test environment

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -18,6 +18,9 @@ Spree.config do |config|
   config.shipping_instructions = true
   config.address_requires_state = true
 
+  # Set allow_backorders to false by default in test environment
+  config.allow_backorders = false if Rails.env == 'test'
+
   # -- spree_paypal_express
   # Auto-capture payments. Without this option, payments must be manually captured in the paypal interface.
   config.auto_capture = true

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -103,7 +103,6 @@ describe EnterprisesController do
         order.set_distribution! current_distributor, order_cycle
         order.line_items << line_item
 
-        Spree::Config.set allow_backorders: false
         variant.on_hand = 0
         variant.save!
       end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -51,7 +51,6 @@ describe Spree::OrdersController do
     let(:line_item) { order.line_items.last }
 
     before do
-      Spree::Config.allow_backorders = false
       order.set_distribution! d, oc
       order.add_variant variant, 5
       variant.update_attributes! on_hand: 3

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -109,7 +109,6 @@ feature %q{
       let!(:li1) { create(:line_item, order: o1, :quantity => 5 ) }
 
       before :each do
-        Spree::Config.set(allow_backorders: false)
         li1.variant.update_attributes(on_hand: 1, on_demand: false)
         visit '/admin/orders/bulk_management'
       end

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -20,13 +20,6 @@ feature "full-page cart", js: true do
       set_order order
     end
 
-    around do |example|
-      allow_backorders = Spree::Config.allow_backorders
-      Spree::Config.allow_backorders = false
-      example.run
-      Spree::Config.allow_backorders = allow_backorders
-    end
-
     describe "fees" do
       let(:percentage_fee) { create(:enterprise_fee, calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 20)) }
 

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -47,7 +47,6 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
     describe "when I have an out of stock product in my cart" do
       before do
-        Spree::Config.set allow_backorders: false
         variant.on_hand = 0
         variant.save!
       end
@@ -388,7 +387,6 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
           end
 
           it "takes us to the cart page with an error when a product becomes out of stock just before we purchase", js: true do
-            Spree::Config.set allow_backorders: false
             variant.on_hand = 0
             variant.save!
 

--- a/spec/models/spree/order_populator_spec.rb
+++ b/spec/models/spree/order_populator_spec.rb
@@ -196,8 +196,6 @@ module Spree
       let(:v) { double(:variant, on_hand: 10) }
 
       context "when backorders are not allowed" do
-        before { Spree::Config.allow_backorders = false }
-
         context "when max_quantity is not provided" do
           it "returns full amount when available" do
             op.quantities_to_add(v, 5, nil).should == [5, nil]


### PR DESCRIPTION
#### What? Why?

The `allow_backorders` admin preference is currently disabled on instances but is not disabled by default in the test environment and has created a number of issues with enabling/disabling it in various specs.

#### What should we test?

Nothing, it just applies to specs.

#### Discourse thread

https://community.openfoodnetwork.org/t/backorders/1080
