### PR TITLE
Subs: OrderCyclesController refactor

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -1,5 +1,3 @@
-require 'open_food_network/order_cycle_form_applicator'
-
 module Admin
   class OrderCyclesController < ResourceController
     include OrderCyclesHelper
@@ -41,7 +39,6 @@ module Admin
       @order_cycle_form = OrderCycleForm.new(@order_cycle, params, spree_current_user)
 
       if @order_cycle_form.save
-        OpenFoodNetwork::OrderCycleFormApplicator.new(@order_cycle, spree_current_user).go!
         flash[:notice] = I18n.t(:order_cycles_create_notice)
         render json: { success: true }
       else
@@ -53,10 +50,6 @@ module Admin
       @order_cycle_form = OrderCycleForm.new(@order_cycle, params, spree_current_user)
 
       if @order_cycle_form.save
-        unless params[:order_cycle][:incoming_exchanges].nil? && params[:order_cycle][:outgoing_exchanges].nil?
-          # Only update apply exchange information if it is actually submmitted
-          OpenFoodNetwork::OrderCycleFormApplicator.new(@order_cycle, spree_current_user).go!
-        end
         flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
         render json: { :success => true }
       else

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -43,9 +43,9 @@ module Admin
     end
 
     def create
-      @order_cycle = OrderCycle.new(params[:order_cycle])
+      @order_cycle_form = OrderCycleForm.new(@order_cycle, params)
 
-      if @order_cycle.save
+      if @order_cycle_form.save
         OpenFoodNetwork::OrderCycleFormApplicator.new(@order_cycle, spree_current_user).go!
         invoke_callbacks(:create, :after)
         flash[:notice] = I18n.t(:order_cycles_create_notice)
@@ -56,9 +56,9 @@ module Admin
     end
 
     def update
-      @order_cycle = OrderCycle.find params[:id]
+      @order_cycle_form = OrderCycleForm.new(@order_cycle, params)
 
-      if @order_cycle.update_attributes(params[:order_cycle])
+      if @order_cycle_form.save
         unless params[:order_cycle][:incoming_exchanges].nil? && params[:order_cycle][:outgoing_exchanges].nil?
           # Only update apply exchange information if it is actually submmitted
           OpenFoodNetwork::OrderCycleFormApplicator.new(@order_cycle, spree_current_user).go!

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -50,8 +50,11 @@ module Admin
       @order_cycle_form = OrderCycleForm.new(@order_cycle, params, spree_current_user)
 
       if @order_cycle_form.save
-        flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
-        render json: { :success => true }
+        respond_to do |format|
+          flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
+          format.html { redirect_to main_app.edit_admin_order_cycle_path(@order_cycle) }
+          format.json { render json: { :success => true } }
+        end
       else
         render json: { errors: @order_cycle.errors.full_messages }, status: :unprocessable_entity
       end

--- a/app/services/order_cycle_form.rb
+++ b/app/services/order_cycle_form.rb
@@ -1,0 +1,13 @@
+class OrderCycleForm
+  attr_accessor :order_cycle, :params
+
+  def initialize(order_cycle, params)
+    @order_cycle = order_cycle
+    @params = params
+  end
+
+  def save
+    order_cycle.assign_attributes(params[:order_cycle])
+    order_cycle.save
+  end
+end

--- a/app/services/order_cycle_form.rb
+++ b/app/services/order_cycle_form.rb
@@ -1,13 +1,50 @@
-class OrderCycleForm
-  attr_accessor :order_cycle, :params
+require 'open_food_network/permissions'
+require 'open_food_network/proxy_order_syncer'
 
-  def initialize(order_cycle, params)
+class OrderCycleForm
+  def initialize(order_cycle, params, user)
     @order_cycle = order_cycle
     @params = params
+    @permissions = OpenFoodNetwork::Permissions.new(user)
   end
 
   def save
+    check_editable_schedule_ids
     order_cycle.assign_attributes(params[:order_cycle])
-    order_cycle.save
+    return false unless order_cycle.valid?
+    order_cycle.transaction do
+      order_cycle.save!
+      sync_subscriptions
+      true
+    end
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
+  private
+
+  attr_accessor :order_cycle, :params, :permissions
+
+  def check_editable_schedule_ids
+    return unless params[:order_cycle][:schedule_ids]
+    requested = params[:order_cycle][:schedule_ids].map(&:to_i)
+    @existing_schedule_ids = @order_cycle.persisted? ? @order_cycle.schedule_ids : []
+    permitted = Schedule.where(id: requested | @existing_schedule_ids).merge(permissions.editable_schedules).pluck(:id)
+    result = @existing_schedule_ids
+    result |= (requested & permitted) # add any requested & permitted ids
+    result -= ((result & permitted) - requested) # remove any existing and permitted ids that were not specifically requested
+    params[:order_cycle][:schedule_ids] = result
+  end
+
+  def sync_subscriptions
+    return unless params[:order_cycle][:schedule_ids]
+    removed_ids = @existing_schedule_ids - @order_cycle.schedule_ids
+    new_ids = @order_cycle.schedule_ids - @existing_schedule_ids
+    if removed_ids.any? || new_ids.any?
+      schedules = Schedule.where(id: removed_ids + new_ids)
+      subscriptions = Subscription.where(schedule_id: schedules)
+      syncer = OpenFoodNetwork::ProxyOrderSyncer.new(subscriptions)
+      syncer.sync!
+    end
   end
 end

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -96,6 +96,40 @@ module Admin
       end
     end
 
