### PR TITLE
Exclude shared JS libs from CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,3 +34,4 @@ checks:
 exclude_patterns:
 - "spec/**/*"
 - "vendor/**/*"
+- "app/assets/javascripts/shared/*"


### PR DESCRIPTION
#### What? Why?

CodeClimate is raising issues from code that we don't own and won't touch thus, causing false negatives.

#### What should we test?

Nothing to test here.

#### Release notes

Exclude JavaScript libraries from Code Climate analysis.