### PR TITLE
Upgrade Skylight from 1.5.1 to 1.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    skylight (1.5.1)
+    skylight (1.6.0)
       activesupport (>= 3.0.0)
     spinjs-rails (1.3)
       rails (>= 3.1)


### PR DESCRIPTION
#### What? Why?

The folks at Skylight updated the gem 5 days ago with a [number of improvements](https://github.com/skylightio/skylight-ruby/blob/a23a7ae870b4580ea81cc671c72549a876fe304f/CHANGELOG.md#160-march-21-2018) that it's worth having.

Besides, we learned the lesson. It's best to keep dependencies up to date while it's easy.

#### What should we test?

Nothing, this does not affect the app.

#### Release notes

Upgraded Skylight to its latest version (1.6.0).