### PR TITLE
Configure mails_from

### DIFF
--- a/app/mailers/spree/base_mailer_decorator.rb
+++ b/app/mailers/spree/base_mailer_decorator.rb
@@ -7,8 +7,11 @@ Spree::BaseMailer.class_eval do
 
   protected
 
+  # This method copies the one defined in Spree's mailers. It should be removed
+  # once in Spree v2.0 and Spree's BaseMailer class lands in our codebase.
+  # Then, we'll be able to rely on its #from_address.
   def from_address
-    Spree::Config[:mails_from] || 'test@example.com'
+    Spree::MailMethod.current.preferred_mails_from
   end
 
   def roadie_options

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -4,8 +4,6 @@ Spree::AppConfiguration.class_eval do
   # we can allow to be modified in the UI by adding appropriate form
   # elements to existing or new configuration pages.
 
-  preference :mails_from, :string, default: 'no-reply@example.com'
-
   # Embedded Shopfronts
   preference :enable_embedded_shopfronts, :boolean, default: false
   preference :embedded_shopfronts_whitelist, :text, default: nil

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -31,12 +31,16 @@ describe UserPasswordsController, type: :controller do
   end
 
   it "renders Darkswarm" do
+    Spree::MailMethod.create!(environment: 'test')
     clear_jobs
+
     user.send_reset_password_instructions
     flush_jobs # Send the reset password instructions
+
     user.reload
     spree_get :edit, reset_password_token: user.reset_password_token
-    response.should render_template "user_passwords/edit"
+
+    expect(response).to render_template "user_passwords/edit"
   end
 
   describe "via ajax" do

--- a/spec/mailers/enterprise_mailer_spec.rb
+++ b/spec/mailers/enterprise_mailer_spec.rb
@@ -5,12 +5,14 @@ describe EnterpriseMailer do
 
   before do
     ActionMailer::Base.deliveries = []
+    Spree::MailMethod.create!(environment: 'test')
   end
 
-  it "should send a welcome email when given an enterprise" do
+  it "sends a welcome email when given an enterprise" do
     EnterpriseMailer.welcome(enterprise).deliver
-    ActionMailer::Base.deliveries.count.should == 1
+
     mail = ActionMailer::Base.deliveries.first
-    expect(mail.subject).to eq "#{enterprise.name} is now on #{Spree::Config[:site_name]}"
+    expect(mail.subject)
+      .to eq "#{enterprise.name} is now on #{Spree::Config[:site_name]}"
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -11,6 +11,8 @@ describe Spree::UserMailer do
     ActionMailer::Base.delivery_method = :test
     ActionMailer::Base.perform_deliveries = true
     ActionMailer::Base.deliveries = []
+
+    Spree::MailMethod.create!(environment: 'test')
   end
 
   it "sends an email when given a user" do


### PR DESCRIPTION
#### What? Why?

While working on #2160, the test email was working but a new signup wasn't. From the logs I saw the `mails_from` setting was fetched from the `spree/app_configuration/mails_from` cache key, while all the other settings were fetched from `spree/mail_method/` instead, as it was supposed to.

That's because while trying to make the `BaseMailer` class in OFN be compatible with Spree 2.0, we started fetching said setting from app-level configuration (by means of `Spree::Config[:mails_from]`), instead of the `MailMethod`, which is what our current Spree version does.

In addition, having a default value in app-level configuration it does things even more confusing. For now, there's no need for it so I removed it.

#### What should we test?

Deploy to staging and try to create a new account. The email should go through Mandrill or whatever SMTP provider you might be using.

#### Release notes

Fix mail settings not allowing to send emails from the app.