### PR TITLE
Remove duplicated directive datepicker from index_utils directory

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/datepicker.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/datepicker.js.coffee
@@ -1,9 +1,0 @@
-angular.module("admin.utils").directive "datepicker", ->
-  require: "ngModel"
-  link: (scope, element, attrs, ngModel) ->
-    element.datepicker
-      dateFormat: "yy-mm-dd"
-      onSelect: (dateText, inst) ->
-        scope.$apply (scope) ->
-          # Fires ngModel.$parsers
-          ngModel.$setViewValue dateText


### PR DESCRIPTION
#### What? Why?

This resolves issue #1947 where a duplicate directive of datepicker existed in the /assets/ directory.

#### What should we test?

Running the testing suite should yield the same results before and after removing the file.

#### How is this related to the Spree upgrade?

No known conflicts with the Spree upgrade
