### PR TITLE
Disable totally unreliable feature test

### DIFF
--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -47,7 +47,7 @@ feature "Using embedded shopfront functionality", js: true do
       end
     end
 
-    it "allows shopping and checkout" do
+    xit "allows shopping and checkout" do
       within_frame 'test_iframe' do
         fill_in "variants[#{variant.id}]", with: 1
         wait_until_enabled 'input.add_to_cart'


### PR DESCRIPTION
#### What? Why?

We need to investigate why it fails so many times, fix it and then enable it back. As it is, it brings cons than pros preventing even PRs that don't touch code from being merged.

This happened all of a sudden. Most of the PRs I've opened lately take few builds even on Semaphore CI to pass.

https://github.com/openfoodfoundation/openfoodnetwork/issues/2233 has been created to keep track of it and eventually solve the underlying issue.