### PR TITLE
Enable Skylight in staging

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,13 @@ module Openfoodnetwork
       end
     end
 
+    # Activate the Skylight agent in staging. You need to provision the
+    # SKYLIGHT_AUTHENTICATION env var in your OFN instance for this to work.
+    #
+    # Check https://github.com/openfoodfoundation/openfoodnetwork/pull/2070 for
+    # details
+    config.skylight.environments += ["staging"]
+
     # Settings dependent on locale
     #
     # We need to set this config before the promo environment gets loaded and


### PR DESCRIPTION
#### What? Why?

This is a follow-up of https://github.com/openfoodfoundation/openfoodnetwork/pull/2070.

When running the production API key in staging, the `log/skylight.log` showed:

```
[SKYLIGHT] [1.5.0] You are running in the staging environment but
haven't added it to config.skylight.environments, so no data will be
sent to skylight.io.
```

According to https://www.skylight.io/support/advanced-setup#setting-up-multiple-environments it turns out we need to create a new app for staging and use its API key.