### PR TITLE
Subs: Confirm date change for Order Cycles with open subscription orders

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/directives/change-warning.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/directives/change-warning.js.coffee
@@ -9,10 +9,14 @@ angular.module("admin.orderCycles").directive "changeWarning", (ConfirmDialog) -
     msg = 'admin.order_cycles.date_warning.msg'
     options = { cancel: t(cancel), confirm: t(proceed) }
 
+    isOpen = (orderCycle) ->
+      moment(orderCycle.orders_open_at, "YYYY-MM-DD HH:mm:SS Z").isBefore() &&
+      moment(orderCycle.orders_close_at, "YYYY-MM-DD HH:mm:SS Z").isAfter()
+
     element.focus ->
       count = scope.orderCycle.subscriptions_count
       return if acknowledged
-      return if moment(scope.orderCycle.orders_close_at).isBefore()
+      return unless isOpen(scope.orderCycle)
       return if count < 1
       ConfirmDialog.open('info', t(msg, n: count), options).then ->
         acknowledged = true

--- a/app/assets/javascripts/admin/order_cycles/directives/change-warning.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/directives/change-warning.js.coffee
@@ -1,0 +1,19 @@
+angular.module("admin.orderCycles").directive "changeWarning", (ConfirmDialog) ->
+  restrict: "A"
+  scope:
+    orderCycle: '=changeWarning'
+  link: (scope, element, attrs) ->
+    acknowledged = false
+    count = scope.orderCycle.subscriptions_count
+    cancel = 'admin.order_cycles.date_warning.cancel'
+    proceed = 'admin.order_cycles.date_warning.proceed'
+    msg = t('admin.order_cycles.date_warning.msg', n: count)
+    options = { cancel: t(cancel), confirm: t(proceed) }
+
+    element.focus ->
+      return if acknowledged
+      return if moment(scope.orderCycle.orders_close_at).isBefore()
+      return if count < 1
+      ConfirmDialog.open('info', msg, options).then ->
+        acknowledged = true
+        element.siblings('img').trigger('click')

--- a/app/assets/javascripts/admin/order_cycles/directives/change-warning.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/directives/change-warning.js.coffee
@@ -4,16 +4,16 @@ angular.module("admin.orderCycles").directive "changeWarning", (ConfirmDialog) -
     orderCycle: '=changeWarning'
   link: (scope, element, attrs) ->
     acknowledged = false
-    count = scope.orderCycle.subscriptions_count
     cancel = 'admin.order_cycles.date_warning.cancel'
     proceed = 'admin.order_cycles.date_warning.proceed'
-    msg = t('admin.order_cycles.date_warning.msg', n: count)
+    msg = 'admin.order_cycles.date_warning.msg'
     options = { cancel: t(cancel), confirm: t(proceed) }
 
     element.focus ->
+      count = scope.orderCycle.subscriptions_count
       return if acknowledged
       return if moment(scope.orderCycle.orders_close_at).isBefore()
       return if count < 1
-      ConfirmDialog.open('info', msg, options).then ->
+      ConfirmDialog.open('info', t(msg, n: count), options).then ->
         acknowledged = true
         element.siblings('img').trigger('click')

--- a/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
@@ -209,6 +209,7 @@ angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, S
       delete order_cycle.editable_variants_for_incoming_exchanges
       delete order_cycle.editable_variants_for_outgoing_exchanges
       delete order_cycle.visible_variants_for_outgoing_exchanges
+      delete order_cycle.subscriptions_count
       order_cycle
 
     removeInactiveExchanges: (order_cycle) ->

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -19,7 +19,7 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render_as_json @collection, ams_prefix: params[:ams_prefix], current_user: spree_current_user
+          render_as_json @collection, ams_prefix: params[:ams_prefix], current_user: spree_current_user, subscriptions_counts: subscriptions_counts
         end
       end
     end
@@ -81,7 +81,7 @@ module Admin
     def bulk_update
       if order_cycle_set.andand.save
         respond_to do |format|
-          format.json { render_as_json @order_cycles, ams_prefix: 'index', current_user: spree_current_user }
+          format.json { render_as_json @order_cycles, ams_prefix: 'index', current_user: spree_current_user, subscriptions_counts: subscriptions_counts }
         end
       else
         respond_to do |format|
@@ -228,6 +228,11 @@ module Admin
     def require_order_cycle_set_params
       return if params[:order_cycle_set]
       render json: { errors: t('admin.order_cycles.bulk_update.no_data') }, status: :unprocessable_entity
