### PR TITLE
Remove contact details section from embedded groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,8 +8,8 @@ class GroupsController < BaseController
   def show
     enable_embedded_shopfront
     if @shopfront_layout == 'embedded'
-       @hide_menu = true
-       @hide_contact_details = true
+      @hide_menu = true
+      @hide_contact_details = true
     end
     @group = EnterpriseGroup.find_by_permalink(params[:id]) || EnterpriseGroup.find(params[:id])
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,7 +7,10 @@ class GroupsController < BaseController
 
   def show
     enable_embedded_shopfront
-    @hide_menu = true if @shopfront_layout == 'embedded'
+    if @shopfront_layout == 'embedded'
+       @hide_menu = true
+       @hide_contact_details = true
+    end
     @group = EnterpriseGroup.find_by_permalink(params[:id]) || EnterpriseGroup.find(params[:id])
   end
 end

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -29,9 +29,7 @@
           %h2.group-name= @group.name
           %p= @group.description
 
-  .small-12.columns.pad-top
-    .row
-      .small-12.medium-12.large-9.columns
+      - content_for(:tabs) do   
         %div{"ng-controller" => "GroupTabsCtrl"}
           %tabset
             %tab{heading: t(:label_map),
@@ -103,8 +101,20 @@
 
                       = render 'shared/components/enterprise_no_results'
 
+
+
+  .small-12.columns.pad-top
+    .row
+    - if @hide_contact_details
+      .small-12.medium-12.large-12.columns
+        = content_for :tabs
+    - else 
+      .small-12.medium-12.large-9.columns
+        = content_for :tabs 
+
       .small-12.medium-12.large-3.columns
-        = render 'contact'
+        - unless @hide_contact_details
+          = render 'contact'
 
   .small-12.columns.pad-top
     .row.pad-top

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -8,7 +8,6 @@ feature "Using embedded shopfront functionality", js: true do
 	let(:enterprise) { create(:distributor_enterprise) }
   	let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
 
-
   	before do
   	  Spree::Config[:enable_embedded_shopfronts] = true
       Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
@@ -28,6 +27,18 @@ feature "Using embedded shopfront functionality", js: true do
 	  	end
 	  end	  
 	end
+
+	it "doesn't display contact details when embedded" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	    within 'div#group-page' do
+          expect(page).to have_no_selector 'div.contact-container'
+          expect(page).to have_no_content '#{group.address.address1}'
+	  	end
+	  end
+	end
+
   
   end
 

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+feature "Using embedded shopfront functionality", js: true do
+
+  Capybara.server_port = 9999
+
+  describe 'embedded groups' do
+	let(:enterprise) { create(:distributor_enterprise) }
+  	let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
+
+
+  	before do
+  	  Spree::Config[:enable_embedded_shopfronts] = true
+      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
+
+      page.driver.browser.js_errors = false
+	  Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+
+  	end
+
+	it "displays in an iframe" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  	  expect(page).to have_selector 'h2.group-name'
+	  	  expect(page).to have_content 'About Us'
+	  	end
+	  end	  
+	end
+  
+  end
+
+end

--- a/spec/support/views/group_iframe_test.html
+++ b/spec/support/views/group_iframe_test.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+
+<iframe src="http://localhost:9999/groups/group1?embedded_shopfront=true" name="group_test_iframe" class="group_test_iframe" id="group_test_iframe" style="width:100%;min-height:35em"></iframe>
+
+</body>
+</html>


### PR DESCRIPTION
Part of task #1783

"remove the contact details"

This pull enacts the above. I.e. It removes the contact details from a group page when that page is being viewed in an embedded setting. 

What should we test?
Tests in spec/features/consumer/shopping/embedded_groups_spec.rb

Also functionality can be manually tested using the embedded-group-preview.html file. i.e. by creating a group and then navigating to: http://localhost:3000/embedded-group-preview.html?your-group-name.

Release notes
Second of four subtasks. Does not solve issue #1783 by itself.