### PR TITLE
Remove deprecated reference to Spree::MailMethod

### DIFF
--- a/app/mailers/spree/base_mailer_decorator.rb
+++ b/app/mailers/spree/base_mailer_decorator.rb
@@ -8,8 +8,7 @@ Spree::BaseMailer.class_eval do
   protected
 
   def from_address
-    Spree::MailMethod.current.andand.preferred_mails_from ||
-      'test@example.com'
+    Spree::Config[:mails_from] || 'test@example.com'
   end
 
   def roadie_options

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -4,6 +4,8 @@ Spree::AppConfiguration.class_eval do
   # we can allow to be modified in the UI by adding appropriate form
   # elements to existing or new configuration pages.
 
+  preference :mails_from, :string, default: 'no-reply@example.com'
+
   # Embedded Shopfronts
   preference :enable_embedded_shopfronts, :boolean, default: false
   preference :embedded_shopfronts_whitelist, :text, default: nil


### PR DESCRIPTION
#### What? Why?

Closes #2016. You'll find all sorts of details there and in its epic. Basically, said class gets removed in https://github.com/spree/spree/pull/2643 in Spree.

By doing it like this we can merge this change in `master` already as it's backward compatible.

#### What should we test?

All emails should keep working.

#### Release notes

No worth adding for this. Better to wait when we actually get to Spree 2.0.

#### How is this related to the Spree upgrade?

Part of the epic about `Spree::MailMethod`. More details in https://github.com/openfoodfoundation/openfoodnetwork/issues/1957