### PR TITLE
Subs: Default Card

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/checkout/payment_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/payment_controller.js.coffee
@@ -9,6 +9,10 @@ Darkswarm.controller "PaymentCtrl", ($scope, $timeout, savedCreditCards, Dates) 
   $scope.secrets.card_month = "1"
   $scope.secrets.card_year = moment().year()
 
+  for card in (savedCreditCards || []) when card.is_default
+    $scope.secrets.selected_card = card.id
+    break
+
   $scope.summary = ->
     [$scope.Checkout.paymentMethod()?.name]
 

--- a/app/assets/javascripts/darkswarm/controllers/checkout/payment_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/payment_controller.js.coffee
@@ -9,7 +9,7 @@ Darkswarm.controller "PaymentCtrl", ($scope, $timeout, savedCreditCards, Dates) 
   $scope.secrets.card_month = "1"
   $scope.secrets.card_year = moment().year()
 
-  for card in (savedCreditCards || []) when card.is_default
+  for card in savedCreditCards when card.is_default
     $scope.secrets.selected_card = card.id
     break
 

--- a/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
@@ -1,6 +1,7 @@
-Darkswarm.controller "CreditCardsCtrl", ($scope, $timeout, CreditCard, CreditCards, Dates) ->
+Darkswarm.controller "CreditCardsCtrl", ($scope, CreditCard, CreditCards) ->
   angular.extend(this, new FieldsetMixin($scope))
   $scope.savedCreditCards = CreditCards.saved
+  $scope.setDefault = CreditCards.setDefault
   $scope.CreditCard = CreditCard
   $scope.secrets = CreditCard.secrets
   $scope.showForm = CreditCard.show

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -1,6 +1,15 @@
-Darkswarm.factory 'CreditCards', (savedCreditCards)->
+Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, RailsFlashLoader)->
   new class CreditCard
-    saved: savedCreditCards
+    saved: $filter('orderBy')(savedCreditCards,'-is_default')
 
     add: (card) ->
       @saved.push card
+
+    setDefault: (card) =>
+      card.is_default = true
+      for othercard in @saved when othercard != card
+        othercard.is_default = false
+      $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
+        RailsFlashLoader.loadFlash({success: t('js.default_card_updated')})
+      , (response) ->
+        RailsFlashLoader.loadFlash({error: response.data.flash.error})

--- a/app/controllers/spree/credit_cards_controller.rb
+++ b/app/controllers/spree/credit_cards_controller.rb
@@ -16,6 +16,18 @@ module Spree
       return render json: { flash: { error: I18n.t(:spree_gateway_error_flash_for_checkout, error: e.message) } }, status: 400
     end
 
+    def update
+      @credit_card = Spree::CreditCard.find_by_id(params[:id])
+      return update_failed unless @credit_card
+      authorize! :update, @credit_card
+
+      if @credit_card.update_attributes(params[:credit_card])
+        render json: @credit_card, serializer: ::Api::CreditCardSerializer, status: :ok
+      else
+        update_failed
+      end
+    end
+
     def destroy
       @credit_card = Spree::CreditCard.find_by_id(params[:id])
       if @credit_card
@@ -64,6 +76,10 @@ module Spree
       # Can't mass assign user:
       card.user_id = spree_current_user.id
       card
+    end
+
+    def update_failed
+      render json: { flash: { error: t(:card_could_not_be_updated) } }, status: 400
     end
   end
 end

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -74,9 +74,11 @@ module InjectionHelper
   end
 
   def inject_saved_credit_cards
-    if spree_current_user
-      data = spree_current_user.credit_cards.with_payment_profile.all
-    end
+    data = if spree_current_user
+             spree_current_user.credit_cards.with_payment_profile.all
+           else
+             []
+           end
 
     inject_json_ams "savedCreditCards", data, Api::CreditCardSerializer
   end

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -61,7 +61,7 @@ class AbilityDecorator
       order.user == user
     end
 
