### PR TITLE
Update activemerchant to v1.78 with new root cert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,9 @@ gem 'spree_auth_devise', github: 'openfoodfoundation/spree_auth_devise', branch:
 gem 'spree_paypal_express', github: "openfoodfoundation/better_spree_paypal_express", branch: "spree-upgrade-intermediate"
 #gem 'spree_paypal_express', github: "spree-contrib/better_spree_paypal_express", branch: "1-3-stable"
 gem 'stripe', '~> 3.3.1'
-gem 'activemerchant', '~> 1.71.0'
+# We need at least this version to have Digicert's root certificate
+# which is needed for Pin Payments (and possibly others).
+gem 'activemerchant', '~> 1.78'
 
 gem 'oauth2', '~> 1.2.0' # Used for Stripe Connect
 gem 'jwt', '~> 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       sprockets (~> 2.2.1)
     active_model_serializers (0.8.3)
       activemodel (>= 3.0)
-    activemerchant (1.71.0)
+    activemerchant (1.78.0)
       activesupport (>= 3.2.14, < 6.x)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
@@ -704,7 +704,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
-  activemerchant (~> 1.71.0)
+  activemerchant (~> 1.78)
   acts-as-taggable-on (~> 3.4)
   andand
   angular-rails-templates (~> 0.2.0)


### PR DESCRIPTION

#### What? Why?

Closes #2265

Update ActiveMerchant including a new root certificate needed for at least Pin Payments.

#### What should we test?

Most changes are in gateways we don't use, I believe. There has been a
change in Stripe, but we use another implementation, I guess.

To verify my guesses and beliefs, we need to check the used payment gateways.

- Pin Payments
- Stripe
- What else do we use?

#### Release notes

Fixed the Pin Payments payment gateway which broke 4 May 2018 due to certificate updates.

#### How is this related to the Spree upgrade?

Newer versions of Spree may declare different dependencies on ActiveMerchant, but there should be no conflicts.

