### PR TITLE
Calculate price sack fees

### DIFF
--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -19,7 +19,7 @@ class EnterpriseFee < ActiveRecord::Base
   attr_accessible :enterprise_id, :fee_type, :name, :tax_category_id, :calculator_type, :inherits_tax_category
 
   FEE_TYPES = %w(packing transport admin sales fundraising)
-  PER_ORDER_CALCULATORS = ['Spree::Calculator::FlatRate', 'Spree::Calculator::FlexiRate']
+  PER_ORDER_CALCULATORS = ['Spree::Calculator::FlatRate', 'Spree::Calculator::FlexiRate', 'Spree::Calculator::PriceSack']
 
 
   validates_inclusion_of :fee_type, :in => FEE_TYPES

--- a/app/models/spree/calculator/price_sack_decorator.rb
+++ b/app/models/spree/calculator/price_sack_decorator.rb
@@ -13,13 +13,13 @@ module Spree
     end
 
     def compute(object)
-      min = self.preferred_minimal_amount.to_i
+      min = preferred_minimal_amount.to_i
       order_amount = line_items_for(object).map { |x| x.price * x.quantity }.sum
 
       if order_amount < min
-        cost = preferred_normal_amount
+        cost = preferred_normal_amount.to_i
       elsif order_amount >= min
-        cost = preferred_discount_amount
+        cost = preferred_discount_amount.to_i
       end
 
       cost

--- a/app/models/spree/calculator/price_sack_decorator.rb
+++ b/app/models/spree/calculator/price_sack_decorator.rb
@@ -11,5 +11,18 @@ module Spree
     def self.description
       I18n.t(:price_sack)
     end
+
+    def compute(object)
+      min = self.preferred_minimal_amount.to_i
+      order_amount = line_items_for(object).map { |x| x.price * x.quantity }.sum
+
+      if order_amount < min
+        cost = preferred_normal_amount
+      elsif order_amount >= min
+        cost = preferred_discount_amount
+      end
+
+      cost
+    end
   end
 end

--- a/spec/models/enterprise_fee_spec.rb
+++ b/spec/models/enterprise_fee_spec.rb
@@ -22,7 +22,7 @@ describe EnterpriseFee do
       oc = create(:simple_order_cycle, coordinator_fees: [ef])
 
       ef.destroy
-      oc.reload.coordinator_fee_ids.should be_empty
+      expect(oc.reload.coordinator_fee_ids).to be_empty
     end
 
     it "removes itself from order cycle exchange fees when destroyed" do
@@ -30,7 +30,7 @@ describe EnterpriseFee do
       ex = create(:exchange, order_cycle: oc, enterprise_fees: [ef])
 
       ef.destroy
-      ex.reload.exchange_fee_ids.should be_empty
+      expect(ex.reload.exchange_fee_ids).to be_empty
     end
 
     describe "for tax_category" do
@@ -69,17 +69,17 @@ describe EnterpriseFee do
       it "does not return fees with FlatRate and FlexiRate calculators" do
         create(:enterprise_fee, calculator: Spree::Calculator::FlatRate.new)
         create(:enterprise_fee, calculator: Spree::Calculator::FlexiRate.new)
+        create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)
 
-        EnterpriseFee.per_item.should be_empty
+        expect(EnterpriseFee.per_item).to be_empty
       end
 
       it "returns fees with any other calculator" do
         ef1 = create(:enterprise_fee, calculator: Spree::Calculator::DefaultTax.new)
         ef2 = create(:enterprise_fee, calculator: Calculator::FlatPercentPerItem.new)
         ef3 = create(:enterprise_fee, calculator: Spree::Calculator::PerItem.new)
-        ef4 = create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)
 
-        EnterpriseFee.per_item.should match_array [ef1, ef2, ef3, ef4]
+        expect(EnterpriseFee.per_item).to match_array [ef1, ef2, ef3]
       end
     end
 
@@ -87,17 +87,17 @@ describe EnterpriseFee do
       it "returns fees with FlatRate and FlexiRate calculators" do
         ef1 = create(:enterprise_fee, calculator: Spree::Calculator::FlatRate.new)
         ef2 = create(:enterprise_fee, calculator: Spree::Calculator::FlexiRate.new)