-    can [:destroy], Spree::CreditCard do |credit_card|
+    can [:update, :destroy], Spree::CreditCard do |credit_card|
       credit_card.user == user
     end
   end

--- a/app/models/spree/credit_card_decorator.rb
+++ b/app/models/spree/credit_card_decorator.rb
@@ -14,8 +14,8 @@ Spree::CreditCard.class_eval do
 
   belongs_to :user
 
-  after_create :ensure_default
-  after_save :ensure_default, if: :is_default_changed?
+  after_create :ensure_single_default_card
+  after_save :ensure_single_default_card, if: :is_default_changed?
 
   # Allows us to use a gateway_payment_profile_id to store Stripe Tokens
   # Should be able to remove once we reach Spree v2.2.0
@@ -35,7 +35,7 @@ Spree::CreditCard.class_eval do
     !user.credit_cards.exists?(is_default: true)
   end
 
-  def ensure_default
+  def ensure_single_default_card
     return unless user
     return unless is_default? || default_missing?
     user.credit_cards.update_all(['is_default=(id=?)', id])

--- a/app/models/spree/credit_card_decorator.rb
+++ b/app/models/spree/credit_card_decorator.rb
@@ -5,7 +5,7 @@ Spree::CreditCard.class_eval do
   attr_accessible :cc_type, :last_digits
 
   # For holding customer preference in memory
-  attr_accessible :save_requested_by_customer
+  attr_accessible :save_requested_by_customer, :is_default
   attr_writer :save_requested_by_customer
 
   # Should be able to remove once we reach Spree v2.2.0
@@ -13,6 +13,9 @@ Spree::CreditCard.class_eval do
   belongs_to :payment_method
 
   belongs_to :user
+
+  after_create :ensure_default
+  after_save :ensure_default, if: :is_default_changed?
 
   # Allows us to use a gateway_payment_profile_id to store Stripe Tokens
   # Should be able to remove once we reach Spree v2.2.0
@@ -24,5 +27,18 @@ Spree::CreditCard.class_eval do
 
   def save_requested_by_customer?
     !!@save_requested_by_customer
+  end
+
+  private
+
+  def default_missing?
+    user.credit_cards.where(is_default: true).none?
+  end
+
+  def ensure_default
+    return unless user
+    return unless is_default? || default_missing?
+    user.credit_cards.update_all(['is_default=(id=?)', id])
+    self.is_default = true
   end
 end

--- a/app/models/spree/credit_card_decorator.rb
+++ b/app/models/spree/credit_card_decorator.rb
@@ -32,7 +32,7 @@ Spree::CreditCard.class_eval do
   private
 
   def default_missing?
-    user.credit_cards.where(is_default: true).none?
+    !user.credit_cards.exists?(is_default: true)
   end
 
   def ensure_default

--- a/app/serializers/api/credit_card_serializer.rb
+++ b/app/serializers/api/credit_card_serializer.rb
@@ -1,6 +1,6 @@
 module Api
   class CreditCardSerializer < ActiveModel::Serializer
-    attributes :id, :brand, :number, :expiry, :formatted, :delete_link
+    attributes :id, :brand, :number, :expiry, :formatted, :delete_link, :is_default
 
     def brand
       object.cc_type.capitalize

--- a/app/views/spree/checkout/payment/_stripe.html.haml
+++ b/app/views/spree/checkout/payment/_stripe.html.haml
@@ -1,4 +1,4 @@
-.row{ "ng-show" => "savedCreditCards != null && savedCreditCards.length > 0" }
+.row{ "ng-show" => "savedCreditCards.length > 0" }
   .small-12.columns
     %h6= t('.used_saved_card')
     %select{ name: "selected_card", required: false, ng: { model: "secrets.selected_card", options: "card.id as card.formatted for card in savedCreditCards" } }