+    end
+
+    def subscriptions_counts
+      return [] if @collection.blank?
+      ProxyOrder.not_canceled.group(:order_cycle_id).where(order_cycle_id: @collection).count
     end
 
     def ams_prefix_whitelist

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -19,7 +19,7 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render_as_json @collection, ams_prefix: params[:ams_prefix], current_user: spree_current_user, subscriptions_counts: subscriptions_counts
+          render_as_json @collection, ams_prefix: params[:ams_prefix], current_user: spree_current_user, subscriptions_count: SubscriptionsCount.new(@collection)
         end
       end
     end
@@ -81,7 +81,7 @@ module Admin
     def bulk_update
       if order_cycle_set.andand.save
         respond_to do |format|
-          format.json { render_as_json @order_cycles, ams_prefix: 'index', current_user: spree_current_user, subscriptions_counts: subscriptions_counts }
+          format.json { render_as_json @order_cycles, ams_prefix: 'index', current_user: spree_current_user, subscriptions_count: SubscriptionsCount.new(@collection) }
         end
       else
         respond_to do |format|
@@ -228,11 +228,6 @@ module Admin
     def require_order_cycle_set_params
       return if params[:order_cycle_set]
       render json: { errors: t('admin.order_cycles.bulk_update.no_data') }, status: :unprocessable_entity
-    end
-
-    def subscriptions_counts
-      return [] if @collection.blank?
-      ProxyOrder.not_canceled.group(:order_cycle_id).where(order_cycle_id: @collection).count
     end
 
     def ams_prefix_whitelist

--- a/app/serializers/api/admin/index_order_cycle_serializer.rb
+++ b/app/serializers/api/admin/index_order_cycle_serializer.rb
@@ -62,7 +62,7 @@ module Api
       end
 
       def subscriptions_count
-        options[:subscriptions_counts][object.id]
+        options[:subscriptions_count].for(object.id)
       end
 
       private

--- a/app/serializers/api/admin/index_order_cycle_serializer.rb
+++ b/app/serializers/api/admin/index_order_cycle_serializer.rb
@@ -7,7 +7,7 @@ module Api
 
       attributes :id, :name, :orders_open_at, :orders_close_at, :status, :variant_count, :deletable
       attributes :coordinator, :producers, :shops, :viewing_as_coordinator
-      attributes :edit_path, :clone_path, :delete_path
+      attributes :edit_path, :clone_path, :delete_path, :subscriptions_count
 
       has_many :schedules, serializer: Api::Admin::IdNameSerializer
 
@@ -59,6 +59,10 @@ module Api
 
       def delete_path
         admin_order_cycle_path(object)
+      end
+
+      def subscriptions_count
+        ProxyOrder.not_canceled.where(order_cycle_id: object.id).count
       end
 
       private

--- a/app/serializers/api/admin/index_order_cycle_serializer.rb
+++ b/app/serializers/api/admin/index_order_cycle_serializer.rb
@@ -62,7 +62,7 @@ module Api
       end
 
       def subscriptions_count
-        ProxyOrder.not_canceled.where(order_cycle_id: object.id).count
+        options[:subscriptions_counts][object.id]
       end
 
       private

--- a/app/serializers/api/admin/order_cycle_serializer.rb
+++ b/app/serializers/api/admin/order_cycle_serializer.rb
@@ -4,7 +4,7 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
   attributes :id, :name, :orders_open_at, :orders_close_at, :coordinator_id, :exchanges
   attributes :editable_variants_for_incoming_exchanges, :editable_variants_for_outgoing_exchanges
   attributes :visible_variants_for_outgoing_exchanges
-  attributes :viewing_as_coordinator, :schedule_ids
+  attributes :viewing_as_coordinator, :schedule_ids, :subscriptions_count
 
   has_many :coordinator_fees, serializer: Api::IdSerializer
 
@@ -18,6 +18,10 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
 
   def viewing_as_coordinator
     Enterprise.managed_by(options[:current_user]).include? object.coordinator
+  end
+
+  def subscriptions_count
+    ProxyOrder.not_canceled.where(order_cycle_id: object.id).count
   end
 
   def exchanges

--- a/app/services/subscriptions_count.rb
+++ b/app/services/subscriptions_count.rb
@@ -1,0 +1,19 @@
+class SubscriptionsCount
+  def initialize(order_cycles)
+    @order_cycles = order_cycles
+  end
+
+  def for(order_cycle_id)
+    active[order_cycle_id] || 0
+  end
+
+  private
+
+  attr_accessor :order_cycles
+
+  def active
+    return @active unless @active.nil?
+    return @active = [] if order_cycles.blank?
+    @active ||= ProxyOrder.not_canceled.group(:order_cycle_id).where(order_cycle_id: order_cycles).count
+  end
+end

