### PR TITLE
Remove typo from SCSS

### DIFF
--- a/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
+++ b/app/assets/stylesheets/darkswarm/modal-enterprises.css.scss
@@ -133,8 +133,6 @@
     font-size: 0.875rem;
     margin-bottom: 0.75rem;
 
-    5rem {}
-
     color: $dark-grey;
   }
 


### PR DESCRIPTION
Accidentally introduced in febe66b7b0ba4f812ca91ed716e5d669145c5ff6.

#### What? Why?

Tiny little fix that removes unneeded code and stops IDEs from complaining about incorrect SCSS syntax. I discovered this trying Netbeans with Ruby on Rails plugin.

#### What should we test?

Nothing. Maybe sanity check the display of the enterprise modal.

#### Release notes

Nothing to mention.

#### How is this related to the Spree upgrade?

Not related.