### PR TITLE
Subs: A dedicated review page for wizard

### DIFF
--- a/app/assets/javascripts/admin/enterprises/services/enterprise_payment_methods.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/services/enterprise_payment_methods.js.coffee
@@ -1,7 +1,7 @@
 angular.module("admin.enterprises")
   .factory "EnterprisePaymentMethods", (enterprise, PaymentMethods) ->
     new class EnterprisePaymentMethods
-      paymentMethods: PaymentMethods.paymentMethods
+      paymentMethods: PaymentMethods.all
 
       constructor: ->
         for payment_method in @paymentMethods

--- a/app/assets/javascripts/admin/enterprises/services/enterprise_shipping_methods.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/services/enterprise_shipping_methods.js.coffee
@@ -1,7 +1,7 @@
 angular.module("admin.enterprises")
   .factory "EnterpriseShippingMethods", (enterprise, ShippingMethods) ->
     new class EnterpriseShippingMethods
-      shippingMethods: ShippingMethods.shippingMethods
+      shippingMethods: ShippingMethods.all
 
       constructor: ->
         for shipping_method in @shippingMethods

--- a/app/assets/javascripts/admin/resources/services/customers.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/customers.js.coffee
@@ -1,8 +1,12 @@
-angular.module("admin.resources").factory "Customers", ($q, InfoDialog, RequestMonitor, CustomerResource) ->
+angular.module("admin.resources").factory "Customers", ($q, $injector, InfoDialog, RequestMonitor, CustomerResource) ->
   new class Customers
     all: []
     byID: {}
     pristineByID: {}
+
+    constructor: ->
+      if $injector.has('customers')
+        @load($injector.get('customers'))
 
     add: (params) ->
       CustomerResource.create params, (customer) =>

--- a/app/assets/javascripts/admin/resources/services/payment_methods.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/payment_methods.js.coffee
@@ -1,7 +1,7 @@
 angular.module("admin.resources")
   .factory "PaymentMethods", ($injector) ->
     new class PaymentMethods
-      paymentMethods: []
+      all: []
       byID: {}
       pristineByID: {}
 
@@ -11,6 +11,6 @@ angular.module("admin.resources")
 
       load: (paymentMethods) ->
         for paymentMethod in paymentMethods
-          @paymentMethods.push paymentMethod
+          @all.push paymentMethod
           @byID[paymentMethod.id] = paymentMethod
           @pristineByID[paymentMethod.id] = angular.copy(paymentMethod)

--- a/app/assets/javascripts/admin/resources/services/schedules.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/schedules.js.coffee
@@ -1,6 +1,6 @@
 angular.module("admin.resources").factory "Schedules", ($q, $injector, RequestMonitor, ScheduleResource, OrderCycles, Dereferencer, StatusMessage) ->
   new class Schedules
-    # all: []
+    all: []
     byID: {}
 
     constructor: ->
