### PR TITLE
Email/confirmation links

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -20,8 +20,8 @@ Darkswarm.controller "LoginCtrl", ($scope, $timeout, $location, $http, $window, 
       $scope.errors = t('devise.confirmations.failed_to_send')
 
   $timeout ->
-    if angular.isDefined($location.search()['confirmation'])
-      if $location.search()['confirmation'] == 'confirmed'
+    if angular.isDefined($location.search()['validation'])
+      if $location.search()['validation'] == 'confirmed'
         $scope.messages = t('devise.confirmations.confirmed')
-      if $location.search()['confirmation'] == 'not_confirmed'
+      if $location.search()['validation'] == 'not_confirmed'
         $scope.errors = t('devise.confirmations.not_confirmed')

--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.controller "LoginCtrl", ($scope, $http, $window, AuthenticationService, Redirections, Loading) ->
+Darkswarm.controller "LoginCtrl", ($scope, $timeout, $location, $http, $window, AuthenticationService, Redirections, Loading) ->
   $scope.path = "/login"
 
   $scope.submit = ->
@@ -18,3 +18,10 @@ Darkswarm.controller "LoginCtrl", ($scope, $http, $window, AuthenticationService
       $scope.messages = t('devise.confirmations.send_instructions')
     .error (data) ->
       $scope.errors = t('devise.confirmations.failed_to_send')
+
+  $timeout ->
+    if angular.isDefined($location.search()['confirmation'])
+      if $location.search()['confirmation'] == 'confirmed'
+        $scope.messages = t('devise.confirmations.confirmed')
+      if $location.search()['confirmation'] == 'not_confirmed'
+        $scope.errors = t('devise.confirmations.not_confirmed')

--- a/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
@@ -8,7 +8,7 @@ Darkswarm.controller "SignupCtrl", ($scope, $http, $window, $location, Redirecti
     password: null
 
   $scope.submit = ->
-    $http.post("/user/spree_user", {spree_user: $scope.spree_user}).success (data)->
+    $http.post("/user/spree_user", {spree_user: $scope.spree_user, return_url: $location.absUrl()}).success (data)->
       $scope.errors = {email: null, password: null}
       $scope.messages = t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
     .error (data) ->

--- a/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
@@ -4,13 +4,8 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
     selectedPath: "/login"
 
     constructor: ->
-      if $location.path() in ["/login", "/signup", "/forgot"] && location.pathname isnt '/register/auth'
-        @open $location.path()
-      else if location.pathname is '/register/auth'
-        if angular.isDefined($location.search()['validation'])
-          @open '/login', 'registration_authentication.html'
-        else
-          @open '/signup', 'registration_authentication.html'
+      if $location.path() in ["/login", "/signup", "/forgot"] || location.pathname is '/register/auth'
+        @open @initialTab(), @initialTemplate()
 
     open: (path = false, template = 'authentication.html') =>
       @modalInstance = $modal.open
@@ -20,6 +15,19 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
       @selectedPath = path || @selectedPath
       Navigation.navigate @selectedPath
 
+    initialTab: ->
+      if angular.isDefined($location.search()['validation'])
+        '/login'
+      else if location.pathname is '/register/auth'
+        '/signup'
+      else
+        $location.path()
+
+    initialTemplate: ->
+      if location.pathname is '/register/auth'
+        'registration_authentication.html'
+      else
+        'authentication.html'
 
     select: (path)=>
       @selectedPath = path

--- a/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
@@ -15,6 +15,9 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
       @selectedPath = path || @selectedPath
       Navigation.navigate @selectedPath
 
+    # Opens the /login tab if returning from email confirmation,
+    # the /signup tab if opened from the enterprise registration page,
+    # otherwise opens whichever tab is selected in the URL params ('/login', '/signup', or '/forgot')
     initialTab: ->
       if angular.isDefined($location.search()['validation'])
         '/login'
@@ -23,6 +26,7 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
       else
         $location.path()
 
+    # Loads the registration page modal when needed, otherwise the default modal
     initialTemplate: ->
       if location.pathname is '/register/auth'
         'registration_authentication.html'

--- a/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
@@ -7,7 +7,10 @@ Darkswarm.factory "AuthenticationService", (Navigation, $modal, $location, Redir
       if $location.path() in ["/login", "/signup", "/forgot"] && location.pathname isnt '/register/auth'
         @open $location.path()
       else if location.pathname is '/register/auth'
-        @open '/signup', 'registration_authentication.html'
+        if angular.isDefined($location.search()['validation'])
+          @open '/login', 'registration_authentication.html'
+        else
+          @open '/signup', 'registration_authentication.html'
 
     open: (path = false, template = 'authentication.html') =>
       @modalInstance = $modal.open

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -38,7 +38,8 @@ class UserConfirmationsController < DeviseController
         'not_confirmed'
       end
 
-    url = session[:confirmation_return_url] || login_path
-    url + "?confirmation=#{result}"
+    path = (session[:confirmation_return_url] || login_path).to_s
+    path += path.include?('?') ? '&' : '?'
+    path + "validation=#{result}"
   end
 end

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -25,20 +25,20 @@ class UserConfirmationsController < DeviseController
   def show
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
 
-    if is_navigational_format?
-      if resource.errors.empty?
-        set_flash_message(:success, :confirmed)
-      else
-        set_flash_message(:error, :not_confirmed)
-      end
-    end
-
     respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource) }
   end
 
   protected
 
-  def after_confirmation_path_for(resource)
-    session[:confirmation_return_url] || login_path
+  def after_confirmation_path_for(_resource)
+    result =
+      if resource.errors.empty?
+        'confirmed'
+      else
+        'not_confirmed'
+      end
+
+    url = session[:confirmation_return_url] || login_path
+    url + "?confirmation=#{result}"
   end
 end

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -33,6 +33,12 @@ class UserConfirmationsController < DeviseController
       end
     end
 
-    respond_with_navigational(resource){ redirect_to login_path }
+    respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource) }
+  end
+
+  protected
+
+  def after_confirmation_path_for(resource)
+    session[:confirmation_return_url] || login_path
   end
 end

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -30,7 +30,7 @@ class UserConfirmationsController < DeviseController
 
   protected
 
