### PR TITLE
Subs: Add message to indicate OC has no close date

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
@@ -13,8 +13,10 @@ angular.module("admin.subscriptions").controller "OrdersPanelController", ($scop
     OrderCycles.byID[id].name
 
   $scope.orderCycleCloses = (id) ->
-    closes_at = moment(OrderCycles.byID[id].orders_close_at)
-    text = if closes_at > moment() then t('js.closes') else t('js.closed')
+    oc = OrderCycles.byID[id]
+    return t('js.subscriptions.close_date_not_set') unless oc?.orders_close_at?
+    closes_at = moment(oc.orders_close_at)
+    text = if closes_at > moment() then t('js.subscriptions.closes') else t('js.subscription.closed')
     "#{text} #{closes_at.fromNow()}"
 
   $scope.stateText = (state) -> t("spree.order_state.#{state}")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2208,8 +2208,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     choose: Choose
     resolve_errors: Please resolve the following errors
     more_items: "+ %{count} More"
-    closes: closes
-    closed: closed
     admin:
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
       modals:
@@ -2371,6 +2369,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     customers:
       select_shop: 'Please select a shop first'
       could_not_create: Sorry! Could not create
+    subscriptions:
+      closes: closes
+      closed: closed
+      close_date_not_set: Close date not set
   producers:
     signup:
       start_free_profile: "Start with a free profile, and expand when you're ready!"


### PR DESCRIPTION
#### What? Why?

Fixes an issue [picked up](https://github.com/openfoodfoundation/openfoodnetwork/pull/2089#issuecomment-367561211) by @sstead while testing #2089: when an order cycle does not have a close date, the corresponding order within the subscription interface said it "closed a few seconds ago". 

#### What should we test?

I've added a message which indicates that the order cycle in question has no close date.

#### Release notes

Feature is yet to be released so this does not require its own release notes.