### PR TITLE
Subs: Allow Charges

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authorised_shops_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authorised_shops_controller.js.coffee
@@ -1,0 +1,3 @@
+angular.module("Darkswarm").controller "AuthorisedShopsCtrl", ($scope, Customers, Shops) ->
+  $scope.customers = Customers.index()
+  $scope.shopsByID = Shops.byID

--- a/app/assets/javascripts/darkswarm/directives/help_modal.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/help_modal.js.coffee
@@ -1,0 +1,10 @@
+Darkswarm.directive "helpModal", ($modal, $compile, $templateCache)->
+  restrict: 'A'
+  scope:
+    helpText: "@helpModal"
+
+  link: (scope, elem, attrs, ctrl)->
+    compiled = $compile($templateCache.get('help-modal.html'))(scope)
+
+    elem.on "click", =>
+      $modal.open(controller: ctrl, template: compiled, scope: scope, windowClass: 'help-modal small')

--- a/app/assets/javascripts/darkswarm/services/customer.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/customer.js.coffee
@@ -1,0 +1,20 @@
+angular.module("Darkswarm").factory 'Customer', ($resource, RailsFlashLoader) ->
+  Customer = $resource('/api/customers/:id/:action.json', {}, {
+    'index':
+      method: 'GET'
+      isArray: true
+    'update':
+      method: 'PUT'
+      params:
+        id: '@id'
+      transformRequest: (data, headersGetter) ->
+        angular.toJson(customer: data)
+  })
+
+  Customer.prototype.update = ->
+    @$update().then (response) =>
+      RailsFlashLoader.loadFlash({success: t('js.changes_saved')})
+    , (response) =>
+      RailsFlashLoader.loadFlash({error: response.data.error})
+
+  Customer

--- a/app/assets/javascripts/darkswarm/services/customers.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/customers.js.coffee
@@ -1,0 +1,13 @@
+angular.module("Darkswarm").factory 'Customers', (Customer) ->
+  new class Customers
+    all: []
+    byID: {}
+
+    index: (params={}) ->
+      Customer.index params, (data) => @load(data)
+      @all
+
+    load: (customers) ->
+      for customer in customers
+        @all.push customer
+        @byID[customer.id] = customer

--- a/app/assets/javascripts/darkswarm/services/customers.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/customers.js.coffee
@@ -4,6 +4,7 @@ angular.module("Darkswarm").factory 'Customers', (Customer) ->
     byID: {}
 
     index: (params={}) ->
+      return @all if @all.length
       Customer.index params, (data) => @load(data)
       @all
 

--- a/app/assets/javascripts/darkswarm/services/shops.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/shops.js.coffee
@@ -1,0 +1,13 @@
+angular.module("Darkswarm").factory 'Shops', ($injector) ->
+  new class Shops
+    all: []
+    byID: {}
+
+    constructor: ->
+      if $injector.has('shops')
+        @load($injector.get('shops'))
+
+    load: (shops) ->
+      for shop in shops
+        @all.push shop
+        @byID[shop.id] = shop

--- a/app/assets/javascripts/templates/help-modal.html.haml
+++ b/app/assets/javascripts/templates/help-modal.html.haml
@@ -1,0 +1,9 @@
+.row.help-icon
+  .small-12.text-center
+    %i.ofn-i_013-help
+.row.help-text
+  .small-12.columns.text-center
+    {{ helpText }}
+.row.text-center
+  %button.primary.small{ ng: { click: '$close()' } }
+    = t(:ok)

--- a/app/assets/stylesheets/darkswarm/account.css.scss
+++ b/app/assets/stylesheets/darkswarm/account.css.scss
@@ -28,6 +28,12 @@
       margin-bottom: 0px;
     }
   }
