### PR TITLE
Change shop/products properties filter join word from '&' to 'OR' 

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
@@ -50,7 +50,7 @@ Darkswarm.controller "ProductsCtrl", ($scope, $filter, $rootScope, Products, Ord
   $scope.appliedPropertiesList = ->
     $scope.activeProperties.map( (property_id) ->
       Properties.properties_by_id[property_id].name
-    ).join(" & ") if $scope.activeProperties?
+    ).join(" " + t('shop.products.filter_properties_or' ) + " ") if $scope.activeProperties?
 
   $scope.clearAll = ->
     $scope.query = ""

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1018,7 +1018,8 @@ en:
       require_customer_login: "This shop is for customers only."
       require_login_html: "Please %{login} if you have an account already. Otherwise, %{register} to become a customer."
       require_customer_html: "Please %{contact} %{enterprise} to become a customer."
-
+    products:
+      filter_properties_or: 'OR'
 
   # Front-end controller translations
   card_could_not_be_saved: card could not be saved


### PR DESCRIPTION
#### What? Why?
Simple change to replace the existing '&' used to join shop/product properties in the filter selection with 'OR'.  The 'OR' has been internationalised in the en.yml file.

This change was requested in OFN #985 

Closes #985  

The change was requested by @NickWeir63 to make the properties filter conditions more accurately represent what is happening on screen.

#### What should we test?
Simple text change.  Test that the join text is shown as described and that, once translated, is works properly in other languages.

