### PR TITLE
Fix enterprise user unsaved changes

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -5,7 +5,7 @@ angular.module("admin.enterprises")
     $scope.ShippingMethods = EnterpriseShippingMethods.shippingMethods
     $scope.navClear = NavigationCheck.clear
     $scope.menu = SideMenu
-    $scope.newManager = { id: '', email: (t('add_manager')) }
+    $scope.newManager = { id: null, email: (t('add_manager')) }
     $scope.StatusMessage = StatusMessage
 
     $scope.$watch 'enterprise_form.$dirty', (newValue) ->
@@ -42,12 +42,13 @@ angular.module("admin.enterprises")
           $scope.enterprise_form.$setDirty()
 
     $scope.addManager = (manager) ->
-      if manager.id? and manager.email?
+      if manager.id? and angular.isNumber(manager.id) and manager.email?
         manager =
           id: manager.id
           email: manager.email
           confirmed: manager.confirmed
         if (user for user in $scope.Enterprise.users when user.id == manager.id).length == 0
           $scope.Enterprise.users.push manager
+          $scope.enterprise_form.$setDirty()
         else
           alert ("#{manager.email}" + " " + t("is_already_manager"))

--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -38,8 +38,7 @@ angular.module("admin.enterprises")
           return
         for i, user of $scope.Enterprise.users when user.id == manager.id
           $scope.Enterprise.users.splice i, 1
-        if $scope.enterprise_form?
-          $scope.enterprise_form.$setDirty()
+          $scope.enterprise_form?.$setDirty()
 
     $scope.addManager = (manager) ->
       if manager.id? and angular.isNumber(manager.id) and manager.email?
@@ -49,6 +48,6 @@ angular.module("admin.enterprises")
           confirmed: manager.confirmed
         if (user for user in $scope.Enterprise.users when user.id == manager.id).length == 0
           $scope.Enterprise.users.push manager
-          $scope.enterprise_form.$setDirty()
+          $scope.enterprise_form?.$setDirty()
         else
           alert ("#{manager.email}" + " " + t("is_already_manager"))

--- a/app/views/admin/enterprises/_ng_form.html.haml
+++ b/app/views/admin/enterprises/_ng_form.html.haml
@@ -3,7 +3,6 @@
 -# So we use onchange and have to get the scope to access the ng controller
 = form_for [main_app, :admin, @enterprise], html: { name: "enterprise_form",
   "ng-controller" => 'enterpriseCtrl',
-  'onchange' => 'angular.element(enterprise_form).scope().setFormDirty()',
   "ng-cloak" => true } do |f|
 
   %save-bar{ dirty: "enterprise_form.$dirty", persist: "true" }

--- a/app/views/admin/enterprises/form/_users.html.haml
+++ b/app/views/admin/enterprises/form/_users.html.haml
@@ -42,7 +42,7 @@
         %tr
           %td
             - # Ignore this input in the submit
-            = hidden_field_tag :ignored, :new_manager, class: "select2 fullwidth", 'user-select' => 'newManager', 'ng-model' => 'newManager'
+            = hidden_field_tag :ignored, nil, class: "select2 fullwidth", 'user-select' => 'newManager', 'ng-model' => 'newManager'
           %td.actions
             %a{ 'ng-click' => 'addManager(newManager)', :class => "icon-plus no-text" }
         %tr.animate-repeat{ id: "manager-{{manager.id}}", ng: { repeat: 'manager in Enterprise.users' }}


### PR DESCRIPTION
#### What? Why?

Closes #1216.

Minor bugfix. Enterprise user form was showing "Unsaved Changes" message before a new user was properly added.

#### What should we test?

Adding new users to an enterprise. The unsaved changes bar shouldn't show before the user has been added to the list.

