### PR TITLE
Subs: translation keys

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/controllers/order_update_issues_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/order_update_issues_controller.js.coffee
@@ -6,5 +6,5 @@ angular.module("admin.subscriptions").controller "OrderUpdateIssuesController", 
 
   $scope.orderCycleCloses = (id) ->
     closes_at = moment(OrderCycles.byID[id].orders_close_at)
-    text = if closes_at > moment() then t('closes') else t('closed')
+    text = if closes_at > moment() then t('js.closes') else t('js.closed')
     "#{text} #{closes_at.fromNow()}"

--- a/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
@@ -14,7 +14,7 @@ angular.module("admin.subscriptions").controller "OrdersPanelController", ($scop
 
   $scope.orderCycleCloses = (id) ->
     closes_at = moment(OrderCycles.byID[id].orders_close_at)
-    text = if closes_at > moment() then t('closes') else t('closed')
+    text = if closes_at > moment() then t('js.closes') else t('js.closed')
     "#{text} #{closes_at.fromNow()}"
 
   $scope.stateText = (state) -> t("spree.order_state.#{state}")

--- a/app/assets/javascripts/admin/subscriptions/directives/confirm_order_edit.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/directives/confirm_order_edit.js.coffee
@@ -5,5 +5,5 @@ angular.module("admin.subscriptions").directive "confirmOrderEdit", (ConfirmDial
     element.bind "click", (event) ->
       unless scope.proxyOrder.order_id?
         event.preventDefault()
-        ConfirmDialog.open('error', t('admin.subscriptions.orders.confirm_edit'), {confirm: t('yes_i_am_sure')}).then ->
+        ConfirmDialog.open('error', t('admin.subscriptions.orders.confirm_edit'), {confirm: t('admin.subscriptions.yes_i_am_sure')}).then ->
           $window.open(attrs.href)

--- a/app/views/admin/subscriptions/_loading_flash.html.haml
+++ b/app/views/admin/subscriptions/_loading_flash.html.haml
@@ -1,3 +1,3 @@
 %div.sixteen.columns.alpha.omega#loading{ ng: { cloak: true, if: 'shop_id && RequestMonitor.loading' } }
   %img.spinner{ src: "/assets/spinning-circles.svg" }
-  %h1 LOADING STANDING ORDERS
+  %h1= t('.loading')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -910,6 +910,8 @@ en:
         allowed_payment_method_types_tip: Only Cash and Stripe payment methods may be used at the moment
         credit_card: Credit Card
         no_cards_available: No cards available
+      loading_flash:
+        loading: LOADING SUBSCRIPTIONS
       product_already_in_order: This product has already been added to the order. Please edit the quantity directly.
       orders:
         number: Number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2204,6 +2204,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     choose: Choose
     resolve_errors: Please resolve the following errors
     more_items: "+ %{count} More"
+    closes: closes
+    closed: closed
     admin:
       modals:
         got_it: Got it


### PR DESCRIPTION
#### What? Why?

@sstead picked up a few missing or incorrect translation keys for the subscriptions feature, so I've added them. 

#### What should we test?
See #1061 for details of missing translations ('closes', 'closed' and 'Yes, I'm sure').

The loading flash on the Subscriptions listing should now read "Loading Subscriptions" instead of "Loading Standing Orders". This is also translatable.

#### Release notes
Feature is yet to be released so this does not require its own release notes.
