### PR TITLE
Fix before_filter for Spree::Admin::OrdersController#print_ticket

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -4,7 +4,7 @@ Spree::Admin::OrdersController.class_eval do
   include OpenFoodNetwork::SpreeApiKeyLoader
   helper CheckoutHelper
   before_filter :load_spree_api_key, :only => :bulk_management
-  before_filter :load_order, only: %i[show edit update fire resend invoice print]
+  before_filter :load_order, only: %i[show edit update fire resend invoice print print_ticket]
 
   before_filter :load_distribution_choices, only: [:new, :edit, :update]
 


### PR DESCRIPTION
The load_order in Spree::Admin::OrdersController seems to be mandatory since recent Spree upgrades. If it doesn't include the #print_ticket method, it prevents the `ticket.html` template from accessing the relevant order.
I'll write feature tests on the ticket thing as soon as possible to prevent this from happening again!