### PR TITLE
Subs: take account of overrides

### DIFF
--- a/app/controllers/admin/subscription_line_items_controller.rb
+++ b/app/controllers/admin/subscription_line_items_controller.rb
@@ -13,6 +13,7 @@ module Admin
       @subscription_line_item.assign_attributes(params[:subscription_line_item])
       fee_calculator = OpenFoodNetwork::EnterpriseFeeCalculator.new(@shop, @order_cycle) if @order_cycle
       OpenFoodNetwork::ScopeVariantToHub.new(@shop).scope(@variant)
+      @subscription_line_item.variant = @variant # Ensures override price is used
       render json: @subscription_line_item, serializer: Api::Admin::SubscriptionLineItemSerializer, fee_calculator: fee_calculator
     end
 

--- a/app/models/proxy_order.rb
+++ b/app/models/proxy_order.rb
@@ -1,3 +1,7 @@
+# Each Subscription has many ProxyOrders, one for each OrderCycle to which the Subscription applies
+# Proxy pattern allows for deferral of initialization until absolutely required
+# This reduces the need to keep Orders in sync with their parent Subscriptions
+
 class ProxyOrder < ActiveRecord::Base
   belongs_to :order, class_name: 'Spree::Order', dependent: :destroy
   belongs_to :subscription

--- a/app/services/order_factory.rb
+++ b/app/services/order_factory.rb
@@ -44,15 +44,14 @@ class OrderFactory
       next unless variant = Spree::Variant.find_by_id(li[:variant_id])
       scoper.scope(variant)
       li[:quantity] = stock_limited_quantity(variant.count_on_hand, li[:quantity])
+      li[:price] = variant.price
       build_item_from(li)
     end
   end
 
   def build_item_from(attrs)
     @order.line_items.build(
-      variant_id: attrs[:variant_id],
-      quantity: attrs[:quantity],
-      skip_stock_check: opts[:skip_stock_check]
+      attrs.merge(skip_stock_check: opts[:skip_stock_check])
     )
   end
 

--- a/app/services/order_factory.rb
+++ b/app/services/order_factory.rb
@@ -1,0 +1,71 @@
+# Builds orders based on a set of attributes
+# There are some idiosyncracies in the order creation process,
+# and it is nice to have them dealt with in one place.
+
+class OrderFactory
+  def initialize(attrs, opts = {})
+    @attrs = attrs.with_indifferent_access
+    @opts = opts.with_indifferent_access
+  end
+
+  def create
+    create_order
+    set_user
+    build_line_items
+    set_addresses
+    create_payment
+    @order
+  end
+
+  private
+
+  attr_reader :attrs, :opts
+
+  def customer
+    @customer ||= Customer.find(attrs[:customer_id])
+  end
+
+  def create_order
+    @order = Spree::Order.create!(create_attrs)
+  end
+
+  def create_attrs
+    create_attrs = attrs.slice(:customer_id, :order_cycle_id, :distributor_id, :shipping_method_id)
+    create_attrs[:email] = customer.email
+    create_attrs
+  end
+
+  def build_line_items
+    attrs[:line_items].each do |li|
+      next unless variant = Spree::Variant.find_by_id(li[:variant_id])
+      li[:quantity] = stock_limited_quantity(variant.on_hand, li[:quantity])
+      build_item_from(li)
+    end
+  end
+
+  def build_item_from(attrs)
+    @order.line_items.build(
+      variant_id: attrs[:variant_id],
+      quantity: attrs[:quantity],
+      skip_stock_check: opts[:skip_stock_check]
+    )
+  end
+
+  def set_user
+    @order.update_attribute(:user_id, customer.user_id)
+  end
+
+  def set_addresses
+    @order.update_attributes(attrs.slice(:bill_address_attributes, :ship_address_attributes))
+  end
+
+  def create_payment
+    @order.update_distribution_charge!
+    @order.payments.create(payment_method_id: attrs[:payment_method_id], amount: @order.reload.total)
+  end
+
+  def stock_limited_quantity(stock, requested)
+    return requested if opts[:skip_stock_check]
+    [stock, requested].min
+  end
+end

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -1,11 +1,11 @@
 describe OrderFactory do
-  let(:variant1) { create(:variant) }
-  let(:variant2) { create(:variant) }
+  let(:variant1) { create(:variant, price: 5.0) }
+  let(:variant2) { create(:variant, price: 7.0) }
   let(:user) { create(:user) }
   let(:customer) { create(:customer, user: user) }
   let(:shop) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle) }
-  let(:shipping_method) { create(:shipping_method) }
+  let(:shipping_method) { create(:shipping_method, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 5.0)) }
   let(:payment_method) { create(:payment_method) }
   let(:ship_address) { create(:address) }
   let(:bill_address) { create(:address) }
@@ -40,6 +40,7 @@ describe OrderFactory do
       expect(order.payments.first.payment_method).to eq payment_method
       expect(order.bill_address).to eq bill_address
       expect(order.ship_address).to eq ship_address
