### PR TITLE
Subs: Fix Order Cycle index crashes

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
@@ -151,23 +151,28 @@ angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, S
       return unless @confirmNoDistributors()
       oc = new OrderCycleResource({order_cycle: this.dataForSubmit()})
       oc.$create (data) ->
-        if data['success']
-          $window.location = destination
+        $window.location = destination
+      , (response) ->
+        if response.data.errors?
+          StatusMessage.display('failure', response.data.errors[0])
         else
-          console.log('Failed to create order cycle')
+          StatusMessage.display('failure', 'Failed to create order cycle')
 
     update: (destination, form) ->
       return unless @confirmNoDistributors()
       oc = new OrderCycleResource({order_cycle: this.dataForSubmit()})
       oc.$update {order_cycle_id: this.order_cycle.id, reloading: (if destination? then 1 else 0)}, (data) =>
-        if data['success']
-          form.$setPristine() if form
-          if destination?
-            $window.location = destination
-          else
-            StatusMessage.display 'success', t('js.order_cycles.update_success')
+        form.$setPristine() if form
+        if destination?
+          $window.location = destination
         else
-          console.log('Failed to update order cycle')
+          StatusMessage.display 'success', t('js.order_cycles.update_success')
+      , (response) ->
+        if response.data.errors?
+          StatusMessage.display('failure', response.data.errors[0])
+        else
+          StatusMessage.display('failure', 'Failed to create order cycle')
+
 
     confirmNoDistributors: ->
       if @order_cycle.outgoing_exchanges.length == 0

