### PR TITLE
Set enterprise form dirty on any change

### DIFF
--- a/app/views/admin/enterprises/_ng_form.html.haml
+++ b/app/views/admin/enterprises/_ng_form.html.haml
@@ -2,6 +2,7 @@
 -# ng-change is only valid for inputs, not for a form.
 -# So we use onchange and have to get the scope to access the ng controller
 = form_for [main_app, :admin, @enterprise], html: { name: "enterprise_form",
+  onchange: "angular.element(enterprise_form).scope().setFormDirty()",
   "ng-controller" => 'enterpriseCtrl',
   "ng-cloak" => true } do |f|
 


### PR DESCRIPTION
Commit 4953c69123059e44f64d0a2ea24f001cd6b2dff4 introduced a bug that the save button is not activated when changing enterprise fields. https://github.com/openfoodfoundation/openfoodnetwork/issues/2195

This is reverting the change and fixes #2195. Sadly, it re-opens https://github.com/openfoodfoundation/openfoodnetwork/issues/1216. But that one is not as severe as the current bug.

#### What should we test?

Test that the named enterprise fields can be edited.
Also test that the manager assignment still works.

#### Release notes

The enterprise save button is clickable again (issue since v1.12).