### PR TITLE
Switched gem FactoryGirl to FactoryBot as FactoryGirl is deprecated.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,7 @@ group :test, :development do
   gem 'fuubar', '~> 2.2.0'
   gem 'rspec-rails', ">= 3.5.2"
   gem 'shoulda-matchers'
-  gem 'factory_girl_rails', require: false
+  gem "factory_bot_rails", require: false
   gem 'capybara', '>= 2.15.4'
   gem 'database_cleaner', '0.7.1', require: false
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,10 +274,10 @@ GEM
     eventmachine (1.2.3)
     excon (0.45.4)
     execjs (2.6.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -731,7 +731,7 @@ DEPENDENCIES
   delayed_job_active_record
   diffy
   eventmachine (>= 1.2.3)
-  factory_girl_rails
+  factory_bot_rails
   figaro
   foreigner
   foundation-icons-sass-rails

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -17,9 +17,9 @@ namespace :openfoodnetwork do
       unless Spree::Zone.find_by_name 'Australia'
         puts "[#{task_name}] Seeding shipping / payment information"
 
-        zone = FactoryGirl.create(:zone, name: 'Australia', zone_members: [])
+        zone = FactoryBot.create(:zone, name: 'Australia', zone_members: [])
         Spree::ZoneMember.create(zone: zone, zoneable: country)
-        address = FactoryGirl.create(
+        address = FactoryBot.create(
           :address,
           address1: "15/1 Ballantyne Street",
           zipcode: "3153",
@@ -27,19 +27,19 @@ namespace :openfoodnetwork do
           country: country,
           state: state
         )
-        enterprise = FactoryGirl.create(:enterprise, address: address)
+        enterprise = FactoryBot.create(:enterprise, address: address)
 
-        FactoryGirl.create(:shipping_method, zone: zone, distributors: [enterprise])
+        FactoryBot.create(:shipping_method, zone: zone, distributors: [enterprise])
       end
 
       # -- Taxonomies
       unless Spree::Taxonomy.find_by_name 'Products'
         puts "[#{task_name}] Seeding taxonomies"
-        taxonomy = Spree::Taxonomy.find_by_name('Products') || FactoryGirl.create(:taxonomy, name: 'Products')
+        taxonomy = Spree::Taxonomy.find_by_name('Products') || FactoryBot.create(:taxonomy, name: 'Products')
         taxonomy_root = taxonomy.root
 
         ['Vegetables', 'Fruit', 'Oils', 'Preserves and Sauces', 'Dairy', 'Meat and Fish'].each do |taxon_name|
-          FactoryGirl.create(:taxon, name: taxon_name, parent_id: taxonomy_root.id)
+          FactoryBot.create(:taxon, name: taxon_name, parent_id: taxonomy_root.id)
         end
       end
 
@@ -47,39 +47,39 @@ namespace :openfoodnetwork do
       unless Spree::Address.find_by_zipcode "3160"
         puts "[#{task_name}] Seeding addresses"
 
-        FactoryGirl.create(:address, address1: "25 Myrtle Street", zipcode: "3153", city: "Bayswater", country: country, state: state)
-        FactoryGirl.create(:address, address1: "6 Rollings Road", zipcode: "3156", city: "Upper Ferntree Gully", country: country, state: state)
-        FactoryGirl.create(:address, address1: "72 Lake Road", zipcode: "3130", city: "Blackburn", country: country, state: state)
-        FactoryGirl.create(:address, address1: "7 Verbena Street", zipcode: "3195", city: "Mordialloc", country: country, state: state)
-        FactoryGirl.create(:address, address1: "20 Galvin Street", zipcode: "3018", city: "Altona", country: country, state: state)
-        FactoryGirl.create(:address, address1: "59 Websters Road", zipcode: "3106", city: "Templestowe", country: country, state: state)
-        FactoryGirl.create(:address, address1: "17 Torresdale Drive", zipcode: "3155", city: "Boronia", country: country, state: state)
-        FactoryGirl.create(:address, address1: "21 Robina CRT", zipcode: "3764", city: "Kilmore", country: country, state: state)
-        FactoryGirl.create(:address, address1: "25 Kendall Street", zipcode: "3134", city: "Ringwood", country: country, state: state)
-        FactoryGirl.create(:address, address1: "2 Mines Road", zipcode: "3135", city: "Ringwood East", country: country, state: state)
-        FactoryGirl.create(:address, address1: "183 Millers Road", zipcode: "3025", city: "Altona North", country: country, state: state)
-        FactoryGirl.create(:address, address1: "310 Pascoe Vale Road", zipcode: "3040", city: "Essendon", country: country, state: state)
-        FactoryGirl.create(:address, address1: "6 Martin Street", zipcode: "3160", city: "Belgrave", country: country, state: state)
+        FactoryBot.create(:address, address1: "25 Myrtle Street", zipcode: "3153", city: "Bayswater", country: country, state: state)
+        FactoryBot.create(:address, address1: "6 Rollings Road", zipcode: "3156", city: "Upper Ferntree Gully", country: country, state: state)
+        FactoryBot.create(:address, address1: "72 Lake Road", zipcode: "3130", city: "Blackburn", country: country, state: state)
+        FactoryBot.create(:address, address1: "7 Verbena Street", zipcode: "3195", city: "Mordialloc", country: country, state: state)
+        FactoryBot.create(:address, address1: "20 Galvin Street", zipcode: "3018", city: "Altona", country: country, state: state)
+        FactoryBot.create(:address, address1: "59 Websters Road", zipcode: "3106", city: "Templestowe", country: country, state: state)
+        FactoryBot.create(:address, address1: "17 Torresdale Drive", zipcode: "3155", city: "Boronia", country: country, state: state)
+        FactoryBot.create(:address, address1: "21 Robina CRT", zipcode: "3764", city: "Kilmore", country: country, state: state)
+        FactoryBot.create(:address, address1: "25 Kendall Street", zipcode: "3134", city: "Ringwood", country: country, state: state)
+        FactoryBot.create(:address, address1: "2 Mines Road", zipcode: "3135", city: "Ringwood East", country: country, state: state)
+        FactoryBot.create(:address, address1: "183 Millers Road", zipcode: "3025", city: "Altona North", country: country, state: state)
+        FactoryBot.create(:address, address1: "310 Pascoe Vale Road", zipcode: "3040", city: "Essendon", country: country, state: state)
+        FactoryBot.create(:address, address1: "6 Martin Street", zipcode: "3160", city: "Belgrave", country: country, state: state)
       end
 
       # -- Enterprises
       unless Enterprise.count > 1
         puts "[#{task_name}] Seeding enterprises"
 
-        3.times { FactoryGirl.create(:supplier_enterprise, address: Spree::Address.find_by_zipcode("3160")) }
+        3.times { FactoryBot.create(:supplier_enterprise, address: Spree::Address.find_by_zipcode("3160")) }
 
-        FactoryGirl.create(:distributor_enterprise, name: "Green Grass", address: Spree::Address.find_by_zipcode("3153"))
-        FactoryGirl.create(:distributor_enterprise, name: "AusFarmers United", address: Spree::Address.find_by_zipcode("3156"))
-        FactoryGirl.create(:distributor_enterprise, name: "Blackburn FreeGrossers", address: Spree::Address.find_by_zipcode("3130"))
-        FactoryGirl.create(:distributor_enterprise, name: "MegaFoods", address: Spree::Address.find_by_zipcode("3195"))
-        FactoryGirl.create(:distributor_enterprise, name: "Eco Butchers", address: Spree::Address.find_by_zipcode("3018"))
-        FactoryGirl.create(:distributor_enterprise, name: "Western Wines", address: Spree::Address.find_by_zipcode("3106"))
-        FactoryGirl.create(:distributor_enterprise, name: "QuickFresh", address: Spree::Address.find_by_zipcode("3155"))
-        FactoryGirl.create(:distributor_enterprise, name: "Fooderers", address: Spree::Address.find_by_zipcode("3764"))
-        FactoryGirl.create(:distributor_enterprise, name: "Food Local", address: Spree::Address.find_by_zipcode("3134"))
-        FactoryGirl.create(:distributor_enterprise, name: "Green Food Trading Corporation", address: Spree::Address.find_by_zipcode("3135"))
-        FactoryGirl.create(:distributor_enterprise, name: "Better Food", address: Spree::Address.find_by_zipcode("3025"))
-        FactoryGirl.create(:distributor_enterprise, name: "Gippsland Poultry", address: Spree::Address.find_by_zipcode("3040"))
+        FactoryBot.create(:distributor_enterprise, name: "Green Grass", address: Spree::Address.find_by_zipcode("3153"))
+        FactoryBot.create(:distributor_enterprise, name: "AusFarmers United", address: Spree::Address.find_by_zipcode("3156"))
+        FactoryBot.create(:distributor_enterprise, name: "Blackburn FreeGrossers", address: Spree::Address.find_by_zipcode("3130"))
+        FactoryBot.create(:distributor_enterprise, name: "MegaFoods", address: Spree::Address.find_by_zipcode("3195"))
+        FactoryBot.create(:distributor_enterprise, name: "Eco Butchers", address: Spree::Address.find_by_zipcode("3018"))
+        FactoryBot.create(:distributor_enterprise, name: "Western Wines", address: Spree::Address.find_by_zipcode("3106"))
+        FactoryBot.create(:distributor_enterprise, name: "QuickFresh", address: Spree::Address.find_by_zipcode("3155"))
+        FactoryBot.create(:distributor_enterprise, name: "Fooderers", address: Spree::Address.find_by_zipcode("3764"))
+        FactoryBot.create(:distributor_enterprise, name: "Food Local", address: Spree::Address.find_by_zipcode("3134"))
+        FactoryBot.create(:distributor_enterprise, name: "Green Food Trading Corporation", address: Spree::Address.find_by_zipcode("3135"))
+        FactoryBot.create(:distributor_enterprise, name: "Better Food", address: Spree::Address.find_by_zipcode("3025"))
+        FactoryBot.create(:distributor_enterprise, name: "Gippsland Poultry", address: Spree::Address.find_by_zipcode("3040"))
       end
 
       # -- Enterprise users
@@ -88,12 +88,12 @@ namespace :openfoodnetwork do
 
         pw = "spree123"
 
-        u = FactoryGirl.create(:user, email: "sup@example.com", password: pw, password_confirmation: pw)
+        u = FactoryBot.create(:user, email: "sup@example.com", password: pw, password_confirmation: pw)
         u.enterprises << Enterprise.is_primary_producer.first
         u.enterprises << Enterprise.is_primary_producer.second
         puts "  Supplier User created:    #{u.email}/#{pw}  (" + u.enterprise_roles.map{ |er| er.enterprise.name}.join(", ") + ")"
 
-        u = FactoryGirl.create(:user, email: "dist@example.com", password: pw, password_confirmation: pw)
+        u = FactoryBot.create(:user, email: "dist@example.com", password: pw, password_confirmation: pw)
         u.enterprises << Enterprise.is_distributor.first
         u.enterprises << Enterprise.is_distributor.second
         puts "  Distributor User created: #{u.email}/#{pw} (" + u.enterprise_roles.map{ |er| er.enterprise.name}.join(", ") + ")"
@@ -102,14 +102,14 @@ namespace :openfoodnetwork do
       # -- Enterprise fees
       unless EnterpriseFee.count > 1
         Enterprise.is_distributor.each do |distributor|
-          FactoryGirl.create(:enterprise_fee, enterprise: distributor)
+          FactoryBot.create(:enterprise_fee, enterprise: distributor)
         end
       end
 
       # -- Enterprise Payment Methods
       unless Spree::PaymentMethod.count > 1
         Enterprise.is_distributor.each do |distributor|
-          FactoryGirl.create(:payment_method, distributors: [distributor], name: "Cheque (#{distributor.name})", environment: 'development')
+          FactoryBot.create(:payment_method, distributors: [distributor], name: "Cheque (#{distributor.name})", environment: 'development')
         end
       end
 
@@ -117,7 +117,7 @@ namespace :openfoodnetwork do
       unless Spree::Product.count > 0
         puts "[#{task_name}] Seeding products"
 
-        prod1 = FactoryGirl.create(:product,
+        prod1 = FactoryBot.create(:product,
                            name: 'Garlic', price: 20.00,
                            supplier: Enterprise.is_primary_producer[0],
                            taxons: [Spree::Taxon.find_by_name('Vegetables')])
@@ -127,7 +127,7 @@ namespace :openfoodnetwork do
                                    enterprise_fee: Enterprise.is_distributor[0].enterprise_fees.first)
 
 
-        prod2 = FactoryGirl.create(:product,
+        prod2 = FactoryBot.create(:product,
                            name: 'Fuji Apple', price: 5.00,
                            supplier: Enterprise.is_primary_producer[1],
                            taxons: [Spree::Taxon.find_by_name('Fruit')])
@@ -136,7 +136,7 @@ namespace :openfoodnetwork do
                                    distributor: Enterprise.is_distributor[1],
                                    enterprise_fee: Enterprise.is_distributor[1].enterprise_fees.first)
 
-        prod3 = FactoryGirl.create(:product,
+        prod3 = FactoryBot.create(:product,
                            name: 'Beef - 5kg Trays', price: 50.00,
                            supplier: Enterprise.is_primary_producer[2],
                            taxons: [Spree::Taxon.find_by_name('Meat and Fish')])
@@ -145,7 +145,7 @@ namespace :openfoodnetwork do
                                    distributor: Enterprise.is_distributor[2],
                                    enterprise_fee: Enterprise.is_distributor[2].enterprise_fees.first)
 
-        prod4 = FactoryGirl.create(:product,
+        prod4 = FactoryBot.create(:product,
                                    name: 'Carrots', price: 3.00,
                                    supplier: Enterprise.is_primary_producer[2],
                                    taxons: [Spree::Taxon.find_by_name('Meat and Fish')])
@@ -154,7 +154,7 @@ namespace :openfoodnetwork do
                                    distributor: Enterprise.is_distributor[2],
                                    enterprise_fee: Enterprise.is_distributor[2].enterprise_fees.first)
 
-        prod5 = FactoryGirl.create(:product,
+        prod5 = FactoryBot.create(:product,
                                    name: 'Potatoes', price: 2.00,
                                    supplier: Enterprise.is_primary_producer[2],
                                    taxons: [Spree::Taxon.find_by_name('Meat and Fish')])
@@ -163,7 +163,7 @@ namespace :openfoodnetwork do
                                    distributor: Enterprise.is_distributor[2],
                                    enterprise_fee: Enterprise.is_distributor[2].enterprise_fees.first)
 
-        prod6 = FactoryGirl.create(:product,
+        prod6 = FactoryBot.create(:product,
                                    name: 'Tomatoes', price: 2.00,
                                    supplier: Enterprise.is_primary_producer[2],
                                    taxons: [Spree::Taxon.find_by_name('Meat and Fish')])
@@ -172,7 +172,7 @@ namespace :openfoodnetwork do
                                    distributor: Enterprise.is_distributor[2],
                                    enterprise_fee: Enterprise.is_distributor[2].enterprise_fees.first)
 
-        prod7 = FactoryGirl.create(:product,
+        prod7 = FactoryBot.create(:product,
                                    name: 'Potatoes', price: 2.00,
                                    supplier: Enterprise.is_primary_producer[2],
                                    taxons: [Spree::Taxon.find_by_name('Meat and Fish')])

--- a/spec/archive/features/consumer/checkout_spec.rb
+++ b/spec/archive/features/consumer/checkout_spec.rb
@@ -487,9 +487,9 @@ feature %q{
     ExchangeFee.create!(exchange: ex2, enterprise_fee: supplier_fee4)
 
     # Distributors
-    distributor1 = FactoryGirl.create(:distributor_enterprise, name: "FruitAndVeg")
+    distributor1 = FactoryBot.create(:distributor_enterprise, name: "FruitAndVeg")
     @distributor1 = distributor1
-    distributor2 = FactoryGirl.create(:distributor_enterprise, name: "MoreFreshStuff")
+    distributor2 = FactoryBot.create(:distributor_enterprise, name: "MoreFreshStuff")
     create_enterprise_group_for distributor1
     distributor_fee1 = create(:enterprise_fee, enterprise: distributor1, fee_type: 'packing', amount: 7)
     distributor_fee2 = create(:enterprise_fee, enterprise: distributor1, fee_type: 'transport', amount: 8)

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -7,14 +7,14 @@ describe Admin::BulkLineItemsController, type: :controller do
     render_views
 
     let(:line_item_attributes) { %i[id quantity max_quantity price supplier final_weight_volume units_product units_variant order] }
-    let!(:dist1) { FactoryGirl.create(:distributor_enterprise) }
-    let!(:order1) { FactoryGirl.create(:order, state: 'complete', completed_at: 1.day.ago, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:order2) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:order3) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:line_item1) { FactoryGirl.create(:line_item, order: order1) }
-    let!(:line_item2) { FactoryGirl.create(:line_item, order: order2) }
-    let!(:line_item3) { FactoryGirl.create(:line_item, order: order2) }
-    let!(:line_item4) { FactoryGirl.create(:line_item, order: order3) }
+    let!(:dist1) { FactoryBot.create(:distributor_enterprise) }
+    let!(:order1) { FactoryBot.create(:order, state: 'complete', completed_at: 1.day.ago, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
+    let!(:order2) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
+    let!(:order3) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
+    let!(:line_item1) { FactoryBot.create(:line_item, order: order1) }
+    let!(:line_item2) { FactoryBot.create(:line_item, order: order2) }
+    let!(:line_item3) { FactoryBot.create(:line_item, order: order2) }
+    let!(:line_item4) { FactoryBot.create(:line_item, order: order3) }
 
     context "as a normal user" do
       before { controller.stub spree_current_user: create_enterprise_user }
@@ -82,11 +82,11 @@ describe Admin::BulkLineItemsController, type: :controller do
       let(:distributor2) { create(:distributor_enterprise) }
       let(:coordinator) { create(:distributor_enterprise) }
       let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-      let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
-      let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-      let!(:line_item2) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-      let!(:order2) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor2, billing_address: FactoryGirl.create(:address) ) }
-      let!(:line_item3) { FactoryGirl.create(:line_item, order: order2, product: FactoryGirl.create(:product, supplier: supplier)) }
+      let!(:order1) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryBot.create(:address) ) }
+      let!(:line_item1) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
+      let!(:line_item2) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
+      let!(:order2) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor2, billing_address: FactoryBot.create(:address) ) }
+      let!(:line_item3) { FactoryBot.create(:line_item, order: order2, product: FactoryBot.create(:product, supplier: supplier)) }
 
       context "producer enterprise" do
         before do
