### PR TITLE
Add manager dropdown UX take 2

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -50,7 +50,7 @@ angular.module("admin.enterprises")
           email: manager.email
           confirmed: manager.confirmed
         if (user for user in $scope.Enterprise.users when user.id == manager.id).length == 0
-          $scope.Enterprise.users.splice(0, 0, manager)
+          $scope.Enterprise.users.unshift(manager)
           $scope.enterprise_form?.$setDirty()
         else
           alert ("#{manager.email}" + " " + t("is_already_manager"))

--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -11,6 +11,9 @@ angular.module("admin.enterprises")
     $scope.$watch 'enterprise_form.$dirty', (newValue) ->
       StatusMessage.display 'notice', t('admin.unsaved_changes') if newValue
 
+    $scope.$watch 'newManager', (newValue) ->
+      $scope.addManager($scope.newManager) if newValue
+
     $scope.setFormDirty = ->
       $scope.$apply ->
         $scope.enterprise_form.$setDirty()
@@ -47,7 +50,7 @@ angular.module("admin.enterprises")
           email: manager.email
           confirmed: manager.confirmed
         if (user for user in $scope.Enterprise.users when user.id == manager.id).length == 0
-          $scope.Enterprise.users.push manager
+          $scope.Enterprise.users.splice(0, 0, manager)
           $scope.enterprise_form?.$setDirty()
         else
           alert ("#{manager.email}" + " " + t("is_already_manager"))

--- a/app/views/admin/enterprises/form/_users.html.haml
+++ b/app/views/admin/enterprises/form/_users.html.haml
@@ -44,7 +44,6 @@
             - # Ignore this input in the submit
             = hidden_field_tag :ignored, nil, class: "select2 fullwidth", 'user-select' => 'newManager', 'ng-model' => 'newManager'
           %td.actions
-            %a{ 'ng-click' => 'addManager(newManager)', :class => "icon-plus no-text" }
         %tr.animate-repeat{ id: "manager-{{manager.id}}", ng: { repeat: 'manager in Enterprise.users' }}
           %td
             = hidden_field_tag "enterprise[user_ids][]", nil, multiple: true, 'ng-value' => 'manager.id'

--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -111,7 +111,6 @@ feature %q{
       it "allows adding new managers" do
         within 'table.managers' do
           targetted_select2_search user3.email, from: '#s2id_ignored'
-          find('a.icon-plus.no-text').click
 
           # user3 has been added and has an unconfirmed email address
           expect(page).to have_css "tr#manager-#{user3.id}"


### PR DESCRIPTION
#### What? Why?

Closes #1216.

Minor bugfix. Enterprise user form was showing "Unsaved Changes" message before a new user was properly added.

#### What should we test?

Adding new users to an enterprise. Users are now added when selected. Other enterprise form elements should still work correctly.

