### PR TITLE
Only include one host in embedded shopfront headers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,8 @@ class ApplicationController < ActionController::Base
 
   def embedded_shopfront_referer
     return if request.referer.blank?
-    URI(request.referer).host.sub!(/^www./, '')
+    domain = URI(request.referer).host.downcase
+    domain.start_with?('www.') ? domain[4..-1] : domain
   end
 
   def embeddable?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,13 +55,11 @@ class ApplicationController < ActionController::Base
   end
 
   def enable_embedded_shopfront
-    whitelist = Spree::Config[:embedded_shopfronts_whitelist]
-    domain = embedded_shopfront_referer
-    return unless Spree::Config[:enable_embedded_shopfronts] && whitelist.present? && domain.present? && whitelist.include?(domain)
-    return if request.referer && URI(request.referer).scheme != 'https' && !Rails.env.test? && !Rails.env.development?
+    return unless embeddable?
+    return if embedding_without_https?
 
     response.headers.delete 'X-Frame-Options'
-    response.headers['Content-Security-Policy'] = "frame-ancestors #{domain}"
+    response.headers['Content-Security-Policy'] = "frame-ancestors #{embedded_shopfront_referer}"
 
     check_embedded_request
     set_embedded_layout
@@ -70,6 +68,16 @@ class ApplicationController < ActionController::Base
   def embedded_shopfront_referer
     return if request.referer.blank?
     URI(request.referer).host.sub!(/^www./, '')
+  end
+
+  def embeddable?
+    whitelist = Spree::Config[:embedded_shopfronts_whitelist]
+    domain = embedded_shopfront_referer
+    Spree::Config[:enable_embedded_shopfronts] && whitelist.present? && domain.present? && whitelist.include?(domain)
+  end
+
+  def embedding_without_https?
+    request.referer && URI(request.referer).scheme != 'https' && !Rails.env.test? && !Rails.env.development?
   end
 
   def check_embedded_request

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -22,10 +22,10 @@ feature "Using embedded shopfront functionality", js: true do
       add_variant_to_order_cycle(exchange, variant)
 
       Spree::Config[:enable_embedded_shopfronts] = true
-      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
+      Spree::Config[:embedded_shopfronts_whitelist] = 'test.com'
 
       page.driver.browser.js_errors = false
-      allow_any_instance_of(ApplicationController).to receive(:embedded_shopfront_referer).and_return('localhost')
+      allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return('https://www.test.com')
       Capybara.current_session.driver.visit('spec/support/views/iframe_test.html')
     end
 

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -25,6 +25,7 @@ feature "Using embedded shopfront functionality", js: true do
       Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
 
       page.driver.browser.js_errors = false
+      allow_any_instance_of(ApplicationController).to receive(:embedded_shopfront_referer).and_return('localhost')
       Capybara.current_session.driver.visit('spec/support/views/iframe_test.html')
     end
 

--- a/spec/requests/embedded_shopfronts_headers_spec.rb
+++ b/spec/requests/embedded_shopfronts_headers_spec.rb
@@ -43,16 +43,19 @@ describe "setting response headers for embedded shopfronts", type: :request do
 
     context "with a valid whitelist" do
       before do
-        Spree::Config[:embedded_shopfronts_whitelist] = "test.com"
+        Spree::Config[:embedded_shopfronts_whitelist] = "example.com external-site.com"
+        allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return('http://www.external-site.com/shop?embedded_shopfront=true')
       end
 
       it "allows iframes on certain pages when enabled in configuration" do
         get shops_path
+
         expect(response.status).to be 200
         expect(response.headers['X-Frame-Options']).to be_nil
-        expect(response.headers['Content-Security-Policy']).to eq "frame-ancestors test.com"
+        expect(response.headers['Content-Security-Policy']).to eq "frame-ancestors external-site.com"
 
         get spree.admin_path
+
         expect(response.status).to be 200
         expect(response.headers['X-Frame-Options']).to eq 'DENY'
         expect(response.headers['Content-Security-Policy']).to eq "frame-ancestors 'none'"


### PR DESCRIPTION
#### What? Why?

Closes #1953. 

Adjustments to the headers that are returned with embedded shopfronts.

#### What should we test?

Embedded shopfronts are working and returning a single URL in the 'frame-ancestors' response header. 

#### Testing notes:

Needs to be checked in an external site with an iframe. The PR needs to be staged first, and the correct URL added to the domain whitelist in the admin settings on the staging server, then an iframe on another site needs to be used to check it, pointing to the correct staging URL.

Checklist: 
- Embedded shopfronts needs to be enabled in instance admin config settings
- The domain of the embedding site needs to be in the whitelist
- The embedding site needs to have HTTPS
- The embedding site's iframe should point to: `https://staging-server-url/your-enterprise/shop?embedded_shopfront=true`

In the headers there should only be one domain name present under `frame-ancestors`. As a side-effect of this PR, the whitelist should work whether it has newlines, spaces, commas or whatever else separating the domains in the list. 