### PR TITLE
Add Skylight instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'blockenspiel'
 gem 'acts-as-taggable-on', '~> 3.4'
 gem 'paper_trail', '~> 3.0.8'
 gem 'diffy'
+gem 'skylight', '< 2.0'
 
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,6 +641,8 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (1.1.0)
       activesupport (>= 3.0.0)
+    skylight (1.5.0)
+      activesupport (>= 3.0.0)
     spinjs-rails (1.3)
       rails (>= 3.1)
     sprockets (2.2.3)
@@ -784,6 +786,7 @@ DEPENDENCIES
   sass-rails (~> 3.2.3)
   shoulda-matchers
   simple_form!
+  skylight (< 2.0)
   spinjs-rails
   spree!
   spree_auth_devise!

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -27,6 +27,9 @@ CURRENCY: AUD
 # see: https://developers.google.com/maps/documentation/javascript/get-api-key
 # GOOGLE_MAPS_API_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# optional, see: https://www.skylight.io/oss
+# SKYLIGHT_AUTHENTICATION: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 # Stripe Connect details for instance account
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings
 # Under 'Connect', the Redirect URI should be set to https://YOUR_SERVER_URL/stripe/callbacks (e.g. https://openfoodnetwork.org.uk/stripe/callbacks)


### PR DESCRIPTION
Hello!

I work at [Skylight](https://www.skylight.io/). If you’re not already familiar with [Skylight](https://www.skylight.io), it is a smart profiler for Rails apps. Skylight makes it easy to pinpoint performance issues in Rails applications.

We are getting ready to launch our [Skylight for Open Source](https://www.skylight.io/oss) program. Similar to Github and Travis, it's completely free for open source apps and allows you to easily collect/share performance data with your contributors.

For your reference, here are a few examples of open source apps using Skylight so you can get a sense of what it can do:

* [The Odin Project](https://www.theodinproject.com/) ([on Skylight](https://oss.skylight.io/app/applications/g0gJSNnzYAws))
* [Homebrew formula browser](http://formulae.brew.sh/) ([on Skylight](https://oss.skylight.io/app/applications/jut3BrkJo722))

I worked with @sauloperez to add Skylight to another open source project (see https://github.com/coopdevs/timeoverflow/pull/322). He mentioned that he runs the Open Food Network (Barcelona) server and would be interested in using Skylight there as well. So I thought I should submit a pull request to see if this is something you would be interested in including.

We work on a lot of open source projects ourselves, and in our experience it can be pretty hard to get contributors to work on application performance issues. Few contributors consider working on performance problems, and the ones that might be interested may not even know where to start. By making performance information more accessible, we hope to inspire potential contributors to tackle slow parts of your app, and have a good way to see if their contributions helped.

This is one of the first "federated" (multi-deployment/installation) open source apps that we are adding to the program, so there are some open technical questions. While I can provide you with a single API token that all installations can share, the performance data will probably aggregate poorly due to differences in versions and other modifications.

So instead, I think it may be best to have a dedicated Skylight account per instance. Following the project's convention, I added a placeholder to `config/application.yml` since that appears to be where environment variables are usually set. That way, each installation can [apply](https://www.skylight.io/oss) for their own API token, or just leave it unset if they are not using Skylight (in which case the Skylight agent may log a message to `log/skylight.log` on boot but won't otherwise prevent the app from working normally).