### PR TITLE
Refactor of LocalizedNumber

### DIFF
--- a/app/models/calculator/flat_percent_per_item.rb
+++ b/app/models/calculator/flat_percent_per_item.rb
@@ -1,5 +1,5 @@
 require_dependency 'spree/calculator'
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 class Calculator::FlatPercentPerItem < Spree::Calculator
   # Spree's FlatPercentItemTotal calculator sums all amounts, and then calculates a percentage
@@ -7,7 +7,7 @@ class Calculator::FlatPercentPerItem < Spree::Calculator
   # In the cart, we display line item individual amounts rounded, so to have consistent
   # calculations we do the same internally. Here, we round adjustments at the individual
   # item level first, then multiply by the item quantity.
-  extend Spree::LocalizedNumber
+  extend Spree::LocalizeNumber
 
   preference :flat_percent, :decimal, :default => 0
 

--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -1,8 +1,8 @@
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 module Spree
   Adjustment.class_eval do
-    extend Spree::LocalizedNumber
+    extend Spree::LocalizeNumber
 
     # Deletion of metadata is handled in the database.
     # So we don't need the option `dependent: :destroy` as long as

--- a/app/models/spree/calculator/flat_percent_item_total_decorator.rb
+++ b/app/models/spree/calculator/flat_percent_item_total_decorator.rb
@@ -1,8 +1,8 @@
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 module Spree
   Calculator::FlatPercentItemTotal.class_eval do
-    extend Spree::LocalizedNumber
+    extend Spree::LocalizeNumber
 
     localize_number :preferred_flat_percent
 

--- a/app/models/spree/calculator/flat_rate_decorator.rb
+++ b/app/models/spree/calculator/flat_rate_decorator.rb
@@ -1,8 +1,8 @@
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 module Spree
   Calculator::FlatRate.class_eval do
-    extend Spree::LocalizedNumber
+    extend Spree::LocalizeNumber
 
     localize_number :preferred_amount
   end

--- a/app/models/spree/calculator/flexi_rate_decorator.rb
+++ b/app/models/spree/calculator/flexi_rate_decorator.rb
@@ -1,8 +1,8 @@
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 module Spree
   Calculator::FlexiRate.class_eval do
-    extend Spree::LocalizedNumber
+    extend Spree::LocalizeNumber
 
     localize_number :preferred_first_item,
                     :preferred_additional_item

--- a/app/models/spree/calculator/per_item_decorator.rb
+++ b/app/models/spree/calculator/per_item_decorator.rb
@@ -1,8 +1,8 @@
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 module Spree
   Calculator::PerItem.class_eval do
-    extend Spree::LocalizedNumber
+    extend Spree::LocalizeNumber
 
     localize_number :preferred_amount
 

--- a/app/models/spree/calculator/price_sack_decorator.rb
+++ b/app/models/spree/calculator/price_sack_decorator.rb
@@ -1,8 +1,8 @@
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 module Spree
   Calculator::PriceSack.class_eval do
-    extend Spree::LocalizedNumber
+    extend Spree::LocalizeNumber
 
     localize_number :preferred_minimal_amount,
                     :preferred_normal_amount,

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,8 +1,8 @@
-require 'spree/localized_number'
+require 'spree/localize_number'
 
 module Spree
   Payment.class_eval do
-    extend Spree::LocalizedNumber
+    extend Spree::LocalizeNumber
 
     has_one :adjustment, as: :source, dependent: :destroy
 

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -3,7 +3,7 @@ require 'open_food_network/variant_and_line_item_naming'
 require 'open_food_network/products_cache'
 
 Spree::Variant.class_eval do
-  extend Spree::LocalizedNumber
+  extend Spree::LocalizeNumber
   # Remove method From Spree, so method from the naming module is used instead
   # This file may be double-loaded in delayed job environment, so we check before
   # removing the Spree method to prevent error.

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -1,5 +1,5 @@
 class VariantOverride < ActiveRecord::Base
-  extend Spree::LocalizedNumber
+  extend Spree::LocalizeNumber
 
   acts_as_taggable
 

--- a/lib/spree/localize_number.rb
+++ b/lib/spree/localize_number.rb
@@ -1,0 +1,9 @@
+require 'spree/localized_number'
+
+module Spree
+  module LocalizeNumber
+    def localize_number(*attributes)
+      LocalizedNumber.new(self, attributes).setup
+    end
+  end
+end

--- a/spec/support/localized_number_helper.rb
+++ b/spec/support/localized_number_helper.rb
@@ -11,9 +11,9 @@ shared_examples "a model using the LocalizedNumber module" do |attributes|
     setter = "#{attribute}="
 
     it "uses the LocalizedNumber.parse method when setting #{attribute}" do
-      allow(Spree::LocalizedNumber).to receive(:parse).and_return(nil)
-      expect(Spree::LocalizedNumber).to receive(:parse).with('1.599,99')
+      expect(Spree::LocalizedNumber).to receive(:parse).with('1.599,99') { 1234.56 }
       subject.send(setter, '1.599,99')
+      expect(subject.send(attribute)).to eq 1234.56
     end
 
     it "creates an error if the input to #{attribute} is invalid" do


### PR DESCRIPTION
#### What? Why?

I did a bit of a refactor of the LocalizedNumber module created by @ltrls to allow more flexibility in the use of decimal separators for numbers entered by users (#1831).

There are a few outstanding issues from #1831 that still need to be addressed, and so they can be added here as well.

#### What should we test?

Functionality should not change, this is just a bit of a tidy up of the code.

#### Release notes

No release notes necessary.
