### PR TITLE
translation missing on product edit page

### DIFF
--- a/app/overrides/spree/admin/products/edit/return_to_bulk_product_edit.html.haml.deface
+++ b/app/overrides/spree/admin/products/edit/return_to_bulk_product_edit.html.haml.deface
@@ -1,3 +1,3 @@
 / replace "code[erb-loud]:contains('button_link_to t(:back_to_products_list)')"
 
-= button_link_to t(:back_to_products_list), bulk_edit_admin_products_path, :icon => 'icon-arrow-left'
+= button_link_to t('admin.products.back_to_products_list'), bulk_edit_admin_products_path, :icon => 'icon-arrow-left'

--- a/app/overrides/spree/admin/shared/_product_tabs/add_distributions.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_distributions.html.haml.deface
@@ -2,4 +2,4 @@
 
 - klass = current == 'Product Distributions' ? 'active' : ''
 %li{:class => klass}
-  = link_to_with_icon 'icon-tasks', 'Product Distributions', product_distributions_admin_product_url(@product)
+  = link_to_with_icon 'icon-tasks', t('admin.products.product_distributions'), product_distributions_admin_product_url(@product)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_group_buy.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_group_buy.html.haml.deface
@@ -2,4 +2,4 @@
 
 - klass = current == 'Group Buy Options' ? 'active' : ''
 %li{:class => klass}
-  = link_to_with_icon 'icon-tasks', 'Group Buy Options', group_buy_options_admin_product_url(@product)
+  = link_to_with_icon 'icon-tasks', t('admin.products.group_buy_options'), group_buy_options_admin_product_url(@product)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
@@ -2,4 +2,4 @@
 
 - klass = current == 'SEO' ? 'active' : ''
 %li{:class => klass}
-  = link_to_with_icon 'icon-tasks', 'SEO', seo_admin_product_url(@product)
+  = link_to_with_icon 'icon-tasks', t('admin.products.seo'), seo_admin_product_url(@product)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,7 @@ en:
       product_distributions: "Product Distributions"
       group_buy_options: "Group Buy Options"
       seo: "SEO"
+      back_to_products_list: "Back to products list"
 
     variant_overrides:
       loading_flash:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -366,6 +366,9 @@ en:
         inherited_property: Inherited Property
       variants:
         to_order_tip: "Items made to order do not have a set stock level, such as loaves of bread made fresh to order."
+      product_distributions: "Product Distributions"
+      group_buy_options: "Group Buy Options"
+      seo: "SEO"
 
     variant_overrides:
       loading_flash:


### PR DESCRIPTION
#### What? Why?

Partially address #1999 (The translation for "None" in the select box is not covered)

This adds i18n keys for the left menu in /admin/products/*/edit
This only adds translation in en.yml and other should be added via transifex (i'm not sure about that).

#### What should we test?

The english version remains unchanged.
After translation are provided on transifex, in in /admin/products/carrots/edit, the left menu and the "back to products list" button are translated.