### PR TITLE
2023 - Shipping/payment methods disappears for manager on uncheck

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -172,8 +172,8 @@ module Admin
     end
 
     def load_methods_and_fees
-      @payment_methods = Spree::PaymentMethod.managed_by(spree_current_user).sort_by!{ |pm| [(@enterprise.payment_methods.include? pm) ? 0 : 1, pm.name] }
-      @shipping_methods = Spree::ShippingMethod.managed_by(spree_current_user).sort_by!{ |sm| [(@enterprise.shipping_methods.include? sm) ? 0 : 1, sm.name] }
+      @payment_methods = Spree::PaymentMethod.all.sort_by!{ |pm| [(@enterprise.payment_methods.include? pm) ? 0 : 1, pm.name] }
+      @shipping_methods = Spree::ShippingMethod.all.sort_by!{ |sm| [(@enterprise.shipping_methods.include? sm) ? 0 : 1, sm.name] }
       @enterprise_fees = EnterpriseFee.managed_by(spree_current_user).for_enterprise(@enterprise).order(:fee_type, :name).all
     end
 

--- a/app/models/distributor_payment_method.rb
+++ b/app/models/distributor_payment_method.rb
@@ -1,0 +1,6 @@
+class DistributorPaymentMethod < ActiveRecord::Base
+  self.table_name = "distributors_payment_methods" 
+  belongs_to :payment_method, class_name: Spree::PaymentMethod
+  belongs_to :distributor, class_name: Enterprise, touch: true
+  belongs_to :creator, class_name: Spree::User
+end

--- a/app/models/distributor_shipping_method.rb
+++ b/app/models/distributor_shipping_method.rb
@@ -2,4 +2,5 @@ class DistributorShippingMethod < ActiveRecord::Base
   self.table_name = "distributors_shipping_methods" 
   belongs_to :shipping_method, class_name: Spree::ShippingMethod
   belongs_to :distributor, class_name: Enterprise, touch: true
+  belongs_to :creator, class_name: Spree::User
 end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -33,9 +33,10 @@ class Enterprise < ActiveRecord::Base
   has_many :enterprise_roles, :dependent => :destroy
   has_many :users, through: :enterprise_roles
   belongs_to :owner, class_name: 'Spree::User', foreign_key: :owner_id, inverse_of: :owned_enterprises
-  has_and_belongs_to_many :payment_methods, join_table: 'distributors_payment_methods', class_name: 'Spree::PaymentMethod', foreign_key: 'distributor_id'
   has_many :distributor_shipping_methods, foreign_key: :distributor_id
   has_many :shipping_methods, through: :distributor_shipping_methods
+  has_many :distributor_payment_methods, foreign_key: :distributor_id
+  has_many :payment_methods, through: :distributor_payment_methods
   has_many :customers
   has_many :billable_periods
   has_many :inventory_items

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -12,6 +12,8 @@ Spree.user_class.class_eval do
   has_one :cart
   has_many :customers
   has_many :credit_cards
+  has_many :created_shipping_methods, class_name: 'DistributorShippingMethod', foreign_key: :creator_id
+  has_many :created_payment_methods, class_name: 'DistributorPaymentMethod', foreign_key: :creator_id
 
   accepts_nested_attributes_for :enterprise_roles, :allow_destroy => true
 

--- a/db/migrate/20180303102146_add_creator_and_enabled_to_distributor_shipping_and_payment.rb
+++ b/db/migrate/20180303102146_add_creator_and_enabled_to_distributor_shipping_and_payment.rb
@@ -1,0 +1,21 @@
+class AddCreatorAndEnabledToDistributorShippingAndPayment < ActiveRecord::Migration
+  def up
+    add_column :distributors_shipping_methods, :creator_id, :integer
+    add_column :distributors_shipping_methods, :enabled, :boolean, :default => true
+    add_index :distributors_shipping_methods, [:creator_id], :name => "index_users_on_distributor_shipping"
+
+    add_column :distributors_payment_methods, :creator_id, :integer
+    add_column :distributors_payment_methods, :enabled, :boolean, :default => true
+    add_index :distributors_payment_methods, [:creator_id], :name => "index_users_on_distributor_payments"
+  end
+
+  def down
+    remove_index :distributors_shipping_methods, :name => "index_users_on_distributor_shipping"
+    remove_column :distributors_shipping_methods, :creator_id
+    remove_column :distributors_shipping_methods, :enabled
+
+    remove_index :distributors_payment_methods, :name => "index_users_on_distributor_payments"
+    remove_column :distributors_payment_methods, :creator_id
+    remove_column :distributors_payment_methods, :enabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180222231639) do
+ActiveRecord::Schema.define(:version => 20180303102146) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -115,18 +115,24 @@ ActiveRecord::Schema.define(:version => 20180222231639) do
   create_table "distributors_payment_methods", :id => false, :force => true do |t|
     t.integer "distributor_id"
     t.integer "payment_method_id"
