### PR TITLE
Bring seeds from ofn install

### DIFF
--- a/db/default/spree/states.yml
+++ b/db/default/spree/states.yml
@@ -1,41 +1,33 @@
-#Australia
-states_101:
-  name: Tasmania
+---
+- name: Tasmania
   country_id: "12"
   id: "101"
   abbr: Tas
-states_102:
-  name: Victoria
+- name: Victoria
   country_id: "12"
   id: "102"
   abbr: Vic
-states_103:
-  name: New South Wales
+- name: New South Wales
   country_id: "12"
   id: "103"
   abbr: NSW
-states_104:
-  name: ACT
+- name: ACT
   country_id: "12"
   id: "104"
   abbr: ACT
-states_105:
-  name: Queensland
+- name: Queensland
   country_id: "12"
   id: "105"
   abbr: QLD
-states_106:
-  name: South Australia
+- name: South Australia
   country_id: "12"
   id: "106"
   abbr: SA
-states_107:
-  name: Northern Territory
+- name: Northern Territory
   country_id: "12"
   id: "107"
   abbr: NT
-states_108:
-  name: Western Australia
+- name: Western Australia
   country_id: "12"
   id: "108"
   abbr: WA

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,6 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
 require 'yaml'
-require 'csv'
 
 # -- Spree
 unless Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
@@ -13,6 +11,7 @@ end
 
 country = Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
 puts "Country is #{country.to_s}"
+
 puts "[db:seed] loading states yaml"
 states = YAML::load_file "db/default/spree/states.yml"
 puts "States: #{states.to_s}"
@@ -22,8 +21,11 @@ puts "[db:seed] Seeding states for " + country.name
 
 states.each do |state|
   puts "State: " + state.to_s
+
   unless Spree::State.find_by_name(state['name'])
-    Spree::State.create!({"name"=>state['name'], "abbr"=>state['abbr'], :country=>country}, without_protection: true)
+    Spree::State.create!(
+      { name: state['name'], abbr: state['abbr'], country: country },
+      without_protection: true
+    )
   end
-  puts "set id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,28 +1,29 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+#
+require 'yaml'
+require 'csv'
 
 # -- Spree
-unless Spree::Country.find_by_name 'Australia'
+unless Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
   puts "[db:seed] Seeding Spree"
   Spree::Core::Engine.load_seed if defined?(Spree::Core)
   Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
 end
 
-# -- States
-unless Spree::State.find_by_name 'Victoria'
-  country = Spree::Country.find_by_name('Australia')
-  puts "[db:seed] Seeding states"
+country = Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
+puts "Country is #{country.to_s}"
+puts "[db:seed] loading states yaml"
+states = YAML::load_file "db/default/spree/states.yml"
+puts "States: #{states.to_s}"
 
-  [
-   ['ACT', 'ACT'],
-   ['New South Wales', 'NSW'],
-   ['Northern Territory', 'NT'],
-   ['Queensland', 'QLD'],
-   ['South Australia', 'SA'],
-   ['Tasmania', 'Tas'],
-   ['Victoria', 'Vic'],
-   ['Western Australia', 'WA']
-  ].each do |state|
-    Spree::State.create!({"name"=>state[0], "abbr"=>state[1], :country=>country}, :without_protection => true)
+# -- Seeding States
+puts "[db:seed] Seeding states for " + country.name
+
+states.each do |state|
+  puts "State: " + state.to_s
+  unless Spree::State.find_by_name(state['name'])
+    Spree::State.create!({"name"=>state['name'], "abbr"=>state['abbr'], :country=>country}, without_protection: true)
   end
+  puts "set id"
 end


### PR DESCRIPTION
#### What? Why?

This is part of what we discussed in https://github.com/openfoodfoundation/ofn-install/pull/122#issuecomment-370812033. With these changes, we can get rid of  [roles/app/files/seeds.rb](https://github.com/openfoodfoundation/ofn-install/blob/master/roles/app/files/seeds.rb) and the ansible tasks that move the file around when deploying. The `seeds.rb` it's going to be already in `db/` for Rails to pick it up.

However, regardless of the `DEFAULT_COUNTRY_CODE` you may have configured in `config/application.yml`, it'll associate Australian states to that country like:

```
 id |        name        | abbr | country_id | id  | iso_name | iso | iso3 | name  | numcode | states_required 
----+--------------------+------+------------+-----+----------+-----+------+-------+---------+-----------------
 52 | Tasmania           | Tas  |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
 53 | Victoria           | Vic  |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
 54 | New South Wales    | NSW  |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
 55 | ACT                | ACT  |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
 56 | Queensland         | QLD  |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
 57 | South Australia    | SA   |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
 58 | Northern Territory | NT   |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
 59 | Western Australia  | WA   |        175 | 175 | SPAIN    | ES  | ESP  | Spain |     724 | t
```

Which is not a big deal for development.

#### What should we test?

Deploys to staging should keep working.

#### Release notes

No worth mentioning.

#### Dependencies

Depends on: https://github.com/openfoodfoundation/ofn-install/pull/122