+    describe "create" do
+      let(:shop) { create(:distributor_enterprise) }
+
+      context "as a manager of a shop" do
+        let(:form_mock) { instance_double(OrderCycleForm) }
+        let(:params) { { format: :json, order_cycle: {} } }
+
+        before do
+          login_as_enterprise_user([shop])
+          allow(OrderCycleForm).to receive(:new) { form_mock }
+        end
+
+        context "when creation is successful" do
+          before { allow(form_mock).to receive(:save) { true } }
+
+          it "returns success: true" do
+            spree_post :create, params
+            json_response = JSON.parse(response.body)
+            expect(json_response['success']).to be true
+          end
+        end
+
+        context "when an error occurs" do
+          before { allow(form_mock).to receive(:save) { false } }
+
+          it "returns an errors hash" do
+            spree_post :create, params
+            json_response = JSON.parse(response.body)
+            expect(json_response['errors']).to be
+          end
+        end
+      end
+    end
+
     describe "update" do
       let(:order_cycle) { create(:simple_order_cycle) }
       let(:producer) { create(:supplier_enterprise) }

--- a/spec/services/order_cycle_form_spec.rb
+++ b/spec/services/order_cycle_form_spec.rb
@@ -105,4 +105,36 @@ describe OrderCycleForm do
       end
     end
   end
+
+  describe "updating exchanges" do
+    let(:user) { instance_double(Spree::User) }
+    let(:order_cycle) { create(:simple_order_cycle) }
+    let(:form_applicator_mock) { instance_double(OpenFoodNetwork::OrderCycleFormApplicator) }
+    let(:form) { OrderCycleForm.new(order_cycle, params, user) }
+    let(:params) { { order_cycle: { name: 'Some new name' } } }
+
+    before do
+      allow(OpenFoodNetwork::OrderCycleFormApplicator).to receive(:new) { form_applicator_mock }
+      allow(form_applicator_mock).to receive(:go!)
+    end
+
+    context "when exchange params are provided" do
+      let(:exchange_params) { { incoming_exchanges: [], outgoing_exchanges: [] } }
+      before { params[:order_cycle].merge!(exchange_params) }
+
+      it "runs the OrderCycleFormApplicator, and saves other changes" do
+        expect(form.save).to be true
+        expect(form_applicator_mock).to have_received(:go!)
+        expect(order_cycle.name).to eq 'Some new name'
+      end
+    end
+
+    context "when no exchange params are provided" do
+      it "does not run the OrderCycleFormApplicator, but saves other changes" do
+        expect(form.save).to be true
+        expect(form_applicator_mock).to_not have_received(:go!)
+        expect(order_cycle.name).to eq 'Some new name'
+      end
+    end
+  end
 end

--- a/spec/services/order_cycle_form_spec.rb
+++ b/spec/services/order_cycle_form_spec.rb
@@ -1,0 +1,55 @@
+describe OrderCycleForm do
+  describe "save" do
+    describe "creating a new order cycle from params" do
+      let(:shop) { create(:enterprise) }
+      let(:order_cycle) { OrderCycle.new }
+      let(:form) { OrderCycleForm.new(order_cycle, params) }
+
+      context "when creation is successful" do
+        let(:params) { { order_cycle: { name: "Test Order Cycle", coordinator_id: shop.id } } }
+
+        it "returns true" do
+          expect do
+            expect(form.save).to be true
+          end.to change(OrderCycle, :count).by(1)
+        end
+      end
+
+      context "when creation fails" do
+        let(:params) { { order_cycle: { name: "Test Order Cycle" } } }
+
+        it "returns false" do
+          expect do
+            expect(form.save).to be false
+          end.to_not change(OrderCycle, :count)
+        end
+      end
+    end
+
+    describe "updating an existing order cycle from params" do
+      let(:shop) { create(:enterprise) }
+      let(:order_cycle) { create(:simple_order_cycle, name: "Old Name") }
+      let(:form) { OrderCycleForm.new(order_cycle, params) }
+
+      context "when update is successful" do
+        let(:params) { { order_cycle: { name: "Test Order Cycle", coordinator_id: shop.id } } }
+
+        it "returns true" do
+          expect do
+            expect(form.save).to be true
+          end.to change(order_cycle.reload, :name).to("Test Order Cycle")
+        end
+      end
+
+      context "when updating fails" do
+        let(:params) { { order_cycle: { name: nil } } }
+
+        it "returns false" do
+          expect do
+            expect(form.save).to be false
+          end.to_not change{ order_cycle.reload.name }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/order_cycle_form_spec.rb
+++ b/spec/services/order_cycle_form_spec.rb
@@ -3,7 +3,7 @@ describe OrderCycleForm do
     describe "creating a new order cycle from params" do
       let(:shop) { create(:enterprise) }
       let(:order_cycle) { OrderCycle.new }
