### PR TITLE
Do not upcase State abbreviation

### DIFF
--- a/app/serializers/api/state_serializer.rb
+++ b/app/serializers/api/state_serializer.rb
@@ -1,7 +1,3 @@
 class Api::StateSerializer < ActiveModel::Serializer
   attributes :id, :name, :abbr
-
-  def abbr
-    object.abbr.upcase
-  end
 end

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -49,7 +49,7 @@ feature "Registration", js: true do
       fill_in 'enterprise_city', with: 'Northcote'
       fill_in 'enterprise_zipcode', with: '3070'
       expect(page).to have_select('enterprise_country', options: %w(Albania Australia), selected: 'Australia')
-      select 'VIC', from: 'enterprise_state'
+      select 'Vic', from: 'enterprise_state'
       perform_and_ensure(:click_button, "Continue", lambda { page.has_content? 'Who is responsible for managing My Awesome Enterprise?' })
 
 


### PR DESCRIPTION
#### What? Why?

I propose to remove the constraint of having uppercased State abbreviations. This would allow us to have other than uppercased State abbreviations. 

<img width="477" alt="screenshot 2017-11-16 15 48 11" src="https://user-images.githubusercontent.com/935744/32897334-968929fe-cae5-11e7-8892-c17f2347194e.png">

⚠️  **It would show the same format as it is stored in the database. So, instances that want abbreviations in uppercase, should update the `abbr` column in the `spree_states` table.**

Also, as a note, the `upcase` ruby method doesn't play well with accents nor other symbols. 

#### What should we test?

Forms and sections that have addresses. 

#### Release notes

Remove constraint of uppercased State abbreviations.
**PLEASE MAKE SURE YOU DOUBLE CHECK HOW STATES APPEAR IN YOUR INSTANCE AFTER DEPLOY**