### PR TITLE
Lower log level in prod to :info so we can debug

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Openfoodnetwork::Application.configure do
   config.force_ssl = true
 
   # See everything in the log (default is :info)
-  config.log_level = :warn
+  config.log_level = :info
 
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new


### PR DESCRIPTION
#### What? Why?

With the current log level `:warn` there are no log lines for any request, which makes it impossible to find out anything about the app in production. With `:info` you see things like:

```
Started PUT "/admin/order_cycles/49.json?reloading=0" for 188.84.185.117 at 2017-10-25 11:10:39 +0000
Processing by Admin::OrderCyclesController#update as JSON
  Parameters: {"order_cycle"=>{"incoming_exchanges"=>[{"id"=>116, "sender_id"=>5, "incoming"=>true, "variants"=>{"4"=>false, "6"=>true, "370"=>true}, "receival_instructions"=>nil, "pickup_time"=>nil, "pickup_instructions"=>nil, "tags"=>nil, "tag_list"=>"", "enterprise_id"=>5, "active"=>true, "enterprise_fee_ids"=>nil}], "outgoing_exchanges"=>[{"id"=>117, "receiver_id"=>5, "incoming"=>false, "variants"=>{"4"=>false, "370"=>true}, "receival_instructions"=>nil, "pickup_time"=>"18h", "pickup_instructions"=>"A recollir al local", "tags"=>nil, "tag_list"=>"", "enterprise_id"=>5, "active"=>true, "enterprise_fee_ids"=>nil}], "name"=>"Setmana 25/10/17", "orders_open_at"=>"2017-10-10 00:00:00 +0200", "orders_close_at"=>"2017-10-26 00:00:00 +0200", "coordinator_id"=>5, "coordinator_fee_ids"=>nil}, "reloading"=>"0", "id"=>"49"}
Completed 200 OK in 1058.8ms (Views: 1.3ms | ActiveRecord: 305.3ms)
```

Any instance will need one day or another to `grep` these production log files to troubleshoot bugs or customer complains.

Obviously this increases the size of the log files but this has to be dealt with log rotation. The data is our most important asset.

You can read about the topic in http://guides.rubyonrails.org/debugging_rails_applications.html#log-levels