--- a/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
@@ -45,7 +45,10 @@ angular.module("admin.resources").factory 'OrderCycles', ($q, $injector, OrderCy
           form.$setPristine() if form?
           StatusMessage.display('success', "Order cycles have been updated.")
         , (response) =>
-          StatusMessage.display('failure', "Oh no! I was unable to save your changes.")
+          if response.data.errors?
+            StatusMessage.display('failure', response.data.errors[0])
+          else
+            StatusMessage.display('failure', "Oh no! I was unable to save your changes.")
 
     saved: (order_cycle) ->
       @diff(order_cycle).length == 0

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -51,10 +51,10 @@ module Admin
           invoke_callbacks(:create, :after)
           flash[:notice] = I18n.t(:order_cycles_create_notice)
           format.html { redirect_to admin_order_cycles_path }
-          format.json { render :json => {:success => true} }
+          format.json { render :json => { success: true } }
         else
           format.html
-          format.json { render :json => {:success => false} }
+          format.json { render :json => { errors: @order_cycle.errors.full_messages }, status: :unprocessable_entity }
         end
       end
     end
@@ -71,9 +71,9 @@ module Admin
           invoke_callbacks(:update, :after)
           flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
           format.html { redirect_to main_app.edit_admin_order_cycle_path(@order_cycle) }
-          format.json { render :json => {:success => true}  }
+          format.json { render :json => { :success => true } }
         else
-          format.json { render :json => {:success => false} }
+          format.json { render :json => { errors: @order_cycle.errors.full_messages }, status: :unprocessable_entity }
         end
       end
     end
@@ -85,7 +85,8 @@ module Admin
         end
       else
         respond_to do |format|
-          format.json { render :json => {:success => false} }
+          order_cycle = order_cycle_set.collection.find{ |oc| oc.errors.present? }
+          format.json { render :json => { errors: order_cycle.errors.full_messages }, status: :unprocessable_entity }
         end
       end
     end
@@ -219,7 +220,7 @@ module Admin
     end
 
     def order_cycle_set
-      OrderCycleSet.new(@order_cycles, params[:order_cycle_set])
+      @order_cycle_set ||= OrderCycleSet.new(@order_cycles, params[:order_cycle_set])
     end
 
     def require_order_cycle_set_params

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -10,6 +10,7 @@ module Admin
     before_filter :require_coordinator, only: :new
     before_filter :remove_protected_attrs, only: [:update]
     before_filter :check_editable_schedule_ids, only: [:create, :update]
+    before_filter :require_order_cycle_set_params, only: [:bulk_update]
     around_filter :protect_invalid_destroy, only: :destroy
     create.after :sync_subscriptions
     update.after :sync_subscriptions
@@ -218,8 +219,12 @@ module Admin
     end
 
     def order_cycle_set
-      return unless params[:order_cycle_set]
       OrderCycleSet.new(@order_cycles, params[:order_cycle_set])
+    end
+
+    def require_order_cycle_set_params
+      return if params[:order_cycle_set]
+      render json: { errors: t('admin.order_cycles.bulk_update.no_data') }, status: :unprocessable_entity
     end
 
     def ams_prefix_whitelist

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -119,9 +119,9 @@ module Admin
         OrderCycle.preload(:schedules).ransack(params[:q]).result.accessible_by(spree_current_user)
       end
 
-      ocs.undated +
-        ocs.soonest_closing +
-        ocs.soonest_opening +
+      ocs.undated |
+        ocs.soonest_closing |
+        ocs.soonest_opening |
         ocs.closed
     end
 

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -14,6 +14,7 @@ class OrderCycle < ActiveRecord::Base
   attr_accessor :incoming_exchanges, :outgoing_exchanges
 
   validates_presence_of :name, :coordinator_id
+  validate :orders_close_at_after_orders_open_at?
 
   after_save :refresh_products_cache
 
@@ -271,5 +272,11 @@ class OrderCycle < ActiveRecord::Base
     product.has_variants? &&
       distributed_variants.include?(product.master) &&
       (product.variants & distributed_variants).empty?
+  end
+
+  def orders_close_at_after_orders_open_at?
+    return if orders_open_at.blank? || orders_close_at.blank?
+    return if orders_close_at > orders_open_at
+    errors.add(:orders_close_at, :after_orders_open_at)
   end
 end

--- a/app/models/order_cycle_set.rb
+++ b/app/models/order_cycle_set.rb
@@ -1,5 +1,5 @@
 class OrderCycleSet < ModelSet
-  def initialize(attributes={})
-    super(OrderCycle, OrderCycle.all, attributes)
+  def initialize(collection, attributes={})
+    super(OrderCycle, collection, attributes)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,8 @@ en:
         email: Customer E-Mail
       spree/payment:
         amount: Amount
+      order_cycle:
+        orders_close_at: Close date
     errors:
       models:
         spree/user:
@@ -74,6 +76,10 @@ en:
               taken: "There's already an account for this email. Please login or reset your password."
         spree/order:
           no_card: There are no valid credit cards available
+        order_cycle:
+          attributes:
+            orders_close_at:
+              after_orders_open_at: must be after open date
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -811,6 +811,8 @@ en:
       destroy_errors:
         orders_present: That order cycle has been selected by a customer and cannot be deleted. To prevent customers from accessing it, please close it instead.
         schedule_present: That order cycle is linked to a schedule and cannot be deleted. Please unlink or delete the schedule first.
+      bulk_update:
+        no_data: Hm, something went wrong. No order cycle data found.
     producer_properties:
       index:
         title: Producer Properties

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -209,7 +209,7 @@ module Admin
         before { create(:enterprise_role, user: distributor_owner, enterprise: coordinator) }
 
         it "updates order cycle properties" do
-          spree_put :bulk_update, order_cycle_set: { collection_attributes: { '0' => {
+          spree_put :bulk_update, format: :json, order_cycle_set: { collection_attributes: { '0' => {
             id: oc.id,
             orders_open_at: Date.current - 21.days,
             orders_close_at: Date.current + 21.days,
@@ -232,7 +232,7 @@ module Admin
         let!(:another_distributor) { create(:distributor_enterprise, users: [distributor_owner]) }
 
         it "doesn't update order cycle properties" do
-          spree_put :bulk_update, order_cycle_set: { collection_attributes: { '0' => {
+          spree_put :bulk_update, format: :json, order_cycle_set: { collection_attributes: { '0' => {
             id: oc.id,
             orders_open_at: Date.current - 21.days,
             orders_close_at: Date.current + 21.days,

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -222,8 +222,10 @@ module Admin
 
         it "does nothing when no data is supplied" do
           expect do
-            spree_put :bulk_update
+            spree_put :bulk_update, format: :json
           end.to change(oc, :orders_open_at).by(0)
+          json_response = JSON.parse(response.body)
+          expect(json_response['errors']).to eq I18n.t('admin.order_cycles.bulk_update.no_data')
         end
       end
 

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -516,7 +516,11 @@ feature %q{
     # Given three order cycles
     oc1 = create(:simple_order_cycle)
     oc2 = create(:simple_order_cycle)
-    oc3 = create(:simple_order_cycle, orders_open_at: Time.zone.local(2040, 12, 12, 12, 12, 12))
+    oc3 = create(:simple_order_cycle,
+      orders_open_at: Time.zone.local(2040, 12, 12, 12, 12, 12),
+      orders_close_at: Time.zone.local(2041, 12, 12, 12, 12, 12)
+    )
+
 
     # When I go to the order cycles page
     login_to_admin_section

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -415,12 +415,12 @@ feature "As a consumer I want to shop with a distributor", js: true do
         page.should have_content "Orders are closed"
       end
       it "shows the last order cycle" do
-        oc1 = create(:simple_order_cycle, distributors: [distributor], orders_close_at: 10.days.ago)
+        oc1 = create(:simple_order_cycle, distributors: [distributor], orders_open_at: 17.days.ago, orders_close_at: 10.days.ago)
         visit shop_path
         page.should have_content "The last cycle closed 10 days ago"
       end
       it "shows the next order cycle" do
-        oc1 = create(:simple_order_cycle, distributors: [distributor], orders_open_at: 10.days.from_now)
+        oc1 = create(:simple_order_cycle, distributors: [distributor], orders_open_at: 10.days.from_now, orders_close_at: 17.days.from_now)
         visit shop_path
         page.should have_content "The next cycle opens in 10 days"
       end

--- a/spec/javascripts/unit/order_cycle_spec.js.coffee
+++ b/spec/javascripts/unit/order_cycle_spec.js.coffee
@@ -812,7 +812,7 @@ describe 'OrderCycle services', ->
         spyOn(OrderCycle, 'dataForSubmit').and.returnValue('this is the submit data')
         $httpBackend.expectPOST('/admin/order_cycles.json', {
           order_cycle: 'this is the submit data'
-          }).respond {success: false}
+        }).respond 400, { errors: [] }
 
         OrderCycle.create('/destination/page')
         $httpBackend.flush()
@@ -840,7 +840,7 @@ describe 'OrderCycle services', ->
         spyOn(OrderCycle, 'dataForSubmit').and.returnValue('this is the submit data')
         $httpBackend.expectPUT('/admin/order_cycles.json?reloading=1', {
           order_cycle: 'this is the submit data'
-          }).respond {success: false}
+        }).respond 400, { errors: [] }
 
         OrderCycle.update('/destination/page')
         $httpBackend.flush()

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -318,7 +318,7 @@ describe Enterprise do
         s = create(:supplier_enterprise)
         d = create(:distributor_enterprise)
         p = create(:product)
-        create(:simple_order_cycle, :orders_open_at => 10.days.from_now, suppliers: [s], distributors: [d], variants: [p.master])
+        create(:simple_order_cycle, :orders_open_at => 10.days.from_now, orders_close_at: 17.days.from_now, suppliers: [s], distributors: [d], variants: [p.master])
         Enterprise.distributors_with_active_order_cycles.should_not include d
       end
     end

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -11,6 +11,11 @@ describe OrderCycle do
     oc.should_not be_valid
   end
 
+  it 'should not be valid when open date is after close date' do
+    oc = build(:simple_order_cycle, orders_open_at: Time.zone.now, orders_close_at: 1.minute.ago)
+    expect(oc).to_not be_valid
+  end
+
   it "has a coordinator and associated fees" do
     oc = create(:simple_order_cycle)
 
@@ -196,13 +201,13 @@ describe OrderCycle do
     let(:d1) { create(:enterprise) }
     let(:d2) { create(:enterprise) }
     let!(:e0) { create(:exchange, incoming: true,
-                order_cycle: oc, sender: create(:enterprise), receiver: oc.coordinator) 
+                order_cycle: oc, sender: create(:enterprise), receiver: oc.coordinator)
     }
     let!(:e1) { create(:exchange, incoming: false,
-                order_cycle: oc, sender: oc.coordinator, receiver: d1) 
+                order_cycle: oc, sender: oc.coordinator, receiver: d1)
     }
     let!(:e2) { create(:exchange, incoming: false,
-                order_cycle: oc, sender: oc.coordinator, receiver: d2) 
+                order_cycle: oc, sender: oc.coordinator, receiver: d2)
     }
     let!(:p0) { create(:simple_product) }
     let!(:p1) { create(:simple_product) }

--- a/spec/models/producer_property_spec.rb
+++ b/spec/models/producer_property_spec.rb
@@ -49,7 +49,7 @@ describe ProducerProperty do
 
     describe "with a producer property for a product in a closed order cycle" do
       before do
-        oc.update_attributes! orders_close_at: 1.week.ago
+        oc.update_attributes! orders_open_at: 2.weeks.ago, orders_close_at: 1.week.ago
       end
 
       it "doesn't return the producer property for .currently_sold_by" do

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -339,7 +339,7 @@ module Spree
           p1 = create(:product)
           p2 = create(:product)
           p3 = create(:product)
-          oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.master], orders_close_at: 1.day.ago)
+          oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.master], orders_open_at: 8.days.ago, orders_close_at: 1.day.ago)
           oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d3], variants: [p3.master], orders_close_at: Date.tomorrow)
           Product.in_an_active_order_cycle.should == [p3]
         end
@@ -532,7 +532,7 @@ module Spree
         let!(:p) { create(:simple_product,
                           variant_unit: 'weight',
                           variant_unit_scale: 1,
-                          variant_unit_name: nil) 
+                          variant_unit_name: nil)
         }
 
         let!(:ot_volume) { create(:option_type, name: 'unit_volume', presentation: 'Volume') }


### PR DESCRIPTION
#### What? Why?

The Order Cycle index sometimes crashes. This is caused by the complex interaction of the scopes used by the OrderCyclesController#collection method, which can cause multiple copies of a single order cycle to be loaded into the page, which breaks AngularJS indexing.  As far as I can tell, the problem lies with order cycles with a start date after the end date, and those with only an open date and no close date. 

I have done two things to resolve this issue:
1. Added validation to the OrderCycle model requiring that close date must be after open date
2. Return the union of the scopes used by the `#collection` method, rather than concatenating them.

I have also refactored the use of OrderCycleSet by the OrderCyclesController, which should have the happy side effect of significantly speeding up the save time on the order cycles index.

#### What should we test?

The Order Cycles index should load properly regardless of the presence or otherwise of dates on order cycles.

An error should be returned when the open date is after the close date. Test this when:
1. Creating a new OC
2. Updating an existing OC from the edit page
3. Updating multiple OCs from the index page