### PR TITLE
Update rubyzip to fix security issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,7 +628,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.3.14)
     sass-rails (3.2.6)


### PR DESCRIPTION
#### What? Why?

Github reported us about CVE-2017-5946 which is a high severity issue.

![dep](https://user-images.githubusercontent.com/762088/39193036-ea8fc4a0-47da-11e8-8841-d7fd48bfffde.png)

This gem is used by Roo which already supports the Rubyzip version that contains the fix (version 1.2.1). Check https://github.com/roo-rb/roo/commit/872bb3a0b67fbecf7dd4bc23ff03b7c2764462b0
for further details.

Rubyzip's changelog for the version 1.2.1 can be found in https://github.com/rubyzip/rubyzip/blob/master/Changelog.md#121. You can also check the [introduced changes](https://github.com/rubyzip/rubyzip/compare/v1.2.0...v1.2.1).

#### What should we test?

Not worth of any testing, given the nature of the changes and the reach of this dependency.