### PR TITLE
Correct 'Next Order Closing' text in shopfront when switching OCs

### DIFF
--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -27,6 +27,7 @@ class ShopController < BaseController
     if request.post?
       if oc = OrderCycle.with_distributor(@distributor).active.find_by_id(params[:order_cycle_id])
         current_order(true).set_order_cycle! oc
+        @current_order_cycle = oc
         render partial: "json/order_cycle"
       else
         render status: 404, json: ""

--- a/spec/controllers/shop_controller_spec.rb
+++ b/spec/controllers/shop_controller_spec.rb
@@ -56,6 +56,20 @@ describe ShopController, type: :controller do
           spree_get :order_cycle
           response.body.should have_content oc1.id
         end
+
+        context "when the order cycle has already been set" do
+          let(:oc1) { create(:simple_order_cycle, distributors: [distributor]) }
+          let(:oc2) { create(:simple_order_cycle, distributors: [distributor]) }
+          let(:order) { create(:order, order_cycle: oc1) }
+
+          before { allow(controller).to receive(:current_order) { order } }
+
+          it "returns the new order cycle details" do
+            spree_post :order_cycle, order_cycle_id: oc2.id
+            expect(response).to be_success
+            expect(response.body).to have_content oc2.id
+          end
+        end
       end
 
       it "should not allow the user to select an invalid order cycle" do
@@ -143,12 +157,12 @@ describe ShopController, type: :controller do
         let!(:tag_rule) { create(:filter_products_tag_rule,
           enterprise: distributor,
           preferred_customer_tags: "member",
-          preferred_variant_tags: "members-only") 
+          preferred_variant_tags: "members-only")
         }
         let!(:default_tag_rule) { create(:filter_products_tag_rule,
           enterprise: distributor,
           is_default: true,
-          preferred_variant_tags: "members-only") 
+          preferred_variant_tags: "members-only")
         }
         let(:product1) { { "id" => 1, "name" => 'product 1', "variants" => [{ "id" => 4, "tag_list" => ["members-only"] }] } }
         let(:product2) { { "id" => 2, "name" => 'product 2', "variants" => [{ "id" => 5, "tag_list" => ["members-only"] }, {"id" => 9, "tag_list" => ["something"]}] } }


### PR DESCRIPTION
#### What? Why?

Closes #1938 

When switching between OCs in the shopfront, the 'Next Order Closing' text was not updating correctly, it was always one change behind. This was very confusing to users.

The reason for this bug was that a cached value of `current_order_cycle` was being rendered by the `ShopController#order_cycle` action, and this meant that the previous order cycle rather than the current one was being used to determine the date to use for the 'Next Order Closing' text. There was not a spec to cover the case of updating an OC, so I added one.

#### What should we test?

- [x] The 'Next Order Closing' text matches the close date of the selected OC after it has been changed

#### Release notes

Fixed a bug which caused the 'Next Order Closing' text in the shopfront to be incorrect in some scenarios.