--- a/app/views/spree/users/_saved_cards.html.haml
+++ b/app/views/spree/users/_saved_cards.html.haml
@@ -3,11 +3,14 @@
     %th= t(:card_type)
     %th= t(:card_number)
     %th= t(:card_expiry_date)
+    %th= t(:default?)
     %th= t(:delete?)
   %tr.card{ id: "card{{ card.id }}", ng: { repeat: "card in savedCreditCards" } }
     %td.brand{ ng: { bind: '::card.brand' } }
     %td.number{ ng: { bind: '::card.number' } }
     %td.expiry{ ng: { bind: '::card.expiry' } }
+    %td.is-default
+      %input{ type: 'radio', name: 'default_card', ng: { model: 'card.is_default', change: 'setDefault(card)', value: "true"} }
     %td.actions
       %a{"rel" => "nofollow", "data-method" => "delete", "ng-href" => "{{card.delete_link}}" }
         = t(:delete)

--- a/app/views/spree/users/_saved_cards.html.haml
+++ b/app/views/spree/users/_saved_cards.html.haml
@@ -3,8 +3,8 @@
     %th= t(:card_type)
     %th= t(:card_number)
     %th= t(:card_expiry_date)
-    %th= t(:default?)
-    %th= t(:delete?)
+    %th= t('.default?')
+    %th= t('.delete?')
   %tr.card{ id: "card{{ card.id }}", ng: { repeat: "card in savedCreditCards" } }
     %td.brand{ ng: { bind: '::card.brand' } }
     %td.number{ ng: { bind: '::card.number' } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1112,6 +1112,7 @@ en:
 
 
   # Front-end controller translations
+  card_could_not_be_updated: Card could not be updated
   card_could_not_be_saved: card could not be saved
   spree_gateway_error_flash_for_checkout: "There was a problem with your payment information: %{error}"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1232,6 +1232,7 @@ en:
   saving_credit_card: Saving credit card...
   card_has_been_removed: "Your card has been removed (number: %{number})"
   card_could_not_be_removed: Sorry, the card could not be removed
+  default?: Default?
 
   ie_warning_headline: "Your browser is out of date :-("
   ie_warning_text: "For the best Open Food Network experience, we strongly recommend upgrading your browser:"
@@ -2344,6 +2345,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     choose: Choose
     resolve_errors: Please resolve the following errors
     more_items: "+ %{count} More"
+    default_card_updated: Default Card Updated
     admin:
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
       modals:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1232,7 +1232,6 @@ en:
   saving_credit_card: Saving credit card...
   card_has_been_removed: "Your card has been removed (number: %{number})"
   card_could_not_be_removed: Sorry, the card could not be removed
-  default?: Default?
 
   ie_warning_headline: "Your browser is out of date :-("
   ie_warning_text: "For the best Open Food Network experience, we strongly recommend upgrading your browser:"
@@ -2732,5 +2731,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         total: Total
         paid?: Paid?
         view: View
+      saved_cards:
+        default?: Default?
+        delete?: Delete?
     localized_number:
       invalid_format: has an invalid format. Please enter a number.

--- a/db/migrate/20180418025217_add_is_default_to_credit_card.rb
+++ b/db/migrate/20180418025217_add_is_default_to_credit_card.rb
@@ -1,0 +1,5 @@
+class AddIsDefaultToCreditCard < ActiveRecord::Migration
+  def change
+    add_column :spree_credit_cards, :is_default, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180316034336) do
+ActiveRecord::Schema.define(:version => 20180418025217) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -490,12 +490,13 @@ ActiveRecord::Schema.define(:version => 20180316034336) do
     t.string   "start_year"
     t.string   "issue_number"
     t.integer  "address_id"
-    t.datetime "created_at",                  :null => false
-    t.datetime "updated_at",                  :null => false
+    t.datetime "created_at",                                     :null => false
+    t.datetime "updated_at",                                     :null => false
     t.string   "gateway_customer_profile_id"
     t.string   "gateway_payment_profile_id"
     t.integer  "user_id"
     t.integer  "payment_method_id"
