### PR TITLE
Limit frame-ancestors to requesting URI for embedded shops

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,10 +57,10 @@ class ApplicationController < ActionController::Base
   def enable_embedded_shopfront
     whitelist = Spree::Config[:embedded_shopfronts_whitelist]
     return unless Spree::Config[:enable_embedded_shopfronts] && whitelist.present?
-    return if request.referer && URI(request.referer).scheme != 'https' && !Rails.env.test? && !Rails.env.development?
+    return if request.referer && URI(request.referer).scheme != 'https' && !Rails.env.test? && !Rails.env.development? && !whitelist.include?(URI(request.referer).host)
 
     response.headers.delete 'X-Frame-Options'
-    response.headers['Content-Security-Policy'] = "frame-ancestors #{whitelist}"
+    response.headers['Content-Security-Policy'] = "frame-ancestors #{URI(request.referer).host}"
 
     check_embedded_request
     set_embedded_layout


### PR DESCRIPTION
#### What? Why?

#1953 
Proposing an alternative to listing every allowed parent in every header. When debugging iframe issues it felt inappropriate to be able to see the list of all URIs that can embed OFN shopfronts from a clients website.

#### What should we test?

Not ready for testing. WIP