### PR TITLE
Added margin bottom on table#listing_products

### DIFF
--- a/app/assets/stylesheets/admin/products.css.scss
+++ b/app/assets/stylesheets/admin/products.css.scss
@@ -30,6 +30,7 @@ th.left-actions, td.left-actions {
 
 table#listing_products.bulk {
   clear: both;
+  margin-bottom: 60px;
 
   colgroup col {
     &.producer {


### PR DESCRIPTION
#### What? Why?

Closes #2081 

I added margin-bottom to table#listing_products to display it a bit above the save bar, even when the screen width is low (for example on 13').

#### What should we test?

The save bar doesn't hide the last line when bulk updating products.