### PR TITLE
Apply spree 2.0 migrations

### DIFF
--- a/db/migrate/20180426145630_create_spree_stock_items.spree.rb
+++ b/db/migrate/20180426145630_create_spree_stock_items.spree.rb
@@ -1,0 +1,15 @@
+# This migration comes from spree (originally 20130211190146)
+class CreateSpreeStockItems < ActiveRecord::Migration
+  def change
+    create_table :spree_stock_items do |t|
+      t.belongs_to :stock_location
+      t.belongs_to :variant
+      t.integer :count_on_hand, null: false, default: 0
+      t.integer :lock_version
+
+      t.timestamps
+    end
+    add_index :spree_stock_items, :stock_location_id
+    add_index :spree_stock_items, [:stock_location_id, :variant_id], :name => 'stock_item_by_loc_and_var_id'
+  end
+end

--- a/db/migrate/20180426145631_create_spree_stock_locations.spree.rb
+++ b/db/migrate/20180426145631_create_spree_stock_locations.spree.rb
@@ -1,0 +1,12 @@
+# This migration comes from spree (originally 20130211191120)
+class CreateSpreeStockLocations < ActiveRecord::Migration
+  def change
+    create_table :spree_stock_locations do |t|
+      t.string :name
+      t.belongs_to :address
+
+      t.timestamps
+    end
+    add_index :spree_stock_locations, :address_id
+  end
+end

--- a/db/migrate/20180426145632_create_default_stock.spree.rb
+++ b/db/migrate/20180426145632_create_default_stock.spree.rb
@@ -1,0 +1,27 @@
+# This migration comes from spree (originally 20130213191427)
+class CreateDefaultStock < ActiveRecord::Migration
+  def up
+    Spree::StockLocation.skip_callback(:create, :after, :create_stock_items)
+    Spree::StockItem.skip_callback(:save, :after, :process_backorders)
+    location = Spree::StockLocation.create(name: 'default')
+    Spree::Variant.all.each do |variant|
+      stock_item = location.stock_items.build(variant: variant)
+      stock_item.send(:count_on_hand=, variant.count_on_hand)
+      stock_item.save!
+    end
+
+    remove_column :spree_variants, :count_on_hand
+  end
+
+  def down
+    add_column :spree_variants, :count_on_hand, :integer
+
+    Spree::StockItem.all.each do |stock_item|
+      stock_item.variant.update_column :count_on_hand, stock_item.count_on_hand
+    end
+
+    Spree::StockLocation.delete_all
+    Spree::StockItem.delete_all
+  end
+end
+

--- a/db/migrate/20180426145633_add_stock_location_id_to_spree_shipments.spree.rb
+++ b/db/migrate/20180426145633_add_stock_location_id_to_spree_shipments.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130226191231)
+class AddStockLocationIdToSpreeShipments < ActiveRecord::Migration
+  def change
+    add_column :spree_shipments, :stock_location_id, :integer
+  end
+end

--- a/db/migrate/20180426145634_add_pending_to_inventory_unit.spree.rb
+++ b/db/migrate/20180426145634_add_pending_to_inventory_unit.spree.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree (originally 20130227143905)
+class AddPendingToInventoryUnit < ActiveRecord::Migration
+  def change
+    add_column :spree_inventory_units, :pending, :boolean, :default => true
+    Spree::InventoryUnit.update_all(:pending => false)
+  end
+end

--- a/db/migrate/20180426145635_remove_on_demand_from_product_and_variant.spree.rb
+++ b/db/migrate/20180426145635_remove_on_demand_from_product_and_variant.spree.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree (originally 20130228164411)
+class RemoveOnDemandFromProductAndVariant < ActiveRecord::Migration
+  def change
+    remove_column :spree_products, :on_demand
+    remove_column :spree_variants, :on_demand
+  end
+end

