### PR TITLE
Remove logo, banner, description and title from embedded groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,7 +7,10 @@ class GroupsController < BaseController
 
   def show
     enable_embedded_shopfront
-    @hide_menu = true if @shopfront_layout == 'embedded'
+    if @shopfront_layout == 'embedded'
+      @hide_menu = true
+      @hide_header = true
+    end
     @group = EnterpriseGroup.find_by_permalink(params[:id]) || EnterpriseGroup.find(params[:id])
   end
 end

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -15,6 +15,7 @@
 
 #group-page.row.pad-top.footer-pad{"ng-controller" => "GroupPageCtrl"}
   .small-12.columns.pad-top
+  - unless @hide_header  
     %header
       .row
         .small-12.columns

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+feature "Using embedded shopfront functionality", js: true do
+
+  Capybara.server_port = 9999
+
+  describe 'embedded groups' do
+	let(:enterprise) { create(:distributor_enterprise) }
+  	let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
+
+
+  	before do
+  	  Spree::Config[:enable_embedded_shopfronts] = true
+      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
+
+      page.driver.browser.js_errors = false
+	  Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+
+  	end
+
+	it "displays in an iframe" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  	  expect(page).to have_selector 'h2.group-name'
+	  	  expect(page).to have_content 'About Us'
+	  	end
+	  end	  
+	end
+  
+  end
+
+end

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -23,10 +23,21 @@ feature "Using embedded shopfront functionality", js: true do
 
 	  within_frame 'group_test_iframe' do
 	  	within 'div#group-page' do
-	  	  expect(page).to have_selector 'h2.group-name'
 	  	  expect(page).to have_content 'About Us'
 	  	end
 	  end	  
+	end
+
+	it "does not display the header when embedded" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  		expect(page).to have_no_selector 'header'
+	  	    expect(page).to have_no_selector 'img.group-logo'
+	  	    expect(page).to have_no_selector 'h2.group-name'
+	  	end
+	  end
 	end
   
   end

--- a/spec/support/views/group_iframe_test.html
+++ b/spec/support/views/group_iframe_test.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+
+<iframe src="http://localhost:9999/groups/group1?embedded_shopfront=true" name="group_test_iframe" class="group_test_iframe" id="group_test_iframe" style="width:100%;min-height:35em"></iframe>
+
+</body>
+</html>


### PR DESCRIPTION
## What? Why?

Part of task #1783

"Remove the logo, banner and Description text fields"

This pull enacts the above. I.e. It removed the whole header element from from the group page template if it's being viewed as an embedded page. This also includes the group name so that has also been removed (as instructed). 

## What should we test?
Tests in spec/features/consumer/shopping/embedded_groups_spec.rb

Also functionality can be manually tested using the embedded-group-preview.html file. i.e. by creating a group and then navigating to: http://localhost:3000/embedded-group-preview.html?your-group-name.

## Release notes
Third of four subtasks. Does not solve issue #1783 by itself.
  