@@ -130,8 +130,8 @@ describe Admin::BulkLineItemsController, type: :controller do
     let(:distributor1) { create(:distributor_enterprise) }
     let(:coordinator) { create(:distributor_enterprise) }
     let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-    let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
+    let!(:order1) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryBot.create(:address) ) }
+    let!(:line_item1) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
     let(:line_item_params) { { quantity: 3, final_weight_volume: 3000, price: 3.00 } }
     let(:params) { { id: line_item1.id, order_id: order1.number, line_item: line_item_params } }
 
@@ -226,8 +226,8 @@ describe Admin::BulkLineItemsController, type: :controller do
     let(:distributor1) { create(:distributor_enterprise) }
     let(:coordinator) { create(:distributor_enterprise) }
     let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-    let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
+    let!(:order1) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryBot.create(:address) ) }
+    let!(:line_item1) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
     let(:params) { { id: line_item1.id, order_id: order1.number } }
 
     before do

--- a/spec/controllers/api/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/order_cycles_controller_spec.rb
@@ -8,8 +8,8 @@ module Api
     render_views
 
     describe "managed" do
-      let!(:oc1) { FactoryGirl.create(:simple_order_cycle) }
-      let!(:oc2) { FactoryGirl.create(:simple_order_cycle) }
+      let!(:oc1) { FactoryBot.create(:simple_order_cycle) }
+      let!(:oc2) { FactoryBot.create(:simple_order_cycle) }
       let(:coordinator) { oc1.coordinator }
       let(:attributes) { [:id, :name, :suppliers, :distributors] }
 