--- a/db/migrate/20180426145636_create_shipping_method_zone.spree.rb
+++ b/db/migrate/20180426145636_create_shipping_method_zone.spree.rb
@@ -1,0 +1,23 @@
+# This migration comes from spree (originally 20130228210442)
+class CreateShippingMethodZone < ActiveRecord::Migration
+  def up
+    create_table :shipping_methods_zones, :id => false do |t|
+      t.integer :shipping_method_id
+      t.integer :zone_id
+    end
+    # This association has been corrected in a latter migration
+    # but when this database migration runs, the table is still incorrectly named
+    # 'shipping_methods_zones' instead of 'spre_shipping_methods_zones'
+    Spree::ShippingMethod.has_and_belongs_to_many :zones, :join_table => 'shipping_methods_zones',
+                                                          :class_name => 'Spree::Zone',
+                                                          :foreign_key => 'shipping_method_id'
+    Spree::ShippingMethod.all.each{|sm| sm.zones << Spree::Zone.find(sm.zone_id)}
+
+    remove_column :spree_shipping_methods, :zone_id
+  end
+
+  def down
+    drop_table :shipping_methods_zones
+    add_column :spree_shipping_methods, :zone_id, :integer
+  end
+end

--- a/db/migrate/20180426145637_remove_shipping_category_id_from_shipping_method.spree.rb
+++ b/db/migrate/20180426145637_remove_shipping_category_id_from_shipping_method.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130301162745)
+class RemoveShippingCategoryIdFromShippingMethod < ActiveRecord::Migration
+  def change
+    remove_column :spree_shipping_methods, :shipping_category_id
+  end
+end

--- a/db/migrate/20180426145638_create_shipping_method_categories.spree.rb
+++ b/db/migrate/20180426145638_create_shipping_method_categories.spree.rb
@@ -1,0 +1,14 @@
+# This migration comes from spree (originally 20130301162924)
+class CreateShippingMethodCategories < ActiveRecord::Migration
+  def change
+    create_table :spree_shipping_method_categories do |t|
+      t.integer :shipping_method_id, :null => false
+      t.integer :shipping_category_id, :null => false
+
+      t.timestamps
+    end
+
+    add_index :spree_shipping_method_categories, :shipping_method_id
+    add_index :spree_shipping_method_categories, :shipping_category_id
+  end
+end

--- a/db/migrate/20180426145639_create_spree_shipping_rates.spree.rb
+++ b/db/migrate/20180426145639_create_spree_shipping_rates.spree.rb
@@ -1,0 +1,25 @@
+# This migration comes from spree (originally 20130304162240)
+class CreateSpreeShippingRates < ActiveRecord::Migration
+  def up
+    create_table :spree_shipping_rates do |t|
+      t.belongs_to :shipment
+      t.belongs_to :shipping_method
+      t.boolean :selected, :default => false
+      t.decimal :cost, :precision => 8, :scale => 2
+      t.timestamps
+    end
+    add_index(:spree_shipping_rates, [:shipment_id, :shipping_method_id],
+              :name => 'spree_shipping_rates_join_index',
+              :unique => true)
+
+    # Spree::Shipment.all.each do |shipment|
+    #   shipping_method = Spree::ShippingMethod.find(shipment.shipment_method_id)
+    #   shipment.add_shipping_method(shipping_method, true)
+    # end
+  end
+
+  def down
+    # add_column :spree_shipments, :shipping_method_id, :integer
+    drop_table :spree_shipping_rates
+  end
+end

--- a/db/migrate/20180426145640_remove_category_match_attributes_from_shipping_method.spree.rb
+++ b/db/migrate/20180426145640_remove_category_match_attributes_from_shipping_method.spree.rb
@@ -1,0 +1,8 @@
+# This migration comes from spree (originally 20130304192936)
+class RemoveCategoryMatchAttributesFromShippingMethod < ActiveRecord::Migration
+  def change
+    remove_column :spree_shipping_methods, :match_none
+    remove_column :spree_shipping_methods, :match_one
+    remove_column :spree_shipping_methods, :match_all
+  end
+end

--- a/db/migrate/20180426145641_create_stock_movements.spree.rb
+++ b/db/migrate/20180426145641_create_stock_movements.spree.rb
@@ -1,0 +1,13 @@
+# This migration comes from spree (originally 20130305143310)
+class CreateStockMovements < ActiveRecord::Migration
+  def change
+    create_table :spree_stock_movements do |t|
+      t.belongs_to :stock_item
+      t.integer :quantity
+      t.string :action
+
+      t.timestamps
+    end
+    add_index :spree_stock_movements, :stock_item_id
+  end
+end

