### PR TITLE
Replace Rohan's email address by optional config

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -16,6 +16,12 @@ CHECKOUT_ZONE: Australia
 # Find currency codes at http://en.wikipedia.org/wiki/ISO_4217.
 CURRENCY: AUD
 
+# The whenever gem can set the `MAILTO` variable for our cron jobs.
+# You can define an email address to notify if any job outputs something.
+# But you need a working mail server setup so that the message is delivered.
+# See: config/schedule.rb
+#SCHEDULE_NOTIFICATIONS: admin@example.com
+
 # SingleSignOn login for Discourse
 #
 # DISCOURSE_SSO_SECRET should be a random string. It must be the same as provided to your Discourse instance.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,8 +2,9 @@ require 'whenever'
 
 # Learn more: http://github.com/javan/whenever
 
-env "MAILTO", "rohan@rohanmitchell.com"
+app_config = YAML.load_file(File.join(__dir__, 'application.yml'))
 
+env "MAILTO", app_config["SCHEDULE_NOTIFICATIONS"] if app_config["SCHEDULE_NOTIFICATIONS"]
 
 # If we use -e with a file containing specs, rspec interprets it and filters out our examples
 job_type :run_file, "cd :path; :environment_variable=:environment bundle exec script/rails runner :task :output"


### PR DESCRIPTION
Rohan's email address is hard-coded, but he doesn't want to receive
these emails any more.

#### What? Why?

Moving to a new server, Rohan was suddenly receiving all these notifications. Our old server didn't have a proper email setup so that these messages were not delivered. The new server does have a working email setup and was sending him lots of notifications every day.

#### What should we test?

Dev's can test that `bundle exec whenever --update-crontab` works correctly. After staging, we should check with `crontab -l` if everything is correct. There is no visible change to the user.

#### Release notes

Admins can now define an email address to notify in case cron jobs have output.

#### How is this related to the Spree upgrade?

Not.
