### PR TITLE
Fix guest checkout login modal

### DIFF
--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -13,7 +13,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
     submit: =>
       Loading.message = t 'submitting_order'
       $http.put('/checkout.json', {order: @preprocess()}).success (data, status)=>
-        Navigation.go data.path
+        Navigation.goWithoutHashFragments data.path
       .error (response, status)=>
         if response.path
           Navigation.go response.path

--- a/app/assets/javascripts/darkswarm/services/navigation.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/navigation.js.coffee
@@ -16,6 +16,10 @@ Darkswarm.factory 'Navigation', ($location, $window) ->
       else
         @navigate(path)
 
+    goWithoutHashFragments: (path) ->
+      # Redirects to specified path, without Angular hash fragments such as '#/login'
+      $window.location.href = $window.location.origin + path
+
     go: (path)->
       if path.match /^http/
         $window.location.href = path


### PR DESCRIPTION
#### What? Why?

Closes #2277

After using the guest checkout the login modal was appearing on the order completed page.

#### What should we test?
Guest checkout works without the login modal opening afterwards.

#### Release notes

Minor fix for #2277, login modal now doesn't open unexpectedly after using guest checkout.