### PR TITLE
Replacing deprecated #ignore with #transient

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -87,7 +87,7 @@ FactoryGirl.define do
 
     coordinator { Enterprise.is_distributor.first || FactoryGirl.create(:distributor_enterprise) }
 
-    ignore do
+    transient do
       suppliers []
       distributors []
       variants []
@@ -148,7 +148,7 @@ FactoryGirl.define do
     shipping_method { create(:shipping_method, distributors: [shop]) }
     begins_at { 1.month.ago }
 
-    ignore do
+    transient do
       with_items false
       with_proxy_orders false
     end
@@ -218,7 +218,7 @@ FactoryGirl.define do
     is_primary_producer false
     sells "any"
 
-    ignore do
+    transient do
       with_payment_and_shipping false
     end
 
@@ -250,7 +250,7 @@ FactoryGirl.define do
   end
 
   factory :enterprise_fee, :class => EnterpriseFee do
-    ignore { amount nil }
+    transient { amount nil }
 
     sequence(:name) { |n| "Enterprise fee #{n}" }
     sequence(:fee_type) { |n| EnterpriseFee::FEE_TYPES[n % EnterpriseFee::FEE_TYPES.count] }
@@ -316,7 +316,7 @@ FactoryGirl.define do
   end
 
   factory :completed_order_with_fees, parent: :order_with_totals_and_distribution do
-    ignore do
+    transient do
       shipping_fee 3
       payment_fee 5
     end
@@ -345,7 +345,7 @@ FactoryGirl.define do
   end
 
   factory :taxed_product, :parent => :product do
-    ignore do
+    transient do
       tax_rate_amount 0
       zone nil
     end
@@ -473,7 +473,7 @@ FactoryGirl.modify do
   end
 
   factory :payment do
-    ignore do
+    transient do
       distributor { order.distributor || Enterprise.is_distributor.first || FactoryGirl.create(:distributor_enterprise) }
     end
     payment_method { FactoryGirl.create(:payment_method, distributors: [distributor]) }


### PR DESCRIPTION
#### What? Why?

Closes #2137 

A change in the FactoryGirl interface resulted in a deprecation warning during tests

#### What should we test?

Factories are defined in several places. The following examples are cited in the documentation:
- lib/spree/core/testing_support/factories/calculator_factory.rb
  * calculator
  * no_amount_calculator

- lib/spree/core/testing_support/factories/order_factory.rb
 * order
 * order_with_totals
 * order_with_inventory_unit_shipped
 * completed_order_with_totals