--- a/app/views/admin/order_cycles/_name_and_timing_form.html.haml
+++ b/app/views/admin/order_cycles/_name_and_timing_form.html.haml
@@ -10,7 +10,7 @@
     = f.label :orders_open_at, t('.orders_open')
   .omega.six.columns
     - if viewing_as_coordinator_of?(@order_cycle)
-      = f.text_field :orders_open_at, 'datetimepicker' => 'order_cycle.orders_open_at', 'ng-model' => 'order_cycle.orders_open_at', 'ng-disabled' => '!loaded()'
+      = f.text_field :orders_open_at, 'datetimepicker' => 'order_cycle.orders_open_at', 'ng-model' => 'order_cycle.orders_open_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'
     - else
       {{ order_cycle.orders_open_at }}
 
@@ -23,7 +23,7 @@
     = f.label :orders_close, t('.orders_close')
   .six.columns.omega
     - if viewing_as_coordinator_of?(@order_cycle)
-      = f.text_field :orders_close_at, 'datetimepicker' => 'order_cycle.orders_close_at', 'ng-model' => 'order_cycle.orders_close_at', 'ng-disabled' => '!loaded()'
+      = f.text_field :orders_close_at, 'datetimepicker' => 'order_cycle.orders_close_at', 'ng-model' => 'order_cycle.orders_close_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'
     - else
       {{ order_cycle.orders_close_at }}
 

--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -8,10 +8,10 @@
         {{ schedule.name + ($last ? '' : ',') }}
     %span{ ng: { show: 'orderCycle.schedules.length == 0'}} None
   %td.orders_open_at{ ng: { show: 'columns.open.visible' } }
-    %input.datetimepicker{ id: 'oc{{::orderCycle.id}}_orders_open_at', name: 'oc{{::orderCycle.id}}[orders_open_at]', type: 'text', ng: { if: 'orderCycle.viewing_as_coordinator', model: 'orderCycle.orders_open_at' }, datetimepicker: 'orderCycle.orders_open_at' }
+    %input.datetimepicker{ id: 'oc{{::orderCycle.id}}_orders_open_at', name: 'oc{{::orderCycle.id}}[orders_open_at]', type: 'text', ng: { if: 'orderCycle.viewing_as_coordinator', model: 'orderCycle.orders_open_at' }, datetimepicker: 'orderCycle.orders_open_at', 'change-warning' => 'orderCycle' }
     %input{ id: 'oc{{::orderCycle.id}}_orders_open_at', name: 'oc{{::orderCycle.id}}[orders_open_at]', type: 'text', ng: { if: '!orderCycle.viewing_as_coordinator', model: 'orderCycle.orders_open_at'}, disabled: true }
   %td.orders_close_at{ ng: { show: 'columns.close.visible' } }
-    %input.datetimepicker{ id: 'oc{{::orderCycle.id}}_orders_close_at', name: 'oc{{::orderCycle.id}}[orders_close_at]', type: 'text', ng: { if: 'orderCycle.viewing_as_coordinator', model: 'orderCycle.orders_close_at' }, datetimepicker: 'orderCycle.orders_close_at' }
+    %input.datetimepicker{ id: 'oc{{::orderCycle.id}}_orders_close_at', name: 'oc{{::orderCycle.id}}[orders_close_at]', type: 'text', ng: { if: 'orderCycle.viewing_as_coordinator', model: 'orderCycle.orders_close_at' }, datetimepicker: 'orderCycle.orders_close_at', 'change-warning' => 'orderCycle'  }
     %input{ id: 'oc{{::orderCycle.id}}_orders_close_at', name: 'oc{{::orderCycle.id}}[orders_close_at]', type: 'text', ng: { if: '!orderCycle.viewing_as_coordinator', model: 'orderCycle.orders_close_at'}, disabled: true }
 
   - unless simple_index

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -902,6 +902,10 @@ en:
         schedule_present: That order cycle is linked to a schedule and cannot be deleted. Please unlink or delete the schedule first.
       bulk_update:
         no_data: Hm, something went wrong. No order cycle data found.
+      date_warning:
+        msg: This order cycle is linked to %{n} open subscription orders. Changing this date now will not affect any orders which have already been placed, but should be avoided if possible. Are you sure you want to proceed?
+        cancel: Cancel
+        proceed: Proceed
     producer_properties:
       index:
         title: Producer Properties

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -338,30 +338,5 @@ module Admin
       end
     end
 
