### PR TITLE
Added 'meta_keywords' to search of products

### DIFF
--- a/app/assets/javascripts/darkswarm/filters/filter_products.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/filter_products.js.coffee
@@ -4,5 +4,5 @@ Darkswarm.filter 'products', (Matcher) ->
     text ?= ""
     return products if text == ""
     products.filter (product) =>
-      propertiesToMatch = [product.name, product.variant_names, product.supplier.name, product.primary_taxon.name]
+      propertiesToMatch = [product.name, product.variant_names, product.supplier.name, product.primary_taxon.name, product.meta_keywords] 
       Matcher.matchBeginning propertiesToMatch, text

--- a/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
@@ -1,5 +1,5 @@
 / insert_bottom "[data-hook='admin_product_tabs']"
 
-- klass = current == 'SEO' ? 'active' : ''
+- klass = current == 'Search' ? 'active' : ''
 %li{:class => klass}
-  = link_to_with_icon 'icon-tasks', t('admin.products.seo'), seo_admin_product_url(@product)
+  = link_to_with_icon 'icon-tasks', 'Search', seo_admin_product_url(@product)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
@@ -1,5 +1,5 @@
 / insert_bottom "[data-hook='admin_product_tabs']"
 
-- klass = current == 'Search' ? 'active' : ''
+- klass = current == t(:Search) ? 'active' : ''
 %li{:class => klass}
   = link_to_with_icon 'icon-tasks', t(:Search), seo_admin_product_url(@product)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
@@ -2,4 +2,4 @@
 
 - klass = current == 'Search' ? 'active' : ''
 %li{:class => klass}
-  = link_to_with_icon 'icon-tasks', 'Search', seo_admin_product_url(@product)
+  = link_to_with_icon 'icon-tasks', t(:Search), seo_admin_product_url(@product)

--- a/app/serializers/api/product_serializer.rb
+++ b/app/serializers/api/product_serializer.rb
@@ -36,7 +36,7 @@ class Api::CachedProductSerializer < ActiveModel::Serializer
   #delegate :cache_key, to: :object
   include ActionView::Helpers::SanitizeHelper
 
-  attributes :id, :name, :permalink
+  attributes :id, :name, :permalink, :meta_keywords
   attributes :on_demand, :group_buy, :notes, :description, :description_html
   attributes :properties_with_values
 

--- a/app/views/spree/admin/products/_seo_form.html.haml
+++ b/app/views/spree/admin/products/_seo_form.html.haml
@@ -1,11 +1,11 @@
 .row{"data-hook" => "admin_product_meta_form"}
   .alpha.eleven.columns
     = f.field_container :meta_description do
-      = f.label :meta_keywords, t(:meta_keywords)
+      = f.label :meta_keywords, t(:product_search_keywords)
       %br/
       = f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6
     = f.field_container :meta_description do
-      = f.label :meta_description, t(:meta_description)
+      = f.label :meta_description, t(:SEO_keywords)
       %br/
       = f.text_field :meta_description, :class => 'fullwidth', :rows => 6
   .alpha.eleven.columns

--- a/app/views/spree/admin/products/_seo_form.html.haml
+++ b/app/views/spree/admin/products/_seo_form.html.haml
@@ -2,10 +2,12 @@
   .alpha.eleven.columns
     = f.field_container :meta_keywords do
       = f.label :meta_keywords, t(:product_search_keywords)
+      %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.product_search_tip') }
       %br/
       = f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6
     = f.field_container :meta_description do
       = f.label :meta_description, t(:SEO_keywords)
+      %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.seo_tip') }
       %br/
       = f.text_field :meta_description, :class => 'fullwidth', :rows => 6
   .alpha.eleven.columns

--- a/app/views/spree/admin/products/_seo_form.html.haml
+++ b/app/views/spree/admin/products/_seo_form.html.haml
@@ -1,6 +1,6 @@
 .row{"data-hook" => "admin_product_meta_form"}
   .alpha.eleven.columns
-    = f.field_container :meta_description do
+    = f.field_container :meta_keywords do
       = f.label :meta_keywords, t(:product_search_keywords)
       %br/
       = f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6

--- a/app/views/spree/admin/products/seo.html.haml
+++ b/app/views/spree/admin/products/seo.html.haml
@@ -1,5 +1,5 @@
 = render :partial => 'spree/admin/shared/product_sub_menu'
-= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'SEO' }
+= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Search' }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 
 = form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f|

--- a/app/views/spree/admin/products/seo.html.haml
+++ b/app/views/spree/admin/products/seo.html.haml
@@ -1,5 +1,5 @@
 = render :partial => 'spree/admin/shared/product_sub_menu'
-= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Search' }
+= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => t(:Search) }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 
 = form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f|

--- a/app/views/spree/admin/products/seo.html.haml
+++ b/app/views/spree/admin/products/seo.html.haml
@@ -2,7 +2,8 @@
 = render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => t(:Search) }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 
-= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f|
-  %fieldset.no-border-top
-    = render :partial => 'seo_form', :locals => { :f => f }
-    = render :partial => 'spree/admin/shared/edit_resource_links'
+%div{ 'ng-app' => 'ofn.admin' }
+  = form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f|
+    %fieldset.no-border-top
+      = render :partial => 'seo_form', :locals => { :f => f }
+      = render :partial => 'spree/admin/shared/edit_resource_links'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -440,6 +440,8 @@ en:
 
     products:
       unit_name_placeholder: 'eg. bunches'