+        ef3 = create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)
 
-        EnterpriseFee.per_order.should match_array [ef1, ef2]
+        expect(EnterpriseFee.per_order).to match_array [ef1, ef2, ef3]
       end
 
       it "does not return fees with any other calculator" do
         ef1 = create(:enterprise_fee, calculator: Spree::Calculator::DefaultTax.new)
         ef2 = create(:enterprise_fee, calculator: Calculator::FlatPercentPerItem.new)
         ef3 = create(:enterprise_fee, calculator: Spree::Calculator::PerItem.new)
-        ef4 = create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)
 
-        EnterpriseFee.per_order.should be_empty
+        expect(EnterpriseFee.per_order).to be_empty
       end
     end
   end

--- a/spec/models/enterprise_fee_spec.rb
+++ b/spec/models/enterprise_fee_spec.rb
@@ -66,7 +66,7 @@ describe EnterpriseFee do
 
   describe "scopes" do
     describe "finding per-item enterprise fees" do
-      it "does not return fees with FlatRate and FlexiRate calculators" do
+      it "does not return fees with FlatRate, FlexiRate and PriceSack calculators" do
         create(:enterprise_fee, calculator: Spree::Calculator::FlatRate.new)
         create(:enterprise_fee, calculator: Spree::Calculator::FlexiRate.new)
         create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)
@@ -84,7 +84,7 @@ describe EnterpriseFee do
     end
 
     describe "finding per-order enterprise fees" do
-      it "returns fees with FlatRate and FlexiRate calculators" do
+      it "returns fees with FlatRate, FlexiRate and PriceSack calculators" do
         ef1 = create(:enterprise_fee, calculator: Spree::Calculator::FlatRate.new)
         ef2 = create(:enterprise_fee, calculator: Spree::Calculator::FlexiRate.new)
         ef3 = create(:enterprise_fee, calculator: Spree::Calculator::PriceSack.new)

--- a/spec/models/spree/calculator/price_sack_spec.rb
+++ b/spec/models/spree/calculator/price_sack_spec.rb
@@ -9,10 +9,20 @@ describe Spree::Calculator::PriceSack do
     calculator
   end
 
-  let(:line_item) { build(:line_item, price: 1, quantity: 2) }
+  let(:line_item) { build(:line_item, price: price, quantity: 2) }
 
-  it "computes with a line item object" do
-    calculator.compute(line_item)
+  context 'when the order amount is below preferred minimal' do
+    let(:price) { 2 }
+    it "computes with a line item object" do
+      expect(calculator.compute(line_item)).to eq(10)
+    end
+  end
+
+  context 'when the order amount is above preferred minimal' do
+    let(:price) { 6 }
+    it "computes with a line item object" do
+      expect(calculator.compute(line_item)).to eq(1)
+    end
   end
 
   context "extends LocalizedNumber" do

--- a/spec/models/spree/calculator/price_sack_spec.rb
+++ b/spec/models/spree/calculator/price_sack_spec.rb
@@ -13,14 +13,14 @@ describe Spree::Calculator::PriceSack do
 
   context 'when the order amount is below preferred minimal' do
     let(:price) { 2 }
-    it "computes with a line item object" do
+    it "uses the preferred normal amount" do
       expect(calculator.compute(line_item)).to eq(10)
     end
   end
 
   context 'when the order amount is above preferred minimal' do
     let(:price) { 6 }
-    it "computes with a line item object" do
+    it "uses the preferred discount amount" do
       expect(calculator.compute(line_item)).to eq(1)
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #2173 
Price Sack fees were not calculated.

Much like #2178 the `compute` method returns the right fee depending on the global order amount. I also added `PriceSack` calculator to the `per_order` list, so the calculation is made on the global order amount and not on each item.

#### What should we test?

When an order is created, the right price sack fee is given.

#### Release notes

Price Sack fee is now calculated depending on the order amount and displayed in the cart when an order is made.