+    t.boolean  "is_default",                  :default => false
   end
 
   add_index "spree_credit_cards", ["payment_method_id"], :name => "index_spree_credit_cards_on_payment_method_id"

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -4,7 +4,8 @@ feature "Credit Cards", js: true do
   include AuthenticationWorkflow
   describe "as a logged in user" do
     let(:user) { create(:user) }
-    let!(:card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ') }
+    let!(:card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ', is_default: true) }
+    let!(:card2) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_FDTG') }
 
     before do
       quick_login_as user
@@ -20,17 +21,39 @@ feature "Credit Cards", js: true do
         to_return(:status => 200, :body => JSON.generate(deleted: true, id: "cus_AZNMJ"))
     end
 
-    it "lists saved cards, shows interface for adding new cards" do
+    it "passes the smoke test" do
       visit "/account"
 
       click_link I18n.t('spree.users.show.tabs.cards')
 
       expect(page).to have_content I18n.t(:saved_cards)
 
+      # Lists saved cards
       within(".card#card#{card.id}") do
         expect(page).to have_content card.cc_type.capitalize
         expect(page).to have_content card.last_digits
+        expect(find_field('default_card')).to be_checked
       end
+
+      within(".card#card#{card2.id}") do
+        expect(page).to have_content card2.cc_type.capitalize
+        expect(page).to have_content card2.last_digits
+        expect(find_field('default_card')).to_not be_checked
+      end
+
+      # Allows switching of default card
+      within(".card#card#{card2.id}") do
+        find_field('default_card').click
+        expect(find_field('default_card')).to be_checked
+      end
+
+      expect(page).to have_content I18n.t('js.default_card_updated')
+
+      within(".card#card#{card.id}") do
+        expect(find_field('default_card')).to_not be_checked
+      end
+      expect(card.reload.is_default).to be false
+      expect(card2.reload.is_default).to be true
 
       # Shows the interface for adding a card
       click_button I18n.t(:add_a_card)
@@ -38,10 +61,12 @@ feature "Credit Cards", js: true do
       expect(page).to have_selector '#card-element.StripeElement'
 
       # Allows deletion of cards
-      click_link I18n.t(:delete)
+      within(".card#card#{card.id}") do
+        click_link I18n.t(:delete)
+      end
 
       expect(page).to have_content I18n.t(:card_has_been_removed, number: "x-#{card.last_digits}")
-      expect(page).to have_content I18n.t(:you_have_no_saved_cards)
+      expect(page).to_not have_selector ".card#card#{card.id}"
     end
   end
 end

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -4,8 +4,8 @@ feature "Credit Cards", js: true do
   include AuthenticationWorkflow
   describe "as a logged in user" do
     let(:user) { create(:user) }
-    let!(:card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ', is_default: true) }
-    let!(:card2) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_FDTG') }
+    let!(:default_card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ', is_default: true) }
+    let!(:non_default_card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_FDTG') }
 
     before do
       quick_login_as user
@@ -29,31 +29,31 @@ feature "Credit Cards", js: true do
       expect(page).to have_content I18n.t(:saved_cards)
 
       # Lists saved cards
-      within(".card#card#{card.id}") do
-        expect(page).to have_content card.cc_type.capitalize
-        expect(page).to have_content card.last_digits
+      within(".card#card#{default_card.id}") do
+        expect(page).to have_content default_card.cc_type.capitalize
+        expect(page).to have_content default_card.last_digits
         expect(find_field('default_card')).to be_checked
       end
 
-      within(".card#card#{card2.id}") do
-        expect(page).to have_content card2.cc_type.capitalize
-        expect(page).to have_content card2.last_digits
+      within(".card#card#{non_default_card.id}") do
+        expect(page).to have_content non_default_card.cc_type.capitalize
+        expect(page).to have_content non_default_card.last_digits
         expect(find_field('default_card')).to_not be_checked
       end
 
       # Allows switching of default card
-      within(".card#card#{card2.id}") do
+      within(".card#card#{non_default_card.id}") do
         find_field('default_card').click
         expect(find_field('default_card')).to be_checked
       end
 
       expect(page).to have_content I18n.t('js.default_card_updated')
 
-      within(".card#card#{card.id}") do
+      within(".card#card#{default_card.id}") do
         expect(find_field('default_card')).to_not be_checked
       end
-      expect(card.reload.is_default).to be false
-      expect(card2.reload.is_default).to be true
+      expect(default_card.reload.is_default).to be false
+      expect(non_default_card.reload.is_default).to be true
 
       # Shows the interface for adding a card
       click_button I18n.t(:add_a_card)
@@ -61,12 +61,12 @@ feature "Credit Cards", js: true do
       expect(page).to have_selector '#card-element.StripeElement'
 
       # Allows deletion of cards
-      within(".card#card#{card.id}") do
+      within(".card#card#{default_card.id}") do
         click_link I18n.t(:delete)
       end
 
-      expect(page).to have_content I18n.t(:card_has_been_removed, number: "x-#{card.last_digits}")
-      expect(page).to_not have_selector ".card#card#{card.id}"
+      expect(page).to have_content I18n.t(:card_has_been_removed, number: "x-#{default_card.last_digits}")
+      expect(page).to_not have_selector ".card#card#{default_card.id}"
     end
   end
 end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -199,10 +199,9 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
           # shows the saved credit card dropdown
           expect(page).to have_content I18n.t("spree.checkout.payment.stripe.used_saved_card")
 
-          # removes the input fields when a saved card is selected"
-          expect(page).to have_selector "#card-element.StripeElement"
-          select "Visa x-1111 Exp:01/2025", from: "selected_card"
+          # default card is selected, form element is not shown
           expect(page).to_not have_selector "#card-element.StripeElement"
+          expect(page).to have_select 'selected_card', selected: "Visa x-1111 Exp:01/2025"
 
           # allows checkout
           place_order

--- a/spec/javascripts/unit/darkswarm/controllers/checkout/payment_controller_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/controllers/checkout/payment_controller_spec.js.coffee
@@ -1,0 +1,17 @@
+describe "PaymentCtrl", ->
+  ctrl = null
+  scope = null
+  card1 = { id: 1, is_default: false }
+  card2 = { id: 3, is_default: true }
+  cards = [card1, card2]
+
+  beforeEach ->
+    module("Darkswarm")
+    angular.module('Darkswarm').value('savedCreditCards', cards)
+    inject ($controller, $rootScope) ->
+      scope = $rootScope.$new()
+      scope.secrets = {}
+      ctrl = $controller 'PaymentCtrl', {$scope: scope}
+
+  it "sets the default card id as the selected_card", ->
+    expect(scope.secrets.selected_card).toEqual card2.id

--- a/spec/javascripts/unit/darkswarm/services/credit_cards_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/credit_cards_spec.js.coffee
@@ -1,0 +1,50 @@
+describe 'CreditCards service', ->
+  CreditCards = $httpBackend = RailsFlashLoader = null
+
+  beforeEach ->
+    module 'Darkswarm'
+    module ($provide)->
+      $provide.value "savedCreditCards", []
+      $provide.value "railsFlash", null
+      null
+
+    inject (_CreditCards_, _$httpBackend_, _RailsFlashLoader_)->
+      CreditCards = _CreditCards_
+      $httpBackend = _$httpBackend_
+      RailsFlashLoader = _RailsFlashLoader_
+
+  describe "setDefault", ->
+    card1 = { last4: "1234", is_default: true }
+    card2 = { last4: "4321", is_default: false }
+    card3 = { last4: "5555", is_default: false }
+    ajax = null
+
+    beforeEach ->
+      CreditCards.saved = [card1, card2, card3]
+      ajax = $httpBackend.expectPUT("/credit_cards/#{card2.id}")
+
+    it "resets the default value on other cards to false", ->
+      CreditCards.setDefault(card2)
+      expect(card1.is_default).toBe false
+      expect(card2.is_default).toBe true
+      expect(card3.is_default).toBe false
+
+    describe "when the update request succeeds", ->
+      beforeEach ->
+        spyOn(RailsFlashLoader,"loadFlash")
+        ajax.respond(200)
+
+      it "loads a success flash", ->
+        CreditCards.setDefault(card2)
+        $httpBackend.flush()
+        expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({success: t('js.default_card_updated')})
+
+    describe "when the update request fails", ->
+      beforeEach ->
+        spyOn(RailsFlashLoader,"loadFlash")
+        ajax.respond(400, flash: { error: 'Some error message'})
+
+      it "loads a error flash", ->
+        CreditCards.setDefault(card2)
+        $httpBackend.flush()
+        expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: 'Some error message'})

--- a/spec/models/spree/credit_card_spec.rb
+++ b/spec/models/spree/credit_card_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+module Spree
+  describe CreditCard do
+    describe "setting default credit card for a user" do
+      let(:user) { create(:user) }
+
+      context "when a card is already set as the default" do
+        let!(:card1) { create(:credit_card, user: user, is_default: true) }
+
+        context "and I create a new card" do
+          let(:attrs) { { user: user } }
+          let!(:card2) { create(:credit_card, attrs) }
+
+          context "without specifying it as the default" do
+            it "keeps the existing default" do
+              expect(card1.reload.is_default).to be true
+              expect(card2.reload.is_default).to be false
+            end
+          end
+
+          context "and I specify it as the default" do
+            let(:attrs) { { user: user, is_default: true } }
+
+            it "switches the default to the new card" do
+              expect(card1.reload.is_default).to be false
+              expect(card2.reload.is_default).to be true
+            end
+          end
+        end
+
+        context "and I update another card" do
+          let(:attrs) { { user: user } }
+          let!(:card2) { create(:credit_card, user: user) }
+
+          before do
+            card2.update_attributes!(attrs)
+          end
+
+          context "without specifying it as the default" do
+            it "keeps the existing default" do
+              expect(card1.reload.is_default).to be true
+              expect(card2.reload.is_default).to be false
+            end
+          end
+
+          context "and I specify it as the default" do
+            let(:attrs) { { user: user, is_default: true } }
+
+            it "switches the default to the updated card" do
+              expect(card1.reload.is_default).to be false
+              expect(card2.reload.is_default).to be true
+            end
+          end
+        end
+      end
+
+      context "when no card is currently set as the default for a user" do
+        context "and I create a new card" do
+          let(:attrs) { { user: user } }
+          let!(:card1) { create(:credit_card, attrs) }
+
+          context "without specifying it as the default" do
+            it "sets it as the default anyway" do
+              expect(card1.reload.is_default).to be true
+            end
+          end
+
+          context "and I specify it as the default" do
+            let(:attrs) { { user: user, is_default: true } }
+
+            it "sets it as the default" do
+              expect(card1.reload.is_default).to be true
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Part 1 of 3 PRs to close #2085 

To be able to process payments for subscriptions, shops need to be able to to charge a credit card saved against customer's account. The approach I decided to take is to allow the customer to set one of their cards as the default and to allow them to authorise shops to charge their default card for services. We COULD do something more sophisticated in the future where specific cards are nominated for specific services, but I think we should start with this and we can work on that later if required.

#### What should we test?

This part is just the part that allows customers to specify a default card. The other stuff comes later.

Basically:
- [ ] as a regular user, I should be able to easily understand which of my saved credit card is the 'default' from the Account page
- [ ] when a new card is added to an account it should become the default if none is already set
- [ ] adding subsequent cards should not change the default card
- [ ] I should be able to update the default card using the interface on the account page

#### Release notes

Customers can now set a default credit card, which can be used to pay OFN shops for services (such as automatic subscription payments)
