### PR TITLE
Subs: Rely on proxy order state to determine whether to confirm or not

### DIFF
--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -25,7 +25,6 @@ class SubscriptionConfirmJob
   def proxy_orders
     ProxyOrder.not_canceled.where('confirmed_at IS NULL AND placed_at IS NOT NULL')
       .joins(:order_cycle).merge(recently_closed_order_cycles)
-      .joins(:subscription).merge(Subscription.not_canceled.not_paused)
       .joins(:order).merge(Spree::Order.complete)
   end
 

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -16,18 +16,18 @@ describe SubscriptionConfirmJob do
       expect(proxy_orders).to include proxy_order
     end
 
+    it "returns proxy orders for paused subscriptions" do
+      subscription.update_attributes!(paused_at: 1.minute.ago)
+      expect(proxy_orders).to include proxy_order
+    end
+
+    it "returns proxy orders for cancelled subscriptions" do
+      subscription.update_attributes!(canceled_at: 1.minute.ago)
+      expect(proxy_orders).to include proxy_order
+    end
+
     it "ignores proxy orders where the OC closed more than 1 hour ago" do
       proxy_order.update_attributes!(order_cycle_id: order_cycle2.id)
-      expect(proxy_orders).to_not include proxy_order
-    end
-
-    it "ignores proxy orders for paused subscriptions" do
-      subscription.update_attributes!(paused_at: 1.minute.ago)
-      expect(proxy_orders).to_not include proxy_order
-    end
-
-    it "ignores proxy orders for cancelled subscriptions" do
-      subscription.update_attributes!(canceled_at: 1.minute.ago)
       expect(proxy_orders).to_not include proxy_order
     end
 


### PR DESCRIPTION
#### What? Why?

When a user cancels or pauses a subscription while an associated order cycle is open, they are asked whether they would like to keep or cancel the orders. A bug existed whereby even if they selected to keep the order, it would not be confirmed properly at the close of the order cycle, because the logic in the subscription confirm job would ignore any proxy orders associated with a paused or cancelled subscription.

This PR changes that logic to allow each order to determine whether it should be confirmed or not, independent of the state of the underlying subscription. 

#### What should we test?

- [ ] It should be possible to opt to cancel a subscription with an open order, then opt to keep that order. The order should be confirmed at the end of the order cycle.

#### Release notes

This is part of the subscriptions feature which has not been released yet, no release notes required.
