### PR TITLE
Subs: Fix summary emails for shop owners

### DIFF
--- a/lib/open_food_network/subscription_summary.rb
+++ b/lib/open_food_network/subscription_summary.rb
@@ -18,7 +18,7 @@ module OpenFoodNetwork
     end
 
     def record_issue(type, order, message)
-      issues[type] ||= []
+      issues[type] ||= {}
       issues[type][order.id] = message
     end
 


### PR DESCRIPTION
#### What? Why?

Subscription placement summary emails (when an OC opens) were failing to send because of a small bug caused by an array being used instead of a hash.

#### What should we test?

Summary emails should now work consistently, it is especially important to check the case where an issue occurs with one or more subscriptions, and that the summary email is sent successfully in this case.

#### Release notes

Feature is yet to be released so this does not require its own release notes.