### PR TITLE
Uk/1663variant order emails

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -32,8 +32,8 @@ class ProducerMailer < Spree::BaseMailer
 
   def line_items_from(order_cycle, producer)
     Spree::LineItem.
-      joins(order: :order_cycle, variant: :product).
-      where('order_cycles.id = ?', order_cycle).
+      from_order_cycle(order_cycle).
+      sorted_by_name_and_unit_value.
       merge(Spree::Product.in_supplier(producer)).
       merge(Spree::Order.by_state('complete'))
   end

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -36,7 +36,6 @@ class ProducerMailer < Spree::BaseMailer
       where('order_cycles.id = ?', order_cycle).
       merge(Spree::Product.in_supplier(producer)).
       merge(Spree::Order.by_state('complete'))
-
   end
 
   def total_from_line_items(line_items)

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -36,6 +36,7 @@ class ProducerMailer < Spree::BaseMailer
       where('order_cycles.id = ?', order_cycle).
       merge(Spree::Product.in_supplier(producer)).
       merge(Spree::Order.by_state('complete'))
+
   end
 
   def total_from_line_items(line_items)

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -32,6 +32,13 @@ Spree::LineItem.class_eval do
     end
   }
 
+  scope :sorted_by_name_and_unit_value,     
+      # Find line items that are from order sorted by variant name and unit value
+      joins(:variant=> :product).
+        reorder('spree_products.name asc, spree_variants.unit_value asc').
+        select('spree_line_items.*')
+  
+
   scope :supplied_by, lambda { |enterprise|
     joins(:product).
       where('spree_products.supplier_id = ?', enterprise)

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -33,7 +33,7 @@ Spree::LineItem.class_eval do
   }
 
   # Find line items that are from order sorted by variant name and unit value
-  scope :sorted_by_name_and_unit_value, joins(:variant => :product).
+  scope :sorted_by_name_and_unit_value, joins(variant: :product).
     reorder('spree_products.name asc, spree_variants.unit_value asc').
     select('spree_line_items.*')
 

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -36,9 +36,9 @@ Spree::LineItem.class_eval do
   scope :sorted_by_name_and_unit_value, joins(variant: :product).
     reorder('lower(spree_products.name) asc, lower(spree_variants.display_name) asc, spree_variants.unit_value asc')
 
