### PR TITLE
Subs neg stock

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -131,7 +131,9 @@ Spree::LineItem.class_eval do
 
   # MONKEYPATCH of Spree method
   # Enables scoping of variant to hub/shop, so we check stock against relevant overrides if they exist
+  # Also skips stock check if requested quantity is zero
   def sufficient_stock?
+    return true if quantity == 0 # This line added
     scoper.scope(variant) # This line added
     return true if Spree::Config[:allow_backorders]
     if new_record? || !order.completed?

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -76,6 +76,12 @@ module Spree
         expect(li.max_quantity).to eq 10
       end
 
+      it "caps at zero when stock is negative" do
+        v.update_attributes(on_hand: -2)
+        li.cap_quantity_at_stock!
+        expect(li.reload.quantity).to eq 0
+      end
+
       context "when a variant override is in place" do
         let!(:hub) { create(:distributor_enterprise) }
         let!(:vo) { create(:variant_override, hub: hub, variant: v, count_on_hand: 2) }
@@ -91,6 +97,16 @@ module Spree
         it "caps quantity to override stock level" do
           li.cap_quantity_at_stock!
           expect(li.quantity).to eq 2
+        end
+
+        context "when count on hand is negative" do
+          before { vo.update_attributes(count_on_hand: -3) }
+
+          it "caps at zero" do
+            v.update_attributes(on_hand: -2)
+            li.cap_quantity_at_stock!
+            expect(li.reload.quantity).to eq 0
+          end
         end
       end
     end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -52,28 +52,28 @@ module Spree
 
       it "caps quantity" do
         li.cap_quantity_at_stock!
-        li.reload.quantity.should == 5
+        expect(li.reload.quantity).to eq 5
       end
 
       it "does not cap max_quantity" do
         li.cap_quantity_at_stock!
-        li.reload.max_quantity.should == 10
+        expect(li.reload.max_quantity).to eq 10
       end
 
       it "works for products without max_quantity" do
         li.update_column :max_quantity, nil
         li.cap_quantity_at_stock!
         li.reload
-        li.quantity.should == 5
-        li.max_quantity.should be_nil
+        expect(li.quantity).to eq 5
+        expect(li.max_quantity).to be nil
       end
 
       it "does nothing for on_demand items" do
         v.update_attributes! on_demand: true
         li.cap_quantity_at_stock!
         li.reload
-        li.quantity.should == 10
-        li.max_quantity.should == 10
+        expect(li.quantity).to eq 10
+        expect(li.max_quantity).to eq 10
       end
 
       context "when a variant override is in place" do
@@ -90,7 +90,7 @@ module Spree
 
         it "caps quantity to override stock level" do
           li.cap_quantity_at_stock!
-          li.quantity.should == 2
+          expect(li.quantity).to eq 2
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Fixes an issue related to capping the quantity of a line item when the stock for the relevant variant is negative. Stock was being capped to zero as expected, but this would then cause an error because it would fail the `sufficient_stock?` validation.

#### What should we test?

This issue particular affected subscriptions which require that all items are added in order to send notification emails, regardless of whether stock is available or not. If a subscription requests variants with negative stock, this should no longer cause an issue when the notification emails are sent.

#### Release notes

Feature is yet to be released so this does not require its own release notes.