### PR TITLE
Localize sample data

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -10,6 +10,7 @@ namespace :openfoodnetwork do
       task_name = "openfoodnetwork:dev:load_sample_data"
 
       spree_user = Spree::User.find_by_email('spree@example.com')
+      country = Spree::Country.find_by_iso(ENV.fetch('DEFAULT_COUNTRY_CODE'))
 
       Spree::MailMethod.create!(
         environment: Rails.env,
@@ -40,19 +41,19 @@ namespace :openfoodnetwork do
       unless Spree::Address.find_by_zipcode "3160"
         puts "[#{task_name}] Seeding addresses"
 
-        FactoryGirl.create(:address, address1: "25 Myrtle Street", zipcode: "3153", city: "Bayswater")
-        FactoryGirl.create(:address, address1: "6 Rollings Road", zipcode: "3156", city: "Upper Ferntree Gully")
-        FactoryGirl.create(:address, address1: "72 Lake Road", zipcode: "3130", city: "Blackburn")
-        FactoryGirl.create(:address, address1: "7 Verbena Street", zipcode: "3195", city: "Mordialloc")
-        FactoryGirl.create(:address, address1: "20 Galvin Street", zipcode: "3018", city: "Altona")
-        FactoryGirl.create(:address, address1: "59 Websters Road", zipcode: "3106", city: "Templestowe")
-        FactoryGirl.create(:address, address1: "17 Torresdale Drive", zipcode: "3155", city: "Boronia")
-        FactoryGirl.create(:address, address1: "21 Robina CRT", zipcode: "3764", city: "Kilmore")
-        FactoryGirl.create(:address, address1: "25 Kendall Street", zipcode: "3134", city: "Ringwood")
-        FactoryGirl.create(:address, address1: "2 Mines Road", zipcode: "3135", city: "Ringwood East")
-        FactoryGirl.create(:address, address1: "183 Millers Road", zipcode: "3025", city: "Altona North")
-        FactoryGirl.create(:address, address1: "310 Pascoe Vale Road", zipcode: "3040", city: "Essendon")
-        FactoryGirl.create(:address, address1: "6 Martin Street", zipcode: "3160", city: "Belgrave")
+        FactoryGirl.create(:address, address1: "25 Myrtle Street", zipcode: "3153", city: "Bayswater", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "6 Rollings Road", zipcode: "3156", city: "Upper Ferntree Gully", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "72 Lake Road", zipcode: "3130", city: "Blackburn", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "7 Verbena Street", zipcode: "3195", city: "Mordialloc", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "20 Galvin Street", zipcode: "3018", city: "Altona", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "59 Websters Road", zipcode: "3106", city: "Templestowe", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "17 Torresdale Drive", zipcode: "3155", city: "Boronia", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "21 Robina CRT", zipcode: "3764", city: "Kilmore", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "25 Kendall Street", zipcode: "3134", city: "Ringwood", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "2 Mines Road", zipcode: "3135", city: "Ringwood East", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "183 Millers Road", zipcode: "3025", city: "Altona North", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "310 Pascoe Vale Road", zipcode: "3040", city: "Essendon", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "6 Martin Street", zipcode: "3160", city: "Belgrave", country: country, state: country.states.first)
       end
 
       # -- Enterprises


### PR DESCRIPTION
#### What? Why?

Closes #2071 

It turns out that the `openfoodnetwork:dev:load_sample_data` rake task was failing due to the state passed to the addresses we create not belonging to the specified country.

Now the country these addresses are created into is the one defined in the OFN instance through `DEFAULT_COUNTRY_CODE`. This however just makes the already defined Australian addresses belong to the said country, so we will have `25 Myrtle Street, 3153, Bayswater` located in `Michigan, Spain`, for instance.

It's the smallest change needed for us to have sample data in staging and so unblock testing. We will iterate from here. Remember, *small is good* :tm: (:point_left: outcome of last Australian international gathering).

#### What should we test?

We should be able to execute:

```shell
$ bundle exec rake openfoodnetwork:dev:load_sample_data
```

from any staging environment and it should work flawlessly.

#### Release notes

Fixed `openfoodnetwork:dev:load_sample_data` rake task to work on all OFN instances.