### PR TITLE
Setup mail method automatically

### DIFF
--- a/app/services/create_mail_method.rb
+++ b/app/services/create_mail_method.rb
@@ -1,0 +1,34 @@
+# Configures Rails to use the specified mail settings. It does so creating
+# a Spree::MailMethod and applying its configuration.
+class CreateMailMethod
+  # Constructor
+  #
+  # @param attributes [Hash] MailMethod attributes
+  def initialize(attributes)
+    @attributes = attributes
+  end
+
+  def call
+    persist_attributes
+    initialize_mail_settings
+  end
+
+  private
+
+  attr_reader :attributes
+
+  # Updates the created mail method's attributes with the ones specified
+  def persist_attributes
+    mail_method.update_attributes(attributes)
+  end
+
+  # Creates a new Spree::MailMethod for the current environment
+  def mail_method
+    Spree::MailMethod.create(environment: attributes[:environment])
+  end
+
+  # Makes Spree apply the specified mail settings
+  def initialize_mail_settings
+    Spree::Core::MailSettings.init
+  end
+end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -22,6 +22,13 @@ CURRENCY: AUD
 # See: config/schedule.rb
 #SCHEDULE_NOTIFICATIONS: admin@example.com
 
+# Mail settings
+MAIL_HOST: 'example.com'
+MAIL_DOMAIN: 'example.com'
+MAIL_PORT: 25
+SMTP_USERNAME: 'ofn'
+SMTP_PASSWORD: 'f00d'
+
 # SingleSignOn login for Discourse
 #
 # DISCOURSE_SSO_SECRET should be a random string. It must be the same as provided to your Discourse instance.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,3 +29,24 @@ states.each do |state|
     )
   end
 end
+
+create_mail_method
+
+def create_mail_method
+  Spree::MailMethod.destroy_all
+
+  CreateMailMethod.new(
+    environment: Rails.env,
+    preferred_enable_mail_delivery: true,
+    preferred_mail_host: ENV['MAIL_HOST'],
+    preferred_mail_domain: ENV['MAIL_DOMAIN'],
+    preferred_mail_port: ENV['MAIL_PORT'],
+    preferred_mail_auth_type: 'login',
+    preferred_smtp_username: ENV['SMTP_USERNAME'],
+    preferred_smtp_password: ENV['SMTP_PASSWORD'],
+    preferred_secure_connection_type: 'None',
+    preferred_mails_from: "no-reply@#{ENV['MAIL_DOMAIN']}",
+    preferred_mail_bcc: '',
+    preferred_intercept_email: ''
+  ).call
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,23 +30,23 @@ states.each do |state|
   end
 end
 
-create_mail_method
-
 def create_mail_method
   Spree::MailMethod.destroy_all
 
   CreateMailMethod.new(
     environment: Rails.env,
     preferred_enable_mail_delivery: true,
-    preferred_mail_host: ENV['MAIL_HOST'],
-    preferred_mail_domain: ENV['MAIL_DOMAIN'],
-    preferred_mail_port: ENV['MAIL_PORT'],
+    preferred_mail_host: ENV.fetch('MAIL_HOST'),
+    preferred_mail_domain: ENV.fetch('MAIL_DOMAIN'),
+    preferred_mail_port: ENV.fetch('MAIL_PORT'),
     preferred_mail_auth_type: 'login',
-    preferred_smtp_username: ENV['SMTP_USERNAME'],
-    preferred_smtp_password: ENV['SMTP_PASSWORD'],
+    preferred_smtp_username: ENV.fetch('SMTP_USERNAME'),
+    preferred_smtp_password: ENV.fetch('SMTP_PASSWORD'),
     preferred_secure_connection_type: 'None',
-    preferred_mails_from: "no-reply@#{ENV['MAIL_DOMAIN']}",
+    preferred_mails_from: "no-reply@#{ENV.fetch('MAIL_DOMAIN')}",
     preferred_mail_bcc: '',
     preferred_intercept_email: ''
   ).call
 end
+
+create_mail_method

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,10 +13,7 @@ namespace :openfoodnetwork do
       country = Spree::Country.find_by_iso(ENV.fetch('DEFAULT_COUNTRY_CODE'))
       state = country.states.first
 
-      Spree::MailMethod.create!(
-        environment: Rails.env,
-        preferred_mails_from: spree_user.email
-      )
+      create_mail_method
 
       # -- Shipping / payment information
       unless Spree::Zone.find_by_name 'Australia'
@@ -211,5 +208,23 @@ namespace :openfoodnetwork do
       spree_user.confirm!
     end
 
+    def create_mail_method
+      Spree::MailMethod.destroy_all
+
+      CreateMailMethod.new(
+        environment: Rails.env,
+        preferred_enable_mail_delivery: true,
+        preferred_mail_host: ENV['MAIL_HOST'],
+        preferred_mail_domain: ENV['DOMAIN'],
+        preferred_mail_port: ENV['MAIL_PORT'],
+        preferred_mail_auth_type: "login",
+        preferred_smtp_username: ENV['SMTP_USERNAME'],
+        preferred_smtp_password: ENV['SMTP_PASSWORD'],
+        preferred_secure_connection_type: "None",
+        preferred_mails_from: "no-reply@#{ENV['DOMAIN']}",
+        preferred_mail_bcc: "",
+        preferred_intercept_email: ""
+      ).call
+    end
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,8 +13,6 @@ namespace :openfoodnetwork do
       country = Spree::Country.find_by_iso(ENV.fetch('DEFAULT_COUNTRY_CODE'))
       state = country.states.first
 
-      create_mail_method
-
       # -- Shipping / payment information
       unless Spree::Zone.find_by_name 'Australia'
         puts "[#{task_name}] Seeding shipping / payment information"
