### PR TITLE
Codeclimate yml update

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,18 +1,35 @@
-engines:
+version: "2"
+plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-48
+    channel: "rubocop-0-48"
   scss-lint:
     enabled: false
   duplication:
     enabled: true
     exclude_patterns:
     - "db/**"
-ratings:
-  paths:
-  - app/**
-  - lib/**
-  - "**.rb"
-exclude_paths:
-- spec/**/*
-- vendor/**/*
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: true
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: true
+  return-statements:
+    enabled: true
+  similar-code:
+    enabled: true
+  identical-code:
+    enabled: true
+exclude_patterns:
+- "spec/**/*"
+- "vendor/**/*"


### PR DESCRIPTION
#### What? Why?

Closes #2036. 

- Made some minor alterations to meet new config specifications. Details here: https://docs.codeclimate.com/v1.0/docs/advanced-configuration#section-analysis-configuration-versions
- Added the new "checks" node to `codeclimate.yml` so they are explicit, rather than implicitly enabled.
- Set some of the new checks to `false`, to match behaviour from our pre-existing `rubocop.yml` rules.
- Removed the "ratings" node, as it is now a deprecated setting, and is enabled by default in all supported files.