-  def after_confirmation_path_for(_resource)
+  def after_confirmation_path_for(resource)
     result =
       if resource.errors.empty?
         'confirmed'

--- a/app/controllers/user_registrations_controller.rb
+++ b/app/controllers/user_registrations_controller.rb
@@ -6,6 +6,7 @@ class UserRegistrationsController < Spree::UserRegistrationsController
     @user = build_resource(params[:spree_user])
     if resource.save
       session[:spree_user_signup] = true
+      session[:confirmation_return_url] = params[:return_url]
       associate_user
 
       respond_to do |format|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,8 @@ en:
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       failed_to_send: "An error occurred whilst sending your confirmation email."
       resend_confirmation_email: "Resend confirmation email."
+      confirmed: "Thanks for confirming your email! You can now sign in."
+      not_confirmed: "Your email address could not be confirmed. Perhaps you have already completed this step?"
     user_registrations:
       spree_user:
        signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."
@@ -107,12 +109,6 @@ en:
         Invalid email or password.
         Were you a guest last time?  Perhaps you need to create an account or reset your password.
       unconfirmed: "You have to confirm your account before continuing."
-    enterprise_confirmations:
-      enterprise:
-        confirmed: Thank you, your email address has been confirmed.
-        not_confirmed: Your email address could not be confirmed. Perhaps you have already completed this step?
-        confirmation_sent: "Confirmation email sent!"
-        confirmation_not_sent: "Could not send a confirmation email."
   enterprise_mailer:
     confirmation_instructions:
       subject: "Please confirm the email address for %{enterprise}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,7 @@ en:
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       failed_to_send: "An error occurred whilst sending your confirmation email."
       resend_confirmation_email: "Resend confirmation email."
