### PR TITLE
Remove ng-disabled conditional from submit button on admin customers…

### DIFF
--- a/app/views/admin/customers/index.html.haml
+++ b/app/views/admin/customers/index.html.haml
@@ -46,7 +46,7 @@
   .row.margin-bottom-50{ ng: { show: "!RequestMonitor.loading && filteredCustomers.length > 0" } }
     %form{ name: "customers_form" }
       %save-bar{ dirty: "customers_form.$dirty", persist: "false" }
-        %input.red{ type: "button", value: "Save Changes", ng: { click: "submitAll(customers_form)", disabled: "!customers_form.$dirty" } }
+        %input.red{ type: "button", value: "Save Changes", ng: { click: "submitAll(customers_form)" } }
 
       %table.index#customers
         %col.email{ width: "20%", 'ng-show' => 'columns.email.visible' }


### PR DESCRIPTION
… index.

#### What? Why?

Closes #1850

This PR is in relation to an issue with the behavior of the admin customers page. When user interaction is limited to removal of a tag and nothing else within the form, the save bar renders but the button is disabled.

Both save-bar and red button check if the form is dirty. Currently if a user removes a tag, the save bar correctly renders, but the red button is disabled. Removing the disabled attribute on the button ensures that the save bar renders and that button is not disabled. Now admin can properly save the customer data even if the only interaction is removing a tag.

#### What should we test?

Should test edge cases where the preferred behavior might be for the save-bar to appear but the button be disabled. We cannot think of use-cases where this would be desired behavior, but we are not as familiar with the full context and form behavior.

#### Release notes

Fixed an issue where save button not activated when a user removes a customer's tag

@boveus contributed to this PR.
