### PR TITLE
Fix payment_method_decorator boot-time warning

### DIFF
--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -1,8 +1,6 @@
 Spree::PaymentMethod.class_eval do
   include Spree::Core::CalculatedAdjustments
 
-  Spree::PaymentMethod::DISPLAY = [:both, :front_end, :back_end]
-
   acts_as_taggable
 
   has_and_belongs_to_many :distributors, join_table: 'distributors_payment_methods', :class_name => 'Enterprise', association_foreign_key: 'distributor_id'


### PR DESCRIPTION
#### What? Why?

Removes the annoying message `warning: already initialized constant Spree::PaymentMethod::DISPLAY` that appears 4 times when booting the app.

We are declaring said constant exactly as our Spree version does so  there's no point on repeating work.

Now when booting the app you will only see:

```shell
$ b rails s
=> Booting Unicorn
=> Rails 3.2.21 application starting in development on http://0.0.0.0:3000
=> Call with -d to detach
=> Ctrl-C to shutdown server
(eval):1: warning: encountered \r in middle of line, treated as a mere space
listening on addr=0.0.0.0:3000 fd=15
worker=0 spawning...
master process ready
worker=0 spawned pid=9169
worker=0 ready
```

#### What should we test?

Enough with all tests passing