### PR TITLE
Subs: Add error message for case when schedule cannot be deleted

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/directives/schedule_dialog.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/directives/schedule_dialog.js.coffee
@@ -31,6 +31,13 @@ angular.module("admin.orderCycles").directive 'scheduleDialog', ($window, $compi
       if confirm(t('are_you_sure'))
         Schedules.remove(scope.schedule).$promise.then (data) ->
           scope.close()
+        , (response) ->
+          errors = response.data.errors
+          if errors?
+            scope.errors.push errors[0]
+          else
+            scope.errors.push "Could not delete schedule: #{scope.schedule.name}"
+
 
     scope.loadMore = ->
       scope.showMore().then ->

--- a/app/assets/javascripts/admin/resources/services/schedules.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/schedules.js.coffee
@@ -39,12 +39,6 @@ angular.module("admin.resources").factory "Schedules", ($q, $injector, RequestMo
             orderCycle.schedules.splice(i, 1) for s, i in orderCycle.schedules by -1 when s.id == schedule.id
         delete @byID[schedule.id]
         StatusMessage.display 'success', "#{t('admin.order_cycles.index.deleted_schedule')}: '#{schedule.name}'"
-      , (response) =>
-        errors = response.data.errors
-        if errors?
-          InfoDialog.open 'error', errors[0]
-        else
-          InfoDialog.open 'error', "Could not delete schedule: #{schedule.name}"
 
     index: ->
       request = ScheduleResource.index (data) => @load(data)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -958,6 +958,10 @@ en:
         why_dont_you_add_one: Why don't you add one? :)
         no_matching_subscriptions: No matching subscriptions found
 
+    schedules:
+      destroy:
+        associated_subscriptions_error: This schedule cannot be deleted because it has associated subscriptions
+
     stripe_connect_settings:
       edit:
         title: "Stripe Connect"


### PR DESCRIPTION
#### What? Why?

Sally picked up [this issue](https://github.com/openfoodfoundation/openfoodnetwork/issues/1059#issuecomment-346242475) while testing #1059. So I added some messaging explaining that schedule cannot be deleted while there are subscriptions that depend on them.

#### What should we test?

Attempting to delete a schedule while there are associated subscriptions should display an error message at the bottom of the modal.

#### Release notes

Feature is yet to be released so this does not require its own release notes.