### PR TITLE
Fixed issue #1913 with expand/collapse of list of producers of a shop

### DIFF
--- a/app/views/shops/_fat.html.haml
+++ b/app/views/shops/_fat.html.haml
@@ -33,17 +33,18 @@
           %enterprise-modal
             %i.ofn-i_036-producers
             %span{"ng-bind" => "::enterprise.name"}
+        %li{"ng-repeat" => "enterprise in hub.producers.slice(7,hub.producers.length)", "class" => "additional-producer"}
+          %enterprise-modal
+            %i.ofn-i_036-producers
+            %span{"ng-bind" => "::enterprise.name"}
         %li{"data-is-link" => "true", "class" => "more-producers-link", "ng-show" => "::hub.producers.length>7"}
-          %a{"ng-click" => "toggleMoreProducers=!toggleMoreProducers"}
+          %a{"ng-click" => "toggleMoreProducers=!toggleMoreProducers; $event.stopPropagation()"}
             .more
               +
               %span{"ng-bind" => "::hub.producers.length-7"}
               = t :label_more
             .less
               = t :label_less
-        %li{"ng-repeat" => "enterprise in hub.producers.slice(7,hub.producers.length)", "class" => "additional-producer"}
-          %enterprise-modal
-            %i.ofn-i_036-producers
-            %span{"ng-bind" => "::enterprise.name"}
+
     %div.show-for-medium-up{"ng-if" => "::hub.producers.length==0"}
       &nbsp;


### PR DESCRIPTION
#### What? Why?

Closes #1913 

Functional: I have fixed the reported issue. I also moved the "show less" button to the end of the list of producers, the "show less" button was in the middle of expanded list of producers which looked really weird to me. Please confirm this is ok.

Tech: added stopPropagation so that the click event list of producers doesn't trigger the shop div click (and collapse) event.
This could be added on the ng-controller hub_node_controller.js.coffee, I have decided to leave it in the template as it's only a simple function call on $event.

#### What should we test?

List of shops and it's producers on the frontend.

#### Release notes

Fixed issue with expand/collapse of list of producers of a shop.