### PR TITLE
Disable api auth as there is no Spree api key set

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'i18n-js', '~> 3.0.0'
 gem 'nokogiri', '>= 1.6.7.1'
 
 gem 'pg'
-gem 'spree', github: 'openfoodfoundation/spree', branch: 'step-6a', ref: 'b1b33c7ec682e042bc939aac39dfa1f2de446227'
+gem 'spree', github: 'openfoodfoundation/spree', branch: 'step-6a', ref: '86bf87f1b1e1b299edc8cd10a2486e44ba0a3987'
 gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'
 gem 'spree_auth_devise', github: 'openfoodfoundation/spree_auth_devise', branch: 'spree-upgrade-intermediate'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,8 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: b1b33c7ec682e042bc939aac39dfa1f2de446227
-  ref: b1b33c7ec682e042bc939aac39dfa1f2de446227
+  revision: 86bf87f1b1e1b299edc8cd10a2486e44ba0a3987
+  ref: 86bf87f1b1e1b299edc8cd10a2486e44ba0a3987
   branch: step-6a
   specs:
     spree (1.3.99)
@@ -807,4 +807,4 @@ RUBY VERSION
    ruby 2.1.5p273
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/controllers/api/enterprises_controller.rb
+++ b/app/controllers/api/enterprises_controller.rb
@@ -60,7 +60,12 @@ module Api
     def override_sells
       has_hub = current_api_user.owned_enterprises.is_hub.any?
       new_enterprise_is_producer = !!params[:enterprise][:is_primary_producer]
-      params[:enterprise][:sells] = (has_hub && !new_enterprise_is_producer) ? 'any' : 'unspecified'
+
+      params[:enterprise][:sells] = if has_hub && !new_enterprise_is_producer
+                                      'any'
+                                    else
+                                      'unspecified'
+                                    end
     end
 
     def override_visible

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -12,7 +12,7 @@ require 'spree/core/calculated_adjustments_decorator'
 require "#{Rails.root}/app/models/spree/payment_method_decorator"
 require "#{Rails.root}/app/models/spree/gateway_decorator"
 
-Spree::Api::Config[:requires_authentication] = true
+Spree::Api::Config[:requires_authentication] = false
 
 Spree.config do |config|
   config.shipping_instructions = true

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -12,8 +12,6 @@ require 'spree/core/calculated_adjustments_decorator'
 require "#{Rails.root}/app/models/spree/payment_method_decorator"
 require "#{Rails.root}/app/models/spree/gateway_decorator"
 
-Spree::Api::Config[:requires_authentication] = false
-
 Spree.config do |config|
   config.shipping_instructions = true
   config.address_requires_state = true

--- a/spec/controllers/api/enterprises_controller_spec.rb
+++ b/spec/controllers/api/enterprises_controller_spec.rb
@@ -7,22 +7,29 @@ module Api
 
     let(:enterprise) { create(:distributor_enterprise) }
 
-    before do
-      stub_authentication!
-      Enterprise.stub(:find).and_return(enterprise)
-    end
-
     context "as an enterprise owner" do
       let(:enterprise_owner) { create_enterprise_user enterprise_limit: 10 }
-      let(:enterprise) { create(:distributor_enterprise, owner: enterprise_owner) }
+      let!(:enterprise) { create(:distributor_enterprise, owner: enterprise_owner) }
 
       before do
-        Spree.user_class.stub :find_by_spree_api_key => enterprise_owner
+        allow(controller).to receive(:spree_current_user) { enterprise_owner }
       end
 
       describe "creating an enterprise" do
         let(:australia) { Spree::Country.find_by_name('Australia') }
