### PR TITLE
Fix incorrect tax on Admin Order Show

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -45,7 +45,7 @@ module CheckoutHelper
 
   def display_checkout_taxes_hash(order)
     order.tax_adjustment_totals.each_with_object(Hash.new) do |(tax_rate, tax_amount), hash|
-      hash[number_to_percentage(tax_rate * 100, :precision => 1)] = Spree::Money.new tax_amount, currency: order.currency
+      hash[number_to_percentage(tax_rate.amount * 100, :precision => 1)] = Spree::Money.new tax_amount, currency: order.currency
     end
   end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -276,10 +276,17 @@ Spree::Order.class_eval do
       tax_rates = adjustment.tax_rates
       tax_rates_hash = Hash[tax_rates.collect do |tax_rate|
         tax_amount = tax_rates.one? ? adjustment.included_tax : tax_rate.compute_tax(adjustment.amount)
-        [tax_rate.amount, tax_amount]
+        [tax_rate, tax_amount]
       end]
       hash.update(tax_rates_hash) { |_tax_rate, amount1, amount2| amount1 + amount2 }
     end
+  end
+
+  def price_adjustment_totals
+    Hash[tax_adjustment_totals.map do |tax_rate, tax_amount|
+      [tax_rate.name,
+       Spree::Money.new(tax_amount, currency: currency)]
+    end]
   end
 
   def has_taxes_included

--- a/lib/open_food_network/sales_tax_report.rb
+++ b/lib/open_food_network/sales_tax_report.rb
@@ -13,7 +13,7 @@ module OpenFoodNetwork
       when "tax_rates"
         [I18n.t(:report_header_order_number),
          I18n.t(:report_header_total_excl_vat, currency_symbol: currency_symbol)] +
-        relevant_rates.map { |rate| "%.1f%% (%s)" % [rate.to_f * 100, currency_symbol] } +
+        relevant_rates.map { |rate| "%.1f%% (%s)" % [rate.amount.to_f * 100, currency_symbol] } +
         [I18n.t(:report_header_total_tax, currency_symbol: currency_symbol),
          I18n.t(:report_header_total_incl_vat, currency_symbol: currency_symbol)]
        else
@@ -66,7 +66,7 @@ module OpenFoodNetwork
 
     def relevant_rates
       return @relevant_rates unless @relevant_rates.nil?
-      @relevant_rates = Spree::TaxRate.pluck(:amount).uniq
+      @relevant_rates = Spree::TaxRate.uniq
     end
 
     def totals_of(line_items)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -295,6 +295,15 @@ FactoryGirl.define do
     distributor { create(:distributor_enterprise) }
   end
 
+  factory :order_with_taxes, parent: :completed_order_with_totals do
+    after(:create) do |order|
+      order.distributor.update_attribute(:charges_sales_tax, true)
+
+      Spree::Zone.global.update_attribute(:default_tax, true)
+      order.line_items.first.product = FactoryGirl.create(:taxed_product, zone: Spree::Zone.global, price: 110.0, tax_rate_amount: 0.1)
+    end
+  end
+
   factory :order_with_credit_payment, parent: :completed_order_with_totals do
     distributor { create(:distributor_enterprise)}
     order_cycle { create(:simple_order_cycle) }

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -215,7 +215,11 @@ feature %q{
         Spree::Config[:enable_receipt_printing?] = true
 
         distributor1.update_attribute(:abn, '12345678')
-        @order = create(:order_with_taxes, distributor: distributor1)
+        @order = create(:order_with_taxes,
+                        distributor: distributor1,
+                        product_price: 110,
+                        tax_rate_amount: 0.1,
+                        tax_rate_name: "Tax 1")
         Spree::TaxRate.adjust(@order)
 
         visit spree.admin_order_path(@order)
@@ -256,10 +260,8 @@ feature %q{
 
       scenario "shows the order taxes" do
         within('table.index tbody#price-adjustments') do
-          @order.price_adjustment_totals.each do |label, total|
-            expect(page).to have_selector "td", match: :first, text: label
-            expect(page).to have_selector "td.total", text: total
-          end
+          expect(page).to have_selector "td", match: :first, text: "Tax 1"
+          expect(page).to have_selector "td.total", text: Spree::Money.new(10)
         end
       end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -308,15 +308,15 @@ describe Spree::Order do
     end
 
     it "contains tax on line_item" do
-      expect(order.tax_adjustment_totals[tax_rate10.amount]).to eq(4.0)
+      expect(order.tax_adjustment_totals[tax_rate10]).to eq(4.0)
     end
 
     it "contains tax on shipping_fee" do
-      expect(order.tax_adjustment_totals[tax_rate15.amount]).to eq(6.0)
+      expect(order.tax_adjustment_totals[tax_rate15]).to eq(6.0)
     end
 
     it "contains tax on enterprise_fee" do
-      expect(order.tax_adjustment_totals[tax_rate20.amount]).to eq(8.0)
+      expect(order.tax_adjustment_totals[tax_rate20]).to eq(8.0)
     end
   end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -323,7 +323,7 @@ describe Spree::Order do
     end
 
     it "contains tax on order adjustment" do
-      order.tax_adjustment_totals[tax_rate25].should == 10.0
+      expect(order.tax_adjustment_totals[tax_rate25]).to eq(10.0)
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #1941 

The Admin Order Show action used Order#price_adjustment_totals to display the amount of taxes. As a Spree method it didn't show taxes on enterprise fees or additional adjustment. I made the Order#tax_adjustment_totals method (which we previously needed for the tax rate report and the invoice2 view) more generic and overrode Order#price_adjustment_totals to make use of it.
I didn't write tests for the new Order#price_adjustment_totals because it's really simple, but wrote more thorough tests for Order#tax_adjustment_totals and feature tests for Admin Order Show view.
I also fixed some old Rspec syntax in this page but I'd understand if you'd prefer it to be in a separate PR (?)

#### What should we test?

What Myriam showed in the issue.

#### Release notes

"Fix VAT decrepency in order management view" ?