### PR TITLE
Set response headers to disable cache - to avoid back button emptying…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   prepend_before_filter :restrict_iframes
+  before_filter :set_cache_headers # Issue #1213, prevent cart emptying via cache when using back button
 
   include EnterprisesHelper
   helper CssSplitter::ApplicationHelper
@@ -150,6 +151,12 @@ class ApplicationController < ActionController::Base
     block.call
     self.formats = old_formats
     nil
+  end
+
+  def set_cache_headers # https://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 
 end


### PR DESCRIPTION
… cart (#1213)

#### What? Why?

Closes #1213 

Prevents use of cache which was resulting in loss of items in cart when pressing back button

#### What should we test?

- Add items to cart
- Click Edit your cart
- Press browser back button
- Items should still be there
- Check general performance when navigating around site

#### Release notes

Pressing the browser back button from the cart page no longer results in newly-added items being removed.