### PR TITLE
Do not update finalized fee adjustments

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -144,6 +144,8 @@ Spree::Order.class_eval do
   end
 
   # After changing line items of a completed order
+  # TODO: perhaps this should be triggered from a controller
+  # rather than an after_save callback?
   def update_shipping_fees!
     shipments.each do |shipment|
       next if shipment.shipped?
@@ -153,6 +155,8 @@ Spree::Order.class_eval do
   end
 
   # After changing line items of a completed order
+  # TODO: perhaps this should be triggered from a controller
+  # rather than an after_save callback?
   def update_payment_fees!
     payments.each do |payment|
       next if payment.completed?
@@ -367,6 +371,7 @@ Spree::Order.class_eval do
   end
 
   def update_adjustment!(adjustment)
+    return if adjustment.finalized?
     state = adjustment.state
     adjustment.state = 'open'
     adjustment.update!(self)


### PR DESCRIPTION
#### What? Why?

As I was testing #1910, I came across an issue whereby transaction fees associated with failed payments, which had been marked as `eligible: false` and `finalized` seemed to be re-opened at the end of the checkout process, resulting in an additional fee 'appearing' the next time the completed order was updated (adding/removing items etc).

The culprit is a set of `after_save` callbacks on `Spree::Order`, which are designed to update shipping and payment fees in the event that a completed order has items added/removed. The way this works is that all such fees are placed in the `open` state, and then updated. This process was opening the `finalized` failed payment adjustment and reseting the `eligible` flag to `true`, meaning that subsequent updates would incorrectly consider it relevant to the calculation of the order total. 

The fix I have provided simply adds a guard clause to the updater method, allowing it to return early if the adjustment is in the `finalized` state.

I have added additional `TODO` comments suggesting that this logic may be better placed in a controller rather than an `after_save` callback...

#### What should we test?

Completed orders with failed payments should be able to updated any number of times without additional `Transaction fees` from failed payments appearing and affecting the order total.

Shipments marked as `shipped` should not be updated when changes are made to the order that would otherwise cause them to be adjusted.

#### Release notes

Fixed a bug that caused failed payments to add a transaction fee to an order when it was updated by an enterprise user.
