### PR TITLE
2113 Display only selected languages in switcher

### DIFF
--- a/app/views/shared/menu/_large_menu.html.haml
+++ b/app/views/shared/menu/_large_menu.html.haml
@@ -60,12 +60,12 @@
           = t 'powered_by'
           %a{href: '/'}
             = t 'title'
-      - if I18n.available_locales.count > 1
+      - if OpenFoodNetwork::I18nConfig.selectable_locales.count > 1
         %li.language-switcher.has-dropdown
           %a{href: '#'}
             %i.ofn-i_071-globe
           %ul.dropdown
-            - I18n.available_locales.each do |l|
+            - OpenFoodNetwork::I18nConfig.selectable_locales.each do |l|
               %li
                 %a{href: "?locale=#{l.to_s}" }= t('language_name', locale: l)
       - if spree_current_user.nil?

--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -40,13 +40,13 @@
         %span.nav-primary
           %i.ofn-i_036-producers
           = t 'label_producers'
-    - if I18n.available_locales.count > 1
+    - if OpenFoodNetwork::I18nConfig.selectable_locales.count > 1
       %li.language-switcher.li-menu
         %a
           %i.ofn-i_071-globe
           = t('language_name')
         %ul
-          - I18n.available_locales.each do |l|
+          - OpenFoodNetwork::I18nConfig.selectable_locales.each do |l|
             - if I18n.locale != l
               %li
                 %a{href: "?locale=#{l.to_s}" }= t('language_name', locale: l)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require_relative "../lib/open_food_network/i18n_config"
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
@@ -104,9 +105,8 @@ module Openfoodnetwork
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    config.i18n.default_locale = ENV["LOCALE"] || ENV["I18N_LOCALE"] || "en"
-    config.i18n.available_locales = ENV["AVAILABLE_LOCALES"].andand.split(/[\s,]/).andand.map(&:strip) || []
-    config.i18n.available_locales = (config.i18n.available_locales + [config.i18n.default_locale, 'en']).uniq
+    config.i18n.default_locale = OpenFoodNetwork::I18nConfig.default_locale
+    config.i18n.available_locales = OpenFoodNetwork::I18nConfig.available_locales
     I18n.locale = config.i18n.locale = config.i18n.default_locale
 
     # Setting this to true causes a performance regression in Rails 3.2.17

--- a/lib/open_food_network/i18n_config.rb
+++ b/lib/open_food_network/i18n_config.rb
@@ -1,0 +1,22 @@
+module OpenFoodNetwork
+  # Provides access to the language settings.
+  # Currently, language settings are read from the environment.
+  # See: config/application.yml
+  class I18nConfig
+    def self.selectable_locales
+      ENV["AVAILABLE_LOCALES"].andand.split(/[\s,]/).andand.map(&:strip) || []
+    end
+
+    def self.available_locales
+      (selectable_locales + [default_locale, 'en']).uniq
+    end
+
+    def self.default_locale
+      ENV["LOCALE"] || ENV["I18N_LOCALE"] || source_locale
+    end
+
+    def self.source_locale
+      "en"
+    end
+  end
+end

--- a/lib/open_food_network/i18n_config.rb
+++ b/lib/open_food_network/i18n_config.rb
@@ -10,7 +10,7 @@ module OpenFoodNetwork
 
     # All locales that can be accessed by the application, including fallbacks.
     def self.available_locales
-      (selectable_locales + [default_locale, 'en']).uniq
+      (selectable_locales + [default_locale, source_locale]).uniq
     end
 
     # The default locale that is used when the user doesn't have a preference.

--- a/lib/open_food_network/i18n_config.rb
+++ b/lib/open_food_network/i18n_config.rb
@@ -4,7 +4,7 @@ module OpenFoodNetwork
   # See: config/application.yml
   class I18nConfig
     def self.selectable_locales
-      ENV["AVAILABLE_LOCALES"].andand.split(/[\s,]/).andand.map(&:strip) || []
+      ENV["AVAILABLE_LOCALES"].andand.split(/[\s,]+/) || []
     end
 
     def self.available_locales

--- a/lib/open_food_network/i18n_config.rb
+++ b/lib/open_food_network/i18n_config.rb
@@ -3,18 +3,23 @@ module OpenFoodNetwork
   # Currently, language settings are read from the environment.
   # See: config/application.yml
   class I18nConfig
+    # Locales that can be selected by users.
     def self.selectable_locales
       ENV["AVAILABLE_LOCALES"].andand.split(/[\s,]+/) || []
     end
 
+    # All locales that can be accessed by the application, including fallbacks.
     def self.available_locales
       (selectable_locales + [default_locale, 'en']).uniq
     end
 
+    # The default locale that is used when the user doesn't have a preference.
     def self.default_locale
       ENV["LOCALE"] || ENV["I18N_LOCALE"] || source_locale
     end
 
+    # This locale is changed with the code and should always be complete.
+    # All translations are done from this locale.
     def self.source_locale
       "en"
     end

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -71,11 +71,10 @@ feature 'Multilingual', js: true do
 
   describe "using the language switcher UI" do
     context "when there is only one language available" do
-      around do |example|
-        available_locales = I18n.available_locales
-        I18n.available_locales = ['en']
-        example.run
-        I18n.available_locales = available_locales
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("LOCALE").and_return("en")
+        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return("en")
       end
 
       it "hides the dropdown language menu" do
@@ -84,21 +83,29 @@ feature 'Multilingual', js: true do
       end
     end
 