-  scope :from_order_cycle, lambda {|order_cycle|
+  scope :from_order_cycle, lambda { |order_cycle|
     joins(order: :order_cycle).
-    where('order_cycles.id = ?', order_cycle)
+      where('order_cycles.id = ?', order_cycle)
   }
 
   scope :supplied_by, lambda { |enterprise|

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -34,8 +34,12 @@ Spree::LineItem.class_eval do
 
   # Find line items that are from order sorted by variant name and unit value
   scope :sorted_by_name_and_unit_value, joins(variant: :product).
-    reorder('lower(spree_products.name) asc, lower(spree_variants.display_name) asc, spree_variants.unit_value asc').
-    select('spree_line_items.*')
+    reorder('lower(spree_products.name) asc, lower(spree_variants.display_name) asc, spree_variants.unit_value asc')
+
+  scope :from_order_cycle, lambda {|order_cycle|
+    joins(order: :order_cycle).
+    where('order_cycles.id = ?', order_cycle)
+  }
 
   scope :supplied_by, lambda { |enterprise|
     joins(:product).

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -32,12 +32,10 @@ Spree::LineItem.class_eval do
     end
   }
 
-  scope :sorted_by_name_and_unit_value,     
-      # Find line items that are from order sorted by variant name and unit value
-      joins(:variant=> :product).
-        reorder('spree_products.name asc, spree_variants.unit_value asc').
-        select('spree_line_items.*')
-  
+  # Find line items that are from order sorted by variant name and unit value
+  scope :sorted_by_name_and_unit_value, joins(:variant => :product).
+    reorder('spree_products.name asc, spree_variants.unit_value asc').
+    select('spree_line_items.*')
 
   scope :supplied_by, lambda { |enterprise|
     joins(:product).

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -34,7 +34,7 @@ Spree::LineItem.class_eval do
 
   # Find line items that are from order sorted by variant name and unit value
   scope :sorted_by_name_and_unit_value, joins(variant: :product).
-    reorder('spree_products.name asc, spree_variants.unit_value asc').
+    reorder('lower(spree_products.name) asc, lower(spree_variants.display_name) asc, spree_variants.unit_value asc').
     select('spree_line_items.*')
 
   scope :supplied_by, lambda { |enterprise|

--- a/app/views/spree/order_mailer/_order_summary.html.haml
+++ b/app/views/spree/order_mailer/_order_summary.html.haml
@@ -11,7 +11,7 @@
         %h4
           = t :email_order_summary_price
   %tbody
-    - @order.line_items.each do |item|
+    - @order.line_items.sorted_by_name_and_unit_value.each do |item|
       %tr
         %td
           = render 'spree/shared/line_item_name', line_item: item

--- a/app/views/spree/orders/_summary.html.haml
+++ b/app/views/spree/orders/_summary.html.haml
@@ -11,7 +11,7 @@
       %th.text-right.total
         %span= t(:total)
   %tbody{"data-hook" => ""}
-    - order.line_items.each do |item|
+    - order.line_items.sorted_by_name_and_unit_value.each do |item|
       %tr.line_item{"data-hook" => "order_details_line_item_row", class: "variant-#{item.variant.id}" }
         %td(data-hook = "order_item_description")
 

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -16,11 +16,11 @@ describe ProducerMailer do
   let(:s3) { create(:supplier_enterprise) }
   let(:d1) { create(:distributor_enterprise, charges_sales_tax: true) }
   let(:d2) { create(:distributor_enterprise) }
-  let(:p1) { create(:product, price: 12.34, supplier: s1, tax_category: tax_category) }
-  let(:p2) { create(:product, price: 23.45, supplier: s2) }
-  let(:p3) { create(:product, price: 34.56, supplier: s1) }
-  let(:p4) { create(:product, price: 45.67, supplier: s1) }
-  let(:p5) { create(:product, price: 56.78, supplier: s1) }
+  let(:p1) { create(:product, name: "Zebra", price: 12.34, supplier: s1, tax_category: tax_category) }
+  let(:p2) { create(:product, name: "Aardvark", price: 23.45, supplier: s2) }
+  let(:p3) { create(:product, name: "Banana", price: 34.56, supplier: s1) }
+  let(:p4) { create(:product, name: "Coffee", price: 45.67, supplier: s1) }
+  let(:p5) { create(:product, name: "Daffodil", price: 56.78, supplier: s1) }
   let(:order_cycle) { create(:simple_order_cycle) }
   let!(:incoming_exchange) { order_cycle.exchanges.create! sender: s1, receiver: d1, incoming: true, receival_instructions: 'Outside shed.' }
 
@@ -71,7 +71,8 @@ describe ProducerMailer do
     expect(mail.cc).to eq [order_cycle.coordinator.contact.email]
   end
 
-  it "contains an aggregated list of produce" do
+  it "contains an aggregated list of produce in alphabetical order" do
+    mail.body.encoded.should match(/Coffee.+\n.+Zebra/)
     body_lines_including(mail, p1.name).each do |line|
       line.should include 'QTY: 3'
       line.should include '@ $10.00 = $30.00'
@@ -79,6 +80,7 @@ describe ProducerMailer do
     body_as_html(mail).find("table.order-summary tr", text: p1.name)
       .should have_selector("td", text: "$30.00")
   end
+
 
   it "displays tax totals for each product" do
     # Tax for p1 line items

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -19,7 +19,7 @@ describe ProducerMailer do
   let(:p1) { create(:product, name: "Zebra", price: 12.34, supplier: s1, tax_category: tax_category) }
   let(:p2) { create(:product, name: "Aardvark", price: 23.45, supplier: s2) }
   let(:p3) { create(:product, name: "Banana", price: 34.56, supplier: s1) }
-  let(:p4) { create(:product, name: "Coffee", price: 45.67, supplier: s1) }
+  let(:p4) { create(:product, name: "coffee", price: 45.67, supplier: s1) }
   let(:p5) { create(:product, name: "Daffodil", price: 56.78, supplier: s1) }
   let(:order_cycle) { create(:simple_order_cycle) }
   let!(:incoming_exchange) { order_cycle.exchanges.create! sender: s1, receiver: d1, incoming: true, receival_instructions: 'Outside shed.' }
@@ -72,7 +72,7 @@ describe ProducerMailer do
   end
 
   it "contains an aggregated list of produce in alphabetical order" do
-    mail.body.encoded.should match(/Coffee.+\n.+Zebra/)
+    expect(mail.body.encoded).to match(/coffee.+\n.+Zebra/)
     body_lines_including(mail, p1.name).each do |line|
       line.should include 'QTY: 3'
       line.should include '@ $10.00 = $30.00'

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -54,7 +54,7 @@ module Spree
       end
 
       it "finds line items sorted by name and unit_value" do
-        o.line_items.sorted_by_name_and_unit_value.should == [li5,li6,li4,li3]
+        expect(o.line_items.sorted_by_name_and_unit_value).to eq([li5,li6,li4,li3])
       end
     end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -14,13 +14,13 @@ module Spree
       let(:li1) { create(:line_item, order: o, product: p1) }
       let(:li2) { create(:line_item, order: o, product: p2) }
 
-      
+
       let(:p3) {create(:product, name: 'Clear Honey') }
       let(:p4) {create(:product, name: 'Apricots') }
       let(:v1) {create(:variant, product: p3, unit_value: 500) }
       let(:v2) {create(:variant, product: p3, unit_value: 250) }
-      let(:v3) {create(:variant, product: p4, unit_value: 500) }
-      let(:v4) {create(:variant, product: p4, unit_value: 1000) }
+      let(:v3) {create(:variant, product: p4, unit_value: 500, display_name: "ZZ") }
+      let(:v4) {create(:variant, product: p4, unit_value: 500, display_name: "aa") }
       let(:li3) { create(:line_item, order: o, product: p3, variant: v1) }
       let(:li4) { create(:line_item, order: o, product: p3, variant: v2) }
       let(:li5) { create(:line_item, order: o, product: p4, variant: v3) }
@@ -54,7 +54,7 @@ module Spree
       end
 
       it "finds line items sorted by name and unit_value" do
-        expect(o.line_items.sorted_by_name_and_unit_value).to eq([li5,li6,li4,li3])
+        expect(o.line_items.sorted_by_name_and_unit_value).to eq([li6,li5,li4,li3])
       end
     end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -26,6 +26,8 @@ module Spree
       let(:li5) { create(:line_item, order: o, product: p4, variant: v3) }
       let(:li6) { create(:line_item, order: o, product: p4, variant: v4) }
 
+      let(:oc_order) { create :order_with_totals_and_distribution }
+
       it "finds line items for products supplied by a particular enterprise" do
         LineItem.supplied_by(s1).should == [li1]
         LineItem.supplied_by(s2).should == [li2]
@@ -55,6 +57,10 @@ module Spree
 
       it "finds line items sorted by name and unit_value" do
         expect(o.line_items.sorted_by_name_and_unit_value).to eq([li6,li5,li4,li3])
+      end
+
+      it "finds line items from a given order cycle" do
+        expect(LineItem.from_order_cycle(oc_order.order_cycle).first.id).to eq oc_order.line_items.first.id
       end
     end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -14,6 +14,18 @@ module Spree
       let(:li1) { create(:line_item, order: o, product: p1) }
       let(:li2) { create(:line_item, order: o, product: p2) }
 
+      
+      let(:p3) {create(:product, name: 'Clear Honey') }
+      let(:p4) {create(:product, name: 'Apricots') }
+      let(:v1) {create(:variant, product: p3, unit_value: 500) }
+      let(:v2) {create(:variant, product: p3, unit_value: 250) }
+      let(:v3) {create(:variant, product: p4, unit_value: 500) }
+      let(:v4) {create(:variant, product: p4, unit_value: 1000) }
+      let(:li3) { create(:line_item, order: o, product: p3, variant: v1) }
+      let(:li4) { create(:line_item, order: o, product: p3, variant: v2) }
+      let(:li5) { create(:line_item, order: o, product: p4, variant: v3) }
+      let(:li6) { create(:line_item, order: o, product: p4, variant: v4) }
+
       it "finds line items for products supplied by a particular enterprise" do
         LineItem.supplied_by(s1).should == [li1]
         LineItem.supplied_by(s2).should == [li2]
@@ -39,6 +51,10 @@ module Spree
         it "finds line items without tax" do
           LineItem.without_tax.should == [li2]
         end
+      end
+
+      it "finds line items sorted by name and unit_value" do
+        o.line_items.sorted_by_name_and_unit_value.should == [li5,li6,li4,li3]
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #1663

This order by variant name and unit value in the items of an order are applied to confirmation email and summary screen after checkout for clients (not producers). It was done in the cart and now in emails.

NOTE : All these changes were already approved and reviewed on PR #1709. This is essentially a rebase on a branch on my fork.

This change was requested to avoid annoying lists of orders without any logic. Now it comes with an alphabetic list of variants and values when name are the same.
It has been done with a scope in the line_item model to get the list of items already sorted on screen.

#### What should we test?

Create an order with two different products (Apricots and Honey, for example) and each of them with, at least, 2 different variants of unit values (Apricots 500g, Apricots 1000, Honey 1000g, Honey 500g).
It should come a list where Aprictos 500g, is the first element and Honey 1000g the last one.

#### Release notes

Order Emails now list products in a logical way: first alphabetically, then by weight. Eg Apples 500g, Apple 1kg, Bananas 500g, Bananas 1kg.