--- a/db/migrate/20180426145642_add_address_fields_to_stock_location.spree.rb
+++ b/db/migrate/20180426145642_add_address_fields_to_stock_location.spree.rb
@@ -1,0 +1,23 @@
+# This migration comes from spree (originally 20130306181701)
+class AddAddressFieldsToStockLocation < ActiveRecord::Migration
+  def change
+    remove_column :spree_stock_locations, :address_id
+
+    add_column :spree_stock_locations, :address1, :string
+    add_column :spree_stock_locations, :address2, :string
+    add_column :spree_stock_locations, :city, :string
+    add_column :spree_stock_locations, :state_id, :integer
+    add_column :spree_stock_locations, :state_name, :string
+    add_column :spree_stock_locations, :country_id, :integer
+    add_column :spree_stock_locations, :zipcode, :string
+    add_column :spree_stock_locations, :phone, :string
+
+
+    usa = Spree::Country.where(:iso => 'US').first
+    # In case USA isn't found.
+    # See #3115
+    country = usa || Spree::Country.first
+    Spree::Country.reset_column_information
+    Spree::StockLocation.update_all(:country_id => country)
+  end
+end

--- a/db/migrate/20180426145643_add_active_field_to_stock_locations.spree.rb
+++ b/db/migrate/20180426145643_add_active_field_to_stock_locations.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130306191917)
+class AddActiveFieldToStockLocations < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :active, :boolean, :default => true
+  end
+end

--- a/db/migrate/20180426145644_add_backorderable_to_stock_item.spree.rb
+++ b/db/migrate/20180426145644_add_backorderable_to_stock_item.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130306195650)
+class AddBackorderableToStockItem < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_items, :backorderable, :boolean, :default => true
+  end
+end

--- a/db/migrate/20180426145645_add_default_quantity_to_stock_movement.spree.rb
+++ b/db/migrate/20180426145645_add_default_quantity_to_stock_movement.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130307161754)
+class AddDefaultQuantityToStockMovement < ActiveRecord::Migration
+  def change
+    change_column :spree_stock_movements, :quantity, :integer, :default => 0
+  end
+end

--- a/db/migrate/20180426145646_add_source_and_destination_to_stock_movements.spree.rb
+++ b/db/migrate/20180426145646_add_source_and_destination_to_stock_movements.spree.rb
@@ -1,0 +1,9 @@
+# This migration comes from spree (originally 20130318151756)
+class AddSourceAndDestinationToStockMovements < ActiveRecord::Migration
+  def change
+    change_table :spree_stock_movements do |t|
+      t.references :source, polymorphic: true
+      t.references :destination, polymorphic: true
+    end
+  end
+end

--- a/db/migrate/20180426145647_add_originator_to_stock_movement.spree.rb
+++ b/db/migrate/20180426145647_add_originator_to_stock_movement.spree.rb
@@ -1,0 +1,8 @@
+# This migration comes from spree (originally 20130319183250)
+class AddOriginatorToStockMovement < ActiveRecord::Migration
+  def change
+    change_table :spree_stock_movements do |t|
+      t.references :originator, polymorphic: true
+    end
+  end
+end

--- a/db/migrate/20180426145648_drop_source_and_destination_from_stock_movement.spree.rb
+++ b/db/migrate/20180426145648_drop_source_and_destination_from_stock_movement.spree.rb
@@ -1,0 +1,16 @@
+# This migration comes from spree (originally 20130319190507)
+class DropSourceAndDestinationFromStockMovement < ActiveRecord::Migration
+  def up
+    change_table :spree_stock_movements do |t|
+      t.remove_references :source, :polymorphic => true
+      t.remove_references :destination, :polymorphic => true
+    end
+  end
+
+  def down
+    change_table :spree_stock_movements do |t|
+      t.references :source, polymorphic: true
+      t.references :destination, polymorphic: true
+    end
+  end
+end

--- a/db/migrate/20180426145649_migrate_inventory_unit_sold_to_on_hand.spree.rb
+++ b/db/migrate/20180426145649_migrate_inventory_unit_sold_to_on_hand.spree.rb
@@ -1,0 +1,10 @@
+# This migration comes from spree (originally 20130325163316)
+class MigrateInventoryUnitSoldToOnHand < ActiveRecord::Migration
+  def up
+    Spree::InventoryUnit.where(:state => 'sold').update_all(:state => 'on_hand')
+  end
+
+  def down
+    Spree::InventoryUnit.where(:state => 'on_hand').update_all(:state => 'sold')
+  end
+end

