### PR TITLE
Closes issue 1926, Changed package screen text from choose your start…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,7 +741,7 @@ en:
         welcome_title: Welcome to the Open Food Network!
         welcome_text: You have successfully created a
         next_step: Next step
-        choose_starting_point: 'Choose your starting point:'
+        choose_starting_point: 'Choose your package:'
       invite_manager:
         user_already_exists: "User already exists"
         error: "Something went wrong"


### PR DESCRIPTION
…ing point to choose your package

#### What? Why?

Closes #1926

Users get confused between terms like profile, type, and package. For the sake of using consistent terminology text has been changed.

We are aware of the Transifex issue, and have only changed en.yml

#### What should we test?

No further testing needed.

#### How is this related to the Spree upgrade?

Not related to the Spree Upgrade.

#### Discourse thread

[discourse](https://github.com/openfoodfoundation/openfoodnetwork/issues/1926)

