### PR TITLE
Cart page shouldnt show admin handling if it is zero

### DIFF
--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -35,13 +35,13 @@
           %td.text-right
             %span.order-total.item-total= display_checkout_subtotal(@order)
           %td
-
-        %tr
-          %td.text-right{colspan:"3"}
-            = t :orders_form_admin
-          %td.text-right
-            %span.order-total.distribution-total= display_checkout_admin_and_handling_adjustments_total_for(@order)
-          %td
+        -if display_checkout_admin_and_handling_adjustments_total_for(@order) != Spree::Money.new(0 , currency: @order.currency)
+          %tr
+            %td.text-right{colspan:"3"}
+              = t :orders_form_admin
+            %td.text-right
+              %span.order-total.distribution-total= display_checkout_admin_and_handling_adjustments_total_for(@order)
+            %td
 
         - checkout_adjustments_for(@order, exclude: [:line_item, :admin_and_handling]).reject{ |a| a.amount == 0 }.reverse_each do |adjustment|
           %tr.order-adjustment

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -143,5 +143,26 @@ feature "full-page cart", js: true do
         expect(page).to have_content item2.variant.name
       end
     end
+
+    context "Admin & Handling" do
+      it "hides row if order includes no adjustments" do
+        add_product_to_cart order, product_fee, quantity: 1
+        visit spree.cart_path
+
+        expect(page).to have_selector('#cart-detail')
+        expect(page).to_not have_content('Admin & Handling')
+      end
+
+      it "shows row if order includes adjustments" do
+        coordinator_fee = create(:enterprise_fee, enterprise: order_cycle.coordinator, fee_type: 'admin', calculator: Spree::Calculator::FlatRate.new(preferred_amount: 1))
+        order_cycle.coordinator_fees << coordinator_fee
+
+        add_product_to_cart order, product_fee, quantity: 1
+        visit spree.cart_path
+
+        expect(page).to have_selector('#cart-detail')
+        expect(page).to have_content('Admin & Handling')
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #424 

In /cart, there is always a row called "Admin & Handling". The purpose of this PR is to hide it if those fees are 0.
This is based on the work done previously by @jtruong2 and on PR #1955 

#### What should we test?

After adding some article in the cart, if the admin & handling fees are 0, then there is no line "Admin & Handling"