### PR TITLE
Fixed missing translations on shops filter - delivery option

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/shipping_type_selector.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/shipping_type_selector.js.coffee
@@ -11,8 +11,10 @@ Darkswarm.directive "shippingTypeSelector", ->
     scope.selectors =
       delivery: scope.filterSelectors.new
         icon: "ofn-i_039-delivery"
+        translation_key: "hubs_delivery"
       pickup: scope.filterSelectors.new
         icon: "ofn-i_038-takeaway"
+        translation_key: "hubs_pickup"
       
     scope.emit = ->
       scope.shippingTypes =

--- a/app/assets/javascripts/templates/shipping_type_selector.html.haml
+++ b/app/assets/javascripts/templates/shipping_type_selector.html.haml
@@ -1,4 +1,4 @@
 %ul.small-block-grid-2.medium-block-grid-4.large-block-grid-2
   %active-selector{"ng-repeat" => "(name, selector) in selectors"}
     %i{"ng-class" => "selector.icon"}
-    {{ name | capitalize }}
+    {{ selector.translation_key | t | capitalize }}


### PR DESCRIPTION
#### What? Why?

Closes #2334 

Fixed translation problem in the shops filter. Used keys "pickup" and "delivery" did not exist. I could have added these new keys but I have decided to use the existing and appropriate keys "hubs_pickup" and "hubs_delivery" instead.

#### What should we test?

Go to shops list in the frontoffice and verify delivery options filter is translated.

#### Release notes

Fixed missing translations on shops filter - delivery option