### PR TITLE
Disable guest checkout for registered users

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -1,6 +1,13 @@
 Darkswarm.controller "LoginCtrl", ($scope, $timeout, $location, $http, $window, AuthenticationService, Redirections, Loading) ->
   $scope.path = "/login"
 
+  $scope.modalMessage = null
+
+  $scope.$watch (->
+    AuthenticationService.modalMessage
+  ), (newValue) ->
+    $scope.errors = newValue
+
   $scope.submit = ->
     Loading.message = t 'logging_in'
     $http.post("/user/spree_user/sign_in", {spree_user: $scope.spree_user}).success (data)->

--- a/app/assets/javascripts/darkswarm/controllers/checkout/checkout_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/checkout_controller.js.coffee
@@ -20,6 +20,7 @@ Darkswarm.controller "CheckoutCtrl", ($scope, localStorageService, Checkout, Cur
 
   $scope.purchase = (event, form) ->
     event.preventDefault()
+    $scope.formdata = form
     $scope.submitted = true
 
     if CurrentUser.id
@@ -27,18 +28,19 @@ Darkswarm.controller "CheckoutCtrl", ($scope, localStorageService, Checkout, Cur
     else
       $scope.ensureUserIsGuest()
 
-  $scope.validateForm = (form) ->
-    if form.$valid
+  $scope.validateForm = ->
+    if $scope.formdata.$valid
       $scope.Checkout.purchase()
     else
-      $scope.$broadcast 'purchaseFormInvalid', form
+      $scope.$broadcast 'purchaseFormInvalid', $scope.formdata
 
-  $scope.ensureUserIsGuest = ->
+  $scope.ensureUserIsGuest = (callback = null) ->
     $http.post("/user/registered_email", {email: $scope.order.email}).success (data)->
       if data.registered == true
         $scope.promptLogin()
       else
         $scope.validateForm() if $scope.submitted
+        callback() if callback
 
   $scope.promptLogin = ->
     SpreeUser.spree_user.email = $scope.order.email

--- a/app/assets/javascripts/darkswarm/controllers/checkout/checkout_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/checkout_controller.js.coffee
@@ -25,7 +25,7 @@ Darkswarm.controller "CheckoutCtrl", ($scope, localStorageService, Checkout, Cur
     if CurrentUser.id
       $scope.validateForm(form)
     else
-      $scope.confirmGuest(true)
+      $scope.ensureUserIsGuest()
 
   $scope.validateForm = (form) ->
     if form.$valid
@@ -33,7 +33,7 @@ Darkswarm.controller "CheckoutCtrl", ($scope, localStorageService, Checkout, Cur
     else
       $scope.$broadcast 'purchaseFormInvalid', form
 
-  $scope.confirmGuest = ->
+  $scope.ensureUserIsGuest = ->
     $http.post("/user/registered_email", {email: $scope.order.email}).success (data)->
       if data.registered == true
         $scope.promptLogin()

--- a/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
@@ -7,6 +7,7 @@ Darkswarm.controller "DetailsCtrl", ($scope, $timeout, $http, CurrentUser, Authe
     event.preventDefault()
     unless CurrentUser.id
       $scope.confirmGuest()
+      return
 
     $scope.next()
 

--- a/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
@@ -6,7 +6,7 @@ Darkswarm.controller "DetailsCtrl", ($scope, $timeout, $http, CurrentUser, Authe
   $scope.login_or_next = (event) ->
     event.preventDefault()
     unless CurrentUser.id
-      $scope.ensureUserIsGuest()
+      $scope.ensureUserIsGuest($scope.next)
       return
 
     $scope.next()

--- a/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
@@ -6,7 +6,7 @@ Darkswarm.controller "DetailsCtrl", ($scope, $timeout, $http, CurrentUser, Authe
   $scope.login_or_next = (event) ->
     event.preventDefault()
     unless CurrentUser.id
-      $scope.confirmGuest()
+      $scope.ensureUserIsGuest()
       return
 
     $scope.next()

--- a/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
@@ -1,7 +1,14 @@
-Darkswarm.controller "DetailsCtrl", ($scope, $timeout) ->
+Darkswarm.controller "DetailsCtrl", ($scope, $timeout, $http, CurrentUser, AuthenticationService, SpreeUser) ->
   angular.extend(this, new FieldsetMixin($scope))
   $scope.name = "details"
   $scope.nextPanel = "billing"
+
+  $scope.login_or_next = (event) ->
+    event.preventDefault()
+    unless CurrentUser.id
+      $scope.confirmGuest()
+
+    $scope.next()
 
   $scope.summary = ->
     [$scope.fullName(),

--- a/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
@@ -1,3 +1,8 @@
+# This class deals with displaying things in the login modal. It chooses
+# the modal tab templates and deals with switching tabs and passing data
+# between the tabs. It has direct access to the instance of the login modal,
+# and provides that access to other controllers as a service.
+
 Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redirections, Loading)->
 
   new class AuthenticationService

--- a/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
@@ -2,6 +2,7 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
 
   new class AuthenticationService
     selectedPath: "/login"
+    modalMessage: null
 
     constructor: ->
       if $location.path() in ["/login", "/signup", "/forgot"] || location.pathname is '/register/auth'
@@ -32,6 +33,8 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
         'registration_authentication.html'
       else
         'authentication.html'
+    pushMessage: (message) ->
+      @modalMessage = String(message)
 
     select: (path)=>
       @selectedPath = path

--- a/app/controllers/spree/users_controller_decorator.rb
+++ b/app/controllers/spree/users_controller_decorator.rb
@@ -15,4 +15,10 @@ Spree::UsersController.class_eval do
 
     @orders = @orders.where('distributor_id != ?', Spree::Config.accounts_distributor_id)
   end
+
+  # Endpoint for queries to check if a user is already registered
+  def registered_email
+    user = Spree.user_class.find_by_email params[:email]
+    render json: { registered: user.present? }
+  end
 end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -17,6 +17,7 @@ Spree::Order.class_eval do
 
   validates :customer, presence: true, if: :require_customer?
   validate :products_available_from_new_distribution, :if => lambda { distributor_id_changed? || order_cycle_id_changed? }
+  validate :disallow_guest_order, if: lambda { using_guest_checkout? && registered_email? }
   attr_accessible :order_cycle_id, :distributor_id, :customer_id
 
   before_validation :shipping_address_from_distributor
@@ -80,6 +81,18 @@ Spree::Order.class_eval do
   def products_available_from_new_distribution
     # Check that the line_items in the current order are available from a newly selected distribution
     errors.add(:base, I18n.t(:spree_order_availability_error)) unless DistributionChangeValidator.new(self).can_change_to_distribution?(distributor, order_cycle)
+  end
+
+  def using_guest_checkout?
+    require_email && !user.andand.id
+  end
+
+  def registered_email?
+    Spree.user_class.find_by_email(email).present?
+  end
+
+  def disallow_guest_order
+    errors.add(:base, I18n.t('devise.failure.already_registered'))
   end
 
   def empty_with_clear_shipping_and_payments!

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -88,7 +88,7 @@ Spree::Order.class_eval do
   end
 
   def registered_email?
-    Spree.user_class.find_by_email(email).present?
+    Spree.user_class.exists?(email: email)
   end
 
   def disallow_guest_order

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -17,7 +17,7 @@ Spree::Order.class_eval do
 
   validates :customer, presence: true, if: :require_customer?
   validate :products_available_from_new_distribution, :if => lambda { distributor_id_changed? || order_cycle_id_changed? }
-  validate :disallow_guest_order, if: lambda { using_guest_checkout? && registered_email? }
+  validate :disallow_guest_order
   attr_accessible :order_cycle_id, :distributor_id, :customer_id
 
   before_validation :shipping_address_from_distributor
@@ -92,7 +92,9 @@ Spree::Order.class_eval do
   end
 
   def disallow_guest_order
-    errors.add(:base, I18n.t('devise.failure.already_registered'))
+    if using_guest_checkout? && registered_email?
+      errors.add(:base, I18n.t('devise.failure.already_registered'))
+    end
   end
 
   def empty_with_clear_shipping_and_payments!

--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -28,5 +28,5 @@
 
       .row
         .small-12.columns.text-right
-          %button.primary{"ng-disabled" => "details.$invalid", "ng-click" => "next($event)"}
+          %button.primary{"ng-disabled" => "details.$invalid", "ng-click" => "login_or_next($event)"}
             = t :next

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
         Invalid email or password.
         Were you a guest last time?  Perhaps you need to create an account or reset your password.
       unconfirmed: "You have to confirm your account before continuing."
+      already_registered: "This email address is already registered. Please log in to continue, or go back and use another email address."
   enterprise_mailer:
     confirmation_instructions:
       subject: "Please confirm the email address for %{enterprise}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,9 @@ en:
         Were you a guest last time?  Perhaps you need to create an account or reset your password.
       unconfirmed: "You have to confirm your account before continuing."
       already_registered: "This email address is already registered. Please log in to continue, or go back and use another email address."
+    user_passwords:
+      spree_user:
+        updated_not_active: "Your password has been reset, but your email has not been confirmed yet."
   enterprise_mailer:
     confirmation_instructions:
       subject: "Please confirm the email address for %{enterprise}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Openfoodnetwork::Application.routes.draw do
 
   get "/register", to: "registration#index", as: :registration
   get "/register/auth", to: "registration#authenticate", as: :registration_auth
+  post "/user/registered_email", to: "spree/users#registered_email"
 
   # Redirects to global website
   get "/connect", to: redirect("https://openfoodnetwork.org/#{ENV['DEFAULT_COUNTRY_CODE'].andand.downcase}/connect/")

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spree/api/testing_support/helpers'
 
 describe Spree::UsersController, type: :controller do
   include AuthenticationWorkflow
@@ -44,6 +45,20 @@ describe Spree::UsersController, type: :controller do
 
       # Doesn't return uncompleted orders" do
       expect(orders).not_to include d1o3
+    end
+  end
+
+  describe "registered_email" do
+    let!(:user) { create(:user) }
+
+    it "returns true if email corresponds to a registered user" do
+      spree_post :registered_email, email: user.email
+      expect(json_response['registered']).to eq true
+    end
+
+    it "returns false if email does not correspond to a registered user" do
+      spree_post :registered_email, email: 'nonregistereduser@example.com'
+      expect(json_response['registered']).to eq false
     end
   end
 end

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -23,42 +23,42 @@ feature "As a consumer I want to check out my cart", js: true do
       add_product_to_cart order, product
     end
 
-    it "does not not render the login form when logged in" do
+    it "does not render the login form when logged in" do
       quick_login_as user
       visit checkout_path
       within "section[role='main']" do
-        page.should_not have_content "Login"
-        page.should have_checkout_details
+        expect(page).to_not have_content "Login"
+        expect(page).to have_checkout_details
       end
     end
 
     it "renders the login buttons when logged out" do
       visit checkout_path
       within "section[role='main']" do
-        page.should have_content "Login"
+        expect(page).to have_content "Login"
         click_button "Login"
       end
-      page.should have_login_modal
+      expect(page).to have_login_modal
     end
 
     it "populates user details once logged in" do
       visit checkout_path
       within("section[role='main']") { click_button "Login" }
-      page.should have_login_modal
+      expect(page).to have_login_modal
       fill_in "Email", with: user.email
       fill_in "Password", with: user.password
       within(".login-modal") { click_button 'Login' }
       toggle_details
 
-      page.should have_field 'First Name', with: 'Foo'
-      page.should have_field 'Last Name', with: 'Bar'
+      expect(page).to have_field 'First Name', with: 'Foo'
+      expect(page).to have_field 'Last Name', with: 'Bar'
     end
 
     context "using the guest checkout" do
       it "allows user to checkout as guest" do
         visit checkout_path
         checkout_as_guest
-        page.should have_checkout_details
+        expect(page).to have_checkout_details
       end
 
       it "asks the user to log in if they are using a registered email" do

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -7,54 +7,76 @@ feature "As a consumer I want to check out my cart", js: true do
   include CheckoutWorkflow
   include UIComponentHelper
 
-  let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
-  let(:supplier) { create(:supplier_enterprise) }
-  let!(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise), variants: [product.variants.first]) }
-  let(:product) { create(:simple_product, supplier: supplier) }
-  let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor) }
-  let(:address) { create(:address, firstname: "Foo", lastname: "Bar") }
-  let(:user) { create(:user, bill_address: address, ship_address: address) }
-  after { Warden.test_reset! }
+  describe "using the checkout" do
+    let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
+    let(:supplier) { create(:supplier_enterprise) }
+    let!(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise), variants: [product.variants.first]) }
+    let(:product) { create(:simple_product, supplier: supplier) }
+    let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor) }
+    let(:address) { create(:address, firstname: "Foo", lastname: "Bar") }
+    let(:user) { create(:user, bill_address: address, ship_address: address) }
 
