### PR TITLE
Template I18n changes

### DIFF
--- a/app/assets/javascripts/admin/dropdown/dropdown.js.coffee
+++ b/app/assets/javascripts/admin/dropdown/dropdown.js.coffee
@@ -1,1 +1,1 @@
-angular.module("admin.dropdown", ['templates'])
+angular.module("admin.dropdown", ['admin.utils'])

--- a/app/assets/javascripts/templates/admin/edit_address_dialog.html.haml
+++ b/app/assets/javascripts/templates/admin/edit_address_dialog.html.haml
@@ -2,7 +2,7 @@
   %h2 {{ addressType === 'bill_address' ?  "#{t('admin.customers.index.edit_bill_address')}" : "#{t('admin.customers.index.edit_ship_address')}" }}
   %form{ name: 'edit_address_form', novalidate: true, ng: { submit: 'updateAddress()'}}
     .row
-      = t('admin.customers.index.required_fileds')
+      {{ 'admin.customers.index.required_fileds' | t }}
       (
       %span.required *
       )
@@ -11,62 +11,62 @@
     %table.no-borders
       %tr
         %td{style: 'width: 30%'}
-          = t('spree.firstname')
+          {{ 'spree.firstname' | t }}
           %span.required *
         %td
           %input{ type: 'text', name: 'firstname', required: true, ng: { model: 'address.firstname'} }
       %tr
         %td
-          = t('spree.lastname')
+          {{ 'spree.lastname' | t }}
           %span.required *
         %td
           %input{ type: 'text', name: 'lastname', required: true, ng: { model: 'address.lastname'} }
       %tr
         %td
-          = t('spree.street_address')
+          {{ 'spree.street_address' | t }}
           %span.required *
         %td
           %input{ type: 'text', name: 'address1', required: true, ng: { model: 'address.address1'} }
       %tr
         %td
-          = t('spree.street_address_1')
+          {{ 'spree.street_address_1' | t }}
         %td
           %input{ type: 'text', name: 'address2', ng: { model: 'address.address2'} }
       %tr
         %td
-          = t('spree.city')
+          {{ 'spree.city' | t }}
           %span.required *
         %td
           %input{ type: 'text', name: 'city', required: true, ng: { model: 'address.city'} }
       %tr
         %td
-          = t('spree.zipcode')
+          {{ 'spree.zipcode' | t }}
           %span.required *
         %td
           %input{ type: 'text', name: 'zipcode', required: true, ng: { model: 'address.zipcode'} }
       %tr
         %td
-          = t('spree.country')
+          {{ 'spree.country' | t }}
           %span.required *
         %td
           %select{ name: 'country', required: true, ng: { model: 'address.country_id' } }
             %option{value: ''}
-              = t('admin.customers.index.select_country')
+              {{ 'admin.customers.index.select_country' | t }}
             %option{ ng: { repeat: 'country in availableCountries' }, value: '{{country.id}}' }
               {{country.name}}
       %tr
         %td
-          = t('spree.state')
+          {{ 'spree.state' | t }}
           %span.required *
         %td
           %select{ name: 'state', required: true, ng: { model: 'address.state_id' } }
             %option{value: ''}
-              = t('admin.customers.index.select_state')
+              {{ 'admin.customers.index.select_state' | t }}
             %option{ ng: { repeat: 'state in states' }, value: '{{state.id}}' }
               {{state.name}}
       %tr
         %td
-          = t('spree.phone')
+          {{ 'spree.phone' | t }}
           %span.required *
         %td
           %input{ type: 'text', name: 'phone', required: true, ng: { model: 'address.phone'} }

--- a/app/assets/javascripts/templates/admin/links_dropdown.html.haml
+++ b/app/assets/javascripts/templates/admin/links_dropdown.html.haml
@@ -1,7 +1,7 @@
 .ofn-drop-down
   %span
     %i.icon-check
