### PR TITLE
Ignore .byebug_history after recent update of byebug gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bundle
 .rbenv-version
+.byebug_history
 .swp
 *.swo
 *.swp


### PR DESCRIPTION
#### What? Why?

`byebug` seems to be creating a new file after the recent update. Just adding it to `.gitingore`.

#### What should we test?

Nothing

#### Release notes

None