-        let(:new_enterprise_params) { {enterprise: {name: 'name', email: 'email@example.com', address_attributes: {address1: '123 Abc Street', city: 'Northcote', zipcode: '3070', state_id: australia.states.first, country_id: australia.id } } } }
+        let(:new_enterprise_params) do
+          {
+            enterprise: {
+              name: 'name', email: 'email@example.com', address_attributes: {
+                address1: '123 Abc Street',
+                city: 'Northcote',
+                zipcode: '3070',
+                state_id: australia.states.first,
+                country_id: australia.id
+              }
+            }
+          }
+        end
 
         it "creates as sells=any when it is not a producer" do
           spree_post :create, new_enterprise_params
@@ -39,35 +46,37 @@ module Api
 
       before do
         enterprise_manager.enterprise_roles.build(enterprise: enterprise).save
-        Spree.user_class.stub :find_by_spree_api_key => enterprise_manager
+        allow(controller).to receive(:spree_current_user) { enterprise_manager }
       end
 
       describe "submitting a valid image" do
         before do
+          allow(Enterprise)
+            .to receive(:find_by_permalink).with(enterprise.id.to_s) { enterprise }
           enterprise.stub(:update_attributes).and_return(true)
         end
 
         it "I can update enterprise image" do
-          spree_post :update_image, logo: 'a logo'
+          spree_post :update_image, logo: 'a logo', id: enterprise.id
           response.should be_success
         end
       end
     end
 
-    describe "as an non-managing user" do
+    context "as an non-managing user" do
       let(:non_managing_user) { create_enterprise_user }
 
       before do
-        Spree.user_class.stub :find_by_spree_api_key => non_managing_user
+        allow(Enterprise)
+          .to receive(:find_by_permalink).with(enterprise.id.to_s) { enterprise }
+        allow(controller).to receive(:spree_current_user) { non_managing_user }
       end
 
       describe "submitting a valid image" do
-        before do
-          enterprise.stub(:update_attributes).and_return(true)
-        end
+        before { enterprise.stub(:update_attributes).and_return(true) }
 
         it "I can't update enterprise image" do
-          spree_post :update_image, logo: 'a logo'
+          spree_post :update_image, logo: 'a logo', id: enterprise.id
           assert_unauthorized!
         end
       end

--- a/spec/controllers/api/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/order_cycles_controller_spec.rb
@@ -14,8 +14,7 @@ module Api
       let(:attributes) { [:id, :name, :suppliers, :distributors] }
 
       before do
-        stub_authentication!
-        Spree.user_class.stub :find_by_spree_api_key => current_api_user
+        allow(controller).to receive(:spree_current_user) { current_api_user }
       end
 
       context "as a normal user" do
@@ -77,38 +76,37 @@ module Api
         let!(:order_cycle) { create(:simple_order_cycle, suppliers: [oc_supplier], distributors: [oc_distributor]) }
 
         context "as the user of a supplier to an order cycle" do
-          before :each do
-            stub_authentication!
-            Spree.user_class.stub :find_by_spree_api_key => oc_supplier_user
-            spree_get :accessible, { :template => 'bulk_index', :format => :json }
+          before do
+            allow(controller).to receive(:spree_current_user) { oc_supplier_user }
           end
 
           it "gives me access" do
+            spree_get :accessible, { :template => 'bulk_index', :format => :json }
+
             json_response.length.should == 1
             json_response[0]['id'].should == order_cycle.id
           end
         end
 
         context "as the user of some other supplier" do
-          before :each do
-            stub_authentication!
-            Spree.user_class.stub :find_by_spree_api_key => other_supplier_user
-            spree_get :accessible, { :template => 'bulk_index', :format => :json }
+          before do
+            allow(controller).to receive(:spree_current_user) { other_supplier_user }
           end
 
           it "does not give me access" do
+            spree_get :accessible, { :template => 'bulk_index', :format => :json }
             json_response.length.should == 0
           end
         end
 
         context "as the user of a hub for the order cycle" do
-          before :each do
-            stub_authentication!
-            Spree.user_class.stub :find_by_spree_api_key => oc_distributor_user
-            spree_get :accessible, { :template => 'bulk_index', :format => :json }
+          before do
+            allow(controller).to receive(:spree_current_user) { oc_distributor_user }
           end
 
           it "gives me access" do