-    = t('admin.actions')
+    {{ 'admin.actions' | t }}
     %i{ 'ng-class' => "expanded && 'icon-caret-up' || !expanded && 'icon-caret-down'" }
   %div.menu{ 'ng-show' => "expanded" }
     %a.menu_item{ 'ng-repeat' => "link in links", href: '{{link.url}}', target: "{{link.target || '_self'}}", data: { method: "{{ link.method || 'get' }}", confirm: "{{link.confirm}}" } }

--- a/app/assets/javascripts/templates/admin/modals/tag_rule_help.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/tag_rule_help.html.haml
@@ -1,19 +1,25 @@
 #tag-rule-help
   .margin-bottom-30.text-center
     .text-big
-      = t('js.admin.modals.tag_rule_help.title')
+      {{ 'js.admin.modals.tag_rule_help.title' | t }}
 
   .margin-bottom-30
-    .text-normal= t('js.admin.modals.tag_rule_help.overview')
-    %p= t('js.admin.modals.tag_rule_help.overview_text')
+    .text-normal
+      {{ 'js.admin.modals.tag_rule_help.overview' | t }}
+    %p
+      {{ 'js.admin.modals.tag_rule_help.overview_text' | t }}
 
   .margin-bottom-30
-    .text-normal= t('js.admin.modals.tag_rule_help.by_default_rules')
-    %p= t('js.admin.modals.tag_rule_help.by_default_rules_text')
+    .text-normal
+      {{ 'js.admin.modals.tag_rule_help.by_default_rules' | t }}
+    %p
+      {{ 'js.admin.modals.tag_rule_help.by_default_rules_text' | t }}
 
   .margin-bottom-30
-    .text-normal= t('js.admin.modals.tag_rule_help.customer_tagged_rules')
-    %p= t('js.admin.modals.tag_rule_help.customer_tagged_rules_text')
+    .text-normal
+      {{ 'js.admin.modals.tag_rule_help.customer_tagged_rules' | t }}
+    %p
+      {{ 'js.admin.modals.tag_rule_help.customer_tagged_rules_text' | t }}
 
   .text-center
     %input.button.red.icon-plus{ type: 'button', value: t('js.admin.modals.got_it'), ng: { click: 'close()' } }

--- a/app/assets/javascripts/templates/admin/new_customer_dialog.html.haml
+++ b/app/assets/javascripts/templates/admin/new_customer_dialog.html.haml
@@ -1,6 +1,6 @@
 #new-customer-dialog
   .text-normal.margin-bottom-30.text-center
-    = t('admin.customers.index.add_a_new_customer_for', shop_name: "{{ CurrentShop.shop.name }}:")
+    {{ 'admin.customers.index.add_a_new_customer_for' | t:{ shop_name: CurrentShop.shop.name } }}
 
   %form{ name: 'new_customer_form', novalidate: true, ng: { submit: "addCustomer()" }}
 
@@ -8,7 +8,7 @@
       %input.fullwidth{ type: 'email', name: 'email', required: true, placeholder: t('admin.customers.index.customer_placeholder'), ng: { model: "email" } }
       %div{ ng: { show: "submitted && new_customer_form.$pristine" } }
         .error{ ng: { show: "(new_customer_form.email.$error.email || new_customer_form.email.$error.required)" } }
-          = t('admin.customers.index.valid_email_error')
+          {{ 'admin.customers.index.valid_email_error' | t }}
         .error{ ng: { repeat: "error in errors", bind: "error" } }
 
     .text-center

--- a/app/assets/javascripts/templates/admin/new_tag_rule_dialog.html.haml
+++ b/app/assets/javascripts/templates/admin/new_tag_rule_dialog.html.haml
@@ -1,6 +1,6 @@
 #new-tag-rule-dialog
   .text-normal.margin-bottom-30.text-center
-    = t('js.admin.new_tag_rule_dialog.select_rule_type')
+    {{ 'js.admin.new_tag_rule_dialog.select_rule_type' | t }}
 
   .text-center.margin-bottom-30
     -# %select.fullwidth{ 'select2-min-search' => 5, 'ng-model' => 'newRuleType', 'ng-options' => 'ruleType.id as ruleType.name for ruleType in availableRuleTypes' }

