### PR TITLE
Changed i18n t() path to get content from locales

### DIFF
--- a/app/views/admin/order_cycles/_simple_form.html.haml
+++ b/app/views/admin/order_cycles/_simple_form.html.haml
@@ -5,12 +5,12 @@
     = label_tag t('.ready_for')
   .six.columns
     = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_time', 'required' => 'required', 'placeholder' => t('.ready_for_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_time', 'size' => 30, 'maxlength' => 35
-    %span.icon-question-sign{'ofn-with-tip' => t('admin.order_cycles.edit.pickup_time_tip')}
+    %span.icon-question-sign{'ofn-with-tip' => t('admin.order_cycles.exchange_form.pickup_time_tip')}
   .two.columns
     = label_tag t('.customer_instructions')
   .six.columns.omega
     = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_instructions', 'placeholder' => t('.customer_instructions_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_instructions', 'size' => 30
-    %span.icon-question-sign{'ofn-with-tip' => t('admin.order_cycles.edit.pickup_instructions_tip')}
+    %span.icon-question-sign{'ofn-with-tip' => t('admin.order_cycles.exchange_form.pickup_instructions_tip')}
 
 = label_tag t('.products')
 %table.exchanges


### PR DESCRIPTION
#### What? Why?

Closes #1849 

The i18n t() tag for tooltips in order_cycles/_simple_form.html.haml partial, which is rendered both in new and edit views, didn't have the right path to get tooltips content from locales. This applies to both new and edit order_cycles views.

#### What should we test?

Tooltip is displaying the right content taken from locales.