### PR TITLE
closes cart page shouldn't show 'admin & handling' if it is zero #424

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -24,11 +24,11 @@ module CheckoutHelper
 
   def display_checkout_admin_and_handling_adjustments_total_for(order)
     adjustments = order.adjustments.eligible.where('originator_type = ? AND source_type != ? ', 'EnterpriseFee', 'Spree::LineItem')
-    adjustment_amount = Spree::Money.new 50, currency: order.currency
+    adjustment_amount = Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
     zero = Spree::Money.new 0 , currency: order.currency
-    return adjustment_amount == zero ? false : amount
+    return adjustment_amount == zero ? false : adjustment_amount
   end
-  # adjustment_amount = Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
+  # adjustment_amount = Spree::Money.new 50, currency: order.currency
 
 
   def checkout_line_item_adjustments(order)

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -24,11 +24,11 @@ module CheckoutHelper
 
   def display_checkout_admin_and_handling_adjustments_total_for(order)
     adjustments = order.adjustments.eligible.where('originator_type = ? AND source_type != ? ', 'EnterpriseFee', 'Spree::LineItem')
-    amount = Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
-    # amount = Spree::Money.new 50, currency: order.currency
-    check_zero = Spree::Money.new 0 , currency: order.currency
-    return amount == check_zero ? false : amount
+    adjustment_amount = Spree::Money.new 50, currency: order.currency
+    zero = Spree::Money.new 0 , currency: order.currency
+    return adjustment_amount == zero ? false : amount
   end
+  # adjustment_amount = Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
 
 
   def checkout_line_item_adjustments(order)

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -24,9 +24,7 @@ module CheckoutHelper
 
   def display_checkout_admin_and_handling_adjustments_total_for(order)
     adjustments = order.adjustments.eligible.where('originator_type = ? AND source_type != ? ', 'EnterpriseFee', 'Spree::LineItem')
-    adjustment_amount = Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
-    zero = Spree::Money.new 0 , currency: order.currency
-    return adjustment_amount == zero ? false : adjustment_amount
+    Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
   end
 
 

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -28,7 +28,6 @@ module CheckoutHelper
     zero = Spree::Money.new 0 , currency: order.currency
     return adjustment_amount == zero ? false : adjustment_amount
   end
-  # adjustment_amount = Spree::Money.new 50, currency: order.currency
 
 
   def checkout_line_item_adjustments(order)

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -24,8 +24,12 @@ module CheckoutHelper
 
   def display_checkout_admin_and_handling_adjustments_total_for(order)
     adjustments = order.adjustments.eligible.where('originator_type = ? AND source_type != ? ', 'EnterpriseFee', 'Spree::LineItem')
-    Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
+    amount = Spree::Money.new adjustments.sum(&:amount) , currency: order.currency
+    # amount = Spree::Money.new 50, currency: order.currency
+    check_zero = Spree::Money.new 0 , currency: order.currency
+    return amount == check_zero ? false : amount
   end
+
 
   def checkout_line_item_adjustments(order)
     order.adjustments.eligible.where(source_type: "Spree::LineItem")
@@ -112,4 +116,5 @@ module CheckoutHelper
       "{{ #{price} | localizeCurrency }}"
     end
   end
+
 end

--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -35,13 +35,13 @@
           %td.text-right
             %span.order-total.item-total= display_checkout_subtotal(@order)
           %td
-
-        %tr
-          %td.text-right{colspan:"3"}
-            = t :orders_form_admin
-          %td.text-right
-            %span.order-total.distribution-total= display_checkout_admin_and_handling_adjustments_total_for(@order)
-          %td
+        -if display_checkout_admin_and_handling_adjustments_total_for(@order)
+          %tr
+            %td.text-right{colspan:"3"}
+              = t :orders_form_admin
+            %td.text-right
+              %span.order-total.distribution-total= display_checkout_admin_and_handling_adjustments_total_for(@order)
+            %td
 
         - checkout_adjustments_for(@order, exclude: [:line_item, :admin_and_handling]).reject{ |a| a.amount == 0 }.reverse_each do |adjustment|
           %tr.order-adjustment

--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -35,7 +35,7 @@
           %td.text-right
             %span.order-total.item-total= display_checkout_subtotal(@order)
           %td
-        -if display_checkout_admin_and_handling_adjustments_total_for(@order)
+        -if display_checkout_admin_and_handling_adjustments_total_for(@order) != Spree::Money.new(0 , currency: @order.currency)
           %tr
             %td.text-right{colspan:"3"}
               = t :orders_form_admin

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -158,10 +158,10 @@ feature "full-page cart", js: true do
       it "shows row if order include adjustments" do
         visit spree.cart_path
 
-        add_product_to_cart order, product_fee, quantity: 2
+        #needs and order with adjustments
 
-        expect(page).to_not have_content('Admin & Handling')
-        expect(page).to have_content('$0.00')
+        expect(page).to have_content('Admin & Handling')
+        expect(page).to have_content()
     end
   end
 end

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -144,5 +144,24 @@ feature "full-page cart", js: true do
         expect(page).to have_content item2.variant.name
       end
     end
+
+    context "Admin & Handling" do
+      it "hides row if order includes no adjustments" do
+        visit spree.cart_path
+
+        add_product_to_cart order, product_fee, quantity: 2
+
+        expect(page).to_not have_content('Admin & Handling')
+        expect(page).to have_content('$0.00')
+      end
+
+      it "shows row if order include adjustments" do
+        visit spree.cart_path
+
+        add_product_to_cart order, product_fee, quantity: 2
+
+        expect(page).to_not have_content('Admin & Handling')
+        expect(page).to have_content('$0.00')
+    end
   end
 end

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -30,4 +30,5 @@ describe CheckoutHelper do
     order.distributor.allow_guest_orders = false
     expect(helper.guest_checkout_allowed?).to be false
   end
+
 end


### PR DESCRIPTION
#### What? Why?

The cart page should hide the table row 'admin & handling' if adjustments equal '$0.00'

#### What should we test?
Test should include 'shows admin & handling row if adjustments exist' and 'hides admin & handling if adjustments do not exist'

#### Release notes

Admin & Handling fee is only displayed in the cart if it is non-zero