### PR TITLE
Change github definition to remove insecure protocol warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 ruby "2.1.5"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'rails', '3.2.21'
 gem 'rails-i18n', '~> 3.0.0'
@@ -17,8 +18,8 @@ gem 'spree_auth_devise', github: 'openfoodfoundation/spree_auth_devise', branch:
 # Our branch contains two changes
 # - Pass customer email and phone number to PayPal (merged to upstream master)
 # - Change type of password from string to password to hide it in the form
-gem 'spree_paypal_express', :github => "openfoodfoundation/better_spree_paypal_express", :branch => "spree-upgrade-intermediate"
-#gem 'spree_paypal_express', :github => "spree-contrib/better_spree_paypal_express", :branch => "1-3-stable"
+gem 'spree_paypal_express', github: "openfoodfoundation/better_spree_paypal_express", branch: "spree-upgrade-intermediate"
+#gem 'spree_paypal_express', github: "spree-contrib/better_spree_paypal_express", branch: "1-3-stable"
 gem 'stripe', '~> 3.3.1'
 gem 'activemerchant', '~> 1.71.0'
 
@@ -30,7 +31,7 @@ gem 'daemons'
 
 # Fix bug in simple_form preventing collection_check_boxes usage within form_for block
 # When merged, revert to upstream gem
-gem 'simple_form', :github => 'RohanM/simple_form'
+gem 'simple_form', github: 'RohanM/simple_form'
 
 gem 'unicorn'
 gem 'angularjs-rails', '1.5.5'
@@ -48,14 +49,14 @@ gem 'representative_view'
 gem 'rabl'
 gem "active_model_serializers"
 gem 'oj'
-gem 'deface', :github => 'spree/deface', :ref => '1110a13'
+gem 'deface', github: 'spree/deface', ref: '1110a13'
 gem 'paperclip'
 gem 'dalli'
 gem 'geocoder'
 gem 'gmaps4rails'
 gem 'spinjs-rails'
-gem 'rack-ssl', :require => 'rack/ssl'
-gem 'custom_error_message', :github => 'jeremydurham/custom-err-msg'
+gem 'rack-ssl', require: 'rack/ssl'
+gem 'custom_error_message', github: 'jeremydurham/custom-err-msg'
 gem 'angularjs-file-upload-rails', '~> 1.1.6'
 gem 'roadie-rails', '~> 1.0.3'
 gem 'figaro'
@@ -101,13 +102,13 @@ gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz'
 
 group :test, :development do
   # Pretty printed test output
-  gem 'turn', '~> 0.8.3', :require => false
+  gem 'turn', '~> 0.8.3', require: false
   gem 'fuubar', '~> 2.2.0'
   gem 'rspec-rails', ">= 3.5.2"
   gem 'shoulda-matchers'
-  gem 'factory_girl_rails', :require => false
+  gem 'factory_girl_rails', require: false
   gem 'capybara', '>= 2.15.4'
-  gem 'database_cleaner', '0.7.1', :require => false
+  gem 'database_cleaner', '0.7.1', require: false
   gem 'awesome_print'
   gem 'letter_opener'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/RohanM/simple_form.git
+  remote: https://github.com/RohanM/simple_form.git
   revision: 45f08a213b40f3d4bda5f5398db841137587160a
   specs:
     simple_form (2.0.2)
@@ -7,13 +7,13 @@ GIT
       activemodel (~> 3.0)
 
 GIT
-  remote: git://github.com/jeremydurham/custom-err-msg.git
+  remote: https://github.com/jeremydurham/custom-err-msg.git
   revision: 3a8ec9dddc7a5b0aab7c69a6060596de300c68f4
   specs:
     custom_error_message (1.1.1)
 
 GIT
-  remote: git://github.com/openfoodfoundation/better_spree_paypal_express.git
+  remote: https://github.com/openfoodfoundation/better_spree_paypal_express.git
   revision: 8d95f4544c682634812becaf50999fba0cd04df0
   branch: spree-upgrade-intermediate
   specs:
@@ -22,14 +22,14 @@ GIT
       spree_core (~> 1.3.99)
 
 GIT
-  remote: git://github.com/openfoodfoundation/ofn-qz.git
+  remote: https://github.com/openfoodfoundation/ofn-qz.git
   revision: 024680ccea429b2e5428d7b964fa67c52add34ec
   specs:
     ofn-qz (0.1.0)
       railties (~> 3.1)
 
 GIT
-  remote: git://github.com/openfoodfoundation/spree.git
+  remote: https://github.com/openfoodfoundation/spree.git
   revision: 5a76d456ff70aea7aae3d25156558d71eb7febf2
   ref: 5a76d45
   branch: step-6a
@@ -91,7 +91,7 @@ GIT
       spree_core (= 1.3.99)
 
 GIT
-  remote: git://github.com/openfoodfoundation/spree_auth_devise.git
+  remote: https://github.com/openfoodfoundation/spree_auth_devise.git
   revision: da9eecefc6fe13dedf4c6f3febec79caad839ec3
   branch: spree-upgrade-intermediate
   specs:
@@ -103,7 +103,7 @@ GIT
       spree_frontend (~> 1.3.6)
 
 GIT
-  remote: git://github.com/spree/deface.git
+  remote: https://github.com/spree/deface.git
   revision: 1110a1336252109bce7f98f9182042e0bc2930ae
   ref: 1110a13
   specs:
@@ -113,7 +113,7 @@ GIT
       rails (>= 3.1)
 
 GIT
-  remote: git://github.com/spree/spree_i18n.git
+  remote: https://github.com/spree/spree_i18n.git
   revision: 752eb67204e9c5a4e22b62591a8fd55fe2285e43
   branch: 1-3-stable
   specs:
@@ -123,7 +123,7 @@ GIT
       spree_core (>= 1.1)
 
 GIT
-  remote: git://github.com/willrjmarshall/foundation_rails_helper.git
+  remote: https://github.com/willrjmarshall/foundation_rails_helper.git
   revision: 4d5d53fdc4b1fb71e66524d298c5c635de82cfbb
   branch: rails3
   specs:
@@ -684,7 +684,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
-    warden (1.2.6)
+    warden (1.2.7)
       rack (>= 1.0)
     webmock (1.8.11)
       addressable (>= 2.2.7)


### PR DESCRIPTION
#### What? Why?

This change removes a warning about an insecure protocol by redefining the github source to use https rather than git

This is a resubmission of #1935 to avoid a messy commit history