### PR TITLE
Adjust use of non-translatable open/closed icons

### DIFF
--- a/app/assets/javascripts/templates/partials/hub_details.html.haml
+++ b/app/assets/javascripts/templates/partials/hub_details.html.haml
@@ -17,8 +17,8 @@
         %a.cta-hub{"ng-href" => "{{::enterprise.path}}",
         "ng-class" => "{primary: enterprise.active, secondary: !enterprise.active}",
         "ofn-change-hub" => "enterprise"}
-          %i.ofn-i_033-open-sign{"ng-if" => "::enterprise.active"}
-          %i.ofn-i_032-closed-sign{"ng-if" => "::!enterprise.active"}
           .hub-name{"ng-bind" => "::enterprise.name"}
+          %span{"ng-if" => "::enterprise.active"} ({{'maps_open' | t}})
+          %span{"ng-if" => "::!enterprise.active"} ({{'maps_closed' | t}})
           .button-address{"ng-bind" => "::[enterprise.address.city, enterprise.address.state_name] | printArray"}
           / %i.ofn-i_007-caret-right

--- a/app/assets/javascripts/templates/partials/producer_details.html.haml
+++ b/app/assets/javascripts/templates/partials/producer_details.html.haml
@@ -14,7 +14,7 @@
         %a.cta-hub{"ng-repeat" => "hub in enterprise.hubs | filter:{id: '!'+enterprise.id} | orderBy:'-active'",
         "ng-href" => "{{::hub.path}}", "ofn-empties-cart" => "hub",
         "ng-class" => "::{primary: hub.active, secondary: !hub.active}"}
-          %i.ofn-i_033-open-sign{"ng-if" => "::hub.active"}
-          %i.ofn-i_032-closed-sign{"ng-if" => "::!hub.active"}
           .hub-name{"ng-bind" => "::hub.name"}
+          %span{"ng-if" => "::hub.active"} ({{'maps_open' | t}})
+          %span{"ng-if" => "::!hub.active"} ({{'maps_closed' | t}})
           .button-address{"ng-bind" => "::[hub.address.city, hub.address.state_name] | printArray"}

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.sass
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.sass
@@ -36,6 +36,8 @@
         text-align: right
         p
           max-width: 400px
+        h4 i
+          margin-right: 0.3rem
         @media all and (max-width: 640px)
           float: left
           clear: left

--- a/app/assets/stylesheets/darkswarm/hub_node.css.scss
+++ b/app/assets/stylesheets/darkswarm/hub_node.css.scss
@@ -8,6 +8,14 @@
       white-space: nowrap;
       overflow-x: hidden;
       overflow-y: visible;
+
+      i {
+        margin-right: 0.5rem;
+      }
+    }
+
+    .active_table_row {
+      line-height: 1rem;
     }
 
     //Generic text link style
@@ -30,7 +38,7 @@
     //Closed & Open column
     .open_closed {
       i {
-        font-size: 2rem;
+        font-size: 1.75rem;
         float: right;
         margin-left: 0.5rem;
       }

--- a/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
+++ b/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
@@ -160,13 +160,6 @@
       color: $clr-brick;
     }
 
