### PR TITLE
Add Skylight dashboard link to footer

### DIFF
--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -142,3 +142,13 @@
 
       .medium-2.columns.text-center
         / Placeholder
+    -if ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL'].present?
+      .row
+        .small-12.medium-8.medium-offset-2.columns.text-center
+          %hr.hr-light
+          %br
+
+      .row
+        .small-12.medium-8.medium-offset-2.columns.text-center
+          .text.small
+            = t :footer_skylight_dashboard_html, {dashboard: link_to('Skylight', ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL'], target: "_blank")}

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -43,6 +43,9 @@ SMTP_PASSWORD: 'f00d'
 # optional, see: https://www.skylight.io/oss
 # SKYLIGHT_AUTHENTICATION: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Should be set if using Skylight, adds a link to Skylight dashboard to our footer
+# SKYLIGHT_PUBLIC_DASHBOARD_URL: "https://oss.skylight.io/app/applications/xxxxxxxxxx"
+
 # Stripe Connect details for instance account
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings
 # Under 'Connect', the Redirect URI should be set to https://YOUR_SERVER_URL/stripe/callbacks (e.g. https://openfoodnetwork.org.uk/stripe/callbacks)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1187,6 +1187,8 @@ en:
   footer_legal_visit: "Find us on"
   footer_legal_text_html: "Open Food Network is a free and open source software platform. Our content is licensed with %{content_license} and our code with %{code_license}."
 
+  footer_skylight_dashboard_html: Performance data is available on %{dashboard}.
+
   home_shop: Shop Now
 
   brandstory_headline: "Food, unincorporated."


### PR DESCRIPTION
#### What? Why?

Closes #2327.

Now that multiple instances of OFN would like to use Skylight, they have requested that each instance display a link to their own dashboard somewhere visible so that contributors can find it.

This PR adds a link to the bottom of the footer on the frontend for the purpose of fulfilling this requirement.

![screen shot 2018-05-24 at 12 08 30 pm](https://user-images.githubusercontent.com/2067859/40461079-fdb201ae-5f4c-11e8-9135-046e8f70ea92.png)


#### What should we test?

This will require a developer to assist with setting up the `SKYLIGHT_PUBLIC_DASHBOARD_URL` env variable (via `application.yml`) for the purposes of testing.

- [x] When the `SKYLIGHT_PUBLIC_DASHBOARD_URL` env variable is set, the link to it is displayed at the bottom of the footer in the frontend.
- [x] When the `SKYLIGHT_PUBLIC_DASHBOARD_URL` env variable is not set, no link is shown in the footer.

#### Release notes

Added a link to the public Skylight dashboard for instance which are using Skylight to gather performance metrics.