### PR TITLE
Detect back button (alternative fix for #1213)

### DIFF
--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -40,6 +40,11 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
 
     update: =>
       @update_running = true
+      # This suppresses updating the cart if the back button was pressed.
+      # Items don't get deleted, but it still needs to be refreshed from the server
+      # as currentOrder in the page will be out of date
+      if (window.performance && window.performance.navigation.type == window.performance.navigation.TYPE_BACK_FORWARD)
+        return # Need to refresh data from the server here, just reloading page doesn't work as this then triggers populate method below.
 
       $http.post('/orders/populate', @data()).success (data, status)=>
         @saved()

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -4,6 +4,7 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
     dirty: false
     update_running: false
     update_enqueued: false
+    back_was_pressed: window.performance && window.performance.navigation.type == window.performance.navigation.TYPE_BACK_FORWARD
     order: CurrentOrder.order
     line_items: CurrentOrder.order?.line_items || []
     line_items_finalised: CurrentOrder.order?.finalised_line_items || []
@@ -42,9 +43,11 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       @update_running = true
       # This suppresses updating the cart if the back button was pressed.
       # Items don't get deleted, but it still needs to be refreshed from the server
-      # as currentOrder in the page will be out of date
-      if (window.performance && window.performance.navigation.type == window.performance.navigation.TYPE_BACK_FORWARD)
-        return # Need to refresh data from the server here, just reloading page doesn't work as this then triggers populate method below.
+      # otherwise currentOrder in the page will be out of date
+      if @back_was_pressed
+        @update_running = false
+        location.reload()
+        return 
 
       $http.post('/orders/populate', @data()).success (data, status)=>
         @saved()

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   prepend_before_filter :restrict_iframes
-  before_filter :set_cache_headers # Issue #1213, prevent cart emptying via cache when using back button
 
   include EnterprisesHelper
   helper CssSplitter::ApplicationHelper
@@ -151,12 +150,6 @@ class ApplicationController < ActionController::Base
     block.call
     self.formats = old_formats
     nil
-  end
-
-  def set_cache_headers # https://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
-    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 
 end


### PR DESCRIPTION
#### What? Why?
Alternative fix for #1213. 

I came up with an alternative approach in case the other hack preventing use of the cache site-wide does result in poor performance. This has three steps: 1) catch the back button press 2) suppress updating of the cart and 3) refresh to get the cart data from the server again. This last full refresh step is a bit ugly, maybe there's a better way? 

Something like this is necessary because of the way the currentOrder data is injected into the page - it's hard to update that dynamically. Stopping the orders#populate method prevents the new items being deleted on the server when the old (cached?) cart is re-synced, but the old currentOrder data is still in the page when back is pressed so the cart can't just be updated with that, hence the reload is needed. If we rewrite the service to use an ajax request (or ngResource) instead, we could get around it.

#### What should we test?

Add items to cart, click edit cart. Pressing back forces refresh of the page [which has the wrong (empty) cart at first] and restores the correct cart contents.

The extra refresh step should not happen on presses of the back button in other contexts (it only happens when the update method gets called in the cart service).

