### PR TITLE
Feature/enable i18n fallback to en

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -98,7 +98,8 @@ module Openfoodnetwork
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = ENV["LOCALE"] || ENV["I18N_LOCALE"] || "en"
-    config.i18n.available_locales = ENV["AVAILABLE_LOCALES"].andand.split(',').andand.map(&:strip) || [config.i18n.default_locale]
+    config.i18n.available_locales = ENV["AVAILABLE_LOCALES"].andand.split(/[\s,]/).andand.map(&:strip) || []
+    config.i18n.available_locales = (config.i18n.available_locales + [config.i18n.default_locale, 'en']).uniq
     I18n.locale = config.i18n.locale = config.i18n.default_locale
 
     # Setting this to true causes a performance regression in Rails 3.2.17

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,8 @@ Openfoodnetwork::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = false
 
+  config.i18n.fallbacks = [:en]
+
   # Show emails using Letter Opener
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_url_options = { host: "0.0.0.0:3000" }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Openfoodnetwork::Application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Openfoodnetwork::Application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)
-  config.i18n.fallbacks = [:en]
+  config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -56,7 +56,7 @@ Openfoodnetwork::Application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,7 @@ Openfoodnetwork::Application.configure do
   # Tests assume English text on the site.
   config.i18n.default_locale = "en"
   config.i18n.available_locales = ['en', 'es']
+  config.i18n.fallbacks = [:en]
   I18n.locale = config.i18n.locale = config.i18n.default_locale
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.


### PR DESCRIPTION
#### What? Why?

Right now in ofn, the process of getting i18n keys translated and into code is a manual process and prone to errors. Due to this, you may have cases that despite the translations have been done in transifex, these do not get into the code when they should and you get  `missing translation` messages in the UI.

This is a very ugly experience for the user so this PR attempts to ensure that, we always fallback to the `en` locale if the key is not found in the current locale (or any available locales).

This PR modifies the `config.i18n.available_locales` list to ensure that both the `I18n.default_locale` and the `en` locale are always *available* and as such they are available both for backend translations and frontend translations (i18n-js gem uses `config.i18n.available_locales` to filter which locales it exports to the frontend).

Additionally, we ensure that the list of I18n fallbacks always includes `en` in ALL environments. This means that even if the default locale of any particular instance of ofn is a non-english based locale (the i18n gem will automatically derive `en` from english based locales), it will still at least use `en` as a fallback if there are no translations found for that locale.

#### What should we test?

- [ ] Missing translations fallback to `en` in both backend and frontend, irrespective of the locale and the environment.

#### Release notes

- Now, i18n translations will always fallback to `en` in both backend and frontend, irrespective of the locale and the environment.

#### GIF

![](https://media.giphy.com/media/SdonQiqUoRGVO/giphy.gif)