### PR TITLE
Subs: make sure that a datepicker is available for subscriptions module

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/date_picker.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/date_picker.js.coffee
@@ -1,0 +1,9 @@
+angular.module("admin.utils").directive "datepicker", ->
+  require: "ngModel"
+  link: (scope, element, attrs, ngModel) ->
+    element.datepicker
+      dateFormat: "yy-mm-dd"
+      onSelect: (dateText, inst) ->
+        scope.$apply (scope) ->
+          # Fires ngModel.$parsers
+          ngModel.$setViewValue dateText

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -159,7 +159,10 @@ feature 'Subscriptions' do
         click_button('Next')
         expect(page).to have_content 'can\'t be blank', count: 2
         expect(page).to have_content 'Oops! Please fill in all of the required fields...'
-        fill_in 'begins_at', with: Time.zone.today.strftime('%F')
+        find_field('begins_at').click
+        within(".ui-datepicker-calendar") do
+          find('.ui-datepicker-today').click
+        end
         select2_select card2_option, from: 'credit_card_id'
 
         click_button('Next')


### PR DESCRIPTION
#### What? Why?

Fixes #2155: the datepicker on the subscriptions form was unavailable because the datepicker directive from the (obsolete) `ofn.admin` module is longer available to `admin.subscriptions`. This fixes the issue by including the datepicker module in the `admin.utils` instead.

#### What should we test?

Date elements within the new/edit subscriptions form should show a datepicker to facilitate the selection of a date.

#### Release notes

Feature is yet to be released so this does not require its own release notes.