--- a/db/migrate/20180426145650_add_stock_location_to_rma.spree.rb
+++ b/db/migrate/20180426145650_add_stock_location_to_rma.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130326175857)
+class AddStockLocationToRma < ActiveRecord::Migration
+  def change
+    add_column :spree_return_authorizations, :stock_location_id, :integer
+  end
+end

--- a/db/migrate/20180426145651_update_shipment_state_for_canceled_orders.spree.rb
+++ b/db/migrate/20180426145651_update_shipment_state_for_canceled_orders.spree.rb
@@ -1,0 +1,16 @@
+# This migration comes from spree (originally 20130328130308)
+class UpdateShipmentStateForCanceledOrders < ActiveRecord::Migration
+  def up
+    shipments = Spree::Shipment.joins(:order).
+      where("spree_orders.state = 'canceled'")
+    case Spree::Shipment.connection.adapter_name
+    when "SQLite3"
+      shipments.update_all("state = 'cancelled'")
+    when "MySQL" || "PostgreSQL"
+      shipments.update_all("spree_shipments.state = 'cancelled'")
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20180426145652_remove_stock_item_and_variant_lock.spree.rb
+++ b/db/migrate/20180426145652_remove_stock_item_and_variant_lock.spree.rb
@@ -1,0 +1,15 @@
+# This migration comes from spree (originally 20130329134939)
+class RemoveStockItemAndVariantLock < ActiveRecord::Migration
+  def up
+    # we are moving to pessimistic locking on stock_items
+    remove_column :spree_stock_items, :lock_version
+
+    # variants no longer manage their count_on_hand so we are removing their lock
+    remove_column :spree_variants, :lock_version
+  end
+
+  def down
+    add_column :spree_stock_items, :lock_version, :integer
+    add_column :spree_variants, :lock_version, :integer
+  end
+end

--- a/db/migrate/20180426145653_add_shipping_rates_to_shipments.spree.rb
+++ b/db/migrate/20180426145653_add_shipping_rates_to_shipments.spree.rb
@@ -1,0 +1,16 @@
+# This migration comes from spree (originally 20130417123427)
+class AddShippingRatesToShipments < ActiveRecord::Migration
+  def up
+    Spree::Shipment.all.each do |shipment|
+      shipment.shipping_rates.create(:shipping_method_id => shipment.shipping_method_id,
+                                     :cost => shipment.cost,
+                                     :selected => true)
+    end
+
+    remove_column :spree_shipments, :shipping_method_id
+  end
+
+  def down
+    add_column :spree_shipments, :shipping_method_id, :integer
+  end
+end

--- a/db/migrate/20180426145654_create_spree_stock_transfers.spree.rb
+++ b/db/migrate/20180426145654_create_spree_stock_transfers.spree.rb
@@ -1,0 +1,15 @@
+# This migration comes from spree (originally 20130418125341)
+class CreateSpreeStockTransfers < ActiveRecord::Migration
+  def change
+    create_table :spree_stock_transfers do |t|
+      t.string :type
+      t.string :reference_number
+      t.integer :source_location_id
+      t.integer :destination_location_id
+      t.timestamps
+    end
+
+    add_index :spree_stock_transfers, :source_location_id
+    add_index :spree_stock_transfers, :destination_location_id
+  end
+end

--- a/db/migrate/20180426145655_drop_products_count_on_hand.spree.rb
+++ b/db/migrate/20180426145655_drop_products_count_on_hand.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130423110707)
+class DropProductsCountOnHand < ActiveRecord::Migration
+  def up
+    remove_column :spree_products, :count_on_hand
+  end
+end

--- a/db/migrate/20180426145656_set_default_shipping_rate_cost.spree.rb
+++ b/db/migrate/20180426145656_set_default_shipping_rate_cost.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130423223847)
+class SetDefaultShippingRateCost < ActiveRecord::Migration
+  def change
+    change_column :spree_shipping_rates, :cost, :decimal, default: 0, precision: 8, scale: 2
+  end
+end