--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -5,14 +5,14 @@ module OpenFoodNetwork
   describe CartController, type: :controller do
     render_views
 
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     let(:product1) do
-      p1 = FactoryGirl.create(:product)
+      p1 = FactoryBot.create(:product)
       p1.update_column(:count_on_hand, 10)
       p1
     end
     let(:cart) { Cart.create(user: user) }
-    let(:distributor) { FactoryGirl.create(:distributor_enterprise) }
+    let(:distributor) { FactoryBot.create(:distributor_enterprise) }
 
     before do
     end
@@ -30,7 +30,7 @@ module OpenFoodNetwork
         end
 
         context 'with an empty order' do
-          let(:order) { FactoryGirl.create(:order, distributor: distributor) }
+          let(:order) { FactoryBot.create(:order, distributor: distributor) }
 
           before(:each) do
             cart.orders << order
@@ -48,9 +48,9 @@ module OpenFoodNetwork
         end
 
         context 'an order with line items' do
-          let(:product) { FactoryGirl.create(:product, distributors: [ distributor ]) }
-          let(:order) { FactoryGirl.create(:order, { distributor: distributor } ) }
-          let(:line_item) { FactoryGirl.create(:line_item, { variant: product.master }) }
+          let(:product) { FactoryBot.create(:product, distributors: [ distributor ]) }
+          let(:order) { FactoryBot.create(:order, { distributor: distributor } ) }
+          let(:line_item) { FactoryBot.create(:line_item, { variant: product.master }) }
 
           before(:each) do
             order.line_items << line_item

--- a/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -25,8 +25,8 @@ describe Spree::Admin::LineItemsController, type: :controller do
     let(:distributor1) { create(:distributor_enterprise) }
     let(:coordinator) { create(:distributor_enterprise) }
     let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-    let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
-    let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
+    let!(:order1) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryBot.create(:address) ) }
+    let!(:line_item1) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
     let(:line_item_params) { { quantity: 3, final_weight_volume: 3000, price: 3.00 } }
     let(:params) { { id: line_item1.id, order_id: order1.number, line_item: line_item_params } }
 

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -35,14 +35,14 @@ describe Spree::Admin::OrdersController, type: :controller do
     let(:order_attributes) { [:id, :full_name, :email, :phone, :completed_at, :distributor, :order_cycle, :number] }
 
     def self.make_simple_data!
