### PR TITLE
Include option text in dropdown cart even if the variant and product …

### DIFF
--- a/app/assets/javascripts/darkswarm/services/variants.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/variants.js.coffee
@@ -17,11 +17,11 @@ Darkswarm.factory 'Variants', ->
 
     extendedVariantName: (variant) =>
       if variant.product_name == variant.name_to_display
-        variant.product_name
+        name = variant.product_name
       else
         name =  "#{variant.product_name} - #{variant.name_to_display}"
-        name += " (#{variant.options_text})" if variant.options_text
-        name
+      name += " (#{variant.options_text})" if variant.options_text
+      name
 
     lineItemFor: (variant) ->
       variant: variant

--- a/spec/javascripts/unit/darkswarm/services/variants_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/variants_spec.js.coffee
@@ -49,6 +49,14 @@ describe 'Variants service', ->
       variant = {product_name: 'product_name', name_to_display: 'product_name'}
       expect(Variants.extendedVariantName(variant)).toEqual "product_name"
 
+    it "includes the options text even if variant name is same as product", ->
+      variant =
+        product_name: 'product_name'
+        name_to_display: 'product_name'
+        options_text: 'options_text'
+
+      expect(Variants.extendedVariantName(variant)).toEqual "product_name (options_text)"
+
     describe "when the product name and the variant name differ", ->
       it "returns a combined name when there is no options text", ->
         variant =


### PR DESCRIPTION
…have the same name

#### What? Why?

Closes #2169 

The "options text" which shows the format of a variant (e.g. "1 bottle") is only added for cases where the variant and product name differ. This can lead to confusing carts where variants in different formats are listed with the same name.

#### What should we test?

Check that options text appears in brackets after each variant in the dropdown cart. If no options text is provided, nothing should appear.

A potential improvement is to only add this if the cart has multiple variants with the same display name - i.e. only if they need distinguishing. Let me know if this would be useful. It's possible that having the bracketed text after every item isn't necessary or looks really ugly. 

#### Release notes

Variants now show their options text (indicating the format) in the cart dropdown even if they have the same name as the product they are a variant of.