### PR TITLE
Fix PayPal spec failure

### DIFF
--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,6 +1,4 @@
 describe Spree.user_class do
-  include AuthenticationWorkflow
-
   describe "associations" do
     it { should have_many(:owned_enterprises) }
 
@@ -95,7 +93,7 @@ describe Spree.user_class do
     end
 
     describe "as admin" do
-      let(:admin) { quick_login_as_admin }
+      let(:admin) { create(:admin_user) }
 
       it "returns all users" do
         expect(admin.known_users).to include u1, u2, u3


### PR DESCRIPTION
#### What? Why?

The user unit spec was improperly using the `quick_login_as_admin` helper method to create an admin user. I am assuming that this was setting the `user_id` in the session, which was not being torn down, because that shouldn't be necessary for unit specs. This was having an affect of subsequent request specs which thought that a user which didn't exist was logged in.

#### What should we test?

Nothing to test

#### Release notes

None