@@ -9,7 +9,7 @@ angular.module("admin.resources").factory "Schedules", ($q, $injector, RequestMo
 
     load: (schedules) ->
       for schedule in schedules
-        # @all.push schedule
+        @all.push schedule
         @byID[schedule.id] = schedule
 
     add: (params) =>

--- a/app/assets/javascripts/admin/resources/services/shipping_methods.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/shipping_methods.js.coffee
@@ -1,7 +1,7 @@
 angular.module("admin.resources")
   .factory "ShippingMethods", ($injector) ->
     new class ShippingMethods
-      shippingMethods: []
+      all: []
       byID: {}
       pristineByID: {}
 
@@ -11,6 +11,6 @@ angular.module("admin.resources")
 
       load: (shippingMethods) ->
         for shippingMethod in shippingMethods
-          @shippingMethods.push shippingMethod
+          @all.push shippingMethod
           @byID[shippingMethod.id] = shippingMethod
           @pristineByID[shippingMethod.id] = angular.copy(shippingMethod)

--- a/app/assets/javascripts/admin/subscriptions/controllers/review_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/review_controller.js.coffee
@@ -1,0 +1,8 @@
+angular.module("admin.subscriptions").controller "ReviewController", ($scope, Customers, Schedules, PaymentMethods, ShippingMethods) ->
+  $scope.formatAddress = (a) ->
+    formatted = []
+    formatted.push "#{a.firstname} #{a.lastname}"
+    formatted.push a.address1
+    formatted.push a.city
+    formatted.push a.zipcode
+    formatted.join(", ")

--- a/app/assets/javascripts/admin/subscriptions/controllers/subscription_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/subscription_controller.js.coffee
@@ -1,11 +1,11 @@
-angular.module("admin.subscriptions").controller "SubscriptionController", ($scope, Subscription, SubscriptionForm, customers, schedules, paymentMethods, shippingMethods) ->
+angular.module("admin.subscriptions").controller "SubscriptionController", ($scope, Subscription, SubscriptionForm, Customers, Schedules, PaymentMethods, ShippingMethods) ->
   $scope.subscription = new Subscription()
   $scope.errors = null
   $scope.save = null
-  $scope.customers = customers
-  $scope.schedules = schedules
-  $scope.paymentMethods = paymentMethods
-  $scope.shippingMethods = shippingMethods
+  $scope.customers = Customers.all
+  $scope.schedules = Schedules.all
+  $scope.paymentMethods = PaymentMethods.all
+  $scope.shippingMethods = ShippingMethods.all
   $scope.distributor_id = $scope.subscription.shop_id # variant selector requires distributor_id
   $scope.view = if $scope.subscription.id? then 'review' else 'details'
   $scope.nextCallbacks = {}

--- a/app/assets/javascripts/admin/subscriptions/controllers/subscription_line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/subscription_line_items_controller.js.coffee
@@ -22,12 +22,3 @@ angular.module("admin.subscriptions").controller "SubscriptionLineItemsControlle
       sli.variant_id == $scope.newItem.variant_id
     return matching[0] if matching.length > 0
     null
-
-  $scope.estimatedSubtotal = ->
-    $scope.subscription.subscription_line_items.reduce (subtotal, item) ->
-      return subtotal if item._destroy
-      subtotal += item.price_estimate * item.quantity
-    , 0
-
-  $scope.estimatedTotal = ->
-    $scope.estimatedSubtotal()

--- a/app/assets/javascripts/admin/subscriptions/services/subscription_actions.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/services/subscription_actions.js.coffee
@@ -1,4 +1,7 @@
-angular.module("admin.subscriptions").factory 'SubscriptionPrototype', ($http, $injector, $q, InfoDialog, ConfirmDialog) ->
+# Wrapper for actions provided by ngResource
+# Used to extend the prototype of the subscription resource created by SubscriptionResource
+
+angular.module("admin.subscriptions").factory 'SubscriptionActions', ($http, $injector, $q, InfoDialog, ConfirmDialog) ->
   buildItem: (item) ->
     return false unless item.variant_id > 0
     return false unless item.quantity > 0

--- a/app/assets/javascripts/admin/subscriptions/services/subscription_functions.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/services/subscription_functions.js.coffee
@@ -1,0 +1,12 @@
+# Provides additional auxillary functions to instances of SubsciptionResource
+# Used to extend the prototype of the subscription resource created by SubscriptionResource
+
+angular.module("admin.subscriptions").factory 'SubscriptionFunctions', ->
+  estimatedSubtotal: ->
+    @subscription_line_items.reduce (subtotal, item) ->
+      return subtotal if item._destroy
+      subtotal += item.price_estimate * item.quantity
+    , 0
+
+  estimatedTotal: ->
+    @estimatedSubtotal()

--- a/app/assets/javascripts/admin/subscriptions/services/subscription_functions.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/services/subscription_functions.js.coffee
@@ -1,7 +1,7 @@
-# Provides additional auxillary functions to instances of SubsciptionResource
-# Used to extend the prototype of the subscription resource created by SubscriptionResource
+# Provides additional auxillary functions to instances of SubscriptionResource
+# Used to extend the extend the protype of the subscription resource created by SubscriptionResource
 
-angular.module("admin.subscriptions").factory 'SubscriptionFunctions', ->
+angular.module("admin.subscriptions").factory 'SubscriptionFunctions', ($injector) ->
   estimatedSubtotal: ->
     @subscription_line_items.reduce (subtotal, item) ->
       return subtotal if item._destroy
@@ -10,3 +10,23 @@ angular.module("admin.subscriptions").factory 'SubscriptionFunctions', ->
 
   estimatedTotal: ->
     @estimatedSubtotal()
+
+  customer: ->
+    return unless @customer_id
+    return unless $injector.has('Customers')
+    $injector.get('Customers').byID[@customer_id]
+
+  schedule: ->
+    return unless @schedule_id
+    return unless $injector.has('Schedules')
+    $injector.get('Schedules').byID[@schedule_id]
+
+  paymentMethod: ->
+    return unless @payment_method_id
+    return unless $injector.has('PaymentMethods')
+    $injector.get('PaymentMethods').byID[@payment_method_id]
+
+  shippingMethod: ->
+    return unless @shipping_method_id
+    return unless $injector.has('ShippingMethods')
+    $injector.get('ShippingMethods').byID[@shipping_method_id]

--- a/app/assets/javascripts/admin/subscriptions/services/subscription_resource.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/services/subscription_resource.js.coffee
@@ -1,4 +1,4 @@
-angular.module("admin.subscriptions").factory 'SubscriptionResource', ($resource, SubscriptionPrototype) ->
+angular.module("admin.subscriptions").factory 'SubscriptionResource', ($resource, SubscriptionActions) ->
   resource = $resource('/admin/subscriptions/:id/:action.json', {}, {
     'index':
       method: 'GET'
@@ -26,6 +26,6 @@ angular.module("admin.subscriptions").factory 'SubscriptionResource', ($resource
         action: 'unpause'
   })
 
-  angular.extend(resource.prototype, SubscriptionPrototype)
+  angular.extend(resource.prototype, SubscriptionActions)
 
   resource

--- a/app/assets/javascripts/admin/subscriptions/services/subscription_resource.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/services/subscription_resource.js.coffee
@@ -1,4 +1,4 @@
-angular.module("admin.subscriptions").factory 'SubscriptionResource', ($resource, SubscriptionActions) ->
+angular.module("admin.subscriptions").factory 'SubscriptionResource', ($resource, SubscriptionActions, SubscriptionFunctions) ->
   resource = $resource('/admin/subscriptions/:id/:action.json', {}, {
     'index':
       method: 'GET'
@@ -27,5 +27,6 @@ angular.module("admin.subscriptions").factory 'SubscriptionResource', ($resource
   })
 
   angular.extend(resource.prototype, SubscriptionActions)
+  angular.extend(resource.prototype, SubscriptionFunctions)
 
   resource

--- a/app/views/admin/subscriptions/_autocomplete.html.haml
+++ b/app/views/admin/subscriptions/_autocomplete.html.haml
@@ -8,7 +8,7 @@
       %tr
         %td{ style: "vertical-align:top" }
           .field
-            = label_tag :add_product_name, t(:name_or_sku)
+            = label_tag :add_variant_id, t(:name_or_sku)
             %input#add_variant_id.variant_autocomplete.fullwidth{ type: 'number', ng: { model: 'newItem.variant_id' } }
         %td{ style: "vertical-align:top" }
           .field

--- a/app/views/admin/subscriptions/_form.html.haml
+++ b/app/views/admin/subscriptions/_form.html.haml
@@ -1,20 +1,27 @@
 %form.margin-bottom-50{ name: 'subscription_form', novalidate: true, ng: { submit: 'save()' } }
   %save-bar{ persist: 'true' }
-    %a.button{ href: main_app.admin_subscriptions_path, ng: { show: "['details','review'].indexOf(view) >= 0", bind: "subscription.id? '#{t(:close)}' : '#{t(:cancel)}'" } }
-    %input{ type: "button", value: t(:back), ng: { click: 'back()', show: '!!backCallbacks[view]'} }
-    %input.red{ type: "button", value: t(:next), ng: { click: 'next()', show: '!!nextCallbacks[view]' } }
-    %input.red{ type: "submit", value: t('admin.subscriptions.create'), ng: { show: "view=='review' && !subscription.id" } }
-    %input.red{ type: "submit", value: t(:save_changes), ng: { show: "view=='review' && subscription.id", disabled: 'subscription_form.$pristine' } }
+    %div{ ng: { hide: 'subscription.id' } }
+      %a.button{ href: main_app.admin_subscriptions_path, ng: { show: "['details','review'].indexOf(view) >= 0" } }= t(:cancel)
+      %input{ type: "button", value: t(:back), ng: { click: 'back()', show: '!!backCallbacks[view]'} }
+      %input.red{ type: "button", value: t(:next), ng: { click: 'next()', show: '!!nextCallbacks[view]' } }
+      %input.red{ type: "submit", value: t('admin.subscriptions.create'), ng: { show: "view == 'review'" } }
+    %div{ ng: { show: 'subscription.id' } }
+      %a.button{ href: main_app.admin_subscriptions_path }= t(:close)
+      %input.red{ type: "button", value: t(:review), ng: { click: "setView('review')", show: "view != 'review'" } }
+      %input.red{ type: "submit", value: t(:save_changes), ng: { disabled: 'subscription_form.$pristine' } }
 
-  .details{ ng: { show: "['details','review'].indexOf(view) >= 0" } }
+  .details{ ng: { show: "view == 'details'" } }
     %ng-form{ name: 'subscription_details_form', ng: { controller: 'DetailsController' } }
       = render 'details'
 
-  .address{ ng: { show: "['address','review'].indexOf(view) >= 0" } }
+  .address{ ng: { show: "view == 'address'" } }
     %ng-form{ name: 'subscription_address_form', ng: { controller: 'AddressController' } }
       = render 'address'
 
-  .products{ ng: { show: "['products','review'].indexOf(view) >= 0" } }
+  .products{ ng: { show: "view == 'products'" } }
     %ng-form{ name: 'subscription_products_form', ng: { controller: 'ProductsController' } }
     = render :partial => "spree/admin/variants/autocomplete", :formats => :js
     = render 'products'
+
+  .review{ ng: { show: "view == 'review'", controller: 'ReviewController' } }
+    = render 'review'

--- a/app/views/admin/subscriptions/_review.html.haml
+++ b/app/views/admin/subscriptions/_review.html.haml
@@ -1,0 +1,93 @@
+%fieldset.no-border-bottom
+  %legend{ align: 'center'}= t("admin.subscriptions.form.review")
+  .row
+    .eight.columns.alpha
+      .row
+        .six.columns.alpha
+          %h3= t('.details')
+        .two.columns.omega.text-right
+          %input#edit-details{ type: "button", value: t(:edit), ng: { click: "setView('details')" } }
+      .row
+        .three.columns.alpha
+          %strong= t('admin.customer')
+        .five.columns.omega {{ subscription.customer().email }}
+      .row
+        .three.columns.alpha
+          %strong= t('admin.schedule')
+        .five.columns.omega {{ subscription.schedule().name }}
+      .row
+        .three.columns.alpha
+          %strong= t('admin.payment_method')
+        .five.columns.omega {{ subscription.paymentMethod().name }}
+      .row
+        .three.columns.alpha
+          %strong= t('admin.shipping_method')
+        .five.columns.omega {{ subscription.shippingMethod().name }}
+      .row
+        .three.columns.alpha
+          %strong= t('admin.begins_at')
+        .five.columns.omega {{ subscription.begins_at }}
+      .row.margin-bottom-30
+        .three.columns.alpha
+          %strong= t('admin.ends_at')
+        .five.columns.omega {{ subscription.ends_at || ('ongoing' | t) }}
+      .row
+        .six.columns.alpha
+          %h3= t('.address')
+        .two.columns.omega.text-right
+          %input#edit-address{ type: "button", value: t(:edit), ng: { click: "setView('address')" } }
+      .row
+        .three.columns.alpha
+          %strong= t('admin.bill_address')
+        .five.columns.omega {{ formatAddress(subscription.bill_address) }}
+      .row
+        .three.columns.alpha
+          %strong= t('admin.ship_address')
+        .five.columns.omega {{ formatAddress(subscription.ship_address) }}
+
+    .one.column
+      &nbsp;
+
+    .seven.columns.omega
+      .row
+        .five.columns.alpha
+          %h3= t('.products')
+        .two.columns.omega.text-right
+          %input#edit-products{ type: "button", value: t(:edit), ng: { click: "setView('products')" } }
+      .row
+        .seven.columns.alpha.omega
+          %table#subscription-line-items
+            %colgroup
+              %col{:style => "width: 62%;"}/
+              %col{:style => "width: 14%;"}/
+              %col{:style => "width: 10%;"}/
+              %col{:style => "width: 14%;"}/
+            %thead
+              %tr
+                %th= t(:item_description)
+                %th.price= t(:price)
+                %th.quantity= t(:qty)
+                %th.total
+                  %span= t(:total)
+            %tbody
+              %tr.item{ id: "sli_{{$index}}", ng: { repeat: "item in subscription.subscription_line_items | filter:{ _destroy: '!true' }", class: { even: 'even', odd: 'odd' } } }
+                %td.description {{ item.description }}
+                %td.price.align-center {{ item.price_estimate | currency }}
+                %td.quantity {{ item.quantity }}
+                %td.total.align-center {{ (item.price_estimate * item.quantity) | currency }}
+            %tbody#subtotal.no-border-top{"data-hook" => "admin_order_form_subtotal"}
+              %tr#subtotal-row
+                %td{:colspan => "3"}
+                  %b
+                    = t(:subtotal)
+                    \:
+                %td.total.align-center
+                  %span {{ subscription.estimatedSubtotal() | currency }}
+            %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
+              %tr
+                %td{:colspan => "3"}
+                  %b
+                    = t(:order_total_price)
+                    \:
+                %td.total.align-center
+                  %span#order_form_total {{ subscription.estimatedTotal() | currency }}

--- a/app/views/admin/subscriptions/_subscription_line_items.html.haml
+++ b/app/views/admin/subscriptions/_subscription_line_items.html.haml
@@ -29,7 +29,7 @@
           = t(:subtotal)
           \:
       %td.total.align-center
-        %span {{ estimatedSubtotal() | currency }}
+        %span {{ subscription.estimatedSubtotal() | currency }}
       %td.actions
   %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
     %tr
@@ -38,5 +38,5 @@
           = t(:order_total_price)
           \:
       %td.total.align-center
-        %span#order_form_total {{ estimatedTotal() | currency }}
+        %span#order_form_total {{ subscription.estimatedTotal() | currency }}
       %td.actions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,6 +912,10 @@ en:
         no_cards_available: No cards available
       loading_flash:
         loading: LOADING SUBSCRIPTIONS
+      review:
+        details: Details
+        address: Address
+        products: Products
       product_already_in_order: This product has already been added to the order. Please edit the quantity directly.
       orders:
         number: Number

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -211,18 +211,20 @@ feature 'Subscriptions' do
           expect(page).to have_selector 'td.total', text: "$27.50"
         end
 
-        click_button('Next')
-
         # Deleting the existing product
         within 'table#subscription-line-items tr.item', match: :first do
           find("a.delete-item").click
         end
+
+        click_button('Next')
 
         # Attempting to submit without a product
         expect{
           click_button('Create Subscription')
           expect(page).to have_content 'Please add at least one product'
         }.to_not change(Subscription, :count)
+
+        click_button('edit-products')
 
         # Adding a new product
         select2_search product2.name, from: I18n.t(:name_or_sku), dropdown_css: '.select2-drop'
@@ -235,6 +237,8 @@ feature 'Subscriptions' do
           expect(page).to have_selector 'td.total', text: "$23.25"
         end
 
+        click_button('Next')
+
         expect{
           click_button('Create Subscription')
           expect(page).to have_content 'Saved'
@@ -244,7 +248,7 @@ feature 'Subscriptions' do
         within 'table#subscription-line-items tr.item', match: :first do
           expect(page).to have_selector 'td.description', text: "#{product2.name} - #{variant2.full_name}"
           expect(page).to have_selector 'td.price', text: "$7.75"
-          expect(page).to have_input 'quantity', with: "3"
+          expect(page).to have_selector 'td.quantity', text: "3"
           expect(page).to have_selector 'td.total', text: "$23.25"
         end
 
@@ -296,10 +300,13 @@ feature 'Subscriptions' do
           visit edit_admin_subscription_path(subscription)
 
           # Customer and Schedule cannot be edited
+          click_button 'edit-details'
           expect(page).to have_selector '#s2id_customer_id.select2-container-disabled'
           expect(page).to have_selector '#s2id_schedule_id.select2-container-disabled'
+          click_button 'Review'
 
           # Existing products should be visible
+          click_button 'edit-products'
           within "#sli_0" do
             expect(page).to have_selector 'td.description', text: "#{product1.name} - #{variant1.full_name}"
             expect(page).to have_selector 'td.price', text: "$13.75"
@@ -369,6 +376,7 @@ feature 'Subscriptions' do
 
           it "reports issues encountered during the update" do
             visit edit_admin_subscription_path(subscription)
+            click_button 'edit-products'
 
             within "#sli_0" do
               fill_in 'quantity', with: "1"

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -201,7 +201,7 @@ feature 'Subscriptions' do
         expect(page).to have_content 'Please add at least one product'
 
         # Adding a product and getting a price estimate
-        targetted_select2_search product1.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+        select2_search product1.name, from: I18n.t(:name_or_sku), dropdown_css: '.select2-drop'
         fill_in 'add_quantity', with: 2
         click_link 'Add'
         within 'table#subscription-line-items tr.item', match: :first do
@@ -225,7 +225,7 @@ feature 'Subscriptions' do
         }.to_not change(Subscription, :count)
 
         # Adding a new product
-        targetted_select2_search product2.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+        select2_search product2.name, from: I18n.t(:name_or_sku), dropdown_css: '.select2-drop'
         fill_in 'add_quantity', with: 3
         click_link 'Add'
         within 'table#subscription-line-items tr.item', match: :first do
@@ -315,7 +315,7 @@ feature 'Subscriptions' do
           expect(page).to have_content 'Please add at least one product'
 
           # Add variant2 to the subscription
-          targetted_select2_search product2.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+          select2_search product2.name, from: I18n.t(:name_or_sku), dropdown_css: '.select2-drop'
           fill_in 'add_quantity', with: 1
           click_link 'Add'
           within "#sli_0" do
@@ -329,7 +329,7 @@ feature 'Subscriptions' do
           expect(page).to have_selector '#order_form_total', text: "$7.75"
 
           # Add variant3 to the subscription (even though it is not available)
-          targetted_select2_search product3.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+          select2_search product3.name, from: I18n.t(:name_or_sku), dropdown_css: '.select2-drop'
           fill_in 'add_quantity', with: 1
           click_link 'Add'
           within "#sli_1" do

--- a/spec/javascripts/unit/admin/enterprises/services/enterprise_payment_methods_spec.js.coffee
+++ b/spec/javascripts/unit/admin/enterprises/services/enterprise_payment_methods_spec.js.coffee
@@ -7,7 +7,7 @@ describe "EnterprisePaymentMethods service", ->
     enterprise =
       payment_method_ids: [ 1, 3 ]
     PaymentMethods =
-        paymentMethods: [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 } ]
+        all: [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 } ]
 
     module 'admin.enterprises'
     module ($provide) ->
@@ -20,10 +20,10 @@ describe "EnterprisePaymentMethods service", ->
 
   describe "selecting payment methods", ->
     it "sets the selected property of each payment method", ->
-      expect(PaymentMethods.paymentMethods[0].selected).toBe true
-      expect(PaymentMethods.paymentMethods[1].selected).toBe false
-      expect(PaymentMethods.paymentMethods[2].selected).toBe true
-      expect(PaymentMethods.paymentMethods[3].selected).toBe false
+      expect(PaymentMethods.all[0].selected).toBe true
+      expect(PaymentMethods.all[1].selected).toBe false
+      expect(PaymentMethods.all[2].selected).toBe true
+      expect(PaymentMethods.all[3].selected).toBe false
 
   describe "determining payment method colour", ->
     it "returns 'blue' when at least one payment method is selected", ->

--- a/spec/javascripts/unit/admin/enterprises/services/enterprise_shipping_methods_spec.js.coffee
+++ b/spec/javascripts/unit/admin/enterprises/services/enterprise_shipping_methods_spec.js.coffee
@@ -7,7 +7,7 @@ describe "EnterpriseShippingMethods service", ->
     enterprise =
       shipping_method_ids: [ 1, 3 ]
     ShippingMethods =
-        shippingMethods: [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 } ]
+        all: [ { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 } ]
 
     module 'admin.enterprises'
     module ($provide) ->
