### PR TITLE
Add custom package

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -246,7 +246,6 @@ Spree::Product.class_eval do
       variant = self.master.dup
       variant.product = self
       variant.is_master = false
-      variant.on_demand = self.on_demand
       self.variants << variant
     end
   end

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -42,12 +42,6 @@ Spree::ShippingMethod.class_eval do
     ]
   end
 
-  def available_to_order_with_distributor_check?(order)
-    available_to_order_without_distributor_check?(order) &&
-      self.distributors.include?(order.distributor)
-  end
-  alias_method_chain :available_to_order?, :distributor_check
-
   def within_zone?(order)
     if order.ship_address
       zone && zone.include?(order.ship_address)

--- a/app/models/stock/package.rb
+++ b/app/models/stock/package.rb
@@ -1,0 +1,33 @@
+# Extends Spree's Package implementation to skip shipping methods that are not
+# valid for OFN.
+#
+# It requires the following configuration in config/initializers/spree.rb:
+#
+#   Spree.config do |config|
+#     ...
+#     config.package_factory = Stock::Package
+#   end
+#
+module Stock
+  class Package < Spree::Stock::Package
+    # Skips the methods that are not used by the order's distributor
+    #
+    # @return [Array<Spree::ShippingMethod>]
+    def shipping_methods
+      super.delete_if do |shipping_method|
+        !ships_with?(order.distributor, shipping_method)
+      end
+    end
+
+    private
+
+    # Checks whether the given distributor provides the specified shipping method
+    #
+    # @param distributor [Spree::Enterprise]
+    # @param shipping_method [Spree::ShippingMethod]
+    # @return [Boolean]
+    def ships_with?(distributor, shipping_method)
+      distributor.shipping_methods.include?(shipping_method)
+    end
+  end
+end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -20,6 +20,8 @@ Spree.config do |config|
   # Auto-capture payments. Without this option, payments must be manually captured in the paypal interface.
   config.auto_capture = true
   #config.override_actionmailer_config = false
+
+  config.package_factory = Stock::Package
 end
 
 # TODO Work out why this is necessary

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -460,7 +460,8 @@ FactoryGirl.modify do
   factory :product do
     primary_taxon { Spree::Taxon.first || FactoryGirl.create(:taxon) }
   end
-  factory :simple_product do
+
+  factory :base_product do
     # Fix product factory name sequence with Kernel.rand so it is not interpreted as a Spree::Product method
     # Pull request: https://github.com/spree/spree/pull/1964
     # When this fix has been merged into a version of Spree that we're using, this line can be removed.
@@ -468,7 +469,6 @@ FactoryGirl.modify do
 
     supplier { Enterprise.is_primary_producer.first || FactoryGirl.create(:supplier_enterprise) }
     primary_taxon { Spree::Taxon.first || FactoryGirl.create(:taxon) }
-    on_hand 3
 
     unit_value 1
     unit_description ''

--- a/spec/models/stock/package_spec.rb
+++ b/spec/models/stock/package_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module Stock
+  describe Package do
+    describe '#shipping_methods' do
+      let(:stock_location) { double(:stock_location) }
+      let(:order) { build(:order) }
+
+      subject(:package) { Package.new(stock_location, order, contents) }
+
+      describe '#shipping_methods' do
+        let(:enterprise) { build(:enterprise) }
+        let(:other_enterprise) { build(:enterprise) }
+
+        let(:order) { build(:order, distributor: enterprise) }
+
+        let(:variant1) do
+          instance_double(
+            Spree::Variant,
+            shipping_category: shipping_method1.shipping_categories.first
+          )
+        end
+        let(:variant2) do
+          instance_double(
+            Spree::Variant,
+            shipping_category: shipping_method2.shipping_categories.first
+          )
+        end
+        let(:variant3) do
+          instance_double(Spree::Variant, shipping_category: nil)
+        end
+
+        let(:contents) do
+          [
+            Package::ContentItem.new(variant1, 1),
+            Package::ContentItem.new(variant1, 1),
+            Package::ContentItem.new(variant2, 1),
+            Package::ContentItem.new(variant3, 1)
+          ]
+        end
+
+        let(:shipping_method1) { create(:shipping_method, distributors: [enterprise]) }
+        let(:shipping_method2) { create(:shipping_method, distributors: [other_enterprise]) }
+
+        it 'does not return shipping methods not used by the package\'s order distributor' do
+          expect(package.shipping_methods).to eq [shipping_method1]
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,7 +114,6 @@ RSpec.configure do |config|
       spree_config.currency = currency
       spree_config.shipping_instructions = true
       spree_config.auto_capture = true
-      spree_config.allow_backorders = false
     end
 
     Spree::Api::Config[:requires_authentication] = true


### PR DESCRIPTION
#### What? Why?

Closes #2205 

It reimplements the logic of `#available_to_order?` by providing a subclass of `Spree::Stock::Package` and relying on https://github.com/coopdevs/spree/pull/6. The implementation takes into account that in OFN only the shipping methods of the order's distributor can be used.

#### What should we test?

This is impossible to test as usual because the app still doesn't run. we'll have to wait for that.

#### Dependencies

Depends on https://github.com/coopdevs/spree/pull/6 to provide an extension hook.
