### PR TITLE
Add spree user as admin of Enterprise 2 in seed

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -193,6 +193,8 @@ namespace :openfoodnetwork do
         .where('spree_products.supplier_id = ?', enterprise2.id)
 
       CreateOrderCycle.new(enterprise2, variants).call
+
+      EnterpriseRole.create!(user: Spree::User.first, enterprise: enterprise2)
     end
 
     # Creates an order cycle for the provided enterprise and selecting all the


### PR DESCRIPTION
#### What? Why?

Just what the subject says. It makes it easier to start using OFN in development.