-      let!(:dist1) { FactoryGirl.create(:distributor_enterprise) }
-      let!(:order1) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-      let!(:order2) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-      let!(:order3) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryGirl.create(:address) ) }
-      let!(:line_item1) { FactoryGirl.create(:line_item, order: order1) }
-      let!(:line_item2) { FactoryGirl.create(:line_item, order: order2) }
-      let!(:line_item3) { FactoryGirl.create(:line_item, order: order2) }
-      let!(:line_item4) { FactoryGirl.create(:line_item, order: order3) }
+      let!(:dist1) { FactoryBot.create(:distributor_enterprise) }
+      let!(:order1) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
+      let!(:order2) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
+      let!(:order3) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
+      let!(:line_item1) { FactoryBot.create(:line_item, order: order1) }
+      let!(:line_item2) { FactoryBot.create(:line_item, order: order2) }
+      let!(:line_item3) { FactoryBot.create(:line_item, order: order2) }
+      let!(:line_item4) { FactoryBot.create(:line_item, order: order3) }
       let(:line_item_attributes) { [:id, :quantity, :max_quantity, :supplier, :units_product, :units_variant] }
     end
 
@@ -95,11 +95,11 @@ describe Spree::Admin::OrdersController, type: :controller do
       let(:distributor2) { create(:distributor_enterprise) }
       let(:coordinator) { create(:distributor_enterprise) }
       let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-      let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
-      let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-      let!(:line_item2) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-      let!(:order2) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor2, billing_address: FactoryGirl.create(:address) ) }
-      let!(:line_item3) { FactoryGirl.create(:line_item, order: order2, product: FactoryGirl.create(:product, supplier: supplier)) }
+      let!(:order1) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryBot.create(:address) ) }
+      let!(:line_item1) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
+      let!(:line_item2) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
+      let!(:order2) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor2, billing_address: FactoryBot.create(:address) ) }
+      let!(:line_item3) { FactoryBot.create(:line_item, order: order2, product: FactoryBot.create(:product, supplier: supplier)) }
 
       context "producer enterprise" do
 

--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -12,8 +12,8 @@ module Spree
     context "as an admin user" do
       sign_in_as_admin!
 
-      let(:order) { FactoryGirl.create(:order, state: 'complete', completed_at: Time.zone.now) }
-      let(:line_item) { FactoryGirl.create(:line_item, order: order, final_weight_volume: 500) }
+      let(:order) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now) }
+      let(:line_item) { FactoryBot.create(:line_item, order: order, final_weight_volume: 500) }
 
       context "as a line item is updated" do
         before { allow(controller).to receive(:order) { order } }

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -75,8 +75,8 @@ module Spree
       end
 
       it "sorts products in ascending id order" do
-        FactoryGirl.create(:product, supplier: supplier)
-        FactoryGirl.create(:product, supplier: supplier)
+        FactoryBot.create(:product, supplier: supplier)
+        FactoryBot.create(:product, supplier: supplier)
 
         spree_get :index, { :template => 'bulk_index', :format => :json }
 
@@ -99,7 +99,7 @@ module Spree
         spree_get :index, { :template => 'bulk_index', :format => :json }
         json_response.size.should == 1
 
-        product5 = FactoryGirl.create(:product)
+        product5 = FactoryBot.create(:product)
         product5.available_on = nil
         product5.save!
 

--- a/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/spec/controllers/spree/api/variants_controller_spec.rb
@@ -4,10 +4,10 @@ module Spree
   describe Spree::Api::VariantsController, type: :controller do
     render_views
 
-    let(:supplier) { FactoryGirl.create(:supplier_enterprise) }
-    let!(:variant1) { FactoryGirl.create(:variant) }
-    let!(:variant2) { FactoryGirl.create(:variant) }
-    let!(:variant3) { FactoryGirl.create(:variant) }
+    let(:supplier) { FactoryBot.create(:supplier_enterprise) }
+    let!(:variant1) { FactoryBot.create(:variant) }
+    let!(:variant2) { FactoryBot.create(:variant) }
+    let!(:variant3) { FactoryBot.create(:variant) }
     let(:attributes) { [:id, :options_text, :price, :on_hand, :unit_value, :unit_description, :on_demand, :display_as, :display_name] }
 
     before do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 require 'ffaker'
 require 'spree/testing_support/factories'
 
-# http://www.rubydoc.info/gems/factory_girl/file/GETTING_STARTED.md
+# http://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md
 #
 # The spree_core gem defines factories in several files. For example:
 #
@@ -15,7 +15,7 @@ require 'spree/testing_support/factories'
 #   * order_with_inventory_unit_shipped
 #   * completed_order_with_totals
 #
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification, class: Spree::Classification do
   end
 
@@ -85,7 +85,7 @@ FactoryGirl.define do
     orders_open_at  { 1.day.ago }
     orders_close_at { 1.week.from_now }
 
-    coordinator { Enterprise.is_distributor.first || FactoryGirl.create(:distributor_enterprise) }
+    coordinator { Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise) }
 
     transient do
       suppliers []
@@ -128,14 +128,14 @@ FactoryGirl.define do
 
   factory :exchange, :class => Exchange do
     incoming    false
-    order_cycle { OrderCycle.first || FactoryGirl.create(:simple_order_cycle) }
-    sender      { incoming ? FactoryGirl.create(:enterprise) : order_cycle.coordinator }
-    receiver    { incoming ? order_cycle.coordinator : FactoryGirl.create(:enterprise) }
+    order_cycle { OrderCycle.first || FactoryBot.create(:simple_order_cycle) }
+    sender      { incoming ? FactoryBot.create(:enterprise) : order_cycle.coordinator }
+    receiver    { incoming ? order_cycle.coordinator : FactoryBot.create(:enterprise) }
   end
 
   factory :schedule, class: Schedule do
     sequence(:name) { |n| "Schedule #{n}" }
-    order_cycles { [OrderCycle.first || FactoryGirl.create(:simple_order_cycle)] }
+    order_cycles { [OrderCycle.first || FactoryBot.create(:simple_order_cycle)] }
   end
 
   factory :subscription, :class => Subscription do
@@ -201,12 +201,12 @@ FactoryGirl.define do
   end
 
   factory :enterprise, :class => Enterprise do
-    owner { FactoryGirl.create :user }
+    owner { FactoryBot.create :user }
     sequence(:name) { |n| "Enterprise #{n}" }
     sells 'any'
     description 'enterprise'
     long_description '<p>Hello, world!</p><p>This is a paragraph.</p>'
-    address { FactoryGirl.create(:address) }
+    address { FactoryBot.create(:address) }
   end
 
   factory :supplier_enterprise, :parent => :enterprise do
@@ -241,7 +241,7 @@ FactoryGirl.define do
     sequence(:permalink) { |n| "group#{n}" }
     description 'this is a group'
     on_front_page false
-    address { FactoryGirl.build(:address) }
+    address { FactoryBot.build(:address) }
   end
 
   sequence(:calculator_amount)
@@ -255,21 +255,21 @@ FactoryGirl.define do
     sequence(:name) { |n| "Enterprise fee #{n}" }
     sequence(:fee_type) { |n| EnterpriseFee::FEE_TYPES[n % EnterpriseFee::FEE_TYPES.count] }
 
-    enterprise { Enterprise.first || FactoryGirl.create(:supplier_enterprise) }
+    enterprise { Enterprise.first || FactoryBot.create(:supplier_enterprise) }
     calculator { build(:calculator_per_item, preferred_amount: amount) }
 
     after(:create) { |ef| ef.calculator.save! }
   end
 
   factory :product_distribution, :class => ProductDistribution do
