### PR TITLE
Automatically confirm the spree@example.com user

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -9,9 +9,11 @@ namespace :openfoodnetwork do
       require_relative '../../spec/support/spree/init'
       task_name = "openfoodnetwork:dev:load_sample_data"
 
+      spree_user = Spree::User.find_by_email('spree@example.com')
+
       Spree::MailMethod.create!(
         environment: Rails.env,
-        preferred_mails_from: 'spree@example.com'
+        preferred_mails_from: spree_user.email
       )
 
       # -- Shipping / payment information
@@ -193,6 +195,8 @@ namespace :openfoodnetwork do
       CreateOrderCycle.new(enterprise2, variants).call
 
       EnterpriseRole.create!(user: Spree::User.first, enterprise: enterprise2)
+
+      spree_user.confirm!
     end
 
     # Creates an order cycle for the provided enterprise and selecting all the


### PR DESCRIPTION
#### What? Why?

This allows you to log in right away with `spree@example.com` after you run `bundle exec openfoodnetwork:dev:load_sample_data` rake task. Otherwise, you see an error message asking you to confirm the email first.

#### What should we test?

Exactly what the paragraph above claims.

#### Release notes

The `spree@example.com` user is now confirmed by default when running `bundle exec openfoodnetwork:dev:load_sample_data`.