### PR TITLE
Bootstrap angular module in new_variant form

### DIFF
--- a/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_unit_value_and_description.html.haml.deface
@@ -11,3 +11,8 @@
     .field{"data-hook" => "unit_description"}
       = f.label :unit_description, t(:spree_admin_unit_description)
       = f.text_field :unit_description, class: "fullwidth", placeholder: t('admin.products.unit_name_placeholder')
+
+    :javascript
+      angular.element(document.getElementById("new_variant")).ready(function() {
+        angular.bootstrap(document.getElementById("new_variant"), ['admin.products']);
+      });


### PR DESCRIPTION
#### What? Why?

Fixes #1932 

In the `new variant` form page, the form is dynamically loaded without rerunning the angular module (re-bootstrapping). The `edit variant` form works because the full page is loaded and so, the angular module is also executed. 

#### What should we test?

Adding, updating or removing variants. 

#### Release notes

Fixed new variant form, not capturing the weight value. 