### PR TITLE
addresses issue #1275

### DIFF
--- a/app/assets/stylesheets/darkswarm/footer.scss
+++ b/app/assets/stylesheets/darkswarm/footer.scss
@@ -88,6 +88,10 @@ footer {
 
     @include panepadding;
 
+    div.row a img {
+      margin-bottom: 20px;
+    }
+
     .row {
       &, p, h1, h2, h3, h4, h5, h6 {
         color: $disabled-med;


### PR DESCRIPTION
#### What? Why?

Adds a css rule to target the logo in .footer-local and padding between the logo and open source info at the bottom to make mobile targeting easier.
<img width="369" alt="screen shot 2018-01-09 at 1 03 39 pm" src="https://user-images.githubusercontent.com/25412073/34740702-91802bba-f53d-11e7-948b-7b549416413c.png">


Closes #1275 

@Aram-Anderson