+    t.integer "creator_id"
+    t.boolean "enabled",           :default => true
   end
 
+  add_index "distributors_payment_methods", ["creator_id"], :name => "index_users_on_distributor_payments"
   add_index "distributors_payment_methods", ["distributor_id"], :name => "index_distributors_payment_methods_on_distributor_id"
   add_index "distributors_payment_methods", ["payment_method_id"], :name => "index_distributors_payment_methods_on_payment_method_id"
 
   create_table "distributors_shipping_methods", :force => true do |t|
     t.integer  "distributor_id"
     t.integer  "shipping_method_id"
-    t.datetime "created_at",         :null => false
-    t.datetime "updated_at",         :null => false
+    t.datetime "created_at",                           :null => false
+    t.datetime "updated_at",                           :null => false
+    t.integer  "creator_id"
+    t.boolean  "enabled",            :default => true
   end
 
+  add_index "distributors_shipping_methods", ["creator_id"], :name => "index_users_on_distributor_shipping"
   add_index "distributors_shipping_methods", ["distributor_id"], :name => "index_distributors_shipping_methods_on_distributor_id"
   add_index "distributors_shipping_methods", ["shipping_method_id"], :name => "index_distributors_shipping_methods_on_shipping_method_id"
 

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -107,23 +107,23 @@ module Admin
       let(:enterprise1) { create(:distributor_enterprise) }
       let(:enterprise2) { create(:distributor_enterprise) }
       let(:manager) { create(:user, enterprise_limit: 10, enterprises: [enterprise2]) }
-      let(:time_zone) { Spree::Zone.create(:name => 'South zone')}
+      let(:time_zone) { Spree::Zone.create(name: 'South zone')}
       let(:shipping_method1) { create(:shipping_method, name: 'Pickup', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise1.id]) }
       let(:shipping_method2) { create(:shipping_method, name: 'Delivery', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise2.id]) }
-      let(:payment_method1) { create(:payment_method, :name => 'Online', distributor_ids: [enterprise1.id]) }
-      let(:payment_method2) { create(:payment_method, :name => 'COD', distributor_ids: [enterprise2.id]) }
-      let(:enterprise_fee1) { create(:enterprise_fee, :enterprise_id => enterprise1.id) }
-      let(:enterprise_fee2) { create(:enterprise_fee, :enterprise_id => enterprise2.id) }
+      let(:payment_method1) { create(:payment_method, name: 'Online', distributor_ids: [enterprise1.id]) }
+      let(:payment_method2) { create(:payment_method, name: 'COD', distributor_ids: [enterprise2.id]) }
+      let(:enterprise_fee1) { create(:enterprise_fee, enterprise_id: enterprise1.id) }
+      let(:enterprise_fee2) { create(:enterprise_fee, enterprise_id: enterprise2.id) }
 
       context "as admin" do
         it "sets required variables" do          
-          allow(controller).to receive_message_chain(:spree_current_user).and_return(admin_user)            
+          allow(controller).to receive(:spree_current_user).and_return(admin_user)            
 
           payment_methods = [payment_method1, payment_method2]
           shipping_methods = [shipping_method1, shipping_method2]
           enterprise_fees = [enterprise_fee1]
 
-          spree_get :edit, {:id => enterprise1.permalink} 
+          spree_get :edit, {id: enterprise1.permalink} 
 
           expect(assigns(:shipping_methods)).to eq shipping_methods   
           expect(assigns(:payment_methods)).to eq payment_methods   
@@ -133,13 +133,13 @@ module Admin
 
       context "as manager" do
         it "sets required variables" do                         
-          allow(controller).to receive_message_chain(:spree_current_user).and_return(manager)        
+          allow(controller).to receive(:spree_current_user).and_return(manager)        
 
           payment_methods = [payment_method2, payment_method1]
           shipping_methods = [shipping_method2, shipping_method1]
           enterprise_fees = [enterprise_fee2]          
 
-          spree_get :edit, {:id => enterprise2.permalink} 
+          spree_get :edit, {id: enterprise2.permalink} 
 
           expect(assigns(:shipping_methods)).to eq shipping_methods
           expect(assigns(:payment_methods)).to eq payment_methods

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -108,10 +108,10 @@ module Admin
       let(:enterprise2) { create(:distributor_enterprise) }
       let(:manager) { create(:user, enterprise_limit: 10, enterprises: [enterprise2]) }
       let(:time_zone) { Spree::Zone.create(:name => 'South zone')}