-    product         { |pd| Spree::Product.first || FactoryGirl.create(:product) }
-    distributor     { |pd| Enterprise.is_distributor.first || FactoryGirl.create(:distributor_enterprise) }
-    enterprise_fee  { |pd| FactoryGirl.create(:enterprise_fee, enterprise: pd.distributor) }
+    product         { |pd| Spree::Product.first || FactoryBot.create(:product) }
+    distributor     { |pd| Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise) }
+    enterprise_fee  { |pd| FactoryBot.create(:enterprise_fee, enterprise: pd.distributor) }
   end
 
   factory :adjustment_metadata, :class => AdjustmentMetadata do
-    adjustment { FactoryGirl.create(:adjustment) }
-    enterprise { FactoryGirl.create(:distributor_enterprise) }
+    adjustment { FactoryBot.create(:adjustment) }
+    enterprise { FactoryBot.create(:distributor_enterprise) }
     fee_name 'fee'
     fee_type 'packing'
     enterprise_role 'distributor'
@@ -286,7 +286,7 @@ FactoryGirl.define do
 
     after(:create) do |order|
       p = create(:simple_product, :distributors => [order.distributor])
-      FactoryGirl.create(:line_item, :order => order, :product => p)
+      FactoryBot.create(:line_item, :order => order, :product => p)
       order.reload
     end
   end
@@ -309,8 +309,8 @@ FactoryGirl.define do
       order.distributor.update_attribute(:charges_sales_tax, true)
       Spree::Zone.global.update_attribute(:default_tax, true)
 
-      p = FactoryGirl.create(:taxed_product, zone: Spree::Zone.global, price: proxy.product_price, tax_rate_amount: proxy.tax_rate_amount, tax_rate_name: proxy.tax_rate_name, distributors: [order.distributor])
-      FactoryGirl.create(:line_item, order: order, product: p, price: p.price)
+      p = FactoryBot.create(:taxed_product, zone: Spree::Zone.global, price: proxy.product_price, tax_rate_amount: proxy.tax_rate_amount, tax_rate_name: proxy.tax_rate_name, distributors: [order.distributor])
+      FactoryBot.create(:line_item, order: order, product: p, price: p.price)
       order.reload
     end
   end
@@ -403,34 +403,34 @@ FactoryGirl.define do
     turnover { rand(100000).to_f/100 }
     account_invoice do
       AccountInvoice.where(user_id: owner_id, year: begins_at.year, month: begins_at.month).first ||
-      FactoryGirl.create(:account_invoice, user: owner, year: begins_at.year, month: begins_at.month)
+      FactoryBot.create(:account_invoice, user: owner, year: begins_at.year, month: begins_at.month)
     end
   end
 
   factory :account_invoice do
-    user { FactoryGirl.create :user }
+    user { FactoryBot.create :user }
     year { 2000 + rand(100) }
     month { 1 + rand(12) }
   end
 
   factory :filter_order_cycles_tag_rule, class: TagRule::FilterOrderCycles do
-    enterprise { FactoryGirl.create :distributor_enterprise }
+    enterprise { FactoryBot.create :distributor_enterprise }
   end
 
   factory :filter_shipping_methods_tag_rule, class: TagRule::FilterShippingMethods do
-    enterprise { FactoryGirl.create :distributor_enterprise }
+    enterprise { FactoryBot.create :distributor_enterprise }
   end
 
   factory :filter_products_tag_rule, class: TagRule::FilterProducts do
-    enterprise { FactoryGirl.create :distributor_enterprise }
+    enterprise { FactoryBot.create :distributor_enterprise }
   end
 
   factory :filter_payment_methods_tag_rule, class: TagRule::FilterPaymentMethods do
-    enterprise { FactoryGirl.create :distributor_enterprise }
+    enterprise { FactoryBot.create :distributor_enterprise }
   end
 
   factory :tag_rule, class: TagRule::DiscountOrder do
-    enterprise { FactoryGirl.create :distributor_enterprise }
+    enterprise { FactoryBot.create :distributor_enterprise }
     before(:create) do |tr|
       tr.calculator = Spree::Calculator::FlatPercentItemTotal.new(calculable: tr)
     end
@@ -442,7 +442,7 @@ FactoryGirl.define do
   end
 
   factory :stripe_account do
-    enterprise { FactoryGirl.create :distributor_enterprise }
+    enterprise { FactoryBot.create :distributor_enterprise }
     stripe_user_id "abc123"
     stripe_publishable_key "xyz456"
   end
@@ -456,9 +456,9 @@ FactoryGirl.define do
 end
 
 
-FactoryGirl.modify do
+FactoryBot.modify do
   factory :product do
-    primary_taxon { Spree::Taxon.first || FactoryGirl.create(:taxon) }
+    primary_taxon { Spree::Taxon.first || FactoryBot.create(:taxon) }
   end
   factory :simple_product do
     # Fix product factory name sequence with Kernel.rand so it is not interpreted as a Spree::Product method
@@ -466,8 +466,8 @@ FactoryGirl.modify do
     # When this fix has been merged into a version of Spree that we're using, this line can be removed.
     sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
 
-    supplier { Enterprise.is_primary_producer.first || FactoryGirl.create(:supplier_enterprise) }
-    primary_taxon { Spree::Taxon.first || FactoryGirl.create(:taxon) }
+    supplier { Enterprise.is_primary_producer.first || FactoryBot.create(:supplier_enterprise) }
+    primary_taxon { Spree::Taxon.first || FactoryBot.create(:taxon) }
     on_hand 3
 
     unit_value 1
@@ -484,7 +484,7 @@ FactoryGirl.modify do
   end
 
   factory :shipping_method do
-    distributors { [Enterprise.is_distributor.first || FactoryGirl.create(:distributor_enterprise)] }
+    distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
     display_on ''
   end
 
@@ -495,13 +495,13 @@ FactoryGirl.modify do
 
   factory :payment do
     transient do
-      distributor { order.distributor || Enterprise.is_distributor.first || FactoryGirl.create(:distributor_enterprise) }
+      distributor { order.distributor || Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise) }
     end
-    payment_method { FactoryGirl.create(:payment_method, distributors: [distributor]) }
+    payment_method { FactoryBot.create(:payment_method, distributors: [distributor]) }
   end
 
   factory :payment_method do