--- a/db/migrate/20180426145657_add_number_to_stock_transfer.spree.rb
+++ b/db/migrate/20180426145657_add_number_to_stock_transfer.spree.rb
@@ -1,0 +1,24 @@
+# This migration comes from spree (originally 20130509115210)
+class AddNumberToStockTransfer < ActiveRecord::Migration
+  def up
+    remove_index :spree_stock_transfers, :source_location_id
+    remove_index :spree_stock_transfers, :destination_location_id
+
+    rename_column :spree_stock_transfers, :reference_number, :reference
+    add_column :spree_stock_transfers, :number, :string
+
+    Spree::StockTransfer.all.each do |transfer|
+      transfer.send(:generate_stock_transfer_number)
+      transfer.save!
+    end
+
+    add_index :spree_stock_transfers, :number
+    add_index :spree_stock_transfers, :source_location_id
+    add_index :spree_stock_transfers, :destination_location_id
+  end
+
+  def down
+    rename_column :spree_stock_transfers, :reference, :reference_number
+    remove_column :spree_stock_transfers, :number, :string
+  end
+end

--- a/db/migrate/20180426145658_add_sku_index_to_spree_variants.spree.rb
+++ b/db/migrate/20180426145658_add_sku_index_to_spree_variants.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130514151929)
+class AddSkuIndexToSpreeVariants < ActiveRecord::Migration
+  def change
+    add_index :spree_variants, :sku
+  end
+end

--- a/db/migrate/20180426145659_add_backorderable_default_to_spree_stock_location.spree.rb
+++ b/db/migrate/20180426145659_add_backorderable_default_to_spree_stock_location.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130515180736)
+class AddBackorderableDefaultToSpreeStockLocation < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :backorderable_default, :boolean, default: true
+  end
+end

--- a/db/migrate/20180426145660_add_propage_all_variants_to_spree_stock_location.spree.rb
+++ b/db/migrate/20180426145660_add_propage_all_variants_to_spree_stock_location.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130516151222)
+class AddPropageAllVariantsToSpreeStockLocation < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :propagate_all_variants, :boolean, default: true
+  end
+end

--- a/db/migrate/20180426145661_rename_shipping_methods_zones_to_spree_shipping_methods_zones.spree.rb
+++ b/db/migrate/20180426145661_rename_shipping_methods_zones_to_spree_shipping_methods_zones.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130611054351)
+class RenameShippingMethodsZonesToSpreeShippingMethodsZones < ActiveRecord::Migration
+  def change
+    rename_table :shipping_methods_zones, :spree_shipping_methods_zones
+  end
+end

--- a/db/migrate/20180426145662_add_deleted_at_to_spree_tax_rates.spree.rb
+++ b/db/migrate/20180426145662_add_deleted_at_to_spree_tax_rates.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130708052307)
+class AddDeletedAtToSpreeTaxRates < ActiveRecord::Migration
+  def change
+    add_column :spree_tax_rates, :deleted_at, :datetime
+  end
+end

--- a/db/migrate/20180426145663_remove_lock_version_from_inventory_units.spree.rb
+++ b/db/migrate/20180426145663_remove_lock_version_from_inventory_units.spree.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree (originally 20130711200933)
+class RemoveLockVersionFromInventoryUnits < ActiveRecord::Migration
+  def change
+    # we are moving to pessimistic locking on stock_items
+    remove_column :spree_inventory_units, :lock_version
+  end
+end

--- a/db/migrate/20180426145664_add_cost_price_to_line_item.spree.rb
+++ b/db/migrate/20180426145664_add_cost_price_to_line_item.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130718042445)
+class AddCostPriceToLineItem < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :cost_price, :decimal, :precision => 8, :scale => 2
+  end
+end

--- a/db/migrate/20180426145665_set_backorderable_to_default_to_false.spree.rb
+++ b/db/migrate/20180426145665_set_backorderable_to_default_to_false.spree.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree (originally 20130718233855)
+class SetBackorderableToDefaultToFalse < ActiveRecord::Migration
+  def change
+    change_column :spree_stock_items, :backorderable, :boolean, :default => false
+    change_column :spree_stock_locations, :backorderable_default, :boolean, :default => false
+  end
+end

