### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,41 +45,15 @@ You can download the source with the command:
 
 ### Get it running
 
-For those new to Rails, the following tutorial will help get you up to speed with configuring a [Rails environment](http://guides.rubyonrails.org/getting_started.html).  If you run into any issues getting your local environment up and running please consult [the wiki](https://github.com/openfoodfoundation/openfoodnetwork/wiki).
+For those new to Rails, the following tutorial will help get you up to speed with configuring a [Rails environment](http://guides.rubyonrails.org/getting_started.html).
 
+When ready, run `script/setup`. If the script succeeds you're ready to start developing. If not, take a look at the output as it should be informative enough to help you troubleshoot.
 
-First, check your dependencies: Ensure that you have Ruby 2.1.5 installed:
+If you run into any other issues getting your local environment up and running please consult [the wiki](https://github.com/openfoodfoundation/openfoodnetwork/wiki).
 
-    ruby --version
+If still you get stuck do not hesitate to open an issue reporting the full output of the script.
 
-Install the project's gem dependencies:
-
-    cd openfoodnetwork
-    bundle install
-    
-Configure the site:
-
-    cp config/application.yml.example config/application.yml
-    edit config/application.yml
-
-Create a PostgreSQL user:
-
-* Login as your system postrgresql priviledged user: `sudo -i -u postgres` (this may vary on your OS). Now your prompt looks like: `[postgres@your_host ~]$`
-* Create the `ofn` database superuser and give it the password `f00d`:
-
-```
-createuser -s -P ofn
-```
-
-Create the development and test databases, using the settings specified in `config/database.yml`, and populate them with a schema and seed data:
-```
-bundle exec rake db:setup
-```
-Load some default data for your environment:
-```
-bundle exec rake openfoodnetwork:dev:load_sample_data
-```
-At long last, your dreams of spinning up a development server can be realised:
+Now, your dreams of spinning up a development server can be realised:
 ```
 bundle exec rails server
 ```

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,64 @@
+#!/usr/bin/env sh
+
+# Set up Rails app. Run this script immediately after cloning the codebase.
+
+# Exit if any command fails
+set -e
+
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NO_COLOR='\033[0m'
+
+RUBY_VERSION=$(cat .ruby-version)
+POSTGRESQL_VERSION='9.5'
+
+DB_USER='ofn'
+DB_PASSWORD='f00d'
+
+# Check ruby version
+if ! ruby --version | grep $RUBY_VERSION > /dev/null; then
+  printf "${RED}Open Food Network requires ruby ${RUBY_VERSION}${NO_COLOR}\n"
+  exit 1
+fi
+
+# Check postgresql version
+if ! psql -V | grep $POSTGRESQL_VERSION > /dev/null; then
+  printf "${RED}Open Food Network requires postgresql ${POSTGRESQL_VERSION}${NO_COLOR}\n"
+  exit 1
+fi
+
+# Set up Ruby dependencies via Bundler
+if ! command -v bundle > /dev/null; then
+  gem install bundler
+fi
+
+bundle check || bundle install
+
+# Set up configurable environment variables
+if [ ! -f config/application.yml ]; then
+  cp config/application.yml.example config/application.yml
+  printf "${YELLOW}Copied config/application.yml Make sure to fill it with the appropriate configuration values.\n\n${NO_COLOR}"
+fi
+
+# Create the development database user
+if ! psql -c '\du' -t | grep $DB_USER > /dev/null; then
+  psql -c "CREATE USER ${DB_USER} WITH SUPERUSER PASSWORD '${DB_PASSWORD}';"
+fi
+
+# Set up the database for both development and test
+# Confirming the default user and password Spree prompts
+printf '\n\n' | bundle exec rake db:setup db:test:prepare
+printf '\n'
+
+# Load some default data for your environment
+bundle exec rake openfoodnetwork:dev:load_sample_data
+printf '\n'
+
+printf "${YELLOW}WELCOME TO OPEN FOOD NETWORK!\n"
+printf '\n'
+
+printf "To login as Spree default user, use:"
+printf '\n'
+printf '\n'
+printf '  email: spree@example.com\n'
+printf "  password: spree123\n${NO_COLOR}"

--- a/script/setup
+++ b/script/setup
@@ -18,13 +18,13 @@ DB_PASSWORD='f00d'
 
 # Check ruby version
 if ! ruby --version | grep $RUBY_VERSION > /dev/null; then
-  printf "${RED}Open Food Network requires ruby ${RUBY_VERSION}${NO_COLOR}\n"
+  printf "${RED}Open Food Network requires ruby ${RUBY_VERSION}${NO_COLOR}. Have a look at: https://github.com/rbenv/rbenv\n"
   exit 1
 fi
 
 # Check node version
 if ! node --version | grep $NODE_VERSION > /dev/null; then
-  printf "${RED}Open Food Network requires node ${NODE_VERSION}${NO_COLOR}\n"
+  printf "${RED}Open Food Network requires node ${NODE_VERSION}${NO_COLOR}. Have a look at: https://github.com/nodenv/nodenv\n"
 fi
 
 # Check postgresql version

--- a/script/setup
+++ b/script/setup
@@ -10,6 +10,7 @@ RED='\033[0;31m'
 NO_COLOR='\033[0m'
 
 RUBY_VERSION=$(cat .ruby-version)
+NODE_VERSION=$(cat .node-version)
 POSTGRESQL_VERSION='9.5'
 
 DB_USER='ofn'
@@ -19,6 +20,11 @@ DB_PASSWORD='f00d'
 if ! ruby --version | grep $RUBY_VERSION > /dev/null; then
   printf "${RED}Open Food Network requires ruby ${RUBY_VERSION}${NO_COLOR}\n"
   exit 1
+fi
+
+# Check node version
+if ! node --version | grep $NODE_VERSION > /dev/null; then
+  printf "${RED}Open Food Network requires node ${NODE_VERSION}${NO_COLOR}\n"
 fi
 
 # Check postgresql version
@@ -32,7 +38,9 @@ if ! command -v bundle > /dev/null; then
   gem install bundler
 fi
 
+# Install all dependencies
 bundle check || bundle install
+npm install
 
 # Set up configurable environment variables
 if [ ! -f config/application.yml ]; then


### PR DESCRIPTION
#### What? Why?

It aims to aid new open source contributors on setting up their dev env by means of a single command with a meaningful output.

Although ofn-install ansible scripts also work for development we don't want to add too much burden to those single-time beginner contributions.

#### Some example output

```shell
➜  openfoodnetwork add-setup-script ✗ script/setup
The Gemfile's dependencies are satisfied
CREATE ROLE
-- create_table("account_invoices", {:force=>true})
   -> 0.5013s
...
[db:seed] Seeding Spree
...
Create the admin user (press enter for defaults).
Email [spree@example.com]: Password [spree123]: stty: stty: stty:
Done!
[db:seed] Seeding states

[openfoodnetwork:dev:load_sample_data] Seeding shipping / payment information
[openfoodnetwork:dev:load_sample_data] Seeding taxonomies
[openfoodnetwork:dev:load_sample_data] Seeding addresses
[openfoodnetwork:dev:load_sample_data] Seeding enterprises
[openfoodnetwork:dev:load_sample_data] Seeding products

WELCOME TO OPEN FOOD NETWORK!

To login as Spree default user, use:

  email: spree@example.com
  password: spree123
```

#### Missing

- [x] Provide password when creating `ofn` pg user.
  
  