### PR TITLE
Fix initial password setting

### DIFF
--- a/app/controllers/admin/manager_invitations_controller.rb
+++ b/app/controllers/admin/manager_invitations_controller.rb
@@ -30,6 +30,8 @@ module Admin
       password = Devise.friendly_token
       new_user = Spree::User.create(email: @email, unconfirmed_email: @email, password: password)
       new_user.reset_password_token = Devise.friendly_token
+      # Same time as used in Devise's lib/devise/models/recoverable.rb.
+      new_user.reset_password_sent_at = Time.now.utc
       new_user.save!
 
       @enterprise.users << new_user

--- a/spec/features/consumer/confirm_invitation_spec.rb
+++ b/spec/features/consumer/confirm_invitation_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+feature "Confirm invitation" do
+  include UIComponentHelper # for be_logged_in_as
+
+  describe "confirm email" do
+    let(:email) { "test@example.org" }
+    let(:user) { Spree::User.create(email: email, unconfirmed_email: email, password: "secret") }
+
+    before do
+      user.reset_password_token = Devise.friendly_token
+      user.reset_password_sent_at = Time.now.utc
+      user.save!
+    end
+
+    it "confirms the email address" do
+      visit spree.spree_user_confirmation_url(confirmation_token: user.confirmation_token)
+      expect(user.reload.confirmed?).to be true
+    end
+
+    it "redirects to set a password" do
+      visit spree.spree_user_confirmation_url(confirmation_token: user.confirmation_token)
+      expect(page).to have_text "Change my password"
+    end
+
+    it "allows you to set a password" do
+      visit spree.spree_user_confirmation_url(confirmation_token: user.confirmation_token)
+      fill_in "Password", with: "my secret"
+      fill_in "Password Confirmation", with: "my secret"
+      click_button
+      expect(page).to have_no_text "Reset password token has expired"
+      expect(page).to be_logged_in_as user
+    end
+  end
+end

--- a/spec/features/consumer/confirm_invitation_spec.rb
+++ b/spec/features/consumer/confirm_invitation_spec.rb
@@ -1,9 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
-feature "Confirm invitation" do
+feature "Confirm invitation as manager" do
   include UIComponentHelper # for be_logged_in_as
 
-  describe "confirm email" do
+  describe "confirm email and set password" do
     let(:email) { "test@example.org" }
     let(:user) { Spree::User.create(email: email, unconfirmed_email: email, password: "secret") }
 
@@ -13,21 +13,16 @@ feature "Confirm invitation" do
       user.save!
     end
 
-    it "confirms the email address" do
-      visit spree.spree_user_confirmation_url(confirmation_token: user.confirmation_token)
-      expect(user.reload.confirmed?).to be true
-    end
-
-    it "redirects to set a password" do
-      visit spree.spree_user_confirmation_url(confirmation_token: user.confirmation_token)
-      expect(page).to have_text "Change my password"
-    end
-
     it "allows you to set a password" do
       visit spree.spree_user_confirmation_url(confirmation_token: user.confirmation_token)
+
+      expect(user.reload.confirmed?).to be true
+      expect(page).to have_text "Change my password"
+
       fill_in "Password", with: "my secret"
       fill_in "Password Confirmation", with: "my secret"
       click_button
+
       expect(page).to have_no_text "Reset password token has expired"
       expect(page).to be_logged_in_as user
     end


### PR DESCRIPTION
#### What? Why?

Closes #2254.

Setting an expiry date for the password reset token makes the token valid.

#### What should we test?

Adding a manager who is not a user yet. Nothing else is affected.

#### Release notes

Fixed an issue with new users setting their password as invited manager.