### PR TITLE
Add phone number to shopfront contact info

### DIFF
--- a/app/views/shopping_shared/_contact.html.haml
+++ b/app/views/shopping_shared/_contact.html.haml
@@ -18,11 +18,14 @@
               = current_distributor.address.zipcode
 
       .small-12.large-4.columns
-        - if current_distributor.website || current_distributor.email_address
+        - if current_distributor.website || current_distributor.email_address || current_distributor.phone
           %div.center
             .header
               = t :shopping_contact_web
             %p
+              - unless current_distributor.phone.blank?
+                = current_distributor.phone
+                %br
               - unless current_distributor.website.blank?
                 %a{href: "http://#{current_distributor.website}", target: "_blank" }
                   = current_distributor.website


### PR DESCRIPTION
#### What? Why?

Closes #1832

Display the contact phone number on the shopfront contact area.

Before:
![before-2](https://user-images.githubusercontent.com/329205/40258361-2ac4a300-5aa6-11e8-81e6-a2b9757738be.png)

After:
![after-2](https://user-images.githubusercontent.com/329205/40258363-2ce8fd70-5aa6-11e8-9cf4-5774f811c42c.png)


#### What should we test?

1. Add phone number to enterprise
1. Check that phone number displays in the contact area on the shopfront