-    describe "#subscriptions_counts" do
-      let(:oc1) { create(:simple_order_cycle) }
-      let(:oc2) { create(:simple_order_cycle) }
-      let(:collection) { OrderCycle.where(id: [oc1, oc2]) }
-
-      context "when the collection has not been set" do
-        it "returns and empty array" do
-          expect(controller.send(:subscriptions_counts)).to eq []
-        end
-      end
-
-      context "when the collection has been set" do
-        let!(:po1) { create(:proxy_order, order_cycle: oc1) }
-        let!(:po2) { create(:proxy_order, order_cycle: oc1) }
-        let!(:po3) { create(:proxy_order, order_cycle: oc2) }
-
-        before { controller.instance_variable_set(:@collection, collection) }
-
-        it "returns grouped count of all active proxy orders associated each order cycle in the collection" do
-          result = controller.send(:subscriptions_counts)
-          expect(result[oc1.id]).to eq 2
-          expect(result[oc2.id]).to eq 1
-        end
-      end
-    end
   end
 end

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -337,5 +337,31 @@ module Admin
         end
       end
     end
+
+    describe "#subscriptions_counts" do
+      let(:oc1) { create(:simple_order_cycle) }
+      let(:oc2) { create(:simple_order_cycle) }
+      let(:collection) { OrderCycle.where(id: [oc1, oc2]) }
+
+      context "when the collection has not been set" do
+        it "returns and empty array" do
+          expect(controller.send(:subscriptions_counts)).to eq []
+        end
+      end
+
+      context "when the collection has been set" do
+        let!(:po1) { create(:proxy_order, order_cycle: oc1) }
+        let!(:po2) { create(:proxy_order, order_cycle: oc1) }
+        let!(:po3) { create(:proxy_order, order_cycle: oc2) }
+
+        before { controller.instance_variable_set(:@collection, collection) }
+
+        it "returns grouped count of all active proxy orders associated each order cycle in the collection" do
+          result = controller.send(:subscriptions_counts)
+          expect(result[oc1.id]).to eq 2
+          expect(result[oc2.id]).to eq 1
+        end
+      end
+    end
   end
 end

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -24,6 +24,7 @@ feature %q{
     oc7 = create(:simple_order_cycle, name: 'oc7',
                 orders_open_at: 2.months.ago, orders_close_at: 5.weeks.ago)
     schedule1 = create(:schedule, name: 'Schedule1', order_cycles: [oc1, oc3])
+    create(:proxy_order, subscription: create(:subscription, schedule: schedule1), order_cycle: oc1)
 
     # When I go to the admin order cycles page
     login_to_admin_section
@@ -111,6 +112,10 @@ feature %q{
     page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
     page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
+
+    # Attempting to edit dates of an open order cycle with active subscriptions
+    find("#oc#{oc1.id}_orders_open_at").click
+    expect(page).to have_selector "#confirm-dialog .message", text: I18n.t('admin.order_cycles.date_warning.msg', n: 1)
   end
 
   describe 'listing order cycles with other locales' do

--- a/spec/services/subscriptions_count_spec.rb
+++ b/spec/services/subscriptions_count_spec.rb
@@ -1,0 +1,34 @@
+describe SubscriptionsCount do
+  let(:oc1) { create(:simple_order_cycle) }
+  let(:oc2) { create(:simple_order_cycle) }
+  let(:subscriptions_count) { SubscriptionsCount.new(order_cycles) }
+
+  describe "#for" do
+    context "when the collection has not been set" do
+      let(:order_cycles) { nil }
+      it "returns 0" do
+        expect(subscriptions_count.for(oc1.id)).to eq 0
+      end
+    end
+
+    context "when the collection has been set" do
+      let(:order_cycles) { OrderCycle.where(id: [oc1]) }
+      let!(:po1) { create(:proxy_order, order_cycle: oc1) }
+      let!(:po2) { create(:proxy_order, order_cycle: oc1) }
+      let!(:po3) { create(:proxy_order, order_cycle: oc2) }
+
+      context "but the requested id is not present in the list of order cycles provided" do
+        it "returns 0" do
+          # Note that po3 applies to oc2, but oc2 in not in the collection
+          expect(subscriptions_count.for(oc2.id)).to eq 0
+        end
+      end
+
+      context "and the requested id is present in the list of order cycles provided" do
+        it "returns a count of active proxy orders associated with the requested order cycle" do
+          expect(subscriptions_count.for(oc1.id)).to eq 2
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

#2293 deals with the logic of what happens when an open order cycle with subscription orders is altered in some way. This PR seeks to provide the user with additional information about what they are doing, and to warn them against making unnecessary changes to an open order cycle.

#### What should we test?

- [ ] If a user attempt to alter the dates of an open order cycle with subscription orders, they should be warned that they should avoid doing so if possible.

#### Release notes

Feature is yet to be released, so no separate release notes required.