--- a/db/migrate/20180426145666_add_created_by_id_to_spree_orders.spree.rb
+++ b/db/migrate/20180426145666_add_created_by_id_to_spree_orders.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130725031716)
+class AddCreatedByIdToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :created_by_id, :integer
+  end
+end

--- a/db/migrate/20180426145667_index_completed_at_on_spree_orders.spree.rb
+++ b/db/migrate/20180426145667_index_completed_at_on_spree_orders.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130729214043)
+class IndexCompletedAtOnSpreeOrders < ActiveRecord::Migration
+  def change
+    add_index :spree_orders, :completed_at
+  end
+end

--- a/db/migrate/20180426145668_add_tax_category_id_to_spree_line_items.spree.rb
+++ b/db/migrate/20180426145668_add_tax_category_id_to_spree_line_items.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20130802014537)
+class AddTaxCategoryIdToSpreeLineItems < ActiveRecord::Migration
+  def change
+    add_column :spree_line_items, :tax_category_id, :integer
+  end
+end

--- a/db/migrate/20180426145669_migrate_tax_categories_to_line_items.spree.rb
+++ b/db/migrate/20180426145669_migrate_tax_categories_to_line_items.spree.rb
@@ -1,0 +1,10 @@
+# This migration comes from spree (originally 20130802022321)
+class MigrateTaxCategoriesToLineItems < ActiveRecord::Migration
+  def change
+  	Spree::LineItem.includes(:variant => { :product => :tax_category }).find_in_batches do |line_items|
+  	  line_items.each do |line_item|
+        line_item.update_column(:tax_category_id, line_item.product.tax_category.id)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180316034336) do
+ActiveRecord::Schema.define(:version => 20180426145669) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -514,14 +514,14 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
   end
 
   create_table "spree_inventory_units", :force => true do |t|
-    t.integer  "lock_version",            :default => 0
     t.string   "state"
     t.integer  "variant_id"
     t.integer  "order_id"
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
     t.integer  "shipment_id"
     t.integer  "return_authorization_id"
+    t.boolean  "pending",                 :default => true
   end
 
   add_index "spree_inventory_units", ["order_id"], :name => "index_inventory_units_on_order_id"
@@ -540,6 +540,8 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.decimal  "distribution_fee",     :precision => 10, :scale => 2
     t.string   "shipping_method_name"
     t.decimal  "final_weight_volume",  :precision => 10, :scale => 2
+    t.decimal  "cost_price",           :precision => 8,  :scale => 2
+    t.integer  "tax_category_id"
   end
 
   add_index "spree_line_items", ["order_id"], :name => "index_line_items_on_order_id"
@@ -621,8 +623,10 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.string   "last_ip_address"
     t.integer  "cart_id"
     t.integer  "customer_id"
+    t.integer  "created_by_id"
   end
 
+  add_index "spree_orders", ["completed_at"], :name => "index_spree_orders_on_completed_at"
   add_index "spree_orders", ["customer_id"], :name => "index_spree_orders_on_customer_id"
   add_index "spree_orders", ["number"], :name => "index_orders_on_number"
 
@@ -745,7 +749,7 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
   add_index "spree_product_scopes", ["product_group_id"], :name => "index_product_scopes_on_product_group_id"
 
   create_table "spree_products", :force => true do |t|
-    t.string   "name",                 :default => "",    :null => false
+    t.string   "name",                 :default => "",   :null => false
     t.text     "description"
     t.datetime "available_on"
     t.datetime "deleted_at"
@@ -754,19 +758,17 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.string   "meta_keywords"
     t.integer  "tax_category_id"
     t.integer  "shipping_category_id"
-    t.datetime "created_at",                              :null => false
-    t.datetime "updated_at",                              :null => false
-    t.integer  "count_on_hand",        :default => 0
+    t.datetime "created_at",                             :null => false
+    t.datetime "updated_at",                             :null => false
     t.integer  "supplier_id"
     t.boolean  "group_buy"
     t.float    "group_buy_unit_size"
-    t.boolean  "on_demand",            :default => false
     t.string   "variant_unit"
     t.float    "variant_unit_scale"
     t.string   "variant_unit_name"
     t.text     "notes"