+      product_search_keywords: Product Search Keywords
+      SEO_keywords: SEO Keywords
       properties:
         property_name: Property Name
         inherited_property: Inherited Property

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,6 +442,7 @@ en:
       unit_name_placeholder: 'eg. bunches'
       product_search_keywords: Product Search Keywords
       SEO_keywords: SEO Keywords
+      Search: Search
       properties:
         property_name: Property Name
         inherited_property: Inherited Property

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,7 +449,6 @@ en:
         to_order_tip: "Items made to order do not have a set stock level, such as loaves of bread made fresh to order."
       product_distributions: "Product Distributions"
       group_buy_options: "Group Buy Options"
-      seo: "SEO"
       back_to_products_list: "Back to products list"
 
     variant_overrides:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,7 +441,9 @@ en:
     products:
       unit_name_placeholder: 'eg. bunches'
       product_search_keywords: Product Search Keywords
+      product_search_tip: Type words to help search your products in the shops. Use space to separate each keyword.
       SEO_keywords: SEO Keywords
+      seo_tip: Type words to help search your products in the web. Use space to separate each keyword.
       Search: Search
       properties:
         property_name: Property Name

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -184,19 +184,17 @@ feature %q{
       product.distributors.should == [@distributors[0]]
     end
 
-    scenario "editing product SEO" do
+    scenario "editing product Search" do
       product = product = create(:simple_product, supplier: @supplier2)
       visit spree.edit_admin_product_path product
-      within('#sidebar') { click_link 'SEO' }
-      fill_in "product_meta_keywords", :with => 'Meta Keywords'
-      fill_in 'Meta Description', :with => 'Meta Description'
+      within('#sidebar') { click_link 'Search' }
+      fill_in 'Product Search Keywords', :with => 'Product Search Keywords'
       fill_in 'Notes', :with => 'Just testing Notes'
       click_button 'Update'
       flash_message.should == "Product \"#{product.name}\" has been successfully updated!"
       product.reload
       product.notes.should == 'Just testing Notes'
-      product.meta_keywords.should == 'Meta Keywords'
-      product.meta_description.should == 'Meta Description'
+      product.meta_keywords.should == 'Product Search Keywords'
     end
 
     scenario "deleting product properties", js: true do

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -191,10 +191,10 @@ feature %q{
       fill_in 'Product Search Keywords', :with => 'Product Search Keywords'
       fill_in 'Notes', :with => 'Just testing Notes'
       click_button 'Update'
-      flash_message.should == "Product \"#{product.name}\" has been successfully updated!"
+      expect(flash_message).to eq("Product \"#{product.name}\" has been successfully updated!")
       product.reload
-      product.notes.should == 'Just testing Notes'
-      product.meta_keywords.should == 'Product Search Keywords'
+      expect(product.notes).to eq('Just testing Notes')
+      expect(product.meta_keywords).to eq('Product Search Keywords')
     end
 
     scenario "deleting product properties", js: true do

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -214,8 +214,8 @@ feature "As a consumer I want to shop with a distributor", js: true do
         page.should_not have_content product.name
 
         fill_in "search", with: "Dome"           # For product with meta_keywords "Domestic"
-        page.should have_content product.name
-        page.should_not have_content product2.name
+        expect(page).to have_content product.name
+        expect(page).not_to have_content product2.name
       end
 
       it "returns search results for products where the search term matches one of the product's variant names" do

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -12,7 +12,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
     let(:supplier) { create(:supplier_enterprise) }
     let(:oc1) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise), orders_close_at: 2.days.from_now) }
     let(:oc2) { create(:simple_order_cycle, distributors: [distributor], coordinator: create(:distributor_enterprise), orders_close_at: 3.days.from_now) }
-    let(:product) { create(:simple_product, supplier: supplier) }
+    let(:product) { create(:simple_product, supplier: supplier, meta_keywords: "Domestic") }
     let(:variant) { product.variants.first }
     let(:order) { create(:order, distributor: distributor) }
 
@@ -169,7 +169,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
     describe "after selecting an order cycle with products visible" do
       let(:variant1) { create(:variant, product: product, price: 20) }
       let(:variant2) { create(:variant, product: product, price: 30, display_name: "Badgers") }
-      let(:product2) { create(:simple_product, supplier: supplier, name: "Meercats") }
+      let(:product2) { create(:simple_product, supplier: supplier, name: "Meercats", meta_keywords: "Wild") }
       let(:variant3) { create(:variant, product: product2, price: 40, display_name: "Ferrets") }
       let(:exchange) { Exchange.find(oc1.exchanges.to_enterprises(distributor).outgoing.first.id) }
 
@@ -212,6 +212,10 @@ feature "As a consumer I want to shop with a distributor", js: true do
         fill_in "search", with: "Meer"           # For product named "Meercats"
         page.should have_content product2.name
         page.should_not have_content product.name
+
+        fill_in "search", with: "Dome"           # For product with meta_keywords "Domestic"
+        page.should have_content product.name
+        page.should_not have_content product2.name
       end
 
       it "returns search results for products where the search term matches one of the product's variant names" do


### PR DESCRIPTION
Copy of #1981 (just added tooltips), **all credits go to @Duende13.**

#### What? Why?

Closes #1936 

It was proposed as solution to be able to look for 'meta_keywords' to avoid that users have to add long names to describe their products and variants, they can add more details into the meta_keywords field, renamed 'Product Search Keywords' to achieve that.

#### What should we test?

To search for products where the meta_keywords or new 'Product Search Keywords' field has been used and applies the filter to find them.