### PR TITLE
Convert specs to RSpec 3.7.0 syntax with Transpec

### DIFF
--- a/spec/archive/features/consumer/checkout_spec.rb
+++ b/spec/archive/features/consumer/checkout_spec.rb
@@ -89,11 +89,12 @@ feature %q{
     click_button 'Add To Cart'
 
     # Then I should see a breakdown of my delivery fees:
-    checkout_fees_table.should ==
+    expect(checkout_fees_table).to eq(
       [['Fuji apples - sales fee by coordinator Edible garden', '$1.00', ''],
        ['Garlic - sales fee by coordinator Edible garden', '$1.00', '']]
+    )
 
-    page.should have_selector 'span.distribution-total', :text => '$2.00'
+    expect(page).to have_selector 'span.distribution-total', :text => '$2.00'
   end
 
   scenario "viewing delivery fees for order cycle distribution", :js => true do
@@ -115,7 +116,7 @@ feature %q{
 
     # Then I should see a breakdown of my delivery fees:
 
-    checkout_fees_table.should ==
+    expect(checkout_fees_table).to eq(
       [["Bananas - packing fee by supplier Supplier 1", "$3.00", ""],
        ["Bananas - transport fee by supplier Supplier 1", "$4.00", ""],
        ["Bananas - packing fee by distributor FruitAndVeg", "$7.00", ""],
@@ -126,8 +127,9 @@ feature %q{
        ["Zucchini - transport fee by distributor FruitAndVeg", "$8.00", ""],
        ["Whole order - admin fee by coordinator My coordinator", "$1.00", ""],
        ["Whole order - sales fee by coordinator My coordinator", "$2.00", ""]]
+    )
 
-    page.should have_selector 'span.distribution-total', :text => '$51.00'
+    expect(page).to have_selector 'span.distribution-total', :text => '$51.00'
   end
 
   scenario "attempting to purchase products that mix product and order cycle distribution", future: true do
@@ -153,7 +155,7 @@ feature %q{
     click_link 'Feijoas'
 
     # Then I should see an error about changing order cycle
-    page.should have_content 'Please complete your order from your current order cycle before shopping in a different order cycle.'
+    expect(page).to have_content 'Please complete your order from your current order cycle before shopping in a different order cycle.'
   end
 
   scenario "removing a product from cart removes its fees", js: true, to_figure_out: true do
@@ -176,11 +178,12 @@ feature %q{
     page.find("a#delete_line_item_#{line_item.id}").click
 
     # Then I should see fees for only the garlic
-    checkout_fees_table.should ==
+    expect(checkout_fees_table).to eq(
 
       [['Garlic - transport fee by coordinator Edible garden', '$3.00', '']]
+    )
 
-    page.should have_selector 'span.distribution-total', :text => '$3.00'
+    expect(page).to have_selector 'span.distribution-total', :text => '$3.00'
   end
 
   scenario "adding products with differing quantities produces correct fees", js: true, :to_figure_out => true do
@@ -199,22 +202,24 @@ feature %q{
     click_button 'Add To Cart'
 
     # Then I should have some delivery fees
-    checkout_fees_table.should ==
+    expect(checkout_fees_table).to eq(
       [['Fuji apples - packing fee by coordinator Edible garden', '$4.00', ''],
        ['Sundowner apples - packing fee by coordinator Edible garden', '$4.00', '']]
+    )
 
-    page.should have_selector 'span.distribution-total', :text => '$8.00'
+    expect(page).to have_selector 'span.distribution-total', :text => '$8.00'
 
     # And I update the quantity of one of them
     fill_in 'order_line_items_attributes_0_quantity', with: 2
     click_button 'Update'
 
     # Then I should see updated delivery fees
-    checkout_fees_table.should ==
+    expect(checkout_fees_table).to eq(
       [['Fuji apples - packing fee by coordinator Edible garden', '$8.00', ''],
        ['Sundowner apples - packing fee by coordinator Edible garden', '$4.00', '']]
+    )
 
-    page.should have_selector 'span.distribution-total', :text => '$12.00'
+    expect(page).to have_selector 'span.distribution-total', :text => '$12.00'
   end
 
   scenario "changing distributor updates delivery fees", :future => true do
@@ -243,7 +248,7 @@ feature %q{
     click_button 'Add To Cart'
 
     # Then I should see shipping costs for the first distributor
-    page.should have_selector 'span.distribution-total', text: '$1.23'
+    expect(page).to have_selector 'span.distribution-total', text: '$1.23'
 
     # When add the second with the second distributor
     click_link 'Continue shopping'
@@ -251,7 +256,7 @@ feature %q{
     click_button 'Add To Cart'
 
     # Then I should see shipping costs for the second distributor
-    page.should have_selector 'span.distribution-total', text: '$4.68'
+    expect(page).to have_selector 'span.distribution-total', text: '$4.68'
   end
 
   scenario "adding a product to cart after emptying cart shows correct delivery fees", js: true, :to_figure_out => true do
@@ -265,7 +270,7 @@ feature %q{
     click_button 'Add To Cart'
 
     # Then I should see the correct delivery fee
-    page.should have_selector 'span.grand-total', text: '$24.99'
+    expect(page).to have_selector 'span.grand-total', text: '$24.99'
 
     # When I empty my cart and add the product again
     click_button 'Empty Cart'
@@ -274,7 +279,7 @@ feature %q{
     click_button 'Add To Cart'
 
     # Then I should see the correct delivery fee
-    page.should have_selector 'span.grand-total', text: '$24.99'
+    expect(page).to have_selector 'span.grand-total', text: '$24.99'
   end
 
   scenario "buying a product", :js => true, :to_figure_out => true do
@@ -309,7 +314,7 @@ feature %q{
        @distributor.next_collection_at
       ].each do |value|
 
-        page.should have_content value
+        expect(page).to have_content value
       end
     end
 
@@ -320,26 +325,26 @@ feature %q{
 
     # -- Checkout: Delivery
     order_charges = page.all("tbody#summary-order-charges tr").map {|row| row.all('td').map(&:text)}.take(2)
-    order_charges.should == [["Shipping:", "$0.00"],
-                             ["Distribution:", "$12.00"]]
+    expect(order_charges).to eq([["Shipping:", "$0.00"],
+                             ["Distribution:", "$12.00"]])
     click_checkout_continue_button
 
     # -- Checkout: Payment
     # Given the distributor I have selected for my order, I should only see payment methods valid for that distributor
-    page.should have_selector     'label', :text => @payment_method_distributor.name
-    page.should_not have_selector 'label', :text => @payment_method_alternative.name
+    expect(page).to have_selector     'label', :text => @payment_method_distributor.name
+    expect(page).not_to have_selector 'label', :text => @payment_method_alternative.name
     click_checkout_continue_button
 
     # -- Checkout: Order complete
-    page.should have_content 'Your order has been processed successfully'
-    page.should have_content @payment_method_distributor.description
+    expect(page).to have_content 'Your order has been processed successfully'
+    expect(page).to have_content @payment_method_distributor.description
 
-    page.should have_selector 'tfoot#order-charges tr.total td', text: 'Distribution'
-    page.should have_selector 'tfoot#order-charges tr.total td', text: '12.00'
+    expect(page).to have_selector 'tfoot#order-charges tr.total td', text: 'Distribution'
+    expect(page).to have_selector 'tfoot#order-charges tr.total td', text: '12.00'
 
     # -- Checkout: Email
     email = ActionMailer::Base.deliveries.last
-    email.body.should =~ /Distribution[\s+]\$12.00/
+    expect(email.body).to match(/Distribution[\s+]\$12.00/)
   end
 
   scenario "buying a product from an order cycle", :js => true do
@@ -378,7 +383,7 @@ feature %q{
        @distributor_oc.next_collection_at
       ].each do |value|
 
-        page.should have_content value
+        expect(page).to have_content value
       end
     end
 
@@ -387,32 +392,32 @@ feature %q{
     click_checkout_continue_button
 
     # -- Checkout: Delivery
-    page.should have_content "DELIVERY METHOD"
+    expect(page).to have_content "DELIVERY METHOD"
     order_charges = page.all("tbody#summary-order-charges tr").map {|row| row.all('td').map(&:text)}.take(2)
-    order_charges.should == [["Distribution:", "$51.00"]]
+    expect(order_charges).to eq([["Distribution:", "$51.00"]])
 
     click_checkout_continue_button
 
     # -- Checkout: Payment
     # Given the distributor I have selected for my order, I should only see payment methods valid for that distributor
-    page.should have_content "PAYMENT INFORMATION"
-    page.should have_selector     'label', :text => @payment_method_distributor_oc.name
-    page.should_not have_selector 'label', :text => @payment_method_alternative.name
+    expect(page).to have_content "PAYMENT INFORMATION"
+    expect(page).to have_selector     'label', :text => @payment_method_distributor_oc.name
+    expect(page).not_to have_selector 'label', :text => @payment_method_alternative.name
     click_checkout_continue_button
 
     # -- Checkout: Order complete
-    page.should have_content 'Your order has been processed successfully'
-    page.should have_content @payment_method_distributor_oc.description
-    page.should have_content @distributor_oc.name
+    expect(page).to have_content 'Your order has been processed successfully'
+    expect(page).to have_content @payment_method_distributor_oc.description
+    expect(page).to have_content @distributor_oc.name
 
-    page.should have_selector 'tfoot#order-charges tr.total td', text: 'Distribution'
-    page.should have_selector 'tfoot#order-charges tr.total td', text: '51.00'
+    expect(page).to have_selector 'tfoot#order-charges tr.total td', text: 'Distribution'
+    expect(page).to have_selector 'tfoot#order-charges tr.total td', text: '51.00'
 
 
     # -- Checkout: Email
     email = ActionMailer::Base.deliveries.last
-    email.reply_to.include?(@distributor_oc.email).should == true
-    email.body.should =~ /Distribution[\s+]\$51.00/
+    expect(email.reply_to.include?(@distributor_oc.email)).to eq(true)
+    expect(email.body).to match(/Distribution[\s+]\$51.00/)
   end
 
   scenario "when I have past orders, it fills in my address", :js => true do
@@ -452,14 +457,14 @@ feature %q{
     visit "/checkout" # Force to old checkout
 
     # -- Checkout: Address
-    page.should have_field 'order_bill_address_attributes_firstname', with: 'Joe'
-    page.should have_field 'order_bill_address_attributes_lastname', with: 'Luck'
-    page.should have_field 'order_bill_address_attributes_address1', with: '19 Sycamore Lane'
-    page.should have_field 'order_bill_address_attributes_city', with: 'Horse Hill'
-    page.should have_field 'order_bill_address_attributes_zipcode', with: '3213'
-    page.should have_field 'order_bill_address_attributes_phone', with: '12999911111'
-    page.should have_select 'order_bill_address_attributes_state_id', selected: 'Victoria'
-    page.should have_select 'order_bill_address_attributes_country_id', selected: 'Australia'
+    expect(page).to have_field 'order_bill_address_attributes_firstname', with: 'Joe'
+    expect(page).to have_field 'order_bill_address_attributes_lastname', with: 'Luck'
+    expect(page).to have_field 'order_bill_address_attributes_address1', with: '19 Sycamore Lane'
+    expect(page).to have_field 'order_bill_address_attributes_city', with: 'Horse Hill'
+    expect(page).to have_field 'order_bill_address_attributes_zipcode', with: '3213'
+    expect(page).to have_field 'order_bill_address_attributes_phone', with: '12999911111'
+    expect(page).to have_select 'order_bill_address_attributes_state_id', selected: 'Victoria'
+    expect(page).to have_select 'order_bill_address_attributes_country_id', selected: 'Australia'
   end
 
 

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -17,7 +17,7 @@ describe Admin::BulkLineItemsController, type: :controller do
     let!(:line_item4) { FactoryGirl.create(:line_item, order: order3) }
 
     context "as a normal user" do
-      before { controller.stub spree_current_user: create_enterprise_user }
+      before { allow(controller).to receive_messages spree_current_user: create_enterprise_user }
 
       it "should deny me access to the index action" do
         spree_get :index, :format => :json
@@ -27,7 +27,7 @@ describe Admin::BulkLineItemsController, type: :controller do
 
     context "as an administrator" do
       before do
-        controller.stub spree_current_user: quick_login_as_admin
+        allow(controller).to receive_messages spree_current_user: quick_login_as_admin
       end
 
       context "when no ransack params are passed in" do
@@ -37,7 +37,7 @@ describe Admin::BulkLineItemsController, type: :controller do
 
         it "retrieves a list of line_items with appropriate attributes, including line items with appropriate attributes" do
           keys = json_response.first.keys.map(&:to_sym)
-          line_item_attributes.all?{ |attr| keys.include? attr }.should == true
+          expect(line_item_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
 
         it "sorts line_items in ascending id line_item" do
@@ -47,11 +47,11 @@ describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "formats final_weight_volume as a float" do
-          json_response.map{ |line_item| line_item['final_weight_volume'] }.all?{ |fwv| fwv.is_a?(Float) }.should == true
+          expect(json_response.map{ |line_item| line_item['final_weight_volume'] }.all?{ |fwv| fwv.is_a?(Float) }).to eq(true)
         end
 
         it "returns distributor object with id key" do
-          json_response.map{ |line_item| line_item['supplier'] }.all?{ |d| d.key?('id') }.should == true
+          expect(json_response.map{ |line_item| line_item['supplier'] }.all?{ |d| d.key?('id') }).to eq(true)
         end
       end
 
@@ -90,7 +90,7 @@ describe Admin::BulkLineItemsController, type: :controller do
 
       context "producer enterprise" do
         before do
-          controller.stub spree_current_user: supplier.owner
+          allow(controller).to receive_messages spree_current_user: supplier.owner
           spree_get :index, :format => :json
         end
 
@@ -101,25 +101,25 @@ describe Admin::BulkLineItemsController, type: :controller do
 
       context "coordinator enterprise" do
         before do
-          controller.stub spree_current_user: coordinator.owner
+          allow(controller).to receive_messages spree_current_user: coordinator.owner
           spree_get :index, :format => :json
         end
 
         it "retrieves a list of line_items" do
           keys = json_response.first.keys.map(&:to_sym)
-          line_item_attributes.all?{ |attr| keys.include? attr }.should == true
+          expect(line_item_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end
 
       context "hub enterprise" do
         before do
-          controller.stub spree_current_user: distributor1.owner
+          allow(controller).to receive_messages spree_current_user: distributor1.owner
           spree_get :index, :format => :json
         end
 
         it "retrieves a list of line_items" do
           keys = json_response.first.keys.map(&:to_sym)
-          line_item_attributes.all?{ |attr| keys.include? attr }.should == true
+          expect(line_item_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end
     end
@@ -138,7 +138,7 @@ describe Admin::BulkLineItemsController, type: :controller do
     context "as an enterprise user" do
       context "producer enterprise" do
         before do
-          controller.stub spree_current_user: supplier.owner
+          allow(controller).to receive_messages spree_current_user: supplier.owner
           spree_put :update, params
         end
 
@@ -151,7 +151,7 @@ describe Admin::BulkLineItemsController, type: :controller do
         render_views
 
         before do
-          controller.stub spree_current_user: coordinator.owner
+          allow(controller).to receive_messages spree_current_user: coordinator.owner
         end
 
         # Used in admin/orders/bulk_management
@@ -205,7 +205,7 @@ describe Admin::BulkLineItemsController, type: :controller do
 
       context "hub enterprise" do
         before do
-          controller.stub spree_current_user: distributor1.owner
+          allow(controller).to receive_messages spree_current_user: distributor1.owner
           xhr :put, :update, params
         end
 
@@ -231,7 +231,7 @@ describe Admin::BulkLineItemsController, type: :controller do
     let(:params) { { id: line_item1.id, order_id: order1.number } }
 
     before do
-      controller.stub spree_current_user: coordinator.owner
+      allow(controller).to receive_messages spree_current_user: coordinator.owner
     end
 
     # Used in admin/orders/bulk_management

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -9,7 +9,7 @@ describe Admin::CustomersController, type: :controller do
 
     context "html" do
       before do
-        controller.stub spree_current_user: enterprise.owner
+        allow(controller).to receive_messages spree_current_user: enterprise.owner
       end
 
       it "returns an empty @collection" do
@@ -23,7 +23,7 @@ describe Admin::CustomersController, type: :controller do
 
       context "where I manage the enterprise" do
         before do
-          controller.stub spree_current_user: enterprise.owner
+          allow(controller).to receive_messages spree_current_user: enterprise.owner
         end
 
         context "and enterprise_id is given in params" do
@@ -50,7 +50,7 @@ describe Admin::CustomersController, type: :controller do
 
       context "and I do not manage the enterprise" do
         before do
-          controller.stub spree_current_user: another_enterprise.owner
+          allow(controller).to receive_messages spree_current_user: another_enterprise.owner
         end
 
         it "returns an empty collection" do
@@ -72,7 +72,7 @@ describe Admin::CustomersController, type: :controller do
         render_views
 
         before do
-          controller.stub spree_current_user: enterprise.owner
+          allow(controller).to receive_messages spree_current_user: enterprise.owner
         end
 
         it "allows me to update the customer" do
@@ -85,7 +85,7 @@ describe Admin::CustomersController, type: :controller do
 
       context "where I don't manage the customer's enterprise" do
         before do
-          controller.stub spree_current_user: another_enterprise.owner
+          allow(controller).to receive_messages spree_current_user: another_enterprise.owner
         end
 
         it "prevents me from updating the customer" do
@@ -109,7 +109,7 @@ describe Admin::CustomersController, type: :controller do
     context "json" do
       context "where I manage the customer's enterprise" do
         before do
-          controller.stub spree_current_user: enterprise.owner
+          allow(controller).to receive_messages spree_current_user: enterprise.owner
         end
 
         it "allows me to create the customer" do
@@ -119,7 +119,7 @@ describe Admin::CustomersController, type: :controller do
 
       context "where I don't manage the customer's enterprise" do
         before do
-          controller.stub spree_current_user: another_enterprise.owner
+          allow(controller).to receive_messages spree_current_user: another_enterprise.owner
         end
 
         it "prevents me from creating the customer" do
@@ -129,7 +129,7 @@ describe Admin::CustomersController, type: :controller do
 
       context "where I am the admin user" do
         before do
-          controller.stub spree_current_user: create(:admin_user)
+          allow(controller).to receive_messages spree_current_user: create(:admin_user)
         end
 
         it "allows admins to create the customer" do

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -23,81 +23,81 @@ module Admin
       let(:enterprise_params) { {enterprise: {name: 'zzz', permalink: 'zzz', is_primary_producer: '0', address_attributes: {address1: 'a', city: 'a', zipcode: 'a', country_id: country.id, state_id: state.id}}} }
 
       it "grants management permission if the current user is an enterprise user" do
-        controller.stub spree_current_user: distributor_manager
+        allow(controller).to receive_messages spree_current_user: distributor_manager
         enterprise_params[:enterprise][:owner_id] = distributor_manager
 
         spree_put :create, enterprise_params
         enterprise = Enterprise.find_by_name 'zzz'
-        response.should redirect_to edit_admin_enterprise_path enterprise
-        distributor_manager.enterprise_roles.where(enterprise_id: enterprise).first.should be
+        expect(response).to redirect_to edit_admin_enterprise_path enterprise
+        expect(distributor_manager.enterprise_roles.where(enterprise_id: enterprise).first).to be
       end
 
       it "overrides the owner_id submitted by the user (when not super admin)" do
-        controller.stub spree_current_user: distributor_manager
+        allow(controller).to receive_messages spree_current_user: distributor_manager
         enterprise_params[:enterprise][:owner_id] = user
 
         spree_put :create, enterprise_params
         enterprise = Enterprise.find_by_name 'zzz'
-        response.should redirect_to edit_admin_enterprise_path enterprise
-        distributor_manager.enterprise_roles.where(enterprise_id: enterprise).first.should be
+        expect(response).to redirect_to edit_admin_enterprise_path enterprise
+        expect(distributor_manager.enterprise_roles.where(enterprise_id: enterprise).first).to be
       end
 
       context "when I already own a hub" do
         before { distributor }
 
         it "creates new non-producers as hubs" do
-          controller.stub spree_current_user: distributor_owner
+          allow(controller).to receive_messages spree_current_user: distributor_owner
           enterprise_params[:enterprise][:owner_id] = distributor_owner
 
           spree_put :create, enterprise_params
           enterprise = Enterprise.find_by_name 'zzz'
-          response.should redirect_to edit_admin_enterprise_path enterprise
-          enterprise.sells.should == 'any'
+          expect(response).to redirect_to edit_admin_enterprise_path enterprise
+          expect(enterprise.sells).to eq('any')
         end
 
         it "creates new producers as sells none" do
-          controller.stub spree_current_user: distributor_owner
+          allow(controller).to receive_messages spree_current_user: distributor_owner
           enterprise_params[:enterprise][:owner_id] = distributor_owner
           enterprise_params[:enterprise][:is_primary_producer] = '1'
 
           spree_put :create, enterprise_params
           enterprise = Enterprise.find_by_name 'zzz'
-          response.should redirect_to edit_admin_enterprise_path enterprise
-          enterprise.sells.should == 'none'
+          expect(response).to redirect_to edit_admin_enterprise_path enterprise
+          expect(enterprise.sells).to eq('none')
         end
 
         it "doesn't affect the hub status for super admins" do
           admin_user.enterprises << create(:distributor_enterprise)
 
-          controller.stub spree_current_user: admin_user
+          allow(controller).to receive_messages spree_current_user: admin_user
           enterprise_params[:enterprise][:owner_id] = admin_user
           enterprise_params[:enterprise][:sells] = 'none'
 
           spree_put :create, enterprise_params
           enterprise = Enterprise.find_by_name 'zzz'
-          response.should redirect_to edit_admin_enterprise_path enterprise
-          enterprise.sells.should == 'none'
+          expect(response).to redirect_to edit_admin_enterprise_path enterprise
+          expect(enterprise.sells).to eq('none')
         end
       end
 
       context "when I do not have a hub" do
         it "does not create the new enterprise as a hub" do
-          controller.stub spree_current_user: supplier_manager
+          allow(controller).to receive_messages spree_current_user: supplier_manager
           enterprise_params[:enterprise][:owner_id] = supplier_manager
 
           spree_put :create, enterprise_params
           enterprise = Enterprise.find_by_name 'zzz'
-          enterprise.sells.should == 'none'
+          expect(enterprise.sells).to eq('none')
         end
 
         it "doesn't affect the hub status for super admins" do
-          controller.stub spree_current_user: admin_user
+          allow(controller).to receive_messages spree_current_user: admin_user
           enterprise_params[:enterprise][:owner_id] = admin_user
           enterprise_params[:enterprise][:sells] = 'any'
 
           spree_put :create, enterprise_params
           enterprise = Enterprise.find_by_name 'zzz'
-          enterprise.sells.should == 'any'
+          expect(enterprise.sells).to eq('any')
         end
       end
     end
@@ -108,7 +108,7 @@ module Admin
       context "as manager" do
         it "does not allow 'sells' to be changed" do
           profile_enterprise.enterprise_roles.build(user: distributor_manager).save
-          controller.stub spree_current_user: distributor_manager
+          allow(controller).to receive_messages spree_current_user: distributor_manager
           enterprise_params = { id: profile_enterprise, enterprise: { sells: 'any' } }
 
           spree_put :update, enterprise_params
@@ -117,7 +117,7 @@ module Admin
         end
 
         it "does not allow owner to be changed" do
-          controller.stub spree_current_user: distributor_manager
+          allow(controller).to receive_messages spree_current_user: distributor_manager
           update_params = { id: distributor, enterprise: { owner_id: distributor_manager } }
           spree_post :update, update_params
 
@@ -126,7 +126,7 @@ module Admin
         end
 
         it "does not allow managers to be changed" do
-          controller.stub spree_current_user: distributor_manager
+          allow(controller).to receive_messages spree_current_user: distributor_manager
           update_params = { id: distributor, enterprise: { user_ids: [distributor_owner.id,distributor_manager.id,user.id] } }
           spree_post :update, update_params
 
@@ -232,7 +232,7 @@ module Admin
 
       context "as owner" do
         it "allows 'sells' to be changed" do
-          controller.stub spree_current_user: profile_enterprise.owner
+          allow(controller).to receive_messages spree_current_user: profile_enterprise.owner
           enterprise_params = { id: profile_enterprise, enterprise: { sells: 'any' } }
 
           spree_put :update, enterprise_params
@@ -241,7 +241,7 @@ module Admin
         end
 
         it "allows owner to be changed" do
-          controller.stub spree_current_user: distributor_owner
+          allow(controller).to receive_messages spree_current_user: distributor_owner
           update_params = { id: distributor, enterprise: { owner_id: distributor_manager } }
           spree_post :update, update_params
 
@@ -250,7 +250,7 @@ module Admin
         end
 
         it "allows managers to be changed" do
-          controller.stub spree_current_user: distributor_owner
+          allow(controller).to receive_messages spree_current_user: distributor_owner
           update_params = { id: distributor, enterprise: { user_ids: [distributor_owner.id,distributor_manager.id,user.id] } }
           spree_post :update, update_params
 
@@ -261,7 +261,7 @@ module Admin
 
       context "as super admin" do
         it "allows 'sells' to be changed" do
-          controller.stub spree_current_user: admin_user
+          allow(controller).to receive_messages spree_current_user: admin_user
           enterprise_params = { id: profile_enterprise, enterprise: { sells: 'any' } }
 
           spree_put :update, enterprise_params
@@ -271,7 +271,7 @@ module Admin
 
 
         it "allows owner to be changed" do
-          controller.stub spree_current_user: admin_user
+          allow(controller).to receive_messages spree_current_user: admin_user
           update_params = { id: distributor, enterprise: { owner_id: distributor_manager } }
           spree_post :update, update_params
 
@@ -280,7 +280,7 @@ module Admin
         end
 
         it "allows managers to be changed" do
-          controller.stub spree_current_user: admin_user
+          allow(controller).to receive_messages spree_current_user: admin_user
           update_params = { id: distributor, enterprise: { user_ids: [distributor_owner.id,distributor_manager.id,user.id] } }
           spree_post :update, update_params
 
@@ -295,7 +295,7 @@ module Admin
 
       context "as a normal user" do
         before do
-          controller.stub spree_current_user: distributor_manager
+          allow(controller).to receive_messages spree_current_user: distributor_manager
         end
 
         it "does not allow access" do
@@ -306,7 +306,7 @@ module Admin
 
       context "as a manager" do
         before do
-          controller.stub spree_current_user: distributor_manager
+          allow(controller).to receive_messages spree_current_user: distributor_manager
           enterprise.enterprise_roles.build(user: distributor_manager).save
         end
 
@@ -318,7 +318,7 @@ module Admin
 
       context "as an owner" do
         before do
-          controller.stub spree_current_user: enterprise.owner
+          allow(controller).to receive_messages spree_current_user: enterprise.owner
         end
 
         context "setting 'sells' to 'none'" do
@@ -461,7 +461,7 @@ module Admin
         it "does not allow 'sells' or 'owner' to be changed" do
           profile_enterprise1.enterprise_roles.build(user: new_owner).save
           profile_enterprise2.enterprise_roles.build(user: new_owner).save
-          controller.stub spree_current_user: new_owner
+          allow(controller).to receive_messages spree_current_user: new_owner
           bulk_enterprise_params = { enterprise_set: { collection_attributes: { '0' => { id: profile_enterprise1.id, sells: 'any', owner_id: new_owner.id }, '1' => { id: profile_enterprise2.id, sells: 'any', owner_id: new_owner.id } } } }
 
           spree_put :bulk_update, bulk_enterprise_params
@@ -474,9 +474,9 @@ module Admin
         end
 
         it "cuts down the list of enterprises displayed when error received on bulk update" do
-          EnterpriseSet.any_instance.stub(:save) { false }
+          allow_any_instance_of(EnterpriseSet).to receive(:save) { false }
           profile_enterprise1.enterprise_roles.build(user: new_owner).save
-          controller.stub spree_current_user: new_owner
+          allow(controller).to receive_messages spree_current_user: new_owner
           bulk_enterprise_params = { enterprise_set: { collection_attributes: { '0' => { id: profile_enterprise1.id, visible: 'false' } } } }
           spree_put :bulk_update, bulk_enterprise_params
           expect(assigns(:enterprise_set).collection).to eq [profile_enterprise1]
@@ -485,7 +485,7 @@ module Admin
 
       context "as the owner of an enterprise" do
         it "allows 'sells' and 'owner' to be changed" do
-          controller.stub spree_current_user: original_owner
+          allow(controller).to receive_messages spree_current_user: original_owner
           bulk_enterprise_params = { enterprise_set: { collection_attributes: { '0' => { id: profile_enterprise1.id, sells: 'any', owner_id: new_owner.id }, '1' => { id: profile_enterprise2.id, sells: 'any', owner_id: new_owner.id } } } }
 
           spree_put :bulk_update, bulk_enterprise_params
@@ -502,7 +502,7 @@ module Admin
         it "allows 'sells' and 'owner' to be changed" do
           profile_enterprise1.enterprise_roles.build(user: new_owner).save
           profile_enterprise2.enterprise_roles.build(user: new_owner).save
-          controller.stub spree_current_user: admin_user
+          allow(controller).to receive_messages spree_current_user: admin_user
           bulk_enterprise_params = { enterprise_set: { collection_attributes: { '0' => { id: profile_enterprise1.id, sells: 'any', owner_id: new_owner.id }, '1' => { id: profile_enterprise2.id, sells: 'any', owner_id: new_owner.id } } } }
 
           spree_put :bulk_update, bulk_enterprise_params
@@ -523,10 +523,10 @@ module Admin
 
       before do
         # As a user with permission
-        controller.stub spree_current_user: user
-        OrderCycle.stub find_by_id: "existing OrderCycle"
-        Enterprise.stub find_by_id: "existing Enterprise"
-        OrderCycle.stub new: "new OrderCycle"
+        allow(controller).to receive_messages spree_current_user: user
+        allow(OrderCycle).to receive_messages find_by_id: "existing OrderCycle"
+        allow(Enterprise).to receive_messages find_by_id: "existing Enterprise"
+        allow(OrderCycle).to receive_messages new: "new OrderCycle"
 
         allow(OpenFoodNetwork::OrderCyclePermissions).to receive(:new) { permission_mock }
         allow(permission_mock).to receive(:visible_enterprises) { [] }
@@ -569,7 +569,7 @@ module Admin
 
       before do
         # As a user with permission
-        controller.stub spree_current_user: user
+        allow(controller).to receive_messages spree_current_user: user
 
         # :create_variant_overrides does not affect visiblity (at time of writing)
         create(:enterprise_relationship, parent: not_visible_enterprise, child: visible_enterprise, permissions_list: [:create_variant_overrides])
@@ -590,7 +590,7 @@ module Admin
         let!(:enterprise3) { create(:enterprise, sells: 'any', owner: create_enterprise_user ) }
 
         before do
-          controller.stub spree_current_user: super_admin
+          allow(controller).to receive_messages spree_current_user: super_admin
         end
 
         context "html" do
@@ -615,7 +615,7 @@ module Admin
         let!(:enterprise3) { create(:enterprise, sells: 'any', owner: create_enterprise_user ) }
 
         before do
-          controller.stub spree_current_user: user
+          allow(controller).to receive_messages spree_current_user: user
         end
 
         context "html" do

--- a/spec/controllers/admin/manager_invitations_controller_spec.rb
+++ b/spec/controllers/admin/manager_invitations_controller_spec.rb
@@ -9,7 +9,7 @@ module Admin
     describe "#create" do
       context "when given email matches an existing user" do
         before do
-          controller.stub spree_current_user: admin
+          allow(controller).to receive_messages spree_current_user: admin
         end
 
         it "returns an error" do
@@ -22,7 +22,7 @@ module Admin
 
       context "signing up a new user" do
         before do
-          controller.stub spree_current_user: admin
+          allow(controller).to receive_messages spree_current_user: admin
         end
 
         it "creates a new user, sends an invitation email, and returns the user id" do

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -7,7 +7,7 @@ module Admin
     let!(:distributor_owner) { create_enterprise_user enterprise_limit: 2 }
 
     before do
-      controller.stub spree_current_user: distributor_owner
+      allow(controller).to receive_messages spree_current_user: distributor_owner
     end
 
     describe "#index" do
@@ -110,11 +110,11 @@ module Admin
 
         it "sets flash message when page is reloading" do
           spree_put :update, id: order_cycle.id, reloading: '1', order_cycle: {}
-          flash[:notice].should == 'Your order cycle has been updated.'
+          expect(flash[:notice]).to eq('Your order cycle has been updated.')
         end
 
         it "does not set flash message otherwise" do
-          flash[:notice].should be_nil
+          expect(flash[:notice]).to be_nil
         end
 
         context "when updating without explicitly submitting exchanges" do
@@ -155,7 +155,7 @@ module Admin
 
           it "removes the variant from outgoing also" do
             spree_put :update, {id: order_cycle.id}.merge(params)
-            Exchange.where(order_cycle_id: order_cycle).with_variant(v).should be_empty
+            expect(Exchange.where(order_cycle_id: order_cycle).with_variant(v)).to be_empty
           end
         end
       end
@@ -176,7 +176,7 @@ module Admin
         render_views
 
         before do
-          controller.stub spree_current_user: user
+          allow(controller).to receive_messages spree_current_user: user
         end
 
         it "allows me to assign only schedules that already I coordinate to the order cycle" do
@@ -256,7 +256,7 @@ module Admin
       let(:order_cycle) { create(:simple_order_cycle) }
 
       before do
-        controller.stub spree_current_user: admin_user
+        allow(controller).to receive_messages spree_current_user: admin_user
       end
 
       it "enqueues a job" do
@@ -268,7 +268,7 @@ module Admin
       it "redirects back to the order cycles path with a success message" do
         spree_post :notify_producers, {id: order_cycle.id}
         expect(response).to redirect_to admin_order_cycles_path
-        flash[:notice].should == 'Emails to be sent to producers have been queued for sending.'
+        expect(flash[:notice]).to eq('Emails to be sent to producers have been queued for sending.')
       end
     end
 

--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -13,7 +13,7 @@ describe Admin::SchedulesController, type: :controller do
     context "html" do
       context "where I manage an order cycle coordinator" do
         before do
-          controller.stub spree_current_user: managed_coordinator.owner
+          allow(controller).to receive_messages spree_current_user: managed_coordinator.owner
         end
 
         it "returns an empty @collection" do
@@ -26,7 +26,7 @@ describe Admin::SchedulesController, type: :controller do
     context "json" do
       context "where I manage an order cycle coordinator" do
         before do
-          controller.stub spree_current_user: managed_coordinator.owner
+          allow(controller).to receive_messages spree_current_user: managed_coordinator.owner
         end
 
         let(:params) { { format: :json } }
@@ -68,7 +68,7 @@ describe Admin::SchedulesController, type: :controller do
         render_views
 
         before do
-          controller.stub spree_current_user: user
+          allow(controller).to receive_messages spree_current_user: user
         end
 
         it "allows me to update basic information" do
@@ -102,7 +102,7 @@ describe Admin::SchedulesController, type: :controller do
 
       context "where I don't manage any of the schedule's coordinators" do
         before do
-          controller.stub spree_current_user: uncoordinated_order_cycle2.coordinator.owner
+          allow(controller).to receive_messages spree_current_user: uncoordinated_order_cycle2.coordinator.owner
         end
 
         it "prevents me from updating the schedule" do

--- a/spec/controllers/api/enterprises_controller_spec.rb
+++ b/spec/controllers/api/enterprises_controller_spec.rb
@@ -33,10 +33,10 @@ module Api
 
         it "creates as sells=any when it is not a producer" do
           spree_post :create, new_enterprise_params
-          response.should be_success
+          expect(response).to be_success
 
           enterprise = Enterprise.last
-          enterprise.sells.should == 'any'
+          expect(enterprise.sells).to eq('any')
         end
       end
     end
@@ -53,12 +53,12 @@ module Api
         before do
           allow(Enterprise)
             .to receive(:find_by_permalink).with(enterprise.id.to_s) { enterprise }
-          enterprise.stub(:update_attributes).and_return(true)
+          allow(enterprise).to receive(:update_attributes).and_return(true)
         end
 
         it "I can update enterprise image" do
           spree_post :update_image, logo: 'a logo', id: enterprise.id
-          response.should be_success
+          expect(response).to be_success
         end
       end
     end
@@ -73,7 +73,7 @@ module Api
       end
 
       describe "submitting a valid image" do
-        before { enterprise.stub(:update_attributes).and_return(true) }
+        before { allow(enterprise).to receive(:update_attributes).and_return(true) }
 
         it "I can't update enterprise image" do
           spree_post :update_image, logo: 'a logo', id: enterprise.id

--- a/spec/controllers/api/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/order_cycles_controller_spec.rb
@@ -32,7 +32,7 @@ module Api
         it "retrieves a list of variants with appropriate attributes" do
           get :managed, { :format => :json }
           keys = json_response.first.keys.map{ |key| key.to_sym }
-          attributes.all?{ |attr| keys.include? attr }.should == true
+          expect(attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end
 
@@ -42,7 +42,7 @@ module Api
         it "retrieves a list of variants with appropriate attributes" do
           get :managed, { :format => :json }
           keys = json_response.first.keys.map{ |key| key.to_sym }
-          attributes.all?{ |attr| keys.include? attr }.should == true
+          expect(attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end
     end
@@ -83,8 +83,8 @@ module Api
           it "gives me access" do
             spree_get :accessible, { :template => 'bulk_index', :format => :json }
 
-            json_response.length.should == 1
-            json_response[0]['id'].should == order_cycle.id
+            expect(json_response.length).to eq(1)
+            expect(json_response[0]['id']).to eq(order_cycle.id)
           end
         end
 
@@ -95,7 +95,7 @@ module Api
 
           it "does not give me access" do
             spree_get :accessible, { :template => 'bulk_index', :format => :json }
-            json_response.length.should == 0
+            expect(json_response.length).to eq(0)
           end
         end
 
@@ -107,8 +107,8 @@ module Api
           it "gives me access" do
             spree_get :accessible, { :template => 'bulk_index', :format => :json }
 
-            json_response.length.should == 1
-            json_response[0]['id'].should == order_cycle.id
+            expect(json_response.length).to eq(1)
+            expect(json_response[0]['id']).to eq(order_cycle.id)
           end
         end
       end

--- a/spec/controllers/api/statuses_controller_spec.rb
+++ b/spec/controllers/api/statuses_controller_spec.rb
@@ -8,22 +8,22 @@ module Api
       it "returns alive when up to date" do
         Spree::Config.last_job_queue_heartbeat_at = Time.now
         spree_get :job_queue
-        response.should be_success
-        response.body.should == {alive: true}.to_json
+        expect(response).to be_success
+        expect(response.body).to eq({alive: true}.to_json)
       end
 
       it "returns dead otherwise" do
         Spree::Config.last_job_queue_heartbeat_at = 10.minutes.ago
         spree_get :job_queue
-        response.should be_success
-        response.body.should == {alive: false}.to_json
+        expect(response).to be_success
+        expect(response.body).to eq({alive: false}.to_json)
       end
 
       it "returns dead when no heartbeat recorded" do
         Spree::Config.last_job_queue_heartbeat_at = nil
         spree_get :job_queue
-        response.should be_success
-        response.body.should == {alive: false}.to_json
+        expect(response).to be_success
+        expect(response.body).to eq({alive: false}.to_json)
       end
     end
   end

--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -25,8 +25,8 @@ module OpenFoodNetwork
           get :show, {id: cart, :format => :json }
           json_response = JSON.parse(response.body)
 
-          json_response['id'].should == cart.id
-          json_response['orders'].size.should == 0
+          expect(json_response['id']).to eq(cart.id)
+          expect(json_response['orders'].size).to eq(0)
         end
 
         context 'with an empty order' do
@@ -41,9 +41,9 @@ module OpenFoodNetwork
             get :show, {id: cart, :format => :json }
             json_response = JSON.parse(response.body)
 
-            json_response['orders'].size.should == 1
-            json_response['orders'].first['distributor'].should == order.distributor.name
-            json_response['orders'].first['line_items'].size.should == 0
+            expect(json_response['orders'].size).to eq(1)
+            expect(json_response['orders'].first['distributor']).to eq(order.distributor.name)
+            expect(json_response['orders'].first['line_items'].size).to eq(0)
           end
         end
 
@@ -63,10 +63,10 @@ module OpenFoodNetwork
             get :show, {id: cart, :format => :json }
             json_response = JSON.parse(response.body)
 
-            json_response['orders'].size.should == 1
-            json_response['orders'].first['distributor'].should == order.distributor.name
-            json_response['orders'].first['line_items'].first["name"].should == product.name
-            json_response['orders'].first['line_items'].first["quantity"].should == line_item.quantity
+            expect(json_response['orders'].size).to eq(1)
+            expect(json_response['orders'].first['distributor']).to eq(order.distributor.name)
+            expect(json_response['orders'].first['line_items'].first["name"]).to eq(product.name)
+            expect(json_response['orders'].first['line_items'].first["quantity"]).to eq(line_item.quantity)
           end
         end
 
@@ -79,9 +79,9 @@ module OpenFoodNetwork
 
             put :add_variant, { cart_id: cart, variant_id: variant.id, quantity: (variant.on_hand-1), distributor_id: distributor, order_cycle_id: nil, max_quantity: nil }
 
-            cart.orders.size.should == 1
-            cart.orders.first.line_items.size.should == 1
-            cart.orders.first.line_items.first.product.should == product1
+            expect(cart.orders.size).to eq(1)
+            expect(cart.orders.first.line_items.size).to eq(1)
+            expect(cart.orders.first.line_items.first.product).to eq(product1)
           end
         end
       end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -7,81 +7,81 @@ describe CheckoutController, type: :controller do
   let(:reset_order_service) { double(ResetOrderService) }
 
   before do
-    order.stub(:checkout_allowed?).and_return true
-    controller.stub(:check_authorization).and_return true
+    allow(order).to receive(:checkout_allowed?).and_return true
+    allow(controller).to receive(:check_authorization).and_return true
   end
 
   it "redirects home when no distributor is selected" do
     get :edit
-    response.should redirect_to root_path
+    expect(response).to redirect_to root_path
   end
 
   it "redirects to the shop when no order cycle is selected" do
-    controller.stub(:current_distributor).and_return(distributor)
+    allow(controller).to receive(:current_distributor).and_return(distributor)
     get :edit
-    response.should redirect_to shop_path
+    expect(response).to redirect_to shop_path
   end
 
   it "redirects home with message if hub is not ready for checkout" do
-    distributor.stub(:ready_for_checkout?) { false }
-    order.stub(distributor: distributor, order_cycle: order_cycle)
-    controller.stub(:current_order).and_return(order)
+    allow(distributor).to receive(:ready_for_checkout?) { false }
+    allow(order).to receive_messages(distributor: distributor, order_cycle: order_cycle)
+    allow(controller).to receive(:current_order).and_return(order)
 
-    order.should_receive(:empty!)
-    order.should_receive(:set_distribution!).with(nil, nil)
+    expect(order).to receive(:empty!)
+    expect(order).to receive(:set_distribution!).with(nil, nil)
 
     get :edit
 
-    response.should redirect_to root_url
-    flash[:info].should == "The hub you have selected is temporarily closed for orders. Please try again later."
+    expect(response).to redirect_to root_url
+    expect(flash[:info]).to eq("The hub you have selected is temporarily closed for orders. Please try again later.")
   end
 
   it "redirects to the cart when some items are out of stock" do
-    controller.stub(:current_distributor).and_return(distributor)
-    controller.stub(:current_order_cycle).and_return(order_cycle)
-    controller.stub(:current_order).and_return(order)
-    order.stub_chain(:insufficient_stock_lines, :present?).and_return true
+    allow(controller).to receive(:current_distributor).and_return(distributor)
+    allow(controller).to receive(:current_order_cycle).and_return(order_cycle)
+    allow(controller).to receive(:current_order).and_return(order)
+    allow(order).to receive_message_chain(:insufficient_stock_lines, :present?).and_return true
     get :edit
-    response.should redirect_to spree.cart_path
+    expect(response).to redirect_to spree.cart_path
   end
 
   it "renders when both distributor and order cycle is selected" do
-    controller.stub(:current_distributor).and_return(distributor)
-    controller.stub(:current_order_cycle).and_return(order_cycle)
-    controller.stub(:current_order).and_return(order)
-    order.stub_chain(:insufficient_stock_lines, :present?).and_return false
+    allow(controller).to receive(:current_distributor).and_return(distributor)
+    allow(controller).to receive(:current_order_cycle).and_return(order_cycle)
+    allow(controller).to receive(:current_order).and_return(order)
+    allow(order).to receive_message_chain(:insufficient_stock_lines, :present?).and_return false
     get :edit
-    response.should be_success
+    expect(response).to be_success
   end
 
   describe "building the order" do
     before do
-      controller.stub(:current_distributor).and_return(distributor)
-      controller.stub(:current_order_cycle).and_return(order_cycle)
-      controller.stub(:current_order).and_return(order)
+      allow(controller).to receive(:current_distributor).and_return(distributor)
+      allow(controller).to receive(:current_order_cycle).and_return(order_cycle)
+      allow(controller).to receive(:current_order).and_return(order)
     end
 
     it "does not clone the ship address from distributor when shipping method requires address" do
       get :edit
-      assigns[:order].ship_address.address1.should be_nil
+      expect(assigns[:order].ship_address.address1).to be_nil
     end
 
     it "clears the ship address when re-rendering edit" do
-      controller.should_receive(:clear_ship_address).and_return true
-      order.stub(:update_attributes).and_return false
+      expect(controller).to receive(:clear_ship_address).and_return true
+      allow(order).to receive(:update_attributes).and_return false
       spree_post :update, format: :json, order: {}
     end
 
     it "clears the ship address when the order state cannot be advanced" do
-      controller.should_receive(:clear_ship_address).and_return true
-      order.stub(:update_attributes).and_return true
-      order.stub(:next).and_return false
+      expect(controller).to receive(:clear_ship_address).and_return true
+      allow(order).to receive(:update_attributes).and_return true
+      allow(order).to receive(:next).and_return false
       spree_post :update, format: :json, order: {}
     end
 
     it "only clears the ship address with a pickup shipping method" do
-      order.stub_chain(:shipping_method, :andand, :require_ship_address).and_return false
-      order.should_receive(:ship_address=)
+      allow(order).to receive_message_chain(:shipping_method, :andand, :require_ship_address).and_return false
+      expect(order).to receive(:ship_address=)
       controller.send(:clear_ship_address)
     end
 
@@ -126,35 +126,35 @@ describe CheckoutController, type: :controller do
 
   context "via xhr" do
     before do
-      controller.stub(:current_distributor).and_return(distributor)
+      allow(controller).to receive(:current_distributor).and_return(distributor)
 
-      controller.stub(:current_order_cycle).and_return(order_cycle)
-      controller.stub(:current_order).and_return(order)
+      allow(controller).to receive(:current_order_cycle).and_return(order_cycle)
+      allow(controller).to receive(:current_order).and_return(order)
     end
 
     it "returns errors" do
       spree_post :update, format: :json, order: {}
-      response.status.should == 400
-      response.body.should == {errors: assigns[:order].errors, flash: {}}.to_json
+      expect(response.status).to eq(400)
+      expect(response.body).to eq({errors: assigns[:order].errors, flash: {}}.to_json)
     end
 
     it "returns flash" do
-      order.stub(:update_attributes).and_return true
-      order.stub(:next).and_return false
+      allow(order).to receive(:update_attributes).and_return true
+      allow(order).to receive(:next).and_return false
       spree_post :update, format: :json, order: {}
-      response.body.should == {errors: assigns[:order].errors, flash: {error: "Payment could not be processed, please check the details you entered"}}.to_json
+      expect(response.body).to eq({errors: assigns[:order].errors, flash: {error: "Payment could not be processed, please check the details you entered"}}.to_json)
     end
 
     it "returns order confirmation url on success" do
       allow(ResetOrderService).to receive(:new).with(controller, order) { reset_order_service }
       expect(reset_order_service).to receive(:call)
 
-      order.stub(:update_attributes).and_return true
-      order.stub(:state).and_return "complete"
+      allow(order).to receive(:update_attributes).and_return true
+      allow(order).to receive(:state).and_return "complete"
 
       spree_post :update, format: :json, order: {}
-      response.status.should == 200
-      response.body.should == {path: spree.order_path(order)}.to_json
+      expect(response.status).to eq(200)
+      expect(response.body).to eq({path: spree.order_path(order)}.to_json)
     end
 
     describe "stale object handling" do
@@ -162,27 +162,27 @@ describe CheckoutController, type: :controller do
         allow(ResetOrderService).to receive(:new).with(controller, order) { reset_order_service }
         expect(reset_order_service).to receive(:call)
 
-        order.stub(:update_attributes).and_return true
-        controller.stub(:state_callback)
+        allow(order).to receive(:update_attributes).and_return true
+        allow(controller).to receive(:state_callback)
 
         # The first time, raise a StaleObjectError. The second time, succeed.
-        order.stub(:next).once.
+        allow(order).to receive(:next).once.
           and_raise(ActiveRecord::StaleObjectError.new(Spree::Variant.new, 'update'))
-        order.stub(:next).once do
+        allow(order).to receive(:next).once do
           order.update_column :state, 'complete'
           true
         end
 
         spree_post :update, format: :json, order: {}
-        response.status.should == 200
+        expect(response.status).to eq(200)
       end
 
       it "tries a maximum of 3 times before giving up and returning an error" do
-        order.stub(:update_attributes).and_return true
-        order.stub(:next) { raise ActiveRecord::StaleObjectError.new(Spree::Variant.new, 'update') }
+        allow(order).to receive(:update_attributes).and_return true
+        allow(order).to receive(:next) { raise ActiveRecord::StaleObjectError.new(Spree::Variant.new, 'update') }
 
         spree_post :update, format: :json, order: {}
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
     end
   end

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -17,18 +17,18 @@ describe EnterprisesController, type: :controller do
     it "sets the shop as the distributor on the order when shopping for the distributor" do
       spree_get :shop, {id: distributor}
 
-      controller.current_order.distributor.should == distributor
-      controller.current_order.order_cycle.should be_nil
+      expect(controller.current_order.distributor).to eq(distributor)
+      expect(controller.current_order.order_cycle).to be_nil
     end
 
     it "sorts order cycles by the distributor's preferred ordering attr" do
       distributor.update_attribute(:preferred_shopfront_order_cycle_order, 'orders_close_at')
       spree_get :shop, {id: distributor}
-      assigns(:order_cycles).should == [order_cycle1, order_cycle2].sort_by(&:orders_close_at)
+      expect(assigns(:order_cycles)).to eq([order_cycle1, order_cycle2].sort_by(&:orders_close_at))
 
       distributor.update_attribute(:preferred_shopfront_order_cycle_order, 'orders_open_at')
       spree_get :shop, {id: distributor}
-      assigns(:order_cycles).should == [order_cycle1, order_cycle2].sort_by(&:orders_open_at)
+      expect(assigns(:order_cycles)).to eq([order_cycle1, order_cycle2].sort_by(&:orders_open_at))
     end
 
     context "using FilterOrderCycles tag rules" do
@@ -76,9 +76,9 @@ describe EnterprisesController, type: :controller do
 
       spree_get :shop, {id: distributor}
 
-      controller.current_order.distributor.should == distributor
-      controller.current_order.order_cycle.should be_nil
-      controller.current_order.line_items.size.should == 0
+      expect(controller.current_order.distributor).to eq(distributor)
+      expect(controller.current_order.order_cycle).to be_nil
+      expect(controller.current_order.line_items.size).to eq(0)
     end
 
     it "should not empty an order if returning to the same distributor" do
@@ -89,9 +89,9 @@ describe EnterprisesController, type: :controller do
 
       spree_get :shop, {id: current_distributor}
 
-      controller.current_order.distributor.should == current_distributor
-      controller.current_order.order_cycle.should be_nil
-      controller.current_order.line_items.size.should == 1
+      expect(controller.current_order.distributor).to eq(current_distributor)
+      expect(controller.current_order.order_cycle).to be_nil
+      expect(controller.current_order.line_items.size).to eq(1)
     end
 
     describe "when an out of stock item is in the cart" do
@@ -110,7 +110,7 @@ describe EnterprisesController, type: :controller do
       it "redirects to the cart" do
         spree_get :shop, {id: current_distributor}
 
-        response.should redirect_to spree.cart_path
+        expect(response).to redirect_to spree.cart_path
       end
     end
 
@@ -119,8 +119,8 @@ describe EnterprisesController, type: :controller do
 
       spree_get :shop, {id: distributor}
 
-      controller.current_order.distributor.should == distributor
-      controller.current_order.order_cycle.should == order_cycle1
+      expect(controller.current_order.distributor).to eq(distributor)
+      expect(controller.current_order.order_cycle).to eq(order_cycle1)
     end
   end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -5,13 +5,13 @@ describe GroupsController, type: :controller do
   let(:enterprise) { create(:distributor_enterprise) }
   let!(:group) { create(:enterprise_group, enterprises: [enterprise], on_front_page: true) }
   it "gets all visible groups" do
-    EnterpriseGroup.stub_chain :on_front_page, :by_position
-    EnterpriseGroup.should_receive :on_front_page
+    allow(EnterpriseGroup).to receive_message_chain :on_front_page, :by_position
+    expect(EnterpriseGroup).to receive :on_front_page
     get :index
   end
 
   it "loads all enterprises for group" do
     get :index
-    response.body.should have_text enterprise.id
+    expect(response.body).to have_text enterprise.id
   end
 end

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -13,9 +13,9 @@ describe LineItemsController, type: :controller do
     end
 
     before do
-      controller.stub spree_current_user: user
-      controller.stub current_order_cycle: order_cycle
-      controller.stub current_distributor: distributor
+      allow(controller).to receive_messages spree_current_user: user
+      allow(controller).to receive_messages current_order_cycle: order_cycle
+      allow(controller).to receive_messages current_distributor: distributor
     end
 
     it "lists items bought by the user from the same shop in the same order_cycle" do
@@ -38,7 +38,7 @@ describe LineItemsController, type: :controller do
     let(:order) { item.order }
     let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: [order.line_item_variants]) }
 
-    before { controller.stub spree_current_user: item.order.user }
+    before { allow(controller).to receive_messages spree_current_user: item.order.user }
 
     context "without a line item id" do
       it "fails and raises an error" do
@@ -110,7 +110,7 @@ describe LineItemsController, type: :controller do
 
         # Delete the item
         item = order.line_items.first
-        controller.stub spree_current_user: order.user
+        allow(controller).to receive_messages spree_current_user: order.user
         request = { format: :json, id: item }
         delete :destroy, request
         expect(response.status).to eq 204
@@ -144,7 +144,7 @@ describe LineItemsController, type: :controller do
       it "updates the fees" do
         expect(order.reload.adjustment_total).to eq enterprise_fee.calculator.preferred_amount
 
-        controller.stub spree_current_user: user
+        allow(controller).to receive_messages spree_current_user: user
         delete :destroy, params
         expect(response.status).to eq 204
 

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -5,7 +5,7 @@ describe RegistrationController, type: :controller do
   describe "redirecting when user not logged in" do
     it "index" do
       get :index
-      response.should redirect_to registration_auth_path(anchor: "signup?after_login=/register")
+      expect(response).to redirect_to registration_auth_path(anchor: "signup?after_login=/register")
     end
   end
 
@@ -14,12 +14,12 @@ describe RegistrationController, type: :controller do
     let!(:enterprise) { create(:distributor_enterprise, owner: user) }
 
     before do
-      controller.stub spree_current_user: user
+      allow(controller).to receive_messages spree_current_user: user
     end
 
     it "index" do
       get :index
-      response.should render_template :limit_reached
+      expect(response).to render_template :limit_reached
     end
   end
 
@@ -27,7 +27,7 @@ describe RegistrationController, type: :controller do
     let!(:user) { create_enterprise_user }
 
     before do
-      controller.stub spree_current_user: user
+      allow(controller).to receive_messages spree_current_user: user
     end
 
     describe "index" do

--- a/spec/controllers/shop_controller_spec.rb
+++ b/spec/controllers/shop_controller_spec.rb
@@ -7,26 +7,26 @@ describe ShopController, type: :controller do
 
   it "redirects to the home page if no distributor is selected" do
     spree_get :show
-    response.should redirect_to root_path
+    expect(response).to redirect_to root_path
   end
 
   describe "with a distributor in place" do
     before do
-      controller.stub(:current_distributor).and_return distributor
+      allow(controller).to receive(:current_distributor).and_return distributor
     end
 
     describe "selecting an order cycle" do
       it "should select an order cycle when only one order cycle is open" do
         oc1 = create(:simple_order_cycle, distributors: [distributor])
         spree_get :show
-        controller.current_order_cycle.should == oc1
+        expect(controller.current_order_cycle).to eq(oc1)
       end
 
       it "should not set an order cycle when multiple order cycles are open" do
         oc1 = create(:simple_order_cycle, distributors: [distributor])
         oc2 = create(:simple_order_cycle, distributors: [distributor])
         spree_get :show
-        controller.current_order_cycle.should be_nil
+        expect(controller.current_order_cycle).to be_nil
       end
 
       it "should allow the user to post to select the current order cycle" do
@@ -34,8 +34,8 @@ describe ShopController, type: :controller do
         oc2 = create(:simple_order_cycle, distributors: [distributor])
 
         spree_post :order_cycle, order_cycle_id: oc2.id
-        response.should be_success
-        controller.current_order_cycle.should == oc2
+        expect(response).to be_success
+        expect(controller.current_order_cycle).to eq(oc2)
       end
 
       context "JSON tests" do
@@ -46,15 +46,15 @@ describe ShopController, type: :controller do
           oc2 = create(:simple_order_cycle, distributors: [distributor])
 
           spree_post :order_cycle, order_cycle_id: oc2.id
-          response.should be_success
-          response.body.should have_content oc2.id
+          expect(response).to be_success
+          expect(response.body).to have_content oc2.id
         end
 
         it "should return the current order cycle when hit with GET" do
           oc1 = create(:simple_order_cycle, distributors: [distributor])
-          controller.stub(:current_order_cycle).and_return oc1
+          allow(controller).to receive(:current_order_cycle).and_return oc1
           spree_get :order_cycle
-          response.body.should have_content oc1.id
+          expect(response.body).to have_content oc1.id
         end
       end
 
@@ -64,8 +64,8 @@ describe ShopController, type: :controller do
         oc3 = create(:simple_order_cycle, distributors: [create(:distributor_enterprise)])
 
         spree_post :order_cycle, order_cycle_id: oc3.id
-        response.status.should == 404
-        controller.current_order_cycle.should be_nil
+        expect(response.status).to eq(404)
+        expect(controller.current_order_cycle).to be_nil
       end
     end
 
@@ -82,16 +82,16 @@ describe ShopController, type: :controller do
         end
 
         it "returns products via JSON" do
-          controller.stub(:current_order_cycle).and_return order_cycle
+          allow(controller).to receive(:current_order_cycle).and_return order_cycle
           xhr :get, :products
-          response.should be_success
+          expect(response).to be_success
         end
 
         it "does not return products if no order cycle is selected" do
-          controller.stub(:current_order_cycle).and_return nil
+          allow(controller).to receive(:current_order_cycle).and_return nil
           xhr :get, :products
-          response.status.should == 404
-          response.body.should be_empty
+          expect(response.status).to eq(404)
+          expect(response.body).to be_empty
         end
       end
     end

--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -6,12 +6,12 @@ describe ShopsController, type: :controller do
   let!(:invisible_distributor) { create(:distributor_enterprise, visible: false) }
 
   before do
-    Enterprise.stub_chain("distributors_with_active_order_cycles.ready_for_checkout") { [distributor] }
+    allow(Enterprise).to receive_message_chain("distributors_with_active_order_cycles.ready_for_checkout") { [distributor] }
   end
 
   # Exclusion from actual rendered view handled in features/consumer/home
   it "shows JSON for invisible hubs" do
     get :index
-    response.body.should have_content invisible_distributor.name
+    expect(response.body).to have_content invisible_distributor.name
   end
 end

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -13,22 +13,22 @@ module Spree
       describe "creating an adjustment" do
         it "sets included tax to zero when no tax rate is specified" do
           spree_post :create, {order_id: order.number, adjustment: {label: 'Testing included tax', amount: '110'}, tax_rate_id: ''}
-          response.should redirect_to spree.admin_order_adjustments_path(order)
+          expect(response).to redirect_to spree.admin_order_adjustments_path(order)
 
           a = Adjustment.last
-          a.label.should == 'Testing included tax'
-          a.amount.should == 110
-          a.included_tax.should == 0
+          expect(a.label).to eq('Testing included tax')
+          expect(a.amount).to eq(110)
+          expect(a.included_tax).to eq(0)
         end
 
         it "calculates included tax when a tax rate is provided" do
           spree_post :create, {order_id: order.number, adjustment: {label: 'Testing included tax', amount: '110'}, tax_rate_id: tax_rate.id.to_s}
-          response.should redirect_to spree.admin_order_adjustments_path(order)
+          expect(response).to redirect_to spree.admin_order_adjustments_path(order)
 
           a = Adjustment.last
-          a.label.should == 'Testing included tax'
-          a.amount.should == 110
-          a.included_tax.should == 10
+          expect(a.label).to eq('Testing included tax')
+          expect(a.amount).to eq(110)
+          expect(a.included_tax).to eq(10)
         end
       end
 
@@ -37,22 +37,22 @@ module Spree
 
         it "sets included tax to zero when no tax rate is specified" do
           spree_put :update, {order_id: order.number, id: adjustment.id, adjustment: {label: 'Testing included tax', amount: '110'}, tax_rate_id: ''}
-          response.should redirect_to spree.admin_order_adjustments_path(order)
+          expect(response).to redirect_to spree.admin_order_adjustments_path(order)
 
           a = Adjustment.last
-          a.label.should == 'Testing included tax'
-          a.amount.should == 110
-          a.included_tax.should == 0
+          expect(a.label).to eq('Testing included tax')
+          expect(a.amount).to eq(110)
+          expect(a.included_tax).to eq(0)
         end
 
         it "calculates included tax when a tax rate is provided" do
           spree_put :update, {order_id: order.number, id: adjustment.id, adjustment: {label: 'Testing included tax', amount: '110'}, tax_rate_id: tax_rate.id.to_s}
-          response.should redirect_to spree.admin_order_adjustments_path(order)
+          expect(response).to redirect_to spree.admin_order_adjustments_path(order)
 
           a = Adjustment.last
-          a.label.should == 'Testing included tax'
-          a.amount.should == 110
-          a.included_tax.should == 10
+          expect(a.label).to eq('Testing included tax')
+          expect(a.amount).to eq(110)
+          expect(a.included_tax).to eq(10)
         end
       end
     end

--- a/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spec/controllers/spree/admin/base_controller_spec.rb
@@ -10,29 +10,31 @@ describe Spree::Admin::BaseController, type: :controller do
 
   it "redirects to Angular login" do
     spree_get :index
-    response.should redirect_to root_path(anchor: "login?after_login=/spree/admin/base")
+    expect(response).to redirect_to root_path(anchor: "login?after_login=/spree/admin/base")
   end
 
   describe "displaying error messages for active distributors not ready for checkout" do
     it "generates an error message when there is one distributor" do
       distributor = double(:distributor, name: 'My Hub')
-      controller.
-        send(:active_distributors_not_ready_for_checkout_message, [distributor]).
-        should ==
+      expect(controller.
+        send(:active_distributors_not_ready_for_checkout_message, [distributor])).
+        to eq(
         "The hub My Hub is listed in an active order cycle, " +
         "but does not have valid shipping and payment methods. " +
         "Until you set these up, customers will not be able to shop at this hub."
+      )
     end
 
     it "generates an error message when there are several distributors" do
       d1 = double(:distributor, name: 'Hub One')
       d2 = double(:distributor, name: 'Hub Two')
-      controller.
-        send(:active_distributors_not_ready_for_checkout_message, [d1, d2]).
-        should ==
+      expect(controller.
+        send(:active_distributors_not_ready_for_checkout_message, [d1, d2])).
+        to eq(
         "The hubs Hub One, Hub Two are listed in an active order cycle, " +
         "but do not have valid shipping and payment methods. " +
         "Until you set these up, customers will not be able to shop at these hubs."
+      )
     end
   end
 

--- a/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -16,7 +16,7 @@ describe Spree::Admin::LineItemsController, type: :controller do
     it "takes variant overrides into account for price" do
       spree_post :create, params
 
-      order.line_items(:reload).last.price.should == 11.11
+      expect(order.line_items(:reload).last.price).to eq(11.11)
     end
   end
 
@@ -33,7 +33,7 @@ describe Spree::Admin::LineItemsController, type: :controller do
     context "as an enterprise user" do
       context "producer enterprise" do
         before do
-          controller.stub spree_current_user: supplier.owner
+          allow(controller).to receive_messages spree_current_user: supplier.owner
           spree_put :update, params
         end
 
@@ -46,7 +46,7 @@ describe Spree::Admin::LineItemsController, type: :controller do
         render_views
 
         before do
-          controller.stub spree_current_user: coordinator.owner
+          allow(controller).to receive_messages spree_current_user: coordinator.owner
         end
 
         # Used in admin/orders/edit
@@ -97,7 +97,7 @@ describe Spree::Admin::LineItemsController, type: :controller do
 
       context "hub enterprise" do
         before do
-          controller.stub spree_current_user: distributor1.owner
+          allow(controller).to receive_messages spree_current_user: distributor1.owner
           xhr :put, :update, params
         end
 

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     it "updates distribution charges" do
       order.line_items << line_item
       order.save
-      Spree::Order.any_instance.should_receive(:update_distribution_charge!)
+      expect_any_instance_of(Spree::Order).to receive(:update_distribution_charge!)
       spree_put :update, {
         id: order,
         order: {
@@ -47,7 +47,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     end
 
     context "as a normal user" do
-      before { controller.stub spree_current_user: create_enterprise_user }
+      before { allow(controller).to receive_messages spree_current_user: create_enterprise_user }
 
       make_simple_data!
 
@@ -61,31 +61,31 @@ describe Spree::Admin::OrdersController, type: :controller do
       make_simple_data!
 
       before do
-        controller.stub spree_current_user: quick_login_as_admin
+        allow(controller).to receive_messages spree_current_user: quick_login_as_admin
         spree_get :index, :format => :json
       end
 
       it "retrieves a list of orders with appropriate attributes, including line items with appropriate attributes" do
         keys = json_response.first.keys.map{ |key| key.to_sym }
-        order_attributes.all?{ |attr| keys.include? attr }.should == true
+        expect(order_attributes.all?{ |attr| keys.include? attr }).to eq(true)
       end
 
       it "sorts orders in ascending id order" do
         ids = json_response.map{ |order| order['id'] }
-        ids[0].should < ids[1]
-        ids[1].should < ids[2]
+        expect(ids[0]).to be < ids[1]
+        expect(ids[1]).to be < ids[2]
       end
 
       it "formats completed_at to 'yyyy-mm-dd hh:mm'" do
-        json_response.map{ |order| order['completed_at'] }.all?{ |a| a.match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$") }.should == true
+        expect(json_response.map{ |order| order['completed_at'] }.all?{ |a| a.match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$") }).to eq(true)
       end
 
       it "returns distributor object with id key" do
-        json_response.map{ |order| order['distributor'] }.all?{ |d| d.has_key?('id') }.should == true
+        expect(json_response.map{ |order| order['distributor'] }.all?{ |d| d.has_key?('id') }).to eq(true)
       end
 
       it "retrieves the order number" do
-        json_response.map{ |order| order['number'] }.all?{ |number| number.match("^R\\d{5,10}$") }.should == true
+        expect(json_response.map{ |order| order['number'] }.all?{ |number| number.match("^R\\d{5,10}$") }).to eq(true)
       end
     end
 
@@ -104,7 +104,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       context "producer enterprise" do
 
         before do
-          controller.stub spree_current_user: supplier.owner
+          allow(controller).to receive_messages spree_current_user: supplier.owner
           spree_get :index, :format => :json
         end
 
@@ -115,25 +115,25 @@ describe Spree::Admin::OrdersController, type: :controller do
 
       context "coordinator enterprise" do
         before do
-          controller.stub spree_current_user: coordinator.owner
+          allow(controller).to receive_messages spree_current_user: coordinator.owner
           spree_get :index, :format => :json
         end
 
         it "retrieves a list of orders" do
           keys = json_response.first.keys.map{ |key| key.to_sym }
-          order_attributes.all?{ |attr| keys.include? attr }.should == true
+          expect(order_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end
 
       context "hub enterprise" do
         before do
-          controller.stub spree_current_user: distributor1.owner
+          allow(controller).to receive_messages spree_current_user: distributor1.owner
           spree_get :index, :format => :json
         end
 
         it "retrieves a list of orders" do
           keys = json_response.first.keys.map{ |key| key.to_sym }
-          order_attributes.all?{ |attr| keys.include? attr }.should == true
+          expect(order_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end
     end
@@ -147,7 +147,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     let(:params) { { id: order.number } }
 
     context "as a normal user" do
-      before { controller.stub spree_current_user: user }
+      before { allow(controller).to receive_messages spree_current_user: user }
 
       it "should prevent me from sending order invoices" do
         spree_get :invoice, params
@@ -157,7 +157,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context "as an enterprise user" do
       context "which is not a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: user }
+        before { allow(controller).to receive_messages spree_current_user: user }
         it "should prevent me from sending order invoices" do
           spree_get :invoice, params
           expect(response).to redirect_to spree.unauthorized_path
@@ -165,7 +165,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       context "which is a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: distributor.owner }
+        before { allow(controller).to receive_messages spree_current_user: distributor.owner }
         context "when the distributor's ABN has not been set" do
           before { distributor.update_attribute(:abn, "") }
           it "should allow me to send order invoices" do
@@ -204,7 +204,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     let(:params) { { id: order.number } }
 
     context "as a normal user" do
-      before { controller.stub spree_current_user: user }
+      before { allow(controller).to receive_messages spree_current_user: user }
 
       it "should prevent me from sending order invoices" do
         spree_get :print, params
@@ -214,7 +214,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context "as an enterprise user" do
       context "which is not a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: user }
+        before { allow(controller).to receive_messages spree_current_user: user }
         it "should prevent me from sending order invoices" do
           spree_get :print, params
           expect(response).to redirect_to spree.unauthorized_path
@@ -222,7 +222,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       context "which is a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: distributor.owner }
+        before { allow(controller).to receive_messages spree_current_user: distributor.owner }
         it "should allow me to send order invoices" do
           spree_get :print, params
           expect(response).to render_template :invoice

--- a/spec/controllers/spree/admin/overview_controller_spec.rb
+++ b/spec/controllers/spree/admin/overview_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::OverviewController, type: :controller do
     let(:user) { create_enterprise_user(enterprise_limit: 2) }
 
     before do
-      controller.stub spree_current_user: user
+      allow(controller).to receive_messages spree_current_user: user
     end
 
     context "when user owns only one enterprise" do
@@ -22,14 +22,14 @@ describe Spree::Admin::OverviewController, type: :controller do
 
           it "redirects to the welcome page for the enterprise" do
             spree_get :index
-            response.should redirect_to welcome_admin_enterprise_path(enterprise)
+            expect(response).to redirect_to welcome_admin_enterprise_path(enterprise)
           end
         end
 
         context "and the enterprise does not have sells='unspecified'" do
           it "renders the single enterprise dashboard" do
             spree_get :index
-            response.should render_template "single_enterprise_dashboard"
+            expect(response).to render_template "single_enterprise_dashboard"
           end
         end
       end
@@ -39,7 +39,7 @@ describe Spree::Admin::OverviewController, type: :controller do
 
         it "renders the single enterprise dashboard" do
           spree_get :index
-          response.should render_template "single_enterprise_dashboard"
+          expect(response).to render_template "single_enterprise_dashboard"
         end
       end
     end
@@ -58,14 +58,14 @@ describe Spree::Admin::OverviewController, type: :controller do
 
           it "redirects to the enterprises index" do
             spree_get :index
-            response.should redirect_to admin_enterprises_path
+            expect(response).to redirect_to admin_enterprises_path
           end
         end
 
         context "and no owned enterprises have sells='unspecified'" do
           it "renders the multiple enterprise dashboard" do
             spree_get :index
-            response.should render_template "multi_enterprise_dashboard"
+            expect(response).to render_template "multi_enterprise_dashboard"
           end
         end
       end
@@ -75,7 +75,7 @@ describe Spree::Admin::OverviewController, type: :controller do
 
         it "renders the multiple enterprise dashboard" do
           spree_get :index
-          response.should render_template "multi_enterprise_dashboard"
+          expect(response).to render_template "multi_enterprise_dashboard"
         end
       end
     end

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -67,7 +67,7 @@ describe Spree::Admin::PaymentMethodsController, type: :controller do
     end
 
     before do
-      controller.stub spree_current_user: user
+      allow(controller).to receive_messages spree_current_user: user
     end
 
     context "on an existing payment method" do

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -12,11 +12,11 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
 
     it "denies access" do
-      response.should redirect_to spree.unauthorized_url
+      expect(response).to redirect_to spree.unauthorized_url
     end
 
     it "does not update any product" do
-      p.reload.name.should_not == "Pine nuts"
+      expect(p.reload.name).not_to eq("Pine nuts")
     end
   end
 
@@ -40,7 +40,7 @@ describe Spree::Admin::ProductsController, type: :controller do
         },
         button: 'create'
       }
-      response.should redirect_to "/admin/products/bulk_edit"
+      expect(response).to redirect_to "/admin/products/bulk_edit"
     end
 
     it "redirects to new when the user hits 'add_another'" do
@@ -60,7 +60,7 @@ describe Spree::Admin::ProductsController, type: :controller do
         },
         button: 'add_another'
       }
-      response.should redirect_to "/admin/products/new"
+      expect(response).to redirect_to "/admin/products/new"
     end
   end
 

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -70,8 +70,8 @@ describe Spree::Admin::ReportsController, type: :controller do
       it "shows all orders in order cycles I coordinate" do
         spree_get :orders_and_fulfillment
 
-        resulting_orders.should     include orderA1, orderA2
-        resulting_orders.should_not include orderB1, orderB2
+        expect(resulting_orders).to     include orderA1, orderA2
+        expect(resulting_orders).not_to include orderB1, orderB2
       end
     end
   end
@@ -84,9 +84,9 @@ describe Spree::Admin::ReportsController, type: :controller do
       it "only shows orders that I have access to" do
         spree_get :orders_and_distributors
 
-        assigns(:search).result.should include(orderA1, orderB1)
-        assigns(:search).result.should_not include(orderA2)
-        assigns(:search).result.should_not include(orderB2)
+        expect(assigns(:search).result).to include(orderA1, orderB1)
+        expect(assigns(:search).result).not_to include(orderA2)
+        expect(assigns(:search).result).not_to include(orderB2)
       end
     end
 
@@ -94,9 +94,9 @@ describe Spree::Admin::ReportsController, type: :controller do
       it "only shows orders that I have access to" do
         spree_get :bulk_coop
 
-        resulting_orders.should     include(orderA1, orderB1)
-        resulting_orders.should_not include(orderA2)
-        resulting_orders.should_not include(orderB2)
+        expect(resulting_orders).to     include(orderA1, orderB1)
+        expect(resulting_orders).not_to include(orderA2)
+        expect(resulting_orders).not_to include(orderB2)
       end
     end
 
@@ -104,9 +104,9 @@ describe Spree::Admin::ReportsController, type: :controller do
       it "only shows orders that I have access to" do
         spree_get :payments
 
-        resulting_orders_prelim.should     include(orderA1, orderB1)
-        resulting_orders_prelim.should_not include(orderA2)
-        resulting_orders_prelim.should_not include(orderB2)
+        expect(resulting_orders_prelim).to     include(orderA1, orderB1)
+        expect(resulting_orders_prelim).not_to include(orderA2)
+        expect(resulting_orders_prelim).not_to include(orderB2)
       end
     end
 
@@ -114,15 +114,15 @@ describe Spree::Admin::ReportsController, type: :controller do
       it "only shows orders that I distribute" do
         spree_get :orders_and_fulfillment
 
-        resulting_orders.should     include orderA1, orderB1
-        resulting_orders.should_not include orderA2, orderB2
+        expect(resulting_orders).to     include orderA1, orderB1
+        expect(resulting_orders).not_to include orderA2, orderB2
       end
 
       it "only shows the selected order cycle" do
         spree_get :orders_and_fulfillment, q: {order_cycle_id_in: [ocA.id.to_s]}
 
-        resulting_orders.should     include(orderA1)
-        resulting_orders.should_not include(orderB1)
+        expect(resulting_orders).to     include(orderA1)
+        expect(resulting_orders).not_to include(orderB1)
       end
     end
   end
@@ -150,8 +150,8 @@ describe Spree::Admin::ReportsController, type: :controller do
         it "only shows product line items that I am supplying" do
           spree_get :bulk_coop
 
-          resulting_products.should     include p1
-          resulting_products.should_not include p2, p3
+          expect(resulting_products).to     include p1
+          expect(resulting_products).not_to include p2, p3
         end
       end
 
@@ -159,7 +159,7 @@ describe Spree::Admin::ReportsController, type: :controller do
         it "shows product line items that I am supplying" do
           spree_get :bulk_coop
 
-          resulting_products.should_not include p1, p2, p3
+          expect(resulting_products).not_to include p1, p2, p3
         end
       end
     end
@@ -173,15 +173,15 @@ describe Spree::Admin::ReportsController, type: :controller do
         it "only shows product line items that I am supplying" do
           spree_get :orders_and_fulfillment
 
-          resulting_products.should     include p1
-          resulting_products.should_not include p2, p3
+          expect(resulting_products).to     include p1
+          expect(resulting_products).not_to include p2, p3
         end
 
         it "only shows the selected order cycle" do
           spree_get :orders_and_fulfillment, q: {order_cycle_id_eq: ocA.id}
 
-          resulting_orders_prelim.should     include(orderA1)
-          resulting_orders_prelim.should_not include(orderB1)
+          expect(resulting_orders_prelim).to     include(orderA1)
+          expect(resulting_orders_prelim).not_to include(orderB1)
         end
       end
 
@@ -189,7 +189,7 @@ describe Spree::Admin::ReportsController, type: :controller do
         it "does not show me line_items I supply" do
           spree_get :orders_and_fulfillment
 
-          resulting_products.should_not include p1, p2, p3
+          expect(resulting_products).not_to include p1, p2, p3
         end
       end
     end
@@ -200,32 +200,32 @@ describe Spree::Admin::ReportsController, type: :controller do
 
     it "should build distributors for the current user" do
       spree_get :products_and_inventory
-      assigns(:distributors).should match_array [c1, c2, d1, d2, d3]
+      expect(assigns(:distributors)).to match_array [c1, c2, d1, d2, d3]
     end
 
     it "builds suppliers for the current user" do
       spree_get :products_and_inventory
-      assigns(:suppliers).should match_array [s1, s2, s3]
+      expect(assigns(:suppliers)).to match_array [s1, s2, s3]
     end
 
     it "builds order cycles for the current user" do
       spree_get :products_and_inventory
-      assigns(:order_cycles).should match_array [ocB, ocA]
+      expect(assigns(:order_cycles)).to match_array [ocB, ocA]
     end
 
     it "assigns report types" do
       spree_get :products_and_inventory
-      assigns(:report_types).should == subject.report_types[:products_and_inventory]
+      expect(assigns(:report_types)).to eq(subject.report_types[:products_and_inventory])
     end
 
     it "creates a ProductAndInventoryReport" do
-      OpenFoodNetwork::ProductsAndInventoryReport.should_receive(:new)
+      expect(OpenFoodNetwork::ProductsAndInventoryReport).to receive(:new)
         .with(@admin_user, {"test" => "foo", "controller" => "spree/admin/reports", "action" => "products_and_inventory"})
         .and_return(report = double(:report))
-      report.stub(:header).and_return []
-      report.stub(:table).and_return []
+      allow(report).to receive(:header).and_return []
+      allow(report).to receive(:table).and_return []
       spree_get :products_and_inventory, test: "foo"
-      assigns(:report).should == report
+      expect(assigns(:report)).to eq(report)
     end
   end
 
@@ -233,40 +233,40 @@ describe Spree::Admin::ReportsController, type: :controller do
     before { login_as_admin }
 
     it "should have report types for customers" do
-      subject.report_types[:customers].should == [
+      expect(subject.report_types[:customers]).to eq([
         ["Mailing List", :mailing_list],
         ["Addresses", :addresses]
-      ]
+      ])
     end
 
     it "should build distributors for the current user" do
       spree_get :customers
-      assigns(:distributors).should match_array [c1, c2, d1, d2, d3]
+      expect(assigns(:distributors)).to match_array [c1, c2, d1, d2, d3]
     end
 
     it "builds suppliers for the current user" do
       spree_get :customers
-      assigns(:suppliers).should match_array [s1, s2, s3]
+      expect(assigns(:suppliers)).to match_array [s1, s2, s3]
     end
 
     it "builds order cycles for the current user" do
       spree_get :customers
-      assigns(:order_cycles).should match_array [ocB, ocA]
+      expect(assigns(:order_cycles)).to match_array [ocB, ocA]
     end
 
     it "assigns report types" do
       spree_get :customers
-      assigns(:report_types).should == subject.report_types[:customers]
+      expect(assigns(:report_types)).to eq(subject.report_types[:customers])
     end
 
     it "creates a CustomersReport" do
-      OpenFoodNetwork::CustomersReport.should_receive(:new)
+      expect(OpenFoodNetwork::CustomersReport).to receive(:new)
         .with(@admin_user, {"test" => "foo", "controller" => "spree/admin/reports", "action" => "customers"})
         .and_return(report = double(:report))
-      report.stub(:header).and_return []
-      report.stub(:table).and_return []
+      allow(report).to receive(:header).and_return []
+      allow(report).to receive(:table).and_return []
       spree_get :customers, test: "foo"
-      assigns(:report).should == report
+      expect(assigns(:report)).to eq(report)
     end
   end
 end

--- a/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -16,23 +16,23 @@ module Spree
 
         it "filters by distributor" do
           spree_get :search, q: 'Prod', distributor_id: d.id.to_s
-          assigns(:variants).should == [v1]
+          expect(assigns(:variants)).to eq([v1])
         end
 
         it "applies variant overrides" do
           spree_get :search, q: 'Prod', distributor_id: d.id.to_s
-          assigns(:variants).should == [v1]
-          assigns(:variants).first.count_on_hand.should == 44
+          expect(assigns(:variants)).to eq([v1])
+          expect(assigns(:variants).first.count_on_hand).to eq(44)
         end
 
         it "filters by order cycle" do
           spree_get :search, q: 'Prod', order_cycle_id: oc.id.to_s
-          assigns(:variants).should == [v1]
+          expect(assigns(:variants)).to eq([v1])
         end
 
         it "does not filter when no distributor or order cycle is specified" do
           spree_get :search, q: 'Prod'
-          assigns(:variants).should match_array [v1, v2]
+          expect(assigns(:variants)).to match_array [v1, v2]
         end
       end
     end

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -38,21 +38,21 @@ module Spree
       it "retrieves a list of managed products" do
         spree_get :managed, { :template => 'bulk_index', :format => :json }
         keys = json_response.first.keys.map{ |key| key.to_sym }
-        attributes.all?{ |attr| keys.include? attr }.should == true
+        expect(attributes.all?{ |attr| keys.include? attr }).to eq(true)
       end
 
       it "soft deletes my products" do
         spree_delete :soft_delete, {product_id: product1.to_param, format: :json}
-        response.status.should == 204
-        lambda { product1.reload }.should_not raise_error
-        product1.deleted_at.should_not be_nil
+        expect(response.status).to eq(204)
+        expect { product1.reload }.not_to raise_error
+        expect(product1.deleted_at).not_to be_nil
       end
 
       it "is denied access to soft deleting another enterprises' product" do
         spree_delete :soft_delete, {product_id: product_other_supplier.to_param, format: :json}
         assert_unauthorized!
-        lambda { product_other_supplier.reload }.should_not raise_error
-        product_other_supplier.deleted_at.should be_nil
+        expect { product_other_supplier.reload }.not_to raise_error
+        expect(product_other_supplier.deleted_at).to be_nil
       end
     end
 
@@ -65,13 +65,13 @@ module Spree
       it "retrieves a list of managed products" do
         spree_get :managed, { :template => 'bulk_index', :format => :json }
         keys = json_response.first.keys.map{ |key| key.to_sym }
-        attributes.all?{ |attr| keys.include? attr }.should == true
+        expect(attributes.all?{ |attr| keys.include? attr }).to eq(true)
       end
 
       it "retrieves a list of products with appropriate attributes" do
         spree_get :index, { :template => 'bulk_index', :format => :json }
         keys = json_response.first.keys.map{ |key| key.to_sym }
-        attributes.all?{ |attr| keys.include? attr }.should == true
+        expect(attributes.all?{ |attr| keys.include? attr }).to eq(true)
       end
 
       it "sorts products in ascending id order" do
@@ -81,37 +81,37 @@ module Spree
         spree_get :index, { :template => 'bulk_index', :format => :json }
 
         ids = json_response.map{ |product| product['id'] }
-        ids[0].should < ids[1]
-        ids[1].should < ids[2]
+        expect(ids[0]).to be < ids[1]
+        expect(ids[1]).to be < ids[2]
       end
 
       it "formats available_on to 'yyyy-mm-dd hh:mm'" do
         spree_get :index, { :template => 'bulk_index', :format => :json }
-        json_response.map{ |product| product['available_on'] }.all?{ |a| a.match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$") }.should == true
+        expect(json_response.map{ |product| product['available_on'] }.all?{ |a| a.match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$") }).to eq(true)
       end
 
       it "returns permalink as permalink_live" do
         spree_get :index, { :template => 'bulk_index', :format => :json }
-        json_response.detect{ |product| product['id'] == product1.id }['permalink_live'].should == product1.permalink
+        expect(json_response.detect{ |product| product['id'] == product1.id }['permalink_live']).to eq(product1.permalink)
       end
 
       it "should allow available_on to be nil" do
         spree_get :index, { :template => 'bulk_index', :format => :json }
-        json_response.size.should == 1
+        expect(json_response.size).to eq(1)
 
         product5 = FactoryGirl.create(:product)
         product5.available_on = nil
         product5.save!
 
         spree_get :index, { :template => 'bulk_index', :format => :json }
-        json_response.size.should == 2
+        expect(json_response.size).to eq(2)
       end
 
       it "soft deletes a product" do
         spree_delete :soft_delete, {product_id: product1.to_param, format: :json}
-        response.status.should == 204
-        lambda { product1.reload }.should_not raise_error
-        product1.deleted_at.should_not be_nil
+        expect(response.status).to eq(204)
+        expect { product1.reload }.not_to raise_error
+        expect(product1.deleted_at).not_to be_nil
       end
     end
 

--- a/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/spec/controllers/spree/api/variants_controller_spec.rb
@@ -20,7 +20,7 @@ module Spree
       it "retrieves a list of variants with appropriate attributes" do
         spree_get :index, { :template => 'bulk_index', :format => :json }
         keys = json_response.first.keys.map{ |key| key.to_sym }
-        attributes.all?{ |attr| keys.include? attr }.should == true
+        expect(attributes.all?{ |attr| keys.include? attr }).to eq(true)
       end
 
       it "is denied access when trying to delete a variant" do
@@ -29,8 +29,8 @@ module Spree
 
         spree_delete :soft_delete, {variant_id: variant.to_param, product_id: product.to_param, format: :json}
         assert_unauthorized!
-        lambda { variant.reload }.should_not raise_error
-        variant.deleted_at.should be_nil
+        expect { variant.reload }.not_to raise_error
+        expect(variant.deleted_at).to be_nil
       end
     end
 
@@ -44,16 +44,16 @@ module Spree
 
       it "soft deletes a variant" do
         spree_delete :soft_delete, {variant_id: variant.to_param, product_id: product.to_param, format: :json}
-        response.status.should == 204
-        lambda { variant.reload }.should_not raise_error
-        variant.deleted_at.should be_present
+        expect(response.status).to eq(204)
+        expect { variant.reload }.not_to raise_error
+        expect(variant.deleted_at).to be_present
       end
 
       it "is denied access to soft deleting another enterprises' variant" do
         spree_delete :soft_delete, {variant_id: variant_other.to_param, product_id: product_other.to_param, format: :json}
         assert_unauthorized!
-        lambda { variant.reload }.should_not raise_error
-        variant.deleted_at.should be_nil
+        expect { variant.reload }.not_to raise_error
+        expect(variant.deleted_at).to be_nil
       end
     end
 
@@ -65,9 +65,9 @@ module Spree
         variant = product.master
 
         spree_delete :soft_delete, {variant_id: variant.to_param, product_id: product.to_param, format: :json}
-        response.status.should == 204
-        lambda { variant.reload }.should_not raise_error
-        variant.deleted_at.should_not be_nil
+        expect(response.status).to eq(204)
+        expect { variant.reload }.not_to raise_error
+        expect(variant.deleted_at).not_to be_nil
       end
     end
   end

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -36,10 +36,10 @@ describe Spree::CreditCardsController, type: :controller do
         expect{ post :new_from_token, params }.to change(Spree::CreditCard, :count).by(1)
 
         card = Spree::CreditCard.last
-        card.gateway_payment_profile_id.should eq "card_1AEEb"
-        card.gateway_customer_profile_id.should eq "cus_AZNMJ"
-        card.user_id.should eq user.id
-        card.last_digits.should eq "4242"
+        expect(card.gateway_payment_profile_id).to eq "card_1AEEb"
+        expect(card.gateway_customer_profile_id).to eq "cus_AZNMJ"
+        expect(card.user_id).to eq user.id
+        expect(card.last_digits).to eq "4242"
       end
 
       context "when saving the card locally fails" do

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -7,40 +7,40 @@ describe Spree::OrdersController, type: :controller do
 
   it "redirects home when no distributor is selected" do
     spree_get :edit
-    response.should redirect_to root_path
+    expect(response).to redirect_to root_path
   end
 
   it "redirects to shop when order is empty" do
-    controller.stub(:current_distributor).and_return(distributor)
-    controller.stub(:current_order_cycle).and_return(order_cycle)
-    controller.stub(:current_order).and_return order
-    order.stub_chain(:line_items, :empty?).and_return true
-    order.stub(:insufficient_stock_lines).and_return []
+    allow(controller).to receive(:current_distributor).and_return(distributor)
+    allow(controller).to receive(:current_order_cycle).and_return(order_cycle)
+    allow(controller).to receive(:current_order).and_return order
+    allow(order).to receive_message_chain(:line_items, :empty?).and_return true
+    allow(order).to receive(:insufficient_stock_lines).and_return []
     session[:access_token] = order.token
     spree_get :edit
-    response.should redirect_to shop_path
+    expect(response).to redirect_to shop_path
   end
 
   it "redirects to the shop when no order cycle is selected" do
-    controller.stub(:current_distributor).and_return(distributor)
+    allow(controller).to receive(:current_distributor).and_return(distributor)
     spree_get :edit
-    response.should redirect_to shop_path
+    expect(response).to redirect_to shop_path
   end
 
   it "redirects home with message if hub is not ready for checkout" do
-    VariantOverride.stub(:indexed).and_return({})
+    allow(VariantOverride).to receive(:indexed).and_return({})
 
     order = subject.current_order(true)
-    distributor.stub(:ready_for_checkout?) { false }
-    order.stub(distributor: distributor, order_cycle: order_cycle)
+    allow(distributor).to receive(:ready_for_checkout?) { false }
+    allow(order).to receive_messages(distributor: distributor, order_cycle: order_cycle)
 
-    order.should_receive(:empty!)
-    order.should_receive(:set_distribution!).with(nil, nil)
+    expect(order).to receive(:empty!)
+    expect(order).to receive(:set_distribution!).with(nil, nil)
 
     spree_get :edit
 
-    response.should redirect_to root_url
-    flash[:info].should == "The hub you have selected is temporarily closed for orders. Please try again later."
+    expect(response).to redirect_to root_url
+    expect(flash[:info]).to eq("The hub you have selected is temporarily closed for orders. Please try again later.")
   end
 
   describe "when an item has insufficient stock" do
@@ -59,7 +59,7 @@ describe Spree::OrdersController, type: :controller do
     it "displays a flash message when we view the cart" do
       spree_get :edit
       expect(response.status).to eq 200
-      flash[:error].should == "An item in your cart has become unavailable."
+      expect(flash[:error]).to eq("An item in your cart has become unavailable.")
     end
   end
 
@@ -67,16 +67,16 @@ describe Spree::OrdersController, type: :controller do
     let(:product) { create(:simple_product) }
 
     it "returns stock levels as JSON" do
-      controller.stub(:variant_ids_in) { [123] }
-      controller.stub(:stock_levels) { 'my_stock_levels' }
-      Spree::OrderPopulator.stub(:new).and_return(populator = double())
-      populator.stub(:populate) { true }
-      populator.stub(:variants_h) { {} }
+      allow(controller).to receive(:variant_ids_in) { [123] }
+      allow(controller).to receive(:stock_levels) { 'my_stock_levels' }
+      allow(Spree::OrderPopulator).to receive(:new).and_return(populator = double())
+      allow(populator).to receive(:populate) { true }
+      allow(populator).to receive(:variants_h) { {} }
 
       xhr :post, :populate, use_route: :spree, format: :json
 
       data = JSON.parse(response.body)
-      data['stock_levels'].should == 'my_stock_levels'
+      expect(data['stock_levels']).to eq('my_stock_levels')
     end
 
     describe "generating stock levels" do
@@ -87,31 +87,35 @@ describe Spree::OrdersController, type: :controller do
 
       before do
         order.reload
-        controller.stub(:current_order) { order }
+        allow(controller).to receive(:current_order) { order }
       end
 
       it "returns a hash with variant id, quantity, max_quantity and stock on hand" do
-        controller.stock_levels(order, [v.id]).should ==
+        expect(controller.stock_levels(order, [v.id])).to eq(
           {v.id => {quantity: 2, max_quantity: 3, on_hand: 4}}
+        )
       end
 
       it "includes all line items, even when the variant_id is not specified" do
-        controller.stock_levels(order, []).should ==
+        expect(controller.stock_levels(order, [])).to eq(
           {v.id => {quantity: 2, max_quantity: 3, on_hand: 4}}
+        )
       end
 
       it "includes an empty quantity entry for variants that aren't in the order" do
-        controller.stock_levels(order, [v.id, v2.id]).should ==
+        expect(controller.stock_levels(order, [v.id, v2.id])).to eq(
           {v.id  => {quantity: 2, max_quantity: 3, on_hand: 4},
            v2.id => {quantity: 0, max_quantity: 0, on_hand: 2}}
+        )
       end
 
       describe "encoding Infinity" do
         let!(:v) { create(:variant, on_demand: true, count_on_hand: 0) }
 
         it "encodes Infinity as a large, finite integer" do
-          controller.stock_levels(order, [v.id]).should ==
+          expect(controller.stock_levels(order, [v.id])).to eq(
             {v.id => {quantity: 2, max_quantity: 3, on_hand: 2147483647}}
+          )
         end
       end
     end
@@ -120,7 +124,7 @@ describe Spree::OrdersController, type: :controller do
       variants_h = [{:variant_id=>"900", :quantity=>2, :max_quantity=>nil},
        {:variant_id=>"940", :quantity=>3, :max_quantity=>3}]
 
-      controller.variant_ids_in(variants_h).should == [900, 940]
+      expect(controller.variant_ids_in(variants_h)).to eq([900, 940])
     end
   end
 
@@ -130,9 +134,9 @@ describe Spree::OrdersController, type: :controller do
       p = create(:product, :distributors => [distributor_product], :group_buy => true)
 
       order = subject.current_order(true)
-      order.stub(:distributor) { distributor_product }
-      order.should_receive(:set_variant_attributes).with(p.master, {'max_quantity' => '3'})
-      controller.stub(:current_order).and_return(order)
+      allow(order).to receive(:distributor) { distributor_product }
+      expect(order).to receive(:set_variant_attributes).with(p.master, {'max_quantity' => '3'})
+      allow(controller).to receive(:current_order).and_return(order)
 
       expect do
         spree_post :populate, :variants => {p.master.id => 1}, :variant_attributes => {p.master.id => {:max_quantity => 3}}
@@ -140,23 +144,23 @@ describe Spree::OrdersController, type: :controller do
     end
 
     it "returns HTTP success when successful" do
-      Spree::OrderPopulator.stub(:new).and_return(populator = double())
-      populator.stub(:populate) { true }
-      populator.stub(:variants_h) { {} }
+      allow(Spree::OrderPopulator).to receive(:new).and_return(populator = double())
+      allow(populator).to receive(:populate) { true }
+      allow(populator).to receive(:variants_h) { {} }
       xhr :post, :populate, use_route: :spree, format: :json
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "returns failure when unsuccessful" do
-      Spree::OrderPopulator.stub(:new).and_return(populator = double())
-      populator.stub(:populate).and_return false
+      allow(Spree::OrderPopulator).to receive(:new).and_return(populator = double())
+      allow(populator).to receive(:populate).and_return false
       xhr :post, :populate, use_route: :spree, format: :json
-      response.status.should == 412
+      expect(response.status).to eq(412)
     end
 
     it "tells populator to overwrite" do
-      Spree::OrderPopulator.stub(:new).and_return(populator = double())
-      populator.should_receive(:populate).with({}, true)
+      allow(Spree::OrderPopulator).to receive(:new).and_return(populator = double())
+      expect(populator).to receive(:populate).with({}, true)
       xhr :post, :populate, use_route: :spree, format: :json
     end
   end
@@ -170,8 +174,8 @@ describe Spree::OrdersController, type: :controller do
           "0" => {quantity: "0", id: "9999"},
           "1" => {quantity: "99", id: li.id}
         }}
-        response.status.should == 302
-        li.reload.quantity.should == 99
+        expect(response.status).to eq(302)
+        expect(li.reload.quantity).to eq(99)
       end
     end
 
@@ -184,9 +188,9 @@ describe Spree::OrdersController, type: :controller do
         "1" => {quantity: "99", id: li.id}
       }
 
-      controller.remove_missing_line_items(attrs).should == {
+      expect(controller.remove_missing_line_items(attrs)).to eq({
         "1" => {quantity: "99", id: li.id}
-      }
+      })
     end
   end
 
@@ -257,7 +261,7 @@ describe Spree::OrdersController, type: :controller do
       it "updates the fees" do
         expect(order.reload.adjustment_total).to eq enterprise_fee.calculator.preferred_amount
 
-        controller.stub spree_current_user: user
+        allow(controller).to receive_messages spree_current_user: user
         spree_post :update, params
 
         expect(order.reload.adjustment_total).to eq enterprise_fee.calculator.preferred_amount * 2

--- a/spec/controllers/spree/store_controller_spec.rb
+++ b/spec/controllers/spree/store_controller_spec.rb
@@ -9,6 +9,6 @@ describe Spree::StoreController, type: :controller do
   end
   it "redirects to home when unauthorized" do
     get :index
-    response.should render_template("shared/unauthorized", layout: 'darkswarm')
+    expect(response).to render_template("shared/unauthorized", layout: 'darkswarm')
   end
 end

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -14,7 +14,7 @@ describe Spree::UserSessionsController, type: :controller do
       context "when referer is not '/checkout'" do
         it "redirects to root" do
           spree_post :create, spree_user: {email: user.email, password: user.password }, :use_route => :spree
-          response.should redirect_to root_path
+          expect(response).to redirect_to root_path
         end
       end
 
@@ -23,7 +23,7 @@ describe Spree::UserSessionsController, type: :controller do
 
         it "redirects to checkout" do
           spree_post :create, spree_user: { email: user.email, password: user.password }, :use_route => :spree
-          response.should redirect_to checkout_path
+          expect(response).to redirect_to checkout_path
         end
       end
     end

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -11,13 +11,13 @@ describe UserPasswordsController, type: :controller do
   describe "create" do
     it "returns errors" do
       spree_post :create, spree_user: {}
-      response.should be_success
-      response.should render_template "spree/user_passwords/new"
+      expect(response).to be_success
+      expect(response).to render_template "spree/user_passwords/new"
     end
 
     it "redirects to login when data is valid" do
       spree_post :create, spree_user: { email: user.email}
-      response.should be_redirect
+      expect(response).to be_redirect
     end
   end
 
@@ -47,8 +47,8 @@ describe UserPasswordsController, type: :controller do
     it "returns errors" do
       xhr :post, :create, spree_user: {}, use_route: :spree
       json = JSON.parse(response.body)
-      response.status.should == 401
-      json.should == {"email"=>["can't be blank"]}
+      expect(response.status).to eq(401)
+      expect(json).to eq({"email"=>["can't be blank"]})
     end
   end
 end

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -11,16 +11,16 @@ describe UserRegistrationsController, type: :controller do
     render_views
     it "returns errors when registration fails" do
       xhr :post, :create, spree_user: {}, :use_route => :spree
-      response.status.should == 401
+      expect(response.status).to eq(401)
       json = JSON.parse(response.body)
-      json.should == {"email" => ["can't be blank"], "password" => ["can't be blank"]}
+      expect(json).to eq({"email" => ["can't be blank"], "password" => ["can't be blank"]})
     end
 
     it "returns 200 when registration succeeds" do
       xhr :post, :create, spree_user: {email: "test@test.com", password: "testy123", password_confirmation: "testy123"}, :use_route => :spree
-      response.status.should == 200
+      expect(response.status).to eq(200)
       json = JSON.parse(response.body)
-      json.should == {"email" => "test@test.com"}
+      expect(json).to eq({"email" => "test@test.com"})
       expect(controller.spree_current_user).to be_nil
     end
   end
@@ -28,8 +28,8 @@ describe UserRegistrationsController, type: :controller do
   context "when registration fails" do
     it "renders new" do
       spree_post :create, spree_user: {}
-      response.status.should == 200
-      response.should render_template "spree/user_registrations/new"
+      expect(response.status).to eq(200)
+      expect(response).to render_template "spree/user_registrations/new"
     end
   end
 
@@ -37,8 +37,8 @@ describe UserRegistrationsController, type: :controller do
     context "when referer is not '/checkout'" do
       it "redirects to root" do
         spree_post :create, spree_user: {email: "test@test.com", password: "testy123", password_confirmation: "testy123"}, :use_route => :spree
-        response.should redirect_to root_path
-        assigns[:user].email.should == "test@test.com"
+        expect(response).to redirect_to root_path
+        expect(assigns[:user].email).to eq("test@test.com")
       end
     end
 
@@ -47,8 +47,8 @@ describe UserRegistrationsController, type: :controller do
 
       it "redirects to checkout" do
         spree_post :create, spree_user: {email: "test@test.com", password: "testy123", password_confirmation: "testy123"}, :use_route => :spree
-        response.should redirect_to checkout_path
-        assigns[:user].email.should == "test@test.com"
+        expect(response).to redirect_to checkout_path
+        expect(assigns[:user].email).to eq("test@test.com")
       end
     end
   end

--- a/spec/features/admin/adjustments_spec.rb
+++ b/spec/features/admin/adjustments_spec.rb
@@ -34,9 +34,9 @@ feature %q{
     click_button 'Continue'
 
     # Then I should see the adjustment, with the correct tax
-    page.should have_selector 'td.label', text: 'Late fee'
-    page.should have_selector 'td.amount', text: '110'
-    page.should have_selector 'td.included-tax', text: '10'
+    expect(page).to have_selector 'td.label', text: 'Late fee'
+    expect(page).to have_selector 'td.amount', text: '110'
+    expect(page).to have_selector 'td.included-tax', text: '10'
   end
 
   scenario "modifying taxed adjustments on an order" do
@@ -51,16 +51,16 @@ feature %q{
     page.find('tr', text: 'Shipping').find('a.icon-edit').click
 
     # Then I should see the uneditable included tax and our tax rate as the default
-    page.should have_field :adjustment_included_tax, with: '10.00', disabled: true
-    page.should have_select :tax_rate_id, selected: 'GST'
+    expect(page).to have_field :adjustment_included_tax, with: '10.00', disabled: true
+    expect(page).to have_select :tax_rate_id, selected: 'GST'
 
     # When I edit the adjustment, removing the tax
     select 'Remove tax', from: :tax_rate_id
     click_button 'Continue'
 
     # Then the adjustment tax should be cleared
-    page.should have_selector 'td.amount', text: '110'
-    page.should have_selector 'td.included-tax', text: '0'
+    expect(page).to have_selector 'td.amount', text: '110'
+    expect(page).to have_selector 'td.included-tax', text: '0'
   end
 
   scenario "modifying an untaxed adjustment on an order" do
@@ -75,15 +75,15 @@ feature %q{
     page.find('tr', text: 'Shipping').find('a.icon-edit').click
 
     # Then I should see the uneditable included tax and 'Remove tax' as the default tax rate
-    page.should have_field :adjustment_included_tax, with: '0.00', disabled: true
-    page.should have_select :tax_rate_id, selected: []
+    expect(page).to have_field :adjustment_included_tax, with: '0.00', disabled: true
+    expect(page).to have_select :tax_rate_id, selected: []
 
     # When I edit the adjustment, setting a tax rate
     select 'GST', from: :tax_rate_id
     click_button 'Continue'
 
     # Then the adjustment tax should be recalculated
-    page.should have_selector 'td.amount', text: '110'
-    page.should have_selector 'td.included-tax', text: '10'
+    expect(page).to have_selector 'td.amount', text: '110'
+    expect(page).to have_selector 'td.included-tax', text: '10'
   end
 end

--- a/spec/features/admin/caching_spec.rb
+++ b/spec/features/admin/caching_spec.rb
@@ -14,7 +14,7 @@ feature 'Caching' do
     it "displays results when things are good" do
       # Given matching data
       Rails.cache.write "products-json-#{distributor.id}-#{order_cycle.id}", "[1, 2, 3]\n"
-      OpenFoodNetwork::ProductsRenderer.stub(:new) { double(:pr, products_json: "[1, 2, 3]\n") }
+      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new) { double(:pr, products_json: "[1, 2, 3]\n") }
 
       # When I visit the cache status page
       visit spree.admin_path
@@ -22,13 +22,13 @@ feature 'Caching' do
       click_link 'Caching'
 
       # Then I should see some status information
-      page.should have_content "OK"
+      expect(page).to have_content "OK"
     end
 
     it "displays results when there are errors" do
       # Given matching data
       Rails.cache.write "products-json-#{distributor.id}-#{order_cycle.id}", "[1, 2, 3]\n"
-      OpenFoodNetwork::ProductsRenderer.stub(:new) { double(:pr, products_json: "[1, 3]\n") }
+      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new) { double(:pr, products_json: "[1, 3]\n") }
 
       # When I visit the cache status page
       visit spree.admin_path
@@ -36,7 +36,7 @@ feature 'Caching' do
       click_link 'Caching'
 
       # Then I should see some status information
-      page.should have_content "Error"
+      expect(page).to have_content "Error"
     end
 
   end

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -18,23 +18,23 @@ feature %q{
     fill_in 'footer_twitter_url', with: 'http://twitter.com/me'
     fill_in 'footer_links_md', with: '[markdown link](/)'
     click_button 'Update'
-    page.should have_content 'Your content has been successfully updated!'
+    expect(page).to have_content 'Your content has been successfully updated!'
 
     visit root_path
 
     # Then social media icons are only shown if they have a value
-    page.should_not have_selector 'i.ofn-i_044-facebook'
-    page.should     have_selector 'i.ofn-i_041-twitter'
+    expect(page).not_to have_selector 'i.ofn-i_044-facebook'
+    expect(page).to     have_selector 'i.ofn-i_041-twitter'
 
     # And markdown is rendered
-    page.should have_link 'markdown link'
+    expect(page).to have_link 'markdown link'
   end
 
   scenario "uploading logos" do
     attach_file 'logo', "#{Rails.root}/app/assets/images/logo-white.png"
     click_button 'Update'
-    page.should have_content 'Your content has been successfully updated!'
+    expect(page).to have_content 'Your content has been successfully updated!'
 
-    ContentConfig.logo.to_s.should include "logo-white"
+    expect(ContentConfig.logo.to_s).to include "logo-white"
   end
 end

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -78,7 +78,7 @@ feature 'Customers' do
         select2_select managed_distributor1.name, from: "shop_id"
 
         within "tr#c_#{customer1.id}" do
-          find_field('name').value.should eq 'John Doe'
+          expect(find_field('name').value).to eq 'John Doe'
 
           fill_in "code", with: "new-customer-code"
           expect(page).to have_css "input[name=code].update-pending"

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -17,12 +17,12 @@ feature %q{
     click_link 'Configuration'
     click_link 'Enterprise Fees'
 
-    page.should have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"
-    page.should have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Packing'
-    page.should have_selector "input[value='$0.50 / kg']"
-    page.should have_select "enterprise_fee_set_collection_attributes_0_tax_category_id", selected: 'GST'
-    page.should have_select "enterprise_fee_set_collection_attributes_0_calculator_type", selected: 'Flat Rate (per item)'
-    page.should have_selector "input[value='#{amount}']"
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Packing'
+    expect(page).to have_selector "input[value='$0.50 / kg']"
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_tax_category_id", selected: 'GST'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_calculator_type", selected: 'Flat Rate (per item)'
+    expect(page).to have_selector "input[value='#{amount}']"
   end
 
   scenario "creating an enterprise fee" do
@@ -43,15 +43,15 @@ feature %q{
     click_button 'Update'
 
     # Then I should see my fee and fields for the calculator
-    page.should have_content "Your enterprise fees have been updated."
-    page.should have_selector "input[value='Hello!']"
+    expect(page).to have_content "Your enterprise fees have been updated."
+    expect(page).to have_selector "input[value='Hello!']"
 
     # When I fill in the calculator fields and click update
     fill_in 'enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent', with: '12.34'
     click_button 'Update'
 
     # Then I should see the correct values in my calculator fields
-    page.should have_selector "#enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent[value='12.34']"
+    expect(page).to have_selector "#enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent[value='12.34']"
   end
 
   scenario "editing an enterprise fee" do
@@ -73,21 +73,21 @@ feature %q{
     click_button 'Update'
 
     # Then I should see the updated fields for my fee
-    page.should have_select "enterprise_fee_set_collection_attributes_0_enterprise_id", selected: 'Foo'
-    page.should have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Admin'
-    page.should have_selector "input[value='Greetings!']"
-    page.should have_select 'enterprise_fee_set_collection_attributes_0_tax_category_id', selected: 'Inherit From Product'
-    page.should have_selector "option[selected]", text: 'Flat Percent (per item)'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id", selected: 'Foo'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Admin'
+    expect(page).to have_selector "input[value='Greetings!']"
+    expect(page).to have_select 'enterprise_fee_set_collection_attributes_0_tax_category_id', selected: 'Inherit From Product'
+    expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'
 
     fee.reload
-    fee.enterprise.should == enterprise
-    fee.name.should == 'Greetings!'
-    fee.fee_type.should == 'admin'
-    fee.calculator_type.should == "Calculator::FlatPercentPerItem"
+    expect(fee.enterprise).to eq(enterprise)
+    expect(fee.name).to eq('Greetings!')
+    expect(fee.fee_type).to eq('admin')
+    expect(fee.calculator_type).to eq("Calculator::FlatPercentPerItem")
 
     # Sets tax_category and inherits_tax_category
-    fee.tax_category.should == nil
-    fee.inherits_tax_category.should == true
+    expect(fee.tax_category).to eq(nil)
+    expect(fee.inherits_tax_category).to eq(true)
   end
 
   scenario "deleting an enterprise fee" do
@@ -125,12 +125,12 @@ feature %q{
     find("a.delete-resource").click
 
     # Then I should see an error
-    page.should have_content "That enterprise fee cannot be deleted as it is referenced by a product distribution: #{p.id} - #{p.name}."
+    expect(page).to have_content "That enterprise fee cannot be deleted as it is referenced by a product distribution: #{p.id} - #{p.name}."
 
     # And my enterprise fee should not have been deleted
     visit admin_enterprise_fees_path
-    page.should have_selector "input[value='#{fee.name}']"
-    EnterpriseFee.find(fee.id).should_not be_nil
+    expect(page).to have_selector "input[value='#{fee.name}']"
+    expect(EnterpriseFee.find(fee.id)).not_to be_nil
   end
 
   context "as an enterprise manager" do
@@ -161,13 +161,13 @@ feature %q{
       select 'Flat Percent', :from => 'enterprise_fee_set_collection_attributes_0_calculator_type'
       click_button 'Update'
 
-      flash_message.should == 'Your enterprise fees have been updated.'
+      expect(flash_message).to eq('Your enterprise fees have been updated.')
 
       # After saving, we should be redirected to the fees for our chosen enterprise
-      page.should_not have_select 'enterprise_fee_set_collection_attributes_1_enterprise_id', selected: 'Second Distributor'
+      expect(page).not_to have_select 'enterprise_fee_set_collection_attributes_1_enterprise_id', selected: 'Second Distributor'
 
       enterprise_fee = EnterpriseFee.find_by_name 'foo'
-      enterprise_fee.enterprise.should == distributor1
+      expect(enterprise_fee.enterprise).to eq(distributor1)
     end
 
     pending "shows me only enterprise fees for the enterprise I select" do
@@ -178,15 +178,15 @@ feature %q{
       within("#e_#{distributor1.id}") { click_link 'Manage' }
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      page.should     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
-      page.should_not have_field 'enterprise_fee_set_collection_attributes_1_name', with: 'Two'
+      expect(page).to     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
+      expect(page).not_to have_field 'enterprise_fee_set_collection_attributes_1_name', with: 'Two'
 
       click_link 'Enterprises'
       within("#e_#{distributor2.id}") { click_link 'Manage' }
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      page.should_not have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
-      page.should     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'Two'
+      expect(page).not_to have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
+      expect(page).to     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'Two'
     end
 
     it "only allows me to select enterprises I have access to" do
@@ -198,7 +198,7 @@ feature %q{
       within("#e_#{distributor2.id}") { click_link 'Manage' }
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      page.should have_select('enterprise_fee_set_collection_attributes_1_enterprise_id',
+      expect(page).to have_select('enterprise_fee_set_collection_attributes_1_enterprise_id',
                               selected: 'Second Distributor',
                               options: ['', 'First Distributor', 'Second Distributor'])
     end

--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -17,9 +17,9 @@ feature %q{
 
     click_link 'Groups'
 
-    page.should have_selector 'td', text: group.name
-    page.should have_selector 'td', text: 'Y'
-    page.should have_selector 'td', text: e.name
+    expect(page).to have_selector 'td', text: group.name
+    expect(page).to have_selector 'td', text: 'Y'
+    expect(page).to have_selector 'td', text: e.name
   end
 
   scenario "creating a new enterprise group", js: true do
@@ -44,13 +44,13 @@ feature %q{
     select2_search 'Victoria', :from => 'State'
     click_button 'Create'
 
-    page.should have_content 'Enterprise group "EGEGEG" has been successfully created!'
+    expect(page).to have_content 'Enterprise group "EGEGEG" has been successfully created!'
 
     eg = EnterpriseGroup.last
-    eg.name.should == 'EGEGEG'
-    eg.description.should == 'This is a description'
-    eg.on_front_page.should be true
-    eg.enterprises.should match_array [e1, e2]
+    expect(eg.name).to eq('EGEGEG')
+    expect(eg.description).to eq('This is a description')
+    expect(eg.on_front_page).to be true
+    expect(eg.enterprises).to match_array [e1, e2]
   end
 
   scenario "editing an enterprise group" do
@@ -61,9 +61,9 @@ feature %q{
     click_link 'Groups'
     first("a.edit-enterprise-group").click
 
-    page.should have_field 'enterprise_group_name', with: 'EGEGEG'
-    page.should have_checked_field 'enterprise_group_on_front_page'
-    page.should have_select 'enterprise_group_enterprise_ids', selected: [e1.name, e2.name]
+    expect(page).to have_field 'enterprise_group_name', with: 'EGEGEG'
+    expect(page).to have_checked_field 'enterprise_group_on_front_page'
+    expect(page).to have_select 'enterprise_group_enterprise_ids', selected: [e1.name, e2.name]
 
     fill_in 'enterprise_group_name', with: 'xyzzy'
     uncheck 'enterprise_group_on_front_page'
@@ -72,12 +72,12 @@ feature %q{
     select e2.name, from: 'enterprise_group_enterprise_ids'
     click_button 'Update'
 
-    page.should have_content 'Enterprise group "xyzzy" has been successfully updated!'
+    expect(page).to have_content 'Enterprise group "xyzzy" has been successfully updated!'
 
     eg = EnterpriseGroup.last
-    eg.name.should == 'xyzzy'
-    eg.on_front_page.should be false
-    eg.enterprises.should == [e2]
+    expect(eg.name).to eq('xyzzy')
+    expect(eg.on_front_page).to be false
+    expect(eg.enterprises).to eq([e2])
   end
 
   scenario "re-ordering enterprise groups" do
@@ -86,11 +86,11 @@ feature %q{
 
     click_link 'Groups'
 
-    page.all('td.name').map(&:text).should == ['A', 'B']
+    expect(page.all('td.name').map(&:text)).to eq(['A', 'B'])
     all("a.move-down").first.click
-    page.all('td.name').map(&:text).should == ['B', 'A']
+    expect(page.all('td.name').map(&:text)).to eq(['B', 'A'])
     all("a.move-up").last.click
-    page.all('td.name').map(&:text).should == ['A', 'B']
+    expect(page.all('td.name').map(&:text)).to eq(['A', 'B'])
   end
 
   scenario "deleting an enterprise group", js: true do
@@ -99,9 +99,9 @@ feature %q{
     click_link 'Groups'
     first("a.delete-resource").click
 
-    page.should have_no_content 'EGEGEG'
+    expect(page).to have_no_content 'EGEGEG'
 
-    EnterpriseGroup.all.should_not include eg
+    expect(EnterpriseGroup.all).not_to include eg
   end
 
   context "as an enterprise user" do

--- a/spec/features/admin/enterprise_relationships_spec.rb
+++ b/spec/features/admin/enterprise_relationships_spec.rb
@@ -24,9 +24,9 @@ feature %q{
 
       # Then I should see the relationships
       within('table#enterprise-relationships') do
-        page.should have_relationship e1, e2, ['to add to order cycle']
-        page.should have_relationship e2, e3, ['to manage products']
-        page.should have_relationship e3, e4,
+        expect(page).to have_relationship e1, e2, ['to add to order cycle']
+        expect(page).to have_relationship e2, e3, ['to manage products']
+        expect(page).to have_relationship e3, e4,
           ['to add to order cycle', 'to manage products']
       end
     end
@@ -47,10 +47,10 @@ feature %q{
       select2_select 'Two', from: 'enterprise_relationship_child_id'
       click_button 'Create'
 
-      page.should have_relationship e1, e2, ['to add to order cycle', 'to add products to inventory', 'to edit profile']
+      expect(page).to have_relationship e1, e2, ['to add to order cycle', 'to add products to inventory', 'to edit profile']
       er = EnterpriseRelationship.where(parent_id: e1, child_id: e2).first
-      er.should be_present
-      er.permissions.map(&:name).should match_array ['add_to_order_cycle', 'edit_profile', 'create_variant_overrides']
+      expect(er).to be_present
+      expect(er.permissions.map(&:name)).to match_array ['add_to_order_cycle', 'edit_profile', 'create_variant_overrides']
     end
 
 
@@ -67,7 +67,7 @@ feature %q{
         click_button 'Create'
 
         # Then I should see an error message
-        page.should have_content "That relationship is already established."
+        expect(page).to have_content "That relationship is already established."
       end.to change(EnterpriseRelationship, :count).by(0)
     end
 
@@ -77,12 +77,12 @@ feature %q{
       er = create(:enterprise_relationship, parent: e1, child: e2, permissions_list: [:add_to_order_cycle])
 
       visit admin_enterprise_relationships_path
-      page.should have_relationship e1, e2, ['to add to order cycle']
+      expect(page).to have_relationship e1, e2, ['to add to order cycle']
 
       first("a.delete-enterprise-relationship").click
 
-      page.should_not have_relationship e1, e2
-      EnterpriseRelationship.where(id: er.id).should be_empty
+      expect(page).not_to have_relationship e1, e2
+      expect(EnterpriseRelationship.where(id: er.id)).to be_empty
     end
   end
 
@@ -102,16 +102,16 @@ feature %q{
     scenario "enterprise user can only see relationships involving their enterprises" do
       visit admin_enterprise_relationships_path
 
-      page.should     have_relationship d1, d2
-      page.should     have_relationship d2, d1
-      page.should_not have_relationship d2, d3
+      expect(page).to     have_relationship d1, d2
+      expect(page).to     have_relationship d2, d1
+      expect(page).not_to have_relationship d2, d3
     end
 
 
     scenario "enterprise user can only add their own enterprises as parent" do
       visit admin_enterprise_relationships_path
-      page.should have_select2 'enterprise_relationship_parent_id', options: ['', d1.name]
-      page.should have_select2 'enterprise_relationship_child_id', options: ['', d1.name, d2.name, d3.name]
+      expect(page).to have_select2 'enterprise_relationship_parent_id', options: ['', d1.name]
+      expect(page).to have_select2 'enterprise_relationship_child_id', options: ['', d1.name, d2.name, d3.name]
     end
   end
 

--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -26,10 +26,10 @@ feature %q{
 
       # Then I should see the relationships
       within('table#enterprise-roles') do
-        page.should have_relationship u1, e1
-        page.should have_relationship u1, e2
-        page.should have_relationship u2, e3
-        page.should have_relationship u2, e4
+        expect(page).to have_relationship u1, e1
+        expect(page).to have_relationship u1, e2
+        expect(page).to have_relationship u2, e3
+        expect(page).to have_relationship u2, e4
       end
     end
 
@@ -42,8 +42,8 @@ feature %q{
       select 'One', from: 'enterprise_role_enterprise_id'
       click_button 'Create'
 
-      page.should have_relationship u, e
-      EnterpriseRole.where(user_id: u, enterprise_id: e).should be_present
+      expect(page).to have_relationship u, e
+      expect(EnterpriseRole.where(user_id: u, enterprise_id: e)).to be_present
     end
 
     scenario "attempting to create a relationship with invalid data" do
@@ -59,7 +59,7 @@ feature %q{
         click_button 'Create'
 
         # Then I should see an error message
-        page.should have_content "That role is already present."
+        expect(page).to have_content "That role is already present."
       end.to change(EnterpriseRole, :count).by(0)
     end
 
@@ -69,14 +69,14 @@ feature %q{
       er = create(:enterprise_role, user: u, enterprise: e)
 
       visit admin_enterprise_roles_path
-      page.should have_relationship u, e
+      expect(page).to have_relationship u, e
 
       within("#enterprise_role_#{er.id}") do
         find("a.delete-enterprise-role").click
       end
 
-      page.should_not have_relationship u, e
-      EnterpriseRole.where(id: er.id).should be_empty
+      expect(page).not_to have_relationship u, e
+      expect(EnterpriseRole.where(id: er.id)).to be_empty
     end
 
     describe "using the enterprise managers interface" do

--- a/spec/features/admin/enterprise_user_spec.rb
+++ b/spec/features/admin/enterprise_user_spec.rb
@@ -46,8 +46,8 @@ feature %q{
         visit spree.admin_products_path
 
         within '#listing_products' do
-          page.should have_content 'Green eggs'
-          page.should_not have_content 'Ham'
+          expect(page).to have_content 'Green eggs'
+          expect(page).not_to have_content 'Ham'
         end
       end
     end
@@ -75,28 +75,28 @@ feature %q{
     describe "dashboard" do
       it "shows me enterprise management controls" do
         within('#enterprises') do
-          page.should have_selector 'h3', text: 'My Enterprises'
-          page.should have_link 'CREATE NEW'
-          page.should have_link supplier_profile.name
-          page.should have_link 'MANAGE MY ENTERPRISES'
+          expect(page).to have_selector 'h3', text: 'My Enterprises'
+          expect(page).to have_link 'CREATE NEW'
+          expect(page).to have_link supplier_profile.name
+          expect(page).to have_link 'MANAGE MY ENTERPRISES'
         end
       end
 
       it "shows me product management controls, but not order_cycle controls" do
-        page.should have_selector '#products'
-        page.should_not have_selector '#order_cycles'
+        expect(page).to have_selector '#products'
+        expect(page).not_to have_selector '#order_cycles'
       end
 
       it "shows me enterprise product info but not payment methods, shipping methods or enterprise fees" do
         # Producer product info
-        page.should have_selector '.producers_tab span', text: 'Total Products'
-        page.should have_selector '.producers_tab span', text: 'Active Products'
-        page.should_not have_selector '.producers_tab span', text: 'Products in OCs'
+        expect(page).to have_selector '.producers_tab span', text: 'Total Products'
+        expect(page).to have_selector '.producers_tab span', text: 'Active Products'
+        expect(page).not_to have_selector '.producers_tab span', text: 'Products in OCs'
 
         # Payment methods, shipping methods, enterprise fees
-        page.should_not have_selector '.hubs_tab span', text: 'Payment Methods'
-        page.should_not have_selector '.hubs_tab span', text: 'Shipping Methods'
-        page.should_not have_selector '.hubs_tab span', text: 'Enterprise Fees'
+        expect(page).not_to have_selector '.hubs_tab span', text: 'Payment Methods'
+        expect(page).not_to have_selector '.hubs_tab span', text: 'Shipping Methods'
+        expect(page).not_to have_selector '.hubs_tab span', text: 'Enterprise Fees'
       end
     end
 
@@ -131,12 +131,12 @@ feature %q{
 
     scenario "should not be able to see system configuration" do
       visit spree.edit_admin_general_settings_path
-      page.should have_content 'Unauthorized'
+      expect(page).to have_content 'Unauthorized'
     end
 
     scenario "should not be able to see user management" do
       visit spree.admin_users_path
-      page.should have_content 'Unauthorized'
+      expect(page).to have_content 'Unauthorized'
     end
   end
 end

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -57,7 +57,7 @@ feature 'Enterprises Index' do
             select d_manager.email, from: 'enterprise_set_collection_attributes_0_owner_id'
           end
           click_button "Update"
-          flash_message.should == 'Enterprises updated successfully'
+          expect(flash_message).to eq('Enterprises updated successfully')
           distributor = Enterprise.find(d.id)
           expect(distributor.visible).to eq false
           expect(distributor.sells).to eq 'any'
@@ -84,7 +84,7 @@ feature 'Enterprises Index' do
             select d_manager.email, from: 'enterprise_set_collection_attributes_1_owner_id'
           end
           click_button "Update"
-          flash_message.should == 'Update failed'
+          expect(flash_message).to eq('Update failed')
           expect(page).to have_content "#{d_manager.email} is not permitted to own any more enterprises (limit is 1)."
           second_distributor.reload
           expect(second_distributor.owner).to_not eq d_manager

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -14,7 +14,7 @@ feature %q{
     click_link 'Enterprises'
     click_link e.name
 
-    page.should have_content e.name
+    expect(page).to have_content e.name
   end
 
   scenario "creating a new enterprise", js: true do
@@ -33,8 +33,8 @@ feature %q{
     choose "Any"
     uncheck 'enterprise_is_primary_producer'
 
-    page.should_not have_checked_field "enterprise_payment_method_ids_#{payment_method.id}"
-    page.should_not have_checked_field "enterprise_shipping_method_ids_#{shipping_method.id}"
+    expect(page).not_to have_checked_field "enterprise_payment_method_ids_#{payment_method.id}"
+    expect(page).not_to have_checked_field "enterprise_shipping_method_ids_#{shipping_method.id}"
 
     # Filling in details
     fill_in 'enterprise_name', :with => 'Eaterprises'
@@ -57,7 +57,7 @@ feature %q{
     select2_search 'Victoria', :from => 'State'
 
     click_button 'Create'
-    flash_message.should == 'Enterprise "Eaterprises" has been successfully created!'
+    expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully created!')
   end
 
   scenario "editing an existing enterprise", js: true do
@@ -82,7 +82,7 @@ feature %q{
 
     fill_in 'enterprise_name', :with => 'Eaterprises'
     fill_in 'enterprise_permalink', with: 'eaterprises-permalink'
-    page.should have_selector '.available'
+    expect(page).to have_selector '.available'
     choose 'Own'
 
     # Require login to view shopfront or for checkout
@@ -112,31 +112,31 @@ feature %q{
     click_link "Primary Details"
     uncheck 'enterprise_is_primary_producer'
     choose 'None'
-    page.should_not have_selector "#enterprise_fees"
-    page.should_not have_selector "#payment_methods"
-    page.should_not have_selector "#shipping_methods"
+    expect(page).not_to have_selector "#enterprise_fees"
+    expect(page).not_to have_selector "#payment_methods"
+    expect(page).not_to have_selector "#shipping_methods"
     check 'enterprise_is_primary_producer'
-    page.should have_selector "#enterprise_fees"
-    page.should_not have_selector "#payment_methods"
-    page.should_not have_selector "#shipping_methods"
+    expect(page).to have_selector "#enterprise_fees"
+    expect(page).not_to have_selector "#payment_methods"
+    expect(page).not_to have_selector "#shipping_methods"
     uncheck 'enterprise_is_primary_producer'
     choose 'Own'
-    page.should have_selector "#enterprise_fees"
-    page.should have_selector "#payment_methods"
-    page.should have_selector "#shipping_methods"
+    expect(page).to have_selector "#enterprise_fees"
+    expect(page).to have_selector "#payment_methods"
+    expect(page).to have_selector "#shipping_methods"
     choose 'Any'
-    page.should have_selector "#enterprise_fees"
-    page.should have_selector "#payment_methods"
-    page.should have_selector "#shipping_methods"
+    expect(page).to have_selector "#enterprise_fees"
+    expect(page).to have_selector "#payment_methods"
+    expect(page).to have_selector "#shipping_methods"
 
     select2_search eg1.name, from: 'Groups'
 
     click_link "Payment Methods"
-    page.should_not have_checked_field "enterprise_payment_method_ids_#{payment_method.id}"
+    expect(page).not_to have_checked_field "enterprise_payment_method_ids_#{payment_method.id}"
     check "enterprise_payment_method_ids_#{payment_method.id}"
 
     click_link "Shipping Methods"
-    page.should_not have_checked_field "enterprise_shipping_method_ids_#{shipping_method.id}"
+    expect(page).not_to have_checked_field "enterprise_shipping_method_ids_#{shipping_method.id}"
     check "enterprise_shipping_method_ids_#{shipping_method.id}"
 
     click_link "Contact"
@@ -165,35 +165,35 @@ feature %q{
     # shopfront_message = find :css, "text-angular#enterprise_preferred_shopfront_message div.ta-scroll-window div.ta-bind"
     # shopfront_message.set 'This is my shopfront message.'
     page.first("input[name='enterprise\[preferred_shopfront_message\]']", visible: false).set('This is my shopfront message.')
-    page.should have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_close_at"
+    expect(page).to have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_close_at"
     choose "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
 
     click_button 'Update'
 
-    flash_message.should == 'Enterprise "Eaterprises" has been successfully updated!'
-    page.should have_field 'enterprise_name', :with => 'Eaterprises'
+    expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully updated!')
+    expect(page).to have_field 'enterprise_name', :with => 'Eaterprises'
     @enterprise.reload
     expect(@enterprise.owner).to eq user
     expect(page).to have_checked_field "enterprise_visible_true"
 
     click_link "Business Details"
-    page.should have_checked_field "enterprise_charges_sales_tax_true"
+    expect(page).to have_checked_field "enterprise_charges_sales_tax_true"
 
     click_link "Payment Methods"
-    page.should have_checked_field "enterprise_payment_method_ids_#{payment_method.id}"
+    expect(page).to have_checked_field "enterprise_payment_method_ids_#{payment_method.id}"
 
     click_link "Shipping Methods"
-    page.should have_checked_field "enterprise_shipping_method_ids_#{shipping_method.id}"
+    expect(page).to have_checked_field "enterprise_shipping_method_ids_#{shipping_method.id}"
 
     click_link "Enterprise Fees"
-    page.should have_selector "td", text: enterprise_fee.name
+    expect(page).to have_selector "td", text: enterprise_fee.name
 
     click_link "About"
-    page.should have_content 'This is an interesting long description'
+    expect(page).to have_content 'This is an interesting long description'
 
     click_link "Shop Preferences"
-    page.should have_content 'This is my shopfront message.'
-    page.should have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
+    expect(page).to have_content 'This is my shopfront message.'
+    expect(page).to have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
     expect(page).to have_checked_field "enterprise_require_login_true"
   end
 
@@ -216,9 +216,9 @@ feature %q{
       expect(current_path).to eq main_app.admin_enterprise_producer_properties_path(s)
 
       # And the producer should have the property
-      s.producer_properties(true).count.should == 1
-      s.producer_properties.first.property.presentation.should == "Certified Organic"
-      s.producer_properties.first.value.should == "NASAA 12345"
+      expect(s.producer_properties(true).count).to eq(1)
+      expect(s.producer_properties.first.property.presentation).to eq("Certified Organic")
+      expect(s.producer_properties.first.value).to eq("NASAA 12345")
     end
 
     it "updates producer properties" do
@@ -239,9 +239,9 @@ feature %q{
       expect(current_path).to eq main_app.admin_enterprise_producer_properties_path(s)
 
       # And the property should be updated
-      s.producer_properties(true).count.should == 1
-      s.producer_properties.first.property.presentation.should == "Biodynamic"
-      s.producer_properties.first.value.should == "Shininess"
+      expect(s.producer_properties(true).count).to eq(1)
+      expect(s.producer_properties.first.property.presentation).to eq("Biodynamic")
+      expect(s.producer_properties.first.value).to eq("Shininess")
     end
 
     it "removes producer properties", js: true do
@@ -254,14 +254,14 @@ feature %q{
       visit main_app.admin_enterprise_producer_properties_path(s)
 
       # And I remove the property
-      page.should have_field 'enterprise_producer_properties_attributes_0_property_name', with: 'Certified Organic'
+      expect(page).to have_field 'enterprise_producer_properties_attributes_0_property_name', with: 'Certified Organic'
       within("#spree_producer_property_#{pp.id}") { page.find('a.remove_fields').click }
       click_button 'Update'
 
       # Then the property should have been removed
       expect(current_path).to eq main_app.admin_enterprise_producer_properties_path(s)
-      page.should_not have_field 'enterprise_producer_properties_attributes_0_property_name', with: 'Certified Organic'
-      s.producer_properties(true).should be_empty
+      expect(page).not_to have_field 'enterprise_producer_properties_attributes_0_property_name', with: 'Certified Organic'
+      expect(s.producer_properties(true)).to be_empty
     end
   end
 
@@ -318,8 +318,8 @@ feature %q{
 
         click_link "Enterprises"
 
-        page.should have_content supplier1.name
-        page.should have_content distributor1.name
+        expect(page).to have_content supplier1.name
+        expect(page).to have_content distributor1.name
 
         within 'li#new_product_link' do
           expect(page).to have_link 'New Enterprise', href: '#'
@@ -346,12 +346,12 @@ feature %q{
         click_button 'Create'
 
         # Then it should be created
-        page.should have_content 'Enterprise "zzz" has been successfully created!'
+        expect(page).to have_content 'Enterprise "zzz" has been successfully created!'
         enterprise = Enterprise.last
-        enterprise.name.should == 'zzz'
+        expect(enterprise.name).to eq('zzz')
 
         # And I should be managing it
-        Enterprise.managed_by(enterprise_user).should include enterprise
+        expect(Enterprise.managed_by(enterprise_user)).to include enterprise
         expect(enterprise.contact).to eq enterprise.owner
       end
 
@@ -381,8 +381,8 @@ feature %q{
       page.evaluate_script("angular.element(enterprise_form).scope().setFormDirty()")
       click_button 'Update'
 
-      flash_message.should == 'Enterprise "Eaterprises" has been successfully updated!'
-      distributor1.reload.name.should == 'Eaterprises'
+      expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully updated!')
+      expect(distributor1.reload.name).to eq('Eaterprises')
     end
 
     describe "enterprises I have edit permission for, but do not manage" do
@@ -397,8 +397,8 @@ feature %q{
         page.evaluate_script("angular.element(enterprise_form).scope().setFormDirty()")
         click_button 'Update'
 
-        flash_message.should == 'Enterprise "Eaterprises" has been successfully updated!'
-        distributor3.reload.name.should == 'Eaterprises'
+        expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully updated!')
+        expect(distributor3.reload.name).to eq('Eaterprises')
       end
 
       it "does not show links to manage shipping methods, payment methods or enterprise fees on the edit page" do
@@ -406,9 +406,9 @@ feature %q{
         within("tbody#e_#{distributor3.id}") { click_link 'Manage' }
 
         within(".side_menu") do
-          page.should_not have_link 'Shipping Methods'
-          page.should_not have_link 'Payment Methods'
-          page.should_not have_link 'Enterprise Fees'
+          expect(page).not_to have_link 'Shipping Methods'
+          expect(page).not_to have_link 'Payment Methods'
+          expect(page).not_to have_link 'Enterprise Fees'
         end
       end
     end
@@ -421,8 +421,8 @@ feature %q{
         click_link "Images"
       end
 
-      page.should have_content "LOGO"
-      page.should have_content "PROMO"
+      expect(page).to have_content "LOGO"
+      expect(page).to have_content "PROMO"
     end
 
     scenario "managing producer properties" do
@@ -443,7 +443,7 @@ feature %q{
       page.evaluate_script("angular.element(enterprise_form).scope().setFormDirty()")
       click_button 'Update'
 
-      supplier1.producer_properties(true).count.should == 1
+      expect(supplier1.producer_properties(true).count).to eq(1)
 
       # -- Destroy
       pp = supplier1.producer_properties.first
@@ -456,7 +456,7 @@ feature %q{
       click_button 'Update'
 
       expect(page).to have_content 'Enterprise "First Supplier" has been successfully updated!'
-      supplier1.producer_properties(true).should be_empty
+      expect(supplier1.producer_properties(true)).to be_empty
     end
   end
 end

--- a/spec/features/admin/external_services_spec.rb
+++ b/spec/features/admin/external_services_spec.rb
@@ -15,7 +15,7 @@ feature 'External services' do
       fill_in 'bugherd_api_key', with: 'abc123'
       click_button 'Update'
 
-      page.should have_content 'General Settings has been successfully updated!'
+      expect(page).to have_content 'General Settings has been successfully updated!'
       expect(Spree::Config.bugherd_api_key).to eq 'abc123'
     end
   end

--- a/spec/features/admin/image_settings_spec.rb
+++ b/spec/features/admin/image_settings_spec.rb
@@ -24,20 +24,20 @@ feature %q{
     visit spree.edit_admin_image_settings_path
 
     # All the styles should default to "Unchanged"
-    page.should have_select 'attachment_styles_format_mini',    selected: 'Unchanged'
-    page.should have_select 'attachment_styles_format_small',   selected: 'Unchanged'
-    page.should have_select 'attachment_styles_format_product', selected: 'Unchanged'
-    page.should have_select 'attachment_styles_format_large',   selected: 'Unchanged'
+    expect(page).to have_select 'attachment_styles_format_mini',    selected: 'Unchanged'
+    expect(page).to have_select 'attachment_styles_format_small',   selected: 'Unchanged'
+    expect(page).to have_select 'attachment_styles_format_product', selected: 'Unchanged'
+    expect(page).to have_select 'attachment_styles_format_large',   selected: 'Unchanged'
 
     # When I change a style to "PNG" and save
     select 'PNG', from: 'attachment_styles_format_mini'
     click_button 'Update'
 
     # Then the change should be saved to the image formats
-    page.should have_content "Image Settings successfully updated."
-    page.should have_select 'attachment_styles_format_mini', selected: 'PNG'
+    expect(page).to have_content "Image Settings successfully updated."
+    expect(page).to have_select 'attachment_styles_format_mini', selected: 'PNG'
 
     styles = Spree::Image.attachment_definitions[:attachment][:styles]
-    styles[:mini].should == ['48x48>', :png]
+    expect(styles[:mini]).to eq(['48x48>', :png])
   end
 end

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -31,17 +31,18 @@ feature %q{
 
     # Then the order cycles should be ordered correctly
     expect(page).to have_selector "#listing_order_cycles tr td:first-child", count: 7
-    page.all('#listing_order_cycles tr td:first-child').map(&:text).should ==
+    expect(page.all('#listing_order_cycles tr td:first-child').map(&:text)).to eq(
       ['oc0', 'oc1', 'oc2', 'oc3', 'oc4', 'oc5', 'oc6']
+    )
 
     # And the rows should have the correct classes
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}.undated"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}.open"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}.open"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}.upcoming"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc4.id}.upcoming"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc5.id}.closed"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc6.id}.closed"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}.undated"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}.open"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}.open"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}.upcoming"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc4.id}.upcoming"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc5.id}.closed"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc6.id}.closed"
 
     find("div#columns-dropdown", :text => "COLUMNS").click
     find("div#columns-dropdown div.menu div.menu_item", text: "Producers").click
@@ -51,66 +52,66 @@ feature %q{
     # And I should see all the details for an order cycle
     within('table#listing_order_cycles tbody tr:nth-child(2)') do
       # Then I should see the basic fields
-      page.should have_selector 'a', text: oc1.name
+      expect(page).to have_selector 'a', text: oc1.name
 
-      page.should have_input "oc#{oc1.id}[orders_open_at]", value: oc1.orders_open_at
-      page.should have_input "oc#{oc1.id}[orders_close_at]", value: oc1.orders_close_at
-      page.should have_content oc1.coordinator.name
+      expect(page).to have_input "oc#{oc1.id}[orders_open_at]", value: oc1.orders_open_at
+      expect(page).to have_input "oc#{oc1.id}[orders_close_at]", value: oc1.orders_close_at
+      expect(page).to have_content oc1.coordinator.name
 
       # And I should see the suppliers and distributors
-      oc1.suppliers.each    { |s| page.should have_content s.name }
-      oc1.distributors.each { |d| page.should have_content d.name }
+      oc1.suppliers.each    { |s| expect(page).to have_content s.name }
+      oc1.distributors.each { |d| expect(page).to have_content d.name }
 
       # And I should see the number of variants
-      page.should have_selector 'td.products', text: '2 variants'
+      expect(page).to have_selector 'td.products', text: '2 variants'
     end
 
     # I can load more order_cycles
-    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc7.id}"
+    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc7.id}"
     click_button "Show 30 more days"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc7.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc7.id}"
 
     # I can filter order cycle by involved enterprises
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     select2_select oc1.suppliers.first.name, from: "involving_filter"
-    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     select2_select "Any Enterprise", from: "involving_filter"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
 
     # I can filter order cycles by name
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     fill_in "query", with: oc0.name
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     fill_in "query", with: ''
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
 
     # I can filter order cycle by schedule
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
     select2_select schedule1.name, from: "schedule_filter"
-    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
+    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
     select2_select 'Any Schedule', from: "schedule_filter"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
-    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    expect(page).to have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
   end
 
   describe 'listing order cycles with other locales' do
@@ -190,8 +191,8 @@ feature %q{
       select 'Coord fee', from: 'order_cycle_coordinator_fee_0_id'
 
       # I should not be able to add a blank supplier
-      page.should have_select 'new_supplier_id', selected: ''
-      page.should have_button 'Add supplier', disabled: true
+      expect(page).to have_select 'new_supplier_id', selected: ''
+      expect(page).to have_button 'Add supplier', disabled: true
 
       # And I add a supplier and some products
       select 'My supplier', from: 'new_supplier_id'
@@ -202,9 +203,9 @@ feature %q{
       check "order_cycle_incoming_exchange_0_variants_#{v2.id}"
 
       # I should not be able to re-add the supplier
-      page.should_not have_select 'new_supplier_id', with_options: ['My supplier']
-      page.should have_button 'Add supplier', disabled: true
-      page.all("td.supplier_name").map(&:text).should == ['My supplier']
+      expect(page).not_to have_select 'new_supplier_id', with_options: ['My supplier']
+      expect(page).to have_button 'Add supplier', disabled: true
+      expect(page.all("td.supplier_name").map(&:text)).to eq(['My supplier'])
 
       # And I add a supplier fee
       within("tr.supplier-#{supplier.id}") { click_button 'Add fee' }
@@ -236,7 +237,7 @@ feature %q{
       click_button 'Create'
 
       # Then my order cycle should have been created
-      page.should have_content 'Your order cycle has been created.'
+      expect(page).to have_content 'Your order cycle has been created.'
 
       oc = OrderCycle.last
 
@@ -245,31 +246,31 @@ feature %q{
       find("div#columns-dropdown div.menu div.menu_item", text: "Shops").click
       find("div#columns-dropdown", :text => "COLUMNS").click
 
-      page.should have_selector 'a', text: 'Plums & Avos'
-      page.should have_input "oc#{oc.id}[orders_open_at]", value: order_cycle_opening_time
-      page.should have_input "oc#{oc.id}[orders_close_at]", value: order_cycle_closing_time
-      page.should have_content 'My coordinator'
+      expect(page).to have_selector 'a', text: 'Plums & Avos'
+      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: order_cycle_opening_time
+      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: order_cycle_closing_time
+      expect(page).to have_content 'My coordinator'
 
-      page.should have_selector 'td.producers', text: 'My supplier'
-      page.should have_selector 'td.shops', text: 'My distributor'
+      expect(page).to have_selector 'td.producers', text: 'My supplier'
+      expect(page).to have_selector 'td.shops', text: 'My distributor'
 
       # And it should have some fees
-      oc.exchanges.incoming.first.enterprise_fees.should == [supplier_fee]
-      oc.coordinator_fees.should                         == [coordinator_fee]
-      oc.exchanges.outgoing.first.enterprise_fees.should == [distributor_fee]
+      expect(oc.exchanges.incoming.first.enterprise_fees).to eq([supplier_fee])
+      expect(oc.coordinator_fees).to                         eq([coordinator_fee])
+      expect(oc.exchanges.outgoing.first.enterprise_fees).to eq([distributor_fee])
 
       # And it should have some variants selected
-      oc.exchanges.first.variants.count.should == 2
-      oc.exchanges.last.variants.count.should == 2
+      expect(oc.exchanges.first.variants.count).to eq(2)
+      expect(oc.exchanges.last.variants.count).to eq(2)
 
       # And my receival and pickup time and instructions should have been saved
       exchange = oc.exchanges.incoming.first
-      exchange.receival_instructions.should == 'receival instructions'
+      expect(exchange.receival_instructions).to eq('receival instructions')
 
       exchange = oc.exchanges.outgoing.first
-      exchange.pickup_time.should == 'pickup time'
-      exchange.pickup_instructions.should == 'pickup instructions'
-      exchange.tag_list.should == ['wholesale']
+      expect(exchange.pickup_time).to eq('pickup time')
+      expect(exchange.pickup_instructions).to eq('pickup instructions')
+      expect(exchange.tag_list).to eq(['wholesale'])
     end
 
     scenario "updating an order cycle", js: true do
@@ -325,7 +326,7 @@ feature %q{
       click_button 'Add supplier'
       page.all("table.exchanges tr.supplier td.products").each { |e| e.click }
 
-      page.should have_selector "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}", visible: true
+      expect(page).to have_selector "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}", visible: true
       page.find("#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}", visible: true).click # uncheck (with visible:true filter)
       check "order_cycle_incoming_exchange_2_variants_#{v1.id}"
       check "order_cycle_incoming_exchange_2_variants_#{v2.id}"
@@ -376,7 +377,7 @@ feature %q{
       click_button 'Update and Close'
 
       # Then my order cycle should have been updated
-      page.should have_content 'Your order cycle has been updated.'
+      expect(page).to have_content 'Your order cycle has been updated.'
 
       oc = OrderCycle.last
 
@@ -385,33 +386,33 @@ feature %q{
       find("div#columns-dropdown div.menu div.menu_item", text: "Shops").click
       find("div#columns-dropdown", :text => "COLUMNS").click
 
-      page.should have_selector 'a', text: 'Plums & Avos'
-      page.should have_input "oc#{oc.id}[orders_open_at]", value: order_cycle_opening_time
-      page.should have_input "oc#{oc.id}[orders_close_at]", value: order_cycle_closing_time
-      page.should have_content coordinator.name
+      expect(page).to have_selector 'a', text: 'Plums & Avos'
+      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: order_cycle_opening_time
+      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: order_cycle_closing_time
+      expect(page).to have_content coordinator.name
 
-      page.should have_selector 'td.producers', text: 'My supplier'
-      page.should have_selector 'td.shops', text: 'My distributor'
+      expect(page).to have_selector 'td.producers', text: 'My supplier'
+      expect(page).to have_selector 'td.shops', text: 'My distributor'
 
       # And my coordinator fees should have been configured
-      oc.coordinator_fee_ids.should match_array [coordinator_fee1.id, coordinator_fee2.id]
+      expect(oc.coordinator_fee_ids).to match_array [coordinator_fee1.id, coordinator_fee2.id]
 
       # And my supplier fees should have been configured
-      oc.exchanges.incoming.last.enterprise_fee_ids.should == [supplier_fee2.id]
+      expect(oc.exchanges.incoming.last.enterprise_fee_ids).to eq([supplier_fee2.id])
 
       # And my distributor fees should have been configured
-      oc.exchanges.outgoing.last.enterprise_fee_ids.should == [distributor_fee2.id]
+      expect(oc.exchanges.outgoing.last.enterprise_fee_ids).to eq([distributor_fee2.id])
 
       # And my tags should have been save
-      oc.exchanges.outgoing.last.tag_list.should == ['wholesale']
+      expect(oc.exchanges.outgoing.last.tag_list).to eq(['wholesale'])
 
       # And it should have some variants selected
       selected_initial_variants = initial_variants.take initial_variants.size - 1
-      oc.variants.map(&:id).should match_array((selected_initial_variants.map(&:id) + [v1.id, v2.id]))
+      expect(oc.variants.map(&:id)).to match_array((selected_initial_variants.map(&:id) + [v1.id, v2.id]))
 
       # And the collection details should have been updated
-      oc.exchanges.where(pickup_time: 'New time 0', pickup_instructions: 'New instructions 0').should be_present
-      oc.exchanges.where(pickup_time: 'New time 1', pickup_instructions: 'New instructions 1').should be_present
+      expect(oc.exchanges.where(pickup_time: 'New time 0', pickup_instructions: 'New instructions 0')).to be_present
+      expect(oc.exchanges.where(pickup_time: 'New time 1', pickup_instructions: 'New instructions 1')).to be_present
     end
   end
 
@@ -430,64 +431,64 @@ feature %q{
     wait_until { page.find('#order_cycle_name').value.present? }
 
     # Then I should see the basic settings
-    page.find('#order_cycle_name').value.should == oc.name
-    page.find('#order_cycle_orders_open_at').value.should == oc.orders_open_at.to_s
-    page.find('#order_cycle_orders_close_at').value.should == oc.orders_close_at.to_s
-    page.should have_content "COORDINATOR #{oc.coordinator.name}"
+    expect(page.find('#order_cycle_name').value).to eq(oc.name)
+    expect(page.find('#order_cycle_orders_open_at').value).to eq(oc.orders_open_at.to_s)
+    expect(page.find('#order_cycle_orders_close_at').value).to eq(oc.orders_close_at.to_s)
+    expect(page).to have_content "COORDINATOR #{oc.coordinator.name}"
 
     # And I should see the suppliers
-    page.should have_selector 'td.supplier_name', :text => oc.suppliers.first.name
-    page.should have_selector 'td.supplier_name', :text => oc.suppliers.last.name
+    expect(page).to have_selector 'td.supplier_name', :text => oc.suppliers.first.name
+    expect(page).to have_selector 'td.supplier_name', :text => oc.suppliers.last.name
 
-    page.should have_field 'order_cycle_incoming_exchange_0_receival_instructions', with: 'instructions 0'
-    page.should have_field 'order_cycle_incoming_exchange_1_receival_instructions', with: 'instructions 1'
+    expect(page).to have_field 'order_cycle_incoming_exchange_0_receival_instructions', with: 'instructions 0'
+    expect(page).to have_field 'order_cycle_incoming_exchange_1_receival_instructions', with: 'instructions 1'
 
     # And the suppliers should have products
     page.all('table.exchanges tbody tr.supplier').each_with_index do |row, i|
       row.find('td.products').click
 
       products_panel = page.all('table.exchanges tr.panel-row .exchange-supplied-products').select { |r| r.visible? }.first
-      products_panel.should have_selector "input[name='order_cycle_incoming_exchange_#{i}_select_all_variants']"
+      expect(products_panel).to have_selector "input[name='order_cycle_incoming_exchange_#{i}_select_all_variants']"
 
       row.find('td.products').click
     end
 
     # And the suppliers should have fees
     supplier = oc.suppliers.sort_by(&:name).first
-    page.should have_select 'order_cycle_incoming_exchange_0_enterprise_fees_0_enterprise_id', selected: supplier.name
-    page.should have_select 'order_cycle_incoming_exchange_0_enterprise_fees_0_enterprise_fee_id', selected: supplier.enterprise_fees.first.name
+    expect(page).to have_select 'order_cycle_incoming_exchange_0_enterprise_fees_0_enterprise_id', selected: supplier.name
+    expect(page).to have_select 'order_cycle_incoming_exchange_0_enterprise_fees_0_enterprise_fee_id', selected: supplier.enterprise_fees.first.name
 
     supplier = oc.suppliers.sort_by(&:name).last
-    page.should have_select 'order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id', selected: supplier.name
-    page.should have_select 'order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_fee_id', selected: supplier.enterprise_fees.first.name
+    expect(page).to have_select 'order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_id', selected: supplier.name
+    expect(page).to have_select 'order_cycle_incoming_exchange_1_enterprise_fees_0_enterprise_fee_id', selected: supplier.enterprise_fees.first.name
 
     # And I should see the distributors
-    page.should have_selector 'td.distributor_name', :text => oc.distributors.first.name
-    page.should have_selector 'td.distributor_name', :text => oc.distributors.last.name
+    expect(page).to have_selector 'td.distributor_name', :text => oc.distributors.first.name
+    expect(page).to have_selector 'td.distributor_name', :text => oc.distributors.last.name
 
-    page.should have_field 'order_cycle_outgoing_exchange_0_pickup_time', with: 'time 0'
-    page.should have_field 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'instructions 0'
-    page.should have_field 'order_cycle_outgoing_exchange_1_pickup_time', with: 'time 1'
-    page.should have_field 'order_cycle_outgoing_exchange_1_pickup_instructions', with: 'instructions 1'
+    expect(page).to have_field 'order_cycle_outgoing_exchange_0_pickup_time', with: 'time 0'
+    expect(page).to have_field 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'instructions 0'
+    expect(page).to have_field 'order_cycle_outgoing_exchange_1_pickup_time', with: 'time 1'
+    expect(page).to have_field 'order_cycle_outgoing_exchange_1_pickup_instructions', with: 'instructions 1'
 
     # And the distributors should have products
     page.all('table.exchanges tbody tr.distributor').each_with_index do |row, i|
       row.find('td.products').click
 
       products_panel = page.all('table.exchanges tr.panel-row .exchange-distributed-products').select { |r| r.visible? }.first
-      products_panel.should have_selector "input[name='order_cycle_outgoing_exchange_#{i}_select_all_variants']"
+      expect(products_panel).to have_selector "input[name='order_cycle_outgoing_exchange_#{i}_select_all_variants']"
 
       row.find('td.products').click
     end
 
     # And the distributors should have fees
     distributor = oc.distributors.sort_by(&:id).first
-    page.should have_select 'order_cycle_outgoing_exchange_0_enterprise_fees_0_enterprise_id', selected: distributor.name
-    page.should have_select 'order_cycle_outgoing_exchange_0_enterprise_fees_0_enterprise_fee_id', selected: distributor.enterprise_fees.first.name
+    expect(page).to have_select 'order_cycle_outgoing_exchange_0_enterprise_fees_0_enterprise_id', selected: distributor.name
+    expect(page).to have_select 'order_cycle_outgoing_exchange_0_enterprise_fees_0_enterprise_fee_id', selected: distributor.enterprise_fees.first.name
 
     distributor = oc.distributors.sort_by(&:id).last
-    page.should have_select 'order_cycle_outgoing_exchange_1_enterprise_fees_0_enterprise_id', selected: distributor.name
-    page.should have_select 'order_cycle_outgoing_exchange_1_enterprise_fees_0_enterprise_fee_id', selected: distributor.enterprise_fees.first.name
+    expect(page).to have_select 'order_cycle_outgoing_exchange_1_enterprise_fees_0_enterprise_id', selected: distributor.name
+    expect(page).to have_select 'order_cycle_outgoing_exchange_1_enterprise_fees_0_enterprise_fee_id', selected: distributor.enterprise_fees.first.name
   end
 
 
@@ -503,13 +504,13 @@ feature %q{
 
     # When I edit the first order cycle, the exchange should appear as incoming
     visit edit_admin_order_cycle_path(oc_incoming)
-    page.should     have_selector 'table.exchanges tr.supplier'
-    page.should_not have_selector 'table.exchanges tr.distributor'
+    expect(page).to     have_selector 'table.exchanges tr.supplier'
+    expect(page).not_to have_selector 'table.exchanges tr.distributor'
 
     # And when I edit the second order cycle, the exchange should appear as outgoing
     visit edit_admin_order_cycle_path(oc_outgoing)
-    page.should     have_selector 'table.exchanges tr.distributor'
-    page.should_not have_selector 'table.exchanges tr.supplier'
+    expect(page).to     have_selector 'table.exchanges tr.distributor'
+    expect(page).not_to have_selector 'table.exchanges tr.supplier'
   end
 
   scenario "updating many order cycle opening/closing times at once", js: true do
@@ -563,8 +564,8 @@ feature %q{
 
     # Then my times should have been saved
     expect(page).to have_selector "#save-bar", text: "Order cycles have been updated."
-    OrderCycle.order('id ASC').map { |oc| oc.orders_open_at.sec }.should == [0, 2, 4]
-    OrderCycle.order('id ASC').map { |oc| oc.orders_close_at.sec }.should == [1, 3, 5]
+    expect(OrderCycle.order('id ASC').map { |oc| oc.orders_open_at.sec }).to eq([0, 2, 4])
+    expect(OrderCycle.order('id ASC').map { |oc| oc.orders_close_at.sec }).to eq([1, 3, 5])
   end
 
   scenario "cloning an order cycle" do
@@ -595,7 +596,7 @@ feature %q{
     d = create(:distributor_enterprise)
     oc = create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master])
     exchange_ids = oc.exchanges.pluck :id
-    ExchangeVariant.where(exchange_id: exchange_ids, variant_id: p.master.id).should_not be_empty
+    expect(ExchangeVariant.where(exchange_id: exchange_ids, variant_id: p.master.id)).not_to be_empty
 
     # When I go to the order cycle page and remove the obsolete master
     login_to_admin_section
@@ -606,8 +607,8 @@ feature %q{
     click_button "Update"
 
     # Then the master variant should have been removed from all exchanges
-    page.should have_content "Your order cycle has been updated."
-    ExchangeVariant.where(exchange_id: exchange_ids, variant_id: p.master.id).should be_empty
+    expect(page).to have_content "Your order cycle has been updated."
+    expect(ExchangeVariant.where(exchange_id: exchange_ids, variant_id: p.master.id)).to be_empty
   end
 
 
@@ -618,13 +619,13 @@ feature %q{
 
       it "displays a warning on the dashboard" do
         login_to_admin_section
-        page.should have_content "The hub #{hub.name} is listed in an active order cycle, but does not have valid shipping and payment methods. Until you set these up, customers will not be able to shop at this hub."
+        expect(page).to have_content "The hub #{hub.name} is listed in an active order cycle, but does not have valid shipping and payment methods. Until you set these up, customers will not be able to shop at this hub."
       end
 
       it "displays a warning on the order cycles screen" do
         login_to_admin_section
         visit admin_order_cycles_path
-        page.should have_content "The hub #{hub.name} is listed in an active order cycle, but does not have valid shipping and payment methods. Until you set these up, customers will not be able to shop at this hub."
+        expect(page).to have_content "The hub #{hub.name} is listed in an active order cycle, but does not have valid shipping and payment methods. Until you set these up, customers will not be able to shop at this hub."
       end
     end
 
@@ -634,7 +635,7 @@ feature %q{
 
       it "does not display the warning on the dashboard" do
         login_to_admin_section
-        page.should_not have_content "does not have valid shipping and payment methods"
+        expect(page).not_to have_content "does not have valid shipping and payment methods"
       end
     end
   end
@@ -685,8 +686,8 @@ feature %q{
         click_link "Order Cycles"
 
         # I should see only the order cycle I am coordinating
-        page.should have_content oc_user_coordinating.name
-        page.should_not have_content oc_for_other_user.name
+        expect(page).to have_content oc_user_coordinating.name
+        expect(page).not_to have_content oc_for_other_user.name
 
 
         find("div#columns-dropdown", :text => "COLUMNS").click
@@ -695,10 +696,10 @@ feature %q{
         find("div#columns-dropdown", :text => "COLUMNS").click
 
         # The order cycle should show all enterprises in the order cycle
-        page.should have_selector 'td.producers', text: supplier_managed.name
-        page.should have_selector 'td.shops', text: distributor_managed.name
-        page.should have_selector 'td.producers', text: supplier_unmanaged.name
-        page.should have_selector 'td.shops', text: distributor_unmanaged.name
+        expect(page).to have_selector 'td.producers', text: supplier_managed.name
+        expect(page).to have_selector 'td.shops', text: distributor_managed.name
+        expect(page).to have_selector 'td.producers', text: supplier_unmanaged.name
+        expect(page).to have_selector 'td.shops', text: distributor_unmanaged.name
       end
 
       scenario "creating a new order cycle" do
@@ -737,11 +738,11 @@ feature %q{
 
         # Should only have suppliers / distributors listed which the user is managing or
         # has E2E permission to add products to order cycles
-        page.should_not have_select 'new_supplier_id', with_options: [supplier_unmanaged.name]
-        page.should_not have_select 'new_distributor_id', with_options: [distributor_unmanaged.name]
+        expect(page).not_to have_select 'new_supplier_id', with_options: [supplier_unmanaged.name]
+        expect(page).not_to have_select 'new_distributor_id', with_options: [distributor_unmanaged.name]
 
         [distributor_unmanaged.name, supplier_managed.name, supplier_unmanaged.name].each do |enterprise_name|
-          page.should_not have_select 'order_cycle_coordinator_id', with_options: [enterprise_name]
+          expect(page).not_to have_select 'order_cycle_coordinator_id', with_options: [enterprise_name]
         end
 
         page.find("table.exchanges tr.distributor-#{distributor_managed.id} td.tags").click
@@ -751,14 +752,14 @@ feature %q{
 
         click_button 'Create'
 
-        flash_message.should == "Your order cycle has been created."
+        expect(flash_message).to eq("Your order cycle has been created.")
         order_cycle = OrderCycle.find_by_name('My order cycle')
-        order_cycle.suppliers.should match_array [supplier_managed, supplier_permitted]
-        order_cycle.coordinator.should == distributor_managed
-        order_cycle.distributors.should match_array [distributor_managed, distributor_permitted]
-        order_cycle.schedules.should == [schedule]
+        expect(order_cycle.suppliers).to match_array [supplier_managed, supplier_permitted]
+        expect(order_cycle.coordinator).to eq(distributor_managed)
+        expect(order_cycle.distributors).to match_array [distributor_managed, distributor_permitted]
+        expect(order_cycle.schedules).to eq([schedule])
         exchange = order_cycle.exchanges.outgoing.to_enterprise(distributor_managed).first
-        exchange.tag_list.should == ["wholesale"]
+        expect(exchange.tag_list).to eq(["wholesale"])
       end
 
       scenario "editing an order cycle we can see (and for now, edit) all exchanges in the order cycle" do
@@ -786,12 +787,12 @@ feature %q{
 
         # When I save, then those exchanges should remain
         click_button 'Update'
-        page.should have_content "Your order cycle has been updated."
+        expect(page).to have_content "Your order cycle has been updated."
 
         oc.reload
-        oc.suppliers.should match_array [supplier_managed, supplier_permitted, supplier_unmanaged]
-        oc.coordinator.should == distributor_managed
-        oc.distributors.should match_array [distributor_managed, distributor_permitted, distributor_unmanaged]
+        expect(oc.suppliers).to match_array [supplier_managed, supplier_permitted, supplier_unmanaged]
+        expect(oc.coordinator).to eq(distributor_managed)
+        expect(oc.distributors).to match_array [distributor_managed, distributor_permitted, distributor_unmanaged]
       end
 
       scenario "editing an order cycle" do
@@ -811,13 +812,13 @@ feature %q{
         click_button 'Update'
 
         # Then the exchanges should be removed
-        page.should have_content "Your order cycle has been updated."
+        expect(page).to have_content "Your order cycle has been updated."
 
         oc.reload
-        oc.suppliers.should == [supplier_unmanaged]
-        oc.coordinator.should == distributor_managed
-        oc.distributors.should == [distributor_unmanaged]
-        oc.schedules.should == [schedule]
+        expect(oc.suppliers).to eq([supplier_unmanaged])
+        expect(oc.coordinator).to eq(distributor_managed)
+        expect(oc.distributors).to eq([distributor_unmanaged])
+        expect(oc.schedules).to eq([schedule])
       end
 
       scenario "cloning an order cycle" do
@@ -831,7 +832,7 @@ feature %q{
 
         # Then I should have clone of the order cycle
         occ = OrderCycle.last
-        occ.name.should == "COPY OF #{oc.name}"
+        expect(occ.name).to eq("COPY OF #{oc.name}")
       end
     end
 
@@ -887,16 +888,16 @@ feature %q{
         # I should be able to see but not toggle v2, because I don't have permission
         expect(page).to have_checked_field "order_cycle_outgoing_exchange_0_variants_#{v2.id}", disabled: true
 
-        page.should_not have_selector "table.exchanges tr.distributor-#{distributor_managed.id} td.tags"
+        expect(page).not_to have_selector "table.exchanges tr.distributor-#{distributor_managed.id} td.tags"
 
         # When I save, any exchanges that I can't manage remain
         click_button 'Update'
-        page.should have_content "Your order cycle has been updated."
+        expect(page).to have_content "Your order cycle has been updated."
 
         oc.reload
-        oc.suppliers.should match_array [supplier_managed, supplier_permitted, supplier_unmanaged]
-        oc.coordinator.should == distributor_managed
-        oc.distributors.should match_array [distributor_managed, distributor_permitted, distributor_unmanaged]
+        expect(oc.suppliers).to match_array [supplier_managed, supplier_permitted, supplier_unmanaged]
+        expect(oc.coordinator).to eq(distributor_managed)
+        expect(oc.distributors).to match_array [distributor_managed, distributor_permitted, distributor_unmanaged]
       end
     end
 
@@ -952,16 +953,16 @@ feature %q{
         # I should be able to see but not toggle v2, because I don't have permission
         expect(page).to have_checked_field "order_cycle_incoming_exchange_0_variants_#{v2.id}", disabled: true
 
-        page.should have_selector "table.exchanges tr.distributor-#{my_distributor.id} td.tags"
+        expect(page).to have_selector "table.exchanges tr.distributor-#{my_distributor.id} td.tags"
 
         # When I save, any exchange that I can't manage remains
         click_button 'Update'
-        page.should have_content "Your order cycle has been updated."
+        expect(page).to have_content "Your order cycle has been updated."
 
         oc.reload
-        oc.suppliers.should match_array [supplier_managed, supplier_permitted, supplier_unmanaged]
-        oc.coordinator.should == distributor_managed
-        oc.distributors.should match_array [my_distributor, distributor_managed, distributor_permitted, distributor_unmanaged]
+        expect(oc.suppliers).to match_array [supplier_managed, supplier_permitted, supplier_unmanaged]
+        expect(oc.coordinator).to eq(distributor_managed)
+        expect(oc.distributors).to match_array [my_distributor, distributor_managed, distributor_permitted, distributor_unmanaged]
       end
     end
   end
@@ -986,9 +987,9 @@ feature %q{
     it "shows me an index of order cycles without enterprise columns" do
       create(:simple_order_cycle, coordinator: enterprise)
       visit admin_order_cycles_path
-      page.should_not have_selector 'th', text: 'SUPPLIERS'
-      page.should_not have_selector 'th', text: 'COORDINATOR'
-      page.should_not have_selector 'th', text: 'DISTRIBUTORS'
+      expect(page).not_to have_selector 'th', text: 'SUPPLIERS'
+      expect(page).not_to have_selector 'th', text: 'COORDINATOR'
+      expect(page).not_to have_selector 'th', text: 'DISTRIBUTORS'
     end
 
     it "creates order cycles", js: true do
@@ -1007,9 +1008,9 @@ feature %q{
       fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
 
       # Then my products / variants should already be selected
-      page.should have_checked_field "order_cycle_incoming_exchange_0_variants_#{v1.id}"
-      page.should have_checked_field "order_cycle_incoming_exchange_0_variants_#{v2.id}"
-      page.should have_checked_field "order_cycle_incoming_exchange_0_variants_#{v3.id}"
+      expect(page).to have_checked_field "order_cycle_incoming_exchange_0_variants_#{v1.id}"
+      expect(page).to have_checked_field "order_cycle_incoming_exchange_0_variants_#{v2.id}"
+      expect(page).to have_checked_field "order_cycle_incoming_exchange_0_variants_#{v3.id}"
 
       # When I unselect a product
       uncheck "order_cycle_incoming_exchange_0_variants_#{v2.id}"
@@ -1018,32 +1019,32 @@ feature %q{
       click_button 'Add coordinator fee'
       click_button 'Add coordinator fee'
       click_link 'order_cycle_coordinator_fee_1_remove'
-      page.should     have_select 'order_cycle_coordinator_fee_0_id'
-      page.should_not have_select 'order_cycle_coordinator_fee_1_id'
+      expect(page).to     have_select 'order_cycle_coordinator_fee_0_id'
+      expect(page).not_to have_select 'order_cycle_coordinator_fee_1_id'
 
       select 'Coord fee', from: 'order_cycle_coordinator_fee_0_id'
       click_button 'Create'
 
       # Then my order cycle should have been created
-      page.should have_content 'Your order cycle has been created.'
+      expect(page).to have_content 'Your order cycle has been created.'
 
       oc = OrderCycle.last
 
-      page.should have_selector 'a', text: 'Plums & Avos'
-      page.should have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 06, 00, 00).strftime("%F %T %z")
-      page.should have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 00, 00).strftime("%F %T %z")
+      expect(page).to have_selector 'a', text: 'Plums & Avos'
+      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 06, 00, 00).strftime("%F %T %z")
+      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 00, 00).strftime("%F %T %z")
 
       # And it should have some variants selected
-      oc.exchanges.incoming.first.variants.count.should == 2
-      oc.exchanges.outgoing.first.variants.count.should == 2
+      expect(oc.exchanges.incoming.first.variants.count).to eq(2)
+      expect(oc.exchanges.outgoing.first.variants.count).to eq(2)
 
       # And it should have the fee
-      oc.coordinator_fees.should == [fee]
+      expect(oc.coordinator_fees).to eq([fee])
 
       # And my pickup time and instructions should have been saved
       ex = oc.exchanges.outgoing.first
-      ex.pickup_time.should == 'pickup time'
-      ex.pickup_instructions.should == 'pickup instructions'
+      expect(ex.pickup_time).to eq('pickup time')
+      expect(ex.pickup_instructions).to eq('pickup instructions')
     end
 
     scenario "editing an order cycle" do
@@ -1060,19 +1061,19 @@ feature %q{
       wait_until { page.find('#order_cycle_name').value.present? }
 
       # Then I should see the basic settings
-      page.should have_field 'order_cycle_name', with: oc.name
-      page.should have_field 'order_cycle_orders_open_at', with: oc.orders_open_at.to_s
-      page.should have_field 'order_cycle_orders_close_at', with: oc.orders_close_at.to_s
-      page.should have_field 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
-      page.should have_field 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
+      expect(page).to have_field 'order_cycle_name', with: oc.name
+      expect(page).to have_field 'order_cycle_orders_open_at', with: oc.orders_open_at.to_s
+      expect(page).to have_field 'order_cycle_orders_close_at', with: oc.orders_close_at.to_s
+      expect(page).to have_field 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
+      expect(page).to have_field 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
 
       # And I should see the products
-      page.should have_checked_field   "order_cycle_incoming_exchange_0_variants_#{v1.id}"
-      page.should have_unchecked_field "order_cycle_incoming_exchange_0_variants_#{v2.id}"
-      page.should have_unchecked_field "order_cycle_incoming_exchange_0_variants_#{v3.id}"
+      expect(page).to have_checked_field   "order_cycle_incoming_exchange_0_variants_#{v1.id}"
+      expect(page).to have_unchecked_field "order_cycle_incoming_exchange_0_variants_#{v2.id}"
+      expect(page).to have_unchecked_field "order_cycle_incoming_exchange_0_variants_#{v3.id}"
 
       # And I should see the coordinator fees
-      page.should have_select 'order_cycle_coordinator_fee_0_id', selected: 'my fee'
+      expect(page).to have_select 'order_cycle_coordinator_fee_0_id', selected: 'my fee'
     end
 
     scenario "updating an order cycle" do
@@ -1103,36 +1104,36 @@ feature %q{
 
       # And I select some fees and update
       click_link 'order_cycle_coordinator_fee_0_remove'
-      page.should_not have_select 'order_cycle_coordinator_fee_0_id'
+      expect(page).not_to have_select 'order_cycle_coordinator_fee_0_id'
       click_button 'Add coordinator fee'
       select 'that fee', from: 'order_cycle_coordinator_fee_0_id'
 
       # When I update, or update and close, both work
       click_button 'Update'
-      page.should have_content 'Your order cycle has been updated.'
+      expect(page).to have_content 'Your order cycle has been updated.'
 
       fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'yyz'
       click_button 'Update and Close'
 
       # Then my order cycle should have been updated
-      page.should have_content 'Your order cycle has been updated.'
+      expect(page).to have_content 'Your order cycle has been updated.'
       oc = OrderCycle.last
 
-      page.should have_selector 'a', text: 'Plums & Avos'
-      page.should have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 06, 00, 00).strftime("%F %T %z")
-      page.should have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 00, 00).strftime("%F %T %z")
+      expect(page).to have_selector 'a', text: 'Plums & Avos'
+      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 06, 00, 00).strftime("%F %T %z")
+      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 00, 00).strftime("%F %T %z")
 
       # And it should have a variant selected
-      oc.exchanges.incoming.first.variants.should == [v2]
-      oc.exchanges.outgoing.first.variants.should == [v2]
+      expect(oc.exchanges.incoming.first.variants).to eq([v2])
+      expect(oc.exchanges.outgoing.first.variants).to eq([v2])
 
       # And it should have the fee
-      oc.coordinator_fees.should == [fee2]
+      expect(oc.coordinator_fees).to eq([fee2])
 
       # And my pickup time and instructions should have been saved
       ex = oc.exchanges.outgoing.first
-      ex.pickup_time.should == 'xy'
-      ex.pickup_instructions.should == 'yyz'
+      expect(ex.pickup_time).to eq('xy')
+      expect(ex.pickup_instructions).to eq('yyz')
     end
   end
 
@@ -1140,9 +1141,9 @@ feature %q{
     create(:simple_order_cycle, name: "Translusent Berries")
     login_to_admin_section
     click_link 'Order Cycles'
-    page.should have_content("Translusent Berries")
+    expect(page).to have_content("Translusent Berries")
     first('a.delete-order-cycle').click
-    page.should_not have_content("Translusent Berries")
+    expect(page).not_to have_content("Translusent Berries")
   end
 
 

--- a/spec/features/admin/overview_spec.rb
+++ b/spec/features/admin/overview_spec.rb
@@ -11,7 +11,7 @@ feature %q{
   context "as an enterprise user" do
     before do
       @enterprise_user = create_enterprise_user
-      Spree::Admin::OverviewController.any_instance.stub(:spree_current_user).and_return @enterprise_user
+      allow_any_instance_of(Spree::Admin::OverviewController).to receive(:spree_current_user).and_return @enterprise_user
       quick_login_as @enterprise_user
     end
 
@@ -24,8 +24,8 @@ feature %q{
 
       it "displays a link to the map page" do
         visit '/admin'
-        page.should have_selector ".dashboard_item h3", text: "Your profile live"
-        page.should have_selector ".dashboard_item .button.bottom", text: "SEE #{d1.name.upcase} LIVE"
+        expect(page).to have_selector ".dashboard_item h3", text: "Your profile live"
+        expect(page).to have_selector ".dashboard_item .button.bottom", text: "SEE #{d1.name.upcase} LIVE"
       end
 
       context "when visibilty is set to false" do
@@ -36,7 +36,7 @@ feature %q{
 
         it "displays a message telling how to set visibility" do
           visit '/admin'
-          page.should have_selector ".alert-box", text: "To allow people to find you, turn on your visibility under Manage #{d1.name}."
+          expect(page).to have_selector ".alert-box", text: "To allow people to find you, turn on your visibility under Manage #{d1.name}."
         end
       end
 
@@ -64,22 +64,22 @@ feature %q{
 
       it "displays information about the enterprise" do
         visit '/admin'
-        page.should have_selector ".dashboard_item#enterprises h3", text: "My Enterprises"
-        page.should have_selector ".dashboard_item#products"
-        page.should have_selector ".dashboard_item#order_cycles"
-        page.should have_selector ".dashboard_item#enterprises .list-item", text: d1.name
-        page.should have_selector ".dashboard_item#enterprises .button.bottom", text: "MANAGE MY ENTERPRISES"
+        expect(page).to have_selector ".dashboard_item#enterprises h3", text: "My Enterprises"
+        expect(page).to have_selector ".dashboard_item#products"
+        expect(page).to have_selector ".dashboard_item#order_cycles"
+        expect(page).to have_selector ".dashboard_item#enterprises .list-item", text: d1.name
+        expect(page).to have_selector ".dashboard_item#enterprises .button.bottom", text: "MANAGE MY ENTERPRISES"
       end
 
       context "but no products or order cycles" do
         it "prompts the user to create a new product and to manage order cycles" do
           visit '/admin'
-          page.should have_selector ".dashboard_item#products h3", text: "Products"
-          page.should have_selector ".dashboard_item#products .list-item", text: "You don't have any active products."
-          page.should have_selector ".dashboard_item#products .button.bottom", text: "CREATE A NEW PRODUCT"
-          page.should have_selector ".dashboard_item#order_cycles h3", text: "Order Cycles"
-          page.should have_selector ".dashboard_item#order_cycles .list-item", text: "You don't have any active order cycles."
-          page.should have_selector ".dashboard_item#order_cycles .button.bottom", text: "MANAGE ORDER CYCLES"
+          expect(page).to have_selector ".dashboard_item#products h3", text: "Products"
+          expect(page).to have_selector ".dashboard_item#products .list-item", text: "You don't have any active products."
+          expect(page).to have_selector ".dashboard_item#products .button.bottom", text: "CREATE A NEW PRODUCT"
+          expect(page).to have_selector ".dashboard_item#order_cycles h3", text: "Order Cycles"
+          expect(page).to have_selector ".dashboard_item#order_cycles .list-item", text: "You don't have any active order cycles."
+          expect(page).to have_selector ".dashboard_item#order_cycles .button.bottom", text: "MANAGE ORDER CYCLES"
         end
       end
 
@@ -89,12 +89,12 @@ feature %q{
 
         it "displays information about products and order cycles" do
           visit '/admin'
-          page.should have_selector ".dashboard_item#products h3", text: "Products"
-          page.should have_selector ".dashboard_item#products .list-item", text: "You don't have any active products."
-          page.should have_selector ".dashboard_item#products .button.bottom", text: "CREATE A NEW PRODUCT"
-          page.should have_selector ".dashboard_item#order_cycles h3", text: "Order Cycles"
-          page.should have_selector ".dashboard_item#order_cycles .list-item", text: "You don't have any active order cycles."
-          page.should have_selector ".dashboard_item#order_cycles .button.bottom", text: "MANAGE ORDER CYCLES"
+          expect(page).to have_selector ".dashboard_item#products h3", text: "Products"
+          expect(page).to have_selector ".dashboard_item#products .list-item", text: "You don't have any active products."
+          expect(page).to have_selector ".dashboard_item#products .button.bottom", text: "CREATE A NEW PRODUCT"
+          expect(page).to have_selector ".dashboard_item#order_cycles h3", text: "Order Cycles"
+          expect(page).to have_selector ".dashboard_item#order_cycles .list-item", text: "You don't have any active order cycles."
+          expect(page).to have_selector ".dashboard_item#order_cycles .button.bottom", text: "MANAGE ORDER CYCLES"
         end
       end
     end

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -24,10 +24,10 @@ feature %q{
       check "payment_method_distributor_ids_#{@distributors[0].id}"
       click_button 'Create'
 
-      flash_message.should == 'Payment Method has been successfully created!'
+      expect(flash_message).to eq('Payment Method has been successfully created!')
 
       payment_method = Spree::PaymentMethod.find_by_name('Cheque payment method')
-      payment_method.distributors.should == [@distributors[0]]
+      expect(payment_method.distributors).to eq([@distributors[0]])
     end
 
     context "using stripe connect" do
@@ -148,12 +148,12 @@ feature %q{
       find(:css, "tags-input .tags input").set "local\n"
       click_button 'Create'
 
-      flash_message.should == 'Payment Method has been successfully created!'
+      expect(flash_message).to eq('Payment Method has been successfully created!')
       expect(first('tags-input .tag-list ti-tag-item')).to have_content "local"
 
       payment_method = Spree::PaymentMethod.find_by_name('Cheque payment method')
-      payment_method.distributors.should == [distributor1]
-      payment_method.tag_list.should == ["local"]
+      expect(payment_method.distributors).to eq([distributor1])
+      expect(payment_method.tag_list).to eq(["local"])
     end
 
     it "shows me only payment methods I have access to" do
@@ -163,9 +163,9 @@ feature %q{
 
       visit spree.admin_payment_methods_path
 
-      page.should     have_content pm1.name
-      page.should     have_content pm2.name
-      page.should_not have_content pm3.name
+      expect(page).to     have_content pm1.name
+      expect(page).to     have_content pm2.name
+      expect(page).not_to have_content pm3.name
     end
 
     it "does not show duplicates of payment methods" do
@@ -173,7 +173,7 @@ feature %q{
       pm2
 
       visit spree.admin_payment_methods_path
-      page.should have_selector 'td', text: 'Two', count: 1
+      expect(page).to have_selector 'td', text: 'Two', count: 1
     end
 
 
@@ -187,8 +187,8 @@ feature %q{
         click_link "Payment Methods"
       end
 
-      page.should     have_content pm1.name
-      page.should     have_content pm2.name
+      expect(page).to     have_content pm1.name
+      expect(page).to     have_content pm2.name
 
       click_link 'Enterprises'
       within("#e_#{distributor2.id}") { click_link 'Manage' }
@@ -196,8 +196,8 @@ feature %q{
         click_link "Payment Methods"
       end
 
-      page.should_not have_content pm1.name
-      page.should     have_content pm2.name
+      expect(page).not_to have_content pm1.name
+      expect(page).to     have_content pm2.name
     end
   end
 end

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -50,9 +50,9 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.updated-count', text: '0'
 
       potatoes = Spree::Product.find_by_name('Potatoes')
-      potatoes.supplier.should == enterprise
-      potatoes.on_hand.should == 6
-      potatoes.price.should == 6.50
+      expect(potatoes.supplier).to eq(enterprise)
+      expect(potatoes.on_hand).to eq(6)
+      expect(potatoes.price).to eq(6.50)
     end
 
     it "displays info about invalid entries but still allows saving of valid entries" do
@@ -80,11 +80,11 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.created-count', text: '1'
       expect(page).to have_selector '.updated-count', text: '0'
 
-      Spree::Product.find_by_name('Bad Potatoes').should == nil
+      expect(Spree::Product.find_by_name('Bad Potatoes')).to eq(nil)
       carrots = Spree::Product.find_by_name('Good Carrots')
-      carrots.supplier.should == enterprise
-      carrots.on_hand.should == 5
-      carrots.price.should == 3.20
+      expect(carrots.supplier).to eq(enterprise)
+      expect(carrots.on_hand).to eq(5)
+      expect(carrots.price).to eq(3.20)
     end
 
     it "displays info about invalid entries but no save button if all items are invalid" do
@@ -132,14 +132,14 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.updated-count', text: '1'
 
       added_coffee = Spree::Variant.find_by_display_name('Emergent Coffee')
-      added_coffee.product.name.should == 'Hypothetical Cake'
-      added_coffee.price.should == 3.50
-      added_coffee.on_hand.should == 6
+      expect(added_coffee.product.name).to eq('Hypothetical Cake')
+      expect(added_coffee.price).to eq(3.50)
+      expect(added_coffee.on_hand).to eq(6)
 
       updated_banana = Spree::Variant.find_by_display_name('Preexisting Banana')
-      updated_banana.product.name.should == 'Hypothetical Cake'
-      updated_banana.price.should == 5.50
-      updated_banana.on_hand.should == 5
+      expect(updated_banana.product.name).to eq('Hypothetical Cake')
+      expect(updated_banana.price).to eq(5.50)
+      expect(updated_banana.on_hand).to eq(5)
     end
 
     it "can add a new product and sub-variants of that product at the same time" do
@@ -164,14 +164,14 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.updated-count', text: '0'
 
       small_bag = Spree::Variant.find_by_display_name('Small Bag')
-      small_bag.product.name.should == 'Potatoes'
-      small_bag.price.should == 3.50
-      small_bag.on_hand.should == 5
+      expect(small_bag.product.name).to eq('Potatoes')
+      expect(small_bag.price).to eq(3.50)
+      expect(small_bag.on_hand).to eq(5)
 
       big_bag = Spree::Variant.find_by_display_name('Big Bag')
-      big_bag.product.name.should == 'Potatoes'
-      big_bag.price.should == 5.50
-      big_bag.on_hand.should == 6
+      expect(big_bag.product.name).to eq('Potatoes')
+      expect(big_bag.price).to eq(5.50)
+      expect(big_bag.on_hand).to eq(6)
     end
   end
 
@@ -241,8 +241,8 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.created-count', text: '1'
       expect(page).to have_selector '.updated-count', text: '0'
 
-      Spree::Product.find_by_name('My Carrots').should be_a Spree::Product
-      Spree::Product.find_by_name('Your Potatoes').should == nil
+      expect(Spree::Product.find_by_name('My Carrots')).to be_a Spree::Product
+      expect(Spree::Product.find_by_name('Your Potatoes')).to eq(nil)
     end
   end
 
@@ -282,11 +282,11 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.updated-count', text: '1'
       expect(page).to have_selector '.reset-count', text: '2'
 
-      Spree::Product.find_by_name('Carrots').on_hand.should == 5    # Present in file, added
-      Spree::Product.find_by_name('Beans').on_hand.should == 6      # Present in file, updated
-      Spree::Product.find_by_name('Sprouts').on_hand.should == 0    # In enterprise, not in file
-      Spree::Product.find_by_name('Cabbage').on_hand.should == 0    # In enterprise, not in file
-      Spree::Product.find_by_name('Lettuce').on_hand.should == 100  # In different enterprise; unchanged
+      expect(Spree::Product.find_by_name('Carrots').on_hand).to eq(5)    # Present in file, added
+      expect(Spree::Product.find_by_name('Beans').on_hand).to eq(6)      # Present in file, updated
+      expect(Spree::Product.find_by_name('Sprouts').on_hand).to eq(0)    # In enterprise, not in file
+      expect(Spree::Product.find_by_name('Cabbage').on_hand).to eq(0)    # In enterprise, not in file
+      expect(Spree::Product.find_by_name('Lettuce').on_hand).to eq(100)  # In different enterprise; unchanged
     end
 
     it "overwrites fields with selected defaults" do
@@ -329,16 +329,16 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.updated-count', text: '0'
 
       carrots = Spree::Product.find_by_name('Carrots')
-      carrots.on_hand.should == 9000
-      carrots.tax_category_id.should == tax_category.id
-      carrots.shipping_category_id.should == shipping_category.id
-      carrots.available_on.should be_within(1.day).of(Time.zone.local(2020, 1, 1))
+      expect(carrots.on_hand).to eq(9000)
+      expect(carrots.tax_category_id).to eq(tax_category.id)
+      expect(carrots.shipping_category_id).to eq(shipping_category.id)
+      expect(carrots.available_on).to be_within(1.day).of(Time.zone.local(2020, 1, 1))
 
       potatoes = Spree::Product.find_by_name('Potatoes')
-      potatoes.on_hand.should == 9000
-      potatoes.tax_category_id.should == tax_category2.id
-      potatoes.shipping_category_id.should == shipping_category.id
-      potatoes.available_on.should be_within(1.day).of(Time.zone.local(2020, 1, 1))
+      expect(potatoes.on_hand).to eq(9000)
+      expect(potatoes.tax_category_id).to eq(tax_category2.id)
+      expect(potatoes.shipping_category_id).to eq(shipping_category.id)
+      expect(potatoes.available_on).to be_within(1.day).of(Time.zone.local(2020, 1, 1))
     end
   end
 end

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -40,23 +40,23 @@ feature %q{
       click_button 'Create'
 
       expect(current_path).to eq spree.bulk_edit_admin_products_path
-      flash_message.should == 'Product "A new product !!!" has been successfully created!'
+      expect(flash_message).to eq('Product "A new product !!!" has been successfully created!')
       product = Spree::Product.find_by_name('A new product !!!')
-      product.supplier.should == @supplier
-      product.variant_unit.should == 'weight'
-      product.variant_unit_scale.should == 1000
-      product.unit_value.should == 5000
-      product.unit_description.should == ""
-      product.variant_unit_name.should == ""
-      product.primary_taxon_id.should == taxon.id
-      product.price.to_s.should == '19.99'
-      product.on_hand.should == 5
-      product.tax_category_id.should == tax_category.id
-      product.shipping_category.should == shipping_category
-      product.description.should == "A description..."
-      product.group_buy.should be_falsey
-      product.master.option_values.map(&:name).should == ['5kg']
-      product.master.options_text.should == "5kg"
+      expect(product.supplier).to eq(@supplier)
+      expect(product.variant_unit).to eq('weight')
+      expect(product.variant_unit_scale).to eq(1000)
+      expect(product.unit_value).to eq(5000)
+      expect(product.unit_description).to eq("")
+      expect(product.variant_unit_name).to eq("")
+      expect(product.primary_taxon_id).to eq(taxon.id)
+      expect(product.price.to_s).to eq('19.99')
+      expect(product.on_hand).to eq(5)
+      expect(product.tax_category_id).to eq(tax_category.id)
+      expect(product.shipping_category).to eq(shipping_category)
+      expect(product.description).to eq("A description...")
+      expect(product.group_buy).to be_falsey
+      expect(product.master.option_values.map(&:name)).to eq(['5kg'])
+      expect(product.master.options_text).to eq("5kg")
     end
 
     scenario "creating an on-demand product", js: true do
@@ -82,9 +82,9 @@ feature %q{
 
       expect(current_path).to eq spree.bulk_edit_admin_products_path
       product = Spree::Product.find_by_name('Hot Cakes')
-      product.variants.count.should == 1
+      expect(product.variants.count).to eq(1)
       variant = product.variants.first
-      variant.on_demand.should be true
+      expect(variant.on_demand).to be true
     end
   end
 
@@ -112,7 +112,7 @@ feature %q{
           fill_in 'product_name', :with => 'A new product !!!'
           fill_in 'product_price', :with => '19.99'
 
-          page.should have_selector('#product_supplier_id')
+          expect(page).to have_selector('#product_supplier_id')
           select 'Another Supplier', :from => 'product_supplier_id'
           select 'Weight (g)', from: 'product_variant_unit_with_scale'
           fill_in 'product_unit_value_with_description', with: '500'
@@ -120,15 +120,15 @@ feature %q{
           select 'None', from: "product_tax_category_id"
 
           # Should only have suppliers listed which the user can manage
-          page.should have_select 'product_supplier_id', with_options: [@supplier2.name, @supplier_permitted.name]
-          page.should_not have_select 'product_supplier_id', with_options: [@supplier.name]
+          expect(page).to have_select 'product_supplier_id', with_options: [@supplier2.name, @supplier_permitted.name]
+          expect(page).not_to have_select 'product_supplier_id', with_options: [@supplier.name]
 
           click_button 'Create'
 
-          flash_message.should == 'Product "A new product !!!" has been successfully created!'
+          expect(flash_message).to eq('Product "A new product !!!" has been successfully created!')
           product = Spree::Product.find_by_name('A new product !!!')
-          product.supplier.should == @supplier2
-          product.tax_category.should be_nil
+          expect(product.supplier).to eq(@supplier2)
+          expect(product.tax_category).to be_nil
         end
       end
     end
@@ -141,10 +141,10 @@ feature %q{
       select 'Permitted Supplier', from: 'product_supplier_id'
       select tax_category.name, from: 'product_tax_category_id'
       click_button 'Update'
-      flash_message.should == 'Product "a product" has been successfully updated!'
+      expect(flash_message).to eq('Product "a product" has been successfully updated!')
       product.reload
-      product.supplier.should == @supplier_permitted
-      product.tax_category.should == tax_category
+      expect(product.supplier).to eq(@supplier_permitted)
+      expect(product.tax_category).to eq(tax_category)
     end
 
     scenario "editing product group buy options" do
@@ -157,10 +157,10 @@ feature %q{
 
       click_button 'Update'
 
-      flash_message.should == "Product \"#{product.name}\" has been successfully updated!"
+      expect(flash_message).to eq("Product \"#{product.name}\" has been successfully updated!")
       product.reload
-      product.group_buy.should be true
-      product.group_buy_unit_size.should == 10.0
+      expect(product.group_buy).to be true
+      expect(product.group_buy_unit_size).to eq(10.0)
     end
 
     scenario "editing product distributions" do
@@ -174,14 +174,14 @@ feature %q{
 
       # Should only have distributors listed which the user can manage
       within "#product_product_distributions_field" do
-        page.should_not have_content @distributors[1].name
-        page.should_not have_content @distributors[2].name
+        expect(page).not_to have_content @distributors[1].name
+        expect(page).not_to have_content @distributors[2].name
       end
 
       click_button 'Update'
-      flash_message.should == "Product \"#{product.name}\" has been successfully updated!"
+      expect(flash_message).to eq("Product \"#{product.name}\" has been successfully updated!")
 
-      product.distributors.should == [@distributors[0]]
+      expect(product.distributors).to eq([@distributors[0]])
     end
 
     scenario "editing product Search" do
@@ -204,16 +204,16 @@ feature %q{
 
       # When I navigate to the product properties page
       visit spree.admin_product_product_properties_path(p)
-      page.should have_select2 'product_product_properties_attributes_0_property_name', selected: 'fooprop'
-      page.should have_field 'product_product_properties_attributes_0_value', with: 'fooval'
+      expect(page).to have_select2 'product_product_properties_attributes_0_property_name', selected: 'fooprop'
+      expect(page).to have_field 'product_product_properties_attributes_0_value', with: 'fooval'
 
       # And I delete the property
       page.all('a.remove_fields').first.click
       click_button 'Update'
 
       # Then the property should have been deleted
-      page.should_not have_field 'product_product_properties_attributes_0_property_name', with: 'fooprop'
-      page.should_not have_field 'product_product_properties_attributes_0_value', with: 'fooval'
+      expect(page).not_to have_field 'product_product_properties_attributes_0_property_name', with: 'fooprop'
+      expect(page).not_to have_field 'product_product_properties_attributes_0_value', with: 'fooval'
       expect(p.reload.property('fooprop')).to be_nil
     end
 
@@ -224,13 +224,13 @@ feature %q{
       Spree::Image.create({:viewable_id => product.master.id, :viewable_type => 'Spree::Variant', :alt => "position 1", :attachment => image, :position => 1})
 
       visit spree.admin_product_images_path(product)
-      page.should have_selector "table[data-hook='images_table'] td img"
-      product.reload.images.count.should == 1
+      expect(page).to have_selector "table[data-hook='images_table'] td img"
+      expect(product.reload.images.count).to eq(1)
 
       page.find('a.delete-resource').click
       wait_until { product.reload.images.count == 0 }
 
-      page.should_not have_selector "table[data-hook='images_table'] td img"
+      expect(page).not_to have_selector "table[data-hook='images_table'] td img"
     end
   end
 end

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -17,16 +17,16 @@ feature %q{
       it "does not show super admin only reports" do
         login_to_admin_as user
         click_link "Reports"
-        page.should_not have_content "Sales Total"
-        page.should_not have_content "Users & Enterprises"
+        expect(page).not_to have_content "Sales Total"
+        expect(page).not_to have_content "Users & Enterprises"
       end
     end
     context "As an admin user" do
       it "shows the super admin only reports" do
         login_to_admin_section
         click_link "Reports"
-        page.should have_content "Sales Total"
-        page.should have_content "Users & Enterprises"
+        expect(page).to have_content "Sales Total"
+        expect(page).to have_content "Users & Enterprises"
       end
     end
   end
@@ -42,9 +42,9 @@ feature %q{
 
       rows = find("table#listing_customers").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-      table.sort.should == [
+      expect(table.sort).to eq([
         ["Email", "First Name", "Last Name", "Suburb"]
-      ].sort
+      ].sort)
     end
 
     scenario "customers report" do
@@ -53,9 +53,9 @@ feature %q{
 
       rows = find("table#listing_customers").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-      table.sort.should == [
+      expect(table.sort).to eq([
         ["First Name", "Last Name", "Billing Address", "Email", "Phone", "Hub", "Hub Address", "Shipping Method"]
-      ].sort
+      ].sort)
     end
   end
 
@@ -69,18 +69,18 @@ feature %q{
       click_link "Payment Methods Report"
       rows = find("table#listing_ocm_orders").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-      table.sort.should == [
+      expect(table.sort).to eq([
         ["First Name", "Last Name", "Hub", "Hub Code", "Email", "Phone", "Shipping Method", "Payment Method", "Amount", "Balance"]
-      ].sort
+      ].sort)
     end
 
     scenario "delivery report" do
       click_link "Delivery Report"
       rows = find("table#listing_ocm_orders").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-      table.sort.should == [
+      expect(table.sort).to eq([
         ["First Name", "Last Name", "Hub", "Hub Code", "Delivery Address", "Delivery Postcode", "Phone", "Shipping Method", "Payment Method", "Amount", "Balance", "Temp Controlled Items?", "Special Instructions"]
-      ].sort
+      ].sort)
     end
   end
 
@@ -121,10 +121,10 @@ feature %q{
 
       rows = find("table#listing_orders.index").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-      table.sort.should == [
+      expect(table.sort).to eq([
         ["Hub", "Code", "First Name", "Last Name", "Supplier", "Product", "Variant", "Quantity", "TempControlled?"]
-      ].sort
-      page.should have_selector 'table#listing_orders tbody tr', count: 5 # Totals row per order
+      ].sort)
+      expect(page).to have_selector 'table#listing_orders tbody tr', count: 5 # Totals row per order
     end
 
     scenario "Pack By Supplier" do
@@ -136,10 +136,10 @@ feature %q{
 
       rows = find("table#listing_orders").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
-      table.sort.should == [
+      expect(table.sort).to eq([
         ["Hub", "Supplier", "Code", "First Name", "Last Name", "Product", "Variant", "Quantity", "TempControlled?"]
-      ].sort
-      all('table#listing_orders tbody tr').count.should == 4 # Totals row per supplier
+      ].sort)
+      expect(all('table#listing_orders tbody tr').count).to eq(4) # Totals row per supplier
     end
   end
 
@@ -149,7 +149,7 @@ feature %q{
     click_link 'Reports'
     click_link 'Orders And Distributors'
 
-    page.should have_content 'Order date'
+    expect(page).to have_content 'Order date'
   end
 
   scenario "bulk co-op report" do
@@ -157,7 +157,7 @@ feature %q{
     click_link 'Reports'
     click_link 'Bulk Co-Op'
 
-    page.should have_content 'Supplier'
+    expect(page).to have_content 'Supplier'
   end
 
   scenario "payments reports" do
@@ -165,7 +165,7 @@ feature %q{
     click_link 'Reports'
     click_link 'Payment Reports'
 
-    page.should have_content 'Payment State'
+    expect(page).to have_content 'Payment State'
   end
 
   describe "sales tax report" do
@@ -204,28 +204,28 @@ feature %q{
 
     it "reports" do
       # Then it should give me access only to managed enterprises
-      page.should     have_select 'q_distributor_id_eq', with_options: [user1.enterprises.first.name]
-      page.should_not have_select 'q_distributor_id_eq', with_options: [user2.enterprises.first.name]
+      expect(page).to     have_select 'q_distributor_id_eq', with_options: [user1.enterprises.first.name]
+      expect(page).not_to have_select 'q_distributor_id_eq', with_options: [user2.enterprises.first.name]
 
       # When I filter to just one distributor
       select user1.enterprises.first.name, from: 'q_distributor_id_eq'
       click_button 'Search'
 
       # Then I should see the relevant order
-      page.should have_content "#{order1.number}"
+      expect(page).to have_content "#{order1.number}"
 
       # And the totals and sales tax should be correct
-      page.should     have_content "1512.99" # items total
-      page.should     have_content "1500.45" # taxable items total
-      page.should     have_content "250.08" # sales tax
-      page.should     have_content "20.0" # enterprise fee tax
+      expect(page).to     have_content "1512.99" # items total
+      expect(page).to     have_content "1500.45" # taxable items total
+      expect(page).to     have_content "250.08" # sales tax
+      expect(page).to     have_content "20.0" # enterprise fee tax
 
       # And the shipping cost and tax should be correct
-      page.should have_content "100.55" # shipping cost
-      page.should have_content "16.76" # shipping tax
+      expect(page).to have_content "100.55" # shipping cost
+      expect(page).to have_content "16.76" # shipping tax
 
       # And the total tax should be correct
-      page.should have_content "286.84" # total tax
+      expect(page).to have_content "286.84" # total tax
     end
   end
 
@@ -235,7 +235,7 @@ feature %q{
       click_link 'Reports'
       click_link 'Orders & Fulfillment Reports'
 
-      page.should have_content 'Supplier'
+      expect(page).to have_content 'Supplier'
     end
 
     context "with two orders on the same day at different times" do
@@ -267,7 +267,7 @@ feature %q{
         click_button 'Search'
 
         # Then I should see the rows for the first order but not the second
-        all('table#listing_orders tbody tr').count.should == 2 # Two rows per order
+        expect(all('table#listing_orders tbody tr').count).to eq(2) # Two rows per order
       end
     end
 
@@ -279,7 +279,7 @@ feature %q{
       login_to_admin_section
       visit spree.orders_and_fulfillment_admin_reports_path
 
-      page.should have_content "My Order Cycle"
+      expect(page).to have_content "My Order Cycle"
     end
   end
 
@@ -311,14 +311,14 @@ feature %q{
       login_to_admin_section
       click_link 'Reports'
 
-      page.should have_content "All products"
-      page.should have_content "Inventory (on hand)"
+      expect(page).to have_content "All products"
+      expect(page).to have_content "Inventory (on hand)"
       click_link 'Products & Inventory'
-      page.should have_content "Supplier"
-      page.should have_table_row ["Supplier", "Producer Suburb", "Product", "Product Properties", "Taxons", "Variant Value", "Price", "Group Buy Unit Quantity", "Amount", "SKU"].map(&:upcase)
-      page.should have_table_row [product1.supplier.name, product1.supplier.address.city, "Product Name", product1.properties.map(&:presentation).join(", "), product1.primary_taxon.name,  "Test",           "100.0",  product1.group_buy_unit_size.to_s, "",       "sku1"]
-      page.should have_table_row [product1.supplier.name, product1.supplier.address.city, "Product Name", product1.properties.map(&:presentation).join(", "), product1.primary_taxon.name,  "Something",      "80.0",   product1.group_buy_unit_size.to_s, "",       "sku2"]
-      page.should have_table_row [product2.supplier.name, product1.supplier.address.city, "Product 2",    product1.properties.map(&:presentation).join(", "), product2.primary_taxon.name,  "100g",           "99.0",   product1.group_buy_unit_size.to_s, "",       "product_sku"]
+      expect(page).to have_content "Supplier"
+      expect(page).to have_table_row ["Supplier", "Producer Suburb", "Product", "Product Properties", "Taxons", "Variant Value", "Price", "Group Buy Unit Quantity", "Amount", "SKU"].map(&:upcase)
+      expect(page).to have_table_row [product1.supplier.name, product1.supplier.address.city, "Product Name", product1.properties.map(&:presentation).join(", "), product1.primary_taxon.name,  "Test",           "100.0",  product1.group_buy_unit_size.to_s, "",       "sku1"]
+      expect(page).to have_table_row [product1.supplier.name, product1.supplier.address.city, "Product Name", product1.properties.map(&:presentation).join(", "), product1.primary_taxon.name,  "Something",      "80.0",   product1.group_buy_unit_size.to_s, "",       "sku2"]
+      expect(page).to have_table_row [product2.supplier.name, product1.supplier.address.city, "Product 2",    product1.properties.map(&:presentation).join(", "), product2.primary_taxon.name,  "100g",           "99.0",   product1.group_buy_unit_size.to_s, "",       "product_sku"]
     end
 
     it "shows the LettuceShare report" do
@@ -326,8 +326,8 @@ feature %q{
       click_link 'Reports'
       click_link 'LettuceShare'
 
-      page.should have_table_row ['PRODUCT', 'Description', 'Qty', 'Pack Size', 'Unit', 'Unit Price', 'Total', 'GST incl.', 'Grower and growing method', 'Taxon'].map(&:upcase)
-      page.should have_table_row ['Product 2', '100g', '', '100', 'g', '99.0', '', '0', 'Supplier Name (Organic - NASAA 12345)', 'Taxon Name']
+      expect(page).to have_table_row ['PRODUCT', 'Description', 'Qty', 'Pack Size', 'Unit', 'Unit Price', 'Total', 'GST incl.', 'Grower and growing method', 'Taxon'].map(&:upcase)
+      expect(page).to have_table_row ['Product 2', '100g', '', '100', 'g', '99.0', '', '0', 'Supplier Name (Organic - NASAA 12345)', 'Taxon Name']
     end
   end
 
@@ -349,7 +349,7 @@ feature %q{
       rows = find("table#users_and_enterprises").all("tr")
       table = rows.map { |r| r.all("th,td").map { |c| c.text.strip }[0..2] }
 
-      table.sort.should == [
+      expect(table.sort).to eq([
         [ "User", "Relationship", "Enterprise" ],
         [ enterprise1.owner.email, "owns", enterprise1.name ],
         [ enterprise1.owner.email, "manages", enterprise1.name ],
@@ -358,7 +358,7 @@ feature %q{
         [ enterprise3.owner.email, "owns", enterprise3.name ],
         [ enterprise3.owner.email, "manages", enterprise3.name ],
         [ enterprise1.owner.email, "manages", enterprise3.name ]
-      ].sort
+      ].sort)
     end
 
     it "filters the list" do
@@ -370,10 +370,10 @@ feature %q{
       rows = find("table#users_and_enterprises").all("tr")
       table = rows.map { |r| r.all("th,td").map { |c| c.text.strip }[0..2] }
 
-      table.sort.should == [
+      expect(table.sort).to eq([
         [ "User", "Relationship", "Enterprise" ],
         [ enterprise1.owner.email, "manages", enterprise3.name ]
-      ].sort
+      ].sort)
     end
   end
 
@@ -421,7 +421,7 @@ feature %q{
     end
 
     it "shows Xero invoices report" do
-      xero_invoice_table.should match_table [
+      expect(xero_invoice_table).to match_table [
         xero_invoice_header,
         xero_invoice_summary_row('Total untaxable produce (no tax)',       12.54, 'GST Free Income'),
         xero_invoice_summary_row('Total taxable produce (tax inclusive)',  1500.45, 'GST on Income'),
@@ -442,7 +442,7 @@ feature %q{
 
       opts = {invoice_number: '5', invoice_date: '2015-02-12', due_date: '2015-03-12', account_code: 'abc123'}
 
-      xero_invoice_table.should match_table [
+      expect(xero_invoice_table).to match_table [
         xero_invoice_header,
         xero_invoice_summary_row('Total untaxable produce (no tax)',       12.54,   'GST Free Income', opts),
         xero_invoice_summary_row('Total taxable produce (tax inclusive)',  1500.45, 'GST on Income',   opts),
@@ -460,7 +460,7 @@ feature %q{
 
       opts = {}
 
-      xero_invoice_table.should match_table [
+      expect(xero_invoice_table).to match_table [
         xero_invoice_header,
         xero_invoice_li_row(line_item1),
         xero_invoice_li_row(line_item2),
@@ -495,7 +495,7 @@ feature %q{
 
         opts = {}
 
-        xero_invoice_table.should match_table [
+        expect(xero_invoice_table).to match_table [
           xero_invoice_header,
           xero_invoice_account_invoice_row(adjustment)
         ]

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -20,10 +20,10 @@ feature 'shipping methods' do
 
       # Shows appropriate fields when logged in as admin
       visit spree.new_admin_shipping_method_path
-      page.should have_field 'shipping_method_name'
-      page.should have_field 'shipping_method_description'
-      page.should have_select 'shipping_method_display_on'
-      page.should have_field 'shipping_method_require_ship_address_true', checked: true
+      expect(page).to have_field 'shipping_method_name'
+      expect(page).to have_field 'shipping_method_description'
+      expect(page).to have_select 'shipping_method_display_on'
+      expect(page).to have_field 'shipping_method_require_ship_address_true', checked: true
 
       # When I create a shipping method and set the distributors
       fill_in 'shipping_method_name', with: 'Carrier Pidgeon'
@@ -32,11 +32,11 @@ feature 'shipping methods' do
       click_button 'Create'
 
       # Then the shipping method should have its distributor set
-      flash_message.should == 'Shipping method "Carrier Pidgeon" has been successfully created!'
+      expect(flash_message).to eq('Shipping method "Carrier Pidgeon" has been successfully created!')
 
       sm = Spree::ShippingMethod.last
-      sm.name.should == 'Carrier Pidgeon'
-      sm.distributors.should match_array [d1, d2]
+      expect(sm.name).to eq('Carrier Pidgeon')
+      expect(sm.distributors).to match_array [d1, d2]
     end
 
     it "at checkout, user can only see shipping methods for their current distributor (checkout spec)"
@@ -45,8 +45,8 @@ feature 'shipping methods' do
     scenario "deleting a shipping method" do
       visit_delete spree.admin_shipping_method_path(@sm)
 
-      page.should have_content "Shipping method \"#{@sm.name}\" has been successfully removed!"
-      Spree::ShippingMethod.where(:id => @sm.id).should be_empty
+      expect(page).to have_content "Shipping method \"#{@sm.name}\" has been successfully removed!"
+      expect(Spree::ShippingMethod.where(:id => @sm.id)).to be_empty
     end
 
     scenario "deleting a shipping method referenced by an order" do
@@ -56,8 +56,8 @@ feature 'shipping methods' do
 
       visit_delete spree.admin_shipping_method_path(@sm)
 
-      page.should have_content "That shipping method cannot be deleted as it is referenced by an order: #{o.number}."
-      Spree::ShippingMethod.find(@sm.id).should_not be_nil
+      expect(page).to have_content "That shipping method cannot be deleted as it is referenced by an order: #{o.number}."
+      expect(Spree::ShippingMethod.find(@sm.id)).not_to be_nil
     end
   end
 
@@ -85,10 +85,10 @@ feature 'shipping methods' do
       click_link 'Create One Now'
 
       # Show the correct fields
-      page.should have_field 'shipping_method_name'
-      page.should have_field 'shipping_method_description'
-      page.should_not have_select 'shipping_method_display_on'
-      page.should have_field 'shipping_method_require_ship_address_true', checked: true
+      expect(page).to have_field 'shipping_method_name'
+      expect(page).to have_field 'shipping_method_description'
+      expect(page).not_to have_select 'shipping_method_display_on'
+      expect(page).to have_field 'shipping_method_require_ship_address_true', checked: true
 
       fill_in 'shipping_method_name', :with => 'Teleport'
 
@@ -97,12 +97,12 @@ feature 'shipping methods' do
 
       click_button 'Create'
 
-      flash_message.should == 'Shipping method "Teleport" has been successfully created!'
+      expect(flash_message).to eq('Shipping method "Teleport" has been successfully created!')
       expect(first('tags-input .tag-list ti-tag-item')).to have_content "local"
 
       shipping_method = Spree::ShippingMethod.find_by_name('Teleport')
-      shipping_method.distributors.should == [distributor1]
-      shipping_method.tag_list.should == ["local"]
+      expect(shipping_method.distributors).to eq([distributor1])
+      expect(shipping_method.tag_list).to eq(["local"])
     end
 
     it "shows me only shipping methods I have access to" do
@@ -112,9 +112,9 @@ feature 'shipping methods' do
 
       visit spree.admin_shipping_methods_path
 
-      page.should     have_content sm1.name
-      page.should     have_content sm2.name
-      page.should_not have_content sm3.name
+      expect(page).to     have_content sm1.name
+      expect(page).to     have_content sm2.name
+      expect(page).not_to have_content sm3.name
     end
 
     it "does not show duplicates of shipping methods" do
@@ -123,7 +123,7 @@ feature 'shipping methods' do
 
       visit spree.admin_shipping_methods_path
 
-      page.should have_selector 'td', text: 'Two', count: 1
+      expect(page).to have_selector 'td', text: 'Two', count: 1
     end
 
     pending "shows me only shipping methods for the enterprise I select" do
@@ -135,8 +135,8 @@ feature 'shipping methods' do
       within(".side_menu") do
         click_link "Shipping Methods"
       end
-      page.should     have_content sm1.name
-      page.should     have_content sm2.name
+      expect(page).to     have_content sm1.name
+      expect(page).to     have_content sm2.name
 
       click_link 'Enterprises'
       within("#e_#{distributor2.id}") { click_link 'Manage' }
@@ -144,8 +144,8 @@ feature 'shipping methods' do
         click_link "Shipping Methods"
       end
 
-      page.should_not have_content sm1.name
-      page.should     have_content sm2.name
+      expect(page).not_to have_content sm1.name
+      expect(page).to     have_content sm2.name
     end
   end
 end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -36,7 +36,7 @@ feature %q{
         click_link 'Products'
         click_link 'Inventory'
 
-        page.should have_select2 'hub_id', options: [hub.name] # Selects the hub automatically when only one is available
+        expect(page).to have_select2 'hub_id', options: [hub.name] # Selects the hub automatically when only one is available
       end
     end
 
@@ -69,20 +69,20 @@ feature %q{
 
         context "with no overrides" do
           it "displays the list of products with variants" do
-            page.should have_table_row ['PRODUCER', 'PRODUCT', 'PRICE', 'ON HAND', 'ON DEMAND?']
-            page.should have_table_row [producer.name, product.name, '', '', '']
-            page.should have_input "variant-overrides-#{variant.id}-price", placeholder: '1.23'
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", placeholder: '12'
+            expect(page).to have_table_row ['PRODUCER', 'PRODUCT', 'PRICE', 'ON HAND', 'ON DEMAND?']
+            expect(page).to have_table_row [producer.name, product.name, '', '', '']
+            expect(page).to have_input "variant-overrides-#{variant.id}-price", placeholder: '1.23'
+            expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", placeholder: '12'
 
-            page.should have_table_row [producer_related.name, product_related.name, '', '', '']
-            page.should have_input "variant-overrides-#{variant_related.id}-price", placeholder: '2.34'
-            page.should have_input "variant-overrides-#{variant_related.id}-count_on_hand", placeholder: '23'
+            expect(page).to have_table_row [producer_related.name, product_related.name, '', '', '']
+            expect(page).to have_input "variant-overrides-#{variant_related.id}-price", placeholder: '2.34'
+            expect(page).to have_input "variant-overrides-#{variant_related.id}-count_on_hand", placeholder: '23'
 
             # filters the products to those the hub can override
-            page.should_not have_content producer_managed.name
-            page.should_not have_content product_managed.name
-            page.should_not have_content producer_unrelated.name
-            page.should_not have_content product_unrelated.name
+            expect(page).not_to have_content producer_managed.name
+            expect(page).not_to have_content product_managed.name
+            expect(page).not_to have_content producer_unrelated.name
+            expect(page).not_to have_content product_unrelated.name
 
             # Filters based on the producer select filter
             expect(page).to have_selector "#v_#{variant.id}"
@@ -142,20 +142,20 @@ feature %q{
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
             check "variant-overrides-#{variant.id}-on_demand"
-            page.should have_content "Changes to one override remain unsaved."
+            expect(page).to have_content "Changes to one override remain unsaved."
 
             expect do
               click_button 'Save Changes'
-              page.should have_content "Changes saved."
+              expect(page).to have_content "Changes saved."
             end.to change(VariantOverride, :count).by(1)
 
             vo = VariantOverride.last
-            vo.variant_id.should == variant.id
-            vo.hub_id.should == hub.id
-            vo.sku.should == "NEWSKU"
-            vo.price.should == 777.77
-            vo.count_on_hand.should == 123
-            vo.on_demand.should == true
+            expect(vo.variant_id).to eq(variant.id)
+            expect(vo.hub_id).to eq(hub.id)
+            expect(vo.sku).to eq("NEWSKU")
+            expect(vo.price).to eq(777.77)
+            expect(vo.count_on_hand).to eq(123)
+            expect(vo.on_demand).to eq(true)
           end
 
           describe "creating and then updating the new override" do
@@ -163,56 +163,56 @@ feature %q{
               # When I create a new override
               fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
-              page.should have_content "Changes to one override remain unsaved."
+              expect(page).to have_content "Changes to one override remain unsaved."
 
               expect do
                 click_button 'Save Changes'
-                page.should have_content "Changes saved."
+                expect(page).to have_content "Changes saved."
               end.to change(VariantOverride, :count).by(1)
 
               # And I update its settings without reloading the page
               fill_in "variant-overrides-#{variant.id}-price", with: '111.11'
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '111'
-              page.should have_content "Changes to one override remain unsaved."
+              expect(page).to have_content "Changes to one override remain unsaved."
 
               # Then I shouldn't see a new override
               expect do
                 click_button 'Save Changes'
-                page.should have_content "Changes saved."
+                expect(page).to have_content "Changes saved."
               end.to change(VariantOverride, :count).by(0)
 
               # And the override should be updated
               vo = VariantOverride.last
-              vo.variant_id.should == variant.id
-              vo.hub_id.should == hub.id
-              vo.price.should == 111.11
-              vo.count_on_hand.should == 111
+              expect(vo.variant_id).to eq(variant.id)
+              expect(vo.hub_id).to eq(hub.id)
+              expect(vo.price).to eq(111.11)
+              expect(vo.count_on_hand).to eq(111)
             end
           end
 
           it "displays an error when unauthorised to access the page" do
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
-            page.should have_content "Changes to one override remain unsaved."
+            expect(page).to have_content "Changes to one override remain unsaved."
 
             user.enterprises.clear
 
             expect do
               click_button 'Save Changes'
-              page.should have_content "I couldn't get authorisation to save those changes, so they remain unsaved."
+              expect(page).to have_content "I couldn't get authorisation to save those changes, so they remain unsaved."
             end.to change(VariantOverride, :count).by(0)
           end
 
           it "displays an error when unauthorised to update a particular override" do
             fill_in "variant-overrides-#{variant_related.id}-price", with: '777.77'
             fill_in "variant-overrides-#{variant_related.id}-count_on_hand", with: '123'
-            page.should have_content "Changes to one override remain unsaved."
+            expect(page).to have_content "Changes to one override remain unsaved."
 
             er2.destroy
 
             expect do
               click_button 'Save Changes'
-              page.should have_content "I couldn't get authorisation to save those changes, so they remain unsaved."
+              expect(page).to have_content "I couldn't get authorisation to save those changes, so they remain unsaved."
             end.to change(VariantOverride, :count).by(0)
           end
         end
@@ -234,25 +234,25 @@ feature %q{
           end
 
           it "product values are affected by overrides" do
-            page.should have_input "variant-overrides-#{variant.id}-price", with: '77.77', placeholder: '1.23'
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: '12'
+            expect(page).to have_input "variant-overrides-#{variant.id}-price", with: '77.77', placeholder: '1.23'
+            expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: '12'
           end
 
           it "updates existing overrides" do
             fill_in "variant-overrides-#{variant.id}-price", with: '22.22'
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '8888'
-            page.should have_content "Changes to one override remain unsaved."
+            expect(page).to have_content "Changes to one override remain unsaved."
 
             expect do
               click_button 'Save Changes'
-              page.should have_content "Changes saved."
+              expect(page).to have_content "Changes saved."
             end.to change(VariantOverride, :count).by(0)
 
             vo.reload
-            vo.variant_id.should == variant.id
-            vo.hub_id.should == hub.id
-            vo.price.should == 22.22
-            vo.count_on_hand.should == 8888
+            expect(vo.variant_id).to eq(variant.id)
+            expect(vo.hub_id).to eq(hub.id)
+            expect(vo.price).to eq(22.22)
+            expect(vo.count_on_hand).to eq(8888)
           end
 
           # Any new fields added to the VO model need to be added to this test
@@ -281,39 +281,39 @@ feature %q{
               end
             end
             page.uncheck "variant-overrides-#{variant.id}-resettable"
-            page.should have_content "Changes to 2 overrides remain unsaved."
+            expect(page).to have_content "Changes to 2 overrides remain unsaved."
 
             expect do
               click_button 'Save Changes'
-              page.should have_content "Changes saved."
+              expect(page).to have_content "Changes saved."
             end.to change(VariantOverride, :count).by(-2)
 
-            VariantOverride.where(id: vo.id).should be_empty
-            VariantOverride.where(id: vo3.id).should be_empty
+            expect(VariantOverride.where(id: vo.id)).to be_empty
+            expect(VariantOverride.where(id: vo3.id)).to be_empty
           end
 
           it "resets stock to defaults" do
             first("div#bulk-actions-dropdown").click
             first("div#bulk-actions-dropdown div.menu div.menu_item", text: "Reset Stock Levels To Defaults").click
-            page.should have_content 'Stocks reset to defaults.'
+            expect(page).to have_content 'Stocks reset to defaults.'
             vo.reload
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '1000', placeholder: '12'
-            vo.count_on_hand.should == 1000
+            expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: '1000', placeholder: '12'
+            expect(vo.count_on_hand).to eq(1000)
           end
 
           it "doesn't reset stock levels if the behaviour is disabled" do
             first("div#bulk-actions-dropdown").click
             first("div#bulk-actions-dropdown div.menu div.menu_item", text: "Reset Stock Levels To Defaults").click
             vo_no_reset.reload
-            page.should have_input "variant-overrides-#{variant2.id}-count_on_hand", with: '40', placeholder: '12'
-            vo_no_reset.count_on_hand.should == 40
+            expect(page).to have_input "variant-overrides-#{variant2.id}-count_on_hand", with: '40', placeholder: '12'
+            expect(vo_no_reset.count_on_hand).to eq(40)
           end
 
           it "prompts to save changes before reset if any are pending" do
             fill_in "variant-overrides-#{variant.id}-price", with: '200'
             first("div#bulk-actions-dropdown").click
             first("div#bulk-actions-dropdown div.menu div.menu_item", text: "Reset Stock Levels To Defaults").click
-            page.should have_content "Save changes first"
+            expect(page).to have_content "Save changes first"
           end
         end
       end

--- a/spec/features/admin/variants_spec.rb
+++ b/spec/features/admin/variants_spec.rb
@@ -21,7 +21,7 @@ feature %q{
     click_button 'Create'
 
     # Then the variant should have been created
-    page.should have_content "Variant \"#{p.name}\" has been successfully created!"
+    expect(page).to have_content "Variant \"#{p.name}\" has been successfully created!"
   end
 
 
@@ -43,19 +43,19 @@ feature %q{
     expect(page).to_not have_selector "div[data-hook='presentation'] input"
 
     # And I should see unit value and description fields for the unit-related option value
-    page.should have_field "unit_value_human", with: "1"
-    page.should have_field "variant_unit_description", with: "foo"
+    expect(page).to have_field "unit_value_human", with: "1"
+    expect(page).to have_field "variant_unit_description", with: "foo"
 
     # When I update the fields and save the variant
     fill_in "unit_value_human", with: "123"
     fill_in "variant_unit_description", with: "bar"
     click_button 'Update'
-    page.should have_content %Q(Variant "#{p.name}" has been successfully updated!)
+    expect(page).to have_content %Q(Variant "#{p.name}" has been successfully updated!)
 
     # Then the unit value and description should have been saved
     v.reload
-    v.unit_value.should == 123
-    v.unit_description.should == 'bar'
+    expect(v.unit_value).to eq(123)
+    expect(v.unit_description).to eq('bar')
   end
 
   it "soft-deletes variants", js: true do
@@ -69,10 +69,10 @@ feature %q{
       page.find('a.delete-resource').click
     end
 
-    page.should_not have_selector "tr#spree_variant_#{v.id}"
+    expect(page).not_to have_selector "tr#spree_variant_#{v.id}"
 
 
     v.reload
-    v.deleted_at.should_not be_nil
+    expect(v.deleted_at).not_to be_nil
   end
 end

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -17,7 +17,7 @@ feature "Authentication", js: true, retry: 3 do
         fill_in "Email", with: user.email
         fill_in "Password", with: user.password
         click_login_button
-        page.should have_content "Find local producers"
+        expect(page).to have_content "Find local producers"
         expect(page).to have_current_path producers_path
       end
     end
@@ -32,20 +32,20 @@ feature "Authentication", js: true, retry: 3 do
           open_login_modal
         end
         scenario "showing login" do
-          page.should have_login_modal
+          expect(page).to have_login_modal
         end
 
         scenario "failing to login" do
           fill_in "Email", with: user.email
           click_login_button
-          page.should have_content "Invalid email or password"
+          expect(page).to have_content "Invalid email or password"
         end
 
         scenario "logging in successfully" do
           fill_in "Email", with: user.email
           fill_in "Password", with: user.password
           click_login_button
-          page.should be_logged_in_as user
+          expect(page).to be_logged_in_as user
         end
 
         describe "signing up" do
@@ -57,7 +57,7 @@ feature "Authentication", js: true, retry: 3 do
             fill_in "Email", with: "test@foo.com"
             fill_in "Choose a password", with: "short"
             click_signup_button
-            page.should have_content "too short"
+            expect(page).to have_content "too short"
           end
 
           scenario "Failing to sign up because email is already registered" do
@@ -97,16 +97,16 @@ feature "Authentication", js: true, retry: 3 do
           scenario "failing to reset password" do
             fill_in "Your email", with: "notanemail@myemail.com"
             click_reset_password_button
-            page.should have_content "Email address not found"
+            expect(page).to have_content "Email address not found"
           end
 
           scenario "resetting password" do
             fill_in "Your email", with: user.email
             expect do
               click_reset_password_button
-              page.should have_reset_password
+              expect(page).to have_reset_password
             end.to enqueue_job Delayed::PerformableMethod
-            Delayed::Job.last.payload_object.method_name.should == :send_reset_password_instructions_without_delay
+            expect(Delayed::Job.last.payload_object.method_name).to eq(:send_reset_password_instructions_without_delay)
           end
         end
       end
@@ -117,7 +117,7 @@ feature "Authentication", js: true, retry: 3 do
         scenario "showing login" do
           open_off_canvas
           open_login_modal
-          page.should have_login_modal
+          expect(page).to have_login_modal
         end
       end
     end
@@ -133,7 +133,7 @@ feature "Authentication", js: true, retry: 3 do
     scenario "Loggin by typing login/ redirects to /#/login" do
       visit "/login"
       uri = URI.parse(current_url)
-      (uri.path + "#" + uri.fragment).should == '/#/login'
+      expect(uri.path + "#" + uri.fragment).to eq('/#/login')
     end
   end
 end

--- a/spec/features/consumer/external_services_spec.rb
+++ b/spec/features/consumer/external_services_spec.rb
@@ -14,26 +14,26 @@ feature 'External services' do
       end
 
       it "is not included in dev" do
-        Rails.env.stub(:development?) { true }
+        allow(Rails.env).to receive(:development?) { true }
         visit root_path
         expect(script_content(with: 'bugherd')).to be_nil
       end
 
       it "is included in staging" do
-        Rails.env.stub(:staging?) { true }
+        allow(Rails.env).to receive(:staging?) { true }
         visit root_path
         expect(script_content(with: 'bugherd')).not_to be_nil
       end
 
       it "is included in production" do
-        Rails.env.stub(:production?) { true }
+        allow(Rails.env).to receive(:production?) { true }
         visit root_path
         expect(script_content(with: 'bugherd')).not_to be_nil
       end
     end
 
     context "in an environment where BugHerd is displayed" do
-      before { Rails.env.stub(:staging?) { true } }
+      before { allow(Rails.env).to receive(:staging?) { true } }
 
       context "when there is no API key set" do
         before { Spree::Config.bugherd_api_key = nil }

--- a/spec/features/consumer/producers_spec.rb
+++ b/spec/features/consumer/producers_spec.rb
@@ -45,14 +45,14 @@ feature %q{
 
       toggle_filter 'Vegetables'
 
-      page.should_not have_content producer1.name
-      page.should     have_content producer2.name
+      expect(page).not_to have_content producer1.name
+      expect(page).to     have_content producer2.name
 
       toggle_filter 'Vegetables'
       toggle_filter 'Fruit'
 
-      page.should     have_content producer1.name
-      page.should_not have_content producer2.name
+      expect(page).to     have_content producer1.name
+      expect(page).not_to have_content producer2.name
     end
 
     describe "filtering by product property" do
@@ -61,36 +61,36 @@ feature %q{
 
         toggle_filter 'Organic'
 
-        page.should     have_content producer1.name
-        page.should_not have_content producer2.name
+        expect(page).to     have_content producer1.name
+        expect(page).not_to have_content producer2.name
 
         toggle_filter 'Organic'
         toggle_filter 'Biodynamic'
 
-        page.should_not have_content producer1.name
-        page.should     have_content producer2.name
+        expect(page).not_to have_content producer1.name
+        expect(page).to     have_content producer2.name
       end
     end
 
     it "shows all producers with expandable details" do
-      page.should have_content producer1.name
+      expect(page).to have_content producer1.name
       expand_active_table_node producer1.name
 
       # -- Taxons
-      page.should have_content 'Fruit'
+      expect(page).to have_content 'Fruit'
 
       # -- Properties
-      page.should have_content 'Organic' # Product property
-      page.should have_content 'Local'   # Producer property
+      expect(page).to have_content 'Organic' # Product property
+      expect(page).to have_content 'Local'   # Producer property
     end
 
     it "doesn't show invisible producers" do
-      page.should_not have_content invisible_producer.name
+      expect(page).not_to have_content invisible_producer.name
     end
 
     it "links to places to buy produce" do
       expand_active_table_node producer1.name
-      page.should have_link shop.name
+      expect(page).to have_link shop.name
     end
   end
 end

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -55,7 +55,7 @@ feature "Registration", js: true do
 
       # Filling in Contact Details
       fill_in 'enterprise_contact', with: 'Saskia Munroe'
-      page.should have_field 'enterprise_email_address', with: user.email
+      expect(page).to have_field 'enterprise_email_address', with: user.email
       fill_in 'enterprise_phone', with: '12 3456 7890'
       perform_and_ensure(:click_button, "Continue", lambda { page.has_content? 'Last step to add My Awesome Enterprise!' })
 

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -91,7 +91,7 @@ feature "full-page cart", js: true do
       end
 
       it "shows the total tax for the order, including product tax and tax on fees" do
-        page.should have_selector '.tax-total', text: '11.00' # 10 + 1
+        expect(page).to have_selector '.tax-total', text: '11.00' # 10 + 1
       end
     end
 

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -25,36 +25,36 @@ feature "As a consumer I want to check out my cart", js: true do
     quick_login_as user
     visit checkout_path
     within "section[role='main']" do
-      page.should_not have_content "Login"
-      page.should have_checkout_details
+      expect(page).not_to have_content "Login"
+      expect(page).to have_checkout_details
     end
   end
 
   it "renders the login buttons when logged out" do
     visit checkout_path
     within "section[role='main']" do
-      page.should have_content "Login"
+      expect(page).to have_content "Login"
       click_button "Login"
     end
-    page.should have_login_modal
+    expect(page).to have_login_modal
   end
 
   it "populates user details once logged in" do
     visit checkout_path
     within("section[role='main']") { click_button "Login" }
-    page.should have_login_modal
+    expect(page).to have_login_modal
     fill_in "Email", with: user.email
     fill_in "Password", with: user.password
     within(".login-modal") { click_button 'Login' }
     toggle_details
 
-    page.should have_field 'First Name', with: 'Foo'
-    page.should have_field 'Last Name', with: 'Bar'
+    expect(page).to have_field 'First Name', with: 'Foo'
+    expect(page).to have_field 'Last Name', with: 'Bar'
   end
 
   it "allows user to checkout as guest" do
     visit checkout_path
     checkout_as_guest
-    page.should have_checkout_details
+    expect(page).to have_checkout_details
   end
 end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -54,9 +54,9 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
       it "returns me to the cart with an error message" do
         visit checkout_path
 
-        page.should_not have_selector 'closing', text: "Checkout now"
-        page.should have_selector 'closing', text: "Your shopping cart"
-        page.should have_content "An item in your cart has become unavailable"
+        expect(page).not_to have_selector 'closing', text: "Checkout now"
+        expect(page).to have_selector 'closing', text: "Your shopping cart"
+        expect(page).to have_content "An item in your cart has become unavailable"
       end
     end
 
@@ -101,23 +101,23 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         end
 
         it "allows user to save default billing address and shipping address" do
-          user.bill_address.should be_nil
-          user.ship_address.should be_nil
+          expect(user.bill_address).to be_nil
+          expect(user.ship_address).to be_nil
 
-          order.bill_address.should be_nil
-          order.ship_address.should be_nil
+          expect(order.bill_address).to be_nil
+          expect(order.ship_address).to be_nil
 
           place_order
-          page.should have_content "Your order has been processed successfully"
+          expect(page).to have_content "Your order has been processed successfully"
 
-          order.reload.bill_address.address1.should eq '123 Your Head'
-          order.reload.ship_address.address1.should eq '123 Your Head'
+          expect(order.reload.bill_address.address1).to eq '123 Your Head'
+          expect(order.reload.ship_address.address1).to eq '123 Your Head'
 
-          order.customer.bill_address.address1.should eq '123 Your Head'
-          order.customer.ship_address.address1.should eq '123 Your Head'
+          expect(order.customer.bill_address.address1).to eq '123 Your Head'
+          expect(order.customer.ship_address.address1).to eq '123 Your Head'
 
-          user.reload.bill_address.address1.should eq '123 Your Head'
-          user.reload.ship_address.address1.should eq '123 Your Head'
+          expect(user.reload.bill_address.address1).to eq '123 Your Head'
+          expect(user.reload.ship_address.address1).to eq '123 Your Head'
         end
 
         it "it doesn't tell about previous orders" do
@@ -154,7 +154,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
           expect do
             place_order
-            page.should have_content "Your order has been processed successfully"
+            expect(page).to have_content "Your order has been processed successfully"
           end.to enqueue_job ConfirmOrderJob
         end
       end
@@ -219,26 +219,26 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
       it "shows the current distributor" do
         visit checkout_path
-        page.should have_content distributor.name
+        expect(page).to have_content distributor.name
       end
 
       it 'does not show the save as defalut address checkbox' do
-        page.should_not have_content "Save as default billing address"
-        page.should_not have_content "Save as default shipping address"
+        expect(page).not_to have_content "Save as default billing address"
+        expect(page).not_to have_content "Save as default shipping address"
       end
 
       it "shows a breakdown of the order price" do
         toggle_shipping
         choose sm2.name
 
-        page.should have_selector 'orderdetails .cart-total', text: with_currency(11.23)
-        page.should have_selector 'orderdetails .shipping', text: with_currency(4.56)
-        page.should have_selector 'orderdetails .total', text: with_currency(15.79)
+        expect(page).to have_selector 'orderdetails .cart-total', text: with_currency(11.23)
+        expect(page).to have_selector 'orderdetails .shipping', text: with_currency(4.56)
+        expect(page).to have_selector 'orderdetails .total', text: with_currency(15.79)
 
         # Tax should not be displayed in checkout, as the customer's choice of shipping method
         # affects the tax and we haven't written code to live-update the tax amount when they
         # make a change.
-        page.should_not have_content product.tax_category.name
+        expect(page).not_to have_content product.tax_category.name
       end
 
       it "shows all shipping methods in order by name" do
@@ -259,7 +259,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         end
         it "shows ship address forms when 'same as billing address' is unchecked" do
           uncheck "Shipping address same as billing address?"
-          find("#ship_address > div.visible").visible?.should be true
+          expect(find("#ship_address > div.visible").visible?).to be true
         end
       end
 
@@ -270,9 +270,9 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         it "shows shipping methods allowed by the rule" do
           # No rules in effect
           toggle_shipping
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).to have_content "Local"
 
           create(:filter_shipping_methods_tag_rule,
             enterprise: distributor,
@@ -288,25 +288,25 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
           checkout_as_guest
 
           # Default rule in effect, disallows access to 'Local'
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should_not have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).not_to have_content "Local"
 
           quick_login_as(user)
           visit checkout_path
 
           # Default rule in still effect, disallows access to 'Local'
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should_not have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).not_to have_content "Local"
 
           customer.update_attribute(:tag_list, "local")
           visit checkout_path
 
           # #local Customer can access 'Local' shipping method
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).to have_content "Local"
         end
       end
     end
@@ -319,9 +319,9 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
       end
 
       it "shows all available payment methods" do
-        page.should have_content pm1.name
-        page.should have_content pm2.name
-        page.should have_content pm3.name
+        expect(page).to have_content pm1.name
+        expect(page).to have_content pm2.name
+        expect(page).to have_content pm3.name
       end
 
       describe "purchasing" do
@@ -407,7 +407,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
           it "takes us to the order confirmation page when submitted with 'same as billing address' checked" do
             place_order
-            page.should have_content "Your order has been processed successfully"
+            expect(page).to have_content "Your order has been processed successfully"
           end
 
           it "takes us to the cart page with an error when a product becomes out of stock just before we purchase", js: true do
@@ -416,9 +416,9 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
             place_order
 
-            page.should_not have_content "Your order has been processed successfully"
-            page.should have_selector 'closing', text: "Your shopping cart"
-            page.should have_content "Out of Stock"
+            expect(page).not_to have_content "Your order has been processed successfully"
+            expect(page).to have_selector 'closing', text: "Your shopping cart"
+            expect(page).to have_content "Out of Stock"
           end
 
           context "when we are charged a shipping fee" do
@@ -426,12 +426,12 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
             it "creates a payment for the full amount inclusive of shipping" do
               place_order
-              page.should have_content "Your order has been processed successfully"
+              expect(page).to have_content "Your order has been processed successfully"
 
               # There are two orders - our order and our new cart
               o = Spree::Order.complete.first
-              o.adjustments.shipping.first.amount.should == 4.56
-              o.payments.first.amount.should == 10 + 1.23 + 4.56 # items + fees + shipping
+              expect(o.adjustments.shipping.first.amount).to eq(4.56)
+              expect(o.payments.first.amount).to eq(10 + 1.23 + 4.56) # items + fees + shipping
             end
           end
 
@@ -470,11 +470,11 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
                   fill_in 'Security Code', with: '123'
 
                   place_order
-                  page.should have_content "Your order has been processed successfully"
+                  expect(page).to have_content "Your order has been processed successfully"
 
                   # Order should have a payment with the correct amount
                   o = Spree::Order.complete.first
-                  o.payments.first.amount.should == 11.23
+                  expect(o.payments.first.amount).to eq(11.23)
                 end
 
                 it "shows the payment processing failed message when submitted with an invalid credit card" do
@@ -485,11 +485,11 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
                   fill_in 'Security Code', with: '123'
 
                   place_order
-                  page.should have_content 'Bogus Gateway: Forced failure'
+                  expect(page).to have_content 'Bogus Gateway: Forced failure'
 
                   # Does not show duplicate shipping fee
                   visit checkout_path
-                  page.should have_selector "th", text: "Shipping", count: 1
+                  expect(page).to have_selector "th", text: "Shipping", count: 1
                 end
               end
             end

--- a/spec/features/consumer/shopping/products_spec.rb
+++ b/spec/features/consumer/shopping/products_spec.rb
@@ -36,7 +36,7 @@ feature "As a consumer I want to view products", js: true do
         modal_should_be_open_for product
 
         within(".reveal-modal") do
-          html.should include("<p><b>Formatted</b> product description.</p>")
+          expect(html).to include("<p><b>Formatted</b> product description.</p>")
         end
       end
 
@@ -51,8 +51,8 @@ feature "As a consumer I want to view products", js: true do
         modal_should_be_open_for product
 
         within(".reveal-modal") do
-          html.should include("<p>Safe</p>")
-          html.should_not include("<script>alert('Dangerous!');</script>")
+          expect(html).to include("<p>Safe</p>")
+          expect(html).not_to include("<script>alert('Dangerous!');</script>")
         end
       end
     end

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -27,9 +27,9 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       # Then we should see the distributor and its logo
       visit shop_path
-      page.should have_text distributor.name
+      expect(page).to have_text distributor.name
       find("#tab_about a").click
-      first("distributor img")['src'].should include distributor.logo.url(:thumb)
+      expect(first("distributor img")['src']).to include distributor.logo.url(:thumb)
     end
 
     it "shows the producers for a distributor" do
@@ -38,7 +38,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       visit shop_path
       find("#tab_producers a").click
-      page.should have_content supplier.name
+      expect(page).to have_content supplier.name
     end
 
     describe "selecting an order cycle" do
@@ -47,7 +47,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
       it "selects an order cycle if only one is open" do
         exchange1.update_attribute :pickup_time, "turtles"
         visit shop_path
-        page.should have_selector "option[selected]", text: 'turtles'
+        expect(page).to have_selector "option[selected]", text: 'turtles'
       end
 
       describe "with multiple order cycles" do
@@ -60,9 +60,9 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
         it "shows a select with all order cycles, but doesn't show the products by default" do
           visit shop_path
-          page.should have_selector "option", text: 'frogs'
-          page.should have_selector "option", text: 'turtles'
-          page.should_not have_selector("input.button.right", visible: true)
+          expect(page).to have_selector "option", text: 'frogs'
+          expect(page).to have_selector "option", text: 'turtles'
+          expect(page).not_to have_selector("input.button.right", visible: true)
         end
 
         it "shows products after selecting an order cycle" do
@@ -70,16 +70,16 @@ feature "As a consumer I want to shop with a distributor", js: true do
           variant.update_attribute(:display_as, "rabbit")
           add_variant_to_order_cycle(exchange1, variant)
           visit shop_path
-          page.should_not have_content product.name
-          Spree::Order.last.order_cycle.should == nil
+          expect(page).not_to have_content product.name
+          expect(Spree::Order.last.order_cycle).to eq(nil)
 
           select "frogs", :from => "order_cycle_id"
-          page.should have_selector "products"
-          page.should have_content "Next order closing in 2 days"
-          Spree::Order.last.order_cycle.should == oc1
-          page.should have_content product.name
-          page.should have_content variant.display_name
-          page.should have_content variant.display_as
+          expect(page).to have_selector "products"
+          expect(page).to have_content "Next order closing in 2 days"
+          expect(Spree::Order.last.order_cycle).to eq(oc1)
+          expect(page).to have_content product.name
+          expect(page).to have_content variant.display_name
+          expect(page).to have_content variant.display_as
 
           open_product_modal product
           modal_should_be_open_for product
@@ -95,23 +95,23 @@ feature "As a consumer I want to shop with a distributor", js: true do
             # -- Selecting an order cycle
             visit shop_path
             select "turtles", from: "order_cycle_id"
-            page.should have_content with_currency(1020.99)
+            expect(page).to have_content with_currency(1020.99)
 
             # -- Cart shows correct price
             fill_in "variants[#{variant.id}]", with: 1
             show_cart
-            within("li.cart") { page.should have_content with_currency(1020.99) }
+            within("li.cart") { expect(page).to have_content with_currency(1020.99) }
 
             # -- Changing order cycle
             select "frogs", from: "order_cycle_id"
-            page.should have_content with_currency(19.99)
+            expect(page).to have_content with_currency(19.99)
 
             # -- Cart should be cleared
             # ng-animate means that the old product row is likely to be present, so we explicitly
             # fill in the quantity in the incoming row
-            page.should_not have_selector "tr.product-cart"
+            expect(page).not_to have_selector "tr.product-cart"
             within('product.ng-enter') { fill_in "variants[#{variant.id}]", with: 1 }
-            within("li.cart") { page.should have_content with_currency(19.99) }
+            within("li.cart") { expect(page).to have_content with_currency(19.99) }
           end
 
           describe "declining to clear the cart" do
@@ -128,11 +128,11 @@ feature "As a consumer I want to shop with a distributor", js: true do
               handle_js_confirm(false) do
                 select "frogs", from: "order_cycle_id"
                 show_cart
-                page.should have_selector "tr.product-cart"
-                page.should have_selector 'li.cart', text: '1 item'
+                expect(page).to have_selector "tr.product-cart"
+                expect(page).to have_selector 'li.cart', text: '1 item'
 
                 # The order cycle choice should not have changed
-                page.should have_select 'order_cycle_id', selected: 'turtles'
+                expect(page).to have_select 'order_cycle_id', selected: 'turtles'
               end
             end
           end
@@ -190,15 +190,15 @@ feature "As a consumer I want to shop with a distributor", js: true do
         visit shop_path
 
         # Page should not have product.price (with or without fee)
-        page.should_not have_price with_currency(10.00)
-        page.should_not have_price with_currency(33.00)
+        expect(page).not_to have_price with_currency(10.00)
+        expect(page).not_to have_price with_currency(33.00)
 
         # Page should have variant prices (with fee)
-        page.should have_price with_currency(43.00)
-        page.should have_price with_currency(53.00)
+        expect(page).to have_price with_currency(43.00)
+        expect(page).to have_price with_currency(53.00)
 
         # Product price should be listed as the lesser of these
-        page.should have_price with_currency(43.00)
+        expect(page).to have_price with_currency(43.00)
       end
 
       it "filters search results properly" do
@@ -206,12 +206,12 @@ feature "As a consumer I want to shop with a distributor", js: true do
         select "frogs", :from => "order_cycle_id"
 
         fill_in "search", with: "74576345634XXXXXX"
-        page.should have_content "Sorry, no results found"
-        page.should_not have_content product2.name
+        expect(page).to have_content "Sorry, no results found"
+        expect(page).not_to have_content product2.name
 
         fill_in "search", with: "Meer"           # For product named "Meercats"
-        page.should have_content product2.name
-        page.should_not have_content product.name
+        expect(page).to have_content product2.name
+        expect(page).not_to have_content product.name
 
         fill_in "search", with: "Dome"           # For product with meta_keywords "Domestic"
         expect(page).to have_content product.name
@@ -225,10 +225,10 @@ feature "As a consumer I want to shop with a distributor", js: true do
         fill_in "search", with: "Badg"           # For variant with display_name "Badgers"
 
         within('div.pad-top') do
-          page.should have_content product.name
-          page.should have_content variant2.display_name
-          page.should_not have_content product2.name
-          page.should_not have_content variant3.display_name
+          expect(page).to have_content product.name
+          expect(page).to have_content variant2.display_name
+          expect(page).not_to have_content product2.name
+          expect(page).not_to have_content variant3.display_name
         end
 
       end
@@ -252,23 +252,23 @@ feature "As a consumer I want to shop with a distributor", js: true do
         it "should save group buy data to the cart and display it on shopfront reload" do
           # -- Quantity
           fill_in "variants[#{variant.id}]", with: 6
-          page.should have_in_cart product.name
+          expect(page).to have_in_cart product.name
           wait_until { !cart_dirty }
 
           li = Spree::Order.order(:created_at).last.line_items.order(:created_at).last
-          li.quantity.should == 6
+          expect(li.quantity).to eq(6)
 
           # -- Max quantity
           fill_in "variant_attributes[#{variant.id}][max_quantity]", with: 7
           wait_until { !cart_dirty }
 
           li = Spree::Order.order(:created_at).last.line_items.order(:created_at).last
-          li.max_quantity.should == 7
+          expect(li.max_quantity).to eq(7)
 
           # -- Reload
           visit shop_path
-          page.should have_field "variants[#{variant.id}]", with: 6
-          page.should have_field "variant_attributes[#{variant.id}][max_quantity]", with: 7
+          expect(page).to have_field "variants[#{variant.id}]", with: 6
+          expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: 7
         end
       end
     end
@@ -288,16 +288,16 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       it "lets us add and remove products from our cart" do
         fill_in "variants[#{variant.id}]", with: '1'
-        page.should have_in_cart product.name
+        expect(page).to have_in_cart product.name
         wait_until { !cart_dirty }
         li = Spree::Order.order(:created_at).last.line_items.order(:created_at).last
-        li.quantity.should == 1
+        expect(li.quantity).to eq(1)
 
         fill_in "variants[#{variant.id}]", with: '0'
-        within('li.cart') { page.should_not have_content product.name }
+        within('li.cart') { expect(page).not_to have_content product.name }
         wait_until { !cart_dirty }
 
-        Spree::LineItem.where(id: li).should be_empty
+        expect(Spree::LineItem.where(id: li)).to be_empty
       end
 
       it "alerts us when we enter a quantity greater than the stock available" do
@@ -308,7 +308,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
           fill_in "variants[#{variant.id}]", with: '10'
         end
 
-        page.should have_field "variants[#{variant.id}]", with: '5'
+        expect(page).to have_field "variants[#{variant.id}]", with: '5'
       end
 
       describe "when a product goes out of stock just before it's added to the cart" do
@@ -323,20 +323,20 @@ feature "As a consumer I want to shop with a distributor", js: true do
           wait_until { !cart_dirty }
 
           within(".out-of-stock-modal") do
-            page.should have_content "stock levels for one or more of the products in your cart have reduced"
-            page.should have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
+            expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+            expect(page).to have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
           end
 
           # -- Page updates
           # Update amount in cart
-          page.should have_field "variants[#{variant.id}]", with: '0', disabled: true
-          page.should have_field "variants[#{variant2.id}]", with: ''
+          expect(page).to have_field "variants[#{variant.id}]", with: '0', disabled: true
+          expect(page).to have_field "variants[#{variant2.id}]", with: ''
 
           # Update amount available in product list
           #   If amount falls to zero, variant should be greyed out and input disabled
-          page.should have_selector "#variant-#{variant.id}.out-of-stock"
-          page.should have_selector "#variants_#{variant.id}[ofn-on-hand='0']"
-          page.should have_selector "#variants_#{variant.id}[disabled='disabled']"
+          expect(page).to have_selector "#variant-#{variant.id}.out-of-stock"
+          expect(page).to have_selector "#variants_#{variant.id}[ofn-on-hand='0']"
+          expect(page).to have_selector "#variants_#{variant.id}[disabled='disabled']"
         end
 
         context "group buy products" do
@@ -353,18 +353,18 @@ feature "As a consumer I want to shop with a distributor", js: true do
             wait_until { !cart_dirty }
 
             within(".out-of-stock-modal") do
-              page.should have_content "stock levels for one or more of the products in your cart have reduced"
-              page.should have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
+              expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+              expect(page).to have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
             end
 
             # -- Page updates
             # Update amount in cart
-            page.should have_field "variant_attributes[#{variant.id}][max_quantity]", with: '0', disabled: true
+            expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: '0', disabled: true
 
             # Update amount available in product list
             #   If amount falls to zero, variant should be greyed out and input disabled
-            page.should have_selector "#variant-#{variant.id}.out-of-stock"
-            page.should have_selector "#variants_#{variant.id}_max[disabled='disabled']"
+            expect(page).to have_selector "#variant-#{variant.id}.out-of-stock"
+            expect(page).to have_selector "#variants_#{variant.id}_max[disabled='disabled']"
           end
         end
 
@@ -379,8 +379,8 @@ feature "As a consumer I want to shop with a distributor", js: true do
             wait_until { !cart_dirty }
 
             within(".out-of-stock-modal") do
-              page.should have_content "stock levels for one or more of the products in your cart have reduced"
-              page.should have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
+              expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+              expect(page).to have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
             end
           end
 
@@ -397,12 +397,12 @@ feature "As a consumer I want to shop with a distributor", js: true do
               wait_until { !cart_dirty }
 
               within(".out-of-stock-modal") do
-                page.should have_content "stock levels for one or more of the products in your cart have reduced"
-                page.should have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
+                expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+                expect(page).to have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
               end
 
-              page.should have_field "variants[#{variant.id}]", with: '1'
-              page.should have_field "variant_attributes[#{variant.id}][max_quantity]", with: '3'
+              expect(page).to have_field "variants[#{variant.id}]", with: '1'
+              expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: '3'
             end
           end
         end
@@ -412,17 +412,17 @@ feature "As a consumer I want to shop with a distributor", js: true do
     context "when no order cycles are available" do
       it "tells us orders are closed" do
         visit shop_path
-        page.should have_content "Orders are closed"
+        expect(page).to have_content "Orders are closed"
       end
       it "shows the last order cycle" do
         oc1 = create(:simple_order_cycle, distributors: [distributor], orders_close_at: 10.days.ago)
         visit shop_path
-        page.should have_content "The last cycle closed 10 days ago"
+        expect(page).to have_content "The last cycle closed 10 days ago"
       end
       it "shows the next order cycle" do
         oc1 = create(:simple_order_cycle, distributors: [distributor], orders_open_at: 10.days.from_now)
         visit shop_path
-        page.should have_content "The next cycle opens in 10 days"
+        expect(page).to have_content "The next cycle opens in 10 days"
       end
     end
 

--- a/spec/features/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/features/consumer/shopping/variant_overrides_spec.rb
@@ -40,28 +40,28 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
 
   describe "viewing products" do
     it "shows the overridden price" do
-      page.should_not have_price with_currency(12.22) # $11.11 + 10% fee
-      page.should have_price with_currency(61.11)
+      expect(page).not_to have_price with_currency(12.22) # $11.11 + 10% fee
+      expect(page).to have_price with_currency(61.11)
     end
 
     it "looks up stock from the override" do
       # Product should appear but one of the variants is out of stock
-      page.should_not have_content v2.options_text
+      expect(page).not_to have_content v2.options_text
 
       # Entire product should not appear - no stock
-      page.should_not have_content p2.name
-      page.should_not have_content v3.options_text
+      expect(page).not_to have_content p2.name
+      expect(page).not_to have_content v3.options_text
 
       # On-demand product with VO of no stock should NOT appear
-      page.should_not have_content v5.options_text
+      expect(page).not_to have_content v5.options_text
     end
 
     it "calculates fees correctly" do
       page.find("#variant-#{v1.id} .graph-button").click
       page.find(".price_breakdown a").click
-      page.should have_selector 'li.cost div', text: with_currency(55.55)
-      page.should have_selector 'li.packing-fee div', text: with_currency(5.56)
-      page.should have_selector 'li.total div', text: "= #{with_currency(61.11)}"
+      expect(page).to have_selector 'li.cost div', text: with_currency(55.55)
+      expect(page).to have_selector 'li.packing-fee div', text: with_currency(5.56)
+      expect(page).to have_selector 'li.total div', text: "= #{with_currency(61.11)}"
     end
 
     it "shows the correct prices when products are in the cart" do
@@ -69,7 +69,7 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
       show_cart
       wait_until_enabled 'li.cart a.button'
       visit shop_path
-      page.should_not have_price with_currency(12.22)
+      expect(page).not_to have_price with_currency(12.22)
     end
 
     # The two specs below reveal an unrelated issue with fee calculation. See:
@@ -78,30 +78,30 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
     it "shows the overridden price with fees in the quick cart" do
       fill_in "variants[#{v1.id}]", with: "2"
       show_cart
-      page.should have_selector "#cart-variant-#{v1.id} .quantity", text: '2'
-      page.should have_selector "#cart-variant-#{v1.id} .price", text: with_currency(61.11)
-      page.should have_selector "#cart-variant-#{v1.id} .total-price", text: with_currency(122.22)
+      expect(page).to have_selector "#cart-variant-#{v1.id} .quantity", text: '2'
+      expect(page).to have_selector "#cart-variant-#{v1.id} .price", text: with_currency(61.11)
+      expect(page).to have_selector "#cart-variant-#{v1.id} .total-price", text: with_currency(122.22)
     end
 
     it "shows the correct prices in the shopping cart" do
       fill_in "variants[#{v1.id}]", with: "2"
       add_to_cart
 
-      page.should have_selector "tr.line-item.variant-#{v1.id} .cart-item-price", text: with_currency(61.11)
-      page.should have_field "order[line_items_attributes][0][quantity]", with: '2'
-      page.should have_selector "tr.line-item.variant-#{v1.id} .cart-item-total", text: with_currency(122.22)
+      expect(page).to have_selector "tr.line-item.variant-#{v1.id} .cart-item-price", text: with_currency(61.11)
+      expect(page).to have_field "order[line_items_attributes][0][quantity]", with: '2'
+      expect(page).to have_selector "tr.line-item.variant-#{v1.id} .cart-item-total", text: with_currency(122.22)
 
-      page.should have_selector "#edit-cart .item-total", text: with_currency(122.22)
-      page.should have_selector "#edit-cart .grand-total", text: with_currency(122.22)
+      expect(page).to have_selector "#edit-cart .item-total", text: with_currency(122.22)
+      expect(page).to have_selector "#edit-cart .grand-total", text: with_currency(122.22)
     end
 
     it "shows the correct prices in the checkout" do
       fill_in "variants[#{v1.id}]", with: "2"
       click_checkout
 
-      page.should have_selector 'form.edit_order .cart-total', text: with_currency(122.22)
-      page.should have_selector 'form.edit_order .shipping', text: with_currency(0.00)
-      page.should have_selector 'form.edit_order .total', text: with_currency(122.22)
+      expect(page).to have_selector 'form.edit_order .cart-total', text: with_currency(122.22)
+      expect(page).to have_selector 'form.edit_order .shipping', text: with_currency(0.00)
+      expect(page).to have_selector 'form.edit_order .total', text: with_currency(122.22)
     end
   end
 
@@ -114,8 +114,8 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
       complete_checkout
 
       o = Spree::Order.complete.last
-      o.line_items.first.price.should == 55.55
-      o.total.should == 122.22
+      expect(o.line_items.first.price).to eq(55.55)
+      expect(o.total).to eq(122.22)
     end
 
     it "subtracts stock from the override" do
@@ -146,7 +146,7 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
       expect do
         complete_checkout
       end.to change { v1.reload.count_on_hand }.by(-2)
-      vo1.reload.count_on_hand.should be_nil
+      expect(vo1.reload.count_on_hand).to be_nil
     end
 
     it "does not show out of stock flags on order confirmation page" do
@@ -156,7 +156,7 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
 
       complete_checkout
 
-      page.should_not have_content "Out of Stock"
+      expect(page).not_to have_content "Out of Stock"
     end
   end
 

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe CheckoutHelper, type: :helper do
   it "generates html for validated inputs" do
-    helper.should_receive(:render).with(
+    expect(helper).to receive(:render).with(
       "shared/validated_input",
       name: "test",
       path: "foo",
@@ -17,14 +17,14 @@ describe CheckoutHelper, type: :helper do
     let(:order) { double(:order, total_tax: 123.45, currency: 'AUD') }
 
     it "retrieves the total tax on the order" do
-      helper.display_checkout_tax_total(order).should == Spree::Money.new(123.45, currency: 'AUD')
+      expect(helper.display_checkout_tax_total(order)).to eq(Spree::Money.new(123.45, currency: 'AUD'))
     end
   end
 
   it "knows if guests can checkout" do
     distributor = create(:distributor_enterprise)
     order = create(:order, distributor: distributor)
-    helper.stub(:current_order) { order }
+    allow(helper).to receive(:current_order) { order }
     expect(helper.guest_checkout_allowed?).to be true
 
     order.distributor.allow_guest_orders = false

--- a/spec/helpers/html_helper_spec.rb
+++ b/spec/helpers/html_helper_spec.rb
@@ -3,39 +3,39 @@ require 'spec_helper'
 describe HtmlHelper, type: :helper do
   describe "stripping html from a string" do
     it "strips tags" do
-      helper.strip_html('<p><b>Hello</b> <em>world</em>!</p>').should == "Hello world!"
+      expect(helper.strip_html('<p><b>Hello</b> <em>world</em>!</p>')).to eq("Hello world!")
     end
 
     it "removes nbsp and amp entities" do
-      helper.strip_html('Hello&nbsp;world&amp;&amp;').should == 'Hello world&&'
+      expect(helper.strip_html('Hello&nbsp;world&amp;&amp;')).to eq('Hello world&&')
     end
 
     it "returns nil for nil input" do
-      helper.strip_html(nil).should be_nil
+      expect(helper.strip_html(nil)).to be_nil
     end
 
     describe "line breaks" do
       it "adds two line breaks after heading tags" do
-        helper.strip_html("<h1>foo</h1>bar").should == "foo\n\nbar";
-        helper.strip_html("<h2>foo</h2>bar").should == "foo\n\nbar";
+        expect(helper.strip_html("<h1>foo</h1>bar")).to eq("foo\n\nbar");
+        expect(helper.strip_html("<h2>foo</h2>bar")).to eq("foo\n\nbar");
       end
 
       it "adds two line breaks after p tags" do
-        helper.strip_html("<p>foo</p>bar").should == "foo\n\nbar";
+        expect(helper.strip_html("<p>foo</p>bar")).to eq("foo\n\nbar");
       end
 
       it "adds two line breaks after div tags" do
-        helper.strip_html("<div>foo</div>bar").should == "foo\n\nbar";
+        expect(helper.strip_html("<div>foo</div>bar")).to eq("foo\n\nbar");
       end
 
       it "adds a line break after br tags" do
-        helper.strip_html("foo<br>bar").should == "foo\nbar";
-        helper.strip_html("foo<br/>bar").should == "foo\nbar";
-        helper.strip_html("foo<br />bar").should == "foo\nbar";
+        expect(helper.strip_html("foo<br>bar")).to eq("foo\nbar");
+        expect(helper.strip_html("foo<br/>bar")).to eq("foo\nbar");
+        expect(helper.strip_html("foo<br />bar")).to eq("foo\nbar");
       end
 
       it "strips line breaks at the end of the string" do
-        helper.strip_html("<div>foo</div><br />").should == "foo";
+        expect(helper.strip_html("<div>foo</div><br />")).to eq("foo");
       end
     end
   end

--- a/spec/helpers/injection_helper_spec.rb
+++ b/spec/helpers/injection_helper_spec.rb
@@ -11,17 +11,17 @@ describe InjectionHelper, type: :helper do
   let!(:d2o1) { create(:completed_order_with_totals, distributor: distributor2, user_id: user.id)}
 
   it "will inject via AMS" do
-    helper.inject_json_ams("test", [enterprise], Api::IdSerializer).should match /#{enterprise.id}/
+    expect(helper.inject_json_ams("test", [enterprise], Api::IdSerializer)).to match /#{enterprise.id}/
   end
 
   it "injects enterprises" do
-    helper.inject_enterprises.should match enterprise.name
-    helper.inject_enterprises.should match enterprise.facebook
+    expect(helper.inject_enterprises).to match enterprise.name
+    expect(helper.inject_enterprises).to match enterprise.facebook
   end
 
   it "only injects activated enterprises" do
     inactive_enterprise = create(:enterprise, sells: 'unspecified')
-    helper.inject_enterprises.should_not match inactive_enterprise.name
+    expect(helper.inject_enterprises).not_to match inactive_enterprise.name
   end
 
   it "injects shipping_methods" do
@@ -30,8 +30,8 @@ describe InjectionHelper, type: :helper do
     order = create(:order, distributor: current_distributor)
     allow(helper).to receive(:current_order) { order }
     allow(helper).to receive(:spree_current_user) { nil }
-    helper.inject_available_shipping_methods.should match sm.id.to_s
-    helper.inject_available_shipping_methods.should match sm.compute_amount(order).to_s
+    expect(helper.inject_available_shipping_methods).to match sm.id.to_s
+    expect(helper.inject_available_shipping_methods).to match sm.compute_amount(order).to_s
   end
 
   it "injects payment methods" do
@@ -40,18 +40,18 @@ describe InjectionHelper, type: :helper do
     order = create(:order, distributor: current_distributor)
     allow(helper).to receive(:current_order) { order }
     allow(helper).to receive(:spree_current_user) { nil }
-    helper.inject_available_payment_methods.should match pm.id.to_s
-    helper.inject_available_payment_methods.should match pm.name
+    expect(helper.inject_available_payment_methods).to match pm.id.to_s
+    expect(helper.inject_available_payment_methods).to match pm.name
   end
 
   it "injects current order" do
-    helper.stub(:current_order).and_return order = create(:order)
-    helper.inject_current_order.should match order.id.to_s
+    allow(helper).to receive(:current_order).and_return order = create(:order)
+    expect(helper.inject_current_order).to match order.id.to_s
   end
 
   it "injects taxons" do
     taxon = create(:taxon)
-    helper.inject_taxons.should match taxon.name
+    expect(helper.inject_taxons).to match taxon.name
   end
 
   it "only injects credit cards with a payment profile" do

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -5,27 +5,27 @@ module Spree
     describe NavigationHelper, type: :helper do
       describe "klass_for" do
         it "returns the class when present" do
-          helper.klass_for('products').should == Spree::Product
+          expect(helper.klass_for('products')).to eq(Spree::Product)
         end
 
         it "returns a symbol when there's no available class" do
-          helper.klass_for('reports').should == :report
+          expect(helper.klass_for('reports')).to eq(:report)
         end
 
         it "returns :overview for the dashboard" do
-          helper.klass_for('dashboard').should == :overview
+          expect(helper.klass_for('dashboard')).to eq(:overview)
         end
 
         it "returns Spree::Order for bulk_order_management" do
-          helper.klass_for('bulk_order_management').should == Spree::Order
+          expect(helper.klass_for('bulk_order_management')).to eq(Spree::Order)
         end
 
         it "returns EnterpriseGroup for group" do
-          helper.klass_for('group').should == EnterpriseGroup
+          expect(helper.klass_for('group')).to eq(EnterpriseGroup)
         end
 
         it "returns VariantOverride for Inventory" do
-          helper.klass_for('Inventory').should == VariantOverride
+          expect(helper.klass_for('Inventory')).to eq(VariantOverride)
         end
       end
     end

--- a/spec/helpers/order_cycles_helper_spec.rb
+++ b/spec/helpers/order_cycles_helper_spec.rb
@@ -5,7 +5,7 @@ describe OrderCyclesHelper, type: :helper do
 
   describe "finding producer enterprise options" do
     before do
-      helper.stub(:permitted_producer_enterprises_for) { "enterprise list" }
+      allow(helper).to receive(:permitted_producer_enterprises_for) { "enterprise list" }
     end
 
     it "asks for a validation option list" do
@@ -16,7 +16,7 @@ describe OrderCyclesHelper, type: :helper do
 
   describe "finding coodinator enterprise options" do
     before do
-      helper.stub(:permitted_coordinating_enterprises_for) { "enterprise list" }
+      allow(helper).to receive(:permitted_coordinating_enterprises_for) { "enterprise list" }
     end
 
     it "asks for a validation option list" do
@@ -27,7 +27,7 @@ describe OrderCyclesHelper, type: :helper do
 
   describe "finding hub enterprise options" do
     before do
-      helper.stub(:permitted_hub_enterprises_for) { "enterprise list" }
+      allow(helper).to receive(:permitted_hub_enterprises_for) { "enterprise list" }
     end
 
     it "asks for a validation option list" do
@@ -71,9 +71,9 @@ describe OrderCyclesHelper, type: :helper do
       exchange = Exchange.find(oc1.exchanges.to_enterprises(d).outgoing.first.id)
       exchange.update_attribute :pickup_time, "turtles"
 
-      helper.stub(:current_order_cycle).and_return oc1
-      helper.stub(:current_distributor).and_return d
-      helper.pickup_time.should == "turtles"
+      allow(helper).to receive(:current_order_cycle).and_return oc1
+      allow(helper).to receive(:current_distributor).and_return d
+      expect(helper.pickup_time).to eq("turtles")
     end
 
     it "gives me the pickup time for any order cycle" do
@@ -84,9 +84,9 @@ describe OrderCyclesHelper, type: :helper do
       exchange = Exchange.find(oc2.exchanges.to_enterprises(d).outgoing.first.id)
       exchange.update_attribute :pickup_time, "turtles"
 
-      helper.stub(:current_order_cycle).and_return oc1
-      helper.stub(:current_distributor).and_return d
-      helper.pickup_time(oc2).should == "turtles"
+      allow(helper).to receive(:current_order_cycle).and_return oc1
+      allow(helper).to receive(:current_distributor).and_return d
+      expect(helper.pickup_time(oc2)).to eq("turtles")
     end
   end
 end

--- a/spec/helpers/products_helper_spec.rb
+++ b/spec/helpers/products_helper_spec.rb
@@ -4,13 +4,13 @@ module Spree
   describe ProductsHelper, type: :helper do
     it "displays variant price differences as absolute, not relative values" do
       variant = make_variant_stub(10.00, 10.00)
-      helper.variant_price_diff(variant).should == "(#{with_currency(10.00)})"
+      expect(helper.variant_price_diff(variant)).to eq("(#{with_currency(10.00)})")
 
       variant = make_variant_stub(10.00, 15.55)
-      helper.variant_price_diff(variant).should == "(#{with_currency(15.55)})"
+      expect(helper.variant_price_diff(variant)).to eq("(#{with_currency(15.55)})")
 
       variant = make_variant_stub(10.00, 5.55)
-      helper.variant_price_diff(variant).should == "(#{with_currency(5.55)})"
+      expect(helper.variant_price_diff(variant)).to eq("(#{with_currency(5.55)})")
     end
 
     private

--- a/spec/helpers/shared_helper_spec.rb
+++ b/spec/helpers/shared_helper_spec.rb
@@ -5,22 +5,22 @@ describe SharedHelper, type: :helper do
   it "does not require emptying the cart when it is empty" do
     d = double(:distributor)
     order = double(:order, line_items: [])
-    helper.stub(:current_order) { order }
-    helper.distributor_link_class(d).should_not =~ /empties-cart/
+    allow(helper).to receive(:current_order) { order }
+    expect(helper.distributor_link_class(d)).not_to match(/empties-cart/)
   end
 
   it "does not require emptying the cart when we are on the same distributor" do
     d = double(:distributor)
     order = double(:order, line_items: [double(:line_item)], distributor: d)
-    helper.stub(:current_order) { order }
-    helper.distributor_link_class(d).should_not =~ /empties-cart/
+    allow(helper).to receive(:current_order) { order }
+    expect(helper.distributor_link_class(d)).not_to match(/empties-cart/)
   end
 
   it "requires emptying the cart otherwise" do
     d1 = double(:distributor)
     d2 = double(:distributor)
     order = double(:order, line_items: [double(:line_item)], distributor: d2)
-    helper.stub(:current_order) { order }
-    helper.distributor_link_class(d1).should =~ /empties-cart/
+    allow(helper).to receive(:current_order) { order }
+    expect(helper.distributor_link_class(d1)).to match(/empties-cart/)
   end
 end

--- a/spec/helpers/shop_helper_spec.rb
+++ b/spec/helpers/shop_helper_spec.rb
@@ -4,8 +4,8 @@ describe ShopHelper, type: :helper do
   it "should build order cycle select options" do
     d = create(:distributor_enterprise)
     o1 = create(:simple_order_cycle, distributors: [d])
-    helper.stub(:current_distributor).and_return d
+    allow(helper).to receive(:current_distributor).and_return d
 
-    helper.order_cycles_name_and_pickup_times([o1]).should == [[helper.pickup_time(o1), o1.id]]
+    expect(helper.order_cycles_name_and_pickup_times([o1])).to eq([[helper.pickup_time(o1), o1.id]])
   end
 end

--- a/spec/jobs/confirm_signup_job_spec.rb
+++ b/spec/jobs/confirm_signup_job_spec.rb
@@ -5,8 +5,8 @@ describe ConfirmSignupJob do
 
   it "sends a confirmation email to the user" do
     mail = double(:mail)
-    Spree::UserMailer.should_receive(:signup_confirmation).with(user).and_return(mail)
-    mail.should_receive(:deliver)
+    expect(Spree::UserMailer).to receive(:signup_confirmation).with(user).and_return(mail)
+    expect(mail).to receive(:deliver)
 
     run_job ConfirmSignupJob.new user.id
   end

--- a/spec/jobs/heartbeat_job_spec.rb
+++ b/spec/jobs/heartbeat_job_spec.rb
@@ -12,7 +12,7 @@ describe HeartbeatJob do
 
     it "updates the last_job_queue_heartbeat_at config var" do
       run_job
-      Time.parse(Spree::Config.last_job_queue_heartbeat_at).should == run_time
+      expect(Time.parse(Spree::Config.last_job_queue_heartbeat_at)).to eq(run_time)
     end
   end
 

--- a/spec/jobs/products_cache_integrity_checker_job_spec.rb
+++ b/spec/jobs/products_cache_integrity_checker_job_spec.rb
@@ -10,7 +10,7 @@ describe ProductsCacheIntegrityCheckerJob do
 
     before do
       Rails.cache.write(cache_key, "[1, 2, 3]\n")
-      OpenFoodNetwork::ProductsRenderer.stub(:new) { double(:pr, products_json: "[1, 3]\n") }
+      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new) { double(:pr, products_json: "[1, 3]\n") }
     end
 
     it "reports errors" do

--- a/spec/jobs/refresh_products_cache_job_spec.rb
+++ b/spec/jobs/refresh_products_cache_job_spec.rb
@@ -6,7 +6,7 @@ describe RefreshProductsCacheJob do
   let(:order_cycle) { create(:simple_order_cycle) }
 
   it "renders products and writes them to cache" do
-    RefreshProductsCacheJob.any_instance.stub(:products_json) { 'products' }
+    allow_any_instance_of(RefreshProductsCacheJob).to receive(:products_json) { 'products' }
 
     run_job RefreshProductsCacheJob.new distributor.id, order_cycle.id
 

--- a/spec/jobs/welcome_enterprise_job_spec.rb
+++ b/spec/jobs/welcome_enterprise_job_spec.rb
@@ -5,8 +5,8 @@ describe WelcomeEnterpriseJob do
 
   it "sends a welcome email to the enterprise" do
     mail = double(:mail)
-    EnterpriseMailer.should_receive(:welcome).with(enterprise).and_return(mail)
-    mail.should_receive(:deliver)
+    expect(EnterpriseMailer).to receive(:welcome).with(enterprise).and_return(mail)
+    expect(mail).to receive(:deliver)
 
     run_job WelcomeEnterpriseJob.new(enterprise.id)
   end

--- a/spec/lib/open_food_network/bulk_coop_report_spec.rb
+++ b/spec/lib/open_food_network/bulk_coop_report_spec.rb
@@ -19,13 +19,13 @@ module OpenFoodNetwork
         it "fetches completed orders" do
           o2 = create(:order)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
 
         it "does not show cancelled orders" do
           o2 = create(:order, state: "canceled", completed_at: 1.day.ago)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
       end
 
@@ -49,8 +49,8 @@ module OpenFoodNetwork
           end
 
           it "shows line items supplied by my producers, with names hidden" do
-            subject.table_items.should == [li2]
-            subject.table_items.first.order.bill_address.firstname.should == "HIDDEN"
+            expect(subject.table_items).to eq([li2])
+            expect(subject.table_items.first.order.bill_address.firstname).to eq("HIDDEN")
           end
         end
 
@@ -63,7 +63,7 @@ module OpenFoodNetwork
           end
 
           it "shows line items supplied by my producers, with names hidden" do
-            subject.table_items.should == []
+            expect(subject.table_items).to eq([])
           end
         end
       end
@@ -81,15 +81,15 @@ module OpenFoodNetwork
           d2.enterprise_roles.create!(user: create(:user))
           o2 = create(:order, distributor: d2, completed_at: 1.day.ago)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
 
         it "only shows the selected order cycle" do
           oc2 = create(:simple_order_cycle)
           o2 = create(:order, distributor: d1, order_cycle: oc2)
           o2.line_items << build(:line_item)
-          subject.stub(:params).and_return(order_cycle_id_in: oc1.id)
-          subject.table_items.should == [li1]
+          allow(subject).to receive(:params).and_return(order_cycle_id_in: oc1.id)
+          expect(subject.table_items).to eq([li1])
         end
       end
     end

--- a/spec/lib/open_food_network/customers_report_spec.rb
+++ b/spec/lib/open_food_network/customers_report_spec.rb
@@ -12,33 +12,33 @@ module OpenFoodNetwork
 
       describe "mailing list report" do
         before do
-          subject.stub(:params).and_return(report_type: "mailing_list")
+          allow(subject).to receive(:params).and_return(report_type: "mailing_list")
         end
 
         it "returns headers for mailing_list" do
-          subject.header.should == ["Email", "First Name", "Last Name", "Suburb"]
+          expect(subject.header).to eq(["Email", "First Name", "Last Name", "Suburb"])
         end
 
         it "builds a table from a list of variants" do
           order = double(:order, email: "test@test.com")
           address = double(:billing_address, firstname: "Firsty",
                            lastname: "Lasty", city: "Suburbia")
-          order.stub(:billing_address).and_return address
-          subject.stub(:orders).and_return [order]
+          allow(order).to receive(:billing_address).and_return address
+          allow(subject).to receive(:orders).and_return [order]
 
-          subject.table.should == [[
+          expect(subject.table).to eq([[
             "test@test.com", "Firsty", "Lasty", "Suburbia"
-          ]]
+          ]])
         end
       end
 
       describe "addresses report" do
         before do
-          subject.stub(:params).and_return(report_type: "addresses")
+          allow(subject).to receive(:params).and_return(report_type: "addresses")
         end
 
         it "returns headers for addresses" do
-          subject.header.should == ["First Name", "Last Name", "Billing Address", "Email", "Phone", "Hub", "Hub Address", "Shipping Method"]
+          expect(subject.header).to eq(["First Name", "Last Name", "Billing Address", "Email", "Phone", "Hub", "Hub Address", "Shipping Method"])
         end
 
         it "builds a table from a list of variants" do
@@ -47,14 +47,14 @@ module OpenFoodNetwork
           o = create(:order, distributor: d, bill_address: a)
           o.shipping_method = create(:shipping_method)
 
-          subject.stub(:orders).and_return [o]
-          subject.table.should == [[
+          allow(subject).to receive(:orders).and_return [o]
+          expect(subject.table).to eq([[
             a.firstname, a.lastname,
             [a.address1, a.address2, a.city].join(" "),
             o.email, a.phone, d.name,
             [d.address.address1, d.address.address2, d.address.city].join(" "),
             o.shipping_method.name
-          ]]
+          ]])
         end
       end
 
@@ -62,13 +62,13 @@ module OpenFoodNetwork
         it "fetches completed orders" do
           o1 = create(:order)
           o2 = create(:order, completed_at: 1.day.ago)
-          subject.orders.should == [o2]
+          expect(subject.orders).to eq([o2])
         end
 
         it "does not show cancelled orders" do
           o1 = create(:order, state: "canceled", completed_at: 1.day.ago)
           o2 = create(:order, completed_at: 1.day.ago)
-          subject.orders.should == [o2]
+          expect(subject.orders).to eq([o2])
         end
       end
     end
@@ -97,8 +97,8 @@ module OpenFoodNetwork
           o1 = create(:order, distributor: d1, completed_at: 1.day.ago)
           o2 = create(:order, distributor: d2, completed_at: 1.day.ago)
 
-          subject.should_receive(:filter).with([o1]).and_return([o1])
-          subject.orders.should == [o1]
+          expect(subject).to receive(:filter).with([o1]).and_return([o1])
+          expect(subject.orders).to eq([o1])
         end
 
         it "does not show orders through a hub that the current user does not manage" do
@@ -107,8 +107,8 @@ module OpenFoodNetwork
           order.line_items << create(:line_item, product: product)
 
           # When I fetch orders, I should see no orders
-          subject.should_receive(:filter).with([]).and_return([])
-          subject.orders.should == []
+          expect(subject).to receive(:filter).with([]).and_return([])
+          expect(subject.orders).to eq([])
         end
       end
 
@@ -117,7 +117,7 @@ module OpenFoodNetwork
         let(:supplier) { create(:supplier_enterprise) }
 
         it "returns all orders sans-params" do
-          subject.filter(orders).should == orders
+          expect(subject.filter(orders)).to eq(orders)
         end
 
         it "returns orders with a specific supplier" do
@@ -130,8 +130,8 @@ module OpenFoodNetwork
           order1.line_items << create(:line_item, product: product1)
           order2.line_items << create(:line_item, product: product2)
 
-          subject.stub(:params).and_return(supplier_id: supplier.id)
-          subject.filter(orders).should == [order1]
+          allow(subject).to receive(:params).and_return(supplier_id: supplier.id)
+          expect(subject.filter(orders)).to eq([order1])
         end
 
         it "filters to a specific distributor" do
@@ -140,8 +140,8 @@ module OpenFoodNetwork
           order1 = create(:order, distributor: d1)
           order2 = create(:order, distributor: d2)
 
-          subject.stub(:params).and_return(distributor_id: d1.id)
-          subject.filter(orders).should == [order1]
+          allow(subject).to receive(:params).and_return(distributor_id: d1.id)
+          expect(subject.filter(orders)).to eq([order1])
         end
 
         it "filters to a specific cycle" do
@@ -150,8 +150,8 @@ module OpenFoodNetwork
           order1 = create(:order, order_cycle: oc1)
           order2 = create(:order, order_cycle: oc2)
 
-          subject.stub(:params).and_return(order_cycle_id: oc1.id)
-          subject.filter(orders).should == [order1]
+          allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id)
+          expect(subject.filter(orders)).to eq([order1])
         end
       end
     end

--- a/spec/lib/open_food_network/distribution_change_validator_spec.rb
+++ b/spec/lib/open_food_network/distribution_change_validator_spec.rb
@@ -10,17 +10,17 @@ describe DistributionChangeValidator do
     let(:order_cycle) { double(:order_cycle) }
 
     it "returns false when a variant is not available for the specified distribution" do
-      order.should_receive(:line_item_variants) { [1] }
-      subject.should_receive(:variants_available_for_distribution).
+      expect(order).to receive(:line_item_variants) { [1] }
+      expect(subject).to receive(:variants_available_for_distribution).
         with(distributor, order_cycle) { [] }
-      subject.can_change_to_distribution?(distributor, order_cycle).should be false
+      expect(subject.can_change_to_distribution?(distributor, order_cycle)).to be false
     end
 
     it "returns true when all variants are available for the specified distribution" do
-      order.should_receive(:line_item_variants) { [1] }
-      subject.should_receive(:variants_available_for_distribution).
+      expect(order).to receive(:line_item_variants) { [1] }
+      expect(subject).to receive(:variants_available_for_distribution).
         with(distributor, order_cycle) { [1] }
-      subject.can_change_to_distribution?(distributor, order_cycle).should be true
+      expect(subject.can_change_to_distribution?(distributor, order_cycle)).to be true
     end
   end
 
@@ -30,14 +30,14 @@ describe DistributionChangeValidator do
       d = double(:distributor, product_distribution_variants: [v])
       oc = double(:order_cycle, variants_distributed_by: [])
 
-      subject.variants_available_for_distribution(d, oc).should == [v]
+      expect(subject.variants_available_for_distribution(d, oc)).to eq([v])
     end
 
     it "finds variants distributed by product distribution when order cycle is nil" do
       v = double(:variant)
       d = double(:distributor, product_distribution_variants: [v])
 
-      subject.variants_available_for_distribution(d, nil).should == [v]
+      expect(subject.variants_available_for_distribution(d, nil)).to eq([v])
     end
 
     it "finds variants distributed by order cycle" do
@@ -45,13 +45,13 @@ describe DistributionChangeValidator do
       d = double(:distributor, product_distribution_variants: [])
       oc = double(:order_cycle)
 
-      oc.should_receive(:variants_distributed_by).with(d) { [v] }
+      expect(oc).to receive(:variants_distributed_by).with(d) { [v] }
 
-      subject.variants_available_for_distribution(d, oc).should == [v]
+      expect(subject.variants_available_for_distribution(d, oc)).to eq([v])
     end
 
     it "returns an empty array when distributor and order cycle are both nil" do
-      subject.variants_available_for_distribution(nil, nil).should == []
+      expect(subject.variants_available_for_distribution(nil, nil)).to eq([])
     end
   end
 
@@ -64,45 +64,45 @@ describe DistributionChangeValidator do
 
     it "matches enterprises which offer all products within the order" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       enterprise = double(:enterprise)
-      enterprise.stub(:distributed_variants) { line_item_variants } # Exactly the same variants as the order
+      allow(enterprise).to receive(:distributed_variants) { line_item_variants } # Exactly the same variants as the order
 
-      subject.available_distributors([enterprise]).should == [enterprise]
+      expect(subject.available_distributors([enterprise])).to eq([enterprise])
     end
 
     it "does not match enterprises with no products available" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       enterprise = double(:enterprise)
-      enterprise.stub(:distributed_variants) { [] } # No variants
+      allow(enterprise).to receive(:distributed_variants) { [] } # No variants
 
-      subject.available_distributors([enterprise]).should_not include enterprise
+      expect(subject.available_distributors([enterprise])).not_to include enterprise
     end
 
     it "does not match enterprises with only some of the same variants in the order available" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       enterprise_with_some_variants = double(:enterprise)
-      enterprise_with_some_variants.stub(:distributed_variants) { [variant1, variant3] } # Only some variants
+      allow(enterprise_with_some_variants).to receive(:distributed_variants) { [variant1, variant3] } # Only some variants
       enterprise_with_some_plus_extras = double(:enterprise)
-      enterprise_with_some_plus_extras.stub(:distributed_variants) { [variant1, variant2, variant3, variant4] } # Only some variants, plus extras
+      allow(enterprise_with_some_plus_extras).to receive(:distributed_variants) { [variant1, variant2, variant3, variant4] } # Only some variants, plus extras
 
-      subject.available_distributors([enterprise_with_some_variants]).should_not include enterprise_with_some_variants
-      subject.available_distributors([enterprise_with_some_plus_extras]).should_not include enterprise_with_some_plus_extras
+      expect(subject.available_distributors([enterprise_with_some_variants])).not_to include enterprise_with_some_variants
+      expect(subject.available_distributors([enterprise_with_some_plus_extras])).not_to include enterprise_with_some_plus_extras
     end
 
     it "matches enterprises which offer all products in the order, plus additional products" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       enterprise = double(:enterprise)
-      enterprise.stub(:distributed_variants) { [variant1, variant2, variant3, variant4, variant5] } # Excess variants
+      allow(enterprise).to receive(:distributed_variants) { [variant1, variant2, variant3, variant4, variant5] } # Excess variants
 
-      subject.available_distributors([enterprise]).should == [enterprise]
+      expect(subject.available_distributors([enterprise])).to eq([enterprise])
     end
 
     it "matches no enterprises when none are provided" do
-      subject.available_distributors([]).should == []
+      expect(subject.available_distributors([])).to eq([])
     end
   end
 
@@ -115,150 +115,150 @@ describe DistributionChangeValidator do
 
     it "matches order cycles which offer all products within the order" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       order_cycle = double(:order_cycle)
-      order_cycle.stub(:distributed_variants) { line_item_variants } # Exactly the same variants as the order
+      allow(order_cycle).to receive(:distributed_variants) { line_item_variants } # Exactly the same variants as the order
 
-      subject.available_order_cycles([order_cycle]).should == [order_cycle]
+      expect(subject.available_order_cycles([order_cycle])).to eq([order_cycle])
     end
 
     it "does not match order cycles with no products available" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       order_cycle = double(:order_cycle)
-      order_cycle.stub(:distributed_variants) { [] } # No variants
+      allow(order_cycle).to receive(:distributed_variants) { [] } # No variants
 
-      subject.available_order_cycles([order_cycle]).should_not include order_cycle
+      expect(subject.available_order_cycles([order_cycle])).not_to include order_cycle
     end
 
     it "does not match order cycles with only some of the same variants in the order available" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       order_cycle_with_some_variants = double(:order_cycle)
-      order_cycle_with_some_variants.stub(:distributed_variants) { [variant1, variant3] } # Only some variants
+      allow(order_cycle_with_some_variants).to receive(:distributed_variants) { [variant1, variant3] } # Only some variants
       order_cycle_with_some_plus_extras = double(:order_cycle)
-      order_cycle_with_some_plus_extras.stub(:distributed_variants) { [variant1, variant2, variant3, variant4] } # Only some variants, plus extras
+      allow(order_cycle_with_some_plus_extras).to receive(:distributed_variants) { [variant1, variant2, variant3, variant4] } # Only some variants, plus extras
 
-      subject.available_order_cycles([order_cycle_with_some_variants]).should_not include order_cycle_with_some_variants
-      subject.available_order_cycles([order_cycle_with_some_plus_extras]).should_not include order_cycle_with_some_plus_extras
+      expect(subject.available_order_cycles([order_cycle_with_some_variants])).not_to include order_cycle_with_some_variants
+      expect(subject.available_order_cycles([order_cycle_with_some_plus_extras])).not_to include order_cycle_with_some_plus_extras
     end
 
     it "matches order cycles which offer all products in the order, plus additional products" do
       line_item_variants = [variant1, variant3, variant5]
-      order.stub(:line_item_variants) { line_item_variants }
+      allow(order).to receive(:line_item_variants) { line_item_variants }
       order_cycle = double(:order_cycle)
-      order_cycle.stub(:distributed_variants) { [variant1, variant2, variant3, variant4, variant5] } # Excess variants
+      allow(order_cycle).to receive(:distributed_variants) { [variant1, variant2, variant3, variant4, variant5] } # Excess variants
 
-      subject.available_order_cycles([order_cycle]).should == [order_cycle]
+      expect(subject.available_order_cycles([order_cycle])).to eq([order_cycle])
     end
 
     it "matches no order cycles when none are provided" do
-      subject.available_order_cycles([]).should == []
+      expect(subject.available_order_cycles([])).to eq([])
     end
   end
 
   describe "checking if a distributor is available for a product" do
     it "returns true when order is nil" do
       subject = DistributionChangeValidator.new(nil)
-      subject.distributor_available_for?(product).should be true
+      expect(subject.distributor_available_for?(product)).to be true
     end
 
     it "returns true when there's an distributor that can cover the new product" do
-      subject.stub(:available_distributors_for).and_return([1])
-      subject.distributor_available_for?(product).should be true
+      allow(subject).to receive(:available_distributors_for).and_return([1])
+      expect(subject.distributor_available_for?(product)).to be true
     end
 
     it "returns false when there's no distributor that can cover the new product" do
-      subject.stub(:available_distributors_for).and_return([])
-      subject.distributor_available_for?(product).should be false
+      allow(subject).to receive(:available_distributors_for).and_return([])
+      expect(subject.distributor_available_for?(product)).to be false
     end
   end
 
   describe "checking if an order cycle is available for a product" do
     it "returns true when the order is nil" do
       subject = DistributionChangeValidator.new(nil)
-      subject.order_cycle_available_for?(product).should be true
+      expect(subject.order_cycle_available_for?(product)).to be true
     end
 
     it "returns true when the product doesn't require an order cycle" do
-      subject.stub(:product_requires_order_cycle).and_return(false)
-      subject.order_cycle_available_for?(product).should be true
+      allow(subject).to receive(:product_requires_order_cycle).and_return(false)
+      expect(subject.order_cycle_available_for?(product)).to be true
     end
 
     it "returns true when there's an order cycle that can cover the product" do
-      subject.stub(:product_requires_order_cycle).and_return(true)
-      subject.stub(:available_order_cycles_for).and_return([1])
-      subject.order_cycle_available_for?(product).should be true
+      allow(subject).to receive(:product_requires_order_cycle).and_return(true)
+      allow(subject).to receive(:available_order_cycles_for).and_return([1])
+      expect(subject.order_cycle_available_for?(product)).to be true
     end
 
     it "returns false otherwise" do
-      subject.stub(:product_requires_order_cycle).and_return(true)
-      subject.stub(:available_order_cycles_for).and_return([])
-      subject.order_cycle_available_for?(product).should be false
+      allow(subject).to receive(:product_requires_order_cycle).and_return(true)
+      allow(subject).to receive(:available_order_cycles_for).and_return([])
+      expect(subject.order_cycle_available_for?(product)).to be false
     end
   end
 
   describe "finding available distributors for a product" do
     it "returns enterprises distributing the product when there's no order" do
       subject = DistributionChangeValidator.new(nil)
-      Enterprise.stub(:distributing_products).and_return([1, 2, 3])
-      subject.should_receive(:available_distributors).never
+      allow(Enterprise).to receive(:distributing_products).and_return([1, 2, 3])
+      expect(subject).to receive(:available_distributors).never
 
-      subject.available_distributors_for(product).should == [1, 2, 3]
+      expect(subject.available_distributors_for(product)).to eq([1, 2, 3])
     end
 
     it "returns enterprises distributing the product when there's no order items" do
-      order.stub(:line_items) { [] }
-      Enterprise.stub(:distributing_products).and_return([1, 2, 3])
-      subject.should_receive(:available_distributors).never
+      allow(order).to receive(:line_items) { [] }
+      allow(Enterprise).to receive(:distributing_products).and_return([1, 2, 3])
+      expect(subject).to receive(:available_distributors).never
 
-      subject.available_distributors_for(product).should == [1, 2, 3]
+      expect(subject.available_distributors_for(product)).to eq([1, 2, 3])
     end
 
     it "filters by available distributors when there are order items" do
-      order.stub(:line_items) { [1, 2, 3] }
-      Enterprise.stub(:distributing_products).and_return([1, 2, 3])
-      subject.should_receive(:available_distributors).and_return([2])
+      allow(order).to receive(:line_items) { [1, 2, 3] }
+      allow(Enterprise).to receive(:distributing_products).and_return([1, 2, 3])
+      expect(subject).to receive(:available_distributors).and_return([2])
 
-      subject.available_distributors_for(product).should == [2]
+      expect(subject.available_distributors_for(product)).to eq([2])
     end
   end
 
   describe "finding available order cycles for a product" do
     it "returns order cycles distributing the product when there's no order" do
       subject = DistributionChangeValidator.new(nil)
-      OrderCycle.stub(:distributing_product).and_return([1, 2, 3])
-      subject.should_receive(:available_order_cycles).never
+      allow(OrderCycle).to receive(:distributing_product).and_return([1, 2, 3])
+      expect(subject).to receive(:available_order_cycles).never
 
-      subject.available_order_cycles_for(product).should == [1, 2, 3]
+      expect(subject.available_order_cycles_for(product)).to eq([1, 2, 3])
     end
 
     it "returns order cycles distributing the product when there's no order items" do
-      order.stub(:line_items) { [] }
-      OrderCycle.stub(:distributing_product).and_return([1, 2, 3])
-      subject.should_receive(:available_order_cycles).never
+      allow(order).to receive(:line_items) { [] }
+      allow(OrderCycle).to receive(:distributing_product).and_return([1, 2, 3])
+      expect(subject).to receive(:available_order_cycles).never
 
-      subject.available_order_cycles_for(product).should == [1, 2, 3]
+      expect(subject.available_order_cycles_for(product)).to eq([1, 2, 3])
     end
 
     it "filters by available order cycles when there are order items" do
-      order.stub(:line_items) { [1, 2, 3] }
-      OrderCycle.stub(:distributing_product).and_return([1, 2, 3])
-      subject.should_receive(:available_order_cycles).and_return([2])
+      allow(order).to receive(:line_items) { [1, 2, 3] }
+      allow(OrderCycle).to receive(:distributing_product).and_return([1, 2, 3])
+      expect(subject).to receive(:available_order_cycles).and_return([2])
 
-      subject.available_order_cycles_for(product).should == [2]
+      expect(subject.available_order_cycles_for(product)).to eq([2])
     end
   end
 
   describe "determining if a product requires an order cycle" do
     it "returns true when the product does not have any product distributions" do
-      product.stub(:product_distributions).and_return([])
-      subject.product_requires_order_cycle(product).should be true
+      allow(product).to receive(:product_distributions).and_return([])
+      expect(subject.product_requires_order_cycle(product)).to be true
     end
 
     it "returns false otherwise" do
-      product.stub(:product_distributions).and_return([1])
-      subject.product_requires_order_cycle(product).should be false
+      allow(product).to receive(:product_distributions).and_return([1])
+      expect(subject.product_requires_order_cycle(product)).to be false
     end
   end
 end

--- a/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_applicator_spec.rb
@@ -9,21 +9,21 @@ module OpenFoodNetwork
       product = create(:simple_product)
 
       efa = EnterpriseFeeApplicator.new enterprise_fee, product.master, 'role'
-      efa.stub(:line_item_adjustment_label) { 'label' }
+      allow(efa).to receive(:line_item_adjustment_label) { 'label' }
       efa.create_line_item_adjustment line_item
 
       adjustment = Spree::Adjustment.last
-      adjustment.label.should == 'label'
-      adjustment.adjustable.should == line_item.order
-      adjustment.source.should == line_item
-      adjustment.originator.should == enterprise_fee
-      adjustment.should be_mandatory
+      expect(adjustment.label).to eq('label')
+      expect(adjustment.adjustable).to eq(line_item.order)
+      expect(adjustment.source).to eq(line_item)
+      expect(adjustment.originator).to eq(enterprise_fee)
+      expect(adjustment).to be_mandatory
 
       md = adjustment.metadata
-      md.enterprise.should == enterprise_fee.enterprise
-      md.fee_name.should == enterprise_fee.name
-      md.fee_type.should == enterprise_fee.fee_type
-      md.enterprise_role.should == 'role'
+      expect(md.enterprise).to eq(enterprise_fee.enterprise)
+      expect(md.fee_name).to eq(enterprise_fee.name)
+      expect(md.fee_type).to eq(enterprise_fee.fee_type)
+      expect(md.enterprise_role).to eq('role')
     end
 
     it "creates an adjustment for an order" do
@@ -32,21 +32,21 @@ module OpenFoodNetwork
       product = create(:simple_product)
 
       efa = EnterpriseFeeApplicator.new enterprise_fee, nil, 'role'
-      efa.stub(:order_adjustment_label) { 'label' }
+      allow(efa).to receive(:order_adjustment_label) { 'label' }
       efa.create_order_adjustment order
 
       adjustment = Spree::Adjustment.last
-      adjustment.label.should == 'label'
-      adjustment.adjustable.should == order
-      adjustment.source.should == order
-      adjustment.originator.should == enterprise_fee
-      adjustment.should be_mandatory
+      expect(adjustment.label).to eq('label')
+      expect(adjustment.adjustable).to eq(order)
+      expect(adjustment.source).to eq(order)
+      expect(adjustment.originator).to eq(enterprise_fee)
+      expect(adjustment).to be_mandatory
 
       md = adjustment.metadata
-      md.enterprise.should == enterprise_fee.enterprise
-      md.fee_name.should == enterprise_fee.name
-      md.fee_type.should == enterprise_fee.fee_type
-      md.enterprise_role.should == 'role'
+      expect(md.enterprise).to eq(enterprise_fee.enterprise)
+      expect(md.fee_name).to eq(enterprise_fee.name)
+      expect(md.fee_type).to eq(enterprise_fee.fee_type)
+      expect(md.enterprise_role).to eq('role')
     end
 
     it "makes an adjustment label for a line item" do
@@ -55,7 +55,7 @@ module OpenFoodNetwork
 
       efa = EnterpriseFeeApplicator.new enterprise_fee, variant, 'distributor'
 
-      efa.send(:line_item_adjustment_label).should == "Bananas - packing fee by distributor Ballantyne"
+      expect(efa.send(:line_item_adjustment_label)).to eq("Bananas - packing fee by distributor Ballantyne")
     end
 
     it "makes an adjustment label for an order" do
@@ -63,7 +63,7 @@ module OpenFoodNetwork
 
       efa = EnterpriseFeeApplicator.new enterprise_fee, nil, 'distributor'
 
-      efa.send(:order_adjustment_label).should == "Whole order - packing fee by distributor Ballantyne"
+      expect(efa.send(:order_adjustment_label)).to eq("Whole order - packing fee by distributor Ballantyne")
     end
   end
 end

--- a/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
@@ -26,13 +26,13 @@ module OpenFoodNetwork
             }
 
             it "calculates via regular computation" do
-              EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master).should == 20
-              EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product2.master).should == 3
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master)).to eq(20)
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product2.master)).to eq(3)
            end
 
             it "calculates via indexed computation" do
-              EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master).should == 20
-              EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product2.master).should == 3
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master)).to eq(20)
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product2.master)).to eq(3)
             end
           end
 
@@ -46,11 +46,11 @@ module OpenFoodNetwork
             end
 
             it "sums via regular computation" do
-              EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master).should == 23
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master)).to eq(23)
             end
 
             it "sums via indexed computation" do
-              EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master).should == 23
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master)).to eq(23)
             end
           end
 
@@ -60,11 +60,11 @@ module OpenFoodNetwork
             }
 
             it "sums via regular computation" do
-              EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master).should == 23
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master)).to eq(23)
             end
 
             it "sums via indexed computation" do
-              EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master).should == 23
+              expect(EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master)).to eq(23)
             end
           end
         end
@@ -76,11 +76,11 @@ module OpenFoodNetwork
           }
 
           it "sums via regular computation" do
-            EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master).should == 2.00
+            expect(EnterpriseFeeCalculator.new(distributor, order_cycle).fees_for(product1.master)).to eq(2.00)
           end
 
           it "sums via indexed computation" do
-            EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master).should == 2.00
+            expect(EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_for(product1.master)).to eq(2.00)
           end
         end
       end
@@ -99,23 +99,23 @@ module OpenFoodNetwork
 
         describe "regular computation" do
           it "returns a breakdown of fees" do
-            EnterpriseFeeCalculator.new(distributor, order_cycle).fees_by_type_for(product1.master).should == {admin: 1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45}
+            expect(EnterpriseFeeCalculator.new(distributor, order_cycle).fees_by_type_for(product1.master)).to eq({admin: 1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45})
           end
 
           it "filters out zero fees" do
             ef_admin.calculator.update_attribute :preferred_amount, 0
-            EnterpriseFeeCalculator.new(distributor, order_cycle).fees_by_type_for(product1.master).should == {sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45}
+            expect(EnterpriseFeeCalculator.new(distributor, order_cycle).fees_by_type_for(product1.master)).to eq({sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45})
           end
         end
 
         describe "indexed computation" do
           it "returns a breakdown of fees" do
-            EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_by_type_for(product1.master).should == {admin: 1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45}
+            expect(EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_by_type_for(product1.master)).to eq({admin: 1.23, sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45})
           end
 
           it "filters out zero fees" do
             ef_admin.calculator.update_attribute :preferred_amount, 0
-            EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_by_type_for(product1.master).should == {sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45}
+            expect(EnterpriseFeeCalculator.new(distributor, order_cycle).indexed_fees_by_type_for(product1.master)).to eq({sales: 4.56, packing: 7.89, transport: 0.12, fundraising: 3.45})
           end
         end
       end
@@ -135,7 +135,7 @@ module OpenFoodNetwork
           EnterpriseFeeCalculator.new.create_line_item_adjustments_for line_item
 
           a = Spree::Adjustment.last
-          a.metadata.fee_name.should == enterprise_fee_line_item.name
+          expect(a.metadata.fee_name).to eq(enterprise_fee_line_item.name)
         end
 
         it "creates adjustments for an order" do
@@ -144,7 +144,7 @@ module OpenFoodNetwork
           EnterpriseFeeCalculator.new.create_order_adjustments_for order
 
           a = Spree::Adjustment.last
-          a.metadata.fee_name.should == enterprise_fee_order.name
+          expect(a.metadata.fee_name).to eq(enterprise_fee_order.name)
         end
       end
     end
@@ -168,18 +168,19 @@ module OpenFoodNetwork
 
       describe "fetching enterprise fees with pre-loaded exchange details" do
         it "scopes enterprise fees to those on exchanges for the current order cycle" do
-          subject.send(:per_item_enterprise_fees_with_exchange_details).should == [ef_exchange]
+          expect(subject.send(:per_item_enterprise_fees_with_exchange_details)).to eq([ef_exchange])
         end
 
         it "includes the exchange variant id" do
-          subject.send(:per_item_enterprise_fees_with_exchange_details).first.variant_id.to_i.should ==
+          expect(subject.send(:per_item_enterprise_fees_with_exchange_details).first.variant_id.to_i).to eq(
             v.id
+          )
         end
 
         it "does not include outgoing exchanges to other distributors" do
           create(:exchange, order_cycle: order_cycle, sender: order_cycle.coordinator, receiver: distributor_other, enterprise_fees: [ef_other_distributor], variants: [v])
 
-          subject.send(:per_item_enterprise_fees_with_exchange_details).should == [ef_exchange]
+          expect(subject.send(:per_item_enterprise_fees_with_exchange_details)).to eq([ef_exchange])
         end
       end
 
@@ -188,14 +189,14 @@ module OpenFoodNetwork
 
         it "loads exchange fees" do
           subject.send(:load_exchange_fees, exchange_fees)
-          indexed_enterprise_fees.should == {v.id => [ef_exchange]}
+          expect(indexed_enterprise_fees).to eq({v.id => [ef_exchange]})
         end
       end
 
       describe "loading coordinator fees" do
         it "loads coordinator fees" do
           subject.send(:load_coordinator_fees)
-          indexed_enterprise_fees.should == {v.id => [ef_coordinator]}
+          expect(indexed_enterprise_fees).to eq({v.id => [ef_coordinator]})
         end
       end
     end

--- a/spec/lib/open_food_network/enterprise_injection_data_spec.rb
+++ b/spec/lib/open_food_network/enterprise_injection_data_spec.rb
@@ -10,12 +10,12 @@ module OpenFoodNetwork
       let!(:er_pi) { create(:enterprise_relationship, parent: producer_inactive, child: enterprise) }
 
       it "only loads activated relatives" do
-        subject.relatives[enterprise.id][:producers].should_not include producer_inactive.id
+        expect(subject.relatives[enterprise.id][:producers]).not_to include producer_inactive.id
       end
 
       it "loads self where appropiate" do
-        subject.relatives[producer.id][:producers].should include producer.id
-        subject.relatives[enterprise.id][:distributors].should include enterprise.id
+        expect(subject.relatives[producer.id][:producers]).to include producer.id
+        expect(subject.relatives[enterprise.id][:distributors]).to include enterprise.id
       end
     end
   end

--- a/spec/lib/open_food_network/enterprise_issue_validator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_issue_validator_spec.rb
@@ -7,8 +7,8 @@ module OpenFoodNetwork
       let(:warnings) { EnterpriseIssueValidator.new(enterprise_invisible).warnings }
 
       it "reports invisible enterprises" do
-        warnings.count.should == 1
-        warnings.first[:description].should include "is not visible"
+        expect(warnings.count).to eq(1)
+        expect(warnings.first[:description]).to include "is not visible"
       end
     end
   end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -3,18 +3,18 @@ require 'open_food_network/feature_toggle'
 module OpenFoodNetwork
   describe FeatureToggle do
     it "returns true when feature is on" do
-      FeatureToggle.stub(:features).and_return({foo: true})
-      FeatureToggle.enabled?(:foo).should be true
+      allow(FeatureToggle).to receive(:features).and_return({foo: true})
+      expect(FeatureToggle.enabled?(:foo)).to be true
     end
 
     it "returns false when feature is off" do
-      FeatureToggle.stub(:features).and_return({foo: false})
-      FeatureToggle.enabled?(:foo).should be false
+      allow(FeatureToggle).to receive(:features).and_return({foo: false})
+      expect(FeatureToggle.enabled?(:foo)).to be false
     end
 
     it "returns false when feature is undefined" do
-      FeatureToggle.stub(:features).and_return({})
-      FeatureToggle.enabled?(:foo).should be false
+      allow(FeatureToggle).to receive(:features).and_return({})
+      expect(FeatureToggle.enabled?(:foo)).to be false
     end
   end
 end

--- a/spec/lib/open_food_network/group_buy_report_spec.rb
+++ b/spec/lib/open_food_network/group_buy_report_spec.rb
@@ -49,7 +49,7 @@ module OpenFoodNetwork
     it "should return a header row describing the report" do
       subject = GroupBuyReport.new [@order1]
       header = subject.header
-      header.should == ["Supplier", "Product", "Unit Size", "Variant", "Weight", "Total Ordered", "Total Max"]
+      expect(header).to eq(["Supplier", "Product", "Unit Size", "Variant", "Weight", "Total Ordered", "Total Max"])
     end
 
     it "should provide the required variant and quantity information in a table" do
@@ -62,7 +62,7 @@ module OpenFoodNetwork
       sum_quantities = line_items.map { |li| li.quantity }.sum
       sum_max_quantities = line_items.map { |li| li.max_quantity || 0 }.sum
 
-      table[0].should == [@variant1.product.supplier.name,@variant1.product.name,"UNITSIZE",@variant1.options_text,@variant1.weight,sum_quantities,sum_max_quantities]
+      expect(table[0]).to eq([@variant1.product.supplier.name,@variant1.product.name,"UNITSIZE",@variant1.options_text,@variant1.weight,sum_quantities,sum_max_quantities])
     end
 
     it "should return a table wherein each rows contains the same number of columns as the heading" do
@@ -72,7 +72,7 @@ module OpenFoodNetwork
       columns = subject.header.length
 
       table.each do |r|
-        r.length.should == columns
+        expect(r.length).to eq(columns)
       end
     end
 
@@ -88,9 +88,9 @@ module OpenFoodNetwork
       variant_groups = variant_rows.group_by { |r| r.variant }
       product_groups = product_rows.group_by { |r| r.product }
 
-      supplier_groups.length.should == 2
-      variant_groups.length.should == 3
-      product_groups.length.should == 3
+      expect(supplier_groups.length).to eq(2)
+      expect(variant_groups.length).to eq(3)
+      expect(product_groups.length).to eq(3)
     end
   end
 end

--- a/spec/lib/open_food_network/lettuce_share_report_spec.rb
+++ b/spec/lib/open_food_network/lettuce_share_report_spec.rb
@@ -8,29 +8,29 @@ module OpenFoodNetwork
 
     describe "grower and method" do
       it "shows just the producer when there is no certification" do
-        report.stub(:producer_name) { "Producer" }
-        report.stub(:certification) { "" }
+        allow(report).to receive(:producer_name) { "Producer" }
+        allow(report).to receive(:certification) { "" }
 
-        report.send(:grower_and_method, v).should == "Producer"
+        expect(report.send(:grower_and_method, v)).to eq("Producer")
       end
 
       it "shows producer and certification when a certification is present" do
-        report.stub(:producer_name) { "Producer" }
-        report.stub(:certification) { "Method" }
+        allow(report).to receive(:producer_name) { "Producer" }
+        allow(report).to receive(:certification) { "Method" }
 
-        report.send(:grower_and_method, v).should == "Producer (Method)"
+        expect(report.send(:grower_and_method, v)).to eq("Producer (Method)")
       end
     end
 
     describe "gst" do
       it "handles tax category without rates" do
-        report.send(:gst, v).should == 0
+        expect(report.send(:gst, v)).to eq(0)
       end
     end
 
     describe "table" do
       it "handles no items" do
-        report.send(:table).should eq []
+        expect(report.send(:table)).to eq []
       end
 
       describe "lists" do
@@ -43,14 +43,14 @@ module OpenFoodNetwork
         let(:v3o) { create(:variant_override, hub: hub, variant: v3, count_on_hand: 0) }
 
         it "all items" do
-          report.stub(:child_variants) { Spree::Variant.where(id: [v, v2, v3]) }
-          report.send(:table).count.should eq 3
+          allow(report).to receive(:child_variants) { Spree::Variant.where(id: [v, v2, v3]) }
+          expect(report.send(:table).count).to eq 3
         end
 
         it "only available items" do
           v.update_column(:count_on_hand, 0)
-          report.stub(:child_variants) { Spree::Variant.where(id: [v, v2, v3, v4]) }
-          report.send(:table).count.should eq 3
+          allow(report).to receive(:child_variants) { Spree::Variant.where(id: [v, v2, v3, v4]) }
+          expect(report.send(:table).count).to eq 3
         end
 
         it "only available items considering overrides" do
@@ -58,11 +58,11 @@ module OpenFoodNetwork
           # create the overrides
           v2o
           v3o
-          report.stub(:child_variants) { Spree::Variant.where(id: [v, v2, v3]) }
-          report.stub(:params) { {distributor_id: hub.id} }
+          allow(report).to receive(:child_variants) { Spree::Variant.where(id: [v, v2, v3]) }
+          allow(report).to receive(:params) { {distributor_id: hub.id} }
           rows = report.send(:table)
-          rows.count.should eq 2
-          rows.map{ |row| row[0] }.should include v.product.name, v2.product.name
+          expect(rows.count).to eq 2
+          expect(rows.map{ |row| row[0] }).to include v.product.name, v2.product.name
         end
 
       end

--- a/spec/lib/open_food_network/option_value_namer_spec.rb
+++ b/spec/lib/open_food_network/option_value_namer_spec.rb
@@ -7,31 +7,31 @@ module OpenFoodNetwork
       let(:subject) { OptionValueNamer.new }
 
       it "when description is blank" do
-        v.stub(:unit_description) { nil }
-        subject.stub(:value_scaled?) { true }
-        subject.stub(:option_value_value_unit) { %w(value unit) }
-        subject.name(v).should == "valueunit"
+        allow(v).to receive(:unit_description) { nil }
+        allow(subject).to receive(:value_scaled?) { true }
+        allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
+        expect(subject.name(v)).to eq("valueunit")
       end
 
       it "when description is present" do
-        v.stub(:unit_description) { 'desc' }
-        subject.stub(:option_value_value_unit) { %w(value unit) }
-        subject.stub(:value_scaled?) { true }
-        subject.name(v).should == "valueunit desc"
+        allow(v).to receive(:unit_description) { 'desc' }
+        allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
+        allow(subject).to receive(:value_scaled?) { true }
+        expect(subject.name(v)).to eq("valueunit desc")
       end
 
       it "when value is blank and description is present" do
-        v.stub(:unit_description) { 'desc' }
-        subject.stub(:option_value_value_unit) { [nil, nil] }
-        subject.stub(:value_scaled?) { true }
-        subject.name(v).should == "desc"
+        allow(v).to receive(:unit_description) { 'desc' }
+        allow(subject).to receive(:option_value_value_unit) { [nil, nil] }
+        allow(subject).to receive(:value_scaled?) { true }
+        expect(subject.name(v)).to eq("desc")
       end
 
       it "spaces value and unit when value is unscaled" do
-        v.stub(:unit_description) { nil }
-        subject.stub(:option_value_value_unit) { %w(value unit) }
-        subject.stub(:value_scaled?) { false }
-        subject.name(v).should == "value unit"
+        allow(v).to receive(:unit_description) { nil }
+        allow(subject).to receive(:option_value_value_unit) { %w(value unit) }
+        allow(subject).to receive(:value_scaled?) { false }
+        expect(subject.name(v)).to eq("value unit")
       end
     end
 
@@ -39,7 +39,7 @@ module OpenFoodNetwork
       it "returns true when the product has a scale" do
         p = Spree::Product.new variant_unit_scale: 1000
         v = Spree::Variant.new
-        v.stub(:product) { p }
+        allow(v).to receive(:product) { p }
         subject = OptionValueNamer.new v
 
         expect(subject.send(:value_scaled?)).to be true
@@ -48,7 +48,7 @@ module OpenFoodNetwork
       it "returns false otherwise" do
         p = Spree::Product.new
         v = Spree::Variant.new
-        v.stub(:product) { p }
+        allow(v).to receive(:product) { p }
         subject = OptionValueNamer.new v
 
         expect(subject.send(:value_scaled?)).to be false
@@ -61,8 +61,8 @@ module OpenFoodNetwork
 
       it "generates simple values" do
         p = double(:product, variant_unit: 'weight', variant_unit_scale: 1.0)
-        v.stub(:product) { p }
-        v.stub(:unit_value) { 100 }
+        allow(v).to receive(:product) { p }
+        allow(v).to receive(:unit_value) { 100 }
 
 
         expect(subject.send(:option_value_value_unit)).to eq [100, 'g']
@@ -70,16 +70,16 @@ module OpenFoodNetwork
 
       it "generates values when unit value is non-integer" do
         p = double(:product, variant_unit: 'weight', variant_unit_scale: 1.0)
-        v.stub(:product) { p }
-        v.stub(:unit_value) { 123.45 }
+        allow(v).to receive(:product) { p }
+        allow(v).to receive(:unit_value) { 123.45 }
 
         expect(subject.send(:option_value_value_unit)).to eq [123.45, 'g']
       end
 
       it "returns a value of 1 when unit value equals the scale" do
         p = double(:product, variant_unit: 'weight', variant_unit_scale: 1000.0)
-        v.stub(:product) { p }
-        v.stub(:unit_value) { 1000.0 }
+        allow(v).to receive(:product) { p }
+        allow(v).to receive(:unit_value) { 1000.0 }
 
         expect(subject.send(:option_value_value_unit)).to eq [1, 'kg']
       end
@@ -87,8 +87,8 @@ module OpenFoodNetwork
       it "generates values for all weight scales" do
         [[1.0, 'g'], [1000.0, 'kg'], [1000000.0, 'T']].each do |scale, unit|
           p = double(:product, variant_unit: 'weight', variant_unit_scale: scale)
-          v.stub(:product) { p }
-          v.stub(:unit_value) { 100 * scale }
+          allow(v).to receive(:product) { p }
+          allow(v).to receive(:unit_value) { 100 * scale }
           expect(subject.send(:option_value_value_unit)).to eq [100, unit]
         end
       end
@@ -96,39 +96,39 @@ module OpenFoodNetwork
       it "generates values for all volume scales" do
         [[0.001, 'mL'], [1.0, 'L'], [1000.0, 'kL']].each do |scale, unit|
           p = double(:product, variant_unit: 'volume', variant_unit_scale: scale)
-          v.stub(:product) { p }
-          v.stub(:unit_value) { 100 * scale }
+          allow(v).to receive(:product) { p }
+          allow(v).to receive(:unit_value) { 100 * scale }
           expect(subject.send(:option_value_value_unit)).to eq [100, unit]
         end
       end
 
       it "chooses the correct scale when value is very small" do
         p = double(:product, variant_unit: 'volume', variant_unit_scale: 0.001)
-        v.stub(:product) { p }
-        v.stub(:unit_value) { 0.0001 }
+        allow(v).to receive(:product) { p }
+        allow(v).to receive(:unit_value) { 0.0001 }
         expect(subject.send(:option_value_value_unit)).to eq [0.1, 'mL']
       end
 
       it "generates values for item units" do
         %w(packet box).each do |unit|
           p = double(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: unit)
-          v.stub(:product) { p }
-          v.stub(:unit_value) { 100 }
+          allow(v).to receive(:product) { p }
+          allow(v).to receive(:unit_value) { 100 }
           expect(subject.send(:option_value_value_unit)).to eq [100, unit.pluralize]
         end
       end
 
       it "generates singular values for item units when value is 1" do
         p = double(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: 'packet')
-        v.stub(:product) { p }
-        v.stub(:unit_value) { 1 }
+        allow(v).to receive(:product) { p }
+        allow(v).to receive(:unit_value) { 1 }
         expect(subject.send(:option_value_value_unit)).to eq [1, 'packet']
       end
 
       it "returns [nil, nil] when unit value is not set" do
         p = double(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: 'foo')
-        v.stub(:product) { p }
-        v.stub(:unit_value) { nil }
+        allow(v).to receive(:product) { p }
+        allow(v).to receive(:unit_value) { nil }
         expect(subject.send(:option_value_value_unit)).to eq [nil, nil]
       end
     end

--- a/spec/lib/open_food_network/order_and_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/order_and_distributor_report_spec.rb
@@ -26,11 +26,11 @@ module OpenFoodNetwork
         subject = OrderAndDistributorReport.new [@order]
 
         header = subject.header
-        header.should == ["Order date", "Order Id",
+        expect(header).to eq(["Order date", "Order Id",
           "Customer Name","Customer Email", "Customer Phone", "Customer City",
           "SKU", "Item name", "Variant", "Quantity", "Max Quantity", "Cost", "Shipping Cost",
           "Payment Method",
-          "Distributor", "Distributor address", "Distributor city", "Distributor postcode", "Shipping instructions"]
+          "Distributor", "Distributor address", "Distributor city", "Distributor postcode", "Shipping instructions"])
       end
 
       it "should denormalise order and distributor details for display as csv" do
@@ -38,11 +38,11 @@ module OpenFoodNetwork
 
         table = subject.table
 
-        table[0].should == [@order.created_at, @order.id,
+        expect(table[0]).to eq([@order.created_at, @order.id,
           @bill_address.full_name, @order.email, @bill_address.phone, @bill_address.city,
           @line_item.product.sku, @line_item.product.name, @line_item.options_text, @line_item.quantity, @line_item.max_quantity, @line_item.price * @line_item.quantity, @line_item.distribution_fee,
           @payment_method.name,
-          @distributor.name, @distributor.address.address1, @distributor.address.city, @distributor.address.zipcode, @shipping_instructions ]
+          @distributor.name, @distributor.address.address1, @distributor.address.city, @distributor.address.zipcode, @shipping_instructions ])
       end
     end
   end

--- a/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
@@ -17,10 +17,10 @@ module OpenFoodNetwork
 
         applicator = OrderCycleFormApplicator.new(oc, user)
 
-        applicator.should_receive(:incoming_exchange_variant_ids).with(incoming_exchange).and_return([1, 3])
-        applicator.should_receive(:exchange_exists?).with(supplier_id, coordinator_id, true).and_return(false)
-        applicator.should_receive(:add_exchange).with(supplier_id, coordinator_id, true, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :receival_instructions => 'receival instructions'})
-        applicator.should_receive(:destroy_untouched_exchanges)
+        expect(applicator).to receive(:incoming_exchange_variant_ids).with(incoming_exchange).and_return([1, 3])
+        expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id, true).and_return(false)
+        expect(applicator).to receive(:add_exchange).with(supplier_id, coordinator_id, true, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :receival_instructions => 'receival instructions'})
+        expect(applicator).to receive(:destroy_untouched_exchanges)
 
         applicator.go!
       end
@@ -35,10 +35,10 @@ module OpenFoodNetwork
 
         applicator = OrderCycleFormApplicator.new(oc, user)
 
-        applicator.should_receive(:outgoing_exchange_variant_ids).with(outgoing_exchange).and_return([1, 3])
-        applicator.should_receive(:exchange_exists?).with(coordinator_id, distributor_id, false).and_return(false)
-        applicator.should_receive(:add_exchange).with(coordinator_id, distributor_id, false, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :pickup_time => 'pickup time', :pickup_instructions => 'pickup instructions', tag_list: 'wholesale'})
-        applicator.should_receive(:destroy_untouched_exchanges)
+        expect(applicator).to receive(:outgoing_exchange_variant_ids).with(outgoing_exchange).and_return([1, 3])
+        expect(applicator).to receive(:exchange_exists?).with(coordinator_id, distributor_id, false).and_return(false)
+        expect(applicator).to receive(:add_exchange).with(coordinator_id, distributor_id, false, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :pickup_time => 'pickup time', :pickup_instructions => 'pickup instructions', tag_list: 'wholesale'})
+        expect(applicator).to receive(:destroy_untouched_exchanges)
 
         applicator.go!
       end
@@ -57,10 +57,10 @@ module OpenFoodNetwork
 
         applicator = OrderCycleFormApplicator.new(oc, user)
 
-        applicator.should_receive(:incoming_exchange_variant_ids).with(incoming_exchange).and_return([1, 3])
-        applicator.should_receive(:exchange_exists?).with(supplier_id, coordinator_id, true).and_return(true)
-        applicator.should_receive(:update_exchange).with(supplier_id, coordinator_id, true, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :receival_instructions => 'receival instructions'})
-        applicator.should_receive(:destroy_untouched_exchanges)
+        expect(applicator).to receive(:incoming_exchange_variant_ids).with(incoming_exchange).and_return([1, 3])
+        expect(applicator).to receive(:exchange_exists?).with(supplier_id, coordinator_id, true).and_return(true)
+        expect(applicator).to receive(:update_exchange).with(supplier_id, coordinator_id, true, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :receival_instructions => 'receival instructions'})
+        expect(applicator).to receive(:destroy_untouched_exchanges)
 
         applicator.go!
       end
@@ -79,10 +79,10 @@ module OpenFoodNetwork
 
         applicator = OrderCycleFormApplicator.new(oc, user)
 
-        applicator.should_receive(:outgoing_exchange_variant_ids).with(outgoing_exchange).and_return([1, 3])
-        applicator.should_receive(:exchange_exists?).with(coordinator_id, distributor_id, false).and_return(true)
-        applicator.should_receive(:update_exchange).with(coordinator_id, distributor_id, false, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :pickup_time => 'pickup time', :pickup_instructions => 'pickup instructions', tag_list: 'wholesale'})
-        applicator.should_receive(:destroy_untouched_exchanges)
+        expect(applicator).to receive(:outgoing_exchange_variant_ids).with(outgoing_exchange).and_return([1, 3])
+        expect(applicator).to receive(:exchange_exists?).with(coordinator_id, distributor_id, false).and_return(true)
+        expect(applicator).to receive(:update_exchange).with(coordinator_id, distributor_id, false, {:variant_ids => [1, 3], :enterprise_fee_ids => [1, 2], :pickup_time => 'pickup time', :pickup_instructions => 'pickup instructions', tag_list: 'wholesale'})
+        expect(applicator).to receive(:destroy_untouched_exchanges)
 
         applicator.go!
       end
@@ -101,10 +101,10 @@ module OpenFoodNetwork
 
           applicator = OrderCycleFormApplicator.new(oc, user)
 
-          applicator.should_receive(:destroy_untouched_exchanges)
+          expect(applicator).to receive(:destroy_untouched_exchanges)
 
           applicator.go!
-          applicator.send(:untouched_exchanges).should == [exchange]
+          expect(applicator.send(:untouched_exchanges)).to eq([exchange])
         end
 
         it "compares exchanges by id only" do
@@ -117,12 +117,12 @@ module OpenFoodNetwork
             @touched_exchanges = [e2]
           end
 
-          applicator.send(:untouched_exchanges).should == []
+          expect(applicator.send(:untouched_exchanges)).to eq([])
         end
 
         context "as a manager of the coordinator" do
           let(:applicator) { OrderCycleFormApplicator.new(nil, user) }
-          before { applicator.stub(:manages_coordinator?) { true } }
+          before { allow(applicator).to receive(:manages_coordinator?) { true } }
 
           it "destroys exchanges" do
             exchanges = [double(:exchange), double(:exchange)]
@@ -135,7 +135,7 @@ module OpenFoodNetwork
 
         context "as a non-manager of the coordinator" do
           let(:applicator) { OrderCycleFormApplicator.new(nil, user) }
-          before { applicator.stub(:manages_coordinator?) { false } }
+          before { allow(applicator).to receive(:manages_coordinator?) { false } }
 
           it "does not destroy any exchanges" do
             expect(applicator).to_not receive(:with_permission)
@@ -270,9 +270,9 @@ module OpenFoodNetwork
             ex = double(:exchange, participant: e)
 
             applicator = OrderCycleFormApplicator.new(nil, user)
-            applicator.stub(:permitted_enterprises) { [e] }
+            allow(applicator).to receive(:permitted_enterprises) { [e] }
 
-            applicator.send(:permission_for, ex).should be true
+            expect(applicator.send(:permission_for, ex)).to be true
           end
 
           it "returns false otherwise" do
@@ -280,9 +280,9 @@ module OpenFoodNetwork
             ex = double(:exchange, participant: e)
 
             applicator = OrderCycleFormApplicator.new(nil, user)
-            applicator.stub(:permitted_enterprises) { [] }
+            allow(applicator).to receive(:permitted_enterprises) { [] }
 
-            applicator.send(:permission_for, ex).should be false
+            expect(applicator.send(:permission_for, ex)).to be false
           end
         end
       end
@@ -298,12 +298,12 @@ module OpenFoodNetwork
         exchange = FactoryGirl.create(:exchange, order_cycle: oc)
         applicator = OrderCycleFormApplicator.new(oc, user)
 
-        applicator.send(:exchange_exists?, exchange.sender_id, exchange.receiver_id, exchange.incoming).should be true
-        applicator.send(:exchange_exists?, exchange.sender_id, exchange.receiver_id, !exchange.incoming).should be false
-        applicator.send(:exchange_exists?, exchange.receiver_id, exchange.sender_id, exchange.incoming).should be false
-        applicator.send(:exchange_exists?, exchange.sender_id, 999999, exchange.incoming).should be false
-        applicator.send(:exchange_exists?, 999999, exchange.receiver_id, exchange.incoming).should be false
-        applicator.send(:exchange_exists?, 999999, 888888, exchange.incoming).should be false
+        expect(applicator.send(:exchange_exists?, exchange.sender_id, exchange.receiver_id, exchange.incoming)).to be true
+        expect(applicator.send(:exchange_exists?, exchange.sender_id, exchange.receiver_id, !exchange.incoming)).to be false
+        expect(applicator.send(:exchange_exists?, exchange.receiver_id, exchange.sender_id, exchange.incoming)).to be false
+        expect(applicator.send(:exchange_exists?, exchange.sender_id, 999999, exchange.incoming)).to be false
+        expect(applicator.send(:exchange_exists?, 999999, exchange.receiver_id, exchange.incoming)).to be false
+        expect(applicator.send(:exchange_exists?, 999999, 888888, exchange.incoming)).to be false
       end
 
       describe "adding exchanges" do
@@ -332,7 +332,7 @@ module OpenFoodNetwork
             expect(exchange.variants).to match_array [variant1, variant2]
             expect(exchange.enterprise_fees).to match_array [enterprise_fee1, enterprise_fee2]
 
-            applicator.send(:touched_exchanges).should == [exchange]
+            expect(applicator.send(:touched_exchanges)).to eq([exchange])
           end
         end
 
@@ -449,7 +449,7 @@ module OpenFoodNetwork
         applicator.send(:touched_exchanges=, [])
         applicator.send(:update_exchange, sender.id, receiver.id, incoming, {:variant_ids => [variant1.id]})
 
-        exchange.variants.should_not == [variant1]
+        expect(exchange.variants).not_to eq([variant1])
       end
     end
   end

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -16,13 +16,13 @@ module OpenFoodNetwork
         it "fetches completed orders" do
           o1 = create(:order)
           o2 = create(:order, completed_at: 1.day.ago)
-          subject.orders.should == [o2]
+          expect(subject.orders).to eq([o2])
         end
 
         it "does not show cancelled orders" do
           o1 = create(:order, state: "canceled", completed_at: 1.day.ago)
           o2 = create(:order, completed_at: 1.day.ago)
-          subject.orders.should == [o2]
+          expect(subject.orders).to eq([o2])
         end
       end
     end
@@ -46,8 +46,8 @@ module OpenFoodNetwork
           o1 = create(:order, distributor: d1, completed_at: 1.day.ago)
           o2 = create(:order, distributor: d2, completed_at: 1.day.ago)
 
-          subject.should_receive(:filter).with([o1]).and_return([o1])
-          subject.orders.should == [o1]
+          expect(subject).to receive(:filter).with([o1]).and_return([o1])
+          expect(subject.orders).to eq([o1])
         end
 
 
@@ -57,8 +57,8 @@ module OpenFoodNetwork
           order.line_items << create(:line_item, product: product)
 
           # When I fetch orders, I should see no orders
-          subject.should_receive(:filter).with([]).and_return([])
-          subject.orders.should == []
+          expect(subject).to receive(:filter).with([]).and_return([])
+          expect(subject.orders).to eq([])
         end
       end
 
@@ -73,15 +73,15 @@ module OpenFoodNetwork
         let!(:payment1) { create(:payment, order: order1, payment_method: pm1) }
 
         it "returns all orders sans-params" do
-          subject.filter(orders).should == orders
+          expect(subject.filter(orders)).to eq(orders)
         end
 
         it "filters to a specific order cycle" do
           oc2 = create(:simple_order_cycle)
           order2 = create(:order, order_cycle: oc2)
 
-          subject.stub(:params).and_return(order_cycle_id: oc1.id)
-          subject.filter(orders).should == [order1]
+          allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id)
+          expect(subject.filter(orders)).to eq([order1])
         end
 
         it "filters to a payment method" do
@@ -91,8 +91,8 @@ module OpenFoodNetwork
           order3 = create(:order, payments: [create(:payment, payment_method: pm3)])
           # payment2 = create(:payment, order: order2, payment_method: pm2)
 
-          subject.stub(:params).and_return(payment_method_in: [pm1.id, pm3.id] )
-          subject.filter(orders).should match_array [order1, order3]
+          allow(subject).to receive(:params).and_return(payment_method_in: [pm1.id, pm3.id] )
+          expect(subject.filter(orders)).to match_array [order1, order3]
         end
 
         it "filters to a shipping method" do
@@ -101,15 +101,15 @@ module OpenFoodNetwork
           order2 = create(:order, shipping_method: sm2)
           order3 = create(:order, shipping_method: sm3)
 
-          subject.stub(:params).and_return(shipping_method_in: [sm1.id, sm3.id])
+          allow(subject).to receive(:params).and_return(shipping_method_in: [sm1.id, sm3.id])
           expect(subject.filter(orders)).to match_array [order1, order3]
         end
 
         it "should do all the filters at once" do
-          subject.stub(:params).and_return(order_cycle_id: oc1.id,
+          allow(subject).to receive(:params).and_return(order_cycle_id: oc1.id,
                                            shipping_method_name: sm1.name,
                                            payment_method_name: pm1.name)
-          subject.filter(orders).should == [order1]
+          expect(subject.filter(orders)).to eq([order1])
         end
       end
     end

--- a/spec/lib/open_food_network/order_cycle_permissions_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_permissions_spec.rb
@@ -14,7 +14,7 @@ module OpenFoodNetwork
         let(:permissions) { OrderCyclePermissions.new(user, nil) }
 
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
         end
 
         it "returns an empty scope" do
@@ -24,7 +24,7 @@ module OpenFoodNetwork
 
       context "as a manager of the coordinator" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
         end
 
         it "returns the coordinator itself" do
@@ -45,7 +45,7 @@ module OpenFoodNetwork
           end
 
           context "where the coordinator sells 'own'" do
-            before { coordinator.stub(:sells) { 'own' } }
+            before { allow(coordinator).to receive(:sells) { 'own' } }
             it "returns just the coordinator" do
               enterprises = permissions.visible_enterprises
               expect(enterprises).to_not include hub, producer
@@ -66,7 +66,7 @@ module OpenFoodNetwork
             end
 
             context "where the coordinator sells 'own'" do
-              before { coordinator.stub(:sells) { 'own' } }
+              before { allow(coordinator).to receive(:sells) { 'own' } }
               it "returns just the coordinator" do
                 enterprises = permissions.visible_enterprises
                 expect(enterprises).to_not include hub, producer
@@ -85,7 +85,7 @@ module OpenFoodNetwork
 
       context "as a manager of a hub" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
         end
 
         context "that has granted P-OC to the coordinator" do
@@ -192,7 +192,7 @@ module OpenFoodNetwork
 
       context "as a manager of a producer" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer]) }
         end
 
         context "which has granted P-OC to the coordinator" do
@@ -308,11 +308,11 @@ module OpenFoodNetwork
         let!(:ex_out) { create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false) }
 
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
         end
 
         it "returns all exchanges in the order cycle, regardless of hubE permissions" do
-          permissions.visible_exchanges.should include ex_in, ex_out
+          expect(permissions.visible_exchanges).to include ex_in, ex_out
         end
       end
 
@@ -321,14 +321,14 @@ module OpenFoodNetwork
         let!(:ex_in) { create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator, incoming: true) }
 
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
         end
 
         context "where my hub is in the order cycle" do
           let!(:ex_out) { create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false) }
 
           it "returns my hub's outgoing exchange" do
-            permissions.visible_exchanges.should == [ex_out]
+            expect(permissions.visible_exchanges).to eq([ex_out])
           end
 
           context "where my hub has been granted P-OC by an incoming producer" do
@@ -337,20 +337,20 @@ module OpenFoodNetwork
             end
 
             it "returns the producer's incoming exchange" do
-              permissions.visible_exchanges.should include ex_in
+              expect(permissions.visible_exchanges).to include ex_in
             end
           end
 
           context "where my hub has not been granted P-OC by an incoming producer" do
             it "returns the producers's incoming exchange, and my own outhoing exchange" do
-              permissions.visible_exchanges.should_not include ex_in
+              expect(permissions.visible_exchanges).not_to include ex_in
             end
           end
         end
 
         context "where my hub isn't in the order cycle" do
           it "does not return the producer's incoming exchanges" do
-            permissions.visible_exchanges.should == []
+            expect(permissions.visible_exchanges).to eq([])
           end
         end
 
@@ -363,7 +363,7 @@ module OpenFoodNetwork
             before { ex_out.variants << variant }
 
             it "returns incoming exchanges supplying the variants in my outgoing exchange" do
-              permissions.visible_exchanges.should include ex_out
+              expect(permissions.visible_exchanges).to include ex_out
             end
           end
         end
@@ -373,14 +373,14 @@ module OpenFoodNetwork
         let!(:ex_out) { create(:exchange, order_cycle: oc, sender: coordinator, receiver: hub, incoming: false) }
 
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer]) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer]) }
         end
 
         context "where my producer supplies to the order cycle" do
           let!(:ex_in) { create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator, incoming: true) }
 
           it "returns my producer's incoming exchange" do
-            permissions.visible_exchanges.should == [ex_in]
+            expect(permissions.visible_exchanges).to eq([ex_in])
           end
 
           context "my producer has granted P-OC to an outgoing hub" do
@@ -389,20 +389,20 @@ module OpenFoodNetwork
             end
 
             it "returns the hub's outgoing exchange" do
-              permissions.visible_exchanges.should include ex_out
+              expect(permissions.visible_exchanges).to include ex_out
             end
           end
 
           context "my producer has not granted P-OC to an outgoing hub" do
             it "does not return the hub's outgoing exchange" do
-              permissions.visible_exchanges.should_not include ex_out
+              expect(permissions.visible_exchanges).not_to include ex_out
             end
           end
         end
 
         context "where my producer doesn't supply the order cycle" do
           it "does not return the hub's outgoing exchanges" do
-            permissions.visible_exchanges.should == []
+            expect(permissions.visible_exchanges).to eq([])
           end
         end
 
@@ -417,13 +417,13 @@ module OpenFoodNetwork
               let!(:ex_in) { create(:exchange, order_cycle: oc, sender: producer, receiver: coordinator, incoming: true) }
 
               it "returns the outgoing exchange" do
-                permissions.visible_exchanges.should include ex_out
+                expect(permissions.visible_exchanges).to include ex_out
               end
             end
 
             context "where my producer doesn't supply to the order cycle" do
               it "does not return the outgoing exchange" do
-                permissions.visible_exchanges.should_not include ex_out
+                expect(permissions.visible_exchanges).not_to include ex_out
               end
             end
           end
@@ -441,7 +441,7 @@ module OpenFoodNetwork
       describe "incoming exchanges" do
         context "as a manager of the coordinator" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
           end
 
           it "returns all variants belonging to the sending producer" do
@@ -453,7 +453,7 @@ module OpenFoodNetwork
 
         context "as a manager of the producer" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer1]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer1]) }
           end
 
           it "returns all variants belonging to the sending producer" do
@@ -465,7 +465,7 @@ module OpenFoodNetwork
 
         context "as a manager of a hub which has been granted P-OC by the producer" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -493,7 +493,7 @@ module OpenFoodNetwork
       describe "outgoing exchanges" do
         context "as a manager of the coordinator" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -535,7 +535,7 @@ module OpenFoodNetwork
 
         context "as manager of an outgoing hub" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -571,7 +571,7 @@ module OpenFoodNetwork
 
         context "as the manager of a producer which has granted P-OC to an outgoing hub" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer1]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer1]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -597,7 +597,7 @@ module OpenFoodNetwork
 
         context "as the manager of a producer which has not granted P-OC to an outgoing hub" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer2]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer2]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -632,7 +632,7 @@ module OpenFoodNetwork
       describe "incoming exchanges" do
         context "as a manager of the coordinator" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
           end
 
           it "returns all variants belonging to the sending producer" do
@@ -644,7 +644,7 @@ module OpenFoodNetwork
 
         context "as a manager of the producer" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer1]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer1]) }
           end
 
           it "returns all variants belonging to the sending producer" do
@@ -656,7 +656,7 @@ module OpenFoodNetwork
 
         context "as a manager of a hub which has been granted P-OC by the producer" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -670,7 +670,7 @@ module OpenFoodNetwork
       describe "outgoing exchanges" do
         context "as a manager of the coordinator" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [coordinator]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -712,7 +712,7 @@ module OpenFoodNetwork
 
         context "as manager of an outgoing hub" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -748,7 +748,7 @@ module OpenFoodNetwork
 
         context "as the manager of a producer which has granted P-OC to an outgoing hub" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer1]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer1]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 
@@ -789,7 +789,7 @@ module OpenFoodNetwork
 
         context "as the manager of a producer which has not granted P-OC to an outgoing hub" do
           before do
-            permissions.stub(:managed_enterprises) { Enterprise.where(id: [producer2]) }
+            allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [producer2]) }
             create(:enterprise_relationship, parent: producer1, child: hub, permissions_list: [:add_to_order_cycle])
           end
 

--- a/spec/lib/open_food_network/order_grouper_spec.rb
+++ b/spec/lib/open_food_network/order_grouper_spec.rb
@@ -16,8 +16,8 @@ module OpenFoodNetwork
         subject = OrderGrouper.new rules, columns
 
         tree = double(:tree)
-        subject.should_receive(:build_tree).with(@items, rules).and_return(tree)
-        subject.should_receive(:build_table).with(tree)
+        expect(subject).to receive(:build_tree).with(@items, rules).and_return(tree)
+        expect(subject).to receive(:build_table).with(tree)
 
         subject.table(@items)
       end
@@ -32,8 +32,8 @@ module OpenFoodNetwork
         columns = [column1, column2]
         subject = OrderGrouper.new rules, columns
         
-        rules.should_receive(:clone).and_return(rules)
-        subject.build_tree(@items, rules).should == @items
+        expect(rules).to receive(:clone).and_return(rules)
+        expect(subject.build_tree(@items, rules)).to eq(@items)
       end
     end
 
@@ -52,42 +52,42 @@ module OpenFoodNetwork
       it "builds branches by removing a rule from 'rules' and running group_and_sort" do
         subject = OrderGrouper.new @rules, @columns
 
-        @rules.should_receive(:clone).and_return(@rules)
-        @rules.should_receive(:delete_at).with(0)
+        expect(@rules).to receive(:clone).and_return(@rules)
+        expect(@rules).to receive(:delete_at).with(0)
         grouped_tree = double(:grouped_tree)
-        subject.should_receive(:group_and_sort).and_return(grouped_tree)
+        expect(subject).to receive(:group_and_sort).and_return(grouped_tree)
 
-        subject.build_tree(@items, @rules).should == grouped_tree
+        expect(subject.build_tree(@items, @rules)).to eq(grouped_tree)
       end
 
       it "separates the first rule from rules before sending to group_and_sort" do
         subject = OrderGrouper.new @rules, @columns
 
         grouped_tree = double(:grouped_tree)
-        subject.should_receive(:group_and_sort).with(@rule1, @rules[1..-1], @items).and_return(grouped_tree)
+        expect(subject).to receive(:group_and_sort).with(@rule1, @rules[1..-1], @items).and_return(grouped_tree)
 
-        subject.build_tree(@items, @rules).should == grouped_tree
+        expect(subject.build_tree(@items, @rules)).to eq(grouped_tree)
       end
 
       it "should group, then sort, send each group to build_tree, and return a branch" do
         summary_columns_object = double(:summary_columns)
-        @rule1.stub(:[]).with(:summary_columns) { summary_columns_object }
+        allow(@rule1).to receive(:[]).with(:summary_columns) { summary_columns_object }
 
         subject = OrderGrouper.new @rules, @columns
 
         number_of_categories = 3
         groups = double(:groups)
-        @items.should_receive(:group_by).and_return(groups)
+        expect(@items).to receive(:group_by).and_return(groups)
         sorted_groups = {}
         1.upto(number_of_categories) { |i| sorted_groups[i] = double(:group, name: "Group "+ i.to_s ) }
-        groups.should_receive(:sort_by).and_return(sorted_groups)
+        expect(groups).to receive(:sort_by).and_return(sorted_groups)
         group = { group1: 1, group2: 2, group3: 3 }
-        subject.should_receive(:build_tree).exactly(number_of_categories).times.and_return(group)
+        expect(subject).to receive(:build_tree).exactly(number_of_categories).times.and_return(group)
 
         group_tree = {}
         1.upto(number_of_categories) { |i| group_tree[i] = group }
         1.upto(number_of_categories) { |i| group_tree[i][:summary_row] = summary_columns_object }
-        subject.group_and_sort(@rule1, @remaining_rules, @items).should == group_tree
+        expect(subject.group_and_sort(@rule1, @remaining_rules, @items)).to eq(group_tree)
       end
     end
 
@@ -114,10 +114,10 @@ module OpenFoodNetwork
       it "should return columns when given an Array" do
         subject = OrderGrouper.new @rules, @columns
 
-        @column1.should_receive(:call)
-        @column2.should_receive(:call)
+        expect(@column1).to receive(:call)
+        expect(@column2).to receive(:call)
 
-        subject.build_table(@items1).should == [["Column1", "Column2"]]
+        expect(subject.build_table(@items1)).to eq([["Column1", "Column2"]])
       end
       
       it "should return a row for each key-value pair when given a Hash" do
@@ -129,7 +129,7 @@ module OpenFoodNetwork
 
         expected_return = []
         groups.length.times { expected_return << ["Column1", "Column2"] }
-        subject.build_table(groups).should == expected_return
+        expect(subject.build_table(groups)).to eq(expected_return)
       end
 
       it "should return an extra row when a :summary_row key appears in a given Hash" do
@@ -145,7 +145,7 @@ module OpenFoodNetwork
             expected_return << ["Column1", "Column2"]
           end
         end
-        subject.build_table(groups).should == expected_return
+        expect(subject.build_table(groups)).to eq(expected_return)
       end
     end
   end

--- a/spec/lib/open_food_network/orders_and_fulfillments_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report_spec.rb
@@ -19,13 +19,13 @@ module OpenFoodNetwork
         it "fetches completed orders" do
           o2 = create(:order)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
 
         it "does not show cancelled orders" do
           o2 = create(:order, state: "canceled", completed_at: 1.day.ago)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
       end
 
@@ -49,8 +49,8 @@ module OpenFoodNetwork
           end
 
           it "shows line items supplied by my producers, with names hidden" do
-            subject.table_items.should == [li2]
-            subject.table_items.first.order.bill_address.firstname.should == "HIDDEN"
+            expect(subject.table_items).to eq([li2])
+            expect(subject.table_items.first.order.bill_address.firstname).to eq("HIDDEN")
           end
         end
 
@@ -63,7 +63,7 @@ module OpenFoodNetwork
           end
 
           it "shows line items supplied by my producers, with names hidden" do
-            subject.table_items.should == []
+            expect(subject.table_items).to eq([])
           end
         end
       end
@@ -81,15 +81,15 @@ module OpenFoodNetwork
           d2.enterprise_roles.create!(user: create(:user))
           o2 = create(:order, distributor: d2, completed_at: 1.day.ago)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
 
         it "only shows the selected order cycle" do
           oc2 = create(:simple_order_cycle)
           o2 = create(:order, distributor: d1, order_cycle: oc2)
           o2.line_items << build(:line_item)
-          subject.stub(:params).and_return(order_cycle_id_in: oc1.id)
-          subject.table_items.should == [li1]
+          allow(subject).to receive(:params).and_return(order_cycle_id_in: oc1.id)
+          expect(subject.table_items).to eq([li1])
         end
       end
     end
@@ -108,7 +108,7 @@ module OpenFoodNetwork
 
         report_types.each do |report_type|
           report = OrdersAndFulfillmentsReport.new user, report_type: report_type
-          report.header.size.should == report.columns.size
+          expect(report.header.size).to eq(report.columns.size)
         end
       end
     end

--- a/spec/lib/open_food_network/packing_report_spec.rb
+++ b/spec/lib/open_food_network/packing_report_spec.rb
@@ -19,13 +19,13 @@ module OpenFoodNetwork
         it "fetches completed orders" do
           o2 = create(:order)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
 
         it "does not show cancelled orders" do
           o2 = create(:order, state: "canceled", completed_at: 1.day.ago)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
       end
 
@@ -49,8 +49,8 @@ module OpenFoodNetwork
           end
 
           it "shows line items supplied by my producers, with names hidden" do
-            subject.table_items.should == [li2]
-            subject.table_items.first.order.bill_address.firstname.should == "HIDDEN"
+            expect(subject.table_items).to eq([li2])
+            expect(subject.table_items.first.order.bill_address.firstname).to eq("HIDDEN")
           end
         end
 
@@ -63,7 +63,7 @@ module OpenFoodNetwork
           end
 
           it "shows line items supplied by my producers, with names hidden" do
-            subject.table_items.should == []
+            expect(subject.table_items).to eq([])
           end
         end
       end
@@ -81,15 +81,15 @@ module OpenFoodNetwork
           d2.enterprise_roles.create!(user: create(:user))
           o2 = create(:order, distributor: d2, completed_at: 1.day.ago)
           o2.line_items << build(:line_item)
-          subject.table_items.should == [li1]
+          expect(subject.table_items).to eq([li1])
         end
 
         it "only shows the selected order cycle" do
           oc2 = create(:simple_order_cycle)
           o2 = create(:order, distributor: d1, order_cycle: oc2)
           o2.line_items << build(:line_item)
-          subject.stub(:params).and_return(order_cycle_id_in: oc1.id)
-          subject.table_items.should == [li1]
+          allow(subject).to receive(:params).and_return(order_cycle_id_in: oc1.id)
+          expect(subject.table_items).to eq([li1])
         end
       end
     end

--- a/spec/lib/open_food_network/permissions_spec.rb
+++ b/spec/lib/open_food_network/permissions_spec.rb
@@ -81,12 +81,12 @@ module OpenFoodNetwork
       let(:e) { double(:enterprise) }
 
       it "returns managed and related enterprises with edit_profile permission" do
-        permissions.
-          should_receive(:managed_and_related_enterprises_granting).
+        expect(permissions).
+          to receive(:managed_and_related_enterprises_granting).
           with(:edit_profile).
           and_return([e])
 
-        permissions.editable_enterprises.should == [e]
+        expect(permissions.editable_enterprises).to eq([e])
       end
     end
 
@@ -95,11 +95,11 @@ module OpenFoodNetwork
       let(:e2) { create(:supplier_enterprise) }
 
       it "compiles the list from variant_override_enterprises_per_hub" do
-        permissions.stub(:variant_override_enterprises_per_hub) do
+        allow(permissions).to receive(:variant_override_enterprises_per_hub) do
           {1 => [e1.id], 2 => [e1.id, e2.id]}
         end
 
-        permissions.variant_override_producers.should match_array [e1, e2]
+        expect(permissions.variant_override_producers).to match_array [e1, e2]
       end
     end
 
@@ -111,30 +111,33 @@ module OpenFoodNetwork
       }
 
       before do
-        permissions.stub(:managed_enterprises) { Enterprise.where(id: hub.id) }
-        permissions.stub(:admin?) { false }
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: hub.id) }
+        allow(permissions).to receive(:admin?) { false }
       end
 
       it "returns enterprises as hub_id => [producer, ...]" do
-        permissions.variant_override_enterprises_per_hub.should ==
+        expect(permissions.variant_override_enterprises_per_hub).to eq(
           {hub.id => [producer.id]}
+        )
       end
 
       it "returns only permissions relating to managed hubs" do
         create(:enterprise_relationship, parent: e1, child: e2,
                          permissions_list: [:create_variant_overrides])
 
-        permissions.variant_override_enterprises_per_hub.should ==
+        expect(permissions.variant_override_enterprises_per_hub).to eq(
           {hub.id => [producer.id]}
+        )
       end
 
       it "returns only create_variant_overrides permissions" do
-        permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub, e2]) }
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub, e2]) }
         create(:enterprise_relationship, parent: e1, child: e2,
                          permissions_list: [:manage_products])
 
-        permissions.variant_override_enterprises_per_hub.should ==
+        expect(permissions.variant_override_enterprises_per_hub).to eq(
           {hub.id => [producer.id]}
+        )
       end
 
       describe "hubs connected to the user by relationships only" do
@@ -144,17 +147,17 @@ module OpenFoodNetwork
         }
 
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: producer_managed.id) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: producer_managed.id) }
         end
 
         it "does not allow the user to create variant overrides for the hub" do
-          permissions.variant_override_enterprises_per_hub.should == {}
+          expect(permissions.variant_override_enterprises_per_hub).to eq({})
         end
       end
 
       it "does not return managed producers (ie. only uses explicitly granted VO permissions)" do
         producer2 = create(:supplier_enterprise)
-        permissions.stub(:managed_enterprises) { Enterprise.where(id: [hub, producer2]) }
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: [hub, producer2]) }
 
         expect(permissions.variant_override_enterprises_per_hub[hub.id]).to_not include producer2.id
       end
@@ -171,19 +174,19 @@ module OpenFoodNetwork
       let!(:p2) { create(:simple_product, supplier: create(:supplier_enterprise) ) }
 
       before do
-        permissions.stub(:managed_enterprise_products) { Spree::Product.where('1=0') }
+        allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where('1=0') }
         allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) { Enterprise.where("1=0") }
       end
 
       it "returns products produced by managed enterprises" do
-        permissions.stub(:managed_enterprise_products) { Spree::Product.where(id: p1) }
-        permissions.editable_products.should == [p1]
+        allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where(id: p1) }
+        expect(permissions.editable_products).to eq([p1])
       end
 
       it "returns products produced by permitted enterprises" do
         allow(permissions).to receive(:related_enterprises_granting).
           with(:manage_products) { Enterprise.where(id: p2.supplier) }
-        permissions.editable_products.should == [p2]
+        expect(permissions.editable_products).to eq([p2])
       end
     end
 
@@ -193,26 +196,26 @@ module OpenFoodNetwork
       let!(:p3) { create(:simple_product, supplier: create(:supplier_enterprise) ) }
 
       before do
-        permissions.stub(:managed_enterprise_products) { Spree::Product.where("1=0") }
+        allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where("1=0") }
         allow(permissions).to receive(:related_enterprises_granting).with(:manage_products) { Enterprise.where("1=0") }
         allow(permissions).to receive(:related_enterprises_granting).with(:add_to_order_cycle) { Enterprise.where("1=0") }
       end
 
       it "returns products produced by managed enterprises" do
-        permissions.stub(:managed_enterprise_products) { Spree::Product.where(id: p1) }
-        permissions.visible_products.should == [p1]
+        allow(permissions).to receive(:managed_enterprise_products) { Spree::Product.where(id: p1) }
+        expect(permissions.visible_products).to eq([p1])
       end
 
       it "returns products produced by enterprises that have granted manage products" do
         allow(permissions).to receive(:related_enterprises_granting).
           with(:manage_products) { Enterprise.where(id: p2.supplier) }
-        permissions.visible_products.should == [p2]
+        expect(permissions.visible_products).to eq([p2])
       end
 
       it "returns products produced by enterprises that have granted P-OC" do
         allow(permissions).to receive(:related_enterprises_granting).
           with(:add_to_order_cycle) { Enterprise.where(id: p3.supplier) }
-        permissions.visible_products.should == [p3]
+        expect(permissions.visible_products).to eq([p3])
       end
     end
 
@@ -220,12 +223,12 @@ module OpenFoodNetwork
       let(:e) { double(:enterprise) }
 
       it "returns managed and related enterprises with manage_products permission" do
-        permissions.
-          should_receive(:managed_and_related_enterprises_granting).
+        expect(permissions).
+          to receive(:managed_and_related_enterprises_granting).
           with(:manage_products).
           and_return([e])
 
-        permissions.managed_product_enterprises.should == [e]
+        expect(permissions.managed_product_enterprises).to eq([e])
       end
     end
 
@@ -235,32 +238,32 @@ module OpenFoodNetwork
       let!(:er) { create(:enterprise_relationship, parent: e1, child: e2, permissions_list: [permission]) }
 
       it "returns the enterprises" do
-        permissions.stub(:managed_enterprises) { e2 }
-        permissions.send(:related_enterprises_granting, permission).should == [e1]
+        allow(permissions).to receive(:managed_enterprises) { e2 }
+        expect(permissions.send(:related_enterprises_granting, permission)).to eq([e1])
       end
 
       it "returns an empty array when there are none" do
-        permissions.stub(:managed_enterprises) { e1 }
-        permissions.send(:related_enterprises_granting, permission).should == []
+        allow(permissions).to receive(:managed_enterprises) { e1 }
+        expect(permissions.send(:related_enterprises_granting, permission)).to eq([])
       end
     end
 
     describe "finding enterprises that are managed or with a particular permission" do
       before do
-        permissions.stub(:managed_enterprises) { Enterprise.where('1=0') }
-        permissions.stub(:related_enterprises_granting) { Enterprise.where('1=0') }
-        permissions.stub(:admin?) { false }
+        allow(permissions).to receive(:managed_enterprises) { Enterprise.where('1=0') }
+        allow(permissions).to receive(:related_enterprises_granting) { Enterprise.where('1=0') }
+        allow(permissions).to receive(:admin?) { false }
       end
 
       it "returns managed enterprises" do
-        permissions.should_receive(:managed_enterprises) { Enterprise.where(id: e1) }
-        permissions.send(:managed_and_related_enterprises_granting, permission).should == [e1]
+        expect(permissions).to receive(:managed_enterprises) { Enterprise.where(id: e1) }
+        expect(permissions.send(:managed_and_related_enterprises_granting, permission)).to eq([e1])
       end
 
       it "returns permitted enterprises" do
-        permissions.should_receive(:related_enterprises_granting).with(permission).
+        expect(permissions).to receive(:related_enterprises_granting).with(permission).
           and_return(Enterprise.where(id: e2))
-        permissions.send(:managed_and_related_enterprises_granting, permission).should == [e2]
+        expect(permissions.send(:managed_and_related_enterprises_granting, permission)).to eq([e2])
       end
     end
 
@@ -274,12 +277,12 @@ module OpenFoodNetwork
       let!(:producer) { create(:supplier_enterprise) }
 
       before do
-        permissions.stub(:coordinated_order_cycles) { Enterprise.where("1=0") }
+        allow(permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
       end
 
       context "as the hub through which the order was placed" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: distributor) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: distributor) }
         end
 
         it "should let me see the order" do
@@ -289,8 +292,8 @@ module OpenFoodNetwork
 
       context "as the coordinator of the order cycle through which the order was placed" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: coordinator) }
-          permissions.stub(:coordinated_order_cycles) { OrderCycle.where(id: order_cycle) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: coordinator) }
+          allow(permissions).to receive(:coordinated_order_cycles) { OrderCycle.where(id: order_cycle) }
         end
 
         it "should let me see the order" do
@@ -300,7 +303,7 @@ module OpenFoodNetwork
 
       context "as a producer which has granted P-OC to the distributor of an order" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: producer) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: producer) }
           create(:enterprise_relationship, parent: producer, child: distributor, permissions_list: [:add_to_order_cycle])
         end
 
@@ -324,7 +327,7 @@ module OpenFoodNetwork
 
       context "as an enterprise that is a distributor in the order cycle, but not the distributor of the order" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: random_enterprise) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: random_enterprise) }
         end
 
         it "should not let me see the order" do
@@ -344,12 +347,12 @@ module OpenFoodNetwork
       let!(:producer) { create(:supplier_enterprise) }
 
       before do
-        permissions.stub(:coordinated_order_cycles) { Enterprise.where("1=0") }
+        allow(permissions).to receive(:coordinated_order_cycles) { Enterprise.where("1=0") }
       end
 
       context "as the hub through which the parent order was placed" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: distributor) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: distributor) }
         end
 
         it "should let me see the line_items" do
@@ -359,8 +362,8 @@ module OpenFoodNetwork
 
       context "as the coordinator of the order cycle through which the parent order was placed" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: coordinator) }
-          permissions.stub(:coordinated_order_cycles) { OrderCycle.where(id: order_cycle) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: coordinator) }
+          allow(permissions).to receive(:coordinated_order_cycles) { OrderCycle.where(id: order_cycle) }
         end
 
         it "should let me see the line_items" do
@@ -370,7 +373,7 @@ module OpenFoodNetwork
 
       context "as the manager producer which has granted P-OC to the distributor of the parent order" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: producer) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: producer) }
           create(:enterprise_relationship, parent: producer, child: distributor, permissions_list: [:add_to_order_cycle])
 
           line_item1.product.supplier = producer
@@ -386,7 +389,7 @@ module OpenFoodNetwork
 
       context "as an enterprise that is a distributor in the order cycle, but not the distributor of the parent order" do
         before do
-          permissions.stub(:managed_enterprises) { Enterprise.where(id: random_enterprise) }
+          allow(permissions).to receive(:managed_enterprises) { Enterprise.where(id: random_enterprise) }
         end
 
         it "should not let me see the line_items" do

--- a/spec/lib/open_food_network/products_and_inventory_report_spec.rb
+++ b/spec/lib/open_food_network/products_and_inventory_report_spec.rb
@@ -13,7 +13,7 @@ module OpenFoodNetwork
       end
 
       it "Should return headers" do
-        subject.header.should == [
+        expect(subject.header).to eq([
           "Supplier",
           "Producer Suburb",
           "Product",
@@ -24,7 +24,7 @@ module OpenFoodNetwork
           "Group Buy Unit Quantity",
           "Amount",
           "SKU"
-        ]
+        ])
       end
 
       it "should build a table from a list of variants" do
@@ -32,15 +32,15 @@ module OpenFoodNetwork
                         full_name: "Variant Name",
                         count_on_hand: 10,
                         price: 100)
-        variant.stub_chain(:product, :supplier, :name).and_return("Supplier")
-        variant.stub_chain(:product, :supplier, :address, :city).and_return("A city")
-        variant.stub_chain(:product, :name).and_return("Product Name")
-        variant.stub_chain(:product, :properties).and_return [double(name: "property1"), double(name: "property2")]
-        variant.stub_chain(:product, :taxons).and_return [double(name: "taxon1"), double(name: "taxon2")]
-        variant.stub_chain(:product, :group_buy_unit_size).and_return(21)
-        subject.stub(:variants).and_return [variant]
+        allow(variant).to receive_message_chain(:product, :supplier, :name).and_return("Supplier")
+        allow(variant).to receive_message_chain(:product, :supplier, :address, :city).and_return("A city")
+        allow(variant).to receive_message_chain(:product, :name).and_return("Product Name")
+        allow(variant).to receive_message_chain(:product, :properties).and_return [double(name: "property1"), double(name: "property2")]
+        allow(variant).to receive_message_chain(:product, :taxons).and_return [double(name: "taxon1"), double(name: "taxon2")]
+        allow(variant).to receive_message_chain(:product, :group_buy_unit_size).and_return(21)
+        allow(subject).to receive(:variants).and_return [variant]
 
-        subject.table.should == [[
+        expect(subject.table).to eq([[
           "Supplier",
           "A city",
           "Product Name",
@@ -51,13 +51,13 @@ module OpenFoodNetwork
           21,
           "",
           "sku"
-        ]]
+        ]])
       end
 
       it "fetches variants for some params" do
-        subject.should_receive(:child_variants).and_return ["children"]
-        subject.should_receive(:filter).with(['children']).and_return ["filter_children"]
-        subject.variants.should == ["filter_children"]
+        expect(subject).to receive(:child_variants).and_return ["children"]
+        expect(subject).to receive(:filter).with(['children']).and_return ["filter_children"]
+        expect(subject.variants).to eq(["filter_children"])
       end
     end
 
@@ -81,7 +81,7 @@ module OpenFoodNetwork
           variant_1 = product1.variants.first
           variant_2 = create(:variant, product: product1)
 
-          subject.child_variants.should match_array [variant_1, variant_2]
+          expect(subject.child_variants).to match_array [variant_1, variant_2]
         end
 
         it "should only return variants managed by the user" do
@@ -90,7 +90,7 @@ module OpenFoodNetwork
           variant_1 = product1.variants.first
           variant_2 = product2.variants.first
 
-          subject.child_variants.should == [variant_2]
+          expect(subject.child_variants).to eq([variant_2])
         end
       end
 
@@ -100,21 +100,21 @@ module OpenFoodNetwork
           product1 = create(:simple_product, supplier: supplier)
           product2 = create(:simple_product, supplier: supplier)
 
-          subject.filter(Spree::Variant.scoped).should match_array [product1.master, product1.variants.first, product2.master, product2.variants.first]
+          expect(subject.filter(Spree::Variant.scoped)).to match_array [product1.master, product1.variants.first, product2.master, product2.variants.first]
         end
         it "should filter deleted products" do
           product1 = create(:simple_product, supplier: supplier)
           product2 = create(:simple_product, supplier: supplier)
           product2.delete
-          subject.filter(Spree::Variant.scoped).should match_array [product1.master, product1.variants.first]
+          expect(subject.filter(Spree::Variant.scoped)).to match_array [product1.master, product1.variants.first]
         end
         describe "based on report type" do
           it "returns only variants on hand" do
             product1 = create(:simple_product, supplier: supplier, on_hand: 99)
             product2 = create(:simple_product, supplier: supplier, on_hand: 0)
 
-            subject.stub(:params).and_return(report_type: 'inventory')
-            subject.filter(variants).should == [product1.variants.first]
+            allow(subject).to receive(:params).and_return(report_type: 'inventory')
+            expect(subject.filter(variants)).to eq([product1.variants.first])
           end
         end
         it "filters to a specific supplier" do
@@ -122,8 +122,8 @@ module OpenFoodNetwork
           product1 = create(:simple_product, supplier: supplier)
           product2 = create(:simple_product, supplier: supplier2)
 
-          subject.stub(:params).and_return(supplier_id: supplier.id)
-          subject.filter(variants).should == [product1.variants.first]
+          allow(subject).to receive(:params).and_return(supplier_id: supplier.id)
+          expect(subject.filter(variants)).to eq([product1.variants.first])
         end
         it "filters to a specific distributor" do
           distributor = create(:distributor_enterprise)
@@ -131,8 +131,8 @@ module OpenFoodNetwork
           product2 = create(:simple_product, supplier: supplier)
           order_cycle = create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor], variants: [product2.variants.first])
 
-          subject.stub(:params).and_return(distributor_id: distributor.id)
-          subject.filter(variants).should == [product2.variants.first]
+          allow(subject).to receive(:params).and_return(distributor_id: distributor.id)
+          expect(subject.filter(variants)).to eq([product2.variants.first])
         end
         it "filters to a specific order cycle" do
           distributor = create(:distributor_enterprise)
@@ -140,8 +140,8 @@ module OpenFoodNetwork
           product2 = create(:simple_product, supplier: supplier)
           order_cycle = create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor], variants: [product1.variants.first])
 
-          subject.stub(:params).and_return(order_cycle_id: order_cycle.id)
-          subject.filter(variants).should == [product1.variants.first]
+          allow(subject).to receive(:params).and_return(order_cycle_id: order_cycle.id)
+          expect(subject.filter(variants)).to eq([product1.variants.first])
         end
 
         it "should do all the filters at once" do
@@ -150,7 +150,7 @@ module OpenFoodNetwork
           product2 = create(:simple_product, supplier: supplier)
           order_cycle = create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor], variants: [product1.variants.first])
 
-          subject.stub(:params).and_return(
+          allow(subject).to receive(:params).and_return(
             order_cycle_id: order_cycle.id,
             supplier_id: supplier.id,
             distributor_id: distributor.id,

--- a/spec/lib/open_food_network/products_renderer_spec.rb
+++ b/spec/lib/open_food_network/products_renderer_spec.rb
@@ -24,15 +24,15 @@ module OpenFoodNetwork
       end
 
       it "sorts products by the distributor's preferred taxon list" do
-        distributor.stub(:preferred_shopfront_taxon_order) {"#{t1.id},#{t2.id}"}
+        allow(distributor).to receive(:preferred_shopfront_taxon_order) {"#{t1.id},#{t2.id}"}
         products = pr.send(:load_products)
-        products.should == [p2, p4, p1, p3]
+        expect(products).to eq([p2, p4, p1, p3])
       end
 
       it "alphabetizes products by name when taxon list is not set" do
-        distributor.stub(:preferred_shopfront_taxon_order) {""}
+        allow(distributor).to receive(:preferred_shopfront_taxon_order) {""}
         products = pr.send(:load_products)
-        products.should == [p1, p2, p3, p4]
+        expect(products).to eq([p1, p2, p3, p4])
       end
     end
 
@@ -45,33 +45,33 @@ module OpenFoodNetwork
       end
 
       it "only returns products for the current order cycle" do
-        pr.products_json.should include product.name
+        expect(pr.products_json).to include product.name
       end
 
       it "doesn't return products not in stock" do
         variant.update_attribute(:count_on_hand, 0)
-        pr.products_json.should_not include product.name
+        expect(pr.products_json).not_to include product.name
       end
 
       it "strips html from description" do
         product.update_attribute(:description, "<a href='44'>turtles</a> frogs")
         json = pr.products_json
-        json.should include "frogs"
-        json.should_not include "<a href"
+        expect(json).to include "frogs"
+        expect(json).not_to include "<a href"
       end
 
       it "returns price including fees" do
         # Price is 19.99
-        OpenFoodNetwork::EnterpriseFeeCalculator.any_instance.
-          stub(:indexed_fees_for).and_return 978.01
+        allow_any_instance_of(OpenFoodNetwork::EnterpriseFeeCalculator).
+          to receive(:indexed_fees_for).and_return 978.01
 
-        pr.products_json.should include "998.0"
+        expect(pr.products_json).to include "998.0"
       end
 
       it "includes the primary taxon" do
         taxon = create(:taxon)
-        Spree::Product.any_instance.stub(:primary_taxon).and_return taxon
-        pr.products_json.should include taxon.name
+        allow_any_instance_of(Spree::Product).to receive(:primary_taxon).and_return taxon
+        expect(pr.products_json).to include taxon.name
       end
 
       it "loads tag_list for variants" do

--- a/spec/lib/open_food_network/referer_parser_spec.rb
+++ b/spec/lib/open_food_network/referer_parser_spec.rb
@@ -5,19 +5,19 @@ module OpenFoodNetwork
   describe RefererParser do
 
     it "handles requests without referer" do
-      RefererParser.path(nil).should be_nil
+      expect(RefererParser.path(nil)).to be_nil
     end
 
     it "handles requests with referer" do
-      RefererParser.path('http://example.org/').should eq('/')
+      expect(RefererParser.path('http://example.org/')).to eq('/')
     end
 
     it "handles requests with invalid referer" do
-      RefererParser.path('this is not a URI').should be_nil
+      expect(RefererParser.path('this is not a URI')).to be_nil
     end
 
     it "handles requests with known issue of referer" do
-      RefererParser.path('http://example.org/##invalid-fragment').should eq('/')
+      expect(RefererParser.path('http://example.org/##invalid-fragment')).to eq('/')
     end
   end
 end

--- a/spec/lib/open_food_network/reports/report_spec.rb
+++ b/spec/lib/open_food_network/reports/report_spec.rb
@@ -53,18 +53,18 @@ module OpenFoodNetwork::Reports
     let(:data) { {one: 1, two: 2, three: 3, four: 4} }
 
     it "returns the header" do
-      report.header.should == %w(One Two Three Four)
+      expect(report.header).to eq(%w(One Two Three Four))
     end
 
     it "returns columns as an array of procs" do
-      report.columns[0].call(data).should == 1
-      report.columns[1].call(data).should == 2
-      report.columns[2].call(data).should == 3
-      report.columns[3].call(data).should == 4
+      expect(report.columns[0].call(data)).to eq(1)
+      expect(report.columns[1].call(data)).to eq(2)
+      expect(report.columns[2].call(data)).to eq(3)
+      expect(report.columns[3].call(data)).to eq(4)
     end
 
     it "supports helpers when outputting columns" do
-      helper_report.columns[0].call(data).should == 1
+      expect(helper_report.columns[0].call(data)).to eq(1)
     end
 
     describe "rules" do
@@ -75,25 +75,25 @@ module OpenFoodNetwork::Reports
       let(:next_summary_columns) { rules_head.next.to_h[:summary_columns] }
 
       it "constructs the head of the rules list" do
-        group_by.call(data).should == 1
-        sort_by.call(data).should == 2
+        expect(group_by.call(data)).to eq(1)
+        expect(sort_by.call(data)).to eq(2)
       end
 
       it "constructs nested rules" do
-        next_group_by.call(data).should == 3
-        next_sort_by.call(data).should == 4
+        expect(next_group_by.call(data)).to eq(3)
+        expect(next_sort_by.call(data)).to eq(4)
       end
 
       it "constructs summary columns for rules" do
-        next_summary_columns[0].call(data).should == 1
-        next_summary_columns[1].call(data).should == 4
+        expect(next_summary_columns[0].call(data)).to eq(1)
+        expect(next_summary_columns[1].call(data)).to eq(4)
       end
     end
 
     describe "outputting rules" do
       it "outputs the rules" do
-        report.rules.should == [{group_by: P1, sort_by: P2},
-                                {group_by: P3, sort_by: P4, summary_columns: [P1, P4]}]
+        expect(report.rules).to eq([{group_by: P1, sort_by: P2},
+                                {group_by: P3, sort_by: P4, summary_columns: [P1, P4]}])
       end
     end
   end

--- a/spec/lib/open_food_network/reports/row_spec.rb
+++ b/spec/lib/open_food_network/reports/row_spec.rb
@@ -10,7 +10,7 @@ module OpenFoodNetwork::Reports
       row.column(&proc)
       row.column(&proc)
 
-      row.to_a.should == [proc, proc, proc]
+      expect(row.to_a).to eq([proc, proc, proc])
     end
   end
 end

--- a/spec/lib/open_food_network/reports/rule_spec.rb
+++ b/spec/lib/open_food_network/reports/rule_spec.rb
@@ -7,17 +7,17 @@ module OpenFoodNetwork::Reports
 
     it "can define a group proc and return it in a hash" do
       rule.group(&proc)
-      rule.to_h.should == {group_by: proc, sort_by: nil}
+      expect(rule.to_h).to eq({group_by: proc, sort_by: nil})
     end
 
     it "can define a sort proc and return it in a hash" do
       rule.sort(&proc)
-      rule.to_h.should == {group_by: nil,  sort_by: proc}
+      expect(rule.to_h).to eq({group_by: nil,  sort_by: proc})
     end
 
     it "can define a nested rule" do
       rule.organise(&proc)
-      rule.next.should be_a Rule
+      expect(rule.next).to be_a Rule
     end
 
     it "can define a summary row and return it in a hash" do
@@ -27,10 +27,10 @@ module OpenFoodNetwork::Reports
         column {}
       end
 
-      rule.to_h[:summary_columns].count.should == 3
-      rule.to_h[:summary_columns][0].should be_a Proc
-      rule.to_h[:summary_columns][1].should be_a Proc
-      rule.to_h[:summary_columns][2].should be_a Proc
+      expect(rule.to_h[:summary_columns].count).to eq(3)
+      expect(rule.to_h[:summary_columns][0]).to be_a Proc
+      expect(rule.to_h[:summary_columns][1]).to be_a Proc
+      expect(rule.to_h[:summary_columns][2]).to be_a Proc
     end
   end
 end

--- a/spec/lib/open_food_network/sales_tax_report_spec.rb
+++ b/spec/lib/open_food_network/sales_tax_report_spec.rb
@@ -11,15 +11,15 @@ module OpenFoodNetwork
       let(:totals) { report.send(:totals_of, [li1, li2]) }
 
       before do
-        report.stub(:tax_included_in).and_return(2, 4)
+        allow(report).to receive(:tax_included_in).and_return(2, 4)
       end
 
       it "calculates total quantity" do
-        totals[:items].should == 3
+        expect(totals[:items]).to eq(3)
       end
 
       it "calculates total price" do
-        totals[:items_total].should == 36
+        expect(totals[:items_total]).to eq(36)
       end
 
       context "when floating point math would result in fractional cents" do
@@ -27,33 +27,33 @@ module OpenFoodNetwork
         let(:li2) { double(:line_item, quantity: 2, amount: 0.12) }
 
         it "rounds to the nearest cent" do
-          totals[:items_total].should == 0.23
+          expect(totals[:items_total]).to eq(0.23)
         end
       end
 
       it "calculates the taxable total price" do
-        totals[:taxable_total].should == 36
+        expect(totals[:taxable_total]).to eq(36)
       end
 
       it "calculates sales tax" do
-        totals[:sales_tax].should == 6
+        expect(totals[:sales_tax]).to eq(6)
       end
 
       context "when there is no tax on a line item" do
         before do
-          report.stub(:tax_included_in) { 0 }
+          allow(report).to receive(:tax_included_in) { 0 }
         end
 
         it "does not appear in taxable total" do
-          totals[:taxable_total].should == 0
+          expect(totals[:taxable_total]).to eq(0)
         end
 
         it "still appears on items total" do
-          totals[:items_total].should == 36
+          expect(totals[:items_total]).to eq(36)
         end
 
         it "does not register sales tax" do
-          totals[:sales_tax].should == 0
+          expect(totals[:sales_tax]).to eq(0)
         end
       end
     end

--- a/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
+++ b/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
@@ -12,12 +12,12 @@ module OpenFoodNetwork
       it "returns the overridden price when one is present" do
         vo
         scoper.scope v
-        v.price.should == 22.22
+        expect(v.price).to eq(22.22)
       end
 
       it "returns the variant's price otherwise" do
         scoper.scope v
-        v.price.should == 11.11
+        expect(v.price).to eq(11.11)
       end
     end
 
@@ -25,12 +25,12 @@ module OpenFoodNetwork
       it "returns the overridden price when one is present" do
         vo
         scoper.scope v
-        v.price_in('AUD').amount.should == 22.22
+        expect(v.price_in('AUD').amount).to eq(22.22)
       end
 
       it "returns the variant's price otherwise" do
         scoper.scope v
-        v.price_in('AUD').amount.should == 11.11
+        expect(v.price_in('AUD').amount).to eq(11.11)
       end
     end
 
@@ -38,12 +38,12 @@ module OpenFoodNetwork
       it "returns the overridden stock level when one is present" do
         vo
         scoper.scope v
-        v.count_on_hand.should == 2
+        expect(v.count_on_hand).to eq(2)
       end
 
       it "returns the variant's stock level otherwise" do
         scoper.scope v
-        v.count_on_hand.should == 1
+        expect(v.count_on_hand).to eq(1)
       end
 
       describe "overriding stock on an on_demand variant" do
@@ -52,18 +52,18 @@ module OpenFoodNetwork
         it "clears on_demand when the stock is overridden" do
           vo
           scoper.scope v
-          v.on_demand.should be false
+          expect(v.on_demand).to be false
         end
 
         it "does not clear on_demand when only the price is overridden" do
           vo_price_only
           scoper.scope v
-          v.on_demand.should be true
+          expect(v.on_demand).to be true
         end
 
         it "does not clear on_demand when there is no override" do
           scoper.scope v
-          v.on_demand.should be true
+          expect(v.on_demand).to be true
         end
       end
 

--- a/spec/lib/open_food_network/user_balance_calculator_spec.rb
+++ b/spec/lib/open_food_network/user_balance_calculator_spec.rb
@@ -25,7 +25,7 @@ module OpenFoodNetwork
       }
 
       it "finds the correct balance for this email and enterprise" do
-        UserBalanceCalculator.new(o1.email, hub1).balance.should == -3
+        expect(UserBalanceCalculator.new(o1.email, hub1).balance).to eq(-3)
       end
 
       context "with another hub" do
@@ -39,7 +39,7 @@ module OpenFoodNetwork
         }
 
         it "does not find the balance for other enterprises" do
-          UserBalanceCalculator.new(o3.email, hub2).balance.should == 5
+          expect(UserBalanceCalculator.new(o3.email, hub2).balance).to eq(5)
         end
       end
 
@@ -54,7 +54,7 @@ module OpenFoodNetwork
         }
 
         it "does not find the balance for other users" do
-          UserBalanceCalculator.new(o4.email, hub1).balance.should == 10
+          expect(UserBalanceCalculator.new(o4.email, hub1).balance).to eq(10)
         end
       end
 
@@ -68,7 +68,7 @@ module OpenFoodNetwork
         }
 
         it "does not include canceled orders in the balance" do
-          UserBalanceCalculator.new(o4.email, hub1).balance.should == -3
+          expect(UserBalanceCalculator.new(o4.email, hub1).balance).to eq(-3)
         end
       end
     end

--- a/spec/lib/open_food_network/users_and_enterprises_report_spec.rb
+++ b/spec/lib/open_food_network/users_and_enterprises_report_spec.rb
@@ -10,8 +10,8 @@ module OpenFoodNetwork
       let!(:subject) { OpenFoodNetwork::UsersAndEnterprisesReport.new {} }
 
       before do
-        subject.stub(:owners_and_enterprises) { owners_and_enterprises }
-        subject.stub(:managers_and_enterprises) { managers_and_enterprises }
+        allow(subject).to receive(:owners_and_enterprises) { owners_and_enterprises }
+        allow(subject).to receive(:managers_and_enterprises) { managers_and_enterprises }
       end
 
       it "should concatenate owner and manager queries" do

--- a/spec/lib/open_food_network/xero_invoices_report_spec.rb
+++ b/spec/lib/open_food_network/xero_invoices_report_spec.rb
@@ -12,10 +12,10 @@ module OpenFoodNetwork
       around { |example| Timecop.travel(Time.zone.local(2015, 5, 5, 14, 0, 0)) { example.run } }
 
       it "uses defaults when blank params are passed" do
-        report.instance_variable_get(:@opts).should == {invoice_date: Date.civil(2015, 5, 5),
+        expect(report.instance_variable_get(:@opts)).to eq({invoice_date: Date.civil(2015, 5, 5),
                                                         due_date: Date.civil(2015, 6, 5),
                                                         account_code: 'food sales',
-                                                        report_type: 'summary'}
+                                                        report_type: 'summary'})
       end
     end
 
@@ -25,53 +25,53 @@ module OpenFoodNetwork
       let(:summary_rows) { report.send(:summary_rows_for_order, order, 1, {}) }
 
       before do
-        report.stub(:produce_summary_rows)  { ['produce'] }
-        report.stub(:fee_summary_rows)      { ['fee'] }
-        report.stub(:shipping_summary_rows) { ['shipping'] }
-        report.stub(:payment_summary_rows)  { ['payment'] }
-        report.stub(:admin_adjustment_summary_rows) { ['admin'] }
-        order.stub(:account_invoice?)       { false }
+        allow(report).to receive(:produce_summary_rows)  { ['produce'] }
+        allow(report).to receive(:fee_summary_rows)      { ['fee'] }
+        allow(report).to receive(:shipping_summary_rows) { ['shipping'] }
+        allow(report).to receive(:payment_summary_rows)  { ['payment'] }
+        allow(report).to receive(:admin_adjustment_summary_rows) { ['admin'] }
+        allow(order).to receive(:account_invoice?)       { false }
       end
 
       it "displays produce summary rows when summary report" do
-        report.stub(:detail?) { false }
-        summary_rows.should include 'produce'
+        allow(report).to receive(:detail?) { false }
+        expect(summary_rows).to include 'produce'
       end
 
       it "does not display produce summary rows when detail report" do
-        report.stub(:detail?) { true }
-        summary_rows.should_not include 'produce'
+        allow(report).to receive(:detail?) { true }
+        expect(summary_rows).not_to include 'produce'
       end
 
       it "displays fee summary rows when summary report" do
-        report.stub(:detail?)         { false }
-        order.stub(:account_invoice?) { true }
-        summary_rows.should include 'fee'
+        allow(report).to receive(:detail?)         { false }
+        allow(order).to receive(:account_invoice?) { true }
+        expect(summary_rows).to include 'fee'
       end
 
       it "displays fee summary rows when this is not an account invoice" do
-        report.stub(:detail?)         { true }
-        order.stub(:account_invoice?) { false }
-        summary_rows.should include 'fee'
+        allow(report).to receive(:detail?)         { true }
+        allow(order).to receive(:account_invoice?) { false }
+        expect(summary_rows).to include 'fee'
       end
 
       it "does not display fee summary rows when this is a detail report for an account invoice" do
-        report.stub(:detail?)         { true }
-        order.stub(:account_invoice?) { true }
-        summary_rows.should_not include 'fee'
+        allow(report).to receive(:detail?)         { true }
+        allow(order).to receive(:account_invoice?) { true }
+        expect(summary_rows).not_to include 'fee'
       end
 
       it "always displays shipping summary rows" do
-        summary_rows.should include 'shipping'
+        expect(summary_rows).to include 'shipping'
       end
 
       it "displays admin adjustment summary rows when summary report" do
-        summary_rows.should include 'admin'
+        expect(summary_rows).to include 'admin'
       end
 
       it "does not display admin adjustment summary rows when detail report" do
-        report.stub(:detail?)         { true }
-        summary_rows.should_not include 'admin'
+        allow(report).to receive(:detail?)         { true }
+        expect(summary_rows).not_to include 'admin'
       end
     end
 
@@ -84,12 +84,12 @@ module OpenFoodNetwork
       let!(:adj_shipping) { create(:adjustment, adjustable: order, label: "Shipping", originator: shipping_method) }
 
       it "returns BillablePeriod adjustments only" do
-        report.send(:account_invoice_adjustments, order).should == [adj_invoice]
+        expect(report.send(:account_invoice_adjustments, order)).to eq([adj_invoice])
       end
 
       it "excludes adjustments where the source is missing" do
         billable_period.destroy
-        report.send(:account_invoice_adjustments, order).should be_empty
+        expect(report.send(:account_invoice_adjustments, order)).to be_empty
       end
     end
 
@@ -98,7 +98,7 @@ module OpenFoodNetwork
 
       describe "when no initial invoice number is given" do
         it "returns the order number" do
-          subject.send(:invoice_number_for, order, 123).should == 'R731032860'
+          expect(subject.send(:invoice_number_for, order, 123)).to eq('R731032860')
         end
       end
 
@@ -106,7 +106,7 @@ module OpenFoodNetwork
         subject { XeroInvoicesReport.new user, {initial_invoice_number: '123'} }
 
         it "increments the number by the index" do
-          subject.send(:invoice_number_for, order, 456).should == 579
+          expect(subject.send(:invoice_number_for, order, 456)).to eq(579)
         end
       end
     end

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -27,28 +27,28 @@ describe Spree::OrderMailer do
     describe "for customers" do
       it "should send an email to the customer when given an order" do
         Spree::OrderMailer.confirm_email_for_customer(@order1.id).deliver
-        ActionMailer::Base.deliveries.count.should == 1
-        ActionMailer::Base.deliveries.first.to.should == [@order1.email]
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+        expect(ActionMailer::Base.deliveries.first.to).to eq([@order1.email])
       end
 
       it "sets a reply-to of the enterprise email" do
         Spree::OrderMailer.confirm_email_for_customer(@order1.id).deliver
-        ActionMailer::Base.deliveries.first.reply_to.should == [@distributor.contact.email]
+        expect(ActionMailer::Base.deliveries.first.reply_to).to eq([@distributor.contact.email])
       end
     end
 
     describe "for shops" do
       it "sends an email to the shop owner when given an order" do
         Spree::OrderMailer.confirm_email_for_shop(@order1.id).deliver
-        ActionMailer::Base.deliveries.count.should == 1
-        ActionMailer::Base.deliveries.first.to.should == [@distributor.contact.email]
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+        expect(ActionMailer::Base.deliveries.first.to).to eq([@distributor.contact.email])
       end
 
       it "sends an email even if a footer_email is given" do
         # Testing bug introduced by a9c37c162e1956028704fbdf74ce1c56c5b3ce7d
         ContentConfig.footer_email = "email@example.com"
         Spree::OrderMailer.confirm_email_for_shop(@order1.id).deliver
-        ActionMailer::Base.deliveries.count.should == 1
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
       end
     end
   end

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -56,7 +56,7 @@ describe ProducerMailer do
   end
 
   it "should send an email when an order cycle is closed" do
-    ActionMailer::Base.deliveries.count.should == 1
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
   end
 
   it "sets a reply-to of the oc coordinator's email" do
@@ -64,7 +64,7 @@ describe ProducerMailer do
   end
 
   it "includes receival instructions" do
-    mail.body.encoded.should include 'Outside shed.'
+    expect(mail.body.encoded).to include 'Outside shed.'
   end
 
   it "cc's the oc coordinator" do
@@ -74,32 +74,32 @@ describe ProducerMailer do
   it "contains an aggregated list of produce in alphabetical order" do
     expect(mail.body.encoded).to match(/coffee.+\n.+Zebra/)
     body_lines_including(mail, p1.name).each do |line|
-      line.should include 'QTY: 3'
-      line.should include '@ $10.00 = $30.00'
+      expect(line).to include 'QTY: 3'
+      expect(line).to include '@ $10.00 = $30.00'
     end
-    body_as_html(mail).find("table.order-summary tr", text: p1.name)
-      .should have_selector("td", text: "$30.00")
+    expect(body_as_html(mail).find("table.order-summary tr", text: p1.name))
+      .to have_selector("td", text: "$30.00")
   end
 
 
   it "displays tax totals for each product" do
     # Tax for p1 line items
-    body_as_html(mail).find("table.order-summary tr", text: p1.name)
-      .should have_selector("td.tax", text: "$2.73")
+    expect(body_as_html(mail).find("table.order-summary tr", text: p1.name))
+      .to have_selector("td.tax", text: "$2.73")
   end
 
   it "does not include incomplete orders" do
-    mail.body.encoded.should_not include p3.name
+    expect(mail.body.encoded).not_to include p3.name
   end
 
   it "does not include canceled orders" do
-    mail.body.encoded.should_not include p5.name
+    expect(mail.body.encoded).not_to include p5.name
   end
 
   it "includes the total" do
-    mail.body.encoded.should include 'Total: $50.00'
-    body_as_html(mail).find("tr.total-row")
-      .should have_selector("td", text: "$50.00")
+    expect(mail.body.encoded).to include 'Total: $50.00'
+    expect(body_as_html(mail).find("tr.total-row"))
+      .to have_selector("td", text: "$50.00")
   end
 
   it "sends no mail when the producer has no orders" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -17,7 +17,7 @@ describe Spree::UserMailer do
 
   it "sends an email when given a user" do
     Spree::UserMailer.signup_confirmation(user).deliver
-    ActionMailer::Base.deliveries.count.should == 1
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
   end
 
   # adapted from https://github.com/spree/spree_auth_devise/blob/70737af/spec/mailers/user_mailer_spec.rb

--- a/spec/models/adjustment_metadata_spec.rb
+++ b/spec/models/adjustment_metadata_spec.rb
@@ -1,6 +1,6 @@
 describe AdjustmentMetadata do
   it "is valid when build from factory" do
     adjustment = create(:adjustment)
-    adjustment.should be_valid
+    expect(adjustment).to be_valid
   end
 end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -13,7 +13,7 @@ describe OpenFoodNetwork::Calculator::Weight do
     order = double(:order, :line_items => [line_item_1, line_item_2, line_item_3])
 
     subject.set_preference(:per_kg, 10)
-    subject.compute(order).should == (10*1 + 20*3) * 10
+    expect(subject.compute(order)).to eq((10*1 + 20*3) * 10)
   end
 
   it "computes shipping cost for a line item" do
@@ -22,6 +22,6 @@ describe OpenFoodNetwork::Calculator::Weight do
     line_item = double(:line_item, :variant => variant, :quantity => 2)
 
     subject.set_preference(:per_kg, 10)
-    subject.compute(line_item).should == 10*2 * 10
+    expect(subject.compute(line_item)).to eq(10*2 * 10)
   end
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe Cart do
 
   describe "associations" do
-    it { should have_many(:orders) }
+    it { is_expected.to have_many(:orders) }
   end
 
   describe 'when adding a product' do
@@ -23,23 +23,23 @@ describe Cart do
       it 'should create an order for the product being added, and associate the product to the selected distribution' do
         subject.add_variant product.master.id, 3, distributor, nil, currency
 
-        subject.orders.size.should == 1
+        expect(subject.orders.size).to eq(1)
         order = subject.orders.first.reload
-        order.currency.should == currency
-        order.distributor.should == product.distributors.first
-        order.order_cycle.should be_nil
-        order.line_items.first.product.should == product
+        expect(order.currency).to eq(currency)
+        expect(order.distributor).to eq(product.distributors.first)
+        expect(order.order_cycle).to be_nil
+        expect(order.line_items.first.product).to eq(product)
       end
 
       it 'should create an order for the product being added, and associate the order with an order cycle and distributor' do
         subject.add_variant product_with_order_cycle.master.id, 3, distributor, order_cycle, currency
 
-        subject.orders.size.should == 1
+        expect(subject.orders.size).to eq(1)
         order = subject.orders.first.reload
-        order.currency.should == currency
-        order.distributor.should == distributor
-        order.order_cycle.should == order_cycle
-        order.line_items.first.product.should == product_with_order_cycle
+        expect(order.currency).to eq(currency)
+        expect(order.distributor).to eq(distributor)
+        expect(order.order_cycle).to eq(order_cycle)
+        expect(order.line_items.first.product).to eq(product_with_order_cycle)
       end
     end
 
@@ -58,30 +58,30 @@ describe Cart do
         subject.add_variant product_from_other_distributor.master.id, 3, other_distributor, nil, currency
 
         subject.reload
-        subject.orders.size.should == 2
+        expect(subject.orders.size).to eq(2)
         new_order_for_other_distributor = subject.orders.find { |order| order.distributor == other_distributor }
-        new_order_for_other_distributor.order_cycle.should be_nil
-        order.line_items.size.should == 1
-        new_order_for_other_distributor.line_items.size.should == 1
-        new_order_for_other_distributor.line_items.first.product.should == product_from_other_distributor
+        expect(new_order_for_other_distributor.order_cycle).to be_nil
+        expect(order.line_items.size).to eq(1)
+        expect(new_order_for_other_distributor.line_items.size).to eq(1)
+        expect(new_order_for_other_distributor.line_items.first.product).to eq(product_from_other_distributor)
       end
 
       it 'should group line item in existing order, when product added for the same distributor' do
         subject.add_variant product.master.id, 3, distributor, nil, currency
 
-        subject.orders.size.should == 1
+        expect(subject.orders.size).to eq(1)
         order = subject.orders.first.reload
-        order.line_items.size.should == 2
-        order.line_items.first.product.should == product
+        expect(order.line_items.size).to eq(2)
+        expect(order.line_items.first.product).to eq(product)
       end
 
       it 'should create a new order for product in an order cycle' do
         subject.add_variant product_with_order_cycle.master.id, 3, distributor, order_cycle, currency
 
-        subject.orders.size.should == 2
+        expect(subject.orders.size).to eq(2)
         new_order_for_distributor = subject.orders.find { |order| order.order_cycle == order_cycle }
         new_order_for_distributor.reload
-        new_order_for_distributor.line_items.first.product.should == product_with_order_cycle
+        expect(new_order_for_distributor.line_items.first.product).to eq(product_with_order_cycle)
       end
     end
 
@@ -96,10 +96,10 @@ describe Cart do
       it 'should group line items in existing order when added for the same distributor and order cycle' do
         subject.add_variant product_with_order_cycle.master.id, 3, distributor, order_cycle, currency
 
-        subject.orders.size.should == 1
+        expect(subject.orders.size).to eq(1)
         order = subject.orders.first.reload
-        order.line_items.size.should == 1
-        order.line_items.find{ |line_item| line_item.product == product_with_order_cycle }.should_not be_nil
+        expect(order.line_items.size).to eq(1)
+        expect(order.line_items.find{ |line_item| line_item.product == product_with_order_cycle }).not_to be_nil
       end
 
       it 'should create line item in new order when product added is for a different order cycle' do
@@ -107,24 +107,24 @@ describe Cart do
 
         subject.add_variant product_with_order_cycle.master.id, 3, distributor, order_cycle2, currency
 
-        subject.orders.size.should == 2
+        expect(subject.orders.size).to eq(2)
         new_order_for_second_order_cycle = subject.orders.find { |order| order.order_cycle == order_cycle2 }
         new_order_for_second_order_cycle.reload
-        new_order_for_second_order_cycle.line_items.size.should == 1
-        new_order_for_second_order_cycle.line_items.first.product.should == product_with_order_cycle
-        new_order_for_second_order_cycle.distributor.should == distributor
-        new_order_for_second_order_cycle.order_cycle.should == order_cycle2
+        expect(new_order_for_second_order_cycle.line_items.size).to eq(1)
+        expect(new_order_for_second_order_cycle.line_items.first.product).to eq(product_with_order_cycle)
+        expect(new_order_for_second_order_cycle.distributor).to eq(distributor)
+        expect(new_order_for_second_order_cycle.order_cycle).to eq(order_cycle2)
       end
 
       it 'should create line_items in new order when added with different distributor, but same order_cycle' do
         subject.add_variant product_with_order_cycle.master.id, 3, other_distributor, order_cycle, currency
 
-        subject.orders.size.should == 2
+        expect(subject.orders.size).to eq(2)
         new_order_for_second_order_cycle = subject.orders.find { |order| order.distributor == other_distributor }
         new_order_for_second_order_cycle.reload
-        new_order_for_second_order_cycle.line_items.size.should == 1
-        new_order_for_second_order_cycle.line_items.find{ |line_item| line_item.product == product_with_order_cycle }.should_not be_nil
-        new_order_for_second_order_cycle.order_cycle.should == order_cycle
+        expect(new_order_for_second_order_cycle.line_items.size).to eq(1)
+        expect(new_order_for_second_order_cycle.line_items.find{ |line_item| line_item.product == product_with_order_cycle }).not_to be_nil
+        expect(new_order_for_second_order_cycle.order_cycle).to eq(order_cycle)
       end
     end
   end

--- a/spec/models/enterprise_fee_spec.rb
+++ b/spec/models/enterprise_fee_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe EnterpriseFee do
   describe "associations" do
-    it { should belong_to(:enterprise) }
+    it { is_expected.to belong_to(:enterprise) }
   end
 
   describe "validations" do
-    it { should validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:name) }
   end
 
   describe "callbacks" do
@@ -22,7 +22,7 @@ describe EnterpriseFee do
       oc = create(:simple_order_cycle, coordinator_fees: [ef])
 
       ef.destroy
-      oc.reload.coordinator_fee_ids.should be_empty
+      expect(oc.reload.coordinator_fee_ids).to be_empty
     end
 
     it "removes itself from order cycle exchange fees when destroyed" do
@@ -30,7 +30,7 @@ describe EnterpriseFee do
       ex = create(:exchange, order_cycle: oc, enterprise_fees: [ef])
 
       ef.destroy
-      ex.reload.exchange_fee_ids.should be_empty
+      expect(ex.reload.exchange_fee_ids).to be_empty
     end
 
     describe "for tax_category" do
@@ -70,7 +70,7 @@ describe EnterpriseFee do
         create(:enterprise_fee, calculator: Spree::Calculator::FlatRate.new)
         create(:enterprise_fee, calculator: Spree::Calculator::FlexiRate.new)
 
-        EnterpriseFee.per_item.should be_empty
+        expect(EnterpriseFee.per_item).to be_empty
       end
 
       it "returns fees with any other calculator" do
@@ -79,7 +79,7 @@ describe EnterpriseFee do
         ef3 = create(:enterprise_fee, calculator: Spree::Calculator::PerItem.new)
         ef4 = create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)
 
-        EnterpriseFee.per_item.should match_array [ef1, ef2, ef3, ef4]
+        expect(EnterpriseFee.per_item).to match_array [ef1, ef2, ef3, ef4]
       end
     end
 
@@ -88,7 +88,7 @@ describe EnterpriseFee do
         ef1 = create(:enterprise_fee, calculator: Spree::Calculator::FlatRate.new)
         ef2 = create(:enterprise_fee, calculator: Spree::Calculator::FlexiRate.new)
 
-        EnterpriseFee.per_order.should match_array [ef1, ef2]
+        expect(EnterpriseFee.per_order).to match_array [ef1, ef2]
       end
 
       it "does not return fees with any other calculator" do
@@ -97,7 +97,7 @@ describe EnterpriseFee do
         ef3 = create(:enterprise_fee, calculator: Spree::Calculator::PerItem.new)
         ef4 = create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)
 
-        EnterpriseFee.per_order.should be_empty
+        expect(EnterpriseFee.per_order).to be_empty
       end
     end
   end

--- a/spec/models/enterprise_group_spec.rb
+++ b/spec/models/enterprise_group_spec.rb
@@ -7,38 +7,38 @@ describe EnterpriseGroup do
       e.name = 'Test Group'
       e.description = 'A valid test group.'
       e.address = build(:address)
-      e.should be_valid
+      expect(e).to be_valid
     end
 
     it "is valid when built from factory" do
       e = build(:enterprise_group)
-      e.should be_valid
+      expect(e).to be_valid
     end
 
     it "replace empty permalink and pass" do
       e = build(:enterprise_group, permalink: '')
-      e.should be_valid
-      e.permalink.should == e.name.parameterize
+      expect(e).to be_valid
+      expect(e.permalink).to eq(e.name.parameterize)
     end
 
     it "restores permalink and pass" do
       e = create(:enterprise_group, permalink: 'p')
       e.permalink = ''
-      e.should be_valid
-      e.permalink.should == 'p'
+      expect(e).to be_valid
+      expect(e.permalink).to eq('p')
     end
 
     it "requires a name" do
       e = build(:enterprise_group, name: '')
-      e.should_not be_valid
+      expect(e).not_to be_valid
     end
 
     it "requires a description" do
       e = build(:enterprise_group, description: '')
     end
 
-    it { should have_attached_file :promo_image }
-    it { should have_attached_file :logo }
+    it { is_expected.to have_attached_file :promo_image }
+    it { is_expected.to have_attached_file :logo }
   end
 
   describe "relations" do
@@ -46,7 +46,7 @@ describe EnterpriseGroup do
       e = create(:supplier_enterprise)
       eg = create(:enterprise_group)
       eg.enterprises << e
-      eg.reload.enterprises.should == [e]
+      expect(eg.reload.enterprises).to eq([e])
     end
 
     # it "can have an image" do
@@ -63,14 +63,14 @@ describe EnterpriseGroup do
       eg2 = create(:enterprise_group, position: 3)
       eg3 = create(:enterprise_group, position: 2)
 
-      EnterpriseGroup.by_position.should == [eg1, eg3, eg2]
+      expect(EnterpriseGroup.by_position).to eq([eg1, eg3, eg2])
     end
 
     it "finds enterprise groups on the front page" do
       eg1 = create(:enterprise_group, on_front_page: true)
       eg2 = create(:enterprise_group, on_front_page: false)
 
-      EnterpriseGroup.on_front_page.should == [eg1]
+      expect(EnterpriseGroup.on_front_page).to eq([eg1])
     end
 
     it "finds a user's enterprise groups" do
@@ -79,7 +79,7 @@ describe EnterpriseGroup do
       eg1 = create(:enterprise_group, owner: user)
       eg2 = create(:enterprise_group)
 
-      EnterpriseGroup.managed_by(user).should == [eg1]
+      expect(EnterpriseGroup.managed_by(user)).to eq([eg1])
     end
 
     describe "finding a permalink" do

--- a/spec/models/enterprise_relationship_spec.rb
+++ b/spec/models/enterprise_relationship_spec.rb
@@ -11,22 +11,22 @@ describe EnterpriseRelationship do
       er2 = create(:enterprise_relationship, parent: e1, child: e2)
       er3 = create(:enterprise_relationship, parent: e2, child: e1)
 
-      EnterpriseRelationship.by_name.should == [er3, er1, er2]
+      expect(EnterpriseRelationship.by_name).to eq([er3, er1, er2])
     end
 
     describe "finding relationships involving some enterprises" do
       let!(:er) { create(:enterprise_relationship, parent: e1, child: e2) }
 
       it "returns relationships where an enterprise is the parent" do
-        EnterpriseRelationship.involving_enterprises([e1]).should == [er]
+        expect(EnterpriseRelationship.involving_enterprises([e1])).to eq([er])
       end
 
       it "returns relationships where an enterprise is the child" do
-        EnterpriseRelationship.involving_enterprises([e2]).should == [er]
+        expect(EnterpriseRelationship.involving_enterprises([e2])).to eq([er])
       end
 
       it "does not return other relationships" do
-        EnterpriseRelationship.involving_enterprises([e3]).should == []
+        expect(EnterpriseRelationship.involving_enterprises([e3])).to eq([])
       end
     end
 
@@ -35,13 +35,13 @@ describe EnterpriseRelationship do
         it "creates a new permission for each item in the list" do
           er = EnterpriseRelationship.create! parent: e1, child: e2, permissions_list: ['one', 'two']
           er.reload
-          er.permissions.map(&:name).should match_array ['one', 'two']
+          expect(er.permissions.map(&:name)).to match_array ['one', 'two']
         end
 
         it "does nothing when the list is nil" do
           er = EnterpriseRelationship.create! parent: e1, child: e2, permissions_list: nil
           er.reload
-          er.permissions.should be_empty
+          expect(er.permissions).to be_empty
         end
       end
 
@@ -51,30 +51,30 @@ describe EnterpriseRelationship do
           er.permissions_list = ['four']
           er.save!
           er.reload
-          er.permissions.map(&:name).should include 'four'
+          expect(er.permissions.map(&:name)).to include 'four'
         end
 
         it "does not duplicate existing permissions" do
           er.permissions_list = ["one", "two", "three"]
           er.save!
           er.reload
-          er.permissions.map(&:name).count.should == 3
-          er.permissions.map(&:name).should match_array ["one", "two", "three"]
+          expect(er.permissions.map(&:name).count).to eq(3)
+          expect(er.permissions.map(&:name)).to match_array ["one", "two", "three"]
         end
 
         it "removes permissions that are not in the list" do
           er.permissions_list = ['one', 'three']
           er.save!
           er.reload
-          er.permissions.map(&:name).should include 'one', 'three'
-          er.permissions.map(&:name).should_not include 'two'
+          expect(er.permissions.map(&:name)).to include 'one', 'three'
+          expect(er.permissions.map(&:name)).not_to include 'two'
         end
 
         it "does removes all permissions when the list provided is nil" do
           er.permissions_list = nil
           er.save!
           er.reload
-          er.permissions.should be_empty
+          expect(er.permissions).to be_empty
         end
       end
     end
@@ -85,11 +85,11 @@ describe EnterpriseRelationship do
       let!(:er3) { create(:enterprise_relationship, parent: e1, child: e3) }
 
       it "finds relationships that grant permissions to some enterprises" do
-        EnterpriseRelationship.permitting([e1, e2]).should match_array [er1, er2]
+        expect(EnterpriseRelationship.permitting([e1, e2])).to match_array [er1, er2]
       end
 
       it "finds relationships that are granted by particular enterprises" do
-        EnterpriseRelationship.permitted_by([e1, e2]).should match_array [er1, er3]
+        expect(EnterpriseRelationship.permitted_by([e1, e2])).to match_array [er1, er3]
       end
     end
 
@@ -101,7 +101,7 @@ describe EnterpriseRelationship do
       er3 = create(:enterprise_relationship, parent: e3, child: e1,
                    permissions_list: ['three', 'four'])
 
-      EnterpriseRelationship.with_permission('two').should match_array [er1, er2]
+      expect(EnterpriseRelationship.with_permission('two')).to match_array [er1, er2]
     end
   end
 
@@ -112,30 +112,31 @@ describe EnterpriseRelationship do
     let(:er_reverse) { create(:enterprise_relationship, parent: e2, child: e1) }
 
     it "includes self where appropriate" do
-      EnterpriseRelationship.relatives[e2.id][:distributors].should include e2.id
-      EnterpriseRelationship.relatives[e2.id][:producers].should_not include e2.id
+      expect(EnterpriseRelationship.relatives[e2.id][:distributors]).to include e2.id
+      expect(EnterpriseRelationship.relatives[e2.id][:producers]).not_to include e2.id
     end
 
     it "categorises enterprises into distributors and producers" do
       e2.update_attribute :is_primary_producer, true
-      EnterpriseRelationship.relatives.should ==
+      expect(EnterpriseRelationship.relatives).to eq(
         {e1.id => {distributors: Set.new([e2.id]), producers: Set.new([e1.id, e2.id])},
          e2.id => {distributors: Set.new([e2.id]), producers: Set.new([e2.id, e1.id])}}
+      )
     end
 
     it "finds inactive enterprises by default" do
       e1.update_attribute :sells, 'unspecified'
-      EnterpriseRelationship.relatives[e2.id][:producers].should == Set.new([e1.id])
+      expect(EnterpriseRelationship.relatives[e2.id][:producers]).to eq(Set.new([e1.id]))
     end
 
     it "does not find inactive enterprises when requested" do
       e1.update_attribute :sells, 'unspecified'
-      EnterpriseRelationship.relatives(true)[e2.id][:producers].should be_empty
+      expect(EnterpriseRelationship.relatives(true)[e2.id][:producers]).to be_empty
     end
 
     it "does not show duplicates" do
       er_reverse
-      EnterpriseRelationship.relatives[e2.id][:producers].should == Set.new([e1.id])
+      expect(EnterpriseRelationship.relatives[e2.id][:producers]).to eq(Set.new([e1.id]))
     end
   end
 

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -17,11 +17,11 @@ describe Enterprise do
   end
 
   describe "associations" do
-    it { should belong_to(:owner) }
-    it { should have_many(:supplied_products) }
-    it { should have_many(:distributed_orders) }
-    it { should belong_to(:address) }
-    it { should have_many(:product_distributions) }
+    it { is_expected.to belong_to(:owner) }
+    it { is_expected.to have_many(:supplied_products) }
+    it { is_expected.to have_many(:distributed_orders) }
+    it { is_expected.to belong_to(:address) }
+    it { is_expected.to have_many(:product_distributions) }
 
     it "destroys enterprise roles upon its own demise" do
       e = create(:enterprise)
@@ -30,7 +30,7 @@ describe Enterprise do
 
       role = e.enterprise_roles.first
       e.destroy
-      EnterpriseRole.where(id: role.id).should be_empty
+      expect(EnterpriseRole.where(id: role.id)).to be_empty
     end
 
     it "destroys supplied products upon destroy" do
@@ -39,7 +39,7 @@ describe Enterprise do
 
       s.destroy
 
-      Spree::Product.where(id: p.id).should be_empty
+      expect(Spree::Product.where(id: p.id)).to be_empty
     end
 
     it "destroys relationships upon destroy" do
@@ -50,7 +50,7 @@ describe Enterprise do
 
       e.destroy
 
-      EnterpriseRelationship.where(id: [er1, er2]).should be_empty
+      expect(EnterpriseRelationship.where(id: [er1, er2])).to be_empty
     end
 
     describe "relationships to other enterprises" do
@@ -62,7 +62,7 @@ describe Enterprise do
       let!(:er2) { create(:enterprise_relationship, parent_id: e.id, child_id: c.id) }
 
       it "finds relatives" do
-        e.relatives.should match_array [p, c]
+        expect(e.relatives).to match_array [p, c]
       end
 
       it "finds relatives_including_self" do
@@ -70,14 +70,14 @@ describe Enterprise do
       end
 
       it "scopes relatives to visible distributors" do
-        e.should_receive(:relatives_including_self).and_return(relatives = [])
-        relatives.should_receive(:is_distributor).and_return relatives
+        expect(e).to receive(:relatives_including_self).and_return(relatives = [])
+        expect(relatives).to receive(:is_distributor).and_return relatives
         e.distributors
       end
 
       it "scopes relatives to visible producers" do
-        e.should_receive(:relatives_including_self).and_return(relatives = [])
-        relatives.should_receive(:is_primary_producer).and_return relatives
+        expect(e).to receive(:relatives_including_self).and_return(relatives = [])
+        expect(relatives).to receive(:is_primary_producer).and_return relatives
         e.suppliers
       end
     end
@@ -113,9 +113,9 @@ describe Enterprise do
 
   describe "validations" do
     subject { FactoryGirl.create(:distributor_enterprise) }
-    it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:permalink) }
-    it { should ensure_length_of(:description).is_at_most(255) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:permalink) }
+    it { is_expected.to ensure_length_of(:description).is_at_most(255) }
 
     it "requires an owner" do
       expect{
@@ -129,25 +129,27 @@ describe Enterprise do
 
       it "prevents duplicate names for new records" do
         e = Enterprise.new name: enterprise.name
-        e.should_not be_valid
-        e.errors[:name].first.should ==
+        expect(e).not_to be_valid
+        expect(e.errors[:name].first).to eq(
           "has already been taken. If this is your enterprise and you would like to claim ownership, please contact the current manager of this profile at owner@example.com."
+        )
       end
 
       it "prevents duplicate names for existing records" do
         e = create(:enterprise, name: 'foo')
         e.name = enterprise.name
-        e.should_not be_valid
-        e.errors[:name].first.should ==
+        expect(e).not_to be_valid
+        expect(e.errors[:name].first).to eq(
           "has already been taken. If this is your enterprise and you would like to claim ownership, please contact the current manager of this profile at owner@example.com."
+        )
       end
 
       it "does not prohibit the saving of an enterprise with no name clash" do
-        enterprise.should be_valid
+        expect(enterprise).to be_valid
       end
 
       it "sets the enterprise contact to the owner by default" do
-        enterprise.contact.should eq enterprise.owner
+        expect(enterprise.contact).to eq enterprise.owner
       end
     end
 
@@ -190,10 +192,10 @@ describe Enterprise do
   describe "delegations" do
     #subject { FactoryGirl.create(:distributor_enterprise, :address => FactoryGirl.create(:address)) }
 
-    it { should delegate(:latitude).to(:address) }
-    it { should delegate(:longitude).to(:address) }
-    it { should delegate(:city).to(:address) }
-    it { should delegate(:state_name).to(:address) }
+    it { is_expected.to delegate(:latitude).to(:address) }
+    it { is_expected.to delegate(:longitude).to(:address) }
+    it { is_expected.to delegate(:city).to(:address) }
+    it { is_expected.to delegate(:state_name).to(:address) }
   end
 
   describe "callbacks" do
@@ -211,7 +213,7 @@ describe Enterprise do
       it 'find visible enterprises' do
         d1 = create(:distributor_enterprise, visible: false)
         s1 = create(:supplier_enterprise)
-        Enterprise.visible.should == [s1]
+        expect(Enterprise.visible).to eq([s1])
       end
     end
 
@@ -232,24 +234,24 @@ describe Enterprise do
 
       it "does not show enterprises with no payment methods" do
         create(:shipping_method, distributors: [e])
-        Enterprise.ready_for_checkout.should_not include e
+        expect(Enterprise.ready_for_checkout).not_to include e
       end
 
       it "does not show enterprises with no shipping methods" do
         create(:payment_method, distributors: [e])
-        Enterprise.ready_for_checkout.should_not include e
+        expect(Enterprise.ready_for_checkout).not_to include e
       end
 
       it "does not show enterprises with unavailable payment methods" do
         create(:shipping_method, distributors: [e])
         create(:payment_method, distributors: [e], active: false)
-        Enterprise.ready_for_checkout.should_not include e
+        expect(Enterprise.ready_for_checkout).not_to include e
       end
 
       it "shows enterprises with available payment and shipping methods" do
         create(:shipping_method, distributors: [e])
         create(:payment_method, distributors: [e])
-        Enterprise.ready_for_checkout.should include e
+        expect(Enterprise.ready_for_checkout).to include e
       end
     end
 
@@ -258,24 +260,24 @@ describe Enterprise do
 
       it "shows enterprises with no payment methods" do
         create(:shipping_method, distributors: [e])
-        Enterprise.not_ready_for_checkout.should include e
+        expect(Enterprise.not_ready_for_checkout).to include e
       end
 
       it "shows enterprises with no shipping methods" do
         create(:payment_method, distributors: [e])
-        Enterprise.not_ready_for_checkout.should include e
+        expect(Enterprise.not_ready_for_checkout).to include e
       end
 
       it "shows enterprises with unavailable payment methods" do
         create(:shipping_method, distributors: [e])
         create(:payment_method, distributors: [e], active: false)
-        Enterprise.not_ready_for_checkout.should include e
+        expect(Enterprise.not_ready_for_checkout).to include e
       end
 
       it "does not show enterprises with available payment and shipping methods" do
         create(:shipping_method, distributors: [e])
         create(:payment_method, distributors: [e])
-        Enterprise.not_ready_for_checkout.should_not include e
+        expect(Enterprise.not_ready_for_checkout).not_to include e
       end
     end
 
@@ -284,24 +286,24 @@ describe Enterprise do
 
       it "returns false for enterprises with no payment methods" do
         create(:shipping_method, distributors: [e])
-        e.reload.should_not be_ready_for_checkout
+        expect(e.reload).not_to be_ready_for_checkout
       end
 
       it "returns false for enterprises with no shipping methods" do
         create(:payment_method, distributors: [e])
-        e.reload.should_not be_ready_for_checkout
+        expect(e.reload).not_to be_ready_for_checkout
       end
 
       it "returns false for enterprises with unavailable payment methods" do
         create(:shipping_method, distributors: [e])
         create(:payment_method, distributors: [e], active: false)
-        e.reload.should_not be_ready_for_checkout
+        expect(e.reload).not_to be_ready_for_checkout
       end
 
       it "returns true for enterprises with available payment and shipping methods" do
         create(:shipping_method, distributors: [e])
         create(:payment_method, distributors: [e])
-        e.reload.should be_ready_for_checkout
+        expect(e.reload).to be_ready_for_checkout
       end
     end
 
@@ -311,7 +313,7 @@ describe Enterprise do
         d = create(:distributor_enterprise)
         p = create(:product)
         create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master])
-        Enterprise.distributors_with_active_order_cycles.should == [d]
+        expect(Enterprise.distributors_with_active_order_cycles).to eq([d])
       end
 
       it "should not find inactive distributors by order cycles" do
@@ -319,7 +321,7 @@ describe Enterprise do
         d = create(:distributor_enterprise)
         p = create(:product)
         create(:simple_order_cycle, :orders_open_at => 10.days.from_now, suppliers: [s], distributors: [d], variants: [p.master])
-        Enterprise.distributors_with_active_order_cycles.should_not include d
+        expect(Enterprise.distributors_with_active_order_cycles).not_to include d
       end
     end
 
@@ -327,25 +329,25 @@ describe Enterprise do
       it "finds active distributors by product distributions" do
         d = create(:distributor_enterprise)
         create(:product, :distributors => [d])
-        Enterprise.active_distributors.should == [d]
+        expect(Enterprise.active_distributors).to eq([d])
       end
 
       it "doesn't show distributors of deleted products" do
         d = create(:distributor_enterprise)
         create(:product, :distributors => [d], :deleted_at => Time.zone.now)
-        Enterprise.active_distributors.should be_empty
+        expect(Enterprise.active_distributors).to be_empty
       end
 
       it "doesn't show distributors of unavailable products" do
         d = create(:distributor_enterprise)
         create(:product, :distributors => [d], :available_on => 1.week.from_now)
-        Enterprise.active_distributors.should be_empty
+        expect(Enterprise.active_distributors).to be_empty
       end
 
       it "doesn't show distributors of out of stock products" do
         d = create(:distributor_enterprise)
         create(:product, :distributors => [d], :on_hand => 0)
-        Enterprise.active_distributors.should be_empty
+        expect(Enterprise.active_distributors).to be_empty
       end
 
       it "finds active distributors by order cycles" do
@@ -353,7 +355,7 @@ describe Enterprise do
         d = create(:distributor_enterprise)
         p = create(:product)
         create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master])
-        Enterprise.active_distributors.should == [d]
+        expect(Enterprise.active_distributors).to eq([d])
       end
 
       it "doesn't show distributors from inactive order cycles" do
@@ -361,7 +363,7 @@ describe Enterprise do
         d = create(:distributor_enterprise)
         p = create(:product)
         create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master], orders_open_at: 1.week.from_now, orders_close_at: 2.weeks.from_now)
-        Enterprise.active_distributors.should be_empty
+        expect(Enterprise.active_distributors).to be_empty
       end
     end
 
@@ -370,7 +372,7 @@ describe Enterprise do
         s = create(:supplier_enterprise)
         p = create(:simple_product, supplier: s)
 
-        Enterprise.supplying_variant_in([p.master]).should == [s]
+        expect(Enterprise.supplying_variant_in([p.master])).to eq([s])
       end
 
       it "finds producers by supply of variant" do
@@ -378,7 +380,7 @@ describe Enterprise do
         p = create(:simple_product, supplier: s)
         v = create(:variant, product: p)
 
-        Enterprise.supplying_variant_in([v]).should == [s]
+        expect(Enterprise.supplying_variant_in([v])).to eq([s])
       end
 
       it "returns multiple enterprises when given multiple variants" do
@@ -387,7 +389,7 @@ describe Enterprise do
         p1 = create(:simple_product, supplier: s1)
         p2 = create(:simple_product, supplier: s2)
 
-        Enterprise.supplying_variant_in([p1.master, p2.master]).should match_array [s1, s2]
+        expect(Enterprise.supplying_variant_in([p1.master, p2.master])).to match_array [s1, s2]
       end
 
       it "does not return duplicates" do
@@ -395,7 +397,7 @@ describe Enterprise do
         p1 = create(:simple_product, supplier: s)
         p2 = create(:simple_product, supplier: s)
 
-        Enterprise.supplying_variant_in([p1.master, p2.master]).should == [s]
+        expect(Enterprise.supplying_variant_in([p1.master, p2.master])).to eq([s])
       end
     end
 
@@ -403,34 +405,34 @@ describe Enterprise do
       it "returns enterprises distributing via a product distribution" do
         d = create(:distributor_enterprise)
         p = create(:product, distributors: [d])
-        Enterprise.distributing_products(p).should == [d]
+        expect(Enterprise.distributing_products(p)).to eq([d])
       end
 
       it "returns enterprises distributing via an order cycle" do
         d = create(:distributor_enterprise)
         p = create(:product)
         oc = create(:simple_order_cycle, distributors: [d], variants: [p.master])
-        Enterprise.distributing_products(p).should == [d]
+        expect(Enterprise.distributing_products(p)).to eq([d])
       end
 
       it "returns enterprises distributing via a product distribution" do
         d = create(:distributor_enterprise)
         p = create(:product, distributors: [d])
-        Enterprise.distributing_products([p]).should == [d]
+        expect(Enterprise.distributing_products([p])).to eq([d])
       end
 
       it "returns enterprises distributing via an order cycle" do
         d = create(:distributor_enterprise)
         p = create(:product)
         oc = create(:simple_order_cycle, distributors: [d], variants: [p.master])
-        Enterprise.distributing_products([p]).should == [d]
+        expect(Enterprise.distributing_products([p])).to eq([d])
       end
 
       it "does not return duplicate enterprises" do
         d = create(:distributor_enterprise)
         p1 = create(:product, distributors: [d])
         p2 = create(:product, distributors: [d])
-        Enterprise.distributing_products([p1, p2]).should == [d]
+        expect(Enterprise.distributing_products([p1, p2])).to eq([d])
       end
     end
 
@@ -443,8 +445,8 @@ describe Enterprise do
         e1.enterprise_roles.build(user: user).save
 
         enterprises = Enterprise.managed_by user
-        enterprises.count.should == 1
-        enterprises.should include e1
+        expect(enterprises.count).to eq(1)
+        expect(enterprises).to include e1
       end
 
       it "shows all enterprises for admin user" do
@@ -453,9 +455,9 @@ describe Enterprise do
         e2 = create(:enterprise)
 
         enterprises = Enterprise.managed_by user
-        enterprises.count.should == 2
-        enterprises.should include e1
-        enterprises.should include e2
+        expect(enterprises.count).to eq(2)
+        expect(enterprises).to include e1
+        expect(enterprises).to include e2
       end
     end
   end
@@ -523,11 +525,11 @@ describe Enterprise do
 
       def should_have_enterprise_relationship(opts={})
         er = EnterpriseRelationship.where(parent_id: opts[:from], child_id: opts[:to]).last
-        er.should_not be_nil
+        expect(er).not_to be_nil
         if opts[:with] == :all_permissions
-          er.permissions.map(&:name).should match_array ['add_to_order_cycle', 'manage_products', 'edit_profile', 'create_variant_overrides']
+          expect(er.permissions.map(&:name)).to match_array ['add_to_order_cycle', 'manage_products', 'edit_profile', 'create_variant_overrides']
         elsif opts.key? :with
-          er.permissions.map(&:name).should match_array opts[:with].map(&:to_s)
+          expect(er.permissions.map(&:name)).to match_array opts[:with].map(&:to_s)
         end
       end
     end
@@ -539,17 +541,17 @@ describe Enterprise do
     end
 
     it "returns false when no products" do
-      @supplier.should_not have_supplied_products_on_hand
+      expect(@supplier).not_to have_supplied_products_on_hand
     end
 
     it "returns false when the product is out of stock" do
       create(:product, :supplier => @supplier, :on_hand => 0)
-      @supplier.should_not have_supplied_products_on_hand
+      expect(@supplier).not_to have_supplied_products_on_hand
     end
 
     it "returns true when the product is in stock" do
       create(:product, :supplier => @supplier, :on_hand => 1)
-      @supplier.should have_supplied_products_on_hand
+      expect(@supplier).to have_supplied_products_on_hand
     end
   end
 
@@ -559,7 +561,7 @@ describe Enterprise do
       inactive_product = create(:product, supplier:  supplier, on_hand: 1, available_on: Date.tomorrow)
       out_of_stock_product = create(:product, supplier:  supplier, on_hand: 0, available_on: Date.yesterday)
       p1 = create(:product, supplier: supplier, on_hand: 1, available_on: Date.yesterday)
-      supplier.supplied_and_active_products_on_hand.should == [p1]
+      expect(supplier.supplied_and_active_products_on_hand).to eq([p1])
     end
   end
 
@@ -568,7 +570,7 @@ describe Enterprise do
       d = create(:distributor_enterprise)
       p = create(:product, distributors: [d])
       v = p.variants.first
-      d.distributed_variants.should match_array [p.master, v]
+      expect(d.distributed_variants).to match_array [p.master, v]
     end
 
     pending "finds variants distributed by order cycle" do
@@ -579,7 +581,7 @@ describe Enterprise do
       oc = create(:simple_order_cycle, distributors: [d], variants: [v])
 
       # This method doesn't do what this test says it does...
-      d.distributed_variants.should match_array [v]
+      expect(d.distributed_variants).to match_array [v]
     end
   end
 
@@ -588,7 +590,7 @@ describe Enterprise do
       d = create(:distributor_enterprise)
       p = create(:product, distributors: [d])
       v = p.variants.first
-      d.product_distribution_variants.should match_array [p.master, v]
+      expect(d.product_distribution_variants).to match_array [p.master, v]
     end
 
     it "does not find variants distributed by order cycle" do
@@ -596,7 +598,7 @@ describe Enterprise do
       p = create(:product)
       v = p.variants.first
       oc = create(:simple_order_cycle, distributors: [d], variants: [v])
-      d.product_distribution_variants.should == []
+      expect(d.product_distribution_variants).to eq([])
     end
   end
 
@@ -609,13 +611,13 @@ describe Enterprise do
     let(:product2) { create(:simple_product, primary_taxon: taxon1, taxons: [taxon1, taxon2]) }
 
     it "gets all taxons of all distributed products" do
-      Spree::Product.stub(:in_distributor).and_return [product1, product2]
-      distributor.distributed_taxons.should match_array [taxon1, taxon2]
+      allow(Spree::Product).to receive(:in_distributor).and_return [product1, product2]
+      expect(distributor.distributed_taxons).to match_array [taxon1, taxon2]
     end
 
     it "gets all taxons of all supplied products" do
-      Spree::Product.stub(:in_supplier).and_return [product1, product2]
-      supplier.supplied_taxons.should match_array [taxon1, taxon2]
+      allow(Spree::Product).to receive(:in_supplier).and_return [product1, product2]
+      expect(supplier.supplied_taxons).to match_array [taxon1, taxon2]
     end
   end
 
@@ -628,9 +630,9 @@ describe Enterprise do
     }
 
     it "strips http from url fields" do
-      distributor.website.should == "www.google.com"
-      distributor.facebook.should == "www.facebook.com/roger"
-      distributor.linkedin.should == "linkedin.com"
+      expect(distributor.website).to eq("www.google.com")
+      expect(distributor.facebook).to eq("www.facebook.com/roger")
+      expect(distributor.linkedin).to eq("linkedin.com")
     end
   end
 
@@ -640,9 +642,9 @@ describe Enterprise do
     it "sets producer properties" do
       supplier.set_producer_property 'Organic Certified', 'NASAA 12345'
 
-      supplier.producer_properties.count.should == 1
-      supplier.producer_properties.first.value.should == 'NASAA 12345'
-      supplier.producer_properties.first.property.presentation.should == 'Organic Certified'
+      expect(supplier.producer_properties.count).to eq(1)
+      expect(supplier.producer_properties.first.value).to eq('NASAA 12345')
+      expect(supplier.producer_properties.first.property.presentation).to eq('Organic Certified')
     end
   end
 
@@ -655,15 +657,15 @@ describe Enterprise do
     let(:non_producer_sell_none) { build(:enterprise, is_primary_producer: false, sells: "none") }
 
     it "should output enterprise categories" do
-      producer_sell_all.is_primary_producer.should == true
-      producer_sell_all.sells.should == "any"
+      expect(producer_sell_all.is_primary_producer).to eq(true)
+      expect(producer_sell_all.sells).to eq("any")
 
-      producer_sell_all.category.should == :producer_hub
-      producer_sell_own.category.should == :producer_shop
-      producer_sell_none.category.should == :producer
-      non_producer_sell_all.category.should == :hub
-      non_producer_sell_own.category.should == :hub
-      non_producer_sell_none.category.should == :hub_profile
+      expect(producer_sell_all.category).to eq(:producer_hub)
+      expect(producer_sell_own.category).to eq(:producer_shop)
+      expect(producer_sell_none.category).to eq(:producer)
+      expect(non_producer_sell_all.category).to eq(:hub)
+      expect(non_producer_sell_own.category).to eq(:hub)
+      expect(non_producer_sell_none.category).to eq(:hub_profile)
     end
   end
 
@@ -671,7 +673,7 @@ describe Enterprise do
     let(:enterprise) { build(:enterprise, name: "Name To Turn Into A Permalink") }
     it "assigns permalink when initialized" do
       allow(Enterprise).to receive(:find_available_permalink).and_return("available_permalink")
-      Enterprise.should_receive(:find_available_permalink).with("Name To Turn Into A Permalink")
+      expect(Enterprise).to receive(:find_available_permalink).with("Name To Turn Into A Permalink")
       expect(
         lambda { enterprise.send(:initialize_permalink) }
       ).to change{

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Exchange do
   it "should be valid when built from factory" do
-    build(:exchange).should be_valid
+    expect(build(:exchange)).to be_valid
   end
 
   [:order_cycle, :sender, :receiver].each do |attr|
     it "should not be valid without #{attr}" do
       e = build(:exchange)
       e.send("#{attr}=", nil)
-      e.should_not be_valid
+      expect(e).not_to be_valid
     end
   end
 
@@ -18,18 +18,18 @@ describe Exchange do
 
     e2 = build(:exchange,
                :order_cycle => e1.order_cycle, :sender => e1.sender, :receiver => e1.receiver, :incoming => e1.incoming)
-    e2.should_not be_valid
+    expect(e2).not_to be_valid
 
     e2.incoming = !e2.incoming
-    e2.should be_valid
+    expect(e2).to be_valid
     e2.incoming = !e2.incoming
 
     e2.receiver = create(:enterprise)
-    e2.should be_valid
+    expect(e2).to be_valid
 
     e2.sender = e2.receiver
     e2.receiver = e1.receiver
-    e2.should be_valid
+    expect(e2).to be_valid
   end
 
   it "has exchange variants" do
@@ -37,7 +37,7 @@ describe Exchange do
     p = create(:product)
 
     e.exchange_variants.create(:variant => p.master)
-    e.variants.count.should == 1
+    expect(e.variants.count).to eq(1)
   end
 
   it "has exchange fees" do
@@ -45,7 +45,7 @@ describe Exchange do
     f = create(:enterprise_fee)
 
     e.exchange_fees.create(:enterprise_fee => f)
-    e.enterprise_fees.count.should == 1
+    expect(e.enterprise_fees.count).to eq(1)
   end
 
   describe "exchange directionality" do
@@ -58,21 +58,21 @@ describe Exchange do
 
     describe "reporting whether it is an incoming exchange" do
       it "returns true for incoming exchanges" do
-        incoming_exchange.should be_incoming
+        expect(incoming_exchange).to be_incoming
       end
 
       it "returns false for outgoing exchanges" do
-        outgoing_exchange.should_not be_incoming
+        expect(outgoing_exchange).not_to be_incoming
       end
     end
 
     describe "finding the exchange participant (the enterprise other than the coordinator)" do
       it "returns the sender for incoming exchanges" do
-        incoming_exchange.participant.should == supplier
+        expect(incoming_exchange.participant).to eq(supplier)
       end
 
       it "returns the receiver for outgoing exchanges" do
-        outgoing_exchange.participant.should == distributor
+        expect(outgoing_exchange.participant).to eq(distributor)
       end
     end
   end
@@ -80,14 +80,14 @@ describe Exchange do
   describe "reporting its role" do
     it "returns 'supplier' when it is an incoming exchange" do
       e = Exchange.new
-      e.stub(:incoming?) { true }
-      e.role.should == 'supplier'
+      allow(e).to receive(:incoming?) { true }
+      expect(e.role).to eq('supplier')
     end
 
     it "returns 'distributor' when it is an outgoing exchange" do
       e = Exchange.new
-      e.stub(:incoming?) { false }
-      e.role.should == 'distributor'
+      allow(e).to receive(:incoming?) { false }
+      expect(e.role).to eq('distributor')
     end
   end
 
@@ -126,32 +126,32 @@ describe Exchange do
         exchange.sender.users << user
         exchange.receiver.users << user
 
-        Exchange.managed_by(user).should == [exchange]
+        expect(Exchange.managed_by(user)).to eq([exchange])
       end
 
       it "does not return exchanges where the user manages only the sender" do
         exchange = create(:exchange, order_cycle: oc)
         exchange.sender.users << user
 
-        Exchange.managed_by(user).should be_empty
+        expect(Exchange.managed_by(user)).to be_empty
       end
 
       it "does not return exchanges where the user manages only the receiver" do
         exchange = create(:exchange, order_cycle: oc)
         exchange.receiver.users << user
 
-        Exchange.managed_by(user).should be_empty
+        expect(Exchange.managed_by(user)).to be_empty
       end
 
       it "does not return exchanges where the user manages neither enterprise" do
         exchange = create(:exchange, order_cycle: oc)
-        Exchange.managed_by(user).should be_empty
+        expect(Exchange.managed_by(user)).to be_empty
       end
     end
 
     it "finds exchanges in a particular order cycle" do
       ex = create(:exchange, order_cycle: oc)
-      Exchange.in_order_cycle(oc).should == [ex]
+      expect(Exchange.in_order_cycle(oc)).to eq([ex])
     end
 
     describe "finding exchanges by direction" do
@@ -159,44 +159,44 @@ describe Exchange do
       let!(:outgoing_exchange) { oc.exchanges.create! sender: coordinator, receiver: distributor, incoming: false }
 
       it "finds incoming exchanges" do
-        Exchange.incoming.should == [incoming_exchange]
+        expect(Exchange.incoming).to eq([incoming_exchange])
       end
 
       it "finds outgoing exchanges" do
-        Exchange.outgoing.should == [outgoing_exchange]
+        expect(Exchange.outgoing).to eq([outgoing_exchange])
       end
 
       it "correctly determines direction of exchanges between the same enterprise" do
         incoming_exchange.update_attributes sender: coordinator, incoming: true
         outgoing_exchange.update_attributes receiver: coordinator, incoming: false
-        Exchange.incoming.should == [incoming_exchange]
-        Exchange.outgoing.should == [outgoing_exchange]
+        expect(Exchange.incoming).to eq([incoming_exchange])
+        expect(Exchange.outgoing).to eq([outgoing_exchange])
       end
 
       it "finds exchanges coming from an enterprise" do
-        Exchange.from_enterprise(supplier).should    == [incoming_exchange]
-        Exchange.from_enterprise(coordinator).should == [outgoing_exchange]
+        expect(Exchange.from_enterprise(supplier)).to    eq([incoming_exchange])
+        expect(Exchange.from_enterprise(coordinator)).to eq([outgoing_exchange])
       end
 
       it "finds exchanges going to an enterprise" do
-        Exchange.to_enterprise(coordinator).should == [incoming_exchange]
-        Exchange.to_enterprise(distributor).should == [outgoing_exchange]
+        expect(Exchange.to_enterprise(coordinator)).to eq([incoming_exchange])
+        expect(Exchange.to_enterprise(distributor)).to eq([outgoing_exchange])
       end
 
       it "finds exchanges coming from any of a number of enterprises" do
-        Exchange.from_enterprises([coordinator]).should == [outgoing_exchange]
-        Exchange.from_enterprises([supplier, coordinator]).should match_array [incoming_exchange, outgoing_exchange]
+        expect(Exchange.from_enterprises([coordinator])).to eq([outgoing_exchange])
+        expect(Exchange.from_enterprises([supplier, coordinator])).to match_array [incoming_exchange, outgoing_exchange]
       end
 
       it "finds exchanges going to any of a number of enterprises" do
-        Exchange.to_enterprises([coordinator]).should == [incoming_exchange]
-        Exchange.to_enterprises([coordinator, distributor]).should match_array [incoming_exchange, outgoing_exchange]
+        expect(Exchange.to_enterprises([coordinator])).to eq([incoming_exchange])
+        expect(Exchange.to_enterprises([coordinator, distributor])).to match_array [incoming_exchange, outgoing_exchange]
       end
 
       it "finds exchanges involving any of a number of enterprises" do
-        Exchange.involving([supplier]).should == [incoming_exchange]
-        Exchange.involving([coordinator]).should match_array [incoming_exchange, outgoing_exchange]
-        Exchange.involving([distributor]).should == [outgoing_exchange]
+        expect(Exchange.involving([supplier])).to eq([incoming_exchange])
+        expect(Exchange.involving([coordinator])).to match_array [incoming_exchange, outgoing_exchange]
+        expect(Exchange.involving([distributor])).to eq([outgoing_exchange])
       end
     end
 
@@ -205,14 +205,14 @@ describe Exchange do
         d = create(:distributor_enterprise)
         ex = create(:exchange, order_cycle: oc, incoming: true)
 
-        oc.exchanges.supplying_to(d).should == [ex]
+        expect(oc.exchanges.supplying_to(d)).to eq([ex])
       end
 
       it "returns outgoing exchanges to the distributor" do
         d = create(:distributor_enterprise)
         ex = create(:exchange, order_cycle: oc, receiver: d, incoming: false)
 
-        oc.exchanges.supplying_to(d).should == [ex]
+        expect(oc.exchanges.supplying_to(d)).to eq([ex])
       end
 
       it "does not return outgoing exchanges to a different distributor" do
@@ -220,7 +220,7 @@ describe Exchange do
         d2 = create(:distributor_enterprise)
         ex = create(:exchange, order_cycle: oc, receiver: d1, incoming: false)
 
-        oc.exchanges.supplying_to(d2).should be_empty
+        expect(oc.exchanges.supplying_to(d2)).to be_empty
       end
     end
 
@@ -229,7 +229,7 @@ describe Exchange do
       ex = create(:exchange)
       ex.variants << v
 
-      Exchange.with_variant(v).should == [ex]
+      expect(Exchange.with_variant(v)).to eq([ex])
     end
 
     it "finds exchanges with any of a number of variants, without returning duplicates" do
@@ -240,7 +240,7 @@ describe Exchange do
       ex.variants << v1
       ex.variants << v2
 
-      Exchange.with_any_variant([v1, v2, v3]).should == [ex]
+      expect(Exchange.with_any_variant([v1, v2, v3])).to eq([ex])
     end
 
     it "finds exchanges with a particular product's master variant" do
@@ -249,7 +249,7 @@ describe Exchange do
       ex.variants << p.master
       p.reload
 
-      Exchange.with_product(p).should == [ex]
+      expect(Exchange.with_product(p)).to eq([ex])
     end
 
     it "finds exchanges with a particular product's non-master variant" do
@@ -259,7 +259,7 @@ describe Exchange do
       ex.variants << v
       p.reload
 
-      Exchange.with_product(p).should == [ex]
+      expect(Exchange.with_product(p)).to eq([ex])
     end
 
     describe "sorting exchanges by primary enterprise name" do
@@ -272,7 +272,7 @@ describe Exchange do
       let!(:ex3) { create(:exchange, sender:   e3, incoming: true) }
 
       it "sorts" do
-        Exchange.by_enterprise_name.should == [ex2, ex3, ex1]
+        expect(Exchange.by_enterprise_name).to eq([ex2, ex3, ex1])
       end
     end
   end
@@ -285,7 +285,7 @@ describe Exchange do
     ex1.update_attribute(:tag_list, "wholesale")
     ex2 = ex1.clone! new_oc
 
-    ex1.eql?(ex2).should be true
+    expect(ex1.eql?(ex2)).to be true
     expect(ex2.reload.tag_list).to eq ["wholesale"]
   end
 
@@ -295,13 +295,13 @@ describe Exchange do
       exchange = oc.exchanges.last
       exchange.payment_enterprise = Enterprise.last
       exchange.save!
-      exchange.stub(:variant_ids) { [1835, 1834] } # Test id ordering
-      exchange.stub(:enterprise_fee_ids) { [1493, 1492] } # Test id ordering
+      allow(exchange).to receive(:variant_ids) { [1835, 1834] } # Test id ordering
+      allow(exchange).to receive(:enterprise_fee_ids) { [1493, 1492] } # Test id ordering
       exchange
     end
 
     it "converts to a hash" do
-      exchange.to_h.should ==
+      expect(exchange.to_h).to eq(
         {'id' => exchange.id, 'order_cycle_id' => oc.id,
         'sender_id' => exchange.sender_id, 'receiver_id' => exchange.receiver_id,
         'incoming' => exchange.incoming,
@@ -310,16 +310,18 @@ describe Exchange do
         'pickup_time' => exchange.pickup_time, 'pickup_instructions' => exchange.pickup_instructions,
         'receival_instructions' => exchange.receival_instructions,
         'created_at' => exchange.created_at, 'updated_at' => exchange.updated_at}
+      )
     end
 
     it "converts to a hash of core attributes only" do
-      exchange.to_h(true).should ==
+      expect(exchange.to_h(true)).to eq(
         {'sender_id' => exchange.sender_id, 'receiver_id' => exchange.receiver_id,
          'incoming' => exchange.incoming,
          'payment_enterprise_id' => exchange.payment_enterprise_id, 'variant_ids' => exchange.variant_ids.sort,
          'enterprise_fee_ids' => exchange.enterprise_fee_ids.sort,
          'pickup_time' => exchange.pickup_time, 'pickup_instructions' => exchange.pickup_instructions,
          'receival_instructions' => exchange.receival_instructions}
+      )
     end
   end
 
@@ -328,17 +330,17 @@ describe Exchange do
       e1 = Exchange.new
       e2 = Exchange.new
 
-      e1.stub(:to_h) { {'sender_id' => 456} }
-      e2.stub(:to_h) { {'sender_id' => 456} }
+      allow(e1).to receive(:to_h) { {'sender_id' => 456} }
+      allow(e2).to receive(:to_h) { {'sender_id' => 456} }
 
-      e1.eql?(e2).should be true
+      expect(e1.eql?(e2)).to be true
     end
 
     it "compares other objects using super" do
       exchange = Exchange.new
       exchange_fee = ExchangeFee.new
 
-      exchange.eql?(exchange_fee).should be false
+      expect(exchange.eql?(exchange_fee)).to be false
     end
   end
 end

--- a/spec/models/model_set_spec.rb
+++ b/spec/models/model_set_spec.rb
@@ -10,7 +10,7 @@ describe ModelSet do
 
       expect { ms.save }.to change(EnterpriseRelationshipPermission, :count).by(2)
 
-      EnterpriseRelationshipPermission.where(name: ['s1', 's2']).count.should == 2
+      expect(EnterpriseRelationshipPermission.where(name: ['s1', 's2']).count).to eq(2)
     end
 
 
@@ -25,7 +25,7 @@ describe ModelSet do
 
       expect { ms.save }.to change(EnterpriseGroup, :count).by(0)
 
-      EnterpriseGroup.where(name: ['e1zz', 'e2yy']).count.should == 2
+      expect(EnterpriseGroup.where(name: ['e1zz', 'e2yy']).count).to eq(2)
     end
 
 
@@ -41,8 +41,8 @@ describe ModelSet do
 
       expect { ms.save }.to change(Enterprise, :count).by(-1)
 
-      Enterprise.where(id: e1.id).should be_empty
-      Enterprise.where(id: e2.id).should be_present
+      expect(Enterprise.where(id: e1.id)).to be_empty
+      expect(Enterprise.where(id: e2.id)).to be_present
     end
 
 

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe OrderCycle do
   it "should be valid when built from factory" do
-    build(:simple_order_cycle).should be_valid
+    expect(build(:simple_order_cycle)).to be_valid
   end
 
   it "should not be valid without a name" do
     oc = build(:simple_order_cycle)
     oc.name = ''
-    oc.should_not be_valid
+    expect(oc).not_to be_valid
   end
 
   it "has a coordinator and associated fees" do
@@ -39,7 +39,7 @@ describe OrderCycle do
     create(:exchange, order_cycle: oc)
     create(:exchange, order_cycle: oc)
 
-    oc.exchanges.count.should == 3
+    expect(oc.exchanges.count).to eq(3)
   end
 
   it "finds order cycles in various stages of their lifecycle" do
@@ -50,13 +50,13 @@ describe OrderCycle do
     oc_undated_open = create(:simple_order_cycle, orders_open_at: 1.week.ago, orders_close_at: nil)
     oc_undated_close = create(:simple_order_cycle, orders_open_at: nil, orders_close_at: 1.week.from_now)
 
-    OrderCycle.active.should == [oc_active]
-    OrderCycle.inactive.should match_array [oc_not_yet_open, oc_already_closed]
-    OrderCycle.upcoming.should == [oc_not_yet_open]
-    OrderCycle.closed.should == [oc_already_closed]
-    OrderCycle.undated.should == [oc_undated, oc_undated_open, oc_undated_close]
-    OrderCycle.not_closed.should == [oc_active, oc_not_yet_open, oc_undated, oc_undated_open, oc_undated_close]
-    OrderCycle.dated.should == [oc_active, oc_not_yet_open, oc_already_closed]
+    expect(OrderCycle.active).to eq([oc_active])
+    expect(OrderCycle.inactive).to match_array [oc_not_yet_open, oc_already_closed]
+    expect(OrderCycle.upcoming).to eq([oc_not_yet_open])
+    expect(OrderCycle.closed).to eq([oc_already_closed])
+    expect(OrderCycle.undated).to eq([oc_undated, oc_undated_open, oc_undated_close])
+    expect(OrderCycle.not_closed).to eq([oc_active, oc_not_yet_open, oc_undated, oc_undated_open, oc_undated_close])
+    expect(OrderCycle.dated).to eq([oc_active, oc_not_yet_open, oc_already_closed])
   end
 
   it "finds order cycles accessible by a user" do
@@ -70,8 +70,8 @@ describe OrderCycle do
     oc_received = create(:simple_order_cycle, distributors: [e2])
     oc_not_accessible = create(:simple_order_cycle, coordinator: e1)
 
-    OrderCycle.accessible_by(user).should include(oc_coordinated, oc_sent, oc_received)
-    OrderCycle.accessible_by(user).should_not include(oc_not_accessible)
+    expect(OrderCycle.accessible_by(user)).to include(oc_coordinated, oc_sent, oc_received)
+    expect(OrderCycle.accessible_by(user)).not_to include(oc_not_accessible)
   end
 
   describe "finding order cycles distributing a product" do
@@ -81,7 +81,7 @@ describe OrderCycle do
       oc = create(:simple_order_cycle, distributors: [d], variants: [p.master])
       p.reload
 
-      OrderCycle.distributing_product(p).should == [oc]
+      expect(OrderCycle.distributing_product(p)).to eq([oc])
     end
 
     it "returns order cycles distributing another variant" do
@@ -91,7 +91,7 @@ describe OrderCycle do
       oc = create(:simple_order_cycle, distributors: [d], variants: [v])
       p.reload
 
-      OrderCycle.distributing_product(p).should == [oc]
+      expect(OrderCycle.distributing_product(p)).to eq([oc])
     end
 
     it "does not return order cycles supplying but not distributing a product" do
@@ -102,7 +102,7 @@ describe OrderCycle do
       ex.variants << p.master
       p.reload
 
-      OrderCycle.distributing_product(p).should == []
+      expect(OrderCycle.distributing_product(p)).to eq([])
     end
   end
 
@@ -111,7 +111,7 @@ describe OrderCycle do
     oc2 = create(:simple_order_cycle, orders_close_at: 1.hour.ago)
     oc3 = create(:simple_order_cycle, orders_close_at: 1.hour.from_now)
 
-    OrderCycle.most_recently_closed.should == [oc2, oc1]
+    expect(OrderCycle.most_recently_closed).to eq([oc2, oc1])
   end
 
   it "finds the soonest opening order cycles" do
@@ -119,7 +119,7 @@ describe OrderCycle do
     oc2 = create(:simple_order_cycle, orders_open_at: 2.hours.from_now)
     oc3 = create(:simple_order_cycle, orders_open_at: 1.hour.ago)
 
-    OrderCycle.soonest_opening.should == [oc2, oc1]
+    expect(OrderCycle.soonest_opening).to eq([oc2, oc1])
   end
 
   it "finds the soonest closing order cycles" do
@@ -127,7 +127,7 @@ describe OrderCycle do
     oc2 = create(:simple_order_cycle, orders_close_at: 2.hour.from_now)
     oc3 = create(:simple_order_cycle, orders_close_at: 1.hour.from_now)
 
-    OrderCycle.soonest_closing.should == [oc3, oc2]
+    expect(OrderCycle.soonest_closing).to eq([oc3, oc2])
   end
 
   describe "finding order cycles with a particular distributor" do
@@ -136,17 +136,17 @@ describe OrderCycle do
 
     it "returns order cycles with that distributor" do
       oc = create(:simple_order_cycle, coordinator: c, distributors: [d])
-      OrderCycle.with_distributor(d).should == [oc]
+      expect(OrderCycle.with_distributor(d)).to eq([oc])
     end
 
     it "does not return order cycles with that enterprise as supplier" do
       oc = create(:simple_order_cycle, coordinator: c, suppliers: [d])
-      OrderCycle.with_distributor(d).should == []
+      expect(OrderCycle.with_distributor(d)).to eq([])
     end
 
     it "does not return order cycles without that distributor" do
       oc = create(:simple_order_cycle, coordinator: c)
-      OrderCycle.with_distributor(d).should == []
+      expect(OrderCycle.with_distributor(d)).to eq([])
     end
   end
 
@@ -158,7 +158,7 @@ describe OrderCycle do
     e2 = create(:exchange, incoming: true,
                 order_cycle: oc, receiver: oc.coordinator, sender: create(:enterprise))
 
-    oc.suppliers.should match_array [e1.sender, e2.sender]
+    expect(oc.suppliers).to match_array [e1.sender, e2.sender]
   end
 
   it "reports its distributors" do
@@ -169,7 +169,7 @@ describe OrderCycle do
     e2 = create(:exchange, incoming: false,
                 order_cycle: oc, sender: oc.coordinator, receiver: create(:enterprise))
 
-    oc.distributors.should match_array [e1.receiver, e2.receiver]
+    expect(oc.distributors).to match_array [e1.receiver, e2.receiver]
   end
 
   it "checks for existance of distributors" do
@@ -178,8 +178,8 @@ describe OrderCycle do
     d2 = create(:distributor_enterprise)
     create(:exchange, order_cycle: oc, sender: oc.coordinator, receiver: d1, incoming: false)
 
-    oc.should have_distributor(d1)
-    oc.should_not have_distributor(d2)
+    expect(oc).to have_distributor(d1)
+    expect(oc).not_to have_distributor(d2)
   end
 
   it "checks for variants" do
@@ -187,8 +187,8 @@ describe OrderCycle do
     p2 = create(:simple_product)
     oc = create(:simple_order_cycle, suppliers: [p1.supplier], variants: [p1.master])
 
-    oc.should have_variant(p1.master)
-    oc.should_not have_variant(p2.master)
+    expect(oc).to have_variant(p1.master)
+    expect(oc).not_to have_variant(p2.master)
   end
 
   describe "product exchanges" do
@@ -224,39 +224,39 @@ describe OrderCycle do
     end
 
     it "reports on the variants exchanged" do
-      oc.variants.should match_array [p0.master, p1.master, p2.master, p2_v, p1_v_visible, p1_v_hidden]
+      expect(oc.variants).to match_array [p0.master, p1.master, p2.master, p2_v, p1_v_visible, p1_v_hidden]
     end
 
     it "returns the correct count of variants" do
-      oc.variants.count.should == 6
+      expect(oc.variants.count).to eq(6)
     end
 
     it "reports on the variants supplied" do
-      oc.supplied_variants.should match_array [p0.master]
+      expect(oc.supplied_variants).to match_array [p0.master]
     end
 
     it "reports on the variants distributed" do
-      oc.distributed_variants.should match_array [p1.master, p2.master, p2_v, p1_v_visible, p1_v_hidden]
+      expect(oc.distributed_variants).to match_array [p1.master, p2.master, p2_v, p1_v_visible, p1_v_hidden]
     end
 
     it "reports on the products distributed by a particular distributor" do
-      oc.products_distributed_by(d2).should == [p1]
+      expect(oc.products_distributed_by(d2)).to eq([p1])
     end
 
     it "reports on the products exchanged" do
-      oc.products.should match_array [p0, p1, p2]
+      expect(oc.products).to match_array [p0, p1, p2]
     end
 
     context "listing variant distributed by a particular distributor" do
       context "when default settings are in play" do
         it "returns an empty list when no distributor is given" do
-          oc.variants_distributed_by(nil).should == []
+          expect(oc.variants_distributed_by(nil)).to eq([])
         end
 
         it "returns all variants in the outgoing exchange for the distributor provided" do
-          oc.variants_distributed_by(d2).should include p1.master, p1_v_visible
-          oc.variants_distributed_by(d2).should_not include p1_v_hidden, p1_v_deleted
-          oc.variants_distributed_by(d1).should include p2_v
+          expect(oc.variants_distributed_by(d2)).to include p1.master, p1_v_visible
+          expect(oc.variants_distributed_by(d2)).not_to include p1_v_hidden, p1_v_deleted
+          expect(oc.variants_distributed_by(d1)).to include p2_v
         end
       end
 
@@ -266,11 +266,11 @@ describe OrderCycle do
         end
 
         it "returns an empty list when no distributor is given" do
-          oc.variants_distributed_by(nil).should == []
+          expect(oc.variants_distributed_by(nil)).to eq([])
         end
 
         it "returns only variants in the exchange that are also in the distributor's inventory" do
-          oc.variants_distributed_by(d1).should_not include p2_v
+          expect(oc.variants_distributed_by(d1)).not_to include p2_v
         end
       end
     end
@@ -286,7 +286,7 @@ describe OrderCycle do
       d = create(:distributor_enterprise)
       oc = create(:simple_order_cycle, distributors: [d], variants: [v_valid, p_invalid.master])
 
-      oc.valid_products_distributed_by(d).should == [p_valid]
+      expect(oc.valid_products_distributed_by(d)).to eq([p_valid])
     end
 
     describe "checking if a product has only an obsolete master variant in a distributution" do
@@ -297,7 +297,7 @@ describe OrderCycle do
         distributed_variants = [master, unassociated_variant]
 
         oc = OrderCycle.new
-        oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants).should be true
+        expect(oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants)).to be true
       end
 
       it "returns false when the product doesn't have variants" do
@@ -306,7 +306,7 @@ describe OrderCycle do
         distributed_variants = [master]
 
         oc = OrderCycle.new
-        oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants).should be false
+        expect(oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants)).to be false
       end
 
       it "returns false when the master isn't distributed" do
@@ -315,7 +315,7 @@ describe OrderCycle do
         distributed_variants = []
 
         oc = OrderCycle.new
-        oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants).should be false
+        expect(oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants)).to be false
       end
 
       it "returns false when the product has other variants distributed" do
@@ -325,7 +325,7 @@ describe OrderCycle do
         distributed_variants = [master, variant]
 
         oc = OrderCycle.new
-        oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants).should be false
+        expect(oc.send(:product_has_only_obsolete_master_in_distribution?, product, distributed_variants)).to be false
       end
     end
   end
@@ -343,23 +343,23 @@ describe OrderCycle do
     end
 
     it "finds the exchange for a distributor" do
-      @oc.exchange_for_distributor(@d1).should == @e1
-      @oc.exchange_for_distributor(@d2).should == @e2
+      expect(@oc.exchange_for_distributor(@d1)).to eq(@e1)
+      expect(@oc.exchange_for_distributor(@d2)).to eq(@e2)
     end
 
     describe "finding pickup time for a distributor" do
       it "looks up the pickup time on the exchange when present" do
-        @oc.pickup_time_for(@d1).should == '5pm Tuesday'
+        expect(@oc.pickup_time_for(@d1)).to eq('5pm Tuesday')
       end
 
       it "returns the distributor's default collection time otherwise" do
-        @oc.pickup_time_for(@d2).should == '2-8pm Friday'
+        expect(@oc.pickup_time_for(@d2)).to eq('2-8pm Friday')
       end
     end
 
     describe "finding pickup instructions for a distributor" do
       it "returns the pickup instructions" do
-        @oc.pickup_instructions_for(@d1).should == "Come get it!"
+        expect(@oc.pickup_instructions_for(@d1)).to eq("Come get it!")
       end
     end
   end
@@ -369,60 +369,60 @@ describe OrderCycle do
 
     it "reports status when an order cycle is upcoming" do
       Timecop.freeze(oc.orders_open_at - 1.second) do
-        oc.should_not be_undated
-        oc.should     be_dated
-        oc.should     be_upcoming
-        oc.should_not be_open
-        oc.should_not be_closed
+        expect(oc).not_to be_undated
+        expect(oc).to     be_dated
+        expect(oc).to     be_upcoming
+        expect(oc).not_to be_open
+        expect(oc).not_to be_closed
       end
     end
 
     it "reports status when an order cycle is open" do
-      oc.should_not be_undated
-      oc.should     be_dated
-      oc.should_not be_upcoming
-      oc.should     be_open
-      oc.should_not be_closed
+      expect(oc).not_to be_undated
+      expect(oc).to     be_dated
+      expect(oc).not_to be_upcoming
+      expect(oc).to     be_open
+      expect(oc).not_to be_closed
     end
 
     it "reports status when an order cycle has closed" do
       Timecop.freeze(oc.orders_close_at + 1.second) do
-        oc.should_not be_undated
-        oc.should     be_dated
-        oc.should_not be_upcoming
-        oc.should_not be_open
-        oc.should     be_closed
+        expect(oc).not_to be_undated
+        expect(oc).to     be_dated
+        expect(oc).not_to be_upcoming
+        expect(oc).not_to be_open
+        expect(oc).to     be_closed
       end
     end
 
     it "reports status when an order cycle is undated" do
       oc.update_attributes!(orders_open_at: nil, orders_close_at: nil)
 
-      oc.should     be_undated
-      oc.should_not be_dated
-      oc.should_not be_upcoming
-      oc.should_not be_open
-      oc.should_not be_closed
+      expect(oc).to     be_undated
+      expect(oc).not_to be_dated
+      expect(oc).not_to be_upcoming
+      expect(oc).not_to be_open
+      expect(oc).not_to be_closed
     end
 
     it "reports status when an order cycle is partially dated - opening time only" do
       oc.update_attributes!(orders_close_at: nil)
 
-      oc.should     be_undated
-      oc.should_not be_dated
-      oc.should_not be_upcoming
-      oc.should_not be_open
-      oc.should_not be_closed
+      expect(oc).to     be_undated
+      expect(oc).not_to be_dated
+      expect(oc).not_to be_upcoming
+      expect(oc).not_to be_open
+      expect(oc).not_to be_closed
     end
 
     it "reports status when an order cycle is partially dated - closing time only" do
       oc.update_attributes!(orders_open_at: nil)
 
-      oc.should     be_undated
-      oc.should_not be_dated
-      oc.should_not be_upcoming
-      oc.should_not be_open
-      oc.should_not be_closed
+      expect(oc).to     be_undated
+      expect(oc).not_to be_dated
+      expect(oc).not_to be_upcoming
+      expect(oc).not_to be_open
+      expect(oc).not_to be_closed
     end
   end
 
@@ -434,16 +434,16 @@ describe OrderCycle do
     oc.clone!
 
     occ = OrderCycle.last
-    occ.name.should == "COPY OF #{oc.name}"
-    occ.orders_open_at.should be_nil
-    occ.orders_close_at.should be_nil
-    occ.coordinator.should_not be_nil
-    occ.preferred_product_selection_from_coordinator_inventory_only.should be true
-    occ.coordinator.should == oc.coordinator
+    expect(occ.name).to eq("COPY OF #{oc.name}")
+    expect(occ.orders_open_at).to be_nil
+    expect(occ.orders_close_at).to be_nil
+    expect(occ.coordinator).not_to be_nil
+    expect(occ.preferred_product_selection_from_coordinator_inventory_only).to be true
+    expect(occ.coordinator).to eq(oc.coordinator)
 
-    occ.coordinator_fee_ids.should_not be_empty
-    occ.coordinator_fee_ids.should == oc.coordinator_fee_ids
-    occ.preferred_product_selection_from_coordinator_inventory_only.should == oc.preferred_product_selection_from_coordinator_inventory_only
+    expect(occ.coordinator_fee_ids).not_to be_empty
+    expect(occ.coordinator_fee_ids).to eq(oc.coordinator_fee_ids)
+    expect(occ.preferred_product_selection_from_coordinator_inventory_only).to eq(oc.preferred_product_selection_from_coordinator_inventory_only)
 
     # to_h gives us a unique hash for each exchange
     # check that the clone has no additional exchanges
@@ -459,12 +459,12 @@ describe OrderCycle do
     it "should give the most recently closed order cycle for a distributor" do
       distributor = create(:distributor_enterprise)
       oc = create(:simple_order_cycle, name: 'oc 1', distributors: [distributor], orders_open_at: 10.days.ago, orders_close_at: 9.days.ago)
-      OrderCycle.most_recently_closed_for(distributor).should == oc
+      expect(OrderCycle.most_recently_closed_for(distributor)).to eq(oc)
     end
 
     it "should return nil when there have been none" do
       distributor = create(:distributor_enterprise)
-      OrderCycle.most_recently_closed_for(distributor).should == nil
+      expect(OrderCycle.most_recently_closed_for(distributor)).to eq(nil)
     end
   end
 
@@ -472,12 +472,12 @@ describe OrderCycle do
     it "should give the soonest opening order cycle for a distributor" do
       distributor = create(:distributor_enterprise)
       oc = create(:simple_order_cycle, name: 'oc 1', distributors: [distributor], orders_open_at: 10.days.from_now, orders_close_at: 11.days.from_now)
-      OrderCycle.first_opening_for(distributor).should == oc
+      expect(OrderCycle.first_opening_for(distributor)).to eq(oc)
     end
 
     it "should return no order cycle when none are impending" do
       distributor = create(:distributor_enterprise)
-      OrderCycle.first_opening_for(distributor).should == nil
+      expect(OrderCycle.first_opening_for(distributor)).to eq(nil)
     end
   end
 
@@ -486,7 +486,7 @@ describe OrderCycle do
       distributor = create(:distributor_enterprise)
       oc = create(:simple_order_cycle, name: 'oc 1', distributors: [distributor], orders_open_at: 1.days.ago, orders_close_at: 11.days.from_now)
       oc2 = create(:simple_order_cycle, name: 'oc 2', distributors: [distributor], orders_open_at: 2.days.ago, orders_close_at: 12.days.from_now)
-      OrderCycle.first_closing_for(distributor).should == oc
+      expect(OrderCycle.first_closing_for(distributor)).to eq(oc)
     end
   end
 
@@ -501,11 +501,11 @@ describe OrderCycle do
     let!(:oc3) { create(:simple_order_cycle, orders_close_at: time3, distributors: [e2]) }
 
     it "returns the closing time, indexed by enterprise id" do
-      OrderCycle.earliest_closing_times[e1.id].should == time1
+      expect(OrderCycle.earliest_closing_times[e1.id]).to eq(time1)
     end
 
     it "returns the earliest closing time" do
-      OrderCycle.earliest_closing_times[e2.id].should == time2
+      expect(OrderCycle.earliest_closing_times[e2.id]).to eq(time2)
     end
   end
 

--- a/spec/models/product_distribution_spec.rb
+++ b/spec/models/product_distribution_spec.rb
@@ -94,7 +94,7 @@ describe ProductDistribution do
     describe "creating an adjustment for a line item" do
       it "creates the adjustment via the enterprise fee" do
         pd = create(:product_distribution)
-        pd.stub(:adjustment_label_for) { 'label' }
+        allow(pd).to receive(:adjustment_label_for) { 'label' }
         line_item = create(:line_item)
 
         expect { pd.send(:create_adjustment_for, line_item) }.to change(Spree::Adjustment, :count).by(1)

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -21,10 +21,10 @@ module Spree
           user.enterprise_roles.create! enterprise: enterprise_any
         end
 
-        it { subject.can_manage_products?(user).should be true }
-        it { subject.can_manage_enterprises?(user).should be true }
-        it { subject.can_manage_orders?(user).should be true }
-        it { subject.can_manage_order_cycles?(user).should be true }
+        it { expect(subject.can_manage_products?(user)).to be true }
+        it { expect(subject.can_manage_enterprises?(user)).to be true }
+        it { expect(subject.can_manage_orders?(user)).to be true }
+        it { expect(subject.can_manage_order_cycles?(user)).to be true }
       end
 
       context "as manager of an enterprise who sell 'own'" do
@@ -32,10 +32,10 @@ module Spree
           user.enterprise_roles.create! enterprise: enterprise_own
         end
 
-        it { subject.can_manage_products?(user).should be true }
-        it { subject.can_manage_enterprises?(user).should be true }
-        it { subject.can_manage_orders?(user).should be true }
-        it { subject.can_manage_order_cycles?(user).should be true }
+        it { expect(subject.can_manage_products?(user)).to be true }
+        it { expect(subject.can_manage_enterprises?(user)).to be true }
+        it { expect(subject.can_manage_orders?(user)).to be true }
+        it { expect(subject.can_manage_order_cycles?(user)).to be true }
       end
 
       context "as manager of an enterprise who sells 'none'" do
@@ -43,10 +43,10 @@ module Spree
           user.enterprise_roles.create! enterprise: enterprise_none
         end
 
-        it { subject.can_manage_products?(user).should be false }
-        it { subject.can_manage_enterprises?(user).should be true }
-        it { subject.can_manage_orders?(user).should be false }
-        it { subject.can_manage_order_cycles?(user).should be false }
+        it { expect(subject.can_manage_products?(user)).to be false }
+        it { expect(subject.can_manage_enterprises?(user)).to be true }
+        it { expect(subject.can_manage_orders?(user)).to be false }
+        it { expect(subject.can_manage_order_cycles?(user)).to be false }
       end
 
       context "as manager of a producer enterprise who sells 'any'" do
@@ -54,10 +54,10 @@ module Spree
           user.enterprise_roles.create! enterprise: enterprise_any_producer
         end
 
-        it { subject.can_manage_products?(user).should be true }
-        it { subject.can_manage_enterprises?(user).should be true }
-        it { subject.can_manage_orders?(user).should be true }
-        it { subject.can_manage_order_cycles?(user).should be true }
+        it { expect(subject.can_manage_products?(user)).to be true }
+        it { expect(subject.can_manage_enterprises?(user)).to be true }
+        it { expect(subject.can_manage_orders?(user)).to be true }
+        it { expect(subject.can_manage_order_cycles?(user)).to be true }
       end
 
       context "as manager of a producer enterprise who sell 'own'" do
@@ -65,10 +65,10 @@ module Spree
           user.enterprise_roles.create! enterprise: enterprise_own_producer
         end
 
-        it { subject.can_manage_products?(user).should be true }
-        it { subject.can_manage_enterprises?(user).should be true }
-        it { subject.can_manage_orders?(user).should be true }
-        it { subject.can_manage_order_cycles?(user).should be true }
+        it { expect(subject.can_manage_products?(user)).to be true }
+        it { expect(subject.can_manage_enterprises?(user)).to be true }
+        it { expect(subject.can_manage_orders?(user)).to be true }
+        it { expect(subject.can_manage_order_cycles?(user)).to be true }
       end
 
       context "as manager of a producer enterprise who sells 'none'" do
@@ -83,10 +83,10 @@ module Spree
             enterprise_none_producer.save!
           end
 
-          it { subject.can_manage_products?(user).should be true }
-          it { subject.can_manage_enterprises?(user).should be true }
-          it { subject.can_manage_orders?(user).should be false }
-          it { subject.can_manage_order_cycles?(user).should be false }
+          it { expect(subject.can_manage_products?(user)).to be true }
+          it { expect(subject.can_manage_enterprises?(user)).to be true }
+          it { expect(subject.can_manage_orders?(user)).to be false }
+          it { expect(subject.can_manage_order_cycles?(user)).to be false }
         end
 
         context "as a profile" do
@@ -96,21 +96,21 @@ module Spree
             enterprise_none_producer.save!
           end
 
-          it { subject.can_manage_products?(user).should be false }
-          it { subject.can_manage_enterprises?(user).should be true }
-          it { subject.can_manage_orders?(user).should be false }
-          it { subject.can_manage_order_cycles?(user).should be false }
+          it { expect(subject.can_manage_products?(user)).to be false }
+          it { expect(subject.can_manage_enterprises?(user)).to be true }
+          it { expect(subject.can_manage_orders?(user)).to be false }
+          it { expect(subject.can_manage_order_cycles?(user)).to be false }
         end
       end
 
       context "as a new user with no enterprises" do
-        it { subject.can_manage_products?(user).should be false }
-        it { subject.can_manage_enterprises?(user).should be false }
-        it { subject.can_manage_orders?(user).should be false }
-        it { subject.can_manage_order_cycles?(user).should be false }
+        it { expect(subject.can_manage_products?(user)).to be false }
+        it { expect(subject.can_manage_enterprises?(user)).to be false }
+        it { expect(subject.can_manage_orders?(user)).to be false }
+        it { expect(subject.can_manage_order_cycles?(user)).to be false }
 
         it "can create enterprises straight off the bat" do
-          subject.is_new_user?(user).should be true
+          expect(subject.is_new_user?(user)).to be true
           expect(user).to have_ability :create, for: Enterprise
         end
       end
@@ -148,80 +148,80 @@ module Spree
         let(:order) { create(:order) }
 
         it "should be able to read/write their enterprises' products and variants" do
-          should have_ability([:admin, :read, :update, :product_distributions, :bulk_edit, :bulk_update, :clone, :destroy], for: p1)
-          should have_ability([:admin, :index, :read, :edit, :update, :search, :destroy, :delete], for: p1.master)
+          is_expected.to have_ability([:admin, :read, :update, :product_distributions, :bulk_edit, :bulk_update, :clone, :destroy], for: p1)
+          is_expected.to have_ability([:admin, :index, :read, :edit, :update, :search, :destroy, :delete], for: p1.master)
         end
 
         it "should be able to read/write related enterprises' products and variants with manage_products permission" do
           er_ps
-          should have_ability([:admin, :read, :update, :product_distributions, :bulk_edit, :bulk_update, :clone, :destroy], for: p_related)
-          should have_ability([:admin, :index, :read, :edit, :update, :search, :destroy, :delete], for: p_related.master)
+          is_expected.to have_ability([:admin, :read, :update, :product_distributions, :bulk_edit, :bulk_update, :clone, :destroy], for: p_related)
+          is_expected.to have_ability([:admin, :index, :read, :edit, :update, :search, :destroy, :delete], for: p_related.master)
         end
 
         it "should not be able to read/write other enterprises' products and variants" do
-          should_not have_ability([:admin, :read, :update, :product_distributions, :bulk_edit, :bulk_update, :clone, :destroy], for: p2)
-          should_not have_ability([:admin, :index, :read, :edit, :update, :search, :destroy], for: p2.master)
+          is_expected.not_to have_ability([:admin, :read, :update, :product_distributions, :bulk_edit, :bulk_update, :clone, :destroy], for: p2)
+          is_expected.not_to have_ability([:admin, :index, :read, :edit, :update, :search, :destroy], for: p2.master)
         end
 
         it "should not be able to access admin actions on orders" do
-          should_not have_ability([:admin], for: Spree::Order)
+          is_expected.not_to have_ability([:admin], for: Spree::Order)
         end
 
         it "should be able to create a new product" do
-          should have_ability(:create, for: Spree::Product)
+          is_expected.to have_ability(:create, for: Spree::Product)
         end
 
         it "should be able to read/write their enterprises' product variants" do
-          should have_ability([:create], for: Spree::Variant)
-          should have_ability([:admin, :index, :read, :create, :edit, :search, :update, :destroy, :delete], for: p1.master)
+          is_expected.to have_ability([:create], for: Spree::Variant)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :search, :update, :destroy, :delete], for: p1.master)
         end
 
         it "should not be able to read/write other enterprises' product variants" do
-          should_not have_ability([:admin, :index, :read, :create, :edit, :search, :update, :destroy], for: p2.master)
+          is_expected.not_to have_ability([:admin, :index, :read, :create, :edit, :search, :update, :destroy], for: p2.master)
         end
 
         it "should be able to read/write their enterprises' product properties" do
-          should have_ability([:admin, :index, :read, :create, :edit, :update_positions, :destroy], for: Spree::ProductProperty)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :update_positions, :destroy], for: Spree::ProductProperty)
         end
 
         it "should be able to read/write their enterprises' product images" do
-          should have_ability([:admin, :index, :read, :create, :edit, :update, :destroy], for: Spree::Image)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :update, :destroy], for: Spree::Image)
         end
 
         it "should be able to read Taxons (in order to create classifications)" do
-          should have_ability([:admin, :index, :read, :search], for: Spree::Taxon)
+          is_expected.to have_ability([:admin, :index, :read, :search], for: Spree::Taxon)
         end
 
         it "should be able to read/write Classifications on a product" do
-          should have_ability([:admin, :index, :read, :create, :edit], for: Spree::Classification)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit], for: Spree::Classification)
         end
 
         it "should be able to read/write their enterprises' producer properties" do
-          should have_ability([:admin, :index, :read, :create, :edit, :update_positions, :destroy], for: ProducerProperty)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :update_positions, :destroy], for: ProducerProperty)
         end
 
         it "should be able to read and create enterprise relationships" do
-          should have_ability([:admin, :index, :create], for: EnterpriseRelationship)
+          is_expected.to have_ability([:admin, :index, :create], for: EnterpriseRelationship)
         end
 
         it "should be able to destroy enterprise relationships for its enterprises" do
-          should have_ability(:destroy, for: er1)
+          is_expected.to have_ability(:destroy, for: er1)
         end
 
         it "should not be able to destroy enterprise relationships for other enterprises" do
-          should_not have_ability(:destroy, for: er2)
+          is_expected.not_to have_ability(:destroy, for: er2)
         end
 
         it "should be able to read some reports" do
-          should have_ability([:admin, :index, :customers, :bulk_coop, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management], for: :report)
+          is_expected.to have_ability([:admin, :index, :customers, :bulk_coop, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management], for: :report)
         end
 
         it "should not be able to read other reports" do
-          should_not have_ability([:sales_total, :group_buys, :payments, :orders_and_distributors, :users_and_enterprises, :xero_invoices], for: :report)
+          is_expected.not_to have_ability([:sales_total, :group_buys, :payments, :orders_and_distributors, :users_and_enterprises, :xero_invoices], for: :report)
         end
 
         it "should not be able to access customer actions" do
-          should_not have_ability([:admin, :index, :update], for: Customer)
+          is_expected.not_to have_ability([:admin, :index, :update], for: Customer)
         end
 
         describe "order_cycles abilities" do
@@ -229,19 +229,19 @@ module Spree
             let!(:order_cycle) { create(:simple_order_cycle) }
 
             it "should not be able to access read/update order_cycle actions" do
-              should_not have_ability([:admin, :index, :read, :edit, :update], for: order_cycle)
+              is_expected.not_to have_ability([:admin, :index, :read, :edit, :update], for: order_cycle)
             end
 
             it "should not be able to access bulk_update, clone order cycle actions" do
-              should_not have_ability([:bulk_update, :clone], for: order_cycle)
+              is_expected.not_to have_ability([:bulk_update, :clone], for: order_cycle)
             end
 
             it "cannot request permitted enterprises for an order cycle" do
-              should_not have_ability([:for_order_cycle], for: Enterprise)
+              is_expected.not_to have_ability([:for_order_cycle], for: Enterprise)
             end
 
             it "cannot request permitted enterprise fees for an order cycle" do
-              should_not have_ability([:for_order_cycle], for: EnterpriseFee)
+              is_expected.not_to have_ability([:for_order_cycle], for: EnterpriseFee)
             end
           end
 
@@ -250,19 +250,19 @@ module Spree
             let!(:exchange){ create(:exchange, incoming: true, order_cycle: order_cycle, receiver: order_cycle.coordinator, sender: s1) }
 
             it "should be able to access read/update order cycle actions" do
-              should have_ability([:admin, :index, :read, :edit, :update], for: order_cycle)
+              is_expected.to have_ability([:admin, :index, :read, :edit, :update], for: order_cycle)
             end
 
             it "should not be able to access bulk/update, clone order cycle actions" do
-              should_not have_ability([:bulk_update, :clone], for: order_cycle)
+              is_expected.not_to have_ability([:bulk_update, :clone], for: order_cycle)
             end
 
             it "can request permitted enterprises for an order cycle" do
-              should have_ability([:for_order_cycle], for: Enterprise)
+              is_expected.to have_ability([:for_order_cycle], for: Enterprise)
             end
 
             it "can request permitted enterprise fees for an order cycle" do
-              should have_ability([:for_order_cycle], for: EnterpriseFee)
+              is_expected.to have_ability([:for_order_cycle], for: EnterpriseFee)
             end
           end
         end
@@ -298,19 +298,19 @@ module Spree
           let!(:er_pd) { create(:enterprise_relationship, parent: d_related, child: d1, permissions_list: [:edit_profile]) }
 
           it "should be able to edit enterprises it manages" do
-            should have_ability([:read, :edit, :update, :bulk_update, :resend_confirmation], for: d1)
+            is_expected.to have_ability([:read, :edit, :update, :bulk_update, :resend_confirmation], for: d1)
           end
 
           it "should be able to edit enterprises it has permission to" do
-            should have_ability([:read, :edit, :update, :bulk_update, :resend_confirmation], for: d_related)
+            is_expected.to have_ability([:read, :edit, :update, :bulk_update, :resend_confirmation], for: d_related)
           end
 
           it "should be able to manage shipping methods, payment methods and enterprise fees for enterprises it manages" do
-            should have_ability([:manage_shipping_methods, :manage_payment_methods, :manage_enterprise_fees], for: d1)
+            is_expected.to have_ability([:manage_shipping_methods, :manage_payment_methods, :manage_enterprise_fees], for: d1)
           end
 
           it "should not be able to manage shipping methods, payment methods and enterprise fees for enterprises it has edit profile permission to" do
-            should_not have_ability([:manage_shipping_methods, :manage_payment_methods, :manage_enterprise_fees], for: d_related)
+            is_expected.not_to have_ability([:manage_shipping_methods, :manage_payment_methods, :manage_enterprise_fees], for: d_related)
           end
         end
 
@@ -323,96 +323,96 @@ module Spree
           let!(:er1) { create(:enterprise_relationship, parent: s1, child: d1, permissions_list: [:create_variant_overrides]) }
 
           it "should be able to access variant overrides page" do
-            should have_ability([:admin, :index, :bulk_update, :bulk_reset], for: VariantOverride)
+            is_expected.to have_ability([:admin, :index, :bulk_update, :bulk_reset], for: VariantOverride)
           end
 
           it "should be able to read/write their own variant overrides" do
-            should have_ability([:admin, :index, :read, :update], for: vo1)
+            is_expected.to have_ability([:admin, :index, :read, :update], for: vo1)
           end
 
           it "should not be able to read/write variant overrides when producer of product hasn't granted permission" do
-            should_not have_ability([:admin, :index, :read, :update], for: vo2)
+            is_expected.not_to have_ability([:admin, :index, :read, :update], for: vo2)
           end
 
           it "should not be able to read/write variant overrides when we can't add hub to order cycle" do
-            should_not have_ability([:admin, :index, :read, :update], for: vo3)
+            is_expected.not_to have_ability([:admin, :index, :read, :update], for: vo3)
           end
 
           it "should not be able to read/write other enterprises' variant overrides" do
-            should_not have_ability([:admin, :index, :read, :update], for: vo4)
+            is_expected.not_to have_ability([:admin, :index, :read, :update], for: vo4)
           end
         end
 
         it "should be able to read/write their enterprises' orders" do
-          should have_ability([:admin, :index, :read, :edit], for: o1)
+          is_expected.to have_ability([:admin, :index, :read, :edit], for: o1)
         end
 
         it "should not be able to read/write other enterprises' orders" do
-          should_not have_ability([:admin, :index, :read, :edit], for: o2)
+          is_expected.not_to have_ability([:admin, :index, :read, :edit], for: o2)
         end
 
         it "should be able to read/write orders that are in the process of being created" do
-          should have_ability([:admin, :index, :read, :edit], for: o3)
+          is_expected.to have_ability([:admin, :index, :read, :edit], for: o3)
         end
 
         it "should be able to create and search on nil (required for creating an order)" do
-          should have_ability([:create, :search], for: nil)
+          is_expected.to have_ability([:create, :search], for: nil)
         end
 
         it "should be able to create a new order" do
-          should have_ability([:admin, :index, :read, :create, :update], for: Spree::Order)
+          is_expected.to have_ability([:admin, :index, :read, :create, :update], for: Spree::Order)
         end
 
         it "should be able to create a new line item" do
-          should have_ability([:admin, :create], for: Spree::LineItem)
+          is_expected.to have_ability([:admin, :create], for: Spree::LineItem)
         end
 
         it "should be able to read/write Payments on a product" do
-          should have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::Payment)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::Payment)
         end
 
         it "should be able to read/write Shipments on a product" do
-          should have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::Shipment)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::Shipment)
         end
 
         it "should be able to read/write Adjustments on a product" do
-          should have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::Adjustment)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::Adjustment)
         end
 
         it "should be able to read/write ReturnAuthorizations on a product" do
-          should have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::ReturnAuthorization)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :update, :fire], for: Spree::ReturnAuthorization)
         end
 
         it "should be able to read/write PaymentMethods" do
-          should have_ability([:admin, :index, :create, :update, :destroy], for: Spree::PaymentMethod)
+          is_expected.to have_ability([:admin, :index, :create, :update, :destroy], for: Spree::PaymentMethod)
         end
 
         it "should be able to read/write ShippingMethods" do
-          should have_ability([:admin, :index, :create, :update, :destroy], for: Spree::ShippingMethod)
+          is_expected.to have_ability([:admin, :index, :create, :update, :destroy], for: Spree::ShippingMethod)
         end
 
         it "should be able to read and create enterprise relationships" do
-          should have_ability([:admin, :index, :create], for: EnterpriseRelationship)
+          is_expected.to have_ability([:admin, :index, :create], for: EnterpriseRelationship)
         end
 
         it "should be able to destroy enterprise relationships for its enterprises" do
-          should have_ability(:destroy, for: er2)
+          is_expected.to have_ability(:destroy, for: er2)
         end
 
         it "should not be able to destroy enterprise relationships for other enterprises" do
-          should_not have_ability(:destroy, for: er1)
+          is_expected.not_to have_ability(:destroy, for: er1)
         end
 
         it "should be able to read some reports" do
-          should have_ability([:admin, :index, :customers, :sales_tax, :group_buys, :bulk_coop, :payments, :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :xero_invoices], for: :report)
+          is_expected.to have_ability([:admin, :index, :customers, :sales_tax, :group_buys, :bulk_coop, :payments, :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :xero_invoices], for: :report)
         end
 
         it "should not be able to read other reports" do
-          should_not have_ability([:sales_total, :users_and_enterprises], for: :report)
+          is_expected.not_to have_ability([:sales_total, :users_and_enterprises], for: :report)
         end
 
         it "should be able to access customer actions" do
-          should have_ability([:admin, :index, :update], for: Customer)
+          is_expected.to have_ability([:admin, :index, :update], for: Customer)
         end
 
         context "for a given order_cycle" do
@@ -420,20 +420,20 @@ module Spree
           let!(:exchange){ create(:exchange, incoming: false, order_cycle: order_cycle, receiver: d1, sender: order_cycle.coordinator) }
 
           it "should be able to access read and update order cycle actions" do
-            should have_ability([:admin, :index, :read, :edit, :update], for: order_cycle)
+            is_expected.to have_ability([:admin, :index, :read, :edit, :update], for: order_cycle)
           end
 
           it "should not be able to access bulk_update, clone order cycle actions" do
-            should_not have_ability([:bulk_update, :clone], for: order_cycle)
+            is_expected.not_to have_ability([:bulk_update, :clone], for: order_cycle)
           end
         end
 
         it "can request permitted enterprises for an order cycle" do
-          should have_ability([:for_order_cycle], for: Enterprise)
+          is_expected.to have_ability([:for_order_cycle], for: Enterprise)
         end
 
         it "can request permitted enterprise fees for an order cycle" do
-          should have_ability([:for_order_cycle], for: EnterpriseFee)
+          is_expected.to have_ability([:for_order_cycle], for: EnterpriseFee)
         end
       end
 
@@ -449,23 +449,23 @@ module Spree
         let(:oc2) { create(:simple_order_cycle) }
 
         it "should be able to read/write OrderCycles they are the co-ordinator of" do
-          should have_ability([:admin, :index, :read, :edit, :update, :bulk_update, :clone, :destroy], for: oc1)
+          is_expected.to have_ability([:admin, :index, :read, :edit, :update, :bulk_update, :clone, :destroy], for: oc1)
         end
 
         it "should not be able to read/write OrderCycles they are not the co-ordinator of" do
-          should_not have_ability([:admin, :index, :read, :create, :edit, :update, :bulk_update, :clone, :destroy], for: oc2)
+          is_expected.not_to have_ability([:admin, :index, :read, :create, :edit, :update, :bulk_update, :clone, :destroy], for: oc2)
         end
 
         it "should be able to create OrderCycles" do
-          should have_ability([:create], for: OrderCycle)
+          is_expected.to have_ability([:create], for: OrderCycle)
         end
 
         it "should be able to read/write EnterpriseFees" do
-          should have_ability([:admin, :index, :read, :create, :edit, :bulk_update, :destroy, :for_order_cycle], for: EnterpriseFee)
+          is_expected.to have_ability([:admin, :index, :read, :create, :edit, :bulk_update, :destroy, :for_order_cycle], for: EnterpriseFee)
         end
 
         it "should be able to add enterprises to order cycles" do
-          should have_ability([:admin, :index, :for_order_cycle, :create], for: Enterprise)
+          is_expected.to have_ability([:admin, :index, :for_order_cycle, :create], for: Enterprise)
         end
       end
 
@@ -478,28 +478,28 @@ module Spree
         end
 
         it 'should have the ability to view the admin account page' do
-          should have_ability([:admin, :show], for: :account)
+          is_expected.to have_ability([:admin, :show], for: :account)
         end
 
         it 'should have the ability to read and edit enterprises that I manage' do
-          should have_ability([:read, :edit, :update, :bulk_update], for: s1)
+          is_expected.to have_ability([:read, :edit, :update, :bulk_update], for: s1)
         end
 
         it 'should not have the ability to read and edit enterprises that I do not manage' do
-          should_not have_ability([:read, :edit, :update, :bulk_update], for: s2)
+          is_expected.not_to have_ability([:read, :edit, :update, :bulk_update], for: s2)
         end
 
         it 'should not have the ability to welcome and register enterprises that I do not own' do
-          should_not have_ability([:welcome, :register], for: s1)
+          is_expected.not_to have_ability([:welcome, :register], for: s1)
         end
 
         it 'should have the ability administrate and create enterpises' do
-          should have_ability([:admin, :index, :create], for: Enterprise)
+          is_expected.to have_ability([:admin, :index, :create], for: Enterprise)
         end
 
         it "should have the ability to search for users which share management of its enterprises" do
-          should have_ability([:admin, :known_users, :customers], for: :search)
-          should_not have_ability([:users], for: :search)
+          is_expected.to have_ability([:admin, :known_users, :customers], for: :search)
+          is_expected.not_to have_ability([:users], for: :search)
         end
       end
 
@@ -507,11 +507,11 @@ module Spree
         let(:user) { s1.owner }
 
         it 'should have the ability to welcome and register enterprises that I own' do
-          should have_ability([:welcome, :register], for: s1)
+          is_expected.to have_ability([:welcome, :register], for: s1)
         end
 
         it 'should have the ability to view the admin account page' do
-          should have_ability([:admin, :show], for: :account)
+          is_expected.to have_ability([:admin, :show], for: :account)
         end
       end
     end

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -445,8 +445,8 @@ module Spree
           user
         end
 
-        let(:oc1) { create(:simple_order_cycle, {coordinator: d1}) }
-        let(:oc2) { create(:simple_order_cycle) }
+        let(:oc1) { create(:simple_order_cycle, coordinator: d1) }
+        let(:oc2) { create(:simple_order_cycle, coordinator: FactoryGirl.create(:distributor_enterprise)) }
 
         it "should be able to read/write OrderCycles they are the co-ordinator of" do
           is_expected.to have_ability([:admin, :index, :read, :edit, :update, :bulk_update, :clone, :destroy], for: oc1)

--- a/spec/models/spree/addresses_spec.rb
+++ b/spec/models/spree/addresses_spec.rb
@@ -2,30 +2,30 @@ require 'spec_helper'
 
 describe Spree::Address do
   describe "associations" do
-    it { should have_one(:enterprise) }
+    it { is_expected.to have_one(:enterprise) }
   end
 
   describe "delegation" do
-    it { should delegate(:name).to(:state).with_prefix }
+    it { is_expected.to delegate(:name).to(:state).with_prefix }
   end
 
   describe "geocode address" do
     let(:address) { FactoryGirl.build(:address) }
 
     it "should include address1, address2, zipcode, city, state and country" do
-      address.geocode_address.should include(address.address1)
-      address.geocode_address.should include(address.address2)
-      address.geocode_address.should include(address.zipcode)
-      address.geocode_address.should include(address.city)
-      address.geocode_address.should include(address.state.name)
-      address.geocode_address.should include(address.country.name)
+      expect(address.geocode_address).to include(address.address1)
+      expect(address.geocode_address).to include(address.address2)
+      expect(address.geocode_address).to include(address.zipcode)
+      expect(address.geocode_address).to include(address.city)
+      expect(address.geocode_address).to include(address.state.name)
+      expect(address.geocode_address).to include(address.country.name)
     end
 
     it "should not include empty fields" do
       address.address2 = nil
       address.city = ""
 
-      address.geocode_address.split(',').length.should eql(4)
+      expect(address.geocode_address.split(',').length).to eql(4)
     end
   end
 
@@ -33,19 +33,19 @@ describe Spree::Address do
     let(:address) { FactoryGirl.build(:address) }
 
     it "should include address1, address2, zipcode, city and state" do
-      address.full_address.should include(address.address1)
-      address.full_address.should include(address.address2)
-      address.full_address.should include(address.zipcode)
-      address.full_address.should include(address.city)
-      address.full_address.should include(address.state.name)
-      address.full_address.should_not include(address.country.name)
+      expect(address.full_address).to include(address.address1)
+      expect(address.full_address).to include(address.address2)
+      expect(address.full_address).to include(address.zipcode)
+      expect(address.full_address).to include(address.city)
+      expect(address.full_address).to include(address.state.name)
+      expect(address.full_address).not_to include(address.country.name)
     end
 
     it "should not include empty fields" do
       address.address2 = nil
       address.city = ""
 
-      address.full_address.split(',').length.should eql(3)
+      expect(address.full_address.split(',').length).to eql(3)
     end
   end
 
@@ -57,13 +57,13 @@ describe Spree::Address do
 
   describe "notifying bugsnag when saved with missing data" do
     it "notifies on create" do
-      Bugsnag.should_receive(:notify)
+      expect(Bugsnag).to receive(:notify)
       a = Spree::Address.new zipcode: nil
       a.save validate: false
     end
 
     it "notifies on update" do
-      Bugsnag.should_receive(:notify)
+      expect(Bugsnag).to receive(:notify)
       a = create(:address)
       a.zipcode = nil
       a.save validate: false

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Adjustment do
     it "has metadata" do
       adjustment = create(:adjustment, metadata: create(:adjustment_metadata))
-      adjustment.metadata.should be
+      expect(adjustment.metadata).to be
     end
 
     describe "querying included tax" do
@@ -13,23 +13,23 @@ module Spree
 
       describe "finding adjustments with and without tax included" do
         it "finds adjustments with tax" do
-          Adjustment.with_tax.should     include adjustment_with_tax
-          Adjustment.with_tax.should_not include adjustment_without_tax
+          expect(Adjustment.with_tax).to     include adjustment_with_tax
+          expect(Adjustment.with_tax).not_to include adjustment_without_tax
         end
 
         it "finds adjustments without tax" do
-          Adjustment.without_tax.should     include adjustment_without_tax
-          Adjustment.without_tax.should_not include adjustment_with_tax
+          expect(Adjustment.without_tax).to     include adjustment_without_tax
+          expect(Adjustment.without_tax).not_to include adjustment_with_tax
         end
       end
 
       describe "checking if an adjustment includes tax" do
         it "returns true when it has > 0 tax" do
-          adjustment_with_tax.should have_tax
+          expect(adjustment_with_tax).to have_tax
         end
 
         it "returns false when it has 0 tax" do
-          adjustment_without_tax.should_not have_tax
+          expect(adjustment_without_tax).not_to have_tax
         end
       end
     end
@@ -48,8 +48,8 @@ module Spree
         end
 
         it "has 100% tax included" do
-          adjustment.amount.should be > 0
-          adjustment.included_tax.should == adjustment.amount
+          expect(adjustment.amount).to be > 0
+          expect(adjustment.included_tax).to eq(adjustment.amount)
         end
 
         it "does not crash when order data has been updated previously" do
@@ -67,7 +67,7 @@ module Spree
 
         it "has a shipping charge of $50" do
           order.create_shipment!
-          adjustment.amount.should == 50
+          expect(adjustment.amount).to eq(50)
         end
 
         describe "when tax on shipping is disabled" do
@@ -76,7 +76,7 @@ module Spree
             Config.shipping_tax_rate = 0
             order.create_shipment!
 
-            adjustment.included_tax.should == 0
+            expect(adjustment.included_tax).to eq(0)
           end
 
           it "records 0% tax on shipments when a rate is set but shipment_inc_vat is false" do
@@ -84,7 +84,7 @@ module Spree
             Config.shipping_tax_rate = 0.25
             order.create_shipment!
 
-            adjustment.included_tax.should == 0
+            expect(adjustment.included_tax).to eq(0)
           end
         end
 
@@ -100,7 +100,7 @@ module Spree
             # total - ( total / (1 + rate) )
             # 50    - ( 50    / (1 + 0.25) )
             # = 10
-            adjustment.included_tax.should == 10.00
+            expect(adjustment.included_tax).to eq(10.00)
           end
 
           it "records 0% tax on shipments when shipping_tax_rate is not set" do
@@ -108,14 +108,14 @@ module Spree
             Config.shipping_tax_rate = nil
             order.create_shipment!
 
-            adjustment.included_tax.should == 0
+            expect(adjustment.included_tax).to eq(0)
           end
 
           it "records 0% tax on shipments when the distributor does not charge sales tax" do
             order.distributor.update_attributes! charges_sales_tax: false
             order.reload.create_shipment!
 
-            adjustment.included_tax.should == 0
+            expect(adjustment.included_tax).to eq(0)
           end
         end
       end
@@ -145,7 +145,7 @@ module Spree
                 # The fee is $50, tax is 10%, and the fee is inclusive of tax
                 # Therefore, the included tax should be 0.1/1.1 * 50 = $4.55
 
-                adjustment.included_tax.should == 4.55
+                expect(adjustment.included_tax).to eq(4.55)
               end
             end
 
@@ -157,8 +157,8 @@ module Spree
               end
 
               it "records the tax on TaxRate adjustment on the order" do
-                adjustment.included_tax.should == 0
-                order.adjustments.tax.first.amount.should == 5.0
+                expect(adjustment.included_tax).to eq(0)
+                expect(order.adjustments.tax.first.amount).to eq(5.0)
               end
             end
 
@@ -170,7 +170,7 @@ module Spree
               end
 
               it "records no tax as charged" do
-                adjustment.included_tax.should == 0
+                expect(adjustment.included_tax).to eq(0)
               end
             end
           end
@@ -181,7 +181,7 @@ module Spree
 
             describe "when the tax rate includes the tax in the price" do
               it "records the tax on the enterprise fee adjustments" do
-                adjustment.included_tax.should == 4.55
+                expect(adjustment.included_tax).to eq(4.55)
               end
             end
 
@@ -193,8 +193,8 @@ module Spree
               end
 
               it "records the tax on TaxRate adjustment on the order" do
-                adjustment.included_tax.should == 0
-                order.adjustments.tax.first.amount.should == 5.0
+                expect(adjustment.included_tax).to eq(0)
+                expect(order.adjustments.tax.first.amount).to eq(5.0)
               end
             end
           end
@@ -218,8 +218,8 @@ module Spree
                 # EnterpriseFee tax category is nil and inheritance only applies to per item fees
                 # so tax on the enterprise_fee adjustment will be 0
                 # Tax on line item is: 0.2/1.2 x $10 = $1.67
-                adjustment.included_tax.should == 0.0
-                line_item.adjustments.first.included_tax.should == 1.67
+                expect(adjustment.included_tax).to eq(0.0)
+                expect(line_item.adjustments.first.included_tax).to eq(1.67)
               end
             end
 
@@ -234,8 +234,8 @@ module Spree
                 # EnterpriseFee tax category is nil and inheritance only applies to per item fees
                 # so total tax on the order is only that which applies to the line_item itself
                 # ie. $10 x 0.2 = $2.0
-                adjustment.included_tax.should == 0
-                order.adjustments.tax.first.amount.should == 2.0
+                expect(adjustment.included_tax).to eq(0)
+                expect(order.adjustments.tax.first.amount).to eq(2.0)
               end
             end
           end
@@ -249,8 +249,8 @@ module Spree
                 # Applying product tax rate of 0.2 to enterprise fee of $50
                 # gives tax on fee of 0.2/1.2 x $50 = $8.33
                 # Tax on line item is: 0.2/1.2 x $10 = $1.67
-                adjustment.included_tax.should == 8.33
-                line_item.adjustments.first.included_tax.should == 1.67
+                expect(adjustment.included_tax).to eq(8.33)
+                expect(line_item.adjustments.first.included_tax).to eq(1.67)
               end
             end
 
@@ -265,8 +265,8 @@ module Spree
                 # EnterpriseFee inherits tax_category from product so total tax on
                 # the order is that which applies to the line item itself, plus the
                 # same rate applied to the fee of $50. ie. ($10 + $50) x 0.2 = $12.0
-                adjustment.included_tax.should == 0
-                order.adjustments.tax.first.amount.should == 12.0
+                expect(adjustment.included_tax).to eq(0)
+                expect(order.adjustments.tax.first.amount).to eq(12.0)
               end
             end
           end
@@ -278,7 +278,7 @@ module Spree
 
         it "sets it, rounding to two decimal places" do
           adjustment.set_included_tax! 0.25
-          adjustment.included_tax.should == 10.00
+          expect(adjustment.included_tax).to eq(10.00)
         end
       end
 
@@ -289,11 +289,11 @@ module Spree
         let!(:other_tax_rate)         { create(:tax_rate, calculator: Spree::Calculator::DefaultTax.new, amount: 0.3) }
 
         it "returns [] if there is no included tax" do
-          adjustment_without_tax.find_closest_tax_rates_from_included_tax.should == []
+          expect(adjustment_without_tax.find_closest_tax_rates_from_included_tax).to eq([])
         end
 
         it "returns the most accurate tax rate" do
-          adjustment_with_tax.find_closest_tax_rates_from_included_tax.should == [tax_rate]
+          expect(adjustment_with_tax.find_closest_tax_rates_from_included_tax).to eq([tax_rate])
         end
       end
     end

--- a/spec/models/spree/calculator/flat_percent_item_total_spec.rb
+++ b/spec/models/spree/calculator/flat_percent_item_total_spec.rb
@@ -4,10 +4,10 @@ describe Spree::Calculator::FlatPercentItemTotal do
   let(:calculator) { Spree::Calculator::FlatPercentItemTotal.new }
   let(:line_item) { instance_double(Spree::LineItem, amount: 10) }
 
-  before { calculator.stub :preferred_flat_percent => 10 }
+  before { allow(calculator).to receive_messages :preferred_flat_percent => 10 }
 
   it "should compute amount correctly for a single line item" do
-    calculator.compute(line_item).should == 1.0
+    expect(calculator.compute(line_item)).to eq(1.0)
   end
 
   context "extends LocalizedNumber" do

--- a/spec/models/spree/calculator/flat_rate_spec.rb
+++ b/spec/models/spree/calculator/flat_rate_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Calculator::FlatRate do
   let(:calculator) { Spree::Calculator::FlatRate.new }
 
-  before { calculator.stub :preferred_amount => 10 }
+  before { allow(calculator).to receive_messages :preferred_amount => 10 }
 
   context "extends LocalizedNumber" do
     it_behaves_like "a model using the LocalizedNumber module", [:preferred_amount]

--- a/spec/models/spree/calculator/flexi_rate_spec.rb
+++ b/spec/models/spree/calculator/flexi_rate_spec.rb
@@ -6,8 +6,8 @@ describe Spree::Calculator::FlexiRate do
 
   describe "computing for a single line item" do
     it "returns the first item rate" do
-      calculator.stub preferred_first_item: 1.0
-      calculator.compute(line_item).round(2).should == 1.0
+      allow(calculator).to receive_messages preferred_first_item: 1.0
+      expect(calculator.compute(line_item).round(2)).to eq(1.0)
     end
   end
 

--- a/spec/models/spree/calculator/per_item_spec.rb
+++ b/spec/models/spree/calculator/per_item_spec.rb
@@ -6,8 +6,8 @@ describe Spree::Calculator::PerItem do
   let(:line_item) { double(:line_item, quantity: 5, product: double(:product)) }
 
   it "correctly calculates on a single line item object" do
-    calculator.stub(calculable: shipping_calculable)
-    calculator.compute(line_item).to_f.should == 50 # 5 x 10
+    allow(calculator).to receive_messages(calculable: shipping_calculable)
+    expect(calculator.compute(line_item).to_f).to eq(50) # 5 x 10
   end
 
   context "extends LocalizedNumber" do

--- a/spec/models/spree/classification_spec.rb
+++ b/spec/models/spree/classification_spec.rb
@@ -8,8 +8,8 @@ module Spree
 
     it "won't destroy if classification is the primary taxon" do
       product.primary_taxon = taxon
-      classification.destroy.should be false
-      classification.errors.messages[:base].should == ["Taxon #{taxon.name} is the primary taxon of #{product.name} and cannot be deleted"]
+      expect(classification.destroy).to be false
+      expect(classification.errors.messages[:base]).to eq(["Taxon #{taxon.name} is the primary taxon of #{product.name} and cannot be deleted"])
     end
 
     describe "callbacks" do

--- a/spec/models/spree/gateway/stripe_connect_spec.rb
+++ b/spec/models/spree/gateway/stripe_connect_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::StripeConnect, type: :model do
   let(:provider) do
     double('provider').tap do |p|
-      p.stub(:purchase)
-      p.stub(:authorize)
-      p.stub(:capture)
+      allow(p).to receive(:purchase)
+      allow(p).to receive(:authorize)
+      allow(p).to receive(:capture)
     end
   end
 
@@ -14,8 +14,8 @@ describe Spree::Gateway::StripeConnect, type: :model do
   before do
     allow(Stripe).to receive(:api_key) { "sk_test_123456" }
     allow(subject).to receive(:stripe_account_id) { stripe_account_id }
-    subject.stub(:options_for_purchase_or_auth).and_return(['money', 'cc', 'opts'])
-    subject.stub(:provider).and_return provider
+    allow(subject).to receive(:options_for_purchase_or_auth).and_return(['money', 'cc', 'opts'])
+    allow(subject).to receive(:provider).and_return provider
   end
 
   describe "#token_from_card_profile_ids" do

--- a/spec/models/spree/image_spec.rb
+++ b/spec/models/spree/image_spec.rb
@@ -7,11 +7,11 @@ module Spree
       let(:formatted) { {mini: ["48x48>", "png"]} }
 
       it "converts style names to symbols" do
-        Image.format_styles(name_str).should == {:mini => "48x48>"}
+        expect(Image.format_styles(name_str)).to eq({:mini => "48x48>"})
       end
 
       it "converts formats to symbols" do
-        Image.format_styles(formatted).should == {:mini => ["48x48>", :png]}
+        expect(Image.format_styles(formatted)).to eq({:mini => ["48x48>", :png]})
       end
     end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -29,14 +29,14 @@ module Spree
       let(:oc_order) { create :order_with_totals_and_distribution }
 
       it "finds line items for products supplied by a particular enterprise" do
-        LineItem.supplied_by(s1).should == [li1]
-        LineItem.supplied_by(s2).should == [li2]
+        expect(LineItem.supplied_by(s1)).to eq([li1])
+        expect(LineItem.supplied_by(s2)).to eq([li2])
       end
 
       it "finds line items for products supplied by one of a number of enterprises" do
-        LineItem.supplied_by_any([s1]).should == [li1]
-        LineItem.supplied_by_any([s2]).should == [li2]
-        LineItem.supplied_by_any([s1, s2]).should match_array [li1, li2]
+        expect(LineItem.supplied_by_any([s1])).to eq([li1])
+        expect(LineItem.supplied_by_any([s2])).to eq([li2])
+        expect(LineItem.supplied_by_any([s1, s2])).to match_array [li1, li2]
       end
 
       describe "finding line items with and without tax" do
@@ -47,11 +47,11 @@ module Spree
         before { li1; li2 }
 
         it "finds line items with tax" do
-          LineItem.with_tax.should == [li1]
+          expect(LineItem.with_tax).to eq([li1])
         end
 
         it "finds line items without tax" do
-          LineItem.without_tax.should == [li2]
+          expect(LineItem.without_tax).to eq([li2])
         end
       end
 
@@ -228,10 +228,10 @@ module Spree
       it "does not return fractional cents" do
         li = LineItem.new
 
-        li.stub(:price) { 55.55 }
-        li.stub_chain(:order, :adjustments, :where, :sum) { 11.11 }
-        li.stub(:quantity) { 2 }
-        li.price_with_adjustments.should == 61.11
+        allow(li).to receive(:price) { 55.55 }
+        allow(li).to receive_message_chain(:order, :adjustments, :where, :sum) { 11.11 }
+        allow(li).to receive(:quantity) { 2 }
+        expect(li.price_with_adjustments).to eq(61.11)
       end
     end
 
@@ -239,10 +239,10 @@ module Spree
       it "returns a value consistent with price_with_adjustments" do
         li = LineItem.new
 
-        li.stub(:price) { 55.55 }
-        li.stub_chain(:order, :adjustments, :where, :sum) { 11.11 }
-        li.stub(:quantity) { 2 }
-        li.amount_with_adjustments.should == 122.22
+        allow(li).to receive(:price) { 55.55 }
+        allow(li).to receive_message_chain(:order, :adjustments, :where, :sum) { 11.11 }
+        allow(li).to receive(:quantity) { 2 }
+        expect(li.amount_with_adjustments).to eq(122.22)
       end
     end
 
@@ -410,45 +410,45 @@ module Spree
 
 	      context "when display_name is blank" do
           before do
-            li.stub(:unit_to_display) { 'unit_to_display' }
-            li.stub(:display_name) { '' }
+            allow(li).to receive(:unit_to_display) { 'unit_to_display' }
+            allow(li).to receive(:display_name) { '' }
           end
 
           it "returns unit_to_display" do
-            li.full_name.should == 'unit_to_display'
+            expect(li.full_name).to eq('unit_to_display')
           end
         end
 
         context "when unit_to_display contains display_name" do
           before do
-            li.stub(:unit_to_display) { '1kg Jar' }
-            li.stub(:display_name) { '1kg' }
+            allow(li).to receive(:unit_to_display) { '1kg Jar' }
+            allow(li).to receive(:display_name) { '1kg' }
           end
 
           it "returns unit_to_display" do
-            li.full_name.should == '1kg Jar'
+            expect(li.full_name).to eq('1kg Jar')
           end
         end
 
         context "when display_name contains unit_to_display" do
           before do
-            li.stub(:unit_to_display) { '10kg' }
-            li.stub(:display_name) { '10kg Box' }
+            allow(li).to receive(:unit_to_display) { '10kg' }
+            allow(li).to receive(:display_name) { '10kg Box' }
           end
 
           it "returns display_name" do
-            li.full_name.should == '10kg Box'
+            expect(li.full_name).to eq('10kg Box')
           end
         end
 
         context "otherwise" do
           before do
-            li.stub(:unit_to_display) { '1 Loaf' }
-            li.stub(:display_name) { 'Spelt Sourdough' }
+            allow(li).to receive(:unit_to_display) { '1 Loaf' }
+            allow(li).to receive(:display_name) { 'Spelt Sourdough' }
           end
 
           it "returns unit_to_display" do
-            li.full_name.should == 'Spelt Sourdough (1 Loaf)'
+            expect(li.full_name).to eq('Spelt Sourdough (1 Loaf)')
           end
         end
       end
@@ -462,7 +462,7 @@ module Spree
           before { allow(li).to receive(:full_name) { p.name + " - something" } }
 
           it "does not show the product name twice" do
-            li.product_and_full_name.should == 'product - something'
+            expect(li.product_and_full_name).to eq('product - something')
           end
         end
 
@@ -470,7 +470,7 @@ module Spree
           before { allow(li).to receive(:full_name) { "display_name (unit)" } }
 
           it "prepends the product name to the full name" do
-            li.product_and_full_name.should == 'product - display_name (unit)'
+            expect(li.product_and_full_name).to eq('product - display_name (unit)')
           end
         end
       end
@@ -478,15 +478,15 @@ module Spree
       describe "getting name for display" do
         it "returns product name" do
           li = create(:line_item, product: create(:product))
-          li.name_to_display.should == li.product.name
+          expect(li.name_to_display).to eq(li.product.name)
         end
       end
 
       describe "getting unit for display" do
         it "returns options_text" do
           li = create(:line_item)
-          li.stub(:options_text).and_return "ponies"
-          li.unit_to_display.should == "ponies"
+          allow(li).to receive(:options_text).and_return "ponies"
+          expect(li.unit_to_display).to eq("ponies")
         end
       end
 
@@ -506,10 +506,10 @@ module Spree
             li.update_attribute(:final_weight_volume, 10)
           }.to change(Spree::OptionValue, :count).by(1)
 
-          li.option_values.should_not include ov_orig
-          li.option_values.should_not include ov_var
+          expect(li.option_values).not_to include ov_orig
+          expect(li.option_values).not_to include ov_var
           ov = li.option_values.last
-          ov.name.should == "10g foo"
+          expect(ov.name).to eq("10g foo")
         end
       end
 
@@ -529,8 +529,8 @@ module Spree
             li.update_attribute(:final_weight_volume, 10)
           }.to change(Spree::OptionValue, :count).by(0)
 
-          li.option_values.should_not include ov_orig
-          li.option_values.should     include ov_new
+          expect(li.option_values).not_to include ov_orig
+          expect(li.option_values).to     include ov_new
         end
       end
 

--- a/spec/models/spree/order_populator_spec.rb
+++ b/spec/models/spree/order_populator_spec.rb
@@ -20,10 +20,10 @@ module Spree
         it "adds a variant" do
           op.populate({variants: {v.id.to_s => {quantity: '1', max_quantity: '2'}}}, true)
           li = order.find_line_item_by_variant(v)
-          li.should be
-          li.quantity.should == 1
-          li.max_quantity.should == 2
-          li.final_weight_volume.should == 1.0
+          expect(li).to be
+          expect(li.quantity).to eq(1)
+          expect(li.max_quantity).to eq(2)
+          expect(li.final_weight_volume).to eq(1.0)
         end
 
         it "updates a variant's quantity, max quantity and final_weight_volume" do
@@ -31,10 +31,10 @@ module Spree
 
           op.populate({variants: {v.id.to_s => {quantity: '2', max_quantity: '3'}}}, true)
           li = order.find_line_item_by_variant(v)
-          li.should be
-          li.quantity.should == 2
-          li.max_quantity.should == 3
-          li.final_weight_volume.should == 2.0
+          expect(li).to be
+          expect(li.quantity).to eq(2)
+          expect(li.max_quantity).to eq(3)
+          expect(li.final_weight_volume).to eq(2.0)
         end
 
         it "removes a variant" do
@@ -43,38 +43,38 @@ module Spree
           op.populate({variants: {}}, true)
           order.line_items(:reload)
           li = order.find_line_item_by_variant(v)
-          li.should_not be
+          expect(li).not_to be
         end
       end
     end
 
     describe "populate" do
       before do
-        op.should_receive(:distributor_and_order_cycle).
+        expect(op).to receive(:distributor_and_order_cycle).
           and_return([distributor, order_cycle])
       end
 
       it "checks that distribution can supply all products in the cart" do
-        op.should_receive(:distribution_can_supply_products_in_cart).
+        expect(op).to receive(:distribution_can_supply_products_in_cart).
           with(distributor, order_cycle).and_return(false)
 
-        op.populate(params).should be false
-        op.errors.to_a.should == ["That distributor or order cycle can't supply all the products in your cart. Please choose another."]
+        expect(op.populate(params)).to be false
+        expect(op.errors.to_a).to eq(["That distributor or order cycle can't supply all the products in your cart. Please choose another."])
       end
 
       it "locks the order" do
-        op.stub(:distribution_can_supply_products_in_cart).and_return(true)
-        order.should_receive(:with_lock)
+        allow(op).to receive(:distribution_can_supply_products_in_cart).and_return(true)
+        expect(order).to receive(:with_lock)
         op.populate(params, true)
       end
 
       it "attempts cart add with max_quantity" do
-        op.stub(:distribution_can_supply_products_in_cart).and_return true
+        allow(op).to receive(:distribution_can_supply_products_in_cart).and_return true
         params = {variants: {"1" => {quantity: 1, max_quantity: 2}}}
-        order.stub(:with_lock).and_yield
-        op.stub(:varies_from_cart) { true }
-        op.stub(:variants_removed) { [] }
-        op.should_receive(:attempt_cart_add).with("1", 1, 2).and_return true
+        allow(order).to receive(:with_lock).and_yield
+        allow(op).to receive(:varies_from_cart) { true }
+        allow(op).to receive(:variants_removed) { [] }
+        expect(op).to receive(:attempt_cart_add).with("1", 1, 2).and_return true
         op.populate(params, true)
       end
     end
@@ -83,68 +83,68 @@ module Spree
       let(:variant) { double(:variant, id: 123) }
 
       it "returns true when item is not in cart and a quantity is specified" do
-        op.should_receive(:line_item_for_variant_id).with(variant.id).and_return(nil)
-        op.send(:varies_from_cart, {variant_id: variant.id, quantity: '2'}).should be true
+        expect(op).to receive(:line_item_for_variant_id).with(variant.id).and_return(nil)
+        expect(op.send(:varies_from_cart, {variant_id: variant.id, quantity: '2'})).to be true
       end
 
       it "returns true when item is not in cart and a max_quantity is specified" do
-        op.should_receive(:line_item_for_variant_id).with(variant.id).and_return(nil)
-        op.send(:varies_from_cart, {variant_id: variant.id, quantity: '0', max_quantity: '2'}).should be true
+        expect(op).to receive(:line_item_for_variant_id).with(variant.id).and_return(nil)
+        expect(op.send(:varies_from_cart, {variant_id: variant.id, quantity: '0', max_quantity: '2'})).to be true
       end
 
       it "returns false when item is not in cart and no quantity or max_quantity are specified" do
-        op.should_receive(:line_item_for_variant_id).with(variant.id).and_return(nil)
-        op.send(:varies_from_cart, {variant_id: variant.id, quantity: '0'}).should be false
+        expect(op).to receive(:line_item_for_variant_id).with(variant.id).and_return(nil)
+        expect(op.send(:varies_from_cart, {variant_id: variant.id, quantity: '0'})).to be false
       end
 
       it "returns true when quantity varies" do
         li = double(:line_item, quantity: 1, max_quantity: nil)
-        op.stub(:line_item_for_variant_id) { li }
+        allow(op).to receive(:line_item_for_variant_id) { li }
 
-        op.send(:varies_from_cart, {variant_id: variant.id, quantity: '2'}).should be true
+        expect(op.send(:varies_from_cart, {variant_id: variant.id, quantity: '2'})).to be true
       end
 
       it "returns true when max_quantity varies" do
         li = double(:line_item, quantity: 1, max_quantity: nil)
-        op.stub(:line_item_for_variant_id) { li }
+        allow(op).to receive(:line_item_for_variant_id) { li }
 
-        op.send(:varies_from_cart, {variant_id: variant.id, quantity: '1', max_quantity: '3'}).should be true
+        expect(op.send(:varies_from_cart, {variant_id: variant.id, quantity: '1', max_quantity: '3'})).to be true
       end
 
       it "returns false when max_quantity varies only in nil vs 0" do
         li = double(:line_item, quantity: 1, max_quantity: nil)
-        op.stub(:line_item_for_variant_id) { li }
+        allow(op).to receive(:line_item_for_variant_id) { li }
 
-        op.send(:varies_from_cart, {variant_id: variant.id, quantity: '1'}).should be false
+        expect(op.send(:varies_from_cart, {variant_id: variant.id, quantity: '1'})).to be false
       end
 
       it "returns false when both are specified and neither varies" do
         li = double(:line_item, quantity: 1, max_quantity: 2)
-        op.stub(:line_item_for_variant_id) { li }
+        allow(op).to receive(:line_item_for_variant_id) { li }
 
-        op.send(:varies_from_cart, {variant_id: variant.id, quantity: '1', max_quantity: '2'}).should be false
+        expect(op.send(:varies_from_cart, {variant_id: variant.id, quantity: '1', max_quantity: '2'})).to be false
       end
     end
 
     describe "variants_removed" do
       it "returns the variant ids when one is in the cart but not in those given" do
-        op.stub(:variant_ids_in_cart) { [123] }
-        op.send(:variants_removed, []).should == [123]
+        allow(op).to receive(:variant_ids_in_cart) { [123] }
+        expect(op.send(:variants_removed, [])).to eq([123])
       end
 
       it "returns nothing when all items in the cart are provided" do
-        op.stub(:variant_ids_in_cart) { [123] }
-        op.send(:variants_removed, [{variant_id: '123'}]).should == []
+        allow(op).to receive(:variant_ids_in_cart) { [123] }
+        expect(op.send(:variants_removed, [{variant_id: '123'}])).to eq([])
       end
 
       it "returns nothing when items are added to cart" do
-        op.stub(:variant_ids_in_cart) { [123] }
-        op.send(:variants_removed, [{variant_id: '123'}, {variant_id: '456'}]).should == []
+        allow(op).to receive(:variant_ids_in_cart) { [123] }
+        expect(op.send(:variants_removed, [{variant_id: '123'}, {variant_id: '456'}])).to eq([])
       end
 
       it "does not return duplicates" do
-        op.stub(:variant_ids_in_cart) { [123, 123] }
-        op.send(:variants_removed, []).should == [123]
+        allow(op).to receive(:variant_ids_in_cart) { [123, 123] }
+        expect(op.send(:variants_removed, [])).to eq([123])
       end
     end
 
@@ -153,40 +153,40 @@ module Spree
       let(:quantity) { 123 }
 
       before do
-        Spree::Variant.stub(:find).and_return(variant)
-        VariantOverride.stub(:for).and_return(nil)
+        allow(Spree::Variant).to receive(:find).and_return(variant)
+        allow(VariantOverride).to receive(:for).and_return(nil)
       end
 
       it "performs additional validations" do
-        op.should_receive(:check_order_cycle_provided_for).with(variant).and_return(true)
-        op.should_receive(:check_variant_available_under_distribution).with(variant).
+        expect(op).to receive(:check_order_cycle_provided_for).with(variant).and_return(true)
+        expect(op).to receive(:check_variant_available_under_distribution).with(variant).
           and_return(true)
-        order.should_receive(:add_variant).with(variant, quantity, nil, currency)
+        expect(order).to receive(:add_variant).with(variant, quantity, nil, currency)
 
         op.attempt_cart_add(333, quantity.to_s)
       end
 
       it "filters quantities through #quantities_to_add" do
-        op.should_receive(:quantities_to_add).with(variant, 123, 123).
+        expect(op).to receive(:quantities_to_add).with(variant, 123, 123).
           and_return([5, 5])
 
-        op.stub(:check_order_cycle_provided_for) { true }
-        op.stub(:check_variant_available_under_distribution) { true }
+        allow(op).to receive(:check_order_cycle_provided_for) { true }
+        allow(op).to receive(:check_variant_available_under_distribution) { true }
 
-        order.should_receive(:add_variant).with(variant, 5, 5, currency)
+        expect(order).to receive(:add_variant).with(variant, 5, 5, currency)
 
         op.attempt_cart_add(333, quantity.to_s, quantity.to_s)
       end
 
       it "removes variants which have become out of stock" do
-        op.should_receive(:quantities_to_add).with(variant, 123, 123).
+        expect(op).to receive(:quantities_to_add).with(variant, 123, 123).
           and_return([0, 0])
 
-        op.stub(:check_order_cycle_provided_for) { true }
-        op.stub(:check_variant_available_under_distribution) { true }
+        allow(op).to receive(:check_order_cycle_provided_for) { true }
+        allow(op).to receive(:check_variant_available_under_distribution) { true }
 
-        order.should_receive(:remove_variant).with(variant)
-        order.should_receive(:add_variant).never
+        expect(order).to receive(:remove_variant).with(variant)
+        expect(order).to receive(:add_variant).never
 
         op.attempt_cart_add(333, quantity.to_s, quantity.to_s)
       end
@@ -198,21 +198,21 @@ module Spree
       context "when backorders are not allowed" do
         context "when max_quantity is not provided" do
           it "returns full amount when available" do
-            op.quantities_to_add(v, 5, nil).should == [5, nil]
+            expect(op.quantities_to_add(v, 5, nil)).to eq([5, nil])
           end
 
           it "returns a limited amount when not entirely available" do
-            op.quantities_to_add(v, 15, nil).should == [10, nil]
+            expect(op.quantities_to_add(v, 15, nil)).to eq([10, nil])
           end
         end
 
         context "when max_quantity is provided" do
           it "returns full amount when available" do
-            op.quantities_to_add(v, 5, 6).should == [5, 6]
+            expect(op.quantities_to_add(v, 5, 6)).to eq([5, 6])
           end
 
           it "also returns the full amount when not entirely available" do
-            op.quantities_to_add(v, 15, 16).should == [10, 16]
+            expect(op.quantities_to_add(v, 15, 16)).to eq([10, 16])
           end
         end
       end
@@ -223,11 +223,11 @@ module Spree
         end
 
         it "does not limit quantity" do
-          op.quantities_to_add(v, 15, nil).should == [15, nil]
+          expect(op.quantities_to_add(v, 15, nil)).to eq([15, nil])
         end
 
         it "does not limit max_quantity" do
-          op.quantities_to_add(v, 15, 16).should == [15, 16]
+          expect(op.quantities_to_add(v, 15, 16)).to eq([15, 16])
         end
       end
     end
@@ -236,9 +236,9 @@ module Spree
       describe "determining if distributor can supply products in cart" do
         it "delegates to DistributionChangeValidator" do
           dcv = double(:dcv)
-          dcv.should_receive(:can_change_to_distribution?).with(distributor, order_cycle).and_return(true)
-          DistributionChangeValidator.should_receive(:new).with(order).and_return(dcv)
-          op.send(:distribution_can_supply_products_in_cart, distributor, order_cycle).should be true
+          expect(dcv).to receive(:can_change_to_distribution?).with(distributor, order_cycle).and_return(true)
+          expect(DistributionChangeValidator).to receive(:new).with(order).and_return(dcv)
+          expect(op.send(:distribution_can_supply_products_in_cart, distributor, order_cycle)).to be true
         end
       end
 
@@ -246,18 +246,18 @@ module Spree
         let(:variant) { double(:variant) }
 
         it "returns false and errors when order cycle is not provided and is required" do
-          op.stub(:order_cycle_required_for).and_return true
-          op.send(:check_order_cycle_provided_for, variant).should be false
-          op.errors.to_a.should == ["Please choose an order cycle for this order."]
+          allow(op).to receive(:order_cycle_required_for).and_return true
+          expect(op.send(:check_order_cycle_provided_for, variant)).to be false
+          expect(op.errors.to_a).to eq(["Please choose an order cycle for this order."])
         end
         it "returns true when order cycle is provided" do
-          op.stub(:order_cycle_required_for).and_return true
+          allow(op).to receive(:order_cycle_required_for).and_return true
           op.instance_variable_set :@order_cycle,  double(:order_cycle)
-          op.send(:check_order_cycle_provided_for, variant).should be true
+          expect(op.send(:check_order_cycle_provided_for, variant)).to be true
         end
         it "returns true when order cycle is not required" do
-          op.stub(:order_cycle_required_for).and_return false
-          op.send(:check_order_cycle_provided_for, variant).should be true
+          allow(op).to receive(:order_cycle_required_for).and_return false
+          expect(op.send(:check_order_cycle_provided_for, variant)).to be true
         end
       end
 
@@ -267,20 +267,20 @@ module Spree
 
         it "delegates to DistributionChangeValidator, returning true when available" do
           dcv = double(:dcv)
-          dcv.should_receive(:variants_available_for_distribution).with(123, 234).and_return([variant])
-          DistributionChangeValidator.should_receive(:new).with(order).and_return(dcv)
+          expect(dcv).to receive(:variants_available_for_distribution).with(123, 234).and_return([variant])
+          expect(DistributionChangeValidator).to receive(:new).with(order).and_return(dcv)
           op.instance_eval { @distributor = 123; @order_cycle = 234 }
-          op.send(:check_variant_available_under_distribution, variant).should be true
-          op.errors.should be_empty
+          expect(op.send(:check_variant_available_under_distribution, variant)).to be true
+          expect(op.errors).to be_empty
         end
 
         it "delegates to DistributionChangeValidator, returning false and erroring otherwise" do
           dcv = double(:dcv)
-          dcv.should_receive(:variants_available_for_distribution).with(123, 234).and_return([])
-          DistributionChangeValidator.should_receive(:new).with(order).and_return(dcv)
+          expect(dcv).to receive(:variants_available_for_distribution).with(123, 234).and_return([])
+          expect(DistributionChangeValidator).to receive(:new).with(order).and_return(dcv)
           op.instance_eval { @distributor = 123; @order_cycle = 234 }
-          op.send(:check_variant_available_under_distribution, variant).should be false
-          op.errors.to_a.should == ["That product is not available from the chosen distributor or order cycle."]
+          expect(op.send(:check_variant_available_under_distribution, variant)).to be false
+          expect(op.errors.to_a).to eq(["That product is not available from the chosen distributor or order cycle."])
         end
       end
     end
@@ -291,21 +291,21 @@ module Spree
         it "requires an order cycle when the product has no product distributions" do
           product = double(:product, product_distributions: [])
           variant = double(:variant, product: product)
-          op.send(:order_cycle_required_for, variant).should be true
+          expect(op.send(:order_cycle_required_for, variant)).to be true
         end
 
         it "does not require an order cycle when the product has product distributions" do
           product = double(:product, product_distributions: [1])
           variant = double(:variant, product: product)
-          op.send(:order_cycle_required_for, variant).should be false
+          expect(op.send(:order_cycle_required_for, variant)).to be false
         end
       end
 
       it "provides the distributor and order cycle for the order" do
-        order.should_receive(:distributor).and_return(distributor)
-        order.should_receive(:order_cycle).and_return(order_cycle)
-        op.send(:distributor_and_order_cycle).should == [distributor,
-                                                         order_cycle]
+        expect(order).to receive(:distributor).and_return(distributor)
+        expect(order).to receive(:order_cycle).and_return(order_cycle)
+        expect(op.send(:distributor_and_order_cycle)).to eq([distributor,
+                                                         order_cycle])
       end
     end
   end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Order do
       subject.add_variant(p.master, 1, 3)
 
       li = Spree::LineItem.last
-      li.max_quantity.should == 3
+      expect(li.max_quantity).to eq(3)
     end
 
     it "does nothing when the line item is not found" do
@@ -25,70 +25,70 @@ describe Spree::Order do
     let(:order) { build(:order) }
 
     it "clears all enterprise fee adjustments on the order" do
-      EnterpriseFee.should_receive(:clear_all_adjustments_on_order).with(subject)
+      expect(EnterpriseFee).to receive(:clear_all_adjustments_on_order).with(subject)
       subject.update_distribution_charge!
     end
 
     it "ensures the correct adjustment(s) are created for the product distribution" do
-      EnterpriseFee.stub(:clear_all_adjustments_on_order)
+      allow(EnterpriseFee).to receive(:clear_all_adjustments_on_order)
       line_item = double(:line_item)
-      subject.stub(:line_items) { [line_item] }
-      subject.stub(:provided_by_order_cycle?) { false }
+      allow(subject).to receive(:line_items) { [line_item] }
+      allow(subject).to receive(:provided_by_order_cycle?) { false }
 
       product_distribution = double(:product_distribution)
-      product_distribution.should_receive(:create_adjustment_for).with(line_item)
-      subject.stub(:product_distribution_for) { product_distribution }
+      expect(product_distribution).to receive(:create_adjustment_for).with(line_item)
+      allow(subject).to receive(:product_distribution_for) { product_distribution }
 
 
       subject.update_distribution_charge!
     end
 
     it "skips line items that don't have a product distribution" do
-      EnterpriseFee.stub(:clear_all_adjustments_on_order)
+      allow(EnterpriseFee).to receive(:clear_all_adjustments_on_order)
       line_item = double(:line_item)
-      subject.stub(:line_items) { [line_item] }
-      subject.stub(:provided_by_order_cycle?) { false }
+      allow(subject).to receive(:line_items) { [line_item] }
+      allow(subject).to receive(:provided_by_order_cycle?) { false }
 
-      subject.stub(:product_distribution_for) { nil }
+      allow(subject).to receive(:product_distribution_for) { nil }
 
       subject.update_distribution_charge!
     end
 
     it "skips order cycle per-order adjustments for orders that don't have an order cycle" do
-      EnterpriseFee.stub(:clear_all_adjustments_on_order)
-      subject.stub(:line_items) { [] }
+      allow(EnterpriseFee).to receive(:clear_all_adjustments_on_order)
+      allow(subject).to receive(:line_items) { [] }
 
-      subject.stub(:order_cycle) { nil }
+      allow(subject).to receive(:order_cycle) { nil }
 
       subject.update_distribution_charge!
     end
 
     it "ensures the correct adjustment(s) are created for order cycles" do
-      EnterpriseFee.stub(:clear_all_adjustments_on_order)
+      allow(EnterpriseFee).to receive(:clear_all_adjustments_on_order)
       line_item = double(:line_item)
-      subject.stub(:line_items) { [line_item] }
-      subject.stub(:provided_by_order_cycle?) { true }
+      allow(subject).to receive(:line_items) { [line_item] }
+      allow(subject).to receive(:provided_by_order_cycle?) { true }
 
       order_cycle = double(:order_cycle)
-      OpenFoodNetwork::EnterpriseFeeCalculator.any_instance.
-        should_receive(:create_line_item_adjustments_for).
+      expect_any_instance_of(OpenFoodNetwork::EnterpriseFeeCalculator).
+        to receive(:create_line_item_adjustments_for).
         with(line_item)
-      OpenFoodNetwork::EnterpriseFeeCalculator.any_instance.stub(:create_order_adjustments_for)
-      subject.stub(:order_cycle) { order_cycle }
+      allow_any_instance_of(OpenFoodNetwork::EnterpriseFeeCalculator).to receive(:create_order_adjustments_for)
+      allow(subject).to receive(:order_cycle) { order_cycle }
 
       subject.update_distribution_charge!
     end
 
     it "ensures the correct per-order adjustment(s) are created for order cycles" do
-      EnterpriseFee.stub(:clear_all_adjustments_on_order)
-      subject.stub(:line_items) { [] }
+      allow(EnterpriseFee).to receive(:clear_all_adjustments_on_order)
+      allow(subject).to receive(:line_items) { [] }
 
       order_cycle = double(:order_cycle)
-      OpenFoodNetwork::EnterpriseFeeCalculator.any_instance.
-        should_receive(:create_order_adjustments_for).
+      expect_any_instance_of(OpenFoodNetwork::EnterpriseFeeCalculator).
+        to receive(:create_order_adjustments_for).
         with(subject)
 
-      subject.stub(:order_cycle) { order_cycle }
+      allow(subject).to receive(:order_cycle) { order_cycle }
 
       subject.update_distribution_charge!
     end
@@ -99,26 +99,26 @@ describe Spree::Order do
       v = double(:variant)
       line_item = double(:line_item, variant: v)
       order_cycle = double(:order_cycle, variants: [v])
-      subject.stub(:order_cycle) { order_cycle }
+      allow(subject).to receive(:order_cycle) { order_cycle }
 
-      subject.send(:provided_by_order_cycle?, line_item).should be true
+      expect(subject.send(:provided_by_order_cycle?, line_item)).to be true
     end
 
     it "returns false otherwise" do
       v = double(:variant)
       line_item = double(:line_item, variant: v)
       order_cycle = double(:order_cycle, variants: [])
-      subject.stub(:order_cycle) { order_cycle }
+      allow(subject).to receive(:order_cycle) { order_cycle }
 
-      subject.send(:provided_by_order_cycle?, line_item).should be false
+      expect(subject.send(:provided_by_order_cycle?, line_item)).to be false
     end
 
     it "returns false when there is no order cycle" do
       v = double(:variant)
       line_item = double(:line_item, variant: v)
-      subject.stub(:order_cycle) { nil }
+      allow(subject).to receive(:order_cycle) { nil }
 
-      subject.send(:provided_by_order_cycle?, line_item).should be false
+      expect(subject.send(:provided_by_order_cycle?, line_item)).to be false
     end
   end
 
@@ -128,9 +128,9 @@ describe Spree::Order do
     line_item = double(:line_item, variant: variant)
 
     product_distribution = double(:product_distribution)
-    product.should_receive(:product_distribution_for).with(subject.distributor) { product_distribution }
+    expect(product).to receive(:product_distribution_for).with(subject.distributor) { product_distribution }
 
-    subject.send(:product_distribution_for, line_item).should == product_distribution
+    expect(subject.send(:product_distribution_for, line_item)).to eq(product_distribution)
   end
 
   describe "getting the admin and handling charge" do
@@ -142,7 +142,7 @@ describe Spree::Order do
       ef.calculator.set_preference :amount, 123.45
       a = ef.create_adjustment("adjustment", o, o, true)
 
-      o.admin_and_handling_total.should == 123.45
+      expect(o.admin_and_handling_total).to eq(123.45)
     end
 
     it "does not include ineligible adjustments" do
@@ -152,7 +152,7 @@ describe Spree::Order do
 
       a.update_column :eligible, false
 
-      o.admin_and_handling_total.should == 0
+      expect(o.admin_and_handling_total).to eq(0)
     end
 
     it "does not include adjustments that do not originate from enterprise fees" do
@@ -160,7 +160,7 @@ describe Spree::Order do
       sm.calculator.set_preference :amount, 123.45
       sm.create_adjustment("adjustment", o, o, true)
 
-      o.admin_and_handling_total.should == 0
+      expect(o.admin_and_handling_total).to eq(0)
     end
 
     it "does not include adjustments whose source is a line item" do
@@ -168,7 +168,7 @@ describe Spree::Order do
       ef.calculator.set_preference :amount, 123.45
       ef.create_adjustment("adjustment", li.order, li, true)
 
-      o.admin_and_handling_total.should == 0
+      expect(o.admin_and_handling_total).to eq(0)
     end
   end
 
@@ -176,7 +176,7 @@ describe Spree::Order do
     let(:order)           { create(:order) }
 
     it "cannot be shipped" do
-      order.ready_to_ship?.should == false
+      expect(order.ready_to_ship?).to eq(false)
     end
   end
 
@@ -192,7 +192,7 @@ describe Spree::Order do
     end
 
     it "cannot be shipped" do
-      order.ready_to_ship?.should == false
+      expect(order.ready_to_ship?).to eq(false)
     end
   end
 
@@ -205,7 +205,7 @@ describe Spree::Order do
     end
 
     it "cannot be shipped" do
-      order.ready_to_ship?.should == false
+      expect(order.ready_to_ship?).to eq(false)
     end
   end
 
@@ -221,7 +221,7 @@ describe Spree::Order do
     end
 
     it "can be shipped" do
-      order.ready_to_ship?.should == true
+      expect(order.ready_to_ship?).to eq(true)
     end
   end
 
@@ -237,12 +237,12 @@ describe Spree::Order do
       end
 
       it "returns the shipping tax" do
-        order.shipping_tax.should == 10
+        expect(order.shipping_tax).to eq(10)
       end
     end
 
     it "returns zero when the order has not been shipped" do
-      order.shipping_tax.should == 0
+      expect(order.shipping_tax).to eq(0)
     end
   end
 
@@ -254,7 +254,7 @@ describe Spree::Order do
     let!(:adjustment2) { create(:adjustment, adjustable: order, originator: enterprise_fee2, label: "EF 2", amount: 123, included_tax: 2.00) }
 
     it "returns a sum of the tax included in all enterprise fees" do
-      order.reload.enterprise_fee_tax.should == 12
+      expect(order.reload.enterprise_fee_tax).to eq(12)
     end
   end
 
@@ -272,7 +272,7 @@ describe Spree::Order do
     end
 
     it "returns a sum of all tax on the order" do
-      order.total_tax.should == 12
+      expect(order.total_tax).to eq(12)
     end
   end
 
@@ -324,7 +324,7 @@ describe Spree::Order do
     it "sets the distributor when no order cycle is set" do
       d = create(:distributor_enterprise)
       subject.set_distributor! d
-      subject.distributor.should == d
+      expect(subject.distributor).to eq(d)
     end
 
     it "keeps the order cycle when it is available at the new distributor" do
@@ -335,8 +335,8 @@ describe Spree::Order do
       subject.order_cycle = oc
       subject.set_distributor! d
 
-      subject.distributor.should == d
-      subject.order_cycle.should == oc
+      expect(subject.distributor).to eq(d)
+      expect(subject.order_cycle).to eq(oc)
     end
 
     it "clears the order cycle if it is not available at that distributor" do
@@ -346,8 +346,8 @@ describe Spree::Order do
       subject.order_cycle = oc
       subject.set_distributor! d
 
-      subject.distributor.should == d
-      subject.order_cycle.should be_nil
+      expect(subject.distributor).to eq(d)
+      expect(subject.order_cycle).to be_nil
     end
 
     it "clears the distributor when setting to nil" do
@@ -355,7 +355,7 @@ describe Spree::Order do
       subject.set_distributor! d
       subject.set_distributor! nil
 
-      subject.distributor.should be_nil
+      expect(subject.distributor).to be_nil
     end
   end
 
@@ -372,7 +372,7 @@ describe Spree::Order do
 
     it "removes the variant's line item" do
       order.remove_variant v1
-      order.line_items(:reload).map(&:variant).should == [v2]
+      expect(order.line_items(:reload).map(&:variant)).to eq([v2])
     end
 
     it "does nothing when there is no matching line item" do
@@ -387,14 +387,14 @@ describe Spree::Order do
       subject.shipping_method = create(:shipping_method)
       subject.save!
       subject.empty!
-      subject.shipping_method.should == nil
+      expect(subject.shipping_method).to eq(nil)
     end
 
     it "removes payments" do
       subject.payments << create(:payment)
       subject.save!
       subject.empty!
-      subject.payments.should == []
+      expect(subject.payments).to eq([])
     end
   end
 
@@ -402,18 +402,18 @@ describe Spree::Order do
     let(:oc) { create(:simple_order_cycle) }
 
     it "empties the cart when changing the order cycle" do
-      subject.should_receive(:empty!)
+      expect(subject).to receive(:empty!)
       subject.set_order_cycle! oc
     end
 
     it "doesn't empty the cart if the order cycle is not different" do
-      subject.should_not_receive(:empty!)
+      expect(subject).not_to receive(:empty!)
       subject.set_order_cycle! subject.order_cycle
     end
 
     it "sets the order cycle when no distributor is set" do
       subject.set_order_cycle! oc
-      subject.order_cycle.should == oc
+      expect(subject.order_cycle).to eq(oc)
     end
 
     it "keeps the distributor when it is available in the new order cycle" do
@@ -423,8 +423,8 @@ describe Spree::Order do
       subject.distributor = d
       subject.set_order_cycle! oc
 
-      subject.order_cycle.should == oc
-      subject.distributor.should == d
+      expect(subject.order_cycle).to eq(oc)
+      expect(subject.distributor).to eq(d)
     end
 
     it "clears the distributor if it is not available at that order cycle" do
@@ -433,8 +433,8 @@ describe Spree::Order do
       subject.distributor = d
       subject.set_order_cycle! oc
 
-      subject.order_cycle.should == oc
-      subject.distributor.should be_nil
+      expect(subject.order_cycle).to eq(oc)
+      expect(subject.distributor).to be_nil
     end
 
     it "clears the order cycle when setting to nil" do
@@ -444,8 +444,8 @@ describe Spree::Order do
 
       subject.set_order_cycle! nil
 
-      subject.order_cycle.should be_nil
-      subject.distributor.should == d
+      expect(subject.order_cycle).to be_nil
+      expect(subject.distributor).to eq(d)
     end
   end
 
@@ -480,8 +480,8 @@ describe Spree::Order do
       FactoryGirl.create(:product_distribution, product: product1, distributor: test_enterprise)
 
       subject.distributor = test_enterprise
-      subject.should_not be_valid
-      subject.errors.messages.should == {:base => ["Distributor or order cycle cannot supply the products in your cart"]}
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages).to eq({:base => ["Distributor or order cycle cannot supply the products in your cart"]})
     end
   end
 
@@ -497,7 +497,7 @@ describe Spree::Order do
       it "finds only orders not in specified state" do
         o = FactoryGirl.create(:completed_order_with_totals)
         o.cancel!
-        Spree::Order.not_state(:canceled).should_not include o
+        expect(Spree::Order.not_state(:canceled)).not_to include o
       end
     end
   end
@@ -512,7 +512,7 @@ describe Spree::Order do
     end
 
     it "autopopulates the shipping address on save" do
-      order.should_receive(:shipping_address_from_distributor).and_return true
+      expect(order).to receive(:shipping_address_from_distributor).and_return true
       order.save
     end
 
@@ -520,14 +520,14 @@ describe Spree::Order do
       order.shipping_method = create(:shipping_method, require_ship_address: false)
       order.ship_address.update_attribute :firstname, "will"
       order.save
-      order.ship_address.firstname.should == distributor.address.firstname
+      expect(order.ship_address.firstname).to eq(distributor.address.firstname)
     end
 
     it "does not populate the shipping address if the shipping method requires a delivery address" do
       order.shipping_method = create(:shipping_method, require_ship_address: true)
       order.ship_address.update_attribute :firstname, "will"
       order.save
-      order.ship_address.firstname.should == "will"
+      expect(order.ship_address.firstname).to eq("will")
     end
 
     it "doesn't attempt to create a shipment if the order is not yet valid" do
@@ -547,11 +547,11 @@ describe Spree::Order do
     end
 
     it "returns true when the order is distributed by the accounts distributor" do
-      order_account_invoice.should be_account_invoice
+      expect(order_account_invoice).to be_account_invoice
     end
 
     it "returns false otherwise" do
-      order_general.should_not be_account_invoice
+      expect(order_general).not_to be_account_invoice
     end
   end
 

--- a/spec/models/spree/order_updater_spec.rb
+++ b/spec/models/spree/order_updater_spec.rb
@@ -9,10 +9,10 @@ describe Spree::OrderUpdater do
     let(:updater) { order.updater }
 
     it "is failed if no valid payments" do
-      order.stub_chain(:payments, :valid, :empty?).and_return(true)
+      allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(true)
 
       updater.update_payment_state
-      order.payment_state.should == 'failed'
+      expect(order.payment_state).to eq('failed')
     end
 
     context "payment total is greater than order total" do
@@ -67,8 +67,8 @@ describe Spree::OrderUpdater do
         it "is credit_owed" do
           order.payment_total = 30
           order.total = 30
-          order.stub_chain(:payments, :valid, :empty?).and_return(false)
-          order.stub_chain(:payments, :completed, :empty?).and_return(false)
+          allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
+          allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
           expect {
             updater.update_payment_state
           }.to change { order.payment_state }.to 'credit_owed'
@@ -79,8 +79,8 @@ describe Spree::OrderUpdater do
         it "is void" do
           order.payment_total = 0
           order.total = 30
-          order.stub_chain(:payments, :valid, :empty?).and_return(false)
-          order.stub_chain(:payments, :completed, :empty?).and_return(false)
+          allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
+          allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
           expect {
             updater.update_payment_state
           }.to change { order.payment_state }.to 'void'

--- a/spec/models/spree/payment_method_spec.rb
+++ b/spec/models/spree/payment_method_spec.rb
@@ -7,24 +7,24 @@ module Spree
       pm2 = create(:payment_method, name: 'AA')
       pm3 = create(:payment_method, name: 'BB')
 
-      PaymentMethod.by_name.should == [pm2, pm3, pm1]
+      expect(PaymentMethod.by_name).to eq([pm2, pm3, pm1])
     end
 
     it "raises errors when required fields are missing" do
       pm = PaymentMethod.new()
       pm.save
-      pm.errors.to_a.should == ["Name can't be blank", "At least one hub must be selected"]
+      expect(pm.errors.to_a).to eq(["Name can't be blank", "At least one hub must be selected"])
     end
 
     it "generates a clean name for known Payment Method types" do
-      Spree::PaymentMethod::Check.clean_name.should == "Cash/EFT/etc. (payments for which automatic validation is not required)"
-      Spree::Gateway::Migs.clean_name.should == "MasterCard Internet Gateway Service (MIGS)"
-      Spree::Gateway::Pin.clean_name.should == "Pin Payments"
-      Spree::Gateway::PayPalExpress.clean_name.should == "PayPal Express"
-      Spree::Gateway::StripeConnect.clean_name.should == "Stripe"
+      expect(Spree::PaymentMethod::Check.clean_name).to eq("Cash/EFT/etc. (payments for which automatic validation is not required)")
+      expect(Spree::Gateway::Migs.clean_name).to eq("MasterCard Internet Gateway Service (MIGS)")
+      expect(Spree::Gateway::Pin.clean_name).to eq("Pin Payments")
+      expect(Spree::Gateway::PayPalExpress.clean_name).to eq("PayPal Express")
+      expect(Spree::Gateway::StripeConnect.clean_name).to eq("Stripe")
 
       # Testing else condition
-      Spree::Gateway::BogusSimple.clean_name.should == "BogusSimple"
+      expect(Spree::Gateway::BogusSimple.clean_name).to eq("BogusSimple")
     end
 
     it "computes the amount of fees" do

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -7,17 +7,17 @@ module Spree
         let(:payment) { create(:payment, source: create(:credit_card)) }
 
         it "can capture and void" do
-          payment.actions.should match_array %w(capture void)
+          expect(payment.actions).to match_array %w(capture void)
         end
 
         describe "when a payment has been taken" do
           before do
-            payment.stub(:state) { 'completed' }
-            payment.stub(:order) { double(:order, payment_state: 'credit_owed') }
+            allow(payment).to receive(:state) { 'completed' }
+            allow(payment).to receive(:order) { double(:order, payment_state: 'credit_owed') }
           end
 
           it "can void and credit" do
-            payment.actions.should match_array %w(void credit)
+            expect(payment.actions).to match_array %w(void credit)
           end
         end
       end
@@ -28,18 +28,18 @@ module Spree
         let(:payment) { create(:payment, source: create(:credit_card), payment_method: pin) }
 
         it "does not void" do
-          payment.actions.should_not include 'void'
+          expect(payment.actions).not_to include 'void'
         end
 
         describe "when a payment has been taken" do
           before do
-            payment.stub(:state) { 'completed' }
-            payment.stub(:order) { double(:order, payment_state: 'credit_owed') }
+            allow(payment).to receive(:state) { 'completed' }
+            allow(payment).to receive(:order) { double(:order, payment_state: 'credit_owed') }
           end
 
           it "can refund instead of crediting" do
-            payment.actions.should_not include 'credit'
-            payment.actions.should     include 'refund'
+            expect(payment.actions).not_to include 'credit'
+            expect(payment.actions).to     include 'refund'
           end
         end
       end
@@ -51,76 +51,76 @@ module Spree
       let(:failure) { double(:success? => false) }
 
       it "always checks the environment" do
-        payment.payment_method.stub(:refund) { success }
-        payment.should_receive(:check_environment)
+        allow(payment.payment_method).to receive(:refund) { success }
+        expect(payment).to receive(:check_environment)
         payment.refund!
       end
 
       describe "calculating refund amount" do
         it "returns the parameter amount when given" do
-          payment.send(:calculate_refund_amount, 123).should === 123.0
+          expect(payment.send(:calculate_refund_amount, 123)).to be === 123.0
         end
 
         it "refunds up to the value of the payment when the outstanding balance is larger" do
-          payment.stub(:credit_allowed) { 123 }
-          payment.stub(:order) { double(:order, outstanding_balance: 1000) }
-          payment.send(:calculate_refund_amount).should == 123
+          allow(payment).to receive(:credit_allowed) { 123 }
+          allow(payment).to receive(:order) { double(:order, outstanding_balance: 1000) }
+          expect(payment.send(:calculate_refund_amount)).to eq(123)
         end
 
         it "refunds up to the outstanding balance of the order when the payment is larger" do
-          payment.stub(:credit_allowed) { 1000 }
-          payment.stub(:order) { double(:order, outstanding_balance: 123) }
-          payment.send(:calculate_refund_amount).should == 123
+          allow(payment).to receive(:credit_allowed) { 1000 }
+          allow(payment).to receive(:order) { double(:order, outstanding_balance: 123) }
+          expect(payment.send(:calculate_refund_amount)).to eq(123)
         end
       end
 
       describe "performing refunds" do
         before do
-          payment.stub(:calculate_refund_amount) { 123 }
-          payment.payment_method.should_receive(:refund).and_return(success)
+          allow(payment).to receive(:calculate_refund_amount) { 123 }
+          expect(payment.payment_method).to receive(:refund).and_return(success)
         end
 
         it "performs the refund without payment profiles" do
-          payment.payment_method.stub(:payment_profiles_supported?) { false }
+          allow(payment.payment_method).to receive(:payment_profiles_supported?) { false }
           payment.refund!
         end
 
         it "performs the refund with payment profiles" do
-          payment.payment_method.stub(:payment_profiles_supported?) { true }
+          allow(payment.payment_method).to receive(:payment_profiles_supported?) { true }
           payment.refund!
         end
       end
 
       it "records the response" do
-        payment.stub(:calculate_refund_amount) { 123 }
-        payment.payment_method.stub(:refund).and_return(success)
-        payment.should_receive(:record_response).with(success)
+        allow(payment).to receive(:calculate_refund_amount) { 123 }
+        allow(payment.payment_method).to receive(:refund).and_return(success)
+        expect(payment).to receive(:record_response).with(success)
         payment.refund!
       end
 
       it "records a payment on success" do
-        payment.stub(:calculate_refund_amount) { 123 }
-        payment.payment_method.stub(:refund).and_return(success)
-        payment.stub(:record_response)
+        allow(payment).to receive(:calculate_refund_amount) { 123 }
+        allow(payment.payment_method).to receive(:refund).and_return(success)
+        allow(payment).to receive(:record_response)
 
         expect do
           payment.refund!
         end.to change(Payment, :count).by(1)
 
         p = Payment.last
-        p.order.should == payment.order
-        p.source.should == payment
-        p.payment_method.should == payment.payment_method
-        p.amount.should == -123
-        p.response_code.should == success.authorization
-        p.state.should == 'completed'
+        expect(p.order).to eq(payment.order)
+        expect(p.source).to eq(payment)
+        expect(p.payment_method).to eq(payment.payment_method)
+        expect(p.amount).to eq(-123)
+        expect(p.response_code).to eq(success.authorization)
+        expect(p.state).to eq('completed')
       end
 
       it "logs the error on failure" do
-        payment.stub(:calculate_refund_amount) { 123 }
-        payment.payment_method.stub(:refund).and_return(failure)
-        payment.stub(:record_response)
-        payment.should_receive(:gateway_error).with(failure)
+        allow(payment).to receive(:calculate_refund_amount) { 123 }
+        allow(payment.payment_method).to receive(:refund).and_return(failure)
+        allow(payment).to receive(:record_response)
+        expect(payment).to receive(:gateway_error).with(failure)
         payment.refund!
       end
     end

--- a/spec/models/spree/preferences/file_configuration_spec.rb
+++ b/spec/models/spree/preferences/file_configuration_spec.rb
@@ -16,40 +16,40 @@ module Spree
       describe "getting preferences" do
         it "returns regular preferences" do
           c.name = 'foo'
-          c.get_preference(:name).should == 'foo'
+          expect(c.get_preference(:name)).to eq('foo')
         end
 
         it "returns file preferences" do
-          c.get_preference(:logo).should be_a Paperclip::Attachment
+          expect(c.get_preference(:logo)).to be_a Paperclip::Attachment
         end
 
         it "returns regular preferences via []" do
           c.name = 'foo'
-          c[:name].should == 'foo'
+          expect(c[:name]).to eq('foo')
         end
 
         it "returns file preferences via []" do
-          c[:logo].should be_a Paperclip::Attachment
+          expect(c[:logo]).to be_a Paperclip::Attachment
         end
       end
 
       describe "getting preference types" do
         it "returns regular preference types" do
-          c.preference_type(:name).should == :string
+          expect(c.preference_type(:name)).to eq(:string)
         end
 
         it "returns file preference types" do
-          c.preference_type(:logo).should == :file
+          expect(c.preference_type(:logo)).to eq(:file)
         end
       end
 
       describe "respond_to?" do
         it "responds to preference getters" do
-          c.respond_to?(:name).should be true
+          expect(c.respond_to?(:name)).to be true
         end
 
         it "responds to preference setters" do
-          c.respond_to?(:name=).should be true
+          expect(c.respond_to?(:name=)).to be true
         end
       end
     end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -4,22 +4,22 @@ module Spree
   describe Product do
 
     describe "associations" do
-      it { should belong_to(:supplier) }
-      it { should belong_to(:primary_taxon) }
-      it { should have_many(:product_distributions) }
+      it { is_expected.to belong_to(:supplier) }
+      it { is_expected.to belong_to(:primary_taxon) }
+      it { is_expected.to have_many(:product_distributions) }
     end
 
     describe "validations and defaults" do
       it "is valid when built from factory" do
-        build(:product).should be_valid
+        expect(build(:product)).to be_valid
       end
 
       it "requires a primary taxon" do
-        build(:simple_product, taxons: [], primary_taxon: nil).should_not be_valid
+        expect(build(:simple_product, taxons: [], primary_taxon: nil)).not_to be_valid
       end
 
       it "requires a supplier" do
-        build(:simple_product, supplier: nil).should_not be_valid
+        expect(build(:simple_product, supplier: nil)).not_to be_valid
       end
 
       it "does not save when master is invalid" do
@@ -35,7 +35,7 @@ module Spree
       it "defaults available_on to now" do
         Timecop.freeze do
           product = Product.new
-          product.available_on.should == Time.zone.now
+          expect(product.available_on).to eq(Time.zone.now)
         end
       end
 
@@ -43,7 +43,7 @@ module Spree
         context "when a tax category is required" do
           it "is invalid when a tax category is not provided" do
             with_products_require_tax_category(true) do
-              build(:product, tax_category_id: nil).should_not be_valid
+              expect(build(:product, tax_category_id: nil)).not_to be_valid
             end
           end
         end
@@ -51,7 +51,7 @@ module Spree
         context "when a tax category is not required" do
           it "is valid when a tax category is not provided" do
             with_products_require_tax_category(false) do
-              build(:product, tax_category_id: nil).should be_valid
+              expect(build(:product, tax_category_id: nil)).to be_valid
             end
           end
         end
@@ -75,7 +75,7 @@ module Spree
 
         it "requires a unit" do
           product.variant_unit = nil
-          product.should_not be_valid
+          expect(product).not_to be_valid
         end
 
         %w(weight volume).each do |unit|
@@ -84,14 +84,14 @@ module Spree
               product.variant_unit = unit
               product.variant_unit_scale = 1
               product.variant_unit_name = nil
-              product.should be_valid
+              expect(product).to be_valid
             end
 
             it "is invalid when unit scale is not set" do
               product.variant_unit = unit
               product.variant_unit_scale = nil
               product.variant_unit_name = nil
-              product.should_not be_valid
+              expect(product).not_to be_valid
             end
           end
         end
@@ -129,14 +129,14 @@ module Spree
             product.variant_unit = 'items'
             product.variant_unit_name = 'loaf'
             product.variant_unit_scale = nil
-            product.should be_valid
+            expect(product).to be_valid
           end
 
           it "is invalid when unit name is not set" do
             product.variant_unit = 'items'
             product.variant_unit_name = nil
             product.variant_unit_scale = nil
-            product.should_not be_valid
+            expect(product).not_to be_valid
           end
         end
       end
@@ -157,7 +157,7 @@ module Spree
           product.variant_unit_scale = nil
           product.variant_unit_name = nil
 
-          product.should_not be_valid
+          expect(product).not_to be_valid
         end
       end
     end
@@ -202,7 +202,7 @@ module Spree
           s2 = create(:supplier_enterprise)
           p1 = create(:product, supplier: s1)
           p2 = create(:product, supplier: s2)
-          Product.in_supplier(s1).should == [p1]
+          expect(Product.in_supplier(s1)).to eq([p1])
         end
       end
 
@@ -212,7 +212,7 @@ module Spree
           d2 = create(:distributor_enterprise)
           p1 = create(:product, distributors: [d1])
           p2 = create(:product, distributors: [d2])
-          Product.in_distributor(d1).should == [p1]
+          expect(Product.in_distributor(d1)).to eq([p1])
         end
 
         it "shows products in order cycle distribution" do
@@ -223,7 +223,7 @@ module Spree
           p2 = create(:product)
           create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [p1.master])
           create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.master])
-          Product.in_distributor(d1).should == [p1]
+          expect(Product.in_distributor(d1)).to eq([p1])
         end
 
         it "shows products in order cycle distribution by variant" do
@@ -236,7 +236,7 @@ module Spree
           v2 = create(:variant, product: p2)
           create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [v1])
           create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [v2])
-          Product.in_distributor(d1).should == [p1]
+          expect(Product.in_distributor(d1)).to eq([p1])
         end
 
         it "doesn't show products listed in the incoming exchange only" do
@@ -248,7 +248,7 @@ module Spree
           ex = oc.exchanges.incoming.first
           ex.variants << p.master
 
-          Product.in_distributor(d).should be_empty
+          expect(Product.in_distributor(d)).to be_empty
         end
 
         it "shows products in both without duplicates" do
@@ -256,7 +256,7 @@ module Spree
           d = create(:distributor_enterprise)
           p = create(:product, distributors: [d])
           create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master])
-          Product.in_distributor(d).should == [p]
+          expect(Product.in_distributor(d)).to eq([p])
         end
       end
 
@@ -266,7 +266,7 @@ module Spree
           d2 = create(:distributor_enterprise)
           p1 = create(:product, distributors: [d1])
           p2 = create(:product, distributors: [d2])
-          Product.in_product_distribution_by(d1).should == [p1]
+          expect(Product.in_product_distribution_by(d1)).to eq([p1])
         end
 
         it "does not show products in order cycle distribution" do
@@ -277,7 +277,7 @@ module Spree
           p2 = create(:product)
           create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [p1.master])
           create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.master])
-          Product.in_product_distribution_by(d1).should == []
+          expect(Product.in_product_distribution_by(d1)).to eq([])
         end
       end
 
@@ -287,7 +287,7 @@ module Spree
           s2 = create(:supplier_enterprise)
           p1 = create(:product, supplier: s1)
           p2 = create(:product, supplier: s2)
-          Product.in_supplier_or_distributor(s1).should == [p1]
+          expect(Product.in_supplier_or_distributor(s1)).to eq([p1])
         end
 
         it "shows products in product distribution" do
@@ -295,7 +295,7 @@ module Spree
           d2 = create(:distributor_enterprise)
           p1 = create(:product, distributors: [d1])
           p2 = create(:product, distributors: [d2])
-          Product.in_supplier_or_distributor(d1).should == [p1]
+          expect(Product.in_supplier_or_distributor(d1)).to eq([p1])
         end
 
         it "shows products in order cycle distribution" do
@@ -306,7 +306,7 @@ module Spree
           p2 = create(:product)
           create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [p1.master])
           create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.master])
-          Product.in_supplier_or_distributor(d1).should == [p1]
+          expect(Product.in_supplier_or_distributor(d1)).to eq([p1])
         end
 
         it "shows products in all three without duplicates" do
@@ -314,7 +314,7 @@ module Spree
           d = create(:distributor_enterprise)
           p = create(:product, supplier: s, distributors: [d])
           create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master])
-          [s, d].each { |e| Product.in_supplier_or_distributor(e).should == [p] }
+          [s, d].each { |e| expect(Product.in_supplier_or_distributor(e)).to eq([p]) }
         end
       end
 
@@ -327,7 +327,7 @@ module Spree
           p2 = create(:product)
           oc1 = create(:simple_order_cycle, suppliers: [s], distributors: [d1], variants: [p1.master])
           oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.master])
-          Product.in_order_cycle(oc1).should == [p1]
+          expect(Product.in_order_cycle(oc1)).to eq([p1])
         end
       end
 
@@ -341,7 +341,7 @@ module Spree
           p3 = create(:product)
           oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d2], variants: [p2.master], orders_close_at: 1.day.ago)
           oc2 = create(:simple_order_cycle, suppliers: [s], distributors: [d3], variants: [p3.master], orders_close_at: Date.tomorrow)
-          Product.in_an_active_order_cycle.should == [p3]
+          expect(Product.in_an_active_order_cycle).to eq([p3])
         end
       end
 
@@ -359,17 +359,17 @@ module Spree
           @e1.enterprise_roles.build(user: user).save
 
           product = Product.managed_by user
-          product.count.should == 1
-          product.should include @p1
+          expect(product.count).to eq(1)
+          expect(product).to include @p1
         end
 
         it "shows all products for admin user" do
           user = create(:admin_user)
 
           product = Product.managed_by user
-          product.count.should == 2
-          product.should include @p1
-          product.should include @p2
+          expect(product.count).to eq(2)
+          expect(product).to include @p1
+          expect(product).to include @p2
         end
       end
 
@@ -415,7 +415,7 @@ module Spree
         distributor = create(:distributor_enterprise)
         product = create(:product)
         product_distribution = create(:product_distribution, product: product, distributor: distributor)
-        product.product_distribution_for(distributor).should == product_distribution
+        expect(product.product_distribution_for(distributor)).to eq(product_distribution)
       end
     end
 
@@ -425,7 +425,7 @@ module Spree
         product.set_property 'Organic Certified', 'NASAA 12345'
         property = product.properties.last
 
-        product.properties_including_inherited.should == [{id: property.id, name: "Organic Certified", value: 'NASAA 12345'}]
+        expect(product.properties_including_inherited).to eq([{id: property.id, name: "Organic Certified", value: 'NASAA 12345'}])
       end
 
       it "returns producer properties as a hash" do
@@ -435,7 +435,7 @@ module Spree
         supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
         property = supplier.properties.last
 
-        product.properties_including_inherited.should == [{id: property.id, name: "Organic Certified", value: 'NASAA 54321'}]
+        expect(product.properties_including_inherited).to eq([{id: property.id, name: "Organic Certified", value: 'NASAA 54321'}])
       end
 
       it "overrides producer properties with product properties" do
@@ -446,7 +446,7 @@ module Spree
         supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
         property = product.properties.last
 
-        product.properties_including_inherited.should == [{id: property.id, name: "Organic Certified", value: 'NASAA 12345'}]
+        expect(product.properties_including_inherited).to eq([{id: property.id, name: "Organic Certified", value: 'NASAA 12345'}])
       end
 
       context "when product has an inherit_properties value set to true" do
@@ -457,7 +457,7 @@ module Spree
           supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
           property = supplier.properties.last
 
-          product.properties_including_inherited.should == [{id: property.id, name: "Organic Certified", value: 'NASAA 54321'}]
+          expect(product.properties_including_inherited).to eq([{id: property.id, name: "Organic Certified", value: 'NASAA 54321'}])
         end
       end
 
@@ -468,7 +468,7 @@ module Spree
         it "does not inherit producer properties" do
           supplier.set_producer_property 'Organic Certified', 'NASAA 54321'
 
-          product.properties_including_inherited.should == []
+          expect(product.properties_including_inherited).to eq([])
         end
       end
 
@@ -484,10 +484,11 @@ module Spree
         product.product_properties.create!({property_id: pc.id, value: '3', position: 3}, {without_protection: true})
         supplier.producer_properties.create!({property_id: pb.id, value: '2', position: 2}, {without_protection: true})
 
-        product.properties_including_inherited.should ==
+        expect(product.properties_including_inherited).to eq(
           [{id: pa.id, name: "A", value: '1'},
            {id: pb.id, name: "B", value: '2'},
            {id: pc.id, name: "C", value: '3'}]
+        )
       end
     end
 
@@ -497,8 +498,8 @@ module Spree
         d2 = create(:distributor_enterprise)
         p = create(:product, distributors: [d1])
 
-        p.should be_in_distributor d1
-        p.should_not be_in_distributor d2
+        expect(p).to be_in_distributor d1
+        expect(p).not_to be_in_distributor d2
       end
 
       it "queries its membership of a particular order cycle distribution" do
@@ -509,8 +510,8 @@ module Spree
         oc1 = create(:simple_order_cycle, :distributors => [d1], :variants => [p1.master])
         oc2 = create(:simple_order_cycle, :distributors => [d2], :variants => [p2.master])
 
-        p1.should be_in_distributor d1
-        p1.should_not be_in_distributor d2
+        expect(p1).to be_in_distributor d1
+        expect(p1).not_to be_in_distributor d2
       end
 
       it "queries its membership of a particular order cycle" do
@@ -521,8 +522,8 @@ module Spree
         oc1 = create(:simple_order_cycle, :distributors => [d1], :variants => [p1.master])
         oc2 = create(:simple_order_cycle, :distributors => [d2], :variants => [p2.master])
 
-        p1.should be_in_order_cycle oc1
-        p1.should_not be_in_order_cycle oc2
+        expect(p1).to be_in_order_cycle oc1
+        expect(p1).not_to be_in_order_cycle oc2
       end
     end
 
@@ -539,11 +540,11 @@ module Spree
 
         it "removes the old option type and assigns the new one" do
           p.update_attributes!(variant_unit: 'volume', variant_unit_scale: 0.001)
-          p.option_types.should == [ot_volume]
+          expect(p.option_types).to eq([ot_volume])
         end
 
         it "does not remove and re-add the option type if it is not changed" do
-          p.option_types.should_receive(:delete).never
+          expect(p.option_types).to receive(:delete).never
           p.update_attributes!(name: 'foo')
         end
 
@@ -552,14 +553,14 @@ module Spree
           v = create(:variant, unit_value: 1, product: p)
           p.reload
 
-          v.option_values.map(&:name).include?("1L").should == false
-          v.option_values.map(&:name).include?("1g").should == true
+          expect(v.option_values.map(&:name).include?("1L")).to eq(false)
+          expect(v.option_values.map(&:name).include?("1g")).to eq(true)
                     expect {
             p.update_attributes!(variant_unit: 'volume', variant_unit_scale: 0.001)
           }.to change(p.master.option_values(true), :count).by(0)
           v.reload
-          v.option_values.map(&:name).include?("1L").should == true
-          v.option_values.map(&:name).include?("1g").should == false
+          expect(v.option_values.map(&:name).include?("1L")).to eq(true)
+          expect(v.option_values.map(&:name).include?("1g")).to eq(false)
         end
 
         it "removes the related option values from its master variant and replaces them" do
@@ -567,14 +568,14 @@ module Spree
           p.master.update_attributes!(unit_value: 1)
           p.reload
 
-          p.master.option_values.map(&:name).include?("1L").should == false
-          p.master.option_values.map(&:name).include?("1g").should == true
+          expect(p.master.option_values.map(&:name).include?("1L")).to eq(false)
+          expect(p.master.option_values.map(&:name).include?("1g")).to eq(true)
                     expect {
             p.update_attributes!(variant_unit: 'volume', variant_unit_scale: 0.001)
           }.to change(p.master.option_values(true), :count).by(0)
           p.reload
-          p.master.option_values.map(&:name).include?("1L").should == true
-          p.master.option_values.map(&:name).include?("1g").should == false
+          expect(p.master.option_values.map(&:name).include?("1L")).to eq(true)
+          expect(p.master.option_values.map(&:name).include?("1g")).to eq(false)
         end
       end
 
@@ -584,7 +585,7 @@ module Spree
         ot3 = create(:option_type, name: 'unit_items', presentation: 'Items')
         ot4 = create(:option_type, name: 'foo_unit_bar', presentation: 'Foo')
 
-        Spree::Product.all_variant_unit_option_types.should match_array [ot1, ot2, ot3]
+        expect(Spree::Product.all_variant_unit_option_types).to match_array [ot1, ot2, ot3]
       end
     end
 
@@ -608,11 +609,11 @@ module Spree
           p.option_type_ids = p.option_type_ids.reject { |id| id == ot.id }
 
           # Then the associated option values should have been removed from the variants
-          v1.option_values(true).should_not include ov1
-          v2.option_values(true).should_not include ov2
+          expect(v1.option_values(true)).not_to include ov1
+          expect(v2.option_values(true)).not_to include ov2
 
           # And the option values themselves should still exist
-          Spree::OptionValue.where(id: [ov1.id, ov2.id]).count.should == 2
+          expect(Spree::OptionValue.where(id: [ov1.id, ov2.id]).count).to eq(2)
         end
       end
     end
@@ -621,7 +622,7 @@ module Spree
       it "considers products that are on_demand as being in stock" do
         product = create(:simple_product, on_demand: true)
         product.master.update_attribute(:count_on_hand, 0)
-        product.has_stock?.should == true
+        expect(product.has_stock?).to eq(true)
       end
 
       describe "finding products in stock for a particular distribution" do
@@ -632,7 +633,7 @@ module Spree
           oc = create(:simple_order_cycle, distributors: [d])
           oc.exchanges.outgoing.first.variants << p.variants.first
 
-          p.should have_stock_for_distribution(oc, d)
+          expect(p).to have_stock_for_distribution(oc, d)
         end
 
         it "returns products with in-stock variants" do
@@ -643,7 +644,7 @@ module Spree
           oc = create(:simple_order_cycle, distributors: [d])
           oc.exchanges.outgoing.first.variants << v
 
-          p.should have_stock_for_distribution(oc, d)
+          expect(p).to have_stock_for_distribution(oc, d)
         end
 
         it "returns products with on-demand variants" do
@@ -654,7 +655,7 @@ module Spree
           oc = create(:simple_order_cycle, distributors: [d])
           oc.exchanges.outgoing.first.variants << v
 
-          p.should have_stock_for_distribution(oc, d)
+          expect(p).to have_stock_for_distribution(oc, d)
         end
 
         it "does not return products that have stock not in the distribution" do
@@ -663,7 +664,7 @@ module Spree
           d = create(:distributor_enterprise)
           oc = create(:simple_order_cycle, distributors: [d])
 
-          p.should_not have_stock_for_distribution(oc, d)
+          expect(p).not_to have_stock_for_distribution(oc, d)
         end
       end
     end
@@ -674,7 +675,7 @@ module Spree
       let(:product) { create(:simple_product) }
 
       it "returns the first taxon as the primary taxon" do
-        product.taxons.should == [product.primary_taxon]
+        expect(product.taxons).to eq([product.primary_taxon])
       end
     end
 
@@ -688,13 +689,13 @@ module Spree
       it "removes the master variant from all order cycles" do
         e.variants << p.master
         p.delete
-        e.variants(true).should be_empty
+        expect(e.variants(true)).to be_empty
       end
 
       it "removes all other variants from order cycles" do
         e.variants << v
         p.delete
-        e.variants(true).should be_empty
+        expect(e.variants(true)).to be_empty
       end
     end
   end

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   describe ShippingMethod do
     it "is valid when built from factory" do
-      build(:shipping_method).should be_valid
+      expect(build(:shipping_method)).to be_valid
     end
 
     it "can have distributors" do
@@ -15,7 +15,7 @@ module Spree
       sm.distributors << d1
       sm.distributors << d2
 
-      sm.reload.distributors.should match_array [d1, d2]
+      expect(sm.reload.distributors).to match_array [d1, d2]
     end
 
     it "finds shipping methods for a particular distributor" do
@@ -24,7 +24,7 @@ module Spree
       sm1 = create(:shipping_method, distributors: [d1])
       sm2 = create(:shipping_method, distributors: [d2])
 
-      ShippingMethod.for_distributor(d1).should == [sm1]
+      expect(ShippingMethod.for_distributor(d1)).to eq([sm1])
     end
 
     it "orders shipping methods by name" do
@@ -32,7 +32,7 @@ module Spree
       sm2 = create(:shipping_method, name: 'AA')
       sm3 = create(:shipping_method, name: 'BB')
 
-      ShippingMethod.by_name.should == [sm2, sm3, sm1]
+      expect(ShippingMethod.by_name).to eq([sm2, sm3, sm1])
     end
 
 
@@ -47,19 +47,19 @@ module Spree
       it "is available to orders that match its distributor" do
         o = create(:order, ship_address: create(:address),
                   distributor: sm.distributors.first, currency: currency)
-        sm.should be_available_to_order o
+        expect(sm).to be_available_to_order o
       end
 
       it "is not available to orders that do not match its distributor" do
         o = create(:order, ship_address: create(:address),
                   distributor: create(:distributor_enterprise), currency: currency)
-        sm.should_not be_available_to_order o
+        expect(sm).not_to be_available_to_order o
       end
 
       it "is available to orders with no shipping address" do
         o = create(:order, ship_address: nil,
                   distributor: sm.distributors.first, currency: currency)
-        sm.should be_available_to_order o
+        expect(sm).to be_available_to_order o
       end
     end
 
@@ -74,19 +74,19 @@ module Spree
       let!(:d3_delivery) { create(:shipping_method, require_ship_address: true, distributors: [d3]) }
 
       it "reports when the services are available" do
-        ShippingMethod.services[d1.id].should == {pickup: true, delivery: true}
+        expect(ShippingMethod.services[d1.id]).to eq({pickup: true, delivery: true})
       end
 
       it "reports when only pickup is available" do
-        ShippingMethod.services[d2.id].should == {pickup: true, delivery: false}
+        expect(ShippingMethod.services[d2.id]).to eq({pickup: true, delivery: false})
       end
 
       it "reports when only delivery is available" do
-        ShippingMethod.services[d3.id].should == {pickup: false, delivery: true}
+        expect(ShippingMethod.services[d3.id]).to eq({pickup: false, delivery: true})
       end
 
       it "returns no entry when no service is available" do
-        ShippingMethod.services[d4.id].should be_nil
+        expect(ShippingMethod.services[d4.id]).to be_nil
       end
     end
 

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -9,7 +9,7 @@ module Spree
         let(:hub) { create(:distributor_enterprise, charges_sales_tax: true) }
 
         it "selects all tax rates" do
-          TaxRate.match(order).should == [tax_rate]
+          expect(TaxRate.match(order)).to eq([tax_rate])
         end
       end
 
@@ -17,7 +17,7 @@ module Spree
         let(:hub) { create(:distributor_enterprise, charges_sales_tax: false) }
 
         it "selects no tax rates" do
-          TaxRate.match(order).should be_empty
+          expect(TaxRate.match(order)).to be_empty
         end
       end
 
@@ -25,7 +25,7 @@ module Spree
         let!(:order) { create(:order, distributor: nil, bill_address: create(:address)) }
 
         it "selects all tax rates" do
-          TaxRate.match(order).should == [tax_rate]
+          expect(TaxRate.match(order)).to eq([tax_rate])
         end
       end
     end
@@ -35,26 +35,26 @@ module Spree
 
       it "sets included_in_price to true" do
         tax_rate.send(:with_tax_included_in_price) do
-          tax_rate.included_in_price.should be true
+          expect(tax_rate.included_in_price).to be true
         end
       end
 
       it "sets the included_in_price value accessible to the calculator to true" do
         tax_rate.send(:with_tax_included_in_price) do
-          tax_rate.calculator.calculable.included_in_price.should be true
+          expect(tax_rate.calculator.calculable.included_in_price).to be true
         end
       end
 
       it "passes through the return value of the block" do
-        tax_rate.send(:with_tax_included_in_price) do
+        expect(tax_rate.send(:with_tax_included_in_price) do
           'asdf'
-        end.should == 'asdf'
+        end).to eq('asdf')
       end
 
       it "restores both values to their original afterwards" do
         tax_rate.send(:with_tax_included_in_price) {}
-        tax_rate.included_in_price.should be false
-        tax_rate.calculator.calculable.included_in_price.should be false
+        expect(tax_rate.included_in_price).to be false
+        expect(tax_rate.calculator.calculable.included_in_price).to be false
       end
 
       it "restores both values when an exception is raised" do
@@ -62,8 +62,8 @@ module Spree
           tax_rate.send(:with_tax_included_in_price) { raise Exception.new 'oops' }
         end.to raise_error 'oops'
 
-        tax_rate.included_in_price.should be false
-        tax_rate.calculator.calculable.included_in_price.should be false
+        expect(tax_rate.included_in_price).to be false
+        expect(tax_rate.calculator.calculable.included_in_price).to be false
       end
     end
   end

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -25,7 +25,7 @@ module Spree
       let!(:p1) { create(:simple_product, supplier: e, taxons: [t1, t2]) }
 
       it "finds taxons" do
-        Taxon.supplied_taxons.should == {e.id => Set.new(p1.taxons.map(&:id))}
+        expect(Taxon.supplied_taxons).to eq({e.id => Set.new(p1.taxons.map(&:id))})
       end
     end
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree.user_class do
   describe "associations" do
-    it { should have_many(:owned_enterprises) }
+    it { is_expected.to have_many(:owned_enterprises) }
 
     describe "addresses" do
       let(:user) { create(:user, bill_address: create(:address)) }
@@ -66,7 +66,7 @@ describe Spree.user_class do
       e = create(:enterprise)
       c = create(:customer, user: u, enterprise: e)
 
-      u.customer_of(e).should == c
+      expect(u.customer_of(e)).to eq(c)
     end
   end
 

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -17,8 +17,8 @@ module Spree
         v_not_deleted = create(:variant)
         v_deleted = create(:variant, deleted_at: Time.zone.now)
 
-        Spree::Variant.not_deleted.should     include v_not_deleted
-        Spree::Variant.not_deleted.should_not include v_deleted
+        expect(Spree::Variant.not_deleted).to     include v_not_deleted
+        expect(Spree::Variant.not_deleted).not_to include v_deleted
       end
 
       describe "finding variants in a distributor" do
@@ -30,12 +30,12 @@ module Spree
         let!(:oc2) { create(:simple_order_cycle, distributors: [d2], variants: [p2.master]) }
 
         it "shows variants in an order cycle distribution" do
-          Variant.in_distributor(d1).should == [p1.master]
+          expect(Variant.in_distributor(d1)).to eq([p1.master])
         end
 
         it "doesn't show duplicates" do
           oc_dup = create(:simple_order_cycle, distributors: [d1], variants: [p1.master])
-          Variant.in_distributor(d1).should == [p1.master]
+          expect(Variant.in_distributor(d1)).to eq([p1.master])
         end
       end
 
@@ -48,14 +48,14 @@ module Spree
         let!(:oc2) { create(:simple_order_cycle, distributors: [d2], variants: [p2.master]) }
 
         it "shows variants in an order cycle" do
-          Variant.in_order_cycle(oc1).should == [p1.master]
+          expect(Variant.in_order_cycle(oc1)).to eq([p1.master])
         end
 
         it "doesn't show duplicates" do
           ex = create(:exchange, order_cycle: oc1, sender: oc1.coordinator, receiver: d2)
           ex.variants << p1.master
 
-          Variant.in_order_cycle(oc1).should == [p1.master]
+          expect(Variant.in_order_cycle(oc1)).to eq([p1.master])
         end
       end
 
@@ -84,17 +84,17 @@ module Spree
         }
 
         it "returns variants in the order cycle and distributor" do
-          p1.variants.for_distribution(oc, d1).should == [v1]
-          p2.variants.for_distribution(oc, d2).should == [v2]
+          expect(p1.variants.for_distribution(oc, d1)).to eq([v1])
+          expect(p2.variants.for_distribution(oc, d2)).to eq([v2])
         end
 
         it "does not return variants in the order cycle but not the distributor" do
-          p1.variants.for_distribution(oc, d2).should be_empty
-          p2.variants.for_distribution(oc, d1).should be_empty
+          expect(p1.variants.for_distribution(oc, d2)).to be_empty
+          expect(p2.variants.for_distribution(oc, d1)).to be_empty
         end
 
         it "does not return variants not in the order cycle" do
-          p_external.variants.for_distribution(oc, d1).should be_empty
+          expect(p_external.variants.for_distribution(oc, d1)).to be_empty
         end
       end
 
@@ -210,8 +210,9 @@ module Spree
       let!(:v3) { create(:variant) }
 
       it "indexes variants by id" do
-        Variant.where(id: [v1, v2, v3]).indexed.should ==
+        expect(Variant.where(id: [v1, v2, v3]).indexed).to eq(
           {v1.id => v1, v2.id => v2, v3.id => v3}
+        )
       end
     end
 
@@ -224,7 +225,7 @@ module Spree
         before { allow(v).to receive(:full_name) { p.name + " - something" } }
 
         it "does not show the product name twice" do
-          v.product_and_full_name.should == 'product - something'
+          expect(v.product_and_full_name).to eq('product - something')
         end
       end
 
@@ -232,7 +233,7 @@ module Spree
         before { allow(v).to receive(:full_name) { "display_name (unit)" } }
 
         it "prepends the product name to the full name" do
-          v.product_and_full_name.should == 'product - display_name (unit)'
+          expect(v.product_and_full_name).to eq('product - display_name (unit)')
         end
       end
     end
@@ -243,8 +244,8 @@ module Spree
         order_cycle = double(:order_cycle)
 
         variant = Variant.new price: 100
-        variant.should_receive(:fees_for).with(distributor, order_cycle) { 23 }
-        variant.price_with_fees(distributor, order_cycle).should == 123
+        expect(variant).to receive(:fees_for).with(distributor, order_cycle) { 23 }
+        expect(variant.price_with_fees(distributor, order_cycle)).to eq(123)
       end
     end
 
@@ -255,9 +256,9 @@ module Spree
         order_cycle = double(:order_cycle)
         variant = Variant.new
 
-        OpenFoodNetwork::EnterpriseFeeCalculator.any_instance.should_receive(:fees_for).with(variant) { 23 }
+        expect_any_instance_of(OpenFoodNetwork::EnterpriseFeeCalculator).to receive(:fees_for).with(variant) { 23 }
 
-        variant.fees_for(distributor, order_cycle).should == 23
+        expect(variant.fees_for(distributor, order_cycle)).to eq(23)
       end
     end
 
@@ -269,9 +270,9 @@ module Spree
         variant = Variant.new
         fees = double(:fees)
 
-        OpenFoodNetwork::EnterpriseFeeCalculator.any_instance.should_receive(:fees_by_type_for).with(variant) { fees }
+        expect_any_instance_of(OpenFoodNetwork::EnterpriseFeeCalculator).to receive(:fees_by_type_for).with(variant) { fees }
 
-        variant.fees_by_type_for(distributor, order_cycle).should == fees
+        expect(variant.fees_by_type_for(distributor, order_cycle)).to eq(fees)
       end
     end
 
@@ -290,16 +291,16 @@ module Spree
           it "is valid when unit value is set and unit description is not" do
             variant.unit_value = 1
             variant.unit_description = nil
-            variant.should be_valid
+            expect(variant).to be_valid
           end
 
           it "is invalid when unit value is not set" do
             variant.unit_value = nil
-            variant.should_not be_valid
+            expect(variant).not_to be_valid
           end
 
           it "has a valid master variant" do
-            product.master.should be_valid
+            expect(product.master).to be_valid
           end
         end
       end
@@ -313,23 +314,23 @@ module Spree
         it "is valid with only unit value set" do
           variant.unit_value = 1
           variant.unit_description = nil
-          variant.should be_valid
+          expect(variant).to be_valid
         end
 
         it "is valid with only unit description set" do
           variant.unit_value = nil
           variant.unit_description = 'Medium'
-          variant.should be_valid
+          expect(variant).to be_valid
         end
 
         it "is invalid when neither unit value nor unit description are set" do
           variant.unit_value = nil
           variant.unit_description = nil
-          variant.should_not be_valid
+          expect(variant).not_to be_valid
         end
 
         it "has a valid master variant" do
-          product.master.should be_valid
+          expect(product.master).to be_valid
         end
       end
     end
@@ -339,67 +340,67 @@ module Spree
         let(:v) { Variant.new }
 
         before do
-          v.stub(:display_name) { 'display_name' }
-          v.stub(:unit_to_display) { 'unit_to_display' }
+          allow(v).to receive(:display_name) { 'display_name' }
+          allow(v).to receive(:unit_to_display) { 'unit_to_display' }
         end
 
         it "returns unit_to_display when display_name is blank" do
-          v.stub(:display_name) { '' }
-          v.full_name.should == 'unit_to_display'
+          allow(v).to receive(:display_name) { '' }
+          expect(v.full_name).to eq('unit_to_display')
         end
 
         it "returns display_name when it contains unit_to_display" do
-          v.stub(:display_name) { 'DiSpLaY_name' }
-          v.stub(:unit_to_display) { 'name' }
-          v.full_name.should == 'DiSpLaY_name'
+          allow(v).to receive(:display_name) { 'DiSpLaY_name' }
+          allow(v).to receive(:unit_to_display) { 'name' }
+          expect(v.full_name).to eq('DiSpLaY_name')
         end
 
         it "returns unit_to_display when it contains display_name" do
-          v.stub(:display_name) { '_to_' }
-          v.stub(:unit_to_display) { 'unit_TO_display' }
-          v.full_name.should == 'unit_TO_display'
+          allow(v).to receive(:display_name) { '_to_' }
+          allow(v).to receive(:unit_to_display) { 'unit_TO_display' }
+          expect(v.full_name).to eq('unit_TO_display')
         end
 
         it "returns a combination otherwise" do
-          v.stub(:display_name) { 'display_name' }
-          v.stub(:unit_to_display) { 'unit_to_display' }
-          v.full_name.should == 'display_name (unit_to_display)'
+          allow(v).to receive(:display_name) { 'display_name' }
+          allow(v).to receive(:unit_to_display) { 'unit_to_display' }
+          expect(v.full_name).to eq('display_name (unit_to_display)')
         end
 
         it "is resilient to regex chars" do
           v = Variant.new display_name: ")))"
-          v.stub(:unit_to_display) { ")))" }
-          v.full_name.should == ")))"
+          allow(v).to receive(:unit_to_display) { ")))" }
+          expect(v.full_name).to eq(")))")
         end
       end
 
       describe "getting name for display" do
         it "returns display_name if present" do
           v = create(:variant, display_name: "foo")
-          v.name_to_display.should == "foo"
+          expect(v.name_to_display).to eq("foo")
         end
 
         it "returns product name if display_name is empty" do
           v = create(:variant, product: create(:product))
-          v.name_to_display.should == v.product.name
+          expect(v.name_to_display).to eq(v.product.name)
           v1 = create(:variant, display_name: "", product: create(:product))
-          v1.name_to_display.should == v1.product.name
+          expect(v1.name_to_display).to eq(v1.product.name)
         end
       end
 
       describe "getting unit for display" do
         it "returns display_as if present" do
           v = create(:variant, display_as: "foo")
-          v.unit_to_display.should == "foo"
+          expect(v.unit_to_display).to eq("foo")
         end
 
         it "returns options_text if display_as is blank" do
           v = create(:variant)
           v1 = create(:variant, display_as: "")
-          v.stub(:options_text).and_return "ponies"
-          v1.stub(:options_text).and_return "ponies"
-          v.unit_to_display.should == "ponies"
-          v1.unit_to_display.should == "ponies"
+          allow(v).to receive(:options_text).and_return "ponies"
+          allow(v1).to receive(:options_text).and_return "ponies"
+          expect(v.unit_to_display).to eq("ponies")
+          expect(v1.unit_to_display).to eq("ponies")
         end
       end
 
@@ -411,7 +412,7 @@ module Spree
           p.update_attributes! variant_unit: 'weight', variant_unit_scale: 1
           v.update_attributes! unit_value: 10, unit_description: 'foo'
 
-          v.reload.weight.should == 0.01
+          expect(v.reload.weight).to eq(0.01)
         end
 
         it "does nothing when unit is not weight" do
@@ -421,7 +422,7 @@ module Spree
           p.update_attributes! variant_unit: 'volume', variant_unit_scale: 1
           v.update_attributes! unit_value: 10, unit_description: 'foo'
 
-          v.reload.weight.should == 123
+          expect(v.reload.weight).to eq(123)
         end
 
         it "does nothing when unit_value is not set" do
@@ -432,9 +433,9 @@ module Spree
 
           # Although invalid, this calls the before_validation callback, which would
           # error if not handling unit_value == nil case
-          v.update_attributes(unit_value: nil, unit_description: 'foo').should be false
+          expect(v.update_attributes(unit_value: nil, unit_description: 'foo')).to be false
 
-          v.reload.weight.should == 123
+          expect(v.reload.weight).to eq(123)
         end
       end
 
@@ -449,7 +450,7 @@ module Spree
             v.update_attributes!(unit_value: 10, unit_description: 'foo')
           }.to change(Spree::OptionValue, :count).by(1)
 
-          v.option_values.should_not include ov_orig
+          expect(v.option_values).not_to include ov_orig
         end
       end
 
@@ -468,8 +469,8 @@ module Spree
             v.update_attributes!(unit_value: 10, unit_description: 'foo')
           }.to change(Spree::OptionValue, :count).by(0)
 
-          v.option_values.should_not include ov_orig
-          v.option_values.should     include ov_new
+          expect(v.option_values).not_to include ov_orig
+          expect(v.option_values).to     include ov_new
         end
       end
 
@@ -478,10 +479,10 @@ module Spree
         let!(:v) { create(:variant, product: p, unit_value: 5, unit_description: 'bar', display_as: '') }
 
         it "requests the name of the new option_value from OptionValueName" do
-          OpenFoodNetwork::OptionValueNamer.any_instance.should_receive(:name).exactly(1).times.and_call_original
+          expect_any_instance_of(OpenFoodNetwork::OptionValueNamer).to receive(:name).exactly(1).times.and_call_original
           v.update_attributes(unit_value: 10, unit_description: 'foo')
           ov = v.option_values.last
-          ov.name.should == "10g foo"
+          expect(ov.name).to eq("10g foo")
         end
       end
 
@@ -490,10 +491,10 @@ module Spree
         let!(:v) { create(:variant, product: p, unit_value: 5, unit_description: 'bar', display_as: 'FOOS!') }
 
         it "does not request the name of the new option_value from OptionValueName" do
-          OpenFoodNetwork::OptionValueNamer.any_instance.should_not_receive(:name)
+          expect_any_instance_of(OpenFoodNetwork::OptionValueNamer).not_to receive(:name)
           v.update_attributes!(unit_value: 10, unit_description: 'foo')
           ov = v.option_values.last
-          ov.name.should == "FOOS!"
+          expect(ov.name).to eq("FOOS!")
         end
       end
     end
@@ -531,7 +532,7 @@ module Spree
       e = create(:exchange, variants: [v])
 
       v.destroy
-      e.reload.variant_ids.should be_empty
+      expect(e.reload.variant_ids).to be_empty
     end
 
     context "as the last variant of a product" do

--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -18,13 +18,13 @@ describe VariantOverride do
     end
 
     it "finds variant overrides for a set of hubs" do
-      VariantOverride.for_hubs([hub1, hub2]).should match_array [vo1, vo2]
+      expect(VariantOverride.for_hubs([hub1, hub2])).to match_array [vo1, vo2]
     end
 
     describe "fetching variant overrides indexed by variant" do
       it "gets indexed variant overrides for one hub" do
-        VariantOverride.indexed(hub1).should == {v => vo1}
-        VariantOverride.indexed(hub2).should == {v => vo2}
+        expect(VariantOverride.indexed(hub1)).to eq({v => vo1})
+        expect(VariantOverride.indexed(hub2)).to eq({v => vo2})
       end
     end
   end
@@ -49,38 +49,38 @@ describe VariantOverride do
   describe "looking up prices" do
     it "returns the numeric price when present" do
       VariantOverride.create!(variant: variant, hub: hub, price: 12.34)
-      VariantOverride.price_for(hub, variant).should == 12.34
+      expect(VariantOverride.price_for(hub, variant)).to eq(12.34)
     end
 
     it "returns nil otherwise" do
-      VariantOverride.price_for(hub, variant).should be_nil
+      expect(VariantOverride.price_for(hub, variant)).to be_nil
     end
   end
 
   describe "looking up count on hand" do
     it "returns the numeric stock level when present" do
       VariantOverride.create!(variant: variant, hub: hub, count_on_hand: 12)
-      VariantOverride.count_on_hand_for(hub, variant).should == 12
+      expect(VariantOverride.count_on_hand_for(hub, variant)).to eq(12)
     end
 
     it "returns nil otherwise" do
-      VariantOverride.count_on_hand_for(hub, variant).should be_nil
+      expect(VariantOverride.count_on_hand_for(hub, variant)).to be_nil
     end
   end
 
   describe "checking if stock levels have been overriden" do
     it "returns true when stock level has been overridden" do
       create(:variant_override, variant: variant, hub: hub, count_on_hand: 12)
-      VariantOverride.stock_overridden?(hub, variant).should be true
+      expect(VariantOverride.stock_overridden?(hub, variant)).to be true
     end
 
     it "returns false when the override has no stock level" do
       create(:variant_override, variant: variant, hub: hub, count_on_hand: nil)
-      VariantOverride.stock_overridden?(hub, variant).should be false
+      expect(VariantOverride.stock_overridden?(hub, variant)).to be false
     end
 
     it "returns false when there is no override for the hub/variant" do
-      VariantOverride.stock_overridden?(hub, variant).should be false
+      expect(VariantOverride.stock_overridden?(hub, variant)).to be false
     end
   end
 
@@ -88,11 +88,11 @@ describe VariantOverride do
     it "decrements stock" do
       vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12)
       VariantOverride.decrement_stock! hub, variant, 2
-      vo.reload.count_on_hand.should == 10
+      expect(vo.reload.count_on_hand).to eq(10)
     end
 
     it "silently logs an error if the variant override does not exist" do
-      Bugsnag.should_receive(:notify)
+      expect(Bugsnag).to receive(:notify)
       VariantOverride.decrement_stock! hub, variant, 2
     end
   end
@@ -103,7 +103,7 @@ describe VariantOverride do
     context "when the vo overrides stock" do
       it "increments stock" do
         vo.increment_stock! 2
-        vo.reload.count_on_hand.should == 10
+        expect(vo.reload.count_on_hand).to eq(10)
       end
     end
 
@@ -111,7 +111,7 @@ describe VariantOverride do
       before { vo.update_attributes(count_on_hand: nil) }
 
       it "silently logs an error" do
-        Bugsnag.should_receive(:notify)
+        expect(Bugsnag).to receive(:notify)
         vo.increment_stock! 2
       end
     end
@@ -120,12 +120,12 @@ describe VariantOverride do
   describe "checking default stock value is present" do
     it "returns true when a default stock level has been set"  do
       vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 20)
-      vo.default_stock?.should be true
+      expect(vo.default_stock?).to be true
     end
 
     it "returns false when the override has no default stock level" do
       vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock:nil)
-      vo.default_stock?.should be false
+      expect(vo.default_stock?).to be false
     end
   end
 
@@ -133,18 +133,18 @@ describe VariantOverride do
     it "resets the on hand level to the value in the default_stock field" do
       vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 20, resettable: true)
       vo.reset_stock!
-      vo.reload.count_on_hand.should == 20
+      expect(vo.reload.count_on_hand).to eq(20)
     end
     it "silently logs an error if the variant override doesn't have a default stock level" do
       vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock:nil, resettable: true)
-      Bugsnag.should_receive(:notify)
+      expect(Bugsnag).to receive(:notify)
       vo.reset_stock!
-      vo.reload.count_on_hand.should == 12
+      expect(vo.reload.count_on_hand).to eq(12)
     end
     it "doesn't reset the level if the behaviour is disabled" do
       vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 10, resettable: false)
       vo.reset_stock!
-      vo.reload.count_on_hand.should == 12
+      expect(vo.reload.count_on_hand).to eq(12)
     end
   end
 

--- a/spec/performance/orders_controller_spec.rb
+++ b/spec/performance/orders_controller_spec.rb
@@ -9,7 +9,7 @@ describe Spree::OrdersController, type: :controller, performance: true do
 
   before do
     order.set_distribution! distributor, order_cycle
-    controller.stub(:current_order) { order }
+    allow(controller).to receive(:current_order) { order }
 
     Spree::Config.currency = 'AUD'
   end

--- a/spec/performance/shop_controller_spec.rb
+++ b/spec/performance/shop_controller_spec.rb
@@ -6,8 +6,8 @@ describe ShopController, type: :controller, performance: true do
   let(:order_cycle) { create(:simple_order_cycle, distributors: [d], coordinator_fees: [enterprise_fee]) }
 
   before do
-    controller.stub(:current_distributor) { d }
-    controller.stub(:current_order_cycle) { order_cycle }
+    allow(controller).to receive(:current_distributor) { d }
+    allow(controller).to receive(:current_order_cycle) { order_cycle }
     Spree::Config.currency = 'AUD'
   end
 
@@ -36,7 +36,7 @@ describe ShopController, type: :controller, performance: true do
     it "returns products via json" do
       results = multi_benchmark(3, cache_key_patterns: cache_key_patterns) do
         xhr :get, :products
-        response.should be_success
+        expect(response).to be_success
       end
     end
   end

--- a/spec/serializers/admin/enterprise_serializer_spec.rb
+++ b/spec/serializers/admin/enterprise_serializer_spec.rb
@@ -2,6 +2,6 @@ describe Api::Admin::EnterpriseSerializer do
   let(:enterprise) { create(:distributor_enterprise) }
   it "serializes an enterprise" do
     serializer = Api::Admin::EnterpriseSerializer.new enterprise 
-    serializer.to_json.should match enterprise.name  
+    expect(serializer.to_json).to match enterprise.name  
   end
 end

--- a/spec/serializers/admin/index_enterprise_serializer_spec.rb
+++ b/spec/serializers/admin/index_enterprise_serializer_spec.rb
@@ -10,7 +10,7 @@ describe Api::Admin::IndexEnterpriseSerializer do
 
     it "sets 'owned' to false" do
       serializer = Api::Admin::IndexEnterpriseSerializer.new enterprise, spree_current_user: user
-      serializer.to_json.should match "\"owned\":false"
+      expect(serializer.to_json).to match "\"owned\":false"
     end
   end
 
@@ -19,7 +19,7 @@ describe Api::Admin::IndexEnterpriseSerializer do
 
     it "sets 'owned' to true" do
       serializer = Api::Admin::IndexEnterpriseSerializer.new enterprise, spree_current_user: user
-      serializer.to_json.should match "\"owned\":true"
+      expect(serializer.to_json).to match "\"owned\":true"
     end
   end
 
@@ -28,7 +28,7 @@ describe Api::Admin::IndexEnterpriseSerializer do
 
     it "sets 'owned' to true" do
       serializer = Api::Admin::IndexEnterpriseSerializer.new enterprise, spree_current_user: user
-      serializer.to_json.should match "\"owned\":true"
+      expect(serializer.to_json).to match "\"owned\":true"
     end
   end
 end

--- a/spec/serializers/admin/variant_override_serializer_spec.rb
+++ b/spec/serializers/admin/variant_override_serializer_spec.rb
@@ -7,9 +7,9 @@ describe Api::Admin::VariantOverrideSerializer do
 
   it "serializes a variant override" do
     serializer = Api::Admin::VariantOverrideSerializer.new variant_override
-    serializer.to_json.should match variant.id.to_s
-    serializer.to_json.should match hub.id.to_s
-    serializer.to_json.should match price.to_s
-    serializer.to_json.should match count_on_hand.to_s
+    expect(serializer.to_json).to match variant.id.to_s
+    expect(serializer.to_json).to match hub.id.to_s
+    expect(serializer.to_json).to match price.to_s
+    expect(serializer.to_json).to match count_on_hand.to_s
   end
 end

--- a/spec/serializers/current_order_serializer.rb
+++ b/spec/serializers/current_order_serializer.rb
@@ -6,14 +6,14 @@ describe Api::CurrentOrderSerializer do
   let(:serializer) { Api::CurrentOrderSerializer.new(order, current_distributor: distributor, current_order_cycle: oc ).to_json }
 
   it "serializers the current order" do
-    serializer.should match order.id.to_s
+    expect(serializer).to match order.id.to_s
   end
 
   it "includes line items" do
-    serializer.should match li.id.to_s
+    expect(serializer).to match li.id.to_s
   end
 
   it "includes variants of line items" do
-    serializer.should match li.variant.name
+    expect(serializer).to match li.variant.name
   end
 end

--- a/spec/serializers/enterprise_serializer_spec.rb
+++ b/spec/serializers/enterprise_serializer_spec.rb
@@ -14,20 +14,20 @@ describe Api::EnterpriseSerializer do
   }
 
   it "serializes an enterprise" do
-    serializer.to_json.should match enterprise.name
+    expect(serializer.to_json).to match enterprise.name
   end
 
   it "serializes taxons as ids only" do
-    serializer.serializable_hash[:taxons].should == [{id: 123}]
-    serializer.serializable_hash[:supplied_taxons].should == [{id: 456}]
+    expect(serializer.serializable_hash[:taxons]).to eq([{id: 123}])
+    expect(serializer.serializable_hash[:supplied_taxons]).to eq([{id: 456}])
   end
 
   it "serializes producers and hubs as ids only" do
-    serializer.serializable_hash[:producers].should == [{id: 123}]
-    serializer.serializable_hash[:hubs].should == [{id: 456}]
+    expect(serializer.serializable_hash[:producers]).to eq([{id: 123}])
+    expect(serializer.serializable_hash[:hubs]).to eq([{id: 456}])
   end
 
   it "serializes icons" do
-    serializer.to_json.should match "map_005-hub.svg"
+    expect(serializer.to_json).to match "map_005-hub.svg"
   end
 end

--- a/spec/serializers/spree/product_serializer_spec.rb
+++ b/spec/serializers/spree/product_serializer_spec.rb
@@ -2,6 +2,6 @@ describe Api::Admin::ProductSerializer do
   let(:product) { create(:simple_product) }
   it "serializes a product" do
     serializer = Api::Admin::ProductSerializer.new product
-    serializer.to_json.should match product.name
+    expect(serializer.to_json).to match product.name
   end
 end

--- a/spec/serializers/spree/variant_serializer_spec.rb
+++ b/spec/serializers/spree/variant_serializer_spec.rb
@@ -2,6 +2,6 @@ describe Api::Admin::VariantSerializer do
   let(:variant) { create(:variant) }
   it "serializes a variant" do
     serializer = Api::Admin::VariantSerializer.new variant
-    serializer.to_json.should match variant.options_text
+    expect(serializer.to_json).to match variant.options_text
   end
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -7,7 +7,7 @@ module OpenFoodNetwork
         user
       end
 
-      controller.stub spree_current_user: @admin_user
+      allow(controller).to receive_messages spree_current_user: @admin_user
     end
 
     def login_as_enterprise_user(enterprises)
@@ -20,7 +20,7 @@ module OpenFoodNetwork
         user
       end
 
-      controller.stub spree_current_user: @enterprise_user
+      allow(controller).to receive_messages spree_current_user: @enterprise_user
     end
   end
 end

--- a/spec/support/feature_toggle_helper.rb
+++ b/spec/support/feature_toggle_helper.rb
@@ -3,7 +3,7 @@ module OpenFoodNetwork
     def set_feature_toggle(feature, status)
       features = OpenFoodNetwork::FeatureToggle.features
       features[feature] = status
-      OpenFoodNetwork::FeatureToggle.stub(:features) { features }
+      allow(OpenFoodNetwork::FeatureToggle).to receive(:features) { features }
     end
   end
 end

--- a/spec/support/matchers/delegate_matchers.rb
+++ b/spec/support/matchers/delegate_matchers.rb
@@ -17,8 +17,8 @@ RSpec::Matchers.define :delegate do |method|
     rescue NoMethodError
       raise "#{@delegator} does not respond to #{@to}!"
     end
-    @delegator.stub(@to).and_return double('receiver')
-    @delegator.send(@to).stub(method).and_return :called
+    allow(@delegator).to receive(@to).and_return double('receiver')
+    allow(@delegator.send(@to)).to receive(method).and_return :called
     @delegator.send(@method) == :called
   end
 

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -71,4 +71,15 @@ end
 
 RSpec.configure do |config|
   config.extend AuthenticationWorkflow, :type => :feature
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -13,7 +13,7 @@ module ShopWorkflow
   end
 
   def set_order(order)
-    ApplicationController.any_instance.stub(:session).and_return({order_id: order.id, access_token: order.token})
+    allow_any_instance_of(ApplicationController).to receive(:session).and_return({order_id: order.id, access_token: order.token})
   end
 
   def add_product_to_cart(order, product, quantity: 1)

--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -49,7 +49,7 @@ module UIComponentHelper
 
   def modal_should_be_open_for(object)
     within ".reveal-modal" do
-      page.should have_content object.name
+      expect(page).to have_content object.name
     end
   end
 

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -21,7 +21,7 @@ module WebHelper
     selector += "[placeholder='#{opts[:placeholder]}']" if opts.key? :placeholder
 
     element = page.all(selector).first
-    element.value.should == opts[:with] if element && opts.key?(:with)
+    expect(element.value).to eq(opts[:with]) if element && opts.key?(:with)
 
     have_selector selector
   end
@@ -47,14 +47,14 @@ module WebHelper
   end
 
   def should_have_failed
-    page.status_code.should == 200
-    errors.count.should > 0
+    expect(page.status_code).to eq(200)
+    expect(errors.count).to be > 0
   end
 
   def successful?
-    page.status_code.should == 200
-    errors.count.should == 0
-    flash_message.should include 'successful'
+    expect(page.status_code).to eq(200)
+    expect(errors.count).to eq(0)
+    expect(flash_message).to include 'successful'
   end
 
   def updated_field(field, value)

--- a/spec/views/json/producers.json.rabl_spec.rb
+++ b/spec/views/json/producers.json.rabl_spec.rb
@@ -5,11 +5,11 @@ describe 'json/_producers.json.rabl' do
   let(:render) { Rabl.render([producer], 'json/producers', view_path: 'app/views', scope: RablHelper::FakeContext.instance) }
   
   pending "renders a list of producers" do
-    render.should have_json_type(Array).at_path ''
-    render.should have_json_type(Object).at_path '0'
+    expect(render).to have_json_type(Array).at_path ''
+    expect(render).to have_json_type(Object).at_path '0'
   end
 
   pending "renders names" do
-    render.should be_json_eql(producer.name.to_json).at_path '0/name'
+    expect(render).to be_json_eql(producer.name.to_json).at_path '0/name'
   end
 end


### PR DESCRIPTION
#### What? Why?

Partially addresses #2097 

This disables `should` syntax and converts all existing specs to `expect` syntax.

This conversion is done by [Transpec](http://yujinakayama.me/transpec/) 3.3.0 with the following command:
    transpec

* 1858 conversions
    from: obj.should
      to: expect(obj).to

* 888 conversions
    from: == expected
      to: eq(expected)

* 368 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 219 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 111 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 89 conversions
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)

* 74 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 24 conversions
    from: it { should_not ... }
      to: it { is_expected.not_to ... }

* 19 conversions
    from: obj.stub_chain(:message1, :message2)
      to: allow(obj).to receive_message_chain(:message1, :message2)

* 7 conversions
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

* 7 conversions
    from: lambda { }.should_not
      to: expect { }.not_to

* 6 conversions
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

* 5 conversions
    from: =~ /pattern/
      to: match(/pattern/)

* 4 conversions
    from: < expected
      to: be < expected

* 1 conversion
    from: === expected
      to: be === expected

* 1 conversion
    from: > expected
      to: be > expected

* 1 conversion
    from: Klass.any_instance.should_not_receive(:message)
      to: expect_any_instance_of(Klass).not_to receive(:message)

* 1 conversion
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 1 addition
      of: RSpec.configure { |c| c.infer_spec_type_from_file_location! }

For more details: https://github.com/yujinakayama/transpec#supported-conversions


#### What should we test?

No behavior change. With green tests is enough.

#### Release notes

Test suite converted from RSpec's `should` to `expect` syntax.