### PR TITLE
Update rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,10 @@ Lint/UselessAssignment:
 Rails/DynamicFindBy:
   Enabled: false
 
+# Same as above, #find_by is not available until Rails 4
+Rails/FindBy:
+  Enabled: false
+
 # This should be the programmer's discretion, perhaps we should review all of
 # the uses of it an make specific exceptions though.
 Rails/SkipsModelValidations:


### PR DESCRIPTION
#### What? Why?

Rubocop issues are popping up suggesting refactoring with the #find_by method, which doesn't exist before Rails 4.

#### What should we test?

Nothing to test.
  