### PR TITLE
Fixed broken translation keys in "new order cycle" screen

### DIFF
--- a/app/views/admin/order_cycles/_name_and_timing_form.html.haml
+++ b/app/views/admin/order_cycles/_name_and_timing_form.html.haml
@@ -31,7 +31,7 @@
 - if subscriptions_enabled?
   .row
     .two.columns.alpha
-      = f.label :schedule_ids, t('admin.order_cycles.schedules')
+      = f.label :schedule_ids, t('admin.order_cycles.index.schedules')
     .twelve.columns
       - if viewing_as_coordinator_of?(@order_cycle)
         %input.fullwidth.ofn-select2#schedule_ids{ name: 'order_cycle[schedule_ids]',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -806,7 +806,7 @@ en:
         name: Name
         orders_open: Orders open at
         coordinator: Coordinator
-        order_closes: Orders close
+        orders_close: Orders close
       row:
         suppliers: suppliers
         distributors: distributors


### PR DESCRIPTION
#### What? Why?

Closes #2307 

"Schedules" and "Orders close" translation keys were not being picked up from translations file. 

"Schedules" - changed the lookup path to pick up the right translation key (already available on translation files)
"Orders close" - renamed key on translation file. I decided to rename instead of just adding "orders_close" as I didn't find any occurrence of the key "order_closes" in both ofn and spree codebase.

#### What should we test?

The translations of the labels of the filters on the "New Order Cycle" screen:
- "Orders close" will have to go through transifex
- "Schedules" is not a new key so it will be immediately fixed.
