### PR TITLE
Fixing 1950 for wrong incrementation of changes count in admin dashboard

### DIFF
--- a/app/assets/javascripts/admin/index_utils/services/pending_changes.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/services/pending_changes.js.coffee
@@ -6,7 +6,7 @@ angular.module("admin.indexUtils").factory "pendingChanges", ($q, resources, Sta
     add: (id, attr, change) =>
       @pendingChanges["#{id}"] = {} unless @pendingChanges.hasOwnProperty("#{id}")
       @pendingChanges["#{id}"]["#{attr}"] = change
-      StatusMessage.display('notice', "You have made #{@changeCount(@pendingChanges)} unsaved changes")
+      StatusMessage.display('notice', t('admin.unsaved_changes'))
 
     removeAll: =>
       @pendingChanges = {}

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -89,6 +89,7 @@ feature 'Customers' do
           find(:css, "tags-input .tags input").set "awesome\n"
           expect(page).to have_css ".tag_watcher.update-pending"
         end
+        expect(page).to have_content I18n.t('admin.unsaved_changes')
         click_button "Save Changes"
 
         # Every says it updated


### PR DESCRIPTION
Fixing 1950 for wrong incrementation of changes count in admin dashboard, displaying the same message no matter the number of changes made

#### What? Why?

Closes #1950 

As suggested by @lin-d-hop I simply removed the counter for unsaved changes thus displaying the same status message no matter how many unsaved changes have been made.

#### What should we test?

statusMessages display correctly for unsaved changes made in customers pane in admin dashboard
