### PR TITLE
#1517 - Payment and shipping methods checkbox issue

### DIFF
--- a/app/views/admin/enterprises/form/_payment_methods.html.haml
+++ b/app/views/admin/enterprises/form/_payment_methods.html.haml
@@ -9,6 +9,8 @@
         %th= t('.applies')
         %th
     %tbody
+      %tr 
+        = f.hidden_field :payment_method_ids, value: nil, multiple: true
       - @payment_methods.each do |payment_method|
         %tr{ ng: { controller: 'paymentMethodsCtrl', init: "findPaymentMethodByID(#{payment_method.id})" } }
           %td= payment_method.name

--- a/app/views/admin/enterprises/form/_shipping_methods.html.haml
+++ b/app/views/admin/enterprises/form/_shipping_methods.html.haml
@@ -6,6 +6,8 @@
         %th= t('.applies')
         %th
     %tbody
+      %tr 
+        = f.hidden_field :shipping_method_ids, value: nil, multiple: true
       - @shipping_methods.each do |shipping_method|
         %tr{ ng: { controller: 'shippingMethodsCtrl', init: "findShippingMethodByID(#{shipping_method.id})" } }
           %td= shipping_method.name


### PR DESCRIPTION

#### What? Why?
This issue occurs when all the selections are unchecked in payment/shipping methods in manage enterprises.


Closes #1517 

When all the checkboxes are unchecked, the form ignores the whole attribute, so all the unchecked payments/shipments will not get updated.
To fix this, added a hidden_tag with the attribute name, with value as empty array, which updates shipping/payment methods.

#### What should we test?

Need to test whether all the shipping/payment methods in manage enterprises is getting updated correctly on check/uncheck especially unchecking all the checkboxes.
http://localhost:3001/admin/enterprises/{id}/edit#/shipping_methods
http://localhost:3001/admin/enterprises/{id}/edit#/payment_methods


#### Dependencies
 https://github.com/openfoodfoundation/openfoodnetwork/pull/2039 - Shipping/payment methods disappears for manager on uncheck

  