### PR TITLE
Fix for issue #1884, sort order cycles by close date on admin/orders …

### DIFF
--- a/app/overrides/spree/admin/orders/index/add_distributor_and_order_cycle_filter_inputs.html.haml.deface
+++ b/app/overrides/spree/admin/orders/index/add_distributor_and_order_cycle_filter_inputs.html.haml.deface
@@ -9,5 +9,5 @@
 .field-block.alpha.eight.columns
   = label_tag nil, t(:order_cycles)
   = select_tag("q[order_cycle_id_in]",
-    options_for_select(OrderCycle.managed_by(spree_current_user).map {|oc| [oc.name, oc.id]}, params[:order_cycle_ids]),
+    options_for_select(OrderCycle.managed_by(spree_current_user).order('order_cycles.orders_close_at ASC').map {|oc| [oc.name, oc.id]}, params[:order_cycle_ids]),
     {class: "select2 fullwidth", multiple: true})

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -30,6 +30,19 @@ feature %q{
     click_button 'Next'
   end
 
+  scenario "order cycles appear in descending order by close date on orders page" do
+    create(:simple_order_cycle, name: 'Two', orders_close_at: 2.weeks.from_now)
+    create(:simple_order_cycle, name: 'Four', orders_close_at: 4.weeks.from_now)
+    create(:simple_order_cycle, name: 'Three', orders_close_at: 3.weeks.from_now)
+
+    login_to_admin_section
+    visit 'admin/orders'
+
+    open_select2('#s2id_q_order_cycle_id_in')
+
+    expect(find('#q_order_cycle_id_in', visible: :all)[:innerHTML]).to have_content(/.*One.*Two.*Three.*Four/m)
+  end
+
   scenario "creating an order with distributor and order cycle" do
     distributor_disabled = create(:distributor_enterprise)
     create(:simple_order_cycle, name: 'Two')


### PR DESCRIPTION
#### What? Why?

Closes #1884 

Adds ordering by close date for order cycles displayed in dropdown on admin/orders page. These we're previously unordered which was confusing for users. 

#### What should we test?

"Order Cycles" dropdown on admin/orders page.

See spec/features/admin/orders_spec.rb for automated tests. Lines 33 - 44.