### PR TITLE
Confirm first user when seeding database

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,3 +50,6 @@ def create_mail_method
 end
 
 create_mail_method
+
+spree_user = Spree::User.first
+spree_user && spree_user.confirm!

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -9,7 +9,6 @@ namespace :openfoodnetwork do
       require_relative '../../spec/support/spree/init'
       task_name = "openfoodnetwork:dev:load_sample_data"
 
-      spree_user = Spree::User.find_by_email('spree@example.com')
       country = Spree::Country.find_by_iso(ENV.fetch('DEFAULT_COUNTRY_CODE'))
       state = country.states.first
 
@@ -202,8 +201,6 @@ namespace :openfoodnetwork do
       CreateOrderCycle.new(enterprise2, variants).call
 
       EnterpriseRole.create!(user: Spree::User.first, enterprise: enterprise2)
-
-      spree_user.confirm!
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #2182 

Confirm first user when seeding database

Currently the first user is not confirmed until running the task
`openfoodnetwork:dev:load_sample_data`. This task does not need to be
run on a minimum implementation of a new server or development setup.

We now confirm the first user during seeding. This could be the default
email address or the user entered email address entered during seeding.

#### What should we test?

Logging in after a `db:setup` is ran no longer requires the first user to be confirmed manually.

1. rake db:setup
1. Try to log in