### PR TITLE
Loads all order cycles for current user whether he is producer, distributor or coordinator

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -338,10 +338,9 @@ Spree::Admin::ReportsController.class_eval do
 
     # Avoids duplicates
     OrderCycle.active_or_complete.involving_managed_producers_of(spree_current_user).each do |order_cycle|
-        @order_cycles << order_cycle unless @order_cycles.include?(order_cycle)
+      @order_cycles << order_cycle unless @order_cycles.include?(order_cycle)
     end
 
-    @order_cycles.sort_by! {|order_cycle| order_cycle.orders_close_at}
-    return @order_cycles
+    @order_cycles.sort_by!(&:orders_close_at)
   end
 end

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -208,7 +208,7 @@ Spree::Admin::ReportsController.class_eval do
     # My suppliers and any suppliers supplying products I distribute
     @suppliers = permissions.visible_enterprises_for_order_reports.is_primary_producer
 
-    @order_cycles = load_order_cycles
+    @order_cycles = OrderCycle.active_or_complete.accessible_by(spree_current_user).order('orders_close_at DESC')
 
     @report_types = report_types[:orders_and_fulfillment]
     @report_type = params[:report_type]
@@ -330,17 +330,5 @@ Spree::Admin::ReportsController.class_eval do
 
   def timestamp
     Time.zone.now.strftime("%Y%m%d")
-  end
-
-  # Loads all order cycles concerned by current user, may he be producer, distributor or coordinator
-  def load_order_cycles
-    @order_cycles = OrderCycle.active_or_complete.involving_managed_distributors_of(spree_current_user)
-
-    # Avoids duplicates
-    OrderCycle.active_or_complete.involving_managed_producers_of(spree_current_user).each do |order_cycle|
-      @order_cycles << order_cycle unless @order_cycles.include?(order_cycle)
-    end
-
-    @order_cycles.sort_by!(&:orders_close_at)
   end
 end

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -208,8 +208,7 @@ Spree::Admin::ReportsController.class_eval do
     # My suppliers and any suppliers supplying products I distribute
     @suppliers = permissions.visible_enterprises_for_order_reports.is_primary_producer
 
-    @order_cycles = OrderCycle.active_or_complete.
-      involving_managed_distributors_of(spree_current_user).order('orders_close_at DESC')
+    @order_cycles = load_order_cycles
 
     @report_types = report_types[:orders_and_fulfillment]
     @report_type = params[:report_type]
@@ -331,5 +330,18 @@ Spree::Admin::ReportsController.class_eval do
 
   def timestamp
     Time.zone.now.strftime("%Y%m%d")
+  end
+
+  # Loads all order cycles concerned by current user, may he be producer, distributor or coordinator
+  def load_order_cycles
+    @order_cycles = OrderCycle.active_or_complete.involving_managed_distributors_of(spree_current_user)
+
+    # Avoids duplicates
+    OrderCycle.active_or_complete.involving_managed_producers_of(spree_current_user).each do |order_cycle|
+        @order_cycles << order_cycle unless @order_cycles.include?(order_cycle)
+    end
+
+    @order_cycles.sort_by! {|order_cycle| order_cycle.orders_close_at}
+    return @order_cycles
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #1889 

Added loading of all active or complete order cycles concerned by the current user to the reports form collection. User will see a collection of all order cycles he is concerned by as producer, distributor or coordinator.

#### What should we test?

The collection of order cycles loaded in the reports form contains all order cycles in which the current user has a role, and there are no duplicates.