+            spree_get :accessible, { :template => 'bulk_index', :format => :json }
+
             json_response.length.should == 1
             json_response[0]['id'].should == order_cycle.id
           end
@@ -125,39 +123,32 @@ module Api
         let(:params) { { format: :json, as: 'distributor' } }
 
         before do
-          stub_authentication!
-          Spree.user_class.stub :find_by_spree_api_key => user
+          allow(controller).to receive(:spree_current_user) { user }
         end
 
         context "as the manager of a supplier in an order cycle" do
-          before do
-            user.enterprise_roles.create(enterprise: producer)
-            spree_get :accessible, params
-          end
+          before { user.enterprise_roles.create(enterprise: producer) }
 
           it "does not return the order cycle" do
+            spree_get :accessible, params
             expect(assigns(:order_cycles)).to_not include oc
           end
         end
 
         context "as the manager of a distributor in an order cycle" do
-          before do
-            user.enterprise_roles.create(enterprise: distributor)
-            spree_get :accessible, params
-          end
+          before { user.enterprise_roles.create(enterprise: distributor) }
 
           it "returns the order cycle" do
+            spree_get :accessible, params
             expect(assigns(:order_cycles)).to include oc
           end
         end
 
         context "as the manager of the coordinator of an order cycle" do
-          before do
-            user.enterprise_roles.create(enterprise: coordinator)
-            spree_get :accessible, params
-          end
+          before { user.enterprise_roles.create(enterprise: coordinator) }
 
           it "returns the order cycle" do
+            spree_get :accessible, params
             expect(assigns(:order_cycles)).to include oc
           end
         end
@@ -173,39 +164,32 @@ module Api
         let(:params) { { format: :json, as: 'producer' } }
 
         before do
-          stub_authentication!
-          Spree.user_class.stub :find_by_spree_api_key => user
+          allow(controller).to receive(:spree_current_user) { user }
         end
 
         context "as the manager of a producer in an order cycle" do
-          before do
-            user.enterprise_roles.create(enterprise: producer)
-            spree_get :accessible, params
-          end
+          before { user.enterprise_roles.create(enterprise: producer) }
 
           it "returns the order cycle" do
+            spree_get :accessible, params
             expect(assigns(:order_cycles)).to include oc
           end
         end
 
         context "as the manager of a distributor in an order cycle" do
-          before do
-            user.enterprise_roles.create(enterprise: distributor)
-            spree_get :accessible, params
-          end
+          before { user.enterprise_roles.create(enterprise: distributor) }
 
           it "does not return the order cycle" do
+            spree_get :accessible, params
             expect(assigns(:order_cycles)).to_not include oc
           end
         end
 
         context "as the manager of the coordinator of an order cycle" do
-          before do
-            user.enterprise_roles.create(enterprise: coordinator)
-            spree_get :accessible, params
-          end
+          before { user.enterprise_roles.create(enterprise: coordinator) }
 
           it "returns the order cycle" do
+            spree_get :accessible, params
             expect(assigns(:order_cycles)).to include oc
           end
         end

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -5,24 +5,27 @@ module Spree
     render_views
 
     before do
-      stub_authentication!
-      Spree.user_class.stub :find_by_spree_api_key => current_api_user
-    end
-
-    def self.make_simple_data!
-      let!(:order) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now) }
-      let!(:line_item) { FactoryGirl.create(:line_item, order: order, final_weight_volume: 500) }
+      allow(controller).to receive(:spree_current_user) { current_api_user }
     end
 
     #test that when a line item is updated, an order's fees are updated too
     context "as an admin user" do
       sign_in_as_admin!
-      make_simple_data!
+
+      let(:order) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now) }
+      let(:line_item) { FactoryGirl.create(:line_item, order: order, final_weight_volume: 500) }
 
       context "as a line item is updated" do
