### PR TITLE
Docker/docker-compose integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+tmp
+log
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && apt-get install -y \
+    git-core \
+    curl \
+    zlib1g-dev \
+    build-essential \
+    libssl-dev \
+    libreadline-dev \
+    libyaml-dev \
+    libsqlite3-dev \
+    sqlite3 \
+    libxml2-dev \
+    libxslt1-dev \
+    libcurl4-openssl-dev \
+    python-software-properties \
+    libffi-dev
+
+RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv && \
+    git clone https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build && \
+    git clone https://github.com/nodenv/nodenv.git /root/.nodenv && \
+    git clone https://github.com/nodenv/node-build.git /root/.nodenv/plugins/node-build
+ENV PATH /root/.rbenv/shims:/root/.rbenv/bin:/root/.nodenv/shims:/root/.nodenv/bin:$PATH
+
+RUN rbenv install 2.1.5
+RUN rbenv global 2.1.5
+RUN echo "gem: --no-document" >> ~/.gemrc
+RUN gem install git-up bundler zeus
+
+RUN nodenv install 5.12.0
+
+RUN apt-get install -y git libpq-dev imagemagick phantomjs
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY Gemfile /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
+RUN bundle install
+
+COPY package.json /app/package.json
+COPY .node-version /app/.node-version
+RUN npm install
+
+ENV TZ Australia/Melbourne
+ENV TIMEZONE Australia/Melbourne
+
+COPY . /app
+
+EXPOSE 3000
+
+CMD rm -f /app/tmp/pids/server.pid \
+    && cp config/application.yml.example config/application.yml \
+    && bundle exec rake db:version || { printf '\n\n' | bundle exec rake db:setup; } \
+    && bundle exec rake db:test:prepare \
+    && bundle exec rails server

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -29,6 +29,9 @@ MAIL_PORT: 25
 SMTP_USERNAME: 'ofn'
 SMTP_PASSWORD: 'f00d'
 
+# Database settings
+DB_HOST: localhost
+
 # SingleSignOn login for Discourse
 #
 # DISCOURSE_SSO_SECRET should be a random string. It must be the same as provided to your Discourse instance.

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ development:
   encoding: unicode
   database: open_food_network_dev
   pool: 5
-  host: localhost
+  host: <%= ENV['DB_HOST'] %>
   username: ofn
   password: f00d
 
@@ -12,7 +12,7 @@ test:
   encoding: unicode
   database: open_food_network_test<%= ENV['TEST_ENV_NUMBER'] %>
   pool: 5
-  host: localhost
+  host: <%= ENV['DB_HOST'] %>
   username: ofn
   password: f00d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  web:
+    build: .
+    volumes:
+      - ${PWD}:/app
+      - /app/node_modules
+    ports:
+      - 3000:3000
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+  db:
+    image: postgres:9.5
+    volumes:
+      - data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: ofn
+      POSTGRES_PASSWORD: f00d
+volumes:
+  data:


### PR DESCRIPTION
#### What? Why?
Docker/docker-compose integration to speed up development environment setup/upgrade using Docker.

Why:
- Fast development environment setup and upgrade.
- Consistent environment.
- No virtual machine.

Why not:
- Docker integration maintenance.

#### What should we test?
- Some specs are failing and I cannot determine why.
- I introduce `DB_HOST` environment variable to specify postgresql container name. I'm not sure if this is a BC break.

#### How it works
Requirements: [Docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/)

To start up the application:

- run `docker-compose up`
- Visit http://localhost:3000

Other useful commands:
```
# Load sample data
docker-compose run --rm web bundle exec rake openfoodnetwork:dev:load_sample_data

# Run tests
docker-compose run --rm web bundle exec rspec spec
docker-compose run --rm web script/karma run
docker-compose run --rm web script/karma start

# Run other commands
docker-compose run --rm web COMMAND
```

#### Pending

- [ ] Update documentation