### PR TITLE
Embedded groups

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/group_page_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/group_page_controller.js.coffee
@@ -19,3 +19,4 @@ Darkswarm.controller "GroupPageCtrl", ($scope, group_enterprises, Enterprises, M
 
   $scope.map = angular.copy MapConfiguration.options
   $scope.mapMarkers = OfnMap.enterprise_markers visible_enterprises
+  $scope.embedded_layout = window.location.search.indexOf("embedded_shopfront=true") != -1

--- a/app/assets/javascripts/darkswarm/directives/target_blank.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/target_blank.js.coffee
@@ -1,0 +1,6 @@
+Darkswarm.directive "embeddedTargetBlank", ->
+  restrict: 'A'
+  compile: (element) ->
+    elems = (element.children().find("a"))
+    if window.location.search.indexOf("embedded_shopfront=true") != -1
+      elems.attr("target", "_blank")

--- a/app/assets/javascripts/darkswarm/services/enterprise_modal.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprise_modal.js.coffee
@@ -3,6 +3,7 @@ Darkswarm.factory "EnterpriseModal", ($modal, $rootScope)->
   new class EnterpriseModal
     open: (enterprise)->
       scope = $rootScope.$new(true) # Spawn an isolate to contain the enterprise
+      scope.embedded_layout = window.location.search.indexOf("embedded_shopfront=true") != -1
 
       scope.enterprise = enterprise
       $modal.open(templateUrl: "enterprise_modal.html", scope: scope)

--- a/app/assets/javascripts/templates/partials/enterprise_header.html.haml
+++ b/app/assets/javascripts/templates/partials/enterprise_header.html.haml
@@ -2,7 +2,7 @@
   .highlight-top.row
     .small-12.medium-7.large-8.columns
       %h3{"ng-if" => "::enterprise.is_distributor"}
-        %a{"ng-href" => "{{::enterprise.path}}", "ofn-change-hub" => "enterprise"}
+        %a{"ng-href" => "{{::enterprise.path}}", "ofn-change-hub" => "enterprise", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}"}
           %i{"ng-class" => "::enterprise.icon_font"}
           %span{"ng-bind" => "::enterprise.name"}
       %h3{"ng-if" => "::!enterprise.is_distributor", "ng-class" => "::{'is_producer' : enterprise.is_primary_producer}"}

--- a/app/assets/javascripts/templates/partials/hub_details.html.haml
+++ b/app/assets/javascripts/templates/partials/hub_details.html.haml
@@ -14,7 +14,7 @@
             {{'hubs_delivery' | t}}
     .row
       .columns.small-12
-        %a.cta-hub{"ng-href" => "{{::enterprise.path}}",
+        %a.cta-hub{"ng-href" => "{{::enterprise.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}",
         "ng-class" => "{primary: enterprise.active, secondary: !enterprise.active}",
         "ofn-change-hub" => "enterprise"}
           .hub-name{"ng-bind" => "::enterprise.name"}

--- a/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
+++ b/app/assets/stylesheets/darkswarm/embedded_shopfront.css.scss
@@ -1,3 +1,5 @@
+@import "typography";
+
 body.embedded {
   nav.top-bar {
     ul.left, ul.center, ul.right li.current_hub {
@@ -28,6 +30,22 @@ body.embedded {
   footer {
     display: none;
   }
+
+  .powered-by-embedded {
+    display: block;
+  }
+
+  .contact {
+    display: none;
+  }
+
+  .embedded-fullwidth {
+    width: 100%;
+  }
+
+  #group-page header {
+    display: none;
+  }
 }
 
 nav.top-bar ul.right li.powered-by {
@@ -50,6 +68,17 @@ nav.top-bar ul.right li.powered-by {
     color: #000;
   }
 }
+
+.powered-by-embedded {
+   opacity: 0.6;
+   @include headingFont;
+   font-size: 1rem;
+   font-weight: 300;
+   color: #555;
+   padding: 0 !important;
+   display: none;
+   margin-top: 6px;
+  }
 
 .blocked-cookies {
   text-align: center;

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -31,7 +31,7 @@
 
   .small-12.columns.pad-top
     .row
-      .small-12.medium-12.large-9.columns
+      .small-12.medium-12.large-9.embedded-fullwidth.columns
         %div{"ng-controller" => "GroupTabsCtrl"}
           %tabset
             %tab{heading: t(:label_map),
@@ -48,9 +48,10 @@
             %tab{heading: t(:groups_about),
                 active: "tabs.about.active",
                 select: "select(\'about\')"}
-              %h1
-                = t :groups_about
-              %p!= @group.long_description
+              .about{ "embedded_target_blank" => true }
+                %h1
+                  = t :groups_about
+                %p!= @group.long_description
 
             %tab{heading: t(:groups_producers),
                 active: "tabs.producers.active",
@@ -103,7 +104,7 @@
 
                       = render 'shared/components/enterprise_no_results'
 
-      .small-12.medium-12.large-3.columns
+      .small-12.medium-12.large-3.columns.contact
         = render 'contact'
 
   .small-12.columns.pad-top
@@ -119,7 +120,11 @@
             %i.ofn-i_050-mail-circle
           =link_to_service "http://", @group.website, title: t(:groups_contact_website) do
             %i.ofn-i_049-web
-        %p
-          &nbsp;
+          .powered-by-embedded
+            %img{src: '/favicon.ico'}
+            %span
+              = t 'powered_by'
+            %span
+              = t 'title'
 
 = render "shared/footer"

--- a/app/views/producers/_fat.html.haml
+++ b/app/views/producers/_fat.html.haml
@@ -76,7 +76,7 @@
     .row.cta-container
       .columns.small-12
         %a.cta-hub{"ng-repeat" => "hub in producer.hubs | visible | orderBy:'-active'",
-        "ng-href" => "{{::hub.path}}", "ofn-change-hub" => "hub",
+        "ng-href" => "{{::hub.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined }}", "ofn-change-hub" => "hub",
         "ng-class" => "::{primary: hub.active, secondary: !hub.active}"}
           %i.ofn-i_068-shop-reversed{"ng-if" => "::hub.active"}
           %i.ofn-i_068-shop-reversed{"ng-if" => "::!hub.active"}

--- a/app/views/producers/_skinny.html.haml
+++ b/app/views/producers/_skinny.html.haml
@@ -1,7 +1,7 @@
 .row.active_table_row{"ng-click" => "toggle($event)", "ng-class" => "{'closed' : !open(), 'is_distributor' : producer.is_distributor}"}
   .columns.small-12.medium-8.large-8.skinny-head
     %span{"ng-if" => "::producer.is_distributor" }
-      %a.is_distributor{"ng-href" => "{{::producer.path}}"}
+      %a.is_distributor{"ng-href" => "{{::producer.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}"}
         .row.vertical-align-middle
           .columns.small-2.medium-2.large-2
             %i{ng: {class: "::producer.producer_icon_font"}}

--- a/app/views/shops/_skinny.html.haml
+++ b/app/views/shops/_skinny.html.haml
@@ -1,6 +1,6 @@
 .row.active_table_row{"ng-if" => "hub.is_distributor", "ng-click" => "toggle($event)", "ng-class" => "{'closed' : !open(), 'is_distributor' : producer.is_distributor}"}
   .columns.small-12.medium-5.large-5.skinny-head
-    %a.hub{"ng-href" => "{{::hub.path}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub", "data-is-link" => "true"}
+    %a.hub{"ng-href" => "{{::hub.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub", "data-is-link" => "true"}
       %i{ng: {class: "::hub.icon_font"}}
       %span.margin-top.hub-name-listing{"ng-bind" => "::hub.name | truncate:40"}
 
@@ -11,7 +11,7 @@
     %span.margin-top{"ng-if" => "hub.distance != null && hub.distance > 0"} ({{ hub.distance / 1000 | number:0 }} km)
 
   .columns.small-4.medium-3.large-3.text-right{"ng-if" => "::hub.active"}
-    %a.hub.open_closed{"ng-href" => "{{::hub.path}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
+    %a.hub.open_closed{"ng-href" => "{{::hub.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
       %i.ofn-i_068-shop-reversed
       %span.margin-top{ ng: { if: "::current()" } }
         %em= t :hubs_shopping_here
@@ -19,7 +19,7 @@
         %span{"ng-bind" => "::hub.orders_close_at | sensible_timeframe"}
 
   .columns.small-4.medium-3.large-3.text-right{"ng-if" => "::!hub.active"}
-    %a.hub.open_closed{"ng-href" => "{{::hub.path}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
+    %a.hub.open_closed{"ng-href" => "{{::hub.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}", "ng-class" => "{primary: hub.active, secondary: !hub.active}", "ofn-change-hub" => "hub"}
       %span.margin-top{ ng: { if: "::current()" } }
         %em= t :hubs_shopping_here
       %span.margin-top{ ng: { if: "::!current()" } }

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+feature "Using embedded shopfront functionality", js: true do
+
+  Capybara.server_port = 9999
+
+  describe 'embedded groups' do
+	let(:enterprise) { create(:distributor_enterprise) }
+  	let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
+
+
+  	before do
+  	  Spree::Config[:enable_embedded_shopfronts] = true
+      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
+
+      page.driver.browser.js_errors = false
+	  Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+
+  	end
+
+	it "displays in an iframe" do
+	  expect(page).to have_selector 'iframe#group_test_iframe'
+
+	  within_frame 'group_test_iframe' do
+	  	within 'div#group-page' do
+	  	  expect(page).to have_content 'About Us'
+	  	end
+	  end	  
+	end
+  
+  end
+
+end

--- a/spec/features/consumer/shopping/embedded_groups_spec.rb
+++ b/spec/features/consumer/shopping/embedded_groups_spec.rb
@@ -5,29 +5,74 @@ feature "Using embedded shopfront functionality", js: true do
   Capybara.server_port = 9999
 
   describe 'embedded groups' do
-	let(:enterprise) { create(:distributor_enterprise) }
-  	let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
+    let(:enterprise) { create(:distributor_enterprise) }
+    let!(:group) { create(:enterprise_group, enterprises: [enterprise], permalink: 'group1', on_front_page: true) }
 
-
-  	before do
-  	  Spree::Config[:enable_embedded_shopfronts] = true
-      Spree::Config[:embedded_shopfronts_whitelist] = 'localhost'
-
+    before do
+      Spree::Config[:enable_embedded_shopfronts] = true
+      Spree::Config[:embedded_shopfronts_whitelist] = 'test.com'
       page.driver.browser.js_errors = false
-	  Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+      allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return('https://www.test.com')
+      Capybara.current_session.driver.visit('spec/support/views/group_iframe_test.html')
+    end
 
-  	end
+    it "displays in an iframe" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
 
-	it "displays in an iframe" do
-	  expect(page).to have_selector 'iframe#group_test_iframe'
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          expect(page).to have_content 'About Us'
+        end
+      end
+    end
 
-	  within_frame 'group_test_iframe' do
-	  	within 'div#group-page' do
-	  	  expect(page).to have_content 'About Us'
-	  	end
-	  end	  
-	end
-  
+    it "displays powered by OFN text at bottom of page" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
+
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          expect(page).to have_selector 'div.powered-by-embedded'
+          expect(page).to have_css "img[src*='favicon.ico']"
+          expect(page).to have_content 'Powered by'
+          expect(page).to have_content 'Open Food Network'
+        end
+      end
+    end
+
+    it "doesn't display contact details when embedded" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
+
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+
+          expect(page).to have_no_selector 'div.contact-container'
+          expect(page).to have_no_content '#{group.address.address1}'
+        end
+      end
+    end
+
+    it "does not display the header when embedded" do
+      expect(page).to have_selector 'iframe#group_test_iframe'
+
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          expect(page).to have_no_selector 'header'
+          expect(page).to have_no_selector 'img.group-logo'
+          expect(page).to have_no_selector 'h2.group-name'
+        end
+      end
+    end
+
+    it 'opens links to shops in a new window' do
+      expect(page).to have_selector 'iframe#group_test_iframe'
+
+      within_frame 'group_test_iframe' do
+        within 'div#group-page' do
+          enterprise_links = page.all(:xpath, "//*[contains(@href, 'enterprise-5/shop')]", :visible => :false).count
+          enterprise_links_with_target_blank = page.all(:xpath, "//*[contains(@href, 'enterprise-5/shop') and @target = '_blank']", :visible => :false).count
+          expect(enterprise_links).to equal(enterprise_links_with_target_blank)
+        end
+      end
+    end
   end
-
 end

--- a/spec/support/views/group_iframe_test.html
+++ b/spec/support/views/group_iframe_test.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+
+<iframe src="http://localhost:9999/groups/group1?embedded_shopfront=true" name="group_test_iframe" class="group_test_iframe" id="group_test_iframe" style="width:100%;min-height:35em"></iframe>
+
+</body>
+</html>

--- a/spec/support/views/group_iframe_test.html
+++ b/spec/support/views/group_iframe_test.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
 
-<iframe src="http://localhost:9999/groups/group1?embedded_shopfront=true" name="group_test_iframe" class="group_test_iframe" id="group_test_iframe" style="width:100%;min-height:35em"></iframe>
+<iframe src="http://localhost:9999/groups/group1?embedded_shopfront=true" class="group_test_iframe" id="group_test_iframe" style="width:100%;min-height:35em"></iframe>
 
 </body>
 </html>


### PR DESCRIPTION
Closes #1783

Two commits. One for initial tests and setup and one that combines all the sub-issues within this issue. The sub issues in question are:

- move the 'powered by open food network' to somewhere lower on the page (the element got removed)
It just adds a small bit of text to the group template saying "Powered by open food network". This only appears when a group page is embedded.
- remove the contact details.
It removes the contact details from a group page when that page is being viewed in an embedded setting.
- Remove the logo, banner and Description text fields.
It removes the whole header element from from the group page template if it's being viewed as an embedded page. This also includes the group name so that has also been removed (as instructed).
- Links to shops open a new window.
If a group page is being viewed as an embedded page, all links to the groups corresponding shops are served with the target = '_blank' attribute so that they open in a new browser window/tab.
All of these are solved by this PR.

### What should we test?

Dev testing: 
- Tests in spec/features/consumer/shopping/embedded_groups_spec.rb
- Also functionality can be manually tested using the embedded-group-preview.html file. i.e. by creating a group and then navigating to: http://localhost:3000/embedded-group-preview.html?your-group-name.

Staging testing:

- Embed a group using an iframe on another website, for example: `<iframe src="https://staging1.openfood.com.au/groups/regional-marketing-group?embedded_shopfront=true" style="width:100%;min-height:35em"></iframe>`
- Load that page and it should embed the group with the defined layout.
- Test following links and navigating around.

Screenshots for comparison:

Standard show view:
<img width="1336" alt="screen shot 2018-02-01 at 12 48 20" src="https://user-images.githubusercontent.com/4159705/35735231-d9ace72a-081b-11e8-8852-958539e8f8cc.png">


Embedded view:
<img width="1333" alt="screen shot 2018-02-01 at 12 48 00" src="https://user-images.githubusercontent.com/4159705/35735236-ded924c0-081b-11e8-9530-62ea1eb48592.png">


Discourse thread
Discussion here:
#1783
and here:
#2031