-      confirmed: "Thanks for confirming your email! You can now sign in."
+      confirmed: "Thanks for confirming your email! You can now log in."
       not_confirmed: "Your email address could not be confirmed. Perhaps you have already completed this step?"
     user_registrations:
       spree_user:

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -20,21 +20,25 @@ describe UserConfirmationsController, type: :controller do
       end
 
       it "redirects the user to login" do
-        expect(response).to redirect_to login_path
-        expect(flash[:error]).to eq I18n.t('devise.user_confirmations.spree_user.not_confirmed')
+        expect(response).to redirect_to login_path(confirmation: 'not_confirmed')
       end
     end
 
     context "that has not been confirmed" do
       it "redirects the user to login" do
         spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
-        expect(response).to redirect_to login_path
-        expect(flash[:success]).to eq I18n.t('devise.user_confirmations.spree_user.confirmed')
+        expect(response).to redirect_to login_path(confirmation: 'confirmed')
       end
 
       it "confirms the user" do
         spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
         expect(unconfirmed_user.reload.confirmed_at).not_to eq(nil)
+      end
+
+      it "redirects to previous url" do
+        session[:confirmation_return_url] = producers_path + '#/login'
+        spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
+        expect(response).to redirect_to producers_path + '#/login?confirmation=confirmed'
       end
     end
   end

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -20,14 +20,14 @@ describe UserConfirmationsController, type: :controller do
       end
 
       it "redirects the user to login" do
-        expect(response).to redirect_to login_path(confirmation: 'not_confirmed')
+        expect(response).to redirect_to login_path(validation: 'not_confirmed')
       end
     end
 
     context "that has not been confirmed" do
       it "redirects the user to login" do
         spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
-        expect(response).to redirect_to login_path(confirmation: 'confirmed')
+        expect(response).to redirect_to login_path(validation: 'confirmed')
       end
 
       it "confirms the user" do
@@ -38,7 +38,13 @@ describe UserConfirmationsController, type: :controller do
       it "redirects to previous url" do
         session[:confirmation_return_url] = producers_path + '#/login'
         spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
-        expect(response).to redirect_to producers_path + '#/login?confirmation=confirmed'
+        expect(response).to redirect_to producers_path + '#/login?validation=confirmed'
+      end
+
+      it "redirects to previous url on /register path" do
+        session[:confirmation_return_url] = registration_path + '#/signup?after_login=%2Fregister'
+        spree_get :show, confirmation_token: unconfirmed_user.confirmation_token
+        expect(response).to redirect_to registration_path + '#/signup?after_login=%2Fregister&validation=confirmed'
       end
     end
   end

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -78,10 +78,12 @@ feature "Authentication", js: true, retry: 3 do
             fill_in "Email", with: "test@foo.com"
             fill_in "Choose a password", with: "test12345"
             fill_in "Confirm password", with: "test12345"
+
             expect do
               click_signup_button
-              page.should have_content I18n.t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
+              expect(page).to have_content I18n.t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
             end.to enqueue_job Delayed::PerformableMethod
+
             expect(Delayed::Job.last.payload_object.method_name).to eq(:send_on_create_confirmation_instructions_without_delay)
           end
         end
@@ -117,6 +119,14 @@ feature "Authentication", js: true, retry: 3 do
           open_login_modal
           page.should have_login_modal
         end
+      end
+    end
+
+    describe "after following email confirmation link" do
+      scenario "shows confirmed message in modal" do
+        visit '/#/login?confirmation=confirmed'
+        expect(page).to have_login_modal
+        expect(page).to have_content I18n.t('devise.confirmations.confirmed')
       end
     end
 

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -124,7 +124,7 @@ feature "Authentication", js: true, retry: 3 do
 
     describe "after following email confirmation link" do
       scenario "shows confirmed message in modal" do
-        visit '/#/login?confirmation=confirmed'
+        visit '/#/login?validation=confirmed'
         expect(page).to have_login_modal
         expect(page).to have_content I18n.t('devise.confirmations.confirmed')
       end


### PR DESCRIPTION
#### What? Why?

Closes #1586 

Redirects user to previous url when clicking email confirmation link. Displays message in login modal to show user has been confirmed and can now log in.

#### What should we test?

User signup confirmation process.