-    it "allows switching language via the main navigation" do
-      visit root_path
-
-      expect(page).to have_content 'SHOPS'
-
-      find('ul.right li.language-switcher').click
-      within'ul.right li.language-switcher ul.dropdown' do
-        expect(page).to have_link I18n.t('language_name', locale: :en), href: '?locale=en'
-        expect(page).to have_link I18n.t('language_name', locale: :es, default: 'Language Name'), href: '?locale=es'
-
-        find('li a[href="?locale=es"]').click
+    context "when there are multiple languages available" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("LOCALE").and_return("en")
+        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return("en,es")
       end
 
-      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
-      expect(page).to have_content 'TIENDAS'
+      it "allows switching language via the main navigation" do
+        visit root_path
+
+        expect(page).to have_content 'SHOPS'
+
+        find('ul.right li.language-switcher').click
+        within'ul.right li.language-switcher ul.dropdown' do
+          expect(page).to have_link I18n.t('language_name', locale: :en), href: '?locale=en'
+          expect(page).to have_link I18n.t('language_name', locale: :es, default: 'Language Name'), href: '?locale=es'
+
+          find('li a[href="?locale=es"]').click
+        end
+
+        expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+        expect(page).to have_content 'TIENDAS'
+      end
     end
   end
 end

--- a/spec/lib/open_food_network/i18n_config_spec.rb
+++ b/spec/lib/open_food_network/i18n_config_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+require 'open_food_network/i18n_config'
+
+module OpenFoodNetwork
+  describe I18nConfig do
+    context "in default test configuration" do
+      before do
+        allow(ENV).to receive(:[]).with("LOCALE").and_return("en")
+        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return("en,es")
+      end
+
+      it "provides the source locale" do
+        expect(I18nConfig.source_locale).to eq "en"
+      end
+
+      it "provides the default locale" do
+        expect(I18nConfig.default_locale).to eq "en"
+      end
+
+      it "provides the default selectable locales" do
+        expect(I18nConfig.selectable_locales).to eq ["en", "es"]
+      end
+
+      it "provides the default available locales" do
+        expect(I18nConfig.available_locales).to eq ["en", "es"]
+      end
+    end
+
+    context "without configuration" do
+      before do
+        allow(ENV).to receive(:[]).with("LOCALE").and_return(nil)
+        allow(ENV).to receive(:[]).with("I18N_LOCALE").and_return(nil)
+        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return(nil)
+      end
+
+      it "provides the source locale" do
+        expect(I18nConfig.source_locale).to eq "en"
+      end
+
+      it "provides the default locale" do
+        expect(I18nConfig.default_locale).to eq "en"
+      end
+
+      it "provides the default selectable locales" do
+        expect(I18nConfig.selectable_locales).to eq []
+      end
+
+      it "provides the default available locales" do
+        expect(I18nConfig.available_locales).to eq ["en"]
+      end
+    end
+
+    context "with UK configuration" do
+      before do
+        allow(ENV).to receive(:[]).with("LOCALE").and_return("en_GB")
+        allow(ENV).to receive(:[]).with("I18N_LOCALE").and_return(nil)
+        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return("en_GB")
+      end
+
+      it "provides the source locale" do
+        expect(I18nConfig.source_locale).to eq "en"
+      end
+
+      it "provides the default locale" do
+        expect(I18nConfig.default_locale).to eq "en_GB"
+      end
+
+      it "provides the default selectable locales" do
+        expect(I18nConfig.selectable_locales).to eq ["en_GB"]
+      end
+
+      it "provides the default available locales" do
+        expect(I18nConfig.available_locales).to eq ["en_GB", "en"]
+      end
+    end
+
+    context "with human syntax" do
+      before do
+        allow(ENV).to receive(:[]).with("LOCALE").and_return("es")
+        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return("es, fr")
+      end
+
+      xit "provides the default selectable locales" do
+        # current: expect(I18nConfig.selectable_locales).to eq ["es", "", "fr"]
+        expect(I18nConfig.selectable_locales).to eq ["es", "fr"]
+      end
+
+      xit "provides the default available locales" do
+        # current: expect(I18nConfig.available_locales).to eq ["es", "", "fr", "en"]
+        expect(I18nConfig.available_locales).to eq ["es", "fr", "en"]
+      end
+    end
+  end
+end

--- a/spec/lib/open_food_network/i18n_config_spec.rb
+++ b/spec/lib/open_food_network/i18n_config_spec.rb
@@ -77,17 +77,15 @@ module OpenFoodNetwork
     context "with human syntax" do
       before do
         allow(ENV).to receive(:[]).with("LOCALE").and_return("es")
-        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return("es, fr")
+        allow(ENV).to receive(:[]).with("AVAILABLE_LOCALES").and_return("es, fr ,, ,de")
       end
 
-      xit "provides the default selectable locales" do
-        # current: expect(I18nConfig.selectable_locales).to eq ["es", "", "fr"]
-        expect(I18nConfig.selectable_locales).to eq ["es", "fr"]
+      it "provides the default selectable locales" do
+        expect(I18nConfig.selectable_locales).to eq ["es", "fr", "de"]
       end
 
-      xit "provides the default available locales" do
-        # current: expect(I18nConfig.available_locales).to eq ["es", "", "fr", "en"]
-        expect(I18nConfig.available_locales).to eq ["es", "fr", "en"]
+      it "provides the default available locales" do
+        expect(I18nConfig.available_locales).to eq ["es", "fr", "de", "en"]
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #2113.

#### What should we test?

The display and behaviour of the language switcher with different locale configurations.

#### Release notes

Fixed bug that always displayed an additional "English" in the language switcher if the server didn't have `en` configured as language.

#### How is this related to the Spree upgrade?

Not at all.