-      let(:form) { OrderCycleForm.new(order_cycle, params) }
+      let(:form) { OrderCycleForm.new(order_cycle, params, shop.owner) }
 
       context "when creation is successful" do
         let(:params) { { order_cycle: { name: "Test Order Cycle", coordinator_id: shop.id } } }
@@ -29,7 +29,7 @@ describe OrderCycleForm do
     describe "updating an existing order cycle from params" do
       let(:shop) { create(:enterprise) }
       let(:order_cycle) { create(:simple_order_cycle, name: "Old Name") }
-      let(:form) { OrderCycleForm.new(order_cycle, params) }
+      let(:form) { OrderCycleForm.new(order_cycle, params, shop.owner) }
 
       context "when update is successful" do
         let(:params) { { order_cycle: { name: "Test Order Cycle", coordinator_id: shop.id } } }
@@ -48,6 +48,59 @@ describe OrderCycleForm do
           expect do
             expect(form.save).to be false
           end.to_not change{ order_cycle.reload.name }
+        end
+      end
+    end
+  end
+
+  describe "updating schedules" do
+    let(:user) { create(:user, enterprise_limit: 10) }
+    let!(:managed_coordinator) { create(:enterprise, owner: user) }
+    let!(:managed_enterprise) { create(:enterprise, owner: user) }
+    let!(:coordinated_order_cycle) { create(:simple_order_cycle, coordinator: managed_coordinator ) }
+    let!(:coordinated_order_cycle2) { create(:simple_order_cycle, coordinator: managed_enterprise ) }
+    let!(:uncoordinated_order_cycle) { create(:simple_order_cycle, coordinator: create(:enterprise) ) }
+    let!(:coordinated_schedule) { create(:schedule, order_cycles: [coordinated_order_cycle] ) }
+    let!(:coordinated_schedule2) { create(:schedule, order_cycles: [coordinated_order_cycle2] ) }
+    let!(:uncoordinated_schedule) { create(:schedule, order_cycles: [uncoordinated_order_cycle] ) }
+
+    context "where I manage the order_cycle's coordinator" do
+      let(:form) { OrderCycleForm.new(coordinated_order_cycle, params, user) }
+      let(:syncer_mock) { instance_double(OpenFoodNetwork::ProxyOrderSyncer, sync!: true) }
+
+      before do
+        allow(OpenFoodNetwork::ProxyOrderSyncer).to receive(:new) { syncer_mock }
+      end
+
+      context "and I add an schedule that I own, and remove another that I own" do
+        let(:params) { { order_cycle: { schedule_ids: [coordinated_schedule2.id] } } }
+
+        it "associates the order cycle to the schedule" do
+          expect(form.save).to be true
+          expect(coordinated_order_cycle.reload.schedules).to include coordinated_schedule2
+          expect(coordinated_order_cycle.reload.schedules).to_not include coordinated_schedule
+          expect(syncer_mock).to have_received(:sync!)
+        end
+      end
+
+      context "and I add a schedule that I don't own" do
+        let(:params) { { order_cycle: { schedule_ids: [coordinated_schedule.id, uncoordinated_schedule.id] } } }
+
+        it "ignores the schedule that I don't own" do
+          expect(form.save).to be true
+          expect(coordinated_order_cycle.reload.schedules).to include coordinated_schedule
+          expect(coordinated_order_cycle.reload.schedules).to_not include uncoordinated_schedule
+          expect(syncer_mock).to_not have_received(:sync!)
+        end
+      end
+
+      context "when I make no changes to the schedule ids" do
+        let(:params) { { order_cycle: { schedule_ids: [coordinated_schedule.id] } } }
+
+        it "ignores the schedule that I don't own" do
+          expect(form.save).to be true
+          expect(coordinated_order_cycle.reload.schedules).to include coordinated_schedule
+          expect(syncer_mock).to_not have_received(:sync!)
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Just a refactor of the `Admin::OrderCyclesController`. I started this work because I thought I needed it to solve another problem, but I ended up taking a different route. It still seems like a valuable change to make though, so I thought I would submit it and see if there is any appetite for pushing it through. If it all seems to hard we can just bin it.

#### What should we test?

The most annoying thing: all admin order cycle pages should behave exactly as before.

#### Release Notes

This is part of the subscriptions feature which has not been released yet, no release notes required.