### PR TITLE
Add updated globe icon to mobile view

### DIFF
--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -43,7 +43,7 @@
     - if I18n.available_locales.count > 1
       %li.language-switcher.li-menu
         %a
-          %i.fa.fa-globe
+          %i.ofn-i_071-globe
           = t('language_name')
         %ul
           - I18n.available_locales.each do |l|


### PR DESCRIPTION
#### What? Why?

Very quick PR to close #2048. Missing icon in new multilingual mobile menu.

#### What should we test?

The icon is there.

