### PR TITLE
Adjust codeclimate engine for migrations folder

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,10 @@ engines:
     channel: rubocop-0-48
   scss-lint:
     enabled: false
+  duplication:
+    enabled: true
+    exclude_patterns:
+    - "db/**"
 ratings:
   paths:
   - app/**


### PR DESCRIPTION
#### What? Why?

Relax Codeclimate duplication engine for migrations folder.

![screenshot from 2018-01-02 12-39-48](https://user-images.githubusercontent.com/9029026/34485654-9ff1f144-efc3-11e7-9dda-3b25a7b2b193.png)

https://docs.codeclimate.com/docs/duplication