-      let(:shipping_method1) { Spree::ShippingMethod.create(name: 'Pickup', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise1.id]) }
-      let(:shipping_method2) { Spree::ShippingMethod.create(name: 'Delivery', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise2.id]) }
-      let(:payment_method1) { Spree::PaymentMethod.create(:name => 'Online', distributor_ids: [enterprise1.id]) }
-      let(:payment_method2) { Spree::PaymentMethod.create(:name => 'COD', distributor_ids: [enterprise2.id]) }
+      let(:shipping_method1) { create(:shipping_method, name: 'Pickup', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise1.id]) }
+      let(:shipping_method2) { create(:shipping_method, name: 'Delivery', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise2.id]) }
+      let(:payment_method1) { create(:payment_method, :name => 'Online', distributor_ids: [enterprise1.id]) }
+      let(:payment_method2) { create(:payment_method, :name => 'COD', distributor_ids: [enterprise2.id]) }
       let(:enterprise_fee1) { create(:enterprise_fee, :enterprise_id => enterprise1.id) }
       let(:enterprise_fee2) { create(:enterprise_fee, :enterprise_id => enterprise2.id) }
 

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -102,6 +102,52 @@ module Admin
       end
     end
 
+    describe "edit" do
+      let(:admin_user) { create(:admin_user) }      
+      let(:enterprise1) { create(:distributor_enterprise) }
+      let(:enterprise2) { create(:distributor_enterprise) }
+      let(:manager) { create(:user, enterprise_limit: 10, enterprises: [enterprise2]) }
+      let(:time_zone) { Spree::Zone.create(:name => 'South zone')}
+      let(:shipping_method1) { Spree::ShippingMethod.create(name: 'Pickup', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise1.id]) }
+      let(:shipping_method2) { Spree::ShippingMethod.create(name: 'Delivery', zone_id: time_zone.id, require_ship_address: true, calculator_type: 'OpenFoodNetwork::Calculator::Weight', distributor_ids: [enterprise2.id]) }
+      let(:payment_method1) { Spree::PaymentMethod.create(:name => 'Online', distributor_ids: [enterprise1.id]) }
+      let(:payment_method2) { Spree::PaymentMethod.create(:name => 'COD', distributor_ids: [enterprise2.id]) }
+      let(:enterprise_fee1) { create(:enterprise_fee, :enterprise_id => enterprise1.id) }
+      let(:enterprise_fee2) { create(:enterprise_fee, :enterprise_id => enterprise2.id) }
+
+      context "as admin" do
+        it "sets required variables" do          
+          allow(controller).to receive_message_chain(:spree_current_user).and_return(admin_user)            
+
+          payment_methods = [payment_method1, payment_method2]
+          shipping_methods = [shipping_method1, shipping_method2]
+          enterprise_fees = [enterprise_fee1]
+
+          spree_get :edit, {:id => enterprise1.permalink} 
+
+          expect(assigns(:shipping_methods)).to eq shipping_methods   
+          expect(assigns(:payment_methods)).to eq payment_methods   
+          expect(assigns(:enterprise_fees)).to eq enterprise_fees             
+        end        
+      end
+
+      context "as manager" do
+        it "sets required variables" do                         
+          allow(controller).to receive_message_chain(:spree_current_user).and_return(manager)        
+
+          payment_methods = [payment_method2, payment_method1]
+          shipping_methods = [shipping_method2, shipping_method1]
+          enterprise_fees = [enterprise_fee2]          
+
+          spree_get :edit, {:id => enterprise2.permalink} 
+
+          expect(assigns(:shipping_methods)).to eq shipping_methods
+          expect(assigns(:payment_methods)).to eq payment_methods
+          expect(assigns(:enterprise_fees)).to eq enterprise_fees
+        end        
+      end
+    end
+
     describe "updating an enterprise" do
       let(:profile_enterprise) { create(:enterprise, sells: 'none') }
 

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -77,6 +77,9 @@ feature 'shipping methods' do
     end
 
     it "creating a shipping method" do
+      # Deleting all the shipping methods so that 'create one now' link is visible
+      DistributorShippingMethod.delete_all
+      Spree::ShippingMethod.delete_all
       click_link 'Enterprises'
       within("#e_#{distributor1.id}") { click_link 'Manage' }
       within(".side_menu") do


### PR DESCRIPTION


#### What? Why?
When manager unchecks shipping/payment method it disappears.

The reason for this is that if the user is not admin, only the payment/shipping methods that are applicable to the current enterprise/ the enterprise which the logged in manager manages is displayed.
Refer :managed_by scope in both payment/shipping method.

Closes #2023 

Instead of using the managed_by scope, used all the shipping/payment methods.

#### What should we test?

Login as a manager and need to test shipping/payment methods of the enterprise which is managed by the manager.
