### PR TITLE
Bug fix in customers edit address

### DIFF
--- a/app/assets/javascripts/admin/customers/directives/edit_address_dialog.js.coffee
+++ b/app/assets/javascripts/admin/customers/directives/edit_address_dialog.js.coffee
@@ -34,4 +34,4 @@ angular.module("admin.customers").directive 'editAddressDialog', ($compile, $tem
 
     scope.filter_states = (countryID) ->
       return [] unless countryID
-      $filter('filter')(scope.availableCountries, {id: countryID})[0].states
+      $filter('filter')(scope.availableCountries, {id: parseInt(countryID)}, true)[0].states


### PR DESCRIPTION
#### What? Why?

Closes #2057 

Fix the /admin/customers edit form to always show the country states for the selected country

In edit_address_dialog.js, `$filter('filter')` don't uses a strict comparaison
This is blocking saving on the french instance because France (id 13) is matched with Barbados (id **13**2), therefore no country states are available to choose.

#### What should we test?

The country states are now always matching the selected country
