### PR TITLE
Fix enterprise description display formatting

### DIFF
--- a/app/assets/javascripts/templates/partials/enterprise_details.html.haml
+++ b/app/assets/javascripts/templates/partials/enterprise_details.html.haml
@@ -15,7 +15,7 @@
 
       .about-container.pad-top
         %img.enterprise-logo{"ng-src" => "{{::enterprise.logo}}", "ng-if" => "::enterprise.logo"}
-        %p.text-small{"ng-bind-html" => "::enterprise.long_description"}
+        %div{"ng-bind-html" => "::enterprise.long_description"}
   .small-12.large-4.columns
     %ng-include{src: "'partials/contact.html'"}
     %ng-include{src: "'partials/follow.html'"}


### PR DESCRIPTION
#### What? Why?

Closes #953 

There was an open issue left in the comments of issue #953, which this does not address due to some open questions. If that gets spun into a new issue this will close the issue.

----

Fix enterprise description display formatting

Removes `text-small` class from container and change container to `div`
instead of `p` for semantic differentiation.

Before:
![before](https://user-images.githubusercontent.com/329205/40245885-b4daef70-5a7b-11e8-9b39-671d35467546.png)

After:
![after](https://user-images.githubusercontent.com/329205/40245886-b66ccb92-5a7b-11e8-981c-d2e88d9ef676.png)

#### What should we test?

Update the "About Us" text for an enterprise to include different heading tags (h1, h2, etc) and observe that the formatting for the headings is now correct.

#### Release notes

Fixes enterprise about us heading formats so that they appear as expected