### PR TITLE
Fix shipping method creation in sample data

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -11,6 +11,7 @@ namespace :openfoodnetwork do
 
       spree_user = Spree::User.find_by_email('spree@example.com')
       country = Spree::Country.find_by_iso(ENV.fetch('DEFAULT_COUNTRY_CODE'))
+      state = country.states.first
 
       Spree::MailMethod.create!(
         environment: Rails.env,
@@ -20,10 +21,20 @@ namespace :openfoodnetwork do
       # -- Shipping / payment information
       unless Spree::Zone.find_by_name 'Australia'
         puts "[#{task_name}] Seeding shipping / payment information"
+
         zone = FactoryGirl.create(:zone, name: 'Australia', zone_members: [])
-        country = Spree::Country.find_by_name('Australia')
         Spree::ZoneMember.create(zone: zone, zoneable: country)
-        FactoryGirl.create(:shipping_method, zone: zone)
+        address = FactoryGirl.create(
+          :address,
+          address1: "15/1 Ballantyne Street",
+          zipcode: "3153",
+          city: "Thornbury",
+          country: country,
+          state: state
+        )
+        enterprise = FactoryGirl.create(:enterprise, address: address)
+
+        FactoryGirl.create(:shipping_method, zone: zone, distributors: [enterprise])
       end
 
       # -- Taxonomies
@@ -41,19 +52,19 @@ namespace :openfoodnetwork do
       unless Spree::Address.find_by_zipcode "3160"
         puts "[#{task_name}] Seeding addresses"
 
-        FactoryGirl.create(:address, address1: "25 Myrtle Street", zipcode: "3153", city: "Bayswater", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "6 Rollings Road", zipcode: "3156", city: "Upper Ferntree Gully", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "72 Lake Road", zipcode: "3130", city: "Blackburn", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "7 Verbena Street", zipcode: "3195", city: "Mordialloc", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "20 Galvin Street", zipcode: "3018", city: "Altona", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "59 Websters Road", zipcode: "3106", city: "Templestowe", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "17 Torresdale Drive", zipcode: "3155", city: "Boronia", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "21 Robina CRT", zipcode: "3764", city: "Kilmore", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "25 Kendall Street", zipcode: "3134", city: "Ringwood", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "2 Mines Road", zipcode: "3135", city: "Ringwood East", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "183 Millers Road", zipcode: "3025", city: "Altona North", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "310 Pascoe Vale Road", zipcode: "3040", city: "Essendon", country: country, state: country.states.first)
-        FactoryGirl.create(:address, address1: "6 Martin Street", zipcode: "3160", city: "Belgrave", country: country, state: country.states.first)
+        FactoryGirl.create(:address, address1: "25 Myrtle Street", zipcode: "3153", city: "Bayswater", country: country, state: state)
+        FactoryGirl.create(:address, address1: "6 Rollings Road", zipcode: "3156", city: "Upper Ferntree Gully", country: country, state: state)
+        FactoryGirl.create(:address, address1: "72 Lake Road", zipcode: "3130", city: "Blackburn", country: country, state: state)
+        FactoryGirl.create(:address, address1: "7 Verbena Street", zipcode: "3195", city: "Mordialloc", country: country, state: state)
+        FactoryGirl.create(:address, address1: "20 Galvin Street", zipcode: "3018", city: "Altona", country: country, state: state)
+        FactoryGirl.create(:address, address1: "59 Websters Road", zipcode: "3106", city: "Templestowe", country: country, state: state)
+        FactoryGirl.create(:address, address1: "17 Torresdale Drive", zipcode: "3155", city: "Boronia", country: country, state: state)
+        FactoryGirl.create(:address, address1: "21 Robina CRT", zipcode: "3764", city: "Kilmore", country: country, state: state)
+        FactoryGirl.create(:address, address1: "25 Kendall Street", zipcode: "3134", city: "Ringwood", country: country, state: state)
+        FactoryGirl.create(:address, address1: "2 Mines Road", zipcode: "3135", city: "Ringwood East", country: country, state: state)
+        FactoryGirl.create(:address, address1: "183 Millers Road", zipcode: "3025", city: "Altona North", country: country, state: state)
+        FactoryGirl.create(:address, address1: "310 Pascoe Vale Road", zipcode: "3040", city: "Essendon", country: country, state: state)
+        FactoryGirl.create(:address, address1: "6 Martin Street", zipcode: "3160", city: "Belgrave", country: country, state: state)
       end
 
       # -- Enterprises


### PR DESCRIPTION
#### What? Why?

Closes #2071

Now that we got the fixes in `master` I deployed to staging, tried again and still the shipping method creation failed. I don't understand why but this line wasn't hit before. If not, it would have failed.

Below you have the relevant pieces of the stack trace. 
```
rake aborted!                                                                                                                               
ActiveRecord::RecordInvalid: La validación falló: Provincia ó Estado no puede estar en blanco                                               
/home/openfoodnetwork/.gem/ruby/2.1.0/gems/activerecord-3.2.21/lib/active_record/validations.rb:56:in `save!'                               
(...)
/home/openfoodnetwork/apps/openfoodnetwork/current/spec/factories.rb:209:in `block (3 levels) in <top (required)>'
/home/openfoodnetwork/apps/openfoodnetwork/current/spec/factories.rb:459:in `block (3 levels) in <top (required)>'
(...)
/home/openfoodnetwork/.gem/ruby/2.1.0/gems/factory_girl-3.3.0/lib/factory_girl/strategy_syntax_method_registrar.rb:19:in `block in define_si
ngular_strategy_method'
/home/openfoodnetwork/apps/openfoodnetwork/current/lib/tasks/dev.rake:29:in `block (3 levels) in <top (required)>'
```
That led me to:

https://github.com/openfoodfoundation/openfoodnetwork/blob/6f5080923fe07313f5773ca205cd9def227b213e/spec/factories.rb#L458-L461

which depends on:

https://github.com/openfoodfoundation/openfoodnetwork/blob/6f5080923fe07313f5773ca205cd9def227b213e/spec/factories.rb#L209

so it's not that `shipping_method` requires a country and a state, that's because `Enterprise` needs them, which is created as part of the `shipping_method` factory as a `distributor` (we associate the shipping method with an enterprise).

#### What should we test?

The command `bundle exec rake openfoodnetwork:dev:load_sample_data` should work flawlessly.

#### Release notes

Not worth it.
