### PR TITLE
Bumping very outdated versions of pry and byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,7 +126,8 @@ group :test do
 end
 
 group :development do
-  gem 'pry-byebug'
+  gem 'byebug', '~> 9.0.0' # 9.1 requires ruby 2.2
+  gem 'pry-byebug', '>= 3.4.3'
   gem 'debugger-linecache'
   gem 'guard'
   gem 'guard-livereload'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,9 +198,7 @@ GEM
     blockenspiel (0.4.5)
     bugsnag (4.1.0)
     builder (3.0.4)
-    byebug (2.7.0)
-      columnize (~> 0.3)
-      debugger-linecache (~> 1.2)
+    byebug (9.0.6)
     cancan (1.6.8)
     capybara (2.7.1)
       addressable
@@ -217,7 +215,7 @@ GEM
     cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    coderay (1.0.9)
+    coderay (1.1.2)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -226,7 +224,6 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     colorize (0.8.1)
-    columnize (0.9.0)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -474,7 +471,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    method_source (0.8.2)
+    method_source (0.9.0)
     mime-types (1.25.1)
     mini_portile2 (2.1.0)
     momentjs-rails (2.5.1)
@@ -523,13 +520,12 @@ GEM
       activerecord (~> 3.0)
     polyglot (0.3.5)
     powerpack (0.1.1)
-    pry (0.9.12.2)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-    pry-byebug (1.3.2)
-      byebug (~> 2.7)
-      pry (~> 0.9.12)
+    pry (0.11.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.4.3)
+      byebug (>= 9.0, < 9.1)
+      pry (~> 0.10)
     rabl (0.7.2)
       activesupport (>= 2.3.14)
       multi_json (~> 1.0)
@@ -629,7 +625,6 @@ GEM
       thor (~> 0.14)
     shoulda-matchers (1.1.0)
       activesupport (>= 3.0.0)
-    slop (3.4.5)
     spinjs-rails (1.3)
       rails (>= 3.1)
     sprockets (2.2.3)
@@ -707,6 +702,7 @@ DEPENDENCIES
   aws-sdk
   blockenspiel
   bugsnag
+  byebug (~> 9.0.0)
   capybara
   coffee-rails (~> 3.2.1)
   compass-rails
@@ -755,7 +751,7 @@ DEPENDENCIES
   parallel_tests
   pg
   poltergeist
-  pry-byebug
+  pry-byebug (>= 3.4.3)
   rabl
   rack-livereload
   rack-ssl


### PR DESCRIPTION
#### What? Why?

Why not? Very outdated versions of `pry` and `byebug` being used.

#### Release notes

No release notes.