### PR TITLE
Ensure domain in SSL header matches request with or without www prefix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
     return if embedding_without_https?
 
     response.headers.delete 'X-Frame-Options'
-    response.headers['Content-Security-Policy'] = "frame-ancestors #{embedded_shopfront_referer}"
+    response.headers['Content-Security-Policy'] = "frame-ancestors #{URI(request.referer).host.downcase}"
 
     check_embedded_request
     set_embedded_layout

--- a/spec/requests/embedded_shopfronts_headers_spec.rb
+++ b/spec/requests/embedded_shopfronts_headers_spec.rb
@@ -44,7 +44,7 @@ describe "setting response headers for embedded shopfronts", type: :request do
     context "with a valid whitelist" do
       before do
         Spree::Config[:embedded_shopfronts_whitelist] = "example.com external-site.com"
-        allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return('http://www.external-site.com/shop?embedded_shopfront=true')
+        allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return('http://external-site.com/shop?embedded_shopfront=true')
       end
 
       it "allows iframes on certain pages when enabled in configuration" do
@@ -59,6 +59,21 @@ describe "setting response headers for embedded shopfronts", type: :request do
         expect(response.status).to be 200
         expect(response.headers['X-Frame-Options']).to eq 'DENY'
         expect(response.headers['Content-Security-Policy']).to eq "frame-ancestors 'none'"
+      end
+    end
+
+    context "with www prefix" do
+      before do
+        Spree::Config[:embedded_shopfronts_whitelist] = "example.com external-site.com"
+        allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return('http://www.external-site.com/shop?embedded_shopfront=true')
+      end
+
+      it "matches the URL structure in the header" do
+        get shops_path
+
+        expect(response.status).to be 200
+        expect(response.headers['X-Frame-Options']).to be_nil
+        expect(response.headers['Content-Security-Policy']).to eq "frame-ancestors www.external-site.com"
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #2302 

Headers need to include or exclude the www prefix when listing the domain in the `Content-Security-Policy` headers to match the requesting site, instead of just specifying the domain.

#### What should we test?

Embedded shopfronts work on sites with or without "www" in the URL.

#### Release notes

Fixes issue with embedded shopfronts not working on sites with "www" in the URL.

