### PR TITLE
Bump ref for ofn-qz

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem 'jquery-rails'
 gem 'jquery-migrate-rails'
 gem 'css_splitter'
 
-gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz'
+gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c'
 
 group :test, :development do
   # Pretty printed test output

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/ofn-qz.git
-  revision: 024680ccea429b2e5428d7b964fa67c52add34ec
+  revision: 60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c
+  ref: 60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c
   specs:
     ofn-qz (0.1.0)
       railties (~> 3.1)


### PR DESCRIPTION
#### What? Why?
I am having trouble building branches from my fork of openfoodnetwork in Travis. Bundler keeps complaining that the gemspec for `ofn-qz` is invalid because the URI of the homepage is not a valid URI. So I fixed it, and bumped to reference here.

Example: https://travis-ci.org/oeoeaio/openfoodnetwork/jobs/343162327

#### What should we test?
Nothing to test, as long as it builds, it should be ok.
