### PR TITLE
Ignore Bundler's vendor/bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ coverage
 libpeerconnection.log
 /config/application.yml
 node_modules
+vendor/bundle/


### PR DESCRIPTION
#### What? Why?

`vendor/bundle` seems to be Bundler's default location for gems. As this wasn't ignored by git, it always shows up as untracked files when I run `git status` and it's quite annoying. I'm just ignoring it now.