@@ -206,25 +204,6 @@ namespace :openfoodnetwork do
       EnterpriseRole.create!(user: Spree::User.first, enterprise: enterprise2)
 
       spree_user.confirm!
-    end
-
-    def create_mail_method
-      Spree::MailMethod.destroy_all
-
-      CreateMailMethod.new(
-        environment: Rails.env,
-        preferred_enable_mail_delivery: true,
-        preferred_mail_host: ENV['MAIL_HOST'],
-        preferred_mail_domain: ENV['MAIL_DOMAIN'],
-        preferred_mail_port: ENV['MAIL_PORT'],
-        preferred_mail_auth_type: "login",
-        preferred_smtp_username: ENV['SMTP_USERNAME'],
-        preferred_smtp_password: ENV['SMTP_PASSWORD'],
-        preferred_secure_connection_type: "None",
-        preferred_mails_from: "no-reply@#{ENV['MAIL_DOMAIN']}",
-        preferred_mail_bcc: "",
-        preferred_intercept_email: ""
-      ).call
     end
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -215,13 +215,13 @@ namespace :openfoodnetwork do
         environment: Rails.env,
         preferred_enable_mail_delivery: true,
         preferred_mail_host: ENV['MAIL_HOST'],
-        preferred_mail_domain: ENV['DOMAIN'],
+        preferred_mail_domain: ENV['MAIL_DOMAIN'],
         preferred_mail_port: ENV['MAIL_PORT'],
         preferred_mail_auth_type: "login",
         preferred_smtp_username: ENV['SMTP_USERNAME'],
         preferred_smtp_password: ENV['SMTP_PASSWORD'],
         preferred_secure_connection_type: "None",
-        preferred_mails_from: "no-reply@#{ENV['DOMAIN']}",
+        preferred_mails_from: "no-reply@#{ENV['MAIL_DOMAIN']}",
         preferred_mail_bcc: "",
         preferred_intercept_email: ""
       ).call

--- a/spec/services/create_mail_method_spec.rb
+++ b/spec/services/create_mail_method_spec.rb
@@ -14,28 +14,36 @@ describe CreateMailMethod do
       allow(Spree::Core::MailSettings).to receive(:init) { mail_settings }
     end
 
-    it 'creates a new MailMethod' do
-      described_class.new(attributes).call
+    context 'unit' do
+      before do
+        allow(mail_method).to receive(:update_attributes).with(attributes)
+      end
 
-      expect(Spree::MailMethod)
-        .to have_received(:create).with(environment: 'test') { mail_method }
+      it 'creates a new MailMethod' do
+        described_class.new(attributes).call
+
+        expect(Spree::MailMethod)
+          .to have_received(:create).with(environment: 'test') { mail_method }
+      end
+
+      it 'updates the MailMethod' do
+        described_class.new(attributes).call
+
+        expect(mail_method)
+          .to have_received(:update_attributes).with(attributes) { mail_method }
+      end
+
+      it 'initializes the mail settings' do
+        described_class.new(attributes).call
+        expect(Spree::Core::MailSettings).to have_received(:init)
+      end
     end
 
-    it 'updates the MailMethod' do
-      expect(mail_method)
-        .to(receive(:update_attributes)).with(attributes) { mail_method }
-
-      described_class.new(attributes).call
-    end
-
-    it 'updates the mail method attributes' do
-      described_class.new(attributes).call
-      expect(mail_method.preferred_smtp_username).to eq('smtp_username')
-    end
-
-    it 'initializes the mail settings' do
-      described_class.new(attributes).call
-      expect(Spree::Core::MailSettings).to have_received(:init)
+    context 'integration' do
+      it 'updates the mail method attributes' do
+        described_class.new(attributes).call
+        expect(mail_method.preferred_smtp_username).to eq('smtp_username')
+      end
     end
   end
 end

--- a/spec/services/create_mail_method_spec.rb
+++ b/spec/services/create_mail_method_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe CreateMailMethod do
+  describe '#call' do
+    let(:mail_method) { Spree::MailMethod.create(environment: 'test') }
+    let(:mail_settings) { instance_double(Spree::Core::MailSettings) }
+    let(:attributes) do
+      { preferred_smtp_username: "smtp_username", environment: "test" }
+    end
+
+    before do
+      allow(Spree::MailMethod)
+        .to receive(:create).with(environment: 'test').and_return(mail_method)
+      allow(Spree::Core::MailSettings).to receive(:init) { mail_settings }
+    end
+
+    it 'creates a new MailMethod' do
+      described_class.new(attributes).call
+
+      expect(Spree::MailMethod)
+        .to have_received(:create).with(environment: 'test') { mail_method }
+    end
+
+    it 'updates the MailMethod' do
+      expect(mail_method)
+        .to(receive(:update_attributes)).with(attributes) { mail_method }
+
+      described_class.new(attributes).call
+    end
+
+    it 'updates the mail method attributes' do
+      described_class.new(attributes).call
+      expect(mail_method.preferred_smtp_username).to eq('smtp_username')
+    end
+
+    it 'initializes the mail settings' do
+      described_class.new(attributes).call
+      expect(Spree::Core::MailSettings).to have_received(:init)
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #2141

This ensures that when either resetting your development database, deploying to staging or even setting up a new OFN instance, the mail will be properly configured given some SMTP and other mail settings.

This aims to cut down the enourmous amounts of time we spend setting up environments.

#### What should we test?

When deploying to staging a working mail method should be present in DB. You can try it out by first running `bundle exec rake openfoodnetwork:dev:load_sample_data` and then navigating to `/admin/mail_methods/1/edit`

#### Release notes

New instances OFN will have the mail automatically configured.

#### Dependencies

Depends on https://github.com/openfoodfoundation/ofn-install/pull/134, which should be provisioned before deploying this. 
