### PR TITLE
Added missing translation key for no results in admin orders page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2243,6 +2243,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   order_cycles_no_permission_to_coordinate_error: "None of your enterprises have permission to coordinate an order cycle"
   order_cycles_no_permission_to_create_error: "You don't have permission to create an order cycle coordinated by that enterprise"
   back_to_orders_list: "Back to order list"
+  no_orders_found: "No Orders Found"
   order_information: "Order Information"
   date_completed: "Date Completed"
   amount: "Amount"


### PR DESCRIPTION
#### What? Why?

Closes #2308

The key no_orders_found used in orders admin page was missing from the translations file.

#### What should we test?

As far as I understand, this key will be picked up by transifex and we will be able to translate it to other languages. I have manually added this key and a translation to other language files and the text is translated correctly.

#### Release notes

Fixed missing translation in admin orders page.