### PR TITLE
Fix translations on account page

### DIFF
--- a/app/views/spree/users/_transactions.html.haml
+++ b/app/views/spree/users/_transactions.html.haml
@@ -1,6 +1,6 @@
 %script{ type: "text/ng-template", id: "account/transactions.html" }
   .active_table.orders{"ng-controller" => "OrdersCtrl", "ng-cloak" => true}
-    %h3.my-orders= t(:transaction_history)
+    %h3.my-orders= t(".transaction_history")
     %distributor.active_table_node.row.animate-repeat{"ng-if" => "Orders.shops.length > 0", "ng-repeat" => "shop in Orders.shops",
     "ng-controller" => "ShopNodeCtrl",
     "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !shop.active}",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2167,6 +2167,7 @@ Please follow the instructions there to make your enterprise visible on the Open
     email: Email
     # TODO: remove 'account_updated' key once we get to Spree 2.0
     account_updated: "Account updated!"
+    my_account: "My account"
     admin:
       orders:
         invoice:


### PR DESCRIPTION
#### What? Why?

Closes #1973 

Fixes 2 translations on the account page.
One of them needed a dot to work, the other one seems to come from Spree upgrade and might be the same as the above keys in the locale file (?)

#### What should we test?

"My account" and "Transaction history" on account page not in a "translation missing" span (?)

#### Release notes

Fix 2 translations on the account page. (?)

#### How is this related to the Spree upgrade?

One of the key might be related to those that will be fixed in Spree 2.0 (I'll look)