-  before do
-    set_order order
-    add_product_to_cart order, product
-  end
+    after { Warden.test_reset! }
 
-  it "does not not render the login form when logged in" do
-    quick_login_as user
-    visit checkout_path
-    within "section[role='main']" do
-      page.should_not have_content "Login"
-      page.should have_checkout_details
+    before do
+      set_order order
+      add_product_to_cart order, product
     end
-  end
 
-  it "renders the login buttons when logged out" do
-    visit checkout_path
-    within "section[role='main']" do
-      page.should have_content "Login"
-      click_button "Login"
+    it "does not not render the login form when logged in" do
+      quick_login_as user
+      visit checkout_path
+      within "section[role='main']" do
+        page.should_not have_content "Login"
+        page.should have_checkout_details
+      end
     end
-    page.should have_login_modal
-  end
 
-  it "populates user details once logged in" do
-    visit checkout_path
-    within("section[role='main']") { click_button "Login" }
-    page.should have_login_modal
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    within(".login-modal") { click_button 'Login' }
-    toggle_details
+    it "renders the login buttons when logged out" do
+      visit checkout_path
+      within "section[role='main']" do
+        page.should have_content "Login"
+        click_button "Login"
+      end
+      page.should have_login_modal
+    end
 
-    page.should have_field 'First Name', with: 'Foo'
-    page.should have_field 'Last Name', with: 'Bar'
-  end
+    it "populates user details once logged in" do
+      visit checkout_path
+      within("section[role='main']") { click_button "Login" }
+      page.should have_login_modal
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user.password
+      within(".login-modal") { click_button 'Login' }
+      toggle_details
 
-  it "allows user to checkout as guest" do
-    visit checkout_path
-    checkout_as_guest
-    page.should have_checkout_details
+      page.should have_field 'First Name', with: 'Foo'
+      page.should have_field 'Last Name', with: 'Bar'
+    end
+
+    context "using the guest checkout" do
+      it "allows user to checkout as guest" do
+        visit checkout_path
+        checkout_as_guest
+        page.should have_checkout_details
+      end
+
+      it "asks the user to log in if they are using a registered email" do
+        visit checkout_path
+        checkout_as_guest
+
+        fill_in 'First Name', with: 'Not'
+        fill_in 'Last Name', with: 'Guest'
+        fill_in 'Email', with: user.email
+        fill_in 'Phone', with: '098712736'
+
+        within '#details' do
+          click_button 'Next'
+        end
+
+        expect(page).to have_selector 'div.login-modal', visible: true
+        expect(page).to have_content I18n.t('devise.failure.already_registered')
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #1159. 

Stops registered users using the guest checkout option.

#### What should we test?

Checkout as a guest using an email address of a registered user.

#### Release notes

Registered users will not be able to use the guest checkout from now on.
