### PR TITLE
Fix mistyped translation key for 'dashboard'

### DIFF
--- a/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/multi_enterprise_dashboard.html.haml
@@ -4,7 +4,7 @@
 
 %div{ 'ng-app' => 'ofn.admin' }
   %h1{ :style => 'margin-bottom: 30px' }
-    = t "dashbord"
+    = t 'dashboard'
 
   - if @enterprises.unconfirmed.any?
 


### PR DESCRIPTION
#### What? Why?

Tiny fix. Correcting the translation key for 'dashboard' in admin section.