### PR TITLE
Upgrade to latest Skylight from 1.6.0 to 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    skylight (1.6.0)
+    skylight (1.6.1)
       activesupport (>= 3.0.0)
     spinjs-rails (1.3)
       rails (>= 3.1)


### PR DESCRIPTION
#### What? Why?

The folks at Skylight recommended us upgrading to 1.6.1, which brings bug fixes.