### PR TITLE
Allow credit owed on payments made via stripe to be refunded

### DIFF
--- a/app/assets/stylesheets/admin/icons.css.scss
+++ b/app/assets/stylesheets/admin/icons.css.scss
@@ -1,3 +1,4 @@
 @import 'plugins/font-awesome';
 
 .icon-refund:before { @extend .icon-ok:before }
+.icon-credit:before { @extend .icon-ok:before }

--- a/app/models/spree/gateway/stripe_connect.rb
+++ b/app/models/spree/gateway/stripe_connect.rb
@@ -31,6 +31,7 @@ module Spree
         StripeAccount.find_by_enterprise_id(preferred_enterprise_id).andand.stripe_user_id
       end
 
+      # NOTE: the name of this method is determined by Spree::Payment::Processing
       def purchase(money, creditcard, gateway_options)
         provider.purchase(*options_for_purchase_or_auth(money, creditcard, gateway_options))
       rescue Stripe::StripeError => e
@@ -38,11 +39,13 @@ module Spree
         failed_activemerchant_billing_response(e.message)
       end
 
+      # NOTE: the name of this method is determined by Spree::Payment::Processing
       def void(response_code, _creditcard, gateway_options)
         gateway_options[:stripe_account] = stripe_account_id
         provider.void(response_code, gateway_options)
       end
 
+      # NOTE: the name of this method is determined by Spree::Payment::Processing
       def credit(money, _creditcard, response_code, gateway_options)
         gateway_options[:stripe_account] = stripe_account_id
         provider.refund(money, response_code, gateway_options)

--- a/app/models/spree/gateway/stripe_connect.rb
+++ b/app/models/spree/gateway/stripe_connect.rb
@@ -43,6 +43,11 @@ module Spree
         provider.void(response_code, gateway_options)
       end
 
+      def credit(money, _creditcard, response_code, gateway_options)
+        gateway_options[:stripe_account] = stripe_account_id
+        provider.refund(money, response_code, gateway_options)
+      end
+
       def create_profile(payment)
         return unless payment.source.gateway_customer_profile_id.nil?
 

--- a/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -66,5 +66,59 @@ describe Spree::Admin::PaymentsController, type: :controller do
         end
       end
     end
+
+    context "requesting a partial credit on a payment" do
+      let(:params) { { id: payment.id, order_id: order.number, e: :credit } }
+
+      # Required for the respond override in the controller decorator to work
+      before { @request.env['HTTP_REFERER'] = spree.admin_order_payments_url(payment) }
+
+      context "that was processed by stripe" do
+        let!(:payment_method) { create(:stripe_payment_method, distributors: [shop], preferred_enterprise_id: shop.id) }
+        let!(:payment) { create(:payment, order: order, state: 'completed', payment_method: payment_method, response_code: 'ch_1a2b3c', amount: order.total + 5) }
+
+
+        before do
+          allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+        end
+
+        context "where the request succeeds" do
+          before do
+            stub_request(:post, "https://sk_test_12345:@api.stripe.com/v1/charges/ch_1a2b3c/refunds").
+              to_return(:status => 200, :body => JSON.generate(id: 're_123', object: 'refund', status: 'succeeded') )
+          end
+
+          it "partially refunds the payment" do
+            order.reload
+            expect(order.payment_total).to eq order.total + 5
+            expect(order.outstanding_balance).to eq(-5)
+            spree_put :fire, params
+            expect(payment.reload.state).to eq 'completed'
+            order.reload
+            expect(order.payment_total).to eq order.total
+            expect(order.outstanding_balance).to eq 0
+          end
+        end
+
+        context "where the request fails" do
+          before do
+            stub_request(:post, "https://sk_test_12345:@api.stripe.com/v1/charges/ch_1a2b3c/refunds").
+              to_return(:status => 200, :body => JSON.generate(error: { message: "Bup-bow!"}) )
+          end
+
+          it "does not void the payment" do
+            order.reload
+            expect(order.payment_total).to eq order.total + 5
+            expect(order.outstanding_balance).to eq(-5)
+            spree_put :fire, params
+            expect(payment.reload.state).to eq 'completed'
+            order.reload
+            expect(order.payment_total).to eq order.total + 5
+            expect(order.outstanding_balance).to eq -5
+            expect(flash[:error]).to eq "Bup-bow!"
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/spree/gateway/stripe_connect_spec.rb
+++ b/spec/models/spree/gateway/stripe_connect_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 
 describe Spree::Gateway::StripeConnect, type: :model do
   let(:provider) do
-    double('provider').tap do |p|
-      p.stub(:purchase)
-      p.stub(:authorize)
-      p.stub(:capture)
+    instance_double(ActiveMerchant::Billing::StripeGateway).tap do |p|
+      allow(p).to receive(:purchase)
+      allow(p).to receive(:authorize)
+      allow(p).to receive(:capture)
+      allow(p).to receive(:refund)
     end
   end
 
@@ -14,8 +15,8 @@ describe Spree::Gateway::StripeConnect, type: :model do
   before do
     allow(Stripe).to receive(:api_key) { "sk_test_123456" }
     allow(subject).to receive(:stripe_account_id) { stripe_account_id }
-    subject.stub(:options_for_purchase_or_auth).and_return(['money', 'cc', 'opts'])
-    subject.stub(:provider).and_return provider
+    allow(subject).to receive(:options_for_purchase_or_auth).and_return(['money', 'cc', 'opts'])
+    allow(subject).to receive(:provider).and_return provider
   end
 
   describe "#token_from_card_profile_ids" do
@@ -68,6 +69,24 @@ describe Spree::Gateway::StripeConnect, type: :model do
 
     it "requests a new token for the customer and card from Stripe, and returns the id of the response" do
       expect(subject.send(:tokenize_instance_customer_card, customer_id, card_id)).to eq token_mock[:id]
+    end
+  end
+
+  describe "#credit" do
+    let(:gateway_options) { { some: 'option' } }
+    let(:money) { double(:money) }
+    let(:response_code) { double(:response_code) }
+
+    before do
+      subject.credit(money, double(:creditcard), response_code, gateway_options)
+    end
+
+    it "delegates to ActiveMerchant::Billing::StripeGateway#refund" do
+      expect(provider).to have_received(:refund)
+    end
+
+    it "adds the stripe_account to the gateway options hash" do
+      expect(provider).to have_received(:refund).with(money, response_code, hash_including(stripe_account: stripe_account_id))
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

I forgot to implement the ability to partially refund payments made via Stripe, so I've done it here.

This is required in the case that the order total changes after the payment has been made (eg. an item is not available), and the customer needs to be refunded for the difference between what they paid and the new order total.

#### What should we test?

That orders with credit owed which have already been paid for via Stripe can have the credit owed amount refunded to the customers credit card. To do this you need to head to the Payments section of an order in the admin interface and you should see a button with a tick as the icon. Clicking this button submit a request for a refund to Stripe, equal to the amount of credit on the order.

![screen shot 2018-05-10 at 7 26 32 pm](https://user-images.githubusercontent.com/2067859/39862928-7e337d14-5488-11e8-906b-be11c779ed81.png)

This should be fine to test using test cards - Stripe is very well designed in that if something works in test mode it will almost certainly work in production mode. Would be good to do at least one test in a production environment once deployed somewhere though.

#### Release notes

Order which have credit owed can now have the credit owed amount refunded to the customer's card.