### PR TITLE
Show payment summary in confirmation email regardless of payment method

### DIFF
--- a/app/views/spree/order_mailer/_payment.html.haml
+++ b/app/views/spree/order_mailer/_payment.html.haml
@@ -1,15 +1,14 @@
-- if @order.payments.first.andand.payment_method.andand.type == "Spree::PaymentMethod::Check" and @order.payments.first.andand.payment_method.andand.description
-  %p.callout
-    %span{:style => "float:right;"}
-      - if @order.paid?
-        = t :email_payment_paid
-      - else
-        = t :email_payment_not_paid
-    %strong
-      = t :email_payment_summary
-  %h4
-    = t :email_payment_method
-    %strong=  @order.payments.first.andand.payment_method.andand.name.andand.html_safe
-  %p
-    %em= @order.payments.first.andand.payment_method.andand.description.andand.html_safe
-  %p &nbsp;
+%p.callout
+  %span{:style => "float:right;"}
+    - if @order.paid?
+      = t :email_payment_paid
+    - else
+      = t :email_payment_not_paid
+  %strong
+    = t :email_payment_summary
+%h4
+  = t :email_payment_method
+  %strong=  @order.payments.first.andand.payment_method.andand.name.andand.html_safe
+%p
+  %em= @order.payments.first.andand.payment_method.andand.description.andand.html_safe
+%p &nbsp;


### PR DESCRIPTION
#### What? Why?

While testing subscriptions, @sstead noticed that confirmation emails for orders with a non-cash payment method did not include a payment summary. After a little bit of investigation I realised that this had been the case since I first [committed](https://github.com/openfoodfoundation/openfoodnetwork/commit/fe0bb49bafcdc046ca6e06eb365c8a6a241e7149) the current version of the confirmation email templates. I have no idea why it is like this so I though I would delete the logic and see what happens.

#### What should we test?

All confirmation emails should include a payment summary, regardless of the payment method on the order.

#### Release notes

Fixed a bug that caused missing payment summaries in order confirmation emails when non-cash payment methods were used.