### PR TITLE
Fix anchor tag website word wrap in profile modal

### DIFF
--- a/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
+++ b/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
@@ -5,12 +5,9 @@
 
 .modal-centered {
   text-align: center;
-
+  
   p {
     margin-bottom: 0;
-  }
-  a {
-    word-wrap: break-word;
   }
 }
 
@@ -98,6 +95,9 @@
 // CONTACT Enterprise
 
 .contact-container {
+  a {
+    word-wrap: break-word;
+  }
   a:hover {
     text-decoration: underline;
   }

--- a/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
+++ b/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
@@ -9,6 +9,9 @@
   p {
     margin-bottom: 0;
   }
+  a {
+    word-wrap: break-word;
+  }
 }
 
 .modal-header, p.modal-header {


### PR DESCRIPTION
Closes #1840

#### What? Why?

Fixed the issue of long website links running off the profile modal. Added word-wrap: break-word to the anchor tags within the modal-centered class.

<img width="1436" alt="screen shot 2017-10-16 at 4 33 06 pm" src="https://user-images.githubusercontent.com/20754511/31641366-56e83b66-b2a1-11e7-8948-266eb829911c.png">