-    i.ofn-i_033-open-sign, i.ofn-i_032-closed-sign {
-      margin-right: 0.1rem;
-      font-size: 2rem;
-      padding: 0.15rem 0.25rem 0.35rem 0.25rem;
-      float: left;
-    }
-
     .hub-name {
       margin-top: 0.75rem;
       margin-bottom: 0.2rem;

--- a/app/views/producers/_fat.html.haml
+++ b/app/views/producers/_fat.html.haml
@@ -1,4 +1,4 @@
-.row.active_table_row{"ng-if" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : !ofn-i_032-closed-sign()}"}
+.row.active_table_row{"ng-if" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : open()}"}
 
   .columns.small-12.medium-7.large-7.fat
     / Will add in long description available once clean up HTML formatting producer.long_description
@@ -77,7 +77,7 @@
         %a.cta-hub{"ng-repeat" => "hub in producer.hubs | visible | orderBy:'-active'",
         "ng-href" => "{{::hub.path}}", "ofn-change-hub" => "hub",
         "ng-class" => "::{primary: hub.active, secondary: !hub.active}"}
-          %i.ofn-i_033-open-sign{"ng-if" => "::hub.active"}
-          %i.ofn-i_032-closed-sign{"ng-if" => "::!hub.active"}
+          %i.ofn-i_068-shop-reversed{"ng-if" => "::hub.active"}
+          %i.ofn-i_068-shop-reversed{"ng-if" => "::!hub.active"}
           .hub-name{"ng-bind" => "::hub.name"}
           .button-address{"ng-bind" => "::[hub.address.city, hub.address.state_name] | printArray"}

--- a/app/views/shopping_shared/_order_cycles.html.haml
+++ b/app/views/shopping_shared/_order_cycles.html.haml
@@ -4,7 +4,7 @@
 
   - if @order_cycles and @order_cycles.empty?
     %h4
-      %i.ofn-i_032-closed-sign
+      %i.ofn-i_012-warning
       = t :shopping_oc_closed
     %p
       = t :shopping_oc_closed_description

--- a/app/views/shops/_fat.html.haml
+++ b/app/views/shops/_fat.html.haml
@@ -1,4 +1,4 @@
-.row.active_table_row{"ng-show" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : !ofn-i_032-closed-sign()}"}
+.row.active_table_row{"ng-show" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : open()}"}
   .columns.small-12.medium-6.large-5.fat
     %div{"ng-if" => "::hub.taxons"}
       %label

--- a/app/views/shops/_skinny.html.haml
+++ b/app/views/shops/_skinny.html.haml
@@ -12,7 +12,7 @@
 
   .columns.small-4.medium-3.large-3.text-right{"ng-if" => "::hub.active"}
     %a.hub.open_closed{"ng-href" => "{{::hub.path}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
-      %i.ofn-i_033-open-sign
+      %i.ofn-i_068-shop-reversed
       %span.margin-top{ ng: { if: "::current()" } }
         %em= t :hubs_shopping_here
       %span.margin-top{ ng: { if: "::!current()" } }
@@ -20,11 +20,11 @@
 
   .columns.small-4.medium-3.large-3.text-right{"ng-if" => "::!hub.active"}
     %a.hub.open_closed{"ng-href" => "{{::hub.path}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
-      %i.ofn-i_032-closed-sign
       %span.margin-top{ ng: { if: "::current()" } }
         %em= t :hubs_shopping_here
       %span.margin-top{ ng: { if: "::!current()" } }
         = t :hubs_orders_closed
+      %i.ofn-i_068-shop-reversed
 
   .columns.small-2.medium-1.large-1.text-right
     %span.margin-top

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1129,6 +1129,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   enterprises_ready_for: "Ready for"
   enterprises_choose: "Choose when you want your order:"
 
+  maps_open: "Open"
+  maps_closed: "Closed"
+
   hubs_buy: "Shop for:"
   hubs_shopping_here: "Shopping here"
   hubs_orders_closed: "Orders closed"


### PR DESCRIPTION
#### What? Why?

Changing use of icons that have non-translatable English text for issue #1561. 

#### What should we test?

Icons on /shops page and on shop where order cycles are closed.

#### Screenshots

BEFORE:
![screenshot from 2017-10-31 12-14-00](https://user-images.githubusercontent.com/9029026/32226559-c06e2eb0-be40-11e7-94e5-9c0a7c2428a8.png)

![screenshot from 2017-10-31 12-13-20](https://user-images.githubusercontent.com/9029026/32226519-a352fd42-be40-11e7-8fd8-ca5fc1ba5af6.png)

AFTER:
![screenshot from 2017-10-31 12-34-09](https://user-images.githubusercontent.com/9029026/32226536-adff2126-be40-11e7-804d-1f7dab479a06.png)

![screenshot from 2017-10-31 12-54-25](https://user-images.githubusercontent.com/9029026/32226537-ae282cc4-be40-11e7-9655-ebbdeccfa9ca.png)