+        before { allow(controller).to receive(:order) { order } }
+
         it "update distribution charge on the order" do
-          line_item_params = { order_id: order.number, id: line_item.id, line_item: { id: line_item.id, final_weight_volume: 520 }, format: :json}
-          allow(controller).to receive(:order) { order }
+          line_item_params = {
+            order_id: order.number,
+            id: line_item.id,
+            line_item: { id: line_item.id, final_weight_volume: 520 },
+            format: :json
+          }
+
           expect(order).to receive(:update_distribution_charge!)
           spree_post :update, line_item_params
         end

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -15,8 +15,7 @@ module Spree
     let(:attributes) { [:id, :name, :supplier, :price, :on_hand, :available_on, :permalink_live] }
 
     before do
-      stub_authentication!
-      Spree.user_class.stub :find_by_spree_api_key => current_api_user
+      allow(controller).to receive(:spree_current_user) { current_api_user }
     end
 
     context "as a normal user" do
@@ -109,14 +108,11 @@ module Spree
     end
 
     describe '#clone' do
-      before do
-        spree_post :clone, product_id: product1.id, format: :json
-      end
-
       context 'as a normal user' do
         sign_in_as_user!
 
         it 'denies access' do
+          spree_post :clone, product_id: product1.id, format: :json
           assert_unauthorized!
         end
       end
@@ -125,10 +121,12 @@ module Spree
         sign_in_as_enterprise_user! [:supplier]
 
         it 'responds with a successful response' do
+          spree_post :clone, product_id: product1.id, format: :json
           expect(response.status).to eq(201)
         end
 
         it 'clones the product' do
+          spree_post :clone, product_id: product1.id, format: :json
           expect(json_response['name']).to eq("COPY OF #{product1.name}")
         end
       end
@@ -137,10 +135,12 @@ module Spree
         sign_in_as_admin!
 
         it 'responds with a successful response' do
+          spree_post :clone, product_id: product1.id, format: :json
           expect(response.status).to eq(201)
         end
 
         it 'clones the product' do
+          spree_post :clone, product_id: product1.id, format: :json
           expect(json_response['name']).to eq("COPY OF #{product1.name}")
         end
       end

--- a/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/spec/controllers/spree/api/variants_controller_spec.rb
@@ -11,8 +11,7 @@ module Spree
     let(:attributes) { [:id, :options_text, :price, :on_hand, :unit_value, :unit_description, :on_demand, :display_as, :display_name] }
 
     before do
-      stub_authentication!
-      Spree.user_class.stub :find_by_spree_api_key => current_api_user
+      allow(controller).to receive(:spree_current_user) { current_api_user }
     end
 
     context "as a normal user" do


### PR DESCRIPTION
#### What? Why?

Closes #1900 
Closes #1965

What we'll do from now on is not to authentication using the api key, we'll check the user session instead.

This amends the change done in a87c89c83db9e54c58ea43e5b273d2906669c624, which introduced the bug. As there is no Spree api key set the auth fails when getting taxons. Spree's issue https://github.com/spree/spree/pull/4446 and its related issues contain the background. 

What we found out so far: They added api auth by default in Oct 2012 but they realized that it wasn't working (they weren't sending the api key to the backend), so they turned the api auth false by default and so bypassing the auth in Nov 2012. 

It's later in January 2014 that they enable it back, experiencing the bug later solved in March 2014 in https://github.com/spree/spree/pull/4446.

#### What should we test?

We should be able to create taxons as well as fetch them. This can be done by searching them within the edit product page.

#### Release notes

Fixes taxons not being shown on the edit product page.

#### How is this related to the Spree upgrade?

This was introduced in https://github.com/openfoodfoundation/openfoodnetwork/commit/a87c89c83db9e54c58ea43e5b273d2906669c624

#### GIF

![](https://media.giphy.com/media/3o6fJ1UwOQxChhf128/giphy-downsized.gif)