### PR TITLE
Disabled product links in cart

### DIFF
--- a/app/overrides/spree/orders/_line_item/disable_link_to_product.html.haml.deface
+++ b/app/overrides/spree/orders/_line_item/disable_link_to_product.html.haml.deface
@@ -1,0 +1,7 @@
+/ replace ".item-thumb-image"
+
+%div.item-thumb-image{"data-hook" => "cart_item_image"}
+  - if variant.images.length == 0
+    = mini_image(variant.product)
+  - else
+    = image_tag(variant.images.first.attachment.url(:mini))

--- a/app/overrides/spree/orders/_line_item/disable_link_to_product.html.haml.deface
+++ b/app/overrides/spree/orders/_line_item/disable_link_to_product.html.haml.deface
@@ -1,7 +1,0 @@
-/ replace ".item-thumb-image"
-
-%div.item-thumb-image{"data-hook" => "cart_item_image"}
-  - if variant.images.length == 0
-    = mini_image(variant.product)
-  - else
-    = image_tag(variant.images.first.attachment.url(:mini))

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -11,9 +11,9 @@
 
     %div.item-thumb-image{"data-hook" => "cart_item_image"}
       - if variant.images.length == 0
-        = link_to mini_image(variant.product), variant.product
+        = mini_image(variant.product)
       - else
-        = link_to image_tag(variant.images.first.attachment.url(:mini)), variant.product
+        = image_tag(variant.images.first.attachment.url(:mini))
 
     = render 'spree/shared/line_item_name', line_item: line_item
 

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -27,6 +27,14 @@ feature "full-page cart", js: true do
       Spree::Config.allow_backorders = allow_backorders
     end
 
+    describe "product description" do
+      it "should not try to link to the product page" do
+        add_product_to_cart order, product_fee, quantity: 2
+        visit spree.cart_path
+        expect(page).to_not have_selector '.item-thumb-image a'
+      end
+    end
+
     describe "fees" do
       let(:percentage_fee) { create(:enterprise_fee, calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 20)) }
 

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -28,7 +28,7 @@ feature "full-page cart", js: true do
     end
 
     describe "product description" do
-      it "should not try to link to the product page" do
+      it "does not link to the product page" do
         add_product_to_cart order, product_fee, quantity: 2
         visit spree.cart_path
         expect(page).to_not have_selector '.item-thumb-image a'


### PR DESCRIPTION
#### What? Why?

This is an interim solution to #1075 which is due to product urls being explicitly rerouted to the homepage in routes.rb
Depending on priority, I suggest raising a further issue to make the behaviour of the products in the cart match the experience of the products in the shop (modal with product description)

#### What should we test?

The shopping cart spec has been updated to explicitly check for links under the product image. Manual testing is just making sure that the images are now non-clickable

#### How is this related to the Spree upgrade?

I specifically chose to use the Deface functionality to implement this, rather than inserting it into the overridden _line_item template. Using Deface rather than overriding the templates makes it easier to upgrade the Spree version. The current changes to this template could (and maybe ought to) be migrated from the override to Deface.