### PR TITLE
Fix 1664: product tag rules not working

### DIFF
--- a/app/serializers/api/variant_serializer.rb
+++ b/app/serializers/api/variant_serializer.rb
@@ -1,6 +1,7 @@
 class Api::VariantSerializer < ActiveModel::Serializer
   attributes :id, :is_master, :count_on_hand, :name_to_display, :unit_to_display, :unit_value
   attributes :options_text, :on_demand, :price, :fees, :price_with_fees, :product_name
+  attributes :tag_list
 
   def price
     object.price
@@ -21,5 +22,11 @@ class Api::VariantSerializer < ActiveModel::Serializer
 
   def product_name
     object.product.name
+  end
+
+  # Used for showing/hiding variants in shopfront based on tag rules
+  def tag_list
+    return [] unless object.respond_to?(:tag_list)
+    object.tag_list
   end
 end

--- a/spec/lib/open_food_network/products_renderer_spec.rb
+++ b/spec/lib/open_food_network/products_renderer_spec.rb
@@ -73,6 +73,11 @@ module OpenFoodNetwork
         Spree::Product.any_instance.stub(:primary_taxon).and_return taxon
         pr.products_json.should include taxon.name
       end
+
+      it "loads tag_list for variants" do
+        VariantOverride.create(variant: variant, hub: distributor, tag_list: 'lalala')
+        expect(pr.products_json).to include "[\"lalala\"]"
+      end
     end
 
     describe "loading variants" do
@@ -96,7 +101,6 @@ module OpenFoodNetwork
         expect(variants[p.id]).to include v1, v3
         expect(variants[p.id]).to_not include v4
       end
-
 
       context "when hub opts to only see variants in its inventory" do
         before do

--- a/spec/serializers/variant_serializer_spec.rb
+++ b/spec/serializers/variant_serializer_spec.rb
@@ -1,27 +1,26 @@
 require 'spec_helper'
 
 describe Api::VariantSerializer do
-  
   subject { Api::VariantSerializer.new variant }
   let(:variant) { create(:variant) }
 
-  it "includes the expected attributes " do 
+  it "includes the expected attributes" do
     expect(subject.attributes.keys).
     to include(
         :id,
-        :name_to_display, 
-        :is_master, 
-        :count_on_hand, 
-        :name_to_display, 
-        :unit_to_display, 
+        :name_to_display,
+        :is_master,
+        :count_on_hand,
+        :name_to_display,
+        :unit_to_display,
         :unit_value,
-        :options_text, 
-        :on_demand, 
-        :price, 
-        :fees, 
-        :price_with_fees, 
-        :product_name
+        :options_text,
+        :on_demand,
+        :price,
+        :fees,
+        :price_with_fees,
+        :product_name,
+        :tag_list # Used to apply tag rules
       )
   end
-
 end


### PR DESCRIPTION
#### What? Why?

Fixes #1664: product tag rules are not working

Caused by a combination of: fe7bd5e2cd35122245ba5ed93003a315e61c7ff2 and 38d3b446cc171a34b9d939fd3402f810a7c8477b

Have added/tweaked specs to prevent this from happening again

#### What should we test?

Tag rules should work properly to show and hide products in the shopfront

#### Release notes

- Fixed a regression bug that prevented tag rules from filtering products properly in the shopfront