### PR TITLE
Add powered by text to bottom of embedded group pages

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,7 +7,10 @@ class GroupsController < BaseController
 
   def show
     enable_embedded_shopfront
-    @hide_menu = true if @shopfront_layout == 'embedded'
+    if @shopfront_layout == 'embedded'
+      @hide_menu = true
+      @show_powered_by_ofn = true
+    end
     @group = EnterpriseGroup.find_by_permalink(params[:id]) || EnterpriseGroup.find(params[:id])
   end
 end

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -119,7 +119,12 @@
             %i.ofn-i_050-mail-circle
           =link_to_service "http://", @group.website, title: t(:groups_contact_website) do
             %i.ofn-i_049-web
-        %p
-          &nbsp;
+        - if @show_powered_by_ofn
+          .powered-by-embedded
+            %img{src: '/favicon.ico'}
+            %span
+              = t 'powered_by'
+            %span
+              = t 'title'
 
 = render "shared/footer"

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -5,30 +5,45 @@ feature "Using embedded shopfront functionality", js: true do
   Capybara.server_port = 9999
 
   describe 'embedded groups' do
-	let(:enterprise) { create(:distributor_enterprise) }
-  	let!(:group) { create(:enterprise_group, enterprises: [enterprise], on_front_page: true) }
+    let(:enterprise) { create(:distributor_enterprise) }
+    let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
 
-
-  	before do
-  	  Spree::Config[:enable_embedded_shopfronts] = true
+    before do
+      Spree::Config[:enable_embedded_shopfronts] = true
       Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
 
       page.driver.browser.js_errors = false
-	  Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+      Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+    end
 
-  	end
+    after do
+      Spree::Config[:enable_embedded_shopfronts] = false
+    end
 
-	it "displays in an iframe" do
-	  expect(page).to have_selector 'iframe#group_test_iframe'
+    it "displays in an iframe" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
 
-	  within_frame 'group_test_iframe' do
-	  	within 'div#group-page' do
-	  	  expect(page).to have_selector 'h2.group-name'
-	  	  expect(page).to have_content 'About Us'
-	  	end
-	  end	  
-	end
-  
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          expect(page).to have_selector 'h2.group-name'
+          expect(page).to have_content 'About Us'
+        end
+      end
+    end
+
+    it "displays powered by OFN text at bottom of page" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
+
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          expect(page).to have_selector 'div.powered-by-embedded'
+          expect(page).to have_css "img[src*='favicon.ico']"
+          expect(page).to have_content 'Powered by'
+          expect(page).to have_content 'Open Food Network'
+        end
+      end
+    end
+
   end
 
 end

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+feature "Using embedded shopfront functionality", js: true do
+
+  Capybara.server_port = 9999
+
+  describe 'embedded groups' do
+	let(:enterprise) { create(:distributor_enterprise) }
+  	let!(:group) { create(:enterprise_group, enterprises: [enterprise], on_front_page: true) }
+
+
+  	before do
+  	  Spree::Config[:enable_embedded_shopfronts] = true
+      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
+
+      page.driver.browser.js_errors = false
+	  Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+
+  	end
+
+	it "displays in an iframe" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  	  expect(page).to have_selector 'h2.group-name'
+	  	  expect(page).to have_content 'About Us'
+	  	end
+	  end	  
+	end
+  
+  end
+
+end

--- a/spec/support/views/group_iframe_test.html
+++ b/spec/support/views/group_iframe_test.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+
+<iframe src="http://localhost:9999/groups/group1?embedded_shopfront=true" name="group_test_iframe" class="group_test_iframe" id="group_test_iframe" style="width:100%;min-height:35em"></iframe>
+
+</body>
+</html>


### PR DESCRIPTION
Part of task #1783

"move the 'powered by open food network' to somewhere lower on the page (the element got removed)"

This pull enacts the above. I.e. it just adds a small bit of text to the group template saying "Powered by open food network". This only appears when a group page is embedded. Also contains an initial test for embedded group functionality as none existed.

What should we test?
Tests in spec/features/consumer/shopping/embedded_groups_spec.rb

Also functionality can be manually tested using the embedded-group-preview.html file. i.e. by creating a group and then navigating to: http://localhost:3000/embedded-group-preview.html?your-group-name.

Release notes
First of four subtasks. Does not solve issue #1783 by itself.