### PR TITLE
Upgrade Skylight from 1.5.0 to 1.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    skylight (1.5.0)
+    skylight (1.5.1)
       activesupport (>= 3.0.0)
     spinjs-rails (1.3)
       rails (>= 3.1)


### PR DESCRIPTION
#### What? Why?

Skylight is not working in production. It doesn't send data to our account, so I hope an upgrade to the latest version helps. Their customer support is helping us deal with the issue and that's what they suggest.
