### PR TITLE
Subs: Only count future orders in subs index order count

### DIFF
--- a/app/views/admin/subscriptions/_table.html.haml
+++ b/app/views/admin/subscriptions/_table.html.haml
@@ -43,7 +43,7 @@
       %td.items.panel-toggle.text-center{ name: 'products', ng: { show: 'columns.items.visible' } }
         %h5{ ng: { bind: 'itemCount(subscription)' } }
       %td.orders.panel-toggle.text-center{ name: 'orders', ng: { show: 'columns.orders.visible' } }
-        %h5{ ng: { bind: 'subscription.not_closed_proxy_orders.length + subscription.closed_proxy_orders.length' } }
+        %h5{ ng: { bind: 'subscription.not_closed_proxy_orders.length' } }
       %td.status.text-center{ ng: { show: 'columns.state.visible' } }
         %span.state{ ng: { class: "subscription.state", bind: "'spree.subscription_state.' + subscription.state | t" } }
       %td.begins_on.text-center{ ng: { show: 'columns.begins_on.visible', bind: '::subscription.begins_at' } }


### PR DESCRIPTION
#### What? Why?

Resolves an issue picked up by @sstead and documented in #1061. The Subscriptions listing page shows the total number of orders associated with a subscription, rather than the number or future orders. This PR resolves that.

#### What should we test?

That the number of orders reported on the subscriptions listing page matches the number of visible orders in the tab when clicked.

#### Release notes

Feature is yet to be released so this does not require its own release notes.