### PR TITLE
Add Skylight's performance monitoring badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/openfoodfoundation/openfoodnetwork.svg?branch=master)](https://travis-ci.org/openfoodfoundation/openfoodnetwork)
 [![Code Climate](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork.png)](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork)
+[![View performance data on Skylight](https://badges.skylight.io/status/EiXQ6sSKij8y.svg)](https://oss.skylight.io/app/applications/EiXQ6sSKij8y)
 
 # Open Food Network
 


### PR DESCRIPTION
#### What? Why?

Adding the badge, which points now to Katuma's performance monitoring information, is required for Skylight to showcase OFN on their website.

This is the only Skylight account we have now, but as soon as Australia creates and sets up their own I suggest we use their badge instead. That is the OFN instance with the higher traffic and so the one that will let us see the worse performance bottlenecks we have and some newer instances may not have experienced.

#### Context

Remember [Skylight](www.skylight.io) was added some time ago in https://github.com/openfoodfoundation/openfoodnetwork/pull/2070
