### PR TITLE
Disable password reset for unconfirmed users

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authentication/forgot_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/forgot_controller.js.coffee
@@ -13,7 +13,7 @@ Darkswarm.controller "ForgotCtrl", ($scope, $http, $location, AuthenticationServ
       $scope.errors = t 'email_required'
 
   $scope.resend_confirmation = ->
-    $http.post("/user/spree_user/confirmation", {spree_user: $scope.spree_user}).success (data)->
+    $http.post("/user/spree_user/confirmation", {spree_user: $scope.spree_user, return_url: $location.absUrl()}).success (data)->
       $scope.messages = t('devise.confirmations.send_instructions')
     .error (data) ->
       $scope.errors = t('devise.confirmations.failed_to_send')

--- a/app/assets/javascripts/darkswarm/controllers/authentication/forgot_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/forgot_controller.js.coffee
@@ -6,7 +6,14 @@ Darkswarm.controller "ForgotCtrl", ($scope, $http, $location, AuthenticationServ
     if $scope.spree_user.email != null
       $http.post("/user/spree_user/password", {spree_user: $scope.spree_user}).success (data)->
         $scope.sent = true
-      .error (data) ->
-        $scope.errors = t 'email_not_found'
+      .error (data, status) ->
+        $scope.errors = data.error
+        $scope.user_unconfirmed = (status == 401)
     else
       $scope.errors = t 'email_required'
+
+  $scope.resend_confirmation = ->
+    $http.post("/user/spree_user/confirmation", {spree_user: $scope.spree_user}).success (data)->
+      $scope.messages = t('devise.confirmations.send_instructions')
+    .error (data) ->
+      $scope.errors = t('devise.confirmations.failed_to_send')

--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -14,7 +14,7 @@ Darkswarm.controller "LoginCtrl", ($scope, $timeout, $location, $http, $window, 
       $scope.user_unconfirmed = (data.error == t('devise.failure.unconfirmed'))
 
   $scope.resend_confirmation = ->
-    $http.post("/user/spree_user/confirmation", {spree_user: $scope.spree_user}).success (data)->
+    $http.post("/user/spree_user/confirmation", {spree_user: $scope.spree_user, return_url: $location.absUrl()}).success (data)->
       $scope.messages = t('devise.confirmations.send_instructions')
     .error (data) ->
       $scope.errors = t('devise.confirmations.failed_to_send')

--- a/app/assets/javascripts/templates/forgot.html.haml
+++ b/app/assets/javascripts/templates/forgot.html.haml
@@ -2,24 +2,28 @@
   %form{ ng: { controller: "ForgotCtrl", submit: "submit()" } }
     .row
       .large-12.columns
-        .alert-box.success.radius{"ng-show" => "sent"}
-          {{'password_reset_sent' | t}}
+        .alert-box.success{"ng-show" => "sent"}
+          {{ 'password_reset_sent' | t }}
 
-    %div{"ng-show" => "!sent"}
-      .alert-box.alert{"ng-show" => "errors != null"}
-        {{ errors }}
+        .alert-box.success{"ng-show" => "messages != null"}
+          {{ messages }}
 
-      .row
-        .large-12.columns
-          %label{for: "email"} {{'signup_email' | t}}
-          %input.title.input-text{name: "email",
-            type: "email",
-            id: "email",
-            tabindex: 1,
-            "ng-model" => "spree_user.email"}
-      .row
-        .large-12.columns
-          %input.button.primary{name: "commit",
-            tabindex: "3",
-            type: "submit",
-            value: "{{'reset_password' | t}}"}
+        .alert-box.alert{"ng-show" => "errors != null"}
+          {{ errors }}
+          %a{ng: {show: 'user_unconfirmed', click: 'resend_confirmation()'}}
+            = t('devise.confirmations.resend_confirmation_email')
+
+    .row
+      .large-12.columns
+        %label{for: "email"} {{'signup_email' | t}}
+        %input.title.input-text{name: "email",
+          type: "email",
+          id: "email",
+          tabindex: 1,
+          "ng-model" => "spree_user.email"}
+    .row
+      .large-12.columns
+        %input.button.primary{name: "commit",
+          tabindex: "3",
+          type: "submit",
+          value: "{{'reset_password' | t}}"}

--- a/app/controllers/user_confirmations_controller.rb
+++ b/app/controllers/user_confirmations_controller.rb
@@ -8,6 +8,7 @@ class UserConfirmationsController < DeviseController
 
   # POST /resource/confirmation
   def create
+    set_return_url if params.key? :return_url
     self.resource = resource_class.send_confirmation_instructions(resource_params)
 
     if is_navigational_format?
@@ -29,6 +30,10 @@ class UserConfirmationsController < DeviseController
   end
 
   protected
+
+  def set_return_url
+    session[:confirmation_return_url] = params[:return_url]
+  end
 
   def after_confirmation_path_for(resource)
     result =

--- a/app/controllers/user_passwords_controller.rb
+++ b/app/controllers/user_passwords_controller.rb
@@ -4,7 +4,7 @@ class UserPasswordsController < Spree::UserPasswordsController
   before_filter :set_admin_redirect, only: :edit
 
   def create
-    return if user_unconfirmed?
+    render_unconfirmed_response && return if user_unconfirmed?
 
     self.resource = resource_class.send_reset_password_instructions(params[resource_name])
 
@@ -29,12 +29,12 @@ class UserPasswordsController < Spree::UserPasswordsController
     session["spree_user_return_to"] = params[:return_to] if params[:return_to]
   end
 
+  def render_unconfirmed_response
+    render json: { error: t('email_unconfirmed') }, status: :unauthorized
+  end
+
   def user_unconfirmed?
     user = Spree::User.find_by_email(params[:spree_user][:email])
-    if user && !user.confirmed?
-      render json: { error: t('email_unconfirmed') }, status: :unauthorized
-    end
-
     user && !user.confirmed?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1628,6 +1628,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   november: "November"
   december: "December"
   email_not_found: "Email address not found"
+  email_unconfirmed: "You must confirm your email address before you can reset your password."
   email_required: "You must provide an email address"
   logging_in: "Hold on a moment, we're logging you in"
   signup_email: "Your email"


### PR DESCRIPTION
#### What? Why?

Closes #2186. User who have not confirmed their email cannot reset their password. If they try to use the password reset, a warning message is shown, including a resend confirmation link.

Also closes #2237. When re-sending email confirmations, the `:return_url` value is updated, so that the redirect after clicking the validation link will return the user to the most recent page from which they requested the validation email, instead of the page they were on when they first signed up.

#### What should we test?

1. Resetting passwords with unconfirmed users. 
2. Resending confirmation emails from a different page then the initial signup.

#### Release notes

Users cannot use password reset until their email address is confirmed. Confirmation emails will redirect to the most recent page from which the email was requested when re-sending confirmation emails.