+
+  .authorised_shops{
+    table {
+      width: 100%;
+    }
+  }
 }
 
 .orders {

--- a/app/assets/stylesheets/darkswarm/help-modal.css.scss
+++ b/app/assets/stylesheets/darkswarm/help-modal.css.scss
@@ -1,0 +1,9 @@
+.help-modal {
+  .help-text {
+    font-size: 1rem;
+    margin: 20px 0px;
+  }
+  .help-icon {
+    font-size: 4rem;
+  }
+}

--- a/app/assets/stylesheets/darkswarm/ui.css.scss
+++ b/app/assets/stylesheets/darkswarm/ui.css.scss
@@ -87,6 +87,9 @@ button.success, .button.success {
   &.tiny {
     padding: 0rem;
     margin: 0;
+  }
+
+  &.right {
     float: right;
   }
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,13 @@
+# Base controller for OFN's API
+# Includes the minimum machinery required by ActiveModelSerializers
+module Api
+  class BaseController < Spree::Api::BaseController
+    # Need to include these because Spree::Api::BaseContoller inherits
+    # from ActionController::Metal rather than ActionController::Base
+    # and they are required by ActiveModelSerializers
+    include ActionController::Serialization
+    include ActionController::UrlFor
+    include Rails.application.routes.url_helpers
+    use_renderers :json
+  end
+end

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class CustomersController < Spree::Api::BaseController
+    respond_to :json
+
+    def update
+      @customer = Customer.find(params[:id])
+      authorize! :update, @customer
+
+      if @customer.update_attributes(params[:customer])
+        render text: @customer.id, :status => 200
+      else
+        invalid_resource!(@customer)
+      end
+    end
+  end
+end

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -1,13 +1,16 @@
 module Api
-  class CustomersController < Spree::Api::BaseController
-    respond_to :json
+  class CustomersController < BaseController
+    def index
+      @customers = current_api_user.customers
+      render json: @customers, each_serializer: CustomerSerializer
+    end
 
     def update
       @customer = Customer.find(params[:id])
       authorize! :update, @customer
 
       if @customer.update_attributes(params[:customer])
-        render text: @customer.id, :status => 200
+        render json: @customer, serializer: CustomerSerializer, status: 200
       else
         invalid_resource!(@customer)
       end

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class CustomersController < BaseController
     def index
-      @customers = current_api_user.customers
+      @customers = current_api_user.customers.of_regular_shops
       render json: @customers, each_serializer: CustomerSerializer
     end
 

--- a/app/controllers/api/statuses_controller.rb
+++ b/app/controllers/api/statuses_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class StatusesController < BaseController
+  class StatusesController < ::BaseController
     respond_to :json
 
     def job_queue

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -69,7 +69,8 @@ module InjectionHelper
   end
 
   def inject_shops
-    shops = Enterprise.where(id: @orders.pluck(:distributor_id).uniq)
+    customers = spree_current_user.customers.of_regular_shops
+    shops = Enterprise.where(id: @orders.pluck(:distributor_id).uniq | customers.pluck(:enterprise_id))
     inject_json_ams "shops", shops.all, Api::ShopForOrdersSerializer
   end
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -23,6 +23,11 @@ class Customer < ActiveRecord::Base
 
   scope :of, ->(enterprise) { where(enterprise_id: enterprise) }
 
+  scope :of_regular_shops, lambda {
+    next scoped unless Spree::Config.accounts_distributor_id
+    where('enterprise_id <> ?', Spree::Config.accounts_distributor_id)
+  }
+
   before_create :associate_user
 
   private

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -64,6 +64,10 @@ class AbilityDecorator
     can [:update, :destroy], Spree::CreditCard do |credit_card|
       credit_card.user == user
     end
+
+    can [:update], Customer do |customer|
+      customer.user == user
+    end
   end
 
   # New users can create an enterprise, and gain other permissions from doing this.

--- a/app/serializers/api/customer_serializer.rb
+++ b/app/serializers/api/customer_serializer.rb
@@ -1,0 +1,5 @@
+module Api
+  class CustomerSerializer < ActiveModel::Serializer
+    attributes :id, :enterprise_id, :name, :code, :email, :allow_charges
+  end
+end

--- a/app/views/shared/components/_show_profiles.html.haml
+++ b/app/views/shared/components/_show_profiles.html.haml
@@ -1,6 +1,6 @@
 .small-12.medium-6.columns.text-right
   .profile-checkbox
-    %button.button.secondary.tiny.help-btn.ng-scope{:popover => t(:components_profiles_popover, sitename: Spree::Config[:site_name]), "popover-placement" => "left"}><
+    %button.button.secondary.tiny.right.help-btn.ng-scope{:popover => t(:components_profiles_popover, sitename: Spree::Config[:site_name]), "popover-placement" => "left"}><
       %i.ofn-i_013-help
     %label
       %input{"ng-model" => "show_profiles", type: "checkbox", name: "profile"}

--- a/app/views/spree/users/_authorised_shops.html.haml
+++ b/app/views/spree/users/_authorised_shops.html.haml
@@ -1,0 +1,13 @@
+%table
+  %tr
+    %th= t(:shop_title)
+    %th= t(:allow_charges?)
+  %tr.customer{ id: "customer{{ customer.id }}", ng: { repeat: "customer in customers" } }
+    %td.shop{ ng: { bind: 'shopsByID[customer.enterprise_id].name' } }
+    %td.allow_charges
+      %input{ type: 'checkbox',
+        name: 'allow_charges',
+        ng: { model: 'customer.allow_charges',
+          change: 'customer.update()',
+          "true-value" => "true",
+          "false-value" => "false" } }

--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -17,6 +17,6 @@
         .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible' } }
           %h3
             = t('.authorised_shops')
-            %button.button.secondary.tiny.help-btn.ng-scope{ :popover => t('.authorised_shops_popover'), "popover-placement" => 'right' }
+            %button.button.secondary.tiny.help-btn.ng-scope{ "help-modal" => t('.authorised_shops_popover') }
               %i.ofn-i_013-help
           = render 'authorised_shops'

--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -2,7 +2,11 @@
   .credit_cards{"ng-controller" => "CreditCardsCtrl"}
     .row
       .small-12.medium-6.columns
-        %h3= t(:saved_cards)
+        %h3
+          = t(:saved_cards)
+          %button.button.secondary.tiny.help-btn.ng-scope{ "help-modal" => t('.saved_cards_popover') }
+            %i.ofn-i_013-help
+
         .saved_cards{ ng: { show: 'savedCreditCards.length > 0' } }
           = render 'saved_cards'
         .no_cards{ ng: { hide: 'savedCreditCards.length > 0' } }

--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -10,6 +10,13 @@
         %button.button.primary{ ng: { click: 'showForm()', hide: 'CreditCard.visible' } }
           = t(:add_a_card)
 
-      .small-12.medium-6.columns.new_card{ ng: { show: 'CreditCard.visible', class: '{visible: CreditCard.visible}' } }
-        %h3= t(:add_a_new_card)
-        = render 'new_card_form'
+      .small-12.medium-6.columns
+        .new_card{ ng: { show: 'CreditCard.visible', class: '{visible: CreditCard.visible}' } }
+          %h3= t(:add_a_new_card)
+          = render 'new_card_form'
+        .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible' } }
+          %h3
+            = t('.authorised_shops')
+            %button.button.secondary.tiny.help-btn.ng-scope{ :popover => t('.authorised_shops_popover'), "popover-placement" => 'right' }
+              %i.ofn-i_013-help
+          = render 'authorised_shops'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2740,5 +2740,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       saved_cards:
         default?: Default?
         delete?: Delete?
+      cards:
+        authorised_shops: Authorised Shops
+        authorised_shops_popover: This is a list of shops which are permitted to charge your default credit card for OFN services (eg. subscriptions). Your card details will be kept secure and will not be shared with shop owners.
     localized_number:
       invalid_format: has an invalid format. Please enter a number.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2743,5 +2743,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       cards:
         authorised_shops: Authorised Shops
         authorised_shops_popover: This is the list of shops which are permitted to charge your default credit card for any subscriptions (ie. repeating orders) you may have. Your card details will be kept secure and will not be shared with shop owners. You will always be notified when you are charged.
+        saved_cards_popover: This is the list of cards you have opted to save for later use. Your 'default' will be selected automatically when you checkout an order, and can be charged by any shops you have allowed to do so (see right).
     localized_number:
       invalid_format: has an invalid format. Please enter a number.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2742,6 +2742,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         delete?: Delete?
       cards:
         authorised_shops: Authorised Shops
-        authorised_shops_popover: This is a list of shops which are permitted to charge your default credit card for OFN services (eg. subscriptions). Your card details will be kept secure and will not be shared with shop owners.
+        authorised_shops_popover: This is the list of shops which are permitted to charge your default credit card for any subscriptions (ie. repeating orders) you may have. Your card details will be kept secure and will not be shared with shop owners. You will always be notified when you are charged.
     localized_number:
       invalid_format: has an invalid format. Please enter a number.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,7 +217,7 @@ Openfoodnetwork::Application.routes.draw do
       get :job_queue
     end
 
-    resources :customers, only: [:update]
+    resources :customers, only: [:index, :update]
 
     post '/product_images/:product_id', to: 'product_images#update_product_image'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,6 +217,8 @@ Openfoodnetwork::Application.routes.draw do
       get :job_queue
     end
 
+    resources :customers, only: [:update]
+
     post '/product_images/:product_id', to: 'product_images#update_product_image'
   end
 

--- a/db/migrate/20180406045821_add_charges_allowed_to_customers.rb
+++ b/db/migrate/20180406045821_add_charges_allowed_to_customers.rb
@@ -1,0 +1,5 @@
+class AddChargesAllowedToCustomers < ActiveRecord::Migration
+  def change
+    add_column :customers, :allow_charges, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,15 +79,16 @@ ActiveRecord::Schema.define(:version => 20180418025217) do
   add_index "coordinator_fees", ["order_cycle_id"], :name => "index_coordinator_fees_on_order_cycle_id"
 
   create_table "customers", :force => true do |t|
-    t.string   "email",           :null => false
-    t.integer  "enterprise_id",   :null => false
+    t.string   "email",                              :null => false
+    t.integer  "enterprise_id",                      :null => false
     t.string   "code"
     t.integer  "user_id"
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
+    t.datetime "created_at",                         :null => false
+    t.datetime "updated_at",                         :null => false
     t.integer  "bill_address_id"
     t.integer  "ship_address_id"
     t.string   "name"
+    t.boolean  "allow_charges",   :default => false, :null => false
   end
 
   add_index "customers", ["bill_address_id"], :name => "index_customers_on_bill_address_id"

--- a/spec/controllers/api/customers_controller_spec.rb
+++ b/spec/controllers/api/customers_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+module Api
+  describe CustomersController, type: :controller do
+    include AuthenticationWorkflow
+    render_views
+
+    let(:user) { create(:user) }
+    let(:customer) { create(:customer, user: user) }
+    let(:params) { { format: :json, id: customer.id, customer: { code: '123' } } }
+
+    describe "#update" do
+      context "as a user who is not associated with the customer" do
+        before do
+          allow(controller).to receive(:spree_current_user) { create(:user) }
+        end
+
+        it "returns unauthorized" do
+          spree_post :update, params
+          assert_unauthorized!
+        end
+      end
+
+      context "as the user associated with the customer" do
+        before do
+          allow(controller).to receive(:spree_current_user) { user }
+        end
+
+        context "when the update request is successful" do
+          it "returns the id of the updated customer" do
+            spree_post :update, params
+            expect(response.status).to eq 200
+            expect(response.body).to eq customer.id.to_s
+          end
+        end
+
+        context "when the update request fails" do
+          before { params[:customer][:email] = '' }
+
+          it "returns a 422, with an error message" do
+            spree_post :update, params
+            expect(response.status).to be 422
+            expect(JSON.parse(response.body)['error']).to be
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/customers_controller_spec.rb
+++ b/spec/controllers/api/customers_controller_spec.rb
@@ -23,6 +23,18 @@ module Api
         expect(json_response.length).to eq 1
         expect(json_response.first[:id]).to eq customer1.id
       end
+
+      context "when the accounts distributor id has been set" do
+        before do
+          Spree::Config.set(accounts_distributor_id: customer1.enterprise.id)
+        end
+
+        it "ignores the customer for that enterprise (if it exists)" do
+          spree_get :index
+          expect(response.status).to eq 200
+          expect(json_response.length).to eq 0
+        end
+      end
     end
 
     describe "#update" do

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -4,6 +4,7 @@ feature "Credit Cards", js: true do
   include AuthenticationWorkflow
   describe "as a logged in user" do
     let(:user) { create(:user) }
+    let!(:customer) { create(:customer, user: user) }
     let!(:default_card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ', is_default: true) }
     let!(:non_default_card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_FDTG') }
 
@@ -49,10 +50,10 @@ feature "Credit Cards", js: true do
 
       expect(page).to have_content I18n.t('js.default_card_updated')
 
+      expect(default_card.reload.is_default).to be false
       within(".card#card#{default_card.id}") do
         expect(find_field('default_card')).to_not be_checked
       end
-      expect(default_card.reload.is_default).to be false
       expect(non_default_card.reload.is_default).to be true
 
       # Shows the interface for adding a card
@@ -67,6 +68,14 @@ feature "Credit Cards", js: true do
 
       expect(page).to have_content I18n.t(:card_has_been_removed, number: "x-#{default_card.last_digits}")
       expect(page).to_not have_selector ".card#card#{default_card.id}"
+
+      # Allows authorisation of card use by shops
+      within "tr#customer#{customer.id}" do
+        expect(find_field('allow_charges')).to_not be_checked
+        find_field('allow_charges').click
+      end
+      expect(page).to have_content I18n.t('js.changes_saved')
+      expect(customer.reload.allow_charges).to be true
     end
   end
 end

--- a/spec/javascripts/unit/darkswarm/services/customer_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/customer_spec.js.coffee
@@ -1,0 +1,39 @@
+describe 'Customer', ->
+  describe "update", ->
+    $httpBackend = null
+    customer = null
+    response = { id: 3, code: '1234' }
+    RailsFlashLoaderMock = jasmine.createSpyObj('RailsFlashLoader', ['loadFlash'])
+
+    beforeEach ->
+      module 'Darkswarm'
+      module ($provide) ->
+        $provide.value 'RailsFlashLoader', RailsFlashLoaderMock
+        null
+
+      inject (_$httpBackend_, Customer)->
+        customer = new Customer(id: 3)
+        $httpBackend = _$httpBackend_
+
+    it "nests the params inside 'customer'", ->
+      $httpBackend
+        .expectPUT('/api/customers/3.json', { customer: { id: 3 } })
+        .respond 200, response
+      customer.update()
+      $httpBackend.flush()
+
+    describe "when the request succeeds", ->
+      it "shows a success flash", ->
+        $httpBackend.expectPUT('/api/customers/3.json').respond 200, response
+        customer.update()
+        $httpBackend.flush()
+        expect(RailsFlashLoaderMock.loadFlash)
+          .toHaveBeenCalledWith({success: jasmine.any(String)})
+
+    describe "when the request fails", ->
+      it "shows a error flash", ->
+        $httpBackend.expectPUT('/api/customers/3.json').respond 400, { error: 'Some error' }
+        customer.update()
+        $httpBackend.flush()
+        expect(RailsFlashLoaderMock.loadFlash)
+          .toHaveBeenCalledWith({error: 'Some error'})

--- a/spec/javascripts/unit/darkswarm/services/customers_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/customers_spec.js.coffee
@@ -1,0 +1,24 @@
+describe 'Customers', ->
+  describe "index", ->
+    $httpBackend = null
+    Customers = null
+    customerList = ['somecustomer']
+
+    beforeEach ->
+      module 'Darkswarm'
+      module ($provide) ->
+        $provide.value 'RailsFlashLoader', null
+        null
+
+      inject (_$httpBackend_, _Customers_)->
+        Customers = _Customers_
+        $httpBackend = _$httpBackend_
+
+    it "asks for customers and returns @all, promises to populate via @load", ->
+      spyOn(Customers,'load').and.callThrough()
+      $httpBackend.expectGET('/api/customers.json').respond 200, customerList
+      result = Customers.index()
+      $httpBackend.flush()
+      expect(Customers.load).toHaveBeenCalled()
+      expect(result).toEqual customerList
+      expect(Customers.all).toEqual customerList

--- a/spec/javascripts/unit/darkswarm/services/shops_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/shops_spec.js.coffee
@@ -1,0 +1,27 @@
+describe 'Shops', ->
+  describe "initialisation", ->
+    Shops = null
+    shops = ['some shop']
+
+    beforeEach ->
+      module 'Darkswarm'
+
+    describe "when the injector does not have a value for 'shops'", ->
+      beforeEach ->
+        inject (_Shops_) ->
+          Shops = _Shops_
+
+      it "does nothing, leaves @all empty", ->
+        expect(Shops.all).toEqual []
+
+    describe "when the injector has a value for 'shops'", ->
+      beforeEach ->
+        module ($provide) ->
+          $provide.value 'shops', shops
+          null
+
+        inject (_Shops_) ->
+          Shops = _Shops_
+
+      it "loads injected shops array into @all", ->
+        expect(Shops.all).toEqual shops

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,0 +1,15 @@
+module OpenFoodNetwork
+  module ApiHelper
+    def json_response
+      json_response = JSON.parse(response.body)
+      case json_response
+      when Hash
+        json_response.with_indifferent_access
+      when Array
+        json_response.map(&:with_indifferent_access)
+      else
+        json_response
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Part 2 of 3 PRs to close #2085
This PR just deals with the permissions layer of the change. It adds a field to `Customer` called `allow_charges` which determines whether a shop will be able to charge the customers default card for services (see part 3).

#### What should we test?

No services actually implement use of this permission layer yet, so all we can really test is that the customer is able to alter the set of shop who are (theoretically) able to charge their card.

- [ ] As a regular user, I should be able to see a list of the shops which are currently able to charge my default credit card for services by visiting my account page
- [ ] I should be able to understand the implications of granting charge permissions
- [ ] I should be able to grant or revoke permission to charge my default card from the interface

#### Release notes

Customers can now authorise individual shops to charge their default credit card for services provide through the OFN (such as automatic subscription payments)

#### Dependencies

This PR depends on #2274, so don't worry about testing it until that has gone through, just putting this here for preliminary code review if anyone gets a chance.
