### PR TITLE
Subs: Remove obsolete subscription fields from order cycles table

### DIFF
--- a/db/migrate/20180316034336_remove_placed_at_and_confirmed_at_from_order_cycles.rb
+++ b/db/migrate/20180316034336_remove_placed_at_and_confirmed_at_from_order_cycles.rb
@@ -1,0 +1,11 @@
+class RemovePlacedAtAndConfirmedAtFromOrderCycles < ActiveRecord::Migration
+  def up
+    remove_column :order_cycles, :standing_orders_placed_at
+    remove_column :order_cycles, :standing_orders_confirmed_at
+  end
+
+  def down
+    add_column :order_cycles, :standing_orders_placed_at, :datetime
+    add_column :order_cycles, :standing_orders_confirmed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180222231639) do
+ActiveRecord::Schema.define(:version => 20180316034336) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -319,10 +319,8 @@ ActiveRecord::Schema.define(:version => 20180222231639) do
     t.datetime "orders_open_at"
     t.datetime "orders_close_at"
     t.integer  "coordinator_id"
-    t.datetime "created_at",                   :null => false
-    t.datetime "updated_at",                   :null => false
-    t.datetime "standing_orders_placed_at"
-    t.datetime "standing_orders_confirmed_at"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
   end
 
   create_table "producer_properties", :force => true do |t|


### PR DESCRIPTION
#### What? Why?

No issue, removes a couple of database fields which are no longer required.

#### What should we test?

Nothing to test really, if the test suite passes we should be fine.

#### Release notes

Feature is yet to be released so this does not require its own release notes.