-    distributors { [Enterprise.is_distributor.first || FactoryGirl.create(:distributor_enterprise)] }
+    distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
   end
 
   factory :option_type do

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -13,8 +13,8 @@ feature %q{
     end
 
     it "displays a list of products" do
-      p1 = FactoryGirl.create(:product)
-      p2 = FactoryGirl.create(:product)
+      p1 = FactoryBot.create(:product)
+      p2 = FactoryBot.create(:product)
 
       visit '/admin/products/bulk_edit'
 
@@ -29,11 +29,11 @@ feature %q{
     end
 
     it "displays a select box for suppliers, with the appropriate supplier selected" do
-      s1 = FactoryGirl.create(:supplier_enterprise)
-      s2 = FactoryGirl.create(:supplier_enterprise)
-      s3 = FactoryGirl.create(:supplier_enterprise)
-      p1 = FactoryGirl.create(:product, supplier: s2)
-      p2 = FactoryGirl.create(:product, supplier: s3)
+      s1 = FactoryBot.create(:supplier_enterprise)
+      s2 = FactoryBot.create(:supplier_enterprise)
+      s3 = FactoryBot.create(:supplier_enterprise)
+      p1 = FactoryBot.create(:product, supplier: s2)
+      p2 = FactoryBot.create(:product, supplier: s3)
 
       visit '/admin/products/bulk_edit'
 
@@ -42,8 +42,8 @@ feature %q{
     end
 
     it "displays a date input for available_on for each product, formatted to yyyy-mm-dd hh:mm:ss" do
-      p1 = FactoryGirl.create(:product, available_on: Date.current)
-      p2 = FactoryGirl.create(:product, available_on: Date.current-1)
+      p1 = FactoryBot.create(:product, available_on: Date.current)
+      p2 = FactoryBot.create(:product, available_on: Date.current-1)
 
       visit '/admin/products/bulk_edit'
       find("div#columns-dropdown", :text => "COLUMNS").click
@@ -55,7 +55,7 @@ feature %q{
     end
 
     it "displays an on hand count in a span for each product" do
-      p1 = FactoryGirl.create(:product, on_hand: 15)
+      p1 = FactoryBot.create(:product, on_hand: 15)
       v1 = p1.variants.first
       v1.on_hand = 4
       v1.save!
@@ -69,9 +69,9 @@ feature %q{
     end
 
     it "displays 'on demand' for any variant that is available on demand" do
-      p1 = FactoryGirl.create(:product)
-      v1 = FactoryGirl.create(:variant, product: p1, is_master: false, on_hand: 4)
-      v2 = FactoryGirl.create(:variant, product: p1, is_master: false, on_hand: 0, on_demand: true)
+      p1 = FactoryBot.create(:product)
+      v1 = FactoryBot.create(:variant, product: p1, is_master: false, on_hand: 4)
+      v2 = FactoryBot.create(:variant, product: p1, is_master: false, on_hand: 0, on_demand: true)
 
       visit '/admin/products/bulk_edit'
       expect(page).to have_selector "a.view-variants", count: 1
@@ -84,7 +84,7 @@ feature %q{
     end
 
     it "displays a select box for the unit of measure for the product's variants" do
-      p = FactoryGirl.create(:product, variant_unit: 'weight', variant_unit_scale: 1, variant_unit_name: '')
+      p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1, variant_unit_name: '')
 
       visit '/admin/products/bulk_edit'
 
@@ -92,7 +92,7 @@ feature %q{
     end
 
     it "displays a text field for the item name when unit is set to 'Items'" do
-      p = FactoryGirl.create(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: 'packet')
+      p = FactoryBot.create(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: 'packet')
 
       visit '/admin/products/bulk_edit'
 
@@ -107,8 +107,8 @@ feature %q{
     end
 
     it "displays a list of variants for each product" do
-      v1 = FactoryGirl.create(:variant, display_name: "something1" )
-      v2 = FactoryGirl.create(:variant, display_name: "something2" )
+      v1 = FactoryBot.create(:variant, display_name: "something1" )
+      v2 = FactoryBot.create(:variant, display_name: "something2" )
 
       visit '/admin/products/bulk_edit'
       expect(page).to have_selector "a.view-variants", count: 2
@@ -121,9 +121,9 @@ feature %q{
     end
 
     it "displays an on_hand input (for each variant) for each product" do
-      p1 = FactoryGirl.create(:product)
-      v1 = FactoryGirl.create(:variant, product: p1, is_master: false, on_hand: 15)
-      v2 = FactoryGirl.create(:variant, product: p1, is_master: false, on_hand: 6)
+      p1 = FactoryBot.create(:product)
+      v1 = FactoryBot.create(:variant, product: p1, is_master: false, on_hand: 15)
+      v2 = FactoryBot.create(:variant, product: p1, is_master: false, on_hand: 6)
 
       visit '/admin/products/bulk_edit'
       expect(page).to have_selector "a.view-variants", count: 1
@@ -136,9 +136,9 @@ feature %q{
 
 
     it "displays a price input (for each variant) for each product" do
-      p1 = FactoryGirl.create(:product, price: 2.0)
-      v1 = FactoryGirl.create(:variant, product: p1, is_master: false, price: 12.75)
-      v2 = FactoryGirl.create(:variant, product: p1, is_master: false, price: 2.50)
+      p1 = FactoryBot.create(:product, price: 2.0)
+      v1 = FactoryBot.create(:variant, product: p1, is_master: false, price: 12.75)
+      v2 = FactoryBot.create(:variant, product: p1, is_master: false, price: 2.50)
 
       visit '/admin/products/bulk_edit'
       expect(page).to have_selector "a.view-variants", count: 1
@@ -150,9 +150,9 @@ feature %q{
     end
 
     it "displays a unit value field (for each variant) for each product" do
-      p1 = FactoryGirl.create(:product, price: 2.0, variant_unit: "weight", variant_unit_scale: "1000")
-      v1 = FactoryGirl.create(:variant, product: p1, is_master: false, price: 12.75, unit_value: 1200, unit_description: "(small bag)", display_as: "bag")
-      v2 = FactoryGirl.create(:variant, product: p1, is_master: false, price: 2.50, unit_value: 4800, unit_description: "(large bag)", display_as: "bin")
+      p1 = FactoryBot.create(:product, price: 2.0, variant_unit: "weight", variant_unit_scale: "1000")
+      v1 = FactoryBot.create(:variant, product: p1, is_master: false, price: 12.75, unit_value: 1200, unit_description: "(small bag)", display_as: "bag")
+      v2 = FactoryBot.create(:variant, product: p1, is_master: false, price: 2.50, unit_value: 4800, unit_description: "(large bag)", display_as: "bin")
 
       visit '/admin/products/bulk_edit'
       expect(page).to have_selector "a.view-variants", count: 1
@@ -167,8 +167,8 @@ feature %q{
 
 
   scenario "creating a new product" do
-    s = FactoryGirl.create(:supplier_enterprise)
-    d = FactoryGirl.create(:distributor_enterprise)
+    s = FactoryBot.create(:supplier_enterprise)
+    d = FactoryBot.create(:distributor_enterprise)
     taxon = create(:taxon)
 
     login_to_admin_section
@@ -194,7 +194,7 @@ feature %q{
 
   scenario "creating new variants" do
     # Given a product without variants or a unit
-    p = FactoryGirl.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
+    p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
     login_to_admin_section
     visit '/admin/products/bulk_edit'
 
@@ -238,11 +238,11 @@ feature %q{
   end
 
   scenario "updating product attributes" do
-    s1 = FactoryGirl.create(:supplier_enterprise)
-    s2 = FactoryGirl.create(:supplier_enterprise)
-    t1 = FactoryGirl.create(:taxon)
-    t2 = FactoryGirl.create(:taxon)
-    p = FactoryGirl.create(:product, supplier: s1, available_on: Date.current, variant_unit: 'volume', variant_unit_scale: 1, primary_taxon: t2, sku: "OLD SKU")
+    s1 = FactoryBot.create(:supplier_enterprise)
+    s2 = FactoryBot.create(:supplier_enterprise)
+    t1 = FactoryBot.create(:taxon)
+    t2 = FactoryBot.create(:taxon)
+    p = FactoryBot.create(:product, supplier: s1, available_on: Date.current, variant_unit: 'volume', variant_unit_scale: 1, primary_taxon: t2, sku: "OLD SKU")
 
     login_to_admin_section
 
@@ -288,7 +288,7 @@ feature %q{
   end
 
   scenario "updating a product with a variant unit of 'items'" do
-    p = FactoryGirl.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
+    p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
 
     login_to_admin_section
 
@@ -309,9 +309,9 @@ feature %q{
   end
 
   scenario "updating a product with variants" do
-    s1 = FactoryGirl.create(:supplier_enterprise)
-    s2 = FactoryGirl.create(:supplier_enterprise)
-    p = FactoryGirl.create(:product, supplier: s1, available_on: Date.current, variant_unit: 'volume', variant_unit_scale: 0.001,
+    s1 = FactoryBot.create(:supplier_enterprise)
+    s2 = FactoryBot.create(:supplier_enterprise)
+    p = FactoryBot.create(:product, supplier: s1, available_on: Date.current, variant_unit: 'volume', variant_unit_scale: 0.001,
       price: 3.0, on_hand: 9, unit_value: 0.25, unit_description: '(bottle)' )
     v = p.variants.first
     v.update_column(:sku, "VARIANTSKU")
@@ -352,8 +352,8 @@ feature %q{
   end
 
   scenario "updating delegated attributes of variants in isolation" do
-    p = FactoryGirl.create(:product)
-    v = FactoryGirl.create(:variant, product: p, price: 3.0)
+    p = FactoryBot.create(:product)
+    v = FactoryBot.create(:variant, product: p, price: 3.0)
 
     login_to_admin_section
 
@@ -378,7 +378,7 @@ feature %q{
   end
 
   scenario "updating a product mutiple times without refresh" do
-    p = FactoryGirl.create(:product, name: 'original name')
+    p = FactoryBot.create(:product, name: 'original name')
     login_to_admin_section
 
     visit '/admin/products/bulk_edit'
@@ -411,7 +411,7 @@ feature %q{
   end
 
   scenario "updating a product after cloning a product" do
-    p = FactoryGirl.create(:product, :name => "product 1")
+    p = FactoryBot.create(:product, :name => "product 1")
     login_to_admin_section
 
     visit '/admin/products/bulk_edit'
@@ -433,8 +433,8 @@ feature %q{
   scenario "updating when a filter has been applied" do
     s1 = create(:supplier_enterprise)
     s2 = create(:supplier_enterprise)
-    p1 = FactoryGirl.create(:simple_product, :name => "product1", supplier: s1)
-    p2 = FactoryGirl.create(:simple_product, :name => "product2", supplier: s2)
+    p1 = FactoryBot.create(:simple_product, :name => "product1", supplier: s1)
+    p2 = FactoryBot.create(:simple_product, :name => "product2", supplier: s2)
     login_to_admin_section
 
     visit '/admin/products/bulk_edit'
@@ -455,11 +455,11 @@ feature %q{
 
   describe "using action buttons" do
     describe "using delete buttons" do
-      let!(:p1) { FactoryGirl.create(:product) }
-      let!(:p2) { FactoryGirl.create(:product) }
+      let!(:p1) { FactoryBot.create(:product) }
+      let!(:p2) { FactoryBot.create(:product) }
       let!(:v1) { p1.variants.first }
       let!(:v2) { p2.variants.first }
-      let!(:v3) { FactoryGirl.create(:variant, product: p2 ) }
+      let!(:v3) { FactoryBot.create(:variant, product: p2 ) }
 
 
       before do
@@ -502,8 +502,8 @@ feature %q{
     end
 
     describe "using edit buttons" do
-      let!(:p1) { FactoryGirl.create(:product) }
-      let!(:p2) { FactoryGirl.create(:product) }
+      let!(:p1) { FactoryBot.create(:product) }
+      let!(:p2) { FactoryBot.create(:product) }
       let!(:v1) { p1.variants.first }
       let!(:v2) { p2.variants.first }
 
@@ -538,9 +538,9 @@ feature %q{
 
     describe "using clone buttons" do
       it "shows a clone button for products, which duplicates the product and adds it to the page when clicked" do
-        p1 = FactoryGirl.create(:product, :name => "P1")
-        p2 = FactoryGirl.create(:product, :name => "P2")
-        p3 = FactoryGirl.create(:product, :name => "P3")
+        p1 = FactoryBot.create(:product, :name => "P1")
+        p2 = FactoryBot.create(:product, :name => "P2")
+        p3 = FactoryBot.create(:product, :name => "P3")
         login_to_admin_section
 
         visit '/admin/products/bulk_edit'
@@ -566,7 +566,7 @@ feature %q{
   describe "using the page" do
     describe "using column display dropdown" do
       it "shows a column display dropdown, which shows a list of columns when clicked" do
-        FactoryGirl.create(:simple_product)
+        FactoryBot.create(:simple_product)
         login_to_admin_section
 
         visit '/admin/products/bulk_edit'
@@ -597,8 +597,8 @@ feature %q{
       it "displays basic filtering controls which filter the product list" do
         s1 = create(:supplier_enterprise)
         s2 = create(:supplier_enterprise)
-        p1 = FactoryGirl.create(:simple_product, :name => "product1", supplier: s1)
-        p2 = FactoryGirl.create(:simple_product, :name => "product2", supplier: s2)
+        p1 = FactoryBot.create(:simple_product, :name => "product1", supplier: s1)
+        p2 = FactoryBot.create(:simple_product, :name => "product2", supplier: s2)
         login_to_admin_section
 
         visit '/admin/products/bulk_edit'

--- a/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
@@ -294,8 +294,8 @@ module OpenFoodNetwork
       end
 
       it "checks whether exchanges exist" do
-        oc = FactoryGirl.create(:simple_order_cycle)
-        exchange = FactoryGirl.create(:exchange, order_cycle: oc)
+        oc = FactoryBot.create(:simple_order_cycle)
+        exchange = FactoryBot.create(:exchange, order_cycle: oc)
         applicator = OrderCycleFormApplicator.new(oc, user)
 
         applicator.send(:exchange_exists?, exchange.sender_id, exchange.receiver_id, exchange.incoming).should be true
@@ -425,9 +425,9 @@ module OpenFoodNetwork
       end
 
       it "does not add exchanges it is not permitted to touch" do
-        sender = FactoryGirl.create(:enterprise)
-        receiver = FactoryGirl.create(:enterprise)
-        oc = FactoryGirl.create(:simple_order_cycle)
+        sender = FactoryBot.create(:enterprise)
+        receiver = FactoryBot.create(:enterprise)
+        oc = FactoryBot.create(:simple_order_cycle)
         applicator = OrderCycleFormApplicator.new(oc, user)
         incoming = true
 
@@ -438,13 +438,13 @@ module OpenFoodNetwork
       end
 
       it "does not update exchanges it is not permitted to touch" do
-        sender = FactoryGirl.create(:enterprise)
-        receiver = FactoryGirl.create(:enterprise)
-        oc = FactoryGirl.create(:simple_order_cycle)
+        sender = FactoryBot.create(:enterprise)
+        receiver = FactoryBot.create(:enterprise)
+        oc = FactoryBot.create(:simple_order_cycle)
         applicator = OrderCycleFormApplicator.new(oc, user)
         incoming = true
-        exchange = FactoryGirl.create(:exchange, order_cycle: oc, sender: sender, receiver: receiver, incoming: incoming)
-        variant1 = FactoryGirl.create(:variant)
+        exchange = FactoryBot.create(:exchange, order_cycle: oc, sender: sender, receiver: receiver, incoming: incoming)
+        variant1 = FactoryBot.create(:variant)
 
         applicator.send(:touched_exchanges=, [])
         applicator.send(:update_exchange, sender.id, receiver.id, incoming, {:variant_ids => [variant1.id]})

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -10,11 +10,11 @@ describe Cart do
   describe 'when adding a product' do
 
     let(:cart) { Cart.create(user: user) }
-    let(:distributor) { FactoryGirl.create(:distributor_enterprise) }
-    let(:other_distributor) { FactoryGirl.create(:distributor_enterprise) }
+    let(:distributor) { FactoryBot.create(:distributor_enterprise) }
+    let(:other_distributor) { FactoryBot.create(:distributor_enterprise) }
     let(:currency) { "AUD" }
 
-    let(:product) { FactoryGirl.create(:product, :distributors => [distributor]) }
+    let(:product) { FactoryBot.create(:product, :distributors => [distributor]) }
 
     let(:product_with_order_cycle) { create(:product) }
     let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor, other_distributor], variants: [product_with_order_cycle.master]) }
@@ -44,11 +44,11 @@ describe Cart do
     end
 
     describe 'to a cart with an order for a distributor' do
-      let(:product_from_other_distributor) { FactoryGirl.create(:product, :distributors => [other_distributor]) }
-      let(:order) { FactoryGirl.create(:order, :distributor => distributor) }
+      let(:product_from_other_distributor) { FactoryBot.create(:product, :distributors => [other_distributor]) }
+      let(:order) { FactoryBot.create(:order, :distributor => distributor) }
 
       before do
-        FactoryGirl.create(:line_item, :order => order, :product => product)
+        FactoryBot.create(:line_item, :order => order, :product => product)
         order.reload
         subject.orders << order
         subject.save!
@@ -86,7 +86,7 @@ describe Cart do
     end
 
     describe 'existing order for distributor and order cycle' do
-      let(:order) { FactoryGirl.create(:order, :distributor => distributor, :order_cycle => order_cycle) }
+      let(:order) { FactoryBot.create(:order, :distributor => distributor, :order_cycle => order_cycle) }
 
       before do
         subject.orders << order

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -112,7 +112,7 @@ describe Enterprise do
   end
 
   describe "validations" do
-    subject { FactoryGirl.create(:distributor_enterprise) }
+    subject { FactoryBot.create(:distributor_enterprise) }
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:permalink) }
     it { should ensure_length_of(:description).is_at_most(255) }
@@ -188,7 +188,7 @@ describe Enterprise do
   end
 
   describe "delegations" do
-    #subject { FactoryGirl.create(:distributor_enterprise, :address => FactoryGirl.create(:address)) }
+    #subject { FactoryBot.create(:distributor_enterprise, :address => FactoryBot.create(:address)) }
 
     it { should delegate(:latitude).to(:address) }
     it { should delegate(:longitude).to(:address) }

--- a/spec/models/spree/addresses_spec.rb
+++ b/spec/models/spree/addresses_spec.rb
@@ -10,7 +10,7 @@ describe Spree::Address do
   end
 
   describe "geocode address" do
-    let(:address) { FactoryGirl.build(:address) }
+    let(:address) { FactoryBot.build(:address) }
 
     it "should include address1, address2, zipcode, city, state and country" do
       address.geocode_address.should include(address.address1)
@@ -30,7 +30,7 @@ describe Spree::Address do
   end
 
   describe "full address" do
-    let(:address) { FactoryGirl.build(:address) }
+    let(:address) { FactoryBot.build(:address) }
 
     it "should include address1, address2, zipcode, city and state" do
       address.full_address.should include(address.address1)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -459,32 +459,32 @@ describe Spree::Order do
   context "validating distributor changes" do
     it "checks that a distributor is available when changing" do
       set_feature_toggle :order_cycles, false
-      order_enterprise = FactoryGirl.create(:enterprise, id: 1, :name => "Order Enterprise")
+      order_enterprise = FactoryBot.create(:enterprise, id: 1, :name => "Order Enterprise")
       subject.distributor = order_enterprise
-      product1 = FactoryGirl.create(:product)
-      product2 = FactoryGirl.create(:product)
-      product3 = FactoryGirl.create(:product)
-      variant11 = FactoryGirl.create(:variant, product: product1)
-      variant12 = FactoryGirl.create(:variant, product: product1)
-      variant21 = FactoryGirl.create(:variant, product: product2)
-      variant31 = FactoryGirl.create(:variant, product: product3)
-      variant32 = FactoryGirl.create(:variant, product: product3)
+      product1 = FactoryBot.create(:product)
+      product2 = FactoryBot.create(:product)
+      product3 = FactoryBot.create(:product)
+      variant11 = FactoryBot.create(:variant, product: product1)
+      variant12 = FactoryBot.create(:variant, product: product1)
+      variant21 = FactoryBot.create(:variant, product: product2)
+      variant31 = FactoryBot.create(:variant, product: product3)
+      variant32 = FactoryBot.create(:variant, product: product3)
 
       # Product Distributions
       # Order Enterprise sells product 1 and product 3
-      FactoryGirl.create(:product_distribution, product: product1, distributor: order_enterprise)
-      FactoryGirl.create(:product_distribution, product: product3, distributor: order_enterprise)
+      FactoryBot.create(:product_distribution, product: product1, distributor: order_enterprise)
+      FactoryBot.create(:product_distribution, product: product3, distributor: order_enterprise)
 
       # Build the current order
-      line_item1 = FactoryGirl.create(:line_item, order: subject, variant: variant11)
-      line_item2 = FactoryGirl.create(:line_item, order: subject, variant: variant12)
-      line_item3 = FactoryGirl.create(:line_item, order: subject, variant: variant31)
+      line_item1 = FactoryBot.create(:line_item, order: subject, variant: variant11)
+      line_item2 = FactoryBot.create(:line_item, order: subject, variant: variant12)
+      line_item3 = FactoryBot.create(:line_item, order: subject, variant: variant31)
       subject.reload
       subject.line_items = [line_item1,line_item2,line_item3]
 
-      test_enterprise = FactoryGirl.create(:enterprise, id: 2, :name => "Test Enterprise")
+      test_enterprise = FactoryBot.create(:enterprise, id: 2, :name => "Test Enterprise")
       # Test Enterprise sells only product 1
-      FactoryGirl.create(:product_distribution, product: product1, distributor: test_enterprise)
+      FactoryBot.create(:product_distribution, product: product1, distributor: test_enterprise)
 
       subject.distributor = test_enterprise
       subject.should_not be_valid
@@ -502,7 +502,7 @@ describe Spree::Order do
       end
 
       it "finds only orders not in specified state" do
-        o = FactoryGirl.create(:completed_order_with_totals)
+        o = FactoryBot.create(:completed_order_with_totals)
         o.cancel!
         Spree::Order.not_state(:canceled).should_not include o
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -141,9 +141,9 @@ RSpec.configure do |config|
   config.include OpenFoodNetwork::DelayedJobHelper
   config.include OpenFoodNetwork::PerformanceHelper
 
-  # FactoryGirl
-  require 'factory_girl_rails'
-  config.include FactoryGirl::Syntax::Methods
+  # FactoryBot
+  require 'factory_bot_rails'
+  config.include FactoryBot::Syntax::Methods
 
   config.include Paperclip::Shoulda::Matchers
 

--- a/spec/support/spree/init.rb
+++ b/spec/support/spree/init.rb
@@ -5,6 +5,6 @@ ProductDistribution.class_eval do
   before_validation :init_enterprise_fee
 
   def init_enterprise_fee
-    self.enterprise_fee ||= EnterpriseFee.where(enterprise_id: distributor).first || FactoryGirl.create(:enterprise_fee, enterprise_id: distributor)
+    self.enterprise_fee ||= EnterpriseFee.where(enterprise_id: distributor).first || FactoryBot.create(:enterprise_fee, enterprise_id: distributor)
   end
 end


### PR DESCRIPTION
#### What? Why?
Hi, I've changed the gem factory_girl to use factory_bot, also I've changed the references for FactoryGirl to FactoryBot everywhere on code, regardless the warn message still exist on latest [factory_bot](https://github.com/thoughtbot/factory_bot/blob/v4.8.2/lib/factory_girl.rb#L5) version

I don't know if Closes #2262  as the message still exist but the message is related to gem version, I suppose that on next update they will remove it?

#### What should we test?

Deprecation warning on FactoryGirl, also if all test still works and nothing is broken, I've tested it locally on a few files but didn't run the entire test suite.
