### PR TITLE
Use Spree's approach for preventing config caching when testing

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -10,6 +10,7 @@ class Enterprise < ActiveRecord::Base
   # This is hopefully a temporary measure, pending the arrival of multiple named inventories
   # for shops. We need this here to allow hubs to restrict visible variants to only those in
   # their inventory if they so choose
+  # TODO: delegate this to a separate model instead of abusing Preferences.
   preference :product_selection_from_inventory_only, :boolean, default: false
 
   devise :confirmable, reconfirmable: true, confirmation_keys: [ :id, :email ]

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -103,7 +103,6 @@ describe EnterprisesController do
         order.set_distribution! current_distributor, order_cycle
         order.line_items << line_item
 
-        Spree::Config.set allow_backorders: false
         variant.on_hand = 0
         variant.save!
       end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -51,7 +51,6 @@ describe Spree::OrdersController do
     let(:line_item) { order.line_items.last }
 
     before do
-      Spree::Config.allow_backorders = false
       order.set_distribution! d, oc
       order.add_variant variant, 5
       variant.update_attributes! on_hand: 3

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -109,7 +109,6 @@ feature %q{
       let!(:li1) { create(:line_item, order: o1, :quantity => 5 ) }
 
       before :each do
-        Spree::Config.set(allow_backorders: false)
         li1.variant.update_attributes(on_hand: 1, on_demand: false)
         visit '/admin/orders/bulk_management'
       end

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -273,6 +273,10 @@ feature %q{
     before do
       Delayed::Job.destroy_all
       quick_login_as_admin
+
+      # This test relies on preference persistence, so we'll turn it on for this spec only.
+      # It will be turned off again automatically by reset_spree_preferences in spec_helper.
+      Spree::Preferences::Store.instance.persistence = true
     end
 
     it "refreshes the cache when I change what products appear on my shopfront" do

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -20,13 +20,6 @@ feature "full-page cart", js: true do
       set_order order
     end
 
-    around do |example|
-      allow_backorders = Spree::Config.allow_backorders
-      Spree::Config.allow_backorders = false
-      example.run
-      Spree::Config.allow_backorders = allow_backorders
-    end
-
     describe "product description" do
       it "does not link to the product page" do
         add_product_to_cart order, product_fee, quantity: 2

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -47,7 +47,6 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
     describe "when I have an out of stock product in my cart" do
       before do
-        Spree::Config.set allow_backorders: false
         variant.on_hand = 0
         variant.save!
       end
@@ -392,7 +391,6 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
           end
 
           it "takes us to the cart page with an error when a product becomes out of stock just before we purchase", js: true do
-            Spree::Config.set allow_backorders: false
             variant.on_hand = 0
             variant.save!
 

--- a/spec/models/spree/order_populator_spec.rb
+++ b/spec/models/spree/order_populator_spec.rb
@@ -196,8 +196,6 @@ module Spree
       let(:v) { double(:variant, on_hand: 10) }
 
       context "when backorders are not allowed" do
-        before { Spree::Config.allow_backorders = false }
-
         context "when max_quantity is not provided" do
           it "returns full amount when available" do
             op.quantities_to_add(v, 5, nil).should == [5, nil]
@@ -220,10 +218,8 @@ module Spree
       end
 
       context "when backorders are allowed" do
-        around do |example|
+        before do
           Spree::Config.allow_backorders = true
-          example.run
-          Spree::Config.allow_backorders = false
         end
 
         it "does not limit quantity" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,11 +100,13 @@ RSpec.configure do |config|
   # Ensure we start with consistent config settings
   config.before(:each) do
     reset_spree_preferences do |spree_config|
+      # These are all settings that differ from Spree's defaults
       spree_config.default_country_id = default_country_id
       spree_config.checkout_zone = checkout_zone
       spree_config.currency = currency
       spree_config.shipping_instructions = true
       spree_config.auto_capture = true
+      spree_config.allow_backorders = false
     end
 
     Spree::Api::Config[:requires_authentication] = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ require 'spree/api/testing_support/setup'
 require 'spree/api/testing_support/helpers'
 require 'spree/api/testing_support/helpers_decorator'
 require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/preferences'
 
 # Capybara config
 require 'capybara/poltergeist'
@@ -93,8 +94,21 @@ RSpec.configure do |config|
   # Geocoding
   config.before(:each) { Spree::Address.any_instance.stub(:geocode).and_return([1,1]) }
 
+  default_country_id = Spree::Config[:default_country_id]
+  checkout_zone  = Spree::Config[:checkout_zone]
+  currency = Spree::Config[:currency]
   # Ensure we start with consistent config settings
-  config.before(:each) { Spree::Config.products_require_tax_category = false }
+  config.before(:each) do
+    reset_spree_preferences do |spree_config|
+      spree_config.default_country_id = default_country_id
+      spree_config.checkout_zone = checkout_zone
+      spree_config.currency = currency
+      spree_config.shipping_instructions = true
+      spree_config.auto_capture = true
+    end
+
+    Spree::Api::Config[:requires_authentication] = true
+  end
 
   # Helpers
   config.include Rails.application.routes.url_helpers
@@ -102,6 +116,7 @@ RSpec.configure do |config|
   config.include Spree::CheckoutHelpers
   config.include Spree::MoneyHelper
   config.include Spree::TestingSupport::ControllerRequests, :type => :controller
+  config.include Spree::TestingSupport::Preferences
   config.include Devise::TestHelpers, :type => :controller
   config.extend  Spree::Api::TestingSupport::Setup, :type => :controller
   config.include Spree::Api::TestingSupport::Helpers, :type => :controller


### PR DESCRIPTION
#### What? Why?

TAKE 3
Solving the same problem as #1903 and #1742. I've also included Matt's work from #1896 using the same approach.

After doing some more investigating, it turns out Spree already has its own [built-in mechanism](https://github.com/openfoodfoundation/spree/blob/step-6a/core/lib/spree/testing_support/preferences.rb) for preventing persistence of config settings in the test environment. I have no idea how we missed it until now, but there you go. 