### PR TITLE
Improve order_and_distributor report's readability

### DIFF
--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -32,15 +32,43 @@ module OpenFoodNetwork
 
       @orders.each do |order|
         order.line_items.each do |line_item|
-          order_and_distributor_details << [order.created_at, order.id,
-            order.bill_address.full_name, order.email, order.bill_address.phone, order.bill_address.city,
-            line_item.product.sku, line_item.product.name, line_item.options_text, line_item.quantity, line_item.max_quantity, line_item.price * line_item.quantity, line_item.distribution_fee,
-            order.payments.first.andand.payment_method.andand.name,
-            order.distributor.andand.name, order.distributor.address.address1, order.distributor.address.city, order.distributor.address.zipcode, order.special_instructions ]
+          order_and_distributor_details << row_for(line_item, order)
         end
       end
 
       order_and_distributor_details
+    end
+
+    private
+
+    # Returns a row with the data to display for the specified line_item and
+    # its order
+    #
+    # @param line_item [Spree::LineItem]
+    # @param order [Spree::Order]
+    # @return [Array]
+    def row_for(line_item, order)
+      [
+        order.created_at,
+        order.id,
+        order.bill_address.full_name,
+        order.email,
+        order.bill_address.phone,
+        order.bill_address.city,
+        line_item.product.sku,
+        line_item.product.name,
+        line_item.options_text,
+        line_item.quantity,
+        line_item.max_quantity,
+        line_item.price * line_item.quantity,
+        line_item.distribution_fee,
+        order.payments.first.andand.payment_method.andand.name,
+        order.distributor.andand.name,
+        order.distributor.address.address1,
+        order.distributor.address.city,
+        order.distributor.address.zipcode,
+        order.special_instructions
+      ]
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

I had to go through the `order_and_distributor` report's code because a user asked us about a particular column in it. As it was, the report's code wasn't particularly readable and I couldn't tell what was that column at a glance. I believe this is possible now.

#### What should we test?

The `order_and_distributor` report

#### Release notes

Improved reabaility of  `order_and_distributor` report's code