+      expect(order.total).to eq 43.0
       expect(order.complete?).to be false
     end
 
@@ -99,6 +100,26 @@ describe OrderFactory do
             expect(order).to be_a Spree::Order
             expect(order.line_items.find_by_variant_id(variant1.id).quantity).to eq 6
           end
+        end
+      end
+    end
+
+    describe "determining the price for line items" do
+      context "when no override is present" do
+        it "uses the price from the variant" do
+          expect{ order }.to change{ Spree::Order.count }.by(1)
+          expect(order.line_items.find_by_variant_id(variant1.id).price).to eq 5.0
+          expect(order.total).to eq 43.0
+        end
+      end
+
+      context "when an override is present" do
+        let!(:override) { create(:variant_override, hub_id: shop.id, variant_id: variant1.id, price: 3.0) }
+
+        it "uses the price from the override" do
+          expect{ order }.to change{ Spree::Order.count }.by(1)
+          expect(order.line_items.find_by_variant_id(variant1.id).price).to eq 3.0
+          expect(order.total).to eq 39.0
         end
       end
     end

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -1,0 +1,81 @@
+describe OrderFactory do
+  let(:variant1) { create(:variant) }
+  let(:variant2) { create(:variant) }
+  let(:user) { create(:user) }
+  let(:customer) { create(:customer, user: user) }
+  let(:shop) { create(:distributor_enterprise) }
+  let(:order_cycle) { create(:simple_order_cycle) }
+  let(:shipping_method) { create(:shipping_method) }
+  let(:payment_method) { create(:payment_method) }
+  let(:ship_address) { create(:address) }
+  let(:bill_address) { create(:address) }
+  let(:opts) { {} }
+  let(:factory) { OrderFactory.new(attrs, opts) }
+  let(:order) { factory.create }
+
+  describe "create" do
+    let(:attrs) do
+      attrs = {}
+      attrs[:line_items] = [{ variant_id: variant1.id, quantity: 2 }, { variant_id: variant2.id, quantity: 4 }]
+      attrs[:customer_id] = customer.id
+      attrs[:distributor_id] = shop.id
+      attrs[:order_cycle_id] = order_cycle.id
+      attrs[:shipping_method_id] = shipping_method.id
+      attrs[:payment_method_id] = payment_method.id
+      attrs[:bill_address_attributes] = bill_address.attributes.except("id")
+      attrs[:ship_address_attributes] = ship_address.attributes.except("id")
+      attrs
+    end
+
+    it "builds a new order based the provided attributes" do
+      expect{ order }.to change{ Spree::Order.count }.by(1)
+      expect(order).to be_a Spree::Order
+      expect(order.line_items.count).to eq 2
+      expect(order.customer).to eq customer
+      expect(order.user).to eq user
+      expect(order.distributor).to eq shop
+      expect(order.order_cycle).to eq order_cycle
+      expect(order.shipping_method).to eq shipping_method
+      expect(order.shipments.reload.first.shipping_method).to eq shipping_method
+      expect(order.payments.first.payment_method).to eq payment_method
+      expect(order.bill_address).to eq bill_address
+      expect(order.ship_address).to eq ship_address
+      expect(order.complete?).to be false
+    end
+
+    context "when the customer does not have a user associated with it" do
+      before { customer.update_attribute(:user_id, nil) }
+
+      it "initialises the order without a user_id" do
+        expect{ order }.to change{ Spree::Order.count }.by(1)
+        expect(order).to be_a Spree::Order
+        expect(order.user).to be nil
+      end
+    end
+
+    context "when requested quantity is greater than available stock" do
+      before do
+        variant1.update_attribute(:count_on_hand, 2)
+        attrs[:line_items].first[:quantity] = 5
+      end
+
+      context "when skip_stock_check is not requested" do
+        it "initialised the order but limits stock to the available amount" do
+          expect{ order }.to change{ Spree::Order.count }.by(1)
+          expect(order).to be_a Spree::Order
+          expect(order.line_items.find_by_variant_id(variant1.id).quantity).to eq 2
+        end
+      end
+
+      context "when skip_stock_check is requested" do
+        let(:opts) { { skip_stock_check: true } }
+
+        it "initialises the order with the requested quantity regardless" do
+          expect{ order }.to change{ Spree::Order.count }.by(1)
+          expect(order).to be_a Spree::Order
+          expect(order.line_items.find_by_variant_id(variant1.id).quantity).to eq 5
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

@sstead realised that subscriptions were not taking account of variant overrides when determining stock availability and price in some circumstances. See #1078 for more detail.

#### What should we test?

All line items in orders created from by a subscription should respect stock limits and prices of any variant overrides for the relevant shop. Places to check:
- [ ] The subscription wizard
- [ ] The edit order interface in the admin section
- [ ] The placement and confirmation emails for the order
- [ ] The customers account page

#### Release notes

Feature is yet to be released so this does not require its own release notes.
