### PR TITLE
Remove Heroku references since nobody is using it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ public/stylesheets
 public/images
 public/spree
 config/abr.yml
-config/heroku_env.rb
 config/newrelic.yml
 config/initializers/feature_toggle.rb
 config/initializers/db2fog.rb

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,6 @@ test:
   username: ofn
   password: f00d
 
-#not used with heroku
 production:
   adapter: postgresql
   encoding: unicode

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,8 +35,3 @@ Openfoodnetwork::Application.configure do
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_url_options = { host: "0.0.0.0:3000" }
 end
-
-
-# Load heroku vars from local file
-heroku_env = File.join(Rails.root, 'config', 'heroku_env.rb')
-load(heroku_env) if File.exists?(heroku_env)


### PR DESCRIPTION
#### What? Why?

A little clean to remove unused clutter. Heroku has only been used initially, but got too expensive. We also have a lot more customisations now with delayed job and monit. It's extremely unlikely that we are going back to Heroku.

#### What should we test?

This does not need testing.

#### Release notes

Nothing to mention.