### PR TITLE
1799 - Missing translations in new shipping methods page

### DIFF
--- a/app/assets/javascripts/templates/admin/tags_input.html.haml
+++ b/app/assets/javascripts/templates/admin/tags_input.html.haml
@@ -1,4 +1,5 @@
 %tags-input{ template: 'admin/tag.html',
+  "placeholder" => t('admin.order_cycles.form.add_a_tag'),
   ng: { model: 'object[tagsAttr]', class: "{'limit-reached': limitReached}"},
   on: { tag: { added: 'tagAdded()', removed:'tagRemoved()' } } }
   %auto-complete{ ng: { if: "findTags" }, source: "findTags({query: $query})",

--- a/app/overrides/spree/admin/shipping_methods/_form/replace_form_fields.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/_form/replace_form_fields.html.haml.deface
@@ -39,7 +39,7 @@
     .alpha.three.columns
       -# The 'Category' label here is just a logical descriptor for the data we are trying to collect for 'requires_ship_address'
       -# and does not relate to shipping categories in any way.
-      = f.label :require_ship_address, "Category"
+      = f.label :require_ship_address, t(:category)
     .two.columns
       = f.radio_button :require_ship_address, true
       &nbsp;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,7 @@ en:
   show_only_unfulfilled_orders: Show only unfulfilled orders
   filter_results: Filter Results
   quantity: Quantity
+  pick_up: Pick up
 
 
   actions:
@@ -645,6 +646,7 @@ en:
         distributor: Distributor
         products: Products
         tags: Tags
+        add_a_tag: Add a tag
         delivery_details: Pickup / Delivery details
         debug_info: Debug information
       name_and_timing_form:


### PR DESCRIPTION
Issue - #1799 
#### What? Why?

Translations were missing in new shipping methods page (admin/shipping_methods/new).
Fixed this by removing hardcoded strings and added missing translations in locale file.

#### What should we test?

Test whether translations are available for all the strings in new shipping methods page (admin/shipping_methods/new).
