### PR TITLE
Subs: prevent fees from displaying in email when subscription order cannot be fulfilled 

### DIFF
--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -34,6 +34,7 @@ class SubscriptionPlacementJob
 
     changes = cap_quantity_and_store_changes(order)
     if order.line_items.where('quantity > 0').empty?
+      order.adjustments.destroy_all
       return send_empty_email(order, changes)
     end
 

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -34,7 +34,7 @@ class SubscriptionPlacementJob
 
     changes = cap_quantity_and_store_changes(order)
     if order.line_items.where('quantity > 0').empty?
-      order.adjustments.destroy_all
+      order.reload.adjustments.destroy_all
       return send_empty_email(order, changes)
     end
 

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -35,6 +35,7 @@ class SubscriptionPlacementJob
     changes = cap_quantity_and_store_changes(order)
     if order.line_items.where('quantity > 0').empty?
       order.reload.adjustments.destroy_all
+      order.update!
       return send_empty_email(order, changes)
     end
 

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -149,7 +149,8 @@ describe SubscriptionPlacementJob do
 
         it "does not place the order, clears, all adjustments, and sends an empty_order email" do
           expect{ job.send(:process, order) }.to_not change{ order.reload.completed_at }.from(nil)
-          expect(order.reload.adjustments).to be_empty
+          expect(order.adjustments).to be_empty
+          expect(order.total).to eq 0
           expect(job).to_not have_received(:send_placement_email)
           expect(job).to have_received(:send_empty_email)
         end

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -147,8 +147,9 @@ describe SubscriptionPlacementJob do
           allow(job).to receive(:unavailable_stock_lines_for) { order.line_items }
         end
 
-        it "does not place the order, sends an empty_order email" do
+        it "does not place the order, clears, all adjustments, and sends an empty_order email" do
           expect{ job.send(:process, order) }.to_not change{ order.reload.completed_at }.from(nil)
+          expect(order.reload.adjustments).to be_empty
           expect(job).to_not have_received(:send_placement_email)
           expect(job).to have_received(:send_empty_email)
         end


### PR DESCRIPTION
#### What? Why?

When none of the items requested in a subscription are available when an order cycle opens, the customer is sent a notification email to let them know that an order could not be placed. Despite the fact that the email says that the order was not processed, some fees were still showing in the order summary shown in the email. This PR should resolve that issue.

#### What should we test?

Notification emails for customers indicating a failure to place an order due to insufficient stock should not show fees of any sort.

#### Release notes

Feature is yet to be released so this does not require its own release notes.