### PR TITLE
Fix enterprise filter in customers

### DIFF
--- a/app/assets/javascripts/admin/customers/controllers/customers_controller.js.coffee
+++ b/app/assets/javascripts/admin/customers/controllers/customers_controller.js.coffee
@@ -12,7 +12,7 @@ angular.module("admin.customers").controller "customersCtrl", ($scope, $q, $filt
 
   $scope.$watch "shop_id", ->
     if $scope.shop_id?
-      CurrentShop.shop = $filter('filter')($scope.shops, {id: $scope.shop_id})[0]
+      CurrentShop.shop = $filter('filter')($scope.shops, {id: parseInt($scope.shop_id)}, true)[0]
       Customers.index({enterprise_id: $scope.shop_id}).then (data) ->
         pendingChanges.removeAll()
         $scope.customers_form.$setPristine()

--- a/spec/javascripts/unit/admin/customers/controllers/customers_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/customers/controllers/customers_controller_spec.js.coffee
@@ -10,9 +10,10 @@ describe "CustomersCtrl", ->
       null
 
     shops = [
-      { name: "Shop 1", id: 1 }
-      { name: "Shop 2", id: 2 }
-      { name: "Shop 3", id: 3 }
+      { name: "Shop 1", id: 1 },
+      { name: "Shop 2", id: 12 },
+      { name: "Shop 3", id: 2 },
+      { name: "Shop 4", id: 3 }
     ]
 
     availableCountries = [
@@ -39,9 +40,9 @@ describe "CustomersCtrl", ->
     beforeEach inject (pendingChanges) ->
       spyOn(pendingChanges, "removeAll")
       scope.customers_form = jasmine.createSpyObj('customers_form', ['$setPristine'])
-      http.expectGET('/admin/customers.json?enterprise_id=3').respond 200, customers
+      http.expectGET('/admin/customers.json?enterprise_id=2').respond 200, customers
       scope.$apply ->
-        scope.shop_id = 3
+        scope.shop_id = "2"
       http.flush()
 
     it "sets the CurrentShop", inject (CurrentShop) ->
@@ -81,7 +82,7 @@ describe "CustomersCtrl", ->
         { text: 'three' }
       ]
       beforeEach ->
-        http.expectGET('/admin/tag_rules/map_by_tag.json?enterprise_id=3').respond 200, tags
+        http.expectGET('/admin/tag_rules/map_by_tag.json?enterprise_id=2').respond 200, tags
 
       it "retrieves the tag list", ->
         promise = scope.findTags('')


### PR DESCRIPTION
#### What? Why?

When selecting an enterprise from the customers page, the actual value being selected wasn't the one the user picked up. It happened to me that when picking `Enterprise 2` the filter got `Fooderers`, which have the id 2 and 12 respectively.

As a result, when I created a customer, it got associated with `Fooderers` while I wanted `Enterprise 2`.

That was because, as explained in [Angular's filter documentation](https://docs.angularjs.org/api/ng/filter/filter), when providing an Object as the filter expression:

> Object: A pattern object can be used to filter specific properties on objects contained by array. For example {name:"M", phone:"1"} predicate will return an array of items which have property name containing "M" and property phone containing "1".

In my case, the filter was returning:

![angular](https://user-images.githubusercontent.com/762088/37668197-312a3694-2c64-11e8-91be-f4951243c1fc.png)

What we need here instead is an exact match on the attribute `id`.

#### What should we test?

When selecting an enterprise from the customers page, only the customers for that enterprise should be shown, and not others. Also, when creating a new customer, it should be listed when refreshing and selecting her enterprise.

#### Release notes

Fix customers being associated with the wrong enterprise when multiple enterprises are available.
