### PR TITLE
Added img tag when producer.description.length==0 to display logo even when no About Us

### DIFF
--- a/app/views/producers/_fat.html.haml
+++ b/app/views/producers/_fat.html.haml
@@ -9,6 +9,7 @@
       %p.text-small{ "ng-bind" => "::producer.description"}
     %div.show-for-medium-up{"ng-if" => "::producer.description.length==0"}
       %label &nbsp;
+      %img.right.show-for-medium-up{"ng-src" => "{{::producer.logo}}" }
 
   .columns.small-12.medium-5.large-5.fat
 


### PR DESCRIPTION
Added img tag when producer.description.length==0 to display logo even when no About Us

#### What? Why?

Closes #1912 

I added the same img tag as above is the "if producer.description.length==0" statement to display logo even when the is no description (ie About Us).

#### What should we test?

Logo displays with or without description