-    t.integer  "primary_taxon_id",                        :null => false
-    t.boolean  "inherits_properties",  :default => true,  :null => false
+    t.integer  "primary_taxon_id",                       :null => false
+    t.boolean  "inherits_properties",  :default => true, :null => false
   end
 
   add_index "spree_products", ["available_on"], :name => "index_products_on_available_on"
@@ -845,11 +847,12 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
   create_table "spree_return_authorizations", :force => true do |t|
     t.string   "number"
     t.string   "state"
-    t.decimal  "amount",     :precision => 10, :scale => 2, :default => 0.0, :null => false
+    t.decimal  "amount",            :precision => 10, :scale => 2, :default => 0.0, :null => false
     t.integer  "order_id"
     t.text     "reason"
-    t.datetime "created_at",                                                 :null => false
-    t.datetime "updated_at",                                                 :null => false
+    t.datetime "created_at",                                                        :null => false
+    t.datetime "updated_at",                                                        :null => false
+    t.integer  "stock_location_id"
   end
 
   create_table "spree_roles", :force => true do |t|
@@ -867,14 +870,14 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
   create_table "spree_shipments", :force => true do |t|
     t.string   "tracking"
     t.string   "number"
-    t.decimal  "cost",               :precision => 8, :scale => 2
+    t.decimal  "cost",              :precision => 8, :scale => 2
     t.datetime "shipped_at"
     t.integer  "order_id"
-    t.integer  "shipping_method_id"
     t.integer  "address_id"
-    t.datetime "created_at",                                       :null => false
-    t.datetime "updated_at",                                       :null => false
+    t.datetime "created_at",                                      :null => false
+    t.datetime "updated_at",                                      :null => false
     t.string   "state"
+    t.integer  "stock_location_id"
   end
 
   add_index "spree_shipments", ["number"], :name => "index_shipments_on_number"
@@ -887,21 +890,42 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.boolean  "temperature_controlled", :default => false, :null => false
   end
 
+  create_table "spree_shipping_method_categories", :force => true do |t|
+    t.integer  "shipping_method_id",   :null => false
+    t.integer  "shipping_category_id", :null => false
+    t.datetime "created_at",           :null => false
+    t.datetime "updated_at",           :null => false
+  end
+
+  add_index "spree_shipping_method_categories", ["shipping_category_id"], :name => "index_spree_shipping_method_categories_on_shipping_category_id"
+  add_index "spree_shipping_method_categories", ["shipping_method_id"], :name => "index_spree_shipping_method_categories_on_shipping_method_id"
+
   create_table "spree_shipping_methods", :force => true do |t|
     t.string   "name"
-    t.integer  "zone_id"
     t.datetime "created_at",                             :null => false
     t.datetime "updated_at",                             :null => false
     t.string   "display_on"
-    t.integer  "shipping_category_id"
-    t.boolean  "match_none"
-    t.boolean  "match_all"
-    t.boolean  "match_one"
     t.datetime "deleted_at"
     t.boolean  "require_ship_address", :default => true
     t.text     "description"
     t.string   "tracking_url"
   end
+
+  create_table "spree_shipping_methods_zones", :id => false, :force => true do |t|
+    t.integer "shipping_method_id"
+    t.integer "zone_id"
+  end
+
+  create_table "spree_shipping_rates", :force => true do |t|
+    t.integer  "shipment_id"
+    t.integer  "shipping_method_id"
+    t.boolean  "selected",                                         :default => false
+    t.decimal  "cost",               :precision => 8, :scale => 2, :default => 0.0
+    t.datetime "created_at",                                                          :null => false
+    t.datetime "updated_at",                                                          :null => false
+  end
+
+  add_index "spree_shipping_rates", ["shipment_id", "shipping_method_id"], :name => "spree_shipping_rates_join_index", :unique => true
 
   create_table "spree_skrill_transactions", :force => true do |t|
     t.string   "email"
@@ -931,6 +955,61 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.integer "country_id"
   end
 