--- a/app/assets/javascripts/templates/admin/panels/enterprise_package.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/enterprise_package.html.haml
@@ -2,128 +2,162 @@
   .alpha.eight.columns
     %div{ ng: { if: "!enterprise.is_primary_producer", switch: "enterprise.sells" } }
       .info{ ng: { switch: { when: "none" } } }
-        %h3= t('js.admin.panels.enterprise_package.hub_profile')
+        %h3
+          {{ 'js.admin.panels.enterprise_package.hub_profile' | t }}
 
         %p
-          %strong= t('js.admin.panels.enterprise_package.hub_profile_cost')
+          %strong
+            {{ 'js.admin.panels.enterprise_package.hub_profile_cost' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.hub_profile_text1')
+        %p
+          {{ 'js.admin.panels.enterprise_package.hub_profile_text1' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.hub_profile_text2')
+        %p
+          {{ 'js.admin.panels.enterprise_package.hub_profile_text2' | t }}
 
       .info{ ng: { switch: { when: "any" } } }
-        %h3= t('js.admin.panels.enterprise_package.hub_shop')
+        %h3
+          {{ 'js.admin.panels.enterprise_package.hub_shop' | t }}
 
         %p
           %strong
             %monthly-pricing-description{ joiner: "comma" }
 
-        %p= t('js.admin.panels.enterprise_package.hub_shop_text1')
+        %p
+          {{ 'js.admin.panels.enterprise_package.hub_shop_text1' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.hub_shop_text2')
+        %p
+          {{ 'js.admin.panels.enterprise_package.hub_shop_text2' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.hub_shop_text3')
+        %p
+          {{ 'js.admin.panels.enterprise_package.hub_shop_text3' | t }}
 
       .info{ ng: { switch: { default: true } } }
         %h3
-          = t('js.admin.panels.enterprise_package.choose_package')
+          {{ 'js.admin.panels.enterprise_package.choose_package' | t }}
           %i.icon-arrow-right
 
         %p
-          %strong= t('js.admin.panels.enterprise_package.choose_package_text1')
+          %strong
+            {{ 'js.admin.panels.enterprise_package.choose_package_text1' | t }}
 
         %p
-          = t('js.admin.panels.enterprise_package.choose_package_text2')
+          {{ 'js.admin.panels.enterprise_package.choose_package_text2' | t }}
 
     %div{ ng: { if: "enterprise.is_primary_producer", switch: "enterprise.sells" } }
       .info{ ng: { switch: { when: "none" } } }
-        %h3= t('js.admin.panels.enterprise_package.profile_only')
+        %h3
+          {{ 'js.admin.panels.enterprise_package.profile_only' | t }}
 
         %p
-          %strong= t('js.admin.panels.enterprise_package.profile_only_cost')
+          %strong
+            {{ 'js.admin.panels.enterprise_package.profile_only_cost' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.profile_only_text1')
+        %p
+          {{ 'js.admin.panels.enterprise_package.profile_only_text1' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.profile_only_text2')
+        %p
+          {{ 'js.admin.panels.enterprise_package.profile_only_text2' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.profile_only_text3')
+        %p
+          {{ 'js.admin.panels.enterprise_package.profile_only_text3' | t }}
 
       .info{ ng: { switch: { when: "own" } } }
-        %h3= t('js.admin.panels.enterprise_package.producer_shop')
+        %h3
+          {{ 'js.admin.panels.enterprise_package.producer_shop' | t }}
 
         %p
           %strong
             %monthly-pricing-description{ joiner: "comma" }
 
-        %p= t('js.admin.panels.enterprise_package.producer_shop_text1')
+        %p
+          {{ 'js.admin.panels.enterprise_package.producer_shop_text1' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.producer_shop_text2')
+        %p
+          {{ 'js.admin.panels.enterprise_package.producer_shop_text2' | t }}
 
       .info{ ng: { switch: { when: "any" } } }
-        %h3= t('js.admin.panels.enterprise_package.producer_hub')
+        %h3
+          {{ 'js.admin.panels.enterprise_package.producer_hub' | t }}
 
         %p
           %strong
             %monthly-pricing-description{ joiner: "comma" }
 
-        %p= t('js.admin.panels.enterprise_package.producer_hub_text1')
+        %p
+          {{ 'js.admin.panels.enterprise_package.producer_hub_text1' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.producer_hub_text2')
+        %p
+          {{ 'js.admin.panels.enterprise_package.producer_hub_text2' | t }}
 
-        %p= t('js.admin.panels.enterprise_package.producer_hub_text3')
+        %p
+          {{ 'js.admin.panels.enterprise_package.producer_hub_text3' | t }}
 
       .info{ ng: { switch: { default: true } } }
         %h3
-          = t('js.admin.panels.enterprise_package.choose_package')
+          {{ 'js.admin.panels.enterprise_package.choose_package' | t }}
           %i.icon-arrow-right
 
         %p
-          %strong= t('js.admin.panels.enterprise_package.choose_package_text1')
+          %strong
+            {{ 'js.admin.panels.enterprise_package.choose_package_text1' | t }}
 
         %p
-          = t('js.admin.panels.enterprise_package.choose_package_text2')
+          {{ 'js.admin.panels.enterprise_package.choose_package_text2' | t }}
 
   .omega.eight.columns{ ng: { switch: "enterprise.is_primary_producer" } }
     %div{ ng: { switch: { when: "false" } } }
       %a.button.selector.hub-profile{ ng: { click: "enterprise.owned && (enterprise.sells='none')", class: "{selected: enterprise.sells=='none', disabled: !enterprise.owned}" } }
         .top
-          %h3= t('js.admin.panels.enterprise_package.profile_only')
-          %p= t('js.admin.panels.enterprise_package.get_listing')
-        .bottom= t('js.admin.panels.enterprise_package.always_free')
+          %h3
+            {{ 'js.admin.panels.enterprise_package.profile_only' | t }}
+          %p
+            {{ 'js.admin.panels.enterprise_package.get_listing' | t }}
+        .bottom
+          {{ 'js.admin.panels.enterprise_package.always_free' | t }}
       %a.button.selector.hub{ ng: { click: "enterprise.owned && (enterprise.sells='any')", class: "{selected: enterprise.sells=='any', disabled: !enterprise.owned}" } }
         .top
-          %h3= t('js.admin.panels.enterprise_package.hub_shop')
-          %p= t('js.admin.panels.enterprise_package.sell_produce_others')
+          %h3
+            {{ 'js.admin.panels.enterprise_package.hub_shop' | t }}
+          %p
+            {{ 'js.admin.panels.enterprise_package.sell_produce_others' | t }}
         .bottom
           %monthly-pricing-description{ joiner: "newline" }
 
     %div{ ng: { switch: { when: "true" } } }
       %a.button.selector.producer-profile{ ng: { click: "enterprise.owned && (enterprise.sells='none')", class: "{selected: enterprise.sells=='none', disabled: !enterprise.owned}" } }
         .top
-          %h3= t('js.admin.panels.enterprise_package.profile_only')
-          %p= t('js.admin.panels.enterprise_package.get_listing')
-        .bottom= t('js.admin.panels.enterprise_package.always_free')
+          %h3
+            {{ 'js.admin.panels.enterprise_package.profile_only' | t }}
+          %p
+            {{ 'js.admin.panels.enterprise_package.get_listing' | t }}
+        .bottom
+          {{ 'js.admin.panels.enterprise_package.always_free' | t }}
       %a.button.selector.producer-shop{ ng: { click: "enterprise.owned && (enterprise.sells='own')", class: "{selected: enterprise.sells=='own', disabled: !enterprise.owned}" } }
         .top
-          %h3= t('js.admin.panels.enterprise_package.producer_shop')
-          %p= t('js.admin.panels.enterprise_package.sell_own_produce')
+          %h3
+            {{ 'js.admin.panels.enterprise_package.producer_shop' | t }}
+          %p
+            {{ 'js.admin.panels.enterprise_package.sell_own_produce' | t }}
         .bottom
           %monthly-pricing-description{ joiner: "newline" }
 
       %a.button.selector.producer-hub{ ng: { click: "enterprise.owned && (enterprise.sells='any')", class: "{selected: enterprise.sells=='any', disabled: !enterprise.owned}" } }
         .top
-          %h3= t('js.admin.panels.enterprise_package.producer_hub')
-          %p= t('js.admin.panels.enterprise_package.sell_both')
+          %h3
+            {{ 'js.admin.panels.enterprise_package.producer_hub' | t }}
+          %p
+            {{ 'js.admin.panels.enterprise_package.sell_both' | t }}
         .bottom
           %monthly-pricing-description{ joiner: "newline" }
 
     %a.button.update.fullwidth{ ng: { show: "enterprise.owned", class: "{disabled: saved() && !saving, saving: saving}", click: "save()" } }
       %span{ ng: {hide: "saved() || saving" } }
-        = t('js.admin.panels.save')
+        {{ 'js.admin.panels.save' | t }}
         %i.icon-save
       %span{ ng: {show: "saved() && !saving" } }
-        = t('js.admin.panels.saved')
+        {{ 'js.admin.panels.saved' | t }}
         %i.icon-ok-sign
       %span{ ng: {show: "saving" } }
-        = t('js.admin.panels.saving')
+        {{ 'js.admin.panels.saving' | t }}
         %i.icon-refresh

--- a/app/assets/javascripts/templates/admin/panels/enterprise_producer.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/enterprise_producer.html.haml
@@ -1,37 +1,47 @@
 .row.enterprise_producer_panel{ ng: { controller: 'indexProducerPanelCtrl' } }
   .alpha.eight.columns
     .info{ ng: { show: "enterprise.is_primary_producer==true" } }
-      %h3= t('js.admin.panels.enterprise_producer.producer')
-      %p= t('js.admin.panels.enterprise_producer.producer_text1')
-
-      %p= t('js.admin.panels.enterprise_producer.producer_text2')
+      %h3
+        {{ 'js.admin.panels.enterprise_producer.producer' | t }}
+      %p
+        {{ 'js.admin.panels.enterprise_producer.producer_text1' | t }}
+      %p
+        {{ 'js.admin.panels.enterprise_producer.producer_text2' | t }}
 
     .info{ ng: { show: "enterprise.is_primary_producer==false" } }
-      %h3= t('js.admin.panels.enterprise_producer.non_producer')
-      %p= t('js.admin.panels.enterprise_producer.non_producer_text1')
-
-      %p= t('js.admin.panels.enterprise_producer.non_producer_text2')
+      %h3
+        {{ 'js.admin.panels.enterprise_producer.non_producer' | t }}
+      %p
+        {{ 'js.admin.panels.enterprise_producer.non_producer_text1' | t }}
+      %p
+        {{ 'js.admin.panels.enterprise_producer.non_producer_text2' | t }}
 
   .omega.eight.columns
     %a.button.selector.producer{ ng: { click: 'enterprise.owned && changeToProducer()', class: "{selected: enterprise.is_primary_producer==true, disabled: !enterprise.owned}" } }
       .top
-        %h3= t('js.admin.panels.enterprise_producer.producer')
-        %p= t('js.admin.panels.enterprise_producer.producer_desc')
-      .bottom= t('js.admin.panels.enterprise_producer.producer_example')
+        %h3
+          {{ 'js.admin.panels.enterprise_producer.producer' | t }}
+        %p
+          {{ 'js.admin.panels.enterprise_producer.producer_desc' | t }}
+      .bottom
+        {{ 'js.admin.panels.enterprise_producer.producer_example' | t }}
 
     %a.button.selector.non-producer{ ng: { click: 'enterprise.owned && changeToNonProducer()', class: "{selected: enterprise.is_primary_producer==false, disabled: !enterprise.owned}" } }
       .top
-        %h3= t('js.admin.panels.enterprise_producer.non_producer')
-        %p= t('js.admin.panels.enterprise_producer.non_producer_desc')
-      .bottom= t('js.admin.panels.enterprise_producer.non_producer_example')
+        %h3
+          {{ 'js.admin.panels.enterprise_producer.non_producer' | t }}
+        %p
+          {{ 'js.admin.panels.enterprise_producer.non_producer_desc' | t }}
+      .bottom
+        {{ 'js.admin.panels.enterprise_producer.non_producer_example' | t }}
 
     %a.button.update.fullwidth{ ng: { show: "enterprise.owned", class: "{disabled: saved() && !saving, saving: saving}", click: "save()" } }
       %span{ ng: {hide: "saved() || saving" } }
-        = t('js.admin.panels.save')
+        {{ 'js.admin.panels.save' | t }}
         %i.icon-save
       %span{ ng: {show: "saved() && !saving" } }
-        = t('js.admin.panels.saved')
+        {{ 'js.admin.panels.saved' | t }}
         %i.icon-ok-sign
       %span{ ng: {show: "saving" } }
-        = t('js.admin.panels.saving')
+        {{ 'js.admin.panels.saving' | t }}
         %i.icon-refresh

--- a/app/assets/javascripts/templates/admin/panels/enterprise_status.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/enterprise_status.html.haml
@@ -2,16 +2,16 @@
   .alpha.omega.sixteen.columns
     %h4.status-ok.text-center{ ng: { show: "issues.length == 0 && warnings.length == 0" } }
       %i.icon-ok-sign
-      = t('js.admin.panels.enterprise_status.status_title', name: '{{ object.name }}')
+      {{ 'js.admin.panels.enterprise_status.status_title' | t:{ name: object.name } }}
 
     %table{ ng: { show: "issues.length > 0 || warnings.length > 0" } }
       %thead
         %th.severity
-          = t('js.admin.panels.enterprise_status.severity')
+          {{ 'js.admin.panels.enterprise_status.severity' | t }}
         %th.description
-          = t('js.admin.panels.enterprise_status.description')
+          {{ 'js.admin.panels.enterprise_status.description' | t }}
         %th.resolve
-          = t('js.admin.panels.enterprise_status.resolve')
+          {{ 'js.admin.panels.enterprise_status.resolve' | t }}
       %tr{ ng: { repeat: "issue in issues"} }
         %td.severity
           %i.icon-warning-sign.issue

--- a/app/assets/javascripts/templates/admin/panels/exchange_distributed_products.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_distributed_products.html.haml
@@ -7,7 +7,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'setExchangeVariants(exchange, incomingExchangeVariantsFor(exchange.enterprise_id), exchange.select_all_variants)',
           'id' => 'order_cycle_outgoing_exchange_{{ $parent.$index }}_select_all_variants' }
-        = t('admin.select_all')
+        {{ 'admin.select_all' | t }}
 
     .exchange-products
       -# Scope product list based on permissions the current user has to view variants in this exchange

--- a/app/assets/javascripts/templates/admin/panels/exchange_supplied_products.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_supplied_products.html.haml
@@ -7,7 +7,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'setExchangeVariants(exchange, suppliedVariants(exchange.enterprise_id), exchange.select_all_variants)',
           'id' => 'order_cycle_incoming_exchange_{{ $index }}_select_all_variants' }
-        = t('admin.select_all')
+        {{ 'admin.select_all' | t }}
 
     .exchange-products
       -# No need to scope product list based on permissions, because if an incoming exchange is visible,
@@ -36,7 +36,7 @@
               'ofn-sync-distributions' => '{{ product.master_id }}',
               'id' => 'order_cycle_incoming_exchange_{{ $parent.$index }}_variants_{{ product.master_id }}',
               'ng-disabled' => '!order_cycle.editable_variants_for_incoming_exchanges.hasOwnProperty(exchange.enterprise_id) || order_cycle.editable_variants_for_incoming_exchanges[exchange.enterprise_id].indexOf(product.master_id) < 0' }
-            = t('admin.obsolete_master')
+            {{ 'admin.obsolete_master' | t }}
 
         .exchange-product-variant{'ng-repeat' => 'variant in product.variants'}
           %label

--- a/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_tags.html.haml
@@ -1,6 +1,6 @@
 .row.exchange-tags
   .sixteen.columns.alpha.omega
     %span.text-normal
-      = t('admin.tags')
+      {{ 'admin.tags' | t }}
     %br
     %tags-with-translation.fullwidth{ object: 'object' }

--- a/app/assets/javascripts/templates/admin/tag_autocomplete.html.haml
+++ b/app/assets/javascripts/templates/admin/tag_autocomplete.html.haml
@@ -3,9 +3,9 @@
     {{$getDisplayText()}}
     %span.tag-with-rules{ ng: { if: "data.rules == 1" } }
       &mdash;
-      = t('admin.has_one_rule')
+      {{ 'admin.has_one_rule' | t }}
     %span.tag-with-rules{ ng: { if: "data.rules > 1" } }
       &mdash;
-      = t('admin.has_n_rules', { num: '{{data.rules}}' })
+      {{ 'admin.has_n_rules' | t:{ num: data.rules } }}
   %span{ ng: { if: "!data.rules" } }
     {{$getDisplayText()}}

--- a/app/assets/javascripts/templates/out_of_stock.html.haml
+++ b/app/assets/javascripts/templates/out_of_stock.html.haml
@@ -1,13 +1,15 @@
 %a.close-reveal-modal{"ng-click" => "$close()"}
   %i.ofn-i_009-close
 
-%h3= t('js.out_of_stock.reduced_stock_available')
+%h3
+  {{ 'js.out_of_stock.reduced_stock_available' | t }}
 
-%p= t('js.out_of_stock.out_of_stock_text')
+%p
+  {{ 'js.out_of_stock.out_of_stock_text' | t }}
 
 %p{'ng-repeat' => "v in variants"}
   %em {{ v.name_to_display }} - {{ v.unit_to_display }}
   %span{'ng-if' => "v.count_on_hand == 0"}
-    = t('js.out_of_stock.now_out_of_stock')
+    {{ 'js.out_of_stock.now_out_of_stock' | t }}
   %span{'ng-if' => "v.count_on_hand > 0"}
-    = t('js.out_of_stock.only_n_remainging', num: '{{ v.count_on_hand }}')
+    {{ 'js.out_of_stock.only_n_remainging' | t:{ num: v.count_on_hand } }}

--- a/app/assets/javascripts/templates/single_line_selectors.html.haml
+++ b/app/assets/javascripts/templates/single_line_selectors.html.haml
@@ -5,7 +5,7 @@
   %li.more
     %a.dropdown{ data: { dropdown: "{{ 'show-more-' + selectorName }}" }, ng: { class: "{active: selectedOverFlowSelectors().length > 0}" } }
       %span
-        = t('js.more_items', count: "{{ overFlowSelectors().length }}")
+        {{ 'js.more_items' | t:{ count: overFlowSelectors().length } }}
       %i.ofn-i_052-point-down
     .f-dropdown.text-right.content{ ng: { attr: { id: "{{ 'show-more-' + selectorName }}" } } }
       %ul


### PR DESCRIPTION
#### What? Why?

Closes #1991 and unblocks multilingual UI testing.

JS template string switched to Angular format to address I18n compilation issues.

#### What should we test?

Compiled template strings in Staging. To see a difference, you need to switch languages. You can choose the Spanish language by appending `?locale=es` to the URL in the browser. For example visit: https://staging1.openfood.com.au/admin/order_cycles/110/edit?locale=es