### PR TITLE
Embedded groups

### DIFF
--- a/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
+++ b/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
@@ -51,6 +51,16 @@ nav.top-bar ul.right li.powered-by {
   }
 }
 
+.powered-by-embedded {
+   opacity: 0.6;
+   font-family: "Oswald", sans-serif;
+   font-size: 1rem;
+   font-weight: 300;
+   color: #555;
+   padding: 0 !important;
+  }
+
+
 .blocked-cookies {
   text-align: center;
   margin-bottom: 0 !important;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -9,5 +9,10 @@ class GroupsController < BaseController
     enable_embedded_shopfront
     @hide_menu = true if @shopfront_layout == 'embedded'
     @group = EnterpriseGroup.find_by_permalink(params[:id]) || EnterpriseGroup.find(params[:id])
+
+    if params[:embedded_shopfront]
+      render 'embedded'
+    end
+
   end
 end

--- a/app/views/groups/embedded.html.haml
+++ b/app/views/groups/embedded.html.haml
@@ -1,0 +1,125 @@
+- content_for(:title) do
+  = @group.name
+- content_for(:description) do
+  = @group.description
+- content_for(:image) do
+  = @group.logo.url
+
+-# inject all enterprises as "enterprises"
+-# it could be more efficient to inject only the enterprises that are related to the group
+= inject_enterprises
+
+-# inject enterprises in this group
+-# further hubs and producers of these enterprises can't be resolved within this small subset
+= inject_group_enterprises
+
+#group-page.row.pad-top.footer-pad{"ng-controller" => "GroupPageCtrl"}
+  .small-12.columns.pad-top
+    %header
+      .row
+        .small-12.columns
+          - if @group.promo_image.present?
+            %img{"src" => @group.promo_image}
+      .row
+        .small-12.columns.group-header.pad-top
+          - if @group.logo.present?
+            %img.group-logo{"src" => @group.logo}
+          - else
+            %img.group-logo{"src" => '/assets/noimage/group.png'}
+          %h2.group-name= @group.name
+          %p= @group.description
+
+  .small-12.columns.pad-top
+    .row
+      .small-12.medium-12.large-9.columns
+        %div{"ng-controller" => "GroupTabsCtrl"}
+          %tabset
+            %tab{heading: t(:label_map),
+                active: "tabs.map.active",
+                select: "select(\'map\')"}
+              .map-container
+                %map{"ng-if" => "(isActive(\'/map\') && (mapShowed = true)) || mapShowed"}
+                  %google-map{options: "map.additional_options", center: "map.center", zoom: "map.zoom", styles: "map.styles", draggable: "true"}
+                    %map-osm-tiles
+                    %map-search
+                    %markers{models: "mapMarkers", fit: "true",
+                    coords: "'self'", icon: "'icon'", click: "'reveal'"}
+
+            %tab{heading: t(:groups_about),
+                active: "tabs.about.active",
+                select: "select(\'about\')"}
+              %h1
+                = t :groups_about
+              %p!= @group.long_description
+
+            %tab{heading: t(:groups_producers),
+                active: "tabs.producers.active",
+                select: "select(\'producers\')"}
+              .producers{"ng-controller" => "GroupEnterprisesCtrl"}
+                .row
+                  .small-12.columns
+                    %h1
+                      = t :groups_producers
+                = render "shared/components/enterprise_search"
+                = render "producers/filters"
+
+                .row
+                  .small-12.columns
+                    .active_table
+                      %producer.active_table_node.row.animate-repeat{id: "{{producer.path}}",
+                      "ng-repeat" => "producer in filteredEnterprises = (group_producers | searchEnterprises:query | taxons:activeTaxons | properties:activeProperties:'supplied_properties')",
+                      "ng-controller" => "GroupEnterpriseNodeCtrl",
+                      "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !producer.active}",
+                      id: "{{producer.hash}}"}
+
+                        .small-12.columns
+                          = render "producers/skinny"
+                          = render "producers/fat"
+
+                      = render 'shared/components/enterprise_no_results'
+
+            %tab{heading: t(:groups_hubs),
+                active: "tabs.hubs.active",
+                select: "select(\'hubs\')"}
+              .hubs{"ng-controller" => "GroupEnterprisesCtrl"}
+                .row
+                  .small-12.columns
+                    %h1
+                      = t :groups_hubs
+
+                = render "shared/components/enterprise_search"
+                = render "shops/filters", resource: "group_hubs", property_filters: "| searchEnterprises:query | taxons:activeTaxons | shipping:shippingTypes | showHubProfiles:show_profiles"
+
+                .row
+                  .small-12.columns
+                    .active_table
+                      %hub.active_table_node.row.animate-repeat{id: "{{hub.hash}}",
+                      "ng-repeat" => "hub in filteredEnterprises = (group_hubs | searchEnterprises:query | taxons:activeTaxons | shipping:shippingTypes | showHubProfiles:show_profiles | properties:activeProperties:'distributed_properties' | orderBy:['-active', '+orders_close_at'])",
+                      "ng-class" => "{'is_profile' : hub.category == 'hub_profile', 'closed' : !open(), 'open' : open(), 'inactive' : !hub.active, 'current' : current()}",
+                      "ng-controller" => "GroupEnterpriseNodeCtrl"}
+                        .small-12.columns
+                          = render 'shops/skinny'
+                          = render 'shops/fat'
+
+                      = render 'shared/components/enterprise_no_results'
+
+      .small-12.medium-12.large-3.columns
+        = render 'contact'
+
+  .small-12.columns.pad-top
+    .row.pad-top
+      .small-12.columns.text-center.small
+        %hr
+        %p.text-small
+          = "Copyright #{Date.current.year} #{@group.name}"
+        %h2
+          =link_to_service "https://www.facebook.com/", @group.facebook, title: t(:groups_contact_facebook) do
+            %i.ofn-i_044-facebook
+          =link_to_service "", @group.email.reverse, title: t(:groups_contact_email), mailto: true do
+            %i.ofn-i_050-mail-circle
+          =link_to_service "http://", @group.website, title: t(:groups_contact_website) do
+            %i.ofn-i_049-web
+        %p
+          &nbsp;
+
+= render "shared/footer"

--- a/app/views/groups/embedded.html.haml
+++ b/app/views/groups/embedded.html.haml
@@ -15,23 +15,9 @@
 
 #group-page.row.pad-top.footer-pad{"ng-controller" => "GroupPageCtrl"}
   .small-12.columns.pad-top
-    %header
-      .row
-        .small-12.columns
-          - if @group.promo_image.present?
-            %img{"src" => @group.promo_image}
-      .row
-        .small-12.columns.group-header.pad-top
-          - if @group.logo.present?
-            %img.group-logo{"src" => @group.logo}
-          - else
-            %img.group-logo{"src" => '/assets/noimage/group.png'}
-          %h2.group-name= @group.name
-          %p= @group.description
-
   .small-12.columns.pad-top
     .row
-      .small-12.medium-12.large-12.columns
+      .small-12.medium-12.large-.columns
         %div{"ng-controller" => "GroupTabsCtrl"}
           %tabset
             %tab{heading: t(:label_map),

--- a/app/views/groups/embedded.html.haml
+++ b/app/views/groups/embedded.html.haml
@@ -119,7 +119,11 @@
             %i.ofn-i_050-mail-circle
           =link_to_service "http://", @group.website, title: t(:groups_contact_website) do
             %i.ofn-i_049-web
-        %p
-          &nbsp;
+          .powered-by-embedded
+            %img{src: '/favicon.ico'}
+            %span
+              = t 'powered_by'
+            %span
+              = t 'title'
 
 = render "shared/footer"

--- a/app/views/groups/embedded.html.haml
+++ b/app/views/groups/embedded.html.haml
@@ -31,7 +31,7 @@
 
   .small-12.columns.pad-top
     .row
-      .small-12.medium-12.large-9.columns
+      .small-12.medium-12.large-12.columns
         %div{"ng-controller" => "GroupTabsCtrl"}
           %tabset
             %tab{heading: t(:label_map),
@@ -103,8 +103,6 @@
 
                       = render 'shared/components/enterprise_no_results'
 
-      .small-12.medium-12.large-3.columns
-        = render 'contact'
 
   .small-12.columns.pad-top
     .row.pad-top

--- a/app/views/groups/embedded.html.haml
+++ b/app/views/groups/embedded.html.haml
@@ -59,8 +59,115 @@
                       id: "{{producer.hash}}"}
 
                         .small-12.columns
-                          = render "producers/skinny"
-                          = render "producers/fat"
+                          .row.active_table_row{"ng-click" => "toggle($event)", "ng-class" => "{'closed' : !open(), 'is_distributor' : producer.is_distributor}"}
+                            .columns.small-12.medium-8.large-8.skinny-head
+                              %span{"ng-if" => "::producer.is_distributor" }
+                                %a.is_distributor{"ng-href" => "{{::producer.path}}", target: "_blank"}
+                                  .row.vertical-align-middle
+                                    .columns.small-2.medium-2.large-2
+                                      %i{ng: {class: "::producer.producer_icon_font"}}
+                                    .columns.small-10.medium-10.large-10
+                                      %span.margin-top
+                                        %strong{"ng-bind" => "::producer.name"}
+                              %span.producer-name{"ng-if" => "::!producer.is_distributor" }
+                                .row.vertical-align-middle
+                                  .columns.small-2.medium-2.large-2
+                                    %i{ng: {class: "::producer.producer_icon_font"}}
+                                  .columns.small-10.medium-10.large-10
+                                    %span.margin-top
+                                      %strong{"ng-bind" => "::producer.name"}
+                            .columns.small-6.medium-2.large-2
+                              %span.margin-top{"ng-bind" => "::producer.address.city"}
+                            .columns.small-4.medium-1.large-1
+                              %span.margin-top{"ng-bind" => "::producer.address.state_name | uppercase"}
+                            .columns.small-2.medium-1.large-1.text-right
+                              %span.margin-top
+                                %i{"ng-class" => "{'ofn-i_005-caret-down' : !open(), 'ofn-i_006-caret-up' : open()}"}
+
+                          .row.active_table_row{"ng-if" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : !ofn-i_032-closed-sign()}"}
+
+                            .columns.small-12.medium-7.large-7.fat
+                              / Will add in long description available once clean up HTML formatting producer.long_description
+                              %div{"ng-if" => "::producer.description"}
+                                %label
+                                  = t :producers_about
+                                %img.right.show-for-medium-up{"ng-src" => "{{::producer.logo}}" }
+                                %p.text-small{ "ng-bind" => "::producer.description"}
+                              %div.show-for-medium-up{"ng-if" => "::producer.description.length==0"}
+                                %label &nbsp;
+
+                            .columns.small-12.medium-5.large-5.fat
+
+                              %div{"ng-if" => "::producer.supplied_taxons"}
+                                %label
+                                  = t :producers_buy
+                                %p.trans-sentence
+                                  %div
+                                    %span.fat-taxons{"ng-repeat" => "taxon in producer.supplied_taxons"}
+                                      %render-svg{path: "{{taxon.icon}}"}
+                                      %span{"ng-bind" => "::taxon.name"}
+                                  %div
+                                    %span.fat-properties{"ng-repeat" => "property in producer.supplied_properties"}
+                                      %span{"ng-bind" => "property.presentation"}
+
+                              %div.show-for-medium-up{"ng-if" => "producer.supplied_taxons.length==0"}
+                                &nbsp;
+
+                              %div{"ng-if" => "::producer.email_address || producer.website || producer.phone"}
+                                %label
+                                  = t :producers_contact
+
+                                %p.word-wrap{"ng-if" => "::producer.phone"}
+                                  = t :producers_contact_phone
+                                  %span{"ng-bind" => "::producer.phone"}
+
+                                %p.word-wrap{"ng-if" => "::producer.email_address"}
+                                  %a{"ng-href" => "{{::producer.email_address | stripUrl}}", target: "_blank", mailto: true}
+                                    %span.email{"ng-bind" => "::producer.email_address | stripUrl"}
+
+                                %p.word-wrap{"ng-if" => "::producer.website"}
+                                  %a{"ng-href" => "http://{{::producer.website | stripUrl}}", target: "_blank" }
+                                    %span{"ng-bind" => "::producer.website | stripUrl"}
+
+                              %div{"ng-if" => "::producer.twitter || producer.facebook || producer.linkedin || producer.instagram"}
+                                %label
+                                  = t :producers_social
+                                .follow-icons
+                                  %span{"ng-if" => "::producer.twitter"}
+                                    %a{"ng-href" => "http://twitter.com/{{::producer.twitter}}", target: "_blank"}
+                                      %i.ofn-i_041-twitter
+
+                                  %span{"ng-if" => "::producer.facebook"}
+                                    %a{"ng-href" => "http://{{::producer.facebook | stripUrl}}", target: "_blank"}
+                                      %i.ofn-i_044-facebook
+
+                                  %span{"ng-if" => "::producer.linkedin"}
+                                    %a{"ng-href" => "http://{{::producer.linkedin | stripUrl}}", target: "_blank"}
+                                      %i.ofn-i_042-linkedin
+
+                                  %span{"ng-if" => "::producer.instagram"}
+                                    %a{"ng-href" => "http://instagram.com/{{::producer.instagram}}", target: "_blank"}
+                                      %i.ofn-i_043-instagram
+
+                          .row.active_table_row.pad-top{"ng-if" => "open() && producer.hubs"}
+                            .columns.small-12
+                              .row
+                                .columns.small-12.fat
+                                  %div{"ng-if" => "::producer.name"}
+                                    %label
+                                      = t :producers_buy_at_html, {enterprise: '<span class="turquoise" ng-bind="::producer.name"></span>'.html_safe}
+                                  %div.show-for-medium-up{"ng-if" => "::!producer.name"}
+                                    &nbsp;
+                              .row.cta-container
+                                .columns.small-12
+                                  %a.cta-hub{"ng-repeat" => "hub in producer.hubs | visible | orderBy:'-active'",
+                                  "ng-href" => "{{::hub.path}}", target: "_blank", "ofn-change-hub" => "hub",
+                                  "ng-class" => "::{primary: hub.active, secondary: !hub.active}"}
+                                    %i.ofn-i_033-open-sign{"ng-if" => "::hub.active"}
+                                    %i.ofn-i_032-closed-sign{"ng-if" => "::!hub.active"}
+                                    .hub-name{"ng-bind" => "::hub.name"}
+                                    .button-address{"ng-bind" => "::[hub.address.city, hub.address.state_name] | printArray"}
+  
 
                       = render 'shared/components/enterprise_no_results'
 
@@ -84,8 +191,103 @@
                       "ng-class" => "{'is_profile' : hub.category == 'hub_profile', 'closed' : !open(), 'open' : open(), 'inactive' : !hub.active, 'current' : current()}",
                       "ng-controller" => "GroupEnterpriseNodeCtrl"}
                         .small-12.columns
-                          = render 'shops/skinny'
-                          = render 'shops/fat'
+                          .row.active_table_row{"ng-if" => "hub.is_distributor", "ng-click" => "toggle($event)", "ng-class" => "{'closed' : !open(), 'is_distributor' : producer.is_distributor}"}
+                            .columns.small-12.medium-5.large-5.skinny-head
+                              %a.hub{"ng-href" => "{{::hub.path}}", target: "_blank", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub", "data-is-link" => "true"}
+                                %i{ng: {class: "::hub.icon_font"}}
+                                %span.margin-top.hub-name-listing{"ng-bind" => "::hub.name | truncate:40"}
+
+                            .columns.small-4.medium-2.large-2
+                              %span.margin-top{"ng-bind" => "::hub.address.city"}
+                            .columns.small-2.medium-1.large-1
+                              %span.margin-top{"ng-bind" => "::hub.address.state_name | uppercase"}
+                              %span.margin-top{"ng-if" => "hub.distance != null && hub.distance > 0"} ({{ hub.distance / 1000 | number:0 }} km)
+
+                            .columns.small-4.medium-3.large-3.text-right{"ng-if" => "::hub.active"}
+                              %a.hub.open_closed{"ng-href" => "{{::hub.path}}", target: "_blank", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
+                                %i.ofn-i_033-open-sign
+                                %span.margin-top{ ng: { if: "::current()" } }
+                                  %em= t :hubs_shopping_here
+                                %span.margin-top{ ng: { if: "::!current()" } }
+                                  %span{"ng-bind" => "::hub.orders_close_at | sensible_timeframe"}
+
+                            .columns.small-4.medium-3.large-3.text-right{"ng-if" => "::!hub.active"}
+                              %a.hub.open_closed{"ng-href" => "{{::hub.path}}", target: "_blank", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
+                                %i.ofn-i_032-closed-sign
+                                %span.margin-top{ ng: { if: "::current()" } }
+                                  %em= t :hubs_shopping_here
+                                %span.margin-top{ ng: { if: "::!current()" } }
+                                  = t :hubs_orders_closed
+
+                            .columns.small-2.medium-1.large-1.text-right
+                              %span.margin-top
+                                %i{"ng-class" => "{'ofn-i_005-caret-down' : !open(), 'ofn-i_006-caret-up' : open()}"}
+
+                          .row.active_table_row{"ng-if" => "!hub.is_distributor", "ng-class" => "closed"}
+                            .columns.small-12.medium-6.large-5.skinny-head
+                              %a.hub{"ng-click" => "openModal(hub)", "ng-class" => "{primary: hub.active, secondary: !hub.active}"}
+                                %i{ng: {class: "hub.icon_font"}}
+                                %span.margin-top.hub-name-listing{"ng-bind" => "::hub.name | truncate:40"}
+
+                            .columns.small-4.medium-2.large-2
+                              %span.margin-top{"ng-bind" => "::hub.address.city"}
+                            .columns.small-2.medium-1.large-1
+                              %span.margin-top{"ng-bind" => "::hub.address.state_name | uppercase"}
+
+                            .columns.small-6.medium-3.large-4.text-right
+                              %span.margin-top{ ng: { if: "::!current()" } }
+                                %em= t :hubs_profile_only
+
+                          .row.active_table_row{"ng-show" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : !ofn-i_032-closed-sign()}"}
+                            .columns.small-12.medium-6.large-5.fat
+                              %div{"ng-if" => "::hub.taxons"}
+                                %label
+                                  = t :hubs_buy
+                                .trans-sentence
+                                  %div
+                                    %span.fat-taxons{"ng-repeat" => "taxon in hub.taxons"}
+                                      %render-svg{path: "{{taxon.icon}}"}
+                                      %span{"ng-bind" => "::taxon.name"}
+                                  %div
+                                    %span.fat-properties{"ng-repeat" => "property in hub.distributed_properties"}
+                                      %span{"ng-bind" => "property.presentation"}
+                              %div.show-for-medium-up{"ng-if" => "::hub.taxons.length==0"}
+                                &nbsp;
+                            .columns.small-12.medium-3.large-2.fat
+                              %div{"ng-if" => "::(hub.pickup || hub.delivery)"}
+                                %label
+                                  = t :hubs_delivery_options
+                                %ul.small-block-grid-2.medium-block-grid-1.large-block-grid-1
+                                  %li.pickup{"ng-if" => "::hub.pickup"}
+                                    %i.ofn-i_038-takeaway
+                                    = t :hubs_pickup
+                                  %li.delivery{"ng-if" => "::hub.delivery"}
+                                    %i.ofn-i_039-delivery
+                                    = t :hubs_delivery
+                            .columns.small-12.medium-3.large-5.fat
+                              %div{"ng-if" => "::hub.producers"}
+                                %label
+                                  = t :hubs_producers
+                                %ul.small-block-grid-2.medium-block-grid-1.large-block-grid-2{"ng-class" => "{'show-more-producers' : toggleMoreProducers}", "class" => "producers-list"}
+                                  %li{"ng-repeat" => "enterprise in hub.producers | limitTo:7"}
+                                    %enterprise-modal
+                                      %i.ofn-i_036-producers
+                                      %span{"ng-bind" => "::enterprise.name"}
+                                  %li{"data-is-link" => "true", "class" => "more-producers-link", "ng-show" => "::hub.producers.length>7"}
+                                    %a{"ng-click" => "toggleMoreProducers=!toggleMoreProducers"}
+                                      .more
+                                        +
+                                        %span{"ng-bind" => "::hub.producers.length-7"}
+                                        = t :label_more
+                                      .less
+                                        = t :label_less
+                                  %li{"ng-repeat" => "enterprise in hub.producers.slice(7,hub.producers.length)", "class" => "additional-producer"}
+                                    %enterprise-modal
+                                      %i.ofn-i_036-producers
+                                      %span{"ng-bind" => "::enterprise.name"}
+                              %div.show-for-medium-up{"ng-if" => "::hub.producers.length==0"}
+                                &nbsp;
+
 
                       = render 'shared/components/enterprise_no_results'
 

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+feature "Using embedded shopfront functionality", js: true do
+
+  Capybara.server_port = 9999
+
+  describe 'embedded groups' do
+	let(:enterprise) { create(:distributor_enterprise) }
+  	let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
+
+
+  	before do
+  	  Spree::Config[:enable_embedded_shopfronts] = true
+      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
+
+      page.driver.browser.js_errors = false
+	  Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+
+  	end
+
+	it "displays in an iframe" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  	  expect(page).to have_content 'About Us'
+	  	end
+	  end	  
+	end
+  
+  end
+
+end

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -51,6 +51,18 @@ feature "Using embedded shopfront functionality", js: true do
 	  	end
 	  end
 	end
+
+	it "does not display the header when embedded" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  		expect(page).to have_no_selector 'header'
+	  	    expect(page).to have_no_selector 'img.group-logo'
+	  	    expect(page).to have_no_selector 'h2.group-name'
+	  	end
+	  end
+	end
   
   end
 

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -27,6 +27,19 @@ feature "Using embedded shopfront functionality", js: true do
 	  	end
 	  end	  
 	end
+
+	it "displays powered by OFN text at bottom of page" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
+ 
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          expect(page).to have_selector 'div.powered-by-embedded'
+          expect(page).to have_css "img[src*='favicon.ico']"
+          expect(page).to have_content 'Powered by'
+          expect(page).to have_content 'Open Food Network'
+        end
+      end
+    end
   
   end
 

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -40,6 +40,17 @@ feature "Using embedded shopfront functionality", js: true do
         end
       end
     end
+
+    it "doesn't display contact details when embedded" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          expect(page).to have_no_selector 'div.contact-container'
+          expect(page).to have_no_content '#{group.address.address1}'
+	  	end
+	  end
+	end
   
   end
 

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -28,7 +28,7 @@ feature "Using embedded shopfront functionality", js: true do
 	  end	  
 	end
 
-	it "displays powered by OFN text at bottom of page" do
+    it "displays powered by OFN text at bottom of page" do
       expect(page).to have_selector 'iframe#group_test_iframe'
  
       within_frame 'group_test_iframe' do
@@ -48,9 +48,9 @@ feature "Using embedded shopfront functionality", js: true do
         within 'div#group-page' do
           expect(page).to have_no_selector 'div.contact-container'
           expect(page).to have_no_content '#{group.address.address1}'
-	  	end
+        end
 	  end
-	end
+    end
 
 	it "does not display the header when embedded" do
 	  expect(page).to have_selector 'iframe#group_test_iframe'
@@ -60,6 +60,19 @@ feature "Using embedded shopfront functionality", js: true do
 	  		expect(page).to have_no_selector 'header'
 	  	    expect(page).to have_no_selector 'img.group-logo'
 	  	    expect(page).to have_no_selector 'h2.group-name'
+	  	end
+	  end
+	end
+
+
+	it 'opens links to shops in a new window' do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  	  enterprise_links = page.all(:xpath, "//*[contains(@href, 'enterprise-5/shop')]", :visible => :false).count
+	  	  enterprise_links_with_target_blank = page.all(:xpath, "//*[contains(@href, 'enterprise-5/shop') and @target = '_blank']", :visible => :false).count
+	  	  expect(enterprise_links).to equal(enterprise_links_with_target_blank)	
 	  	end
 	  end
 	end

--- a/spec/support/views/group_iframe_test.html
+++ b/spec/support/views/group_iframe_test.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+
+<iframe src="http://localhost:9999/groups/group1?embedded_shopfront=true" name="group_test_iframe" class="group_test_iframe" id="group_test_iframe" style="width:100%;min-height:35em"></iframe>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #1783 

Six commits. Two for initial tests and setup and four for each of the remaining sub-issues within this issue. The sub issues in question are:

1. move the 'powered by open food network' to somewhere lower on the page (the element got removed)
- It just adds a small bit of text to the group template saying "Powered by open food network". This only appears when a group page is embedded.

2. remove the contact details.
- It removes the contact details from a group page when that page is being viewed in an embedded setting.

3. Remove the logo, banner and Description text fields.
- It removes the whole header element from from the group page template if it's being viewed as an embedded page. This also includes the group name so that has also been removed (as instructed).

4. Links to shops open a new window.
- If a group page is being viewed as an embedded page, all links to the groups corresponding shops are served with the target = '_blank' attribute so that they open in a new browser window/tab.

All of these are solved by this PR. 

#### What should we test?

Tests in spec/features/consumer/shopping/embedded_groups_spec.rb

Also functionality can be manually tested using the embedded-group-preview.html file. i.e. by creating a group and then navigating to: http://localhost:3000/embedded-group-preview.html?your-group-name.

_Screenshots for comparison:_

Standard show view:
<img width="1336" alt="screen shot 2018-02-01 at 12 48 20" src="https://user-images.githubusercontent.com/4159705/35679713-00a46e24-0750-11e8-9754-16d24d1da0dc.png">


Embedded view:
<img width="1333" alt="screen shot 2018-02-01 at 12 48 00" src="https://user-images.githubusercontent.com/4159705/35679732-0a47b86e-0750-11e8-8429-142ca886de2c.png">


#### Discourse thread

Discussion here:
https://github.com/openfoodfoundation/openfoodnetwork/issues/1783
and here:
https://github.com/openfoodfoundation/openfoodnetwork/pull/2031