### PR TITLE
Subs: messaging around unpausing a subscription

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/services/subscription_actions.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/services/subscription_actions.js.coffee
@@ -55,8 +55,12 @@ angular.module("admin.subscriptions").factory 'SubscriptionActions', ($http, $in
   unpause: ->
     ConfirmDialog.open('error', t('admin.subscriptions.confirm_unpause_msg'), {confirm: t('admin.subscriptions.yes_i_am_sure')})
     .then =>
-      @$unpause().then angular.noop, ->
-        InfoDialog.open 'error', t('admin.subscriptions.unpause_failure_msg')
+      @$unpause().then angular.noop, (response) =>
+        if response.data?.errors?.canceled_orders?
+          InfoDialog.open('info', response.data.errors.canceled_orders)
+            .then (=> @$unpause(canceled_orders: 'notified'))
+        else
+          InfoDialog.open 'error', t('admin.subscriptions.unpause_failure_msg')
 
   cancelOrder: (order) ->
     if order.id?

--- a/app/assets/javascripts/admin/utils/services/info_dialog.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/info_dialog.js.coffee
@@ -1,13 +1,22 @@
-angular.module("admin.utils").factory 'InfoDialog', ($rootScope, $compile, $injector, $templateCache, DialogDefaults) ->
+angular.module("admin.utils").factory 'InfoDialog', ($rootScope, $q, $compile, $templateCache, DialogDefaults) ->
   new class InfoDialog
+    icon_classes: {
+      error: 'icon-exclamation-sign'
+      info: 'icon-info-sign'
+    }
+
     open: (type, message, templateUrl='admin/info_dialog.html', options={}) ->
+      deferred = $q.defer()
       scope = $rootScope.$new()
       scope.message = message
       scope.dialog_class = type
+      scope.icon_class = @icon_classes[type]
       scope.options = options
       template = $compile($templateCache.get(templateUrl))(scope)
       template.dialog(DialogDefaults)
       template.dialog('open')
       scope.close = ->
+        deferred.resolve()
         template.dialog('close')
         null
+      deferred.promise

--- a/app/assets/javascripts/templates/admin/info_dialog.html.haml
+++ b/app/assets/javascripts/templates/admin/info_dialog.html.haml
@@ -1,7 +1,7 @@
 #info-dialog{ ng: { class: "dialog_class" } }
   .message.clearfix.margin-bottom-30
     .icon.text-center
-      %i.icon-exclamation-sign
+      %i{ ng: { class: "icon_class" } }
     .text
       {{ message }}
   .action-buttons.text-center

--- a/app/assets/stylesheets/admin/components/dialogs.css.scss
+++ b/app/assets/stylesheets/admin/components/dialogs.css.scss
@@ -14,7 +14,7 @@
 
     .icon {
       width: 20%;
-      font-size: 2rem;
+      font-size: 4rem;
     }
   }
 
@@ -22,6 +22,14 @@
     .message {
       .icon {
         color: #da5354;
+      }
+    }
+  }
+
+  &.info {
+    .message {
+      .icon {
+        color: #5498da;
       }
     }
   }

--- a/app/assets/stylesheets/admin/components/jquery_dialog.scss
+++ b/app/assets/stylesheets/admin/components/jquery_dialog.scss
@@ -10,6 +10,7 @@ light: #ccc
   -moz-box-shadow: 3px 3px 4px #797979;
   -webkit-box-shadow: 3px 3px 4px #797979;
   box-shadow: 3px 3px 4px #797979;
+  position: fixed;
 
   /* For IE 8 */
   -ms-filter: "progid:DXImageTransform.Microsoft.Shadow(Strength=4, Direction=135, Color='#545454')";

--- a/app/models/proxy_order.rb
+++ b/app/models/proxy_order.rb
@@ -14,7 +14,7 @@ class ProxyOrder < ActiveRecord::Base
   scope :not_closed, -> { joins(:order_cycle).merge(OrderCycle.not_closed) }
   scope :canceled, -> { where('proxy_orders.canceled_at IS NOT NULL') }
   scope :not_canceled, -> { where('proxy_orders.canceled_at IS NULL') }
-  scope :placed_and_open, -> { joins(:order).not_closed.where(spree_orders: { state: 'complete' }) }
+  scope :placed_and_open, -> { joins(:order).not_closed.where(spree_orders: { state: ['complete', 'resumed'] }) }
 
   def state
     # NOTE: the order is important here

--- a/app/models/proxy_order.rb
+++ b/app/models/proxy_order.rb
@@ -9,8 +9,10 @@ class ProxyOrder < ActiveRecord::Base
 
   delegate :number, :completed_at, :total, to: :order, allow_nil: true
 
+  scope :active, -> { joins(:order_cycle).merge(OrderCycle.active) }
   scope :closed, -> { joins(:order_cycle).merge(OrderCycle.closed) }
   scope :not_closed, -> { joins(:order_cycle).merge(OrderCycle.not_closed) }
+  scope :canceled, -> { where('proxy_orders.canceled_at IS NOT NULL') }
   scope :not_canceled, -> { where('proxy_orders.canceled_at IS NULL') }
   scope :placed_and_open, -> { joins(:order).not_closed.where(spree_orders: { state: 'complete' }) }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -927,6 +927,7 @@ en:
       confirm_unpause_msg: Are you sure you want to unpause this subscription?
       unpause_failure_msg: 'Sorry, unpausing failed!'
       confirm_cancel_open_orders_msg: "Some orders for this subscription are currently open. The customer has already been notified that the order will be placed. Would you like to cancel these order(s) or keep them?"
+      resume_canceled_orders_msg: "Some orders for this subscription can be resumed right now. You can resume them from the orders dropdown."
       yes_cancel_them: Cancel them
       no_keep_them: Keep them
       yes_i_am_sure: Yes, I'm sure


### PR DESCRIPTION
#### What? Why?

It was not clear what happened to the orders for open order cycles when a subscription is unpaused. I have added some messaging to communicate the need to manually resume any orders for open order cycles if that is what is desired.

#### What should we test?

Check that appropriate messaging is displayed when:
a) A subscription is paused and then unpaused within the same order cycle.
b) A subscription is paused in once order cycle and then unpaused in a subsequent order cycle.

#### Release notes

Feature is yet to be released so this does not require its own release notes.