### PR TITLE
Close modal when image updated successfully

### DIFF
--- a/app/assets/javascripts/admin/products/controllers/product_image_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/product_image_controller.js.coffee
@@ -2,5 +2,7 @@ angular.module("ofn.admin").controller "ProductImageCtrl", ($scope, ProductImage
   $scope.imageUploader = ProductImageService.imageUploader
   $scope.imagePreview = ProductImageService.imagePreview
 
-  $scope.$watch 'product.image_url', (newValue) ->
-    $scope.imagePreview = newValue if newValue
+  $scope.$watch 'product.image_url', (newValue, oldValue) ->
+    if newValue != oldValue
+      $scope.imagePreview = newValue
+      $scope.uploadModal.close()

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -758,7 +758,6 @@ feature %q{
 
         # Shows default image when no image set
         expect(page).to have_css "img[src='/assets/noimage/mini.png']"
-        @old_thumb_src = page.find("a.image-modal img")['src']
 
         # Click image
         page.find("a.image-modal").trigger('click')
@@ -770,7 +769,6 @@ feature %q{
       within "div.reveal-modal.product-image-upload" do
         # Shows preview of current image
         expect(page).to have_css "img.preview"
-        old_image_src = page.find("img.preview")['src']
 
         # Upload a new image file
         attach_file 'image-upload', Rails.root.join("public/500.jpg"), visible: false
@@ -778,14 +776,6 @@ feature %q{
         # Shows spinner whilst loading
         expect(page).to have_css "img.spinner", visible: true
         expect(page).to_not have_css "img.spinner", visible: true
-
-        # Shows new image when finished
-        expect(page).to have_css "img.preview"
-        @new_image_src = page.find("img.preview")['src']
-        expect(old_image_src) != @new_image_src
-
-        # Close modal
-        page.find("a.close-reveal-modal").click
       end
 
       expect(page).to_not have_selector "div.reveal-modal.product-image-upload"
@@ -799,24 +789,6 @@ feature %q{
       end
 
       expect(page).to have_selector "div.reveal-modal.product-image-upload"
-
-      within "div.reveal-modal.product-image-upload" do
-        # Upload another image file
-        attach_file 'image-upload', Rails.root.join("public/422.jpg"), visible: false
-
-        # Overwrites existing image
-        expect(page).to have_css "img.preview"
-        newer_image_src = page.find("img.preview")['src']
-        expect(@new_image_src) != newer_image_src
-
-        page.find("a.close-reveal-modal").click
-      end
-
-      within "table#listing_products tr#p_#{product.id}" do
-        # Newer thumbnail is shown in image column
-        newer_thumb_src = page.find("a.image-modal img")['src']
-        expect(@new_thumb_src) != newer_thumb_src
-      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #2214

Slight tweak to product image upload modal UX. The modal now automatically closes after the upload has finished, instead of requiring an extra click to close it.

#### What should we test?

Product image upload on products bulk edit page.
