### PR TITLE
Lowercase tag when adding a tag to the array

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/tags_with_translation.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/tags_with_translation.js.coffee
@@ -25,7 +25,8 @@ angular.module("admin.utils").directive "tagsWithTranslation", ($timeout) ->
       scope.object[scope.tagsAttr] ||= []
       compileTagList()
 
-      scope.tagAdded = ->
+      scope.tagAdded = (tag)->
+        tag.text = tag.text.toLowerCase()
         scope.onTagAdded()
         compileTagList()
 

--- a/app/assets/javascripts/templates/admin/tags_input.html.haml
+++ b/app/assets/javascripts/templates/admin/tags_input.html.haml
@@ -1,7 +1,7 @@
 %tags-input{ template: 'admin/tag.html',
   "placeholder" => t('admin.order_cycles.form.add_a_tag'),
   ng: { model: 'object[tagsAttr]', class: "{'limit-reached': limitReached}"},
-  on: { tag: { added: 'tagAdded()', removed:'tagRemoved()' } } }
+  on: { tag: { added: 'tagAdded($tag)', removed:'tagRemoved()' } } }
   %auto-complete{ ng: { if: "findTags" }, source: "findTags({query: $query})",
                  template: "admin/tag_autocomplete.html",
                  "min-length" => "0",


### PR DESCRIPTION
#### What? Why?

Closes #2244 and #2245 

Hi there,  tags are persisted as lowercase by the gem actAsTaggableOn, so there is no point to show to the user the upcased/mixedcase tags when they add it, this PR will downcase the tag after adding it on the view.

#### What should we test?

* Tags uppercase
[Video on issue #2244 and #2245 ](https://www.useloom.com/share/10dd6338f34a45b6b14f98ab59f436af)