@@ -20,10 +20,10 @@ describe "EnterpriseShippingMethods service", ->
 
   describe "selecting shipping methods", ->
     it "sets the selected property of each shipping method", ->
-      expect(ShippingMethods.shippingMethods[0].selected).toBe true
-      expect(ShippingMethods.shippingMethods[1].selected).toBe false
-      expect(ShippingMethods.shippingMethods[2].selected).toBe true
-      expect(ShippingMethods.shippingMethods[3].selected).toBe false
+      expect(ShippingMethods.all[0].selected).toBe true
+      expect(ShippingMethods.all[1].selected).toBe false
+      expect(ShippingMethods.all[2].selected).toBe true
+      expect(ShippingMethods.all[3].selected).toBe false
 
   describe "determining shipping method colour", ->
     it "returns 'blue' when at least one shipping method is selected", ->

--- a/spec/javascripts/unit/admin/subscriptions/services/subscription_functions_spec.js.coffee
+++ b/spec/javascripts/unit/admin/subscriptions/services/subscription_functions_spec.js.coffee
@@ -1,0 +1,64 @@
+describe "SubscriptionFunctions", ->
+  subscription = null
+
+  beforeEach ->
+    module 'admin.subscriptions'
+    module ($provide) ->
+      $provide.value 'Customers', { byID: { 1: 'customer1' } }
+      $provide.value 'Schedules', { byID: { 2: 'schedule2' } }
+      $provide.value 'PaymentMethods', { byID: { 3: 'payment method 3' } }
+      $provide.value 'ShippingMethods', { byID: { 4: 'shipping method 4' } }
+      null
+
+    inject ($injector, SubscriptionFunctions) ->
+      class Subscription
+      angular.extend(Subscription.prototype, SubscriptionFunctions)
+      subscription = new Subscription
+
+  describe "#customer", ->
+    describe "when the id is not set", ->
+      it "returns null", ->
+        expect(subscription.customer()).toBeUndefined()
+
+    describe "when the customer_id is set", ->
+      beforeEach ->
+        subscription.customer_id = 1
+
+      it "looks up the customer from the Customers service", ->
+        expect(subscription.customer()).toEqual 'customer1'
+
+  describe "#schedule", ->
+    describe "when the id is not set", ->
+      it "returns null", ->
+        expect(subscription.schedule()).toBeUndefined()
+
+    describe "when the schedule_id is set", ->
+      beforeEach ->
+        subscription.schedule_id = 2
+
+      it "looks up the schedule from the Schedules service", ->
+        expect(subscription.schedule()).toEqual 'schedule2'
+
+  describe "#paymentMethod", ->
+    describe "when the id is not set", ->
+      it "returns null", ->
+        expect(subscription.paymentMethod()).toBeUndefined()
+
+    describe "when the payment_method_id is set", ->
+      beforeEach ->
+        subscription.payment_method_id = 3
+
+      it "looks up the payment_method from the PaymentMethods service", ->
+        expect(subscription.paymentMethod()).toEqual 'payment method 3'
+
+  describe "#shippingMethod", ->
+    describe "when the id is not set", ->
+      it "returns null", ->
+        expect(subscription.shippingMethod()).toBeUndefined()
+
+    describe "when the shipping_method_id is set", ->
+      beforeEach ->
+        subscription.shipping_method_id = 4
+
+      it "looks up the shipping_method from the ShippingMethods service", ->
+        expect(subscription.shippingMethod()).toEqual 'shipping method 4'


### PR DESCRIPTION
#### What? Why?
The wizard that is used by enterprise users to create new subscriptions has a `Review` step, that currently just shows all of the previous form elements on a single page, making for a fairly average UX. This PR replaces that view with a dedicated review view, making for a much nicer summary at the end of the wizard.

#### What should we test?

The subscription wizard feature should still make sense when creating and editing subscriptions. In particular the buttons that allow navigation backwards and forwards through the wizard should be logical and intuitive.

#### Release notes

This feature has not been released yet and so this will just be a part of the !!!SUBSCRIPTIONS!!! release notes.
