### PR TITLE
Remove in_stock dead scope

### DIFF
--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -34,7 +34,6 @@ Spree::Variant.class_eval do
   scope :with_order_cycles_inner, joins(exchanges: :order_cycle)
 
   scope :not_deleted, where(deleted_at: nil)
-  scope :in_stock, where('spree_variants.count_on_hand > 0 OR spree_variants.on_demand=?', true)
   scope :in_order_cycle, lambda { |order_cycle|
     with_order_cycles_inner.
       merge(Exchange.outgoing).

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -21,23 +21,6 @@ module Spree
         Spree::Variant.not_deleted.should_not include v_deleted
       end
 
-      describe "finding variants in stock" do
-        before do
-          p = create(:product, on_hand: 0)
-          @v_in_stock = create(:variant, product: p)
-          @v_on_demand = create(:variant, product: p, on_demand: true)
-          @v_no_stock = create(:variant, product: p)
-
-          @v_in_stock.update_attribute(:count_on_hand, 1)
-          @v_on_demand.update_attribute(:count_on_hand, 0)
-          @v_no_stock.update_attribute(:count_on_hand, 0)
-        end
-
-        it "returns variants in stock or on demand, but not those that are neither" do
-          Variant.where(is_master: false).in_stock.should match_array [@v_in_stock, @v_on_demand]
-        end
-      end
-
       describe "finding variants in a distributor" do
         let!(:d1) { create(:distributor_enterprise) }
         let!(:d2) { create(:distributor_enterprise) }


### PR DESCRIPTION
#### What? Why?

Partially addresses https://github.com/openfoodfoundation/openfoodnetwork/issues/2014

This makes the upgrade to Spree 2.0 a bit easier. `spree_variants.count_on_hand` is removed in that version and this column was used in the `in_stock` scope that we no longer use.

#### What should we test?

Variants should work as expected: creation, edition, etc.

#### Release notes

Removed `in_stock` unused ActiveRecord scope.

#### How is this related to the Spree upgrade?

It's a backward compatible change towards https://github.com/openfoodfoundation/openfoodnetwork/issues/2014