+  create_table "spree_stock_items", :force => true do |t|
+    t.integer  "stock_location_id"
+    t.integer  "variant_id"
+    t.integer  "count_on_hand",     :default => 0,     :null => false
+    t.datetime "created_at",                           :null => false
+    t.datetime "updated_at",                           :null => false
+    t.boolean  "backorderable",     :default => false
+  end
+
+  add_index "spree_stock_items", ["stock_location_id", "variant_id"], :name => "stock_item_by_loc_and_var_id"
+  add_index "spree_stock_items", ["stock_location_id"], :name => "index_spree_stock_items_on_stock_location_id"
+
+  create_table "spree_stock_locations", :force => true do |t|
+    t.string   "name"
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
+    t.string   "address1"
+    t.string   "address2"
+    t.string   "city"
+    t.integer  "state_id"
+    t.string   "state_name"
+    t.integer  "country_id"
+    t.string   "zipcode"
+    t.string   "phone"
+    t.boolean  "active",                 :default => true
+    t.boolean  "backorderable_default",  :default => false
+    t.boolean  "propagate_all_variants", :default => true
+  end
+
+  create_table "spree_stock_movements", :force => true do |t|
+    t.integer  "stock_item_id"
+    t.integer  "quantity",        :default => 0
+    t.string   "action"
+    t.datetime "created_at",                     :null => false
+    t.datetime "updated_at",                     :null => false
+    t.integer  "originator_id"
+    t.string   "originator_type"
+  end
+
+  add_index "spree_stock_movements", ["stock_item_id"], :name => "index_spree_stock_movements_on_stock_item_id"
+
+  create_table "spree_stock_transfers", :force => true do |t|
+    t.string   "type"
+    t.string   "reference"
+    t.integer  "source_location_id"
+    t.integer  "destination_location_id"
+    t.datetime "created_at",              :null => false
+    t.datetime "updated_at",              :null => false
+    t.string   "number"
+  end
+
+  add_index "spree_stock_transfers", ["destination_location_id"], :name => "index_spree_stock_transfers_on_destination_location_id"
+  add_index "spree_stock_transfers", ["number"], :name => "index_spree_stock_transfers_on_number"
+  add_index "spree_stock_transfers", ["source_location_id"], :name => "index_spree_stock_transfers_on_source_location_id"
+
   create_table "spree_tax_categories", :force => true do |t|
     t.string   "name"
     t.string   "description"
@@ -949,6 +1028,7 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.boolean  "included_in_price",                                :default => false
     t.string   "name"
     t.boolean  "show_rate_in_label",                               :default => true
+    t.datetime "deleted_at"
   end
 
   create_table "spree_taxonomies", :force => true do |t|
@@ -1048,11 +1128,8 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.datetime "deleted_at"
     t.boolean  "is_master",                                      :default => false
     t.integer  "product_id"
-    t.integer  "count_on_hand",                                  :default => 0
     t.decimal  "cost_price",       :precision => 8, :scale => 2
     t.integer  "position"
-    t.integer  "lock_version",                                   :default => 0
-    t.boolean  "on_demand",                                      :default => false
     t.string   "cost_currency"
     t.float    "unit_value"
     t.string   "unit_description",                               :default => ""
@@ -1061,6 +1138,7 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
   end
 
   add_index "spree_variants", ["product_id"], :name => "index_variants_on_product_id"
+  add_index "spree_variants", ["sku"], :name => "index_spree_variants_on_sku"
 
   create_table "spree_zone_members", :force => true do |t|
     t.integer  "zoneable_id"
@@ -1330,9 +1408,6 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
 
   add_foreign_key "spree_shipments", "spree_addresses", name: "spree_shipments_address_id_fk", column: "address_id"
   add_foreign_key "spree_shipments", "spree_orders", name: "spree_shipments_order_id_fk", column: "order_id"
-
-  add_foreign_key "spree_shipping_methods", "spree_shipping_categories", name: "spree_shipping_methods_shipping_category_id_fk", column: "shipping_category_id"
-  add_foreign_key "spree_shipping_methods", "spree_zones", name: "spree_shipping_methods_zone_id_fk", column: "zone_id"
 
   add_foreign_key "spree_state_changes", "spree_users", name: "spree_state_changes_user_id_fk", column: "user_id"
 


### PR DESCRIPTION
#### What? Why?

Closes #2236 

Installs and applies Spree v2.0.4 migrations to update the `db/schema.rb`.

#### Dependencies

~~:warning: This needs https://github.com/openfoodfoundation/openfoodnetwork/pull/2252 to be merged first. I'll rebase it as soon as that happens.~~

done