### PR TITLE
fixed country_state selectors on checkout

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/checkout/country_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/country_controller.js.coffee
@@ -1,0 +1,8 @@
+Darkswarm.controller "CountryCtrl", ($scope, availableCountries) ->
+
+  $scope.countries = availableCountries
+
+  $scope.countriesById = $scope.countries.reduce (obj, country) ->
+    obj[country.id] = country
+    obj
+  , {}

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -66,16 +66,6 @@ module CheckoutHelper
     Spree::Money.new order.total - order.total_tax, currency: order.currency
   end
 
-  def checkout_state_options(source_address)
-    if source_address == :billing
-      address = @order.billing_address
-    elsif source_address == :shipping
-      address = @order.shipping_address
-    end
-
-    [[]] + address.country.states.map { |c| [c.name, c.id] }
-  end
-
   def validated_input(name, path, args = {})
     attributes = {
       required: true,

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -76,10 +76,6 @@ module CheckoutHelper
     [[]] + address.country.states.map { |c| [c.name, c.id] }
   end
 
-  def checkout_country_options
-    available_countries.map { |c| [c.name, c.id] }
-  end
-
   def validated_input(name, path, args = {})
     attributes = {
       required: true,

--- a/app/views/checkout/_billing.html.haml
+++ b/app/views/checkout/_billing.html.haml
@@ -33,7 +33,7 @@
 
             .small-6.columns
               %label{ for: 'order.bill_address.state_id' } {{ "state" | t }}
-              %select.chunky{ id: 'order.bill_address.state_id', ng: { model: 'order.bill_address.state_id', options: 's.id as s.abbr for s in countriesById[order.bill_address.country_id].states' } }
+              %select.chunky{ id: 'order.bill_address.state_id', ng: { model: 'order.bill_address.state_id', options: 's.id as s.name for s in countriesById[order.bill_address.country_id].states' } }
 
           .row
             .small-6.columns

--- a/app/views/checkout/_billing.html.haml
+++ b/app/views/checkout/_billing.html.haml
@@ -32,16 +32,13 @@
               = validated_input t(:city), "order.bill_address.city"
 
             .small-6.columns
-              %label{ for: 'order.bill_address.state_id' } {{ "state" | t }}
-              %select.chunky{ id: 'order.bill_address.state_id', ng: { model: 'order.bill_address.state_id', options: 's.id as s.name for s in countriesById[order.bill_address.country_id].states' } }
-
+              = validated_select t(:state), "order.bill_address.state_id", {}, {"ng-options" => "s.id as s.name for s in countriesById[order.bill_address.country_id].states"}
           .row
             .small-6.columns
               = validated_input t(:postcode), "order.bill_address.zipcode"
 
             .small-6.columns.right
-              %label{ for: 'order.bill_address.country_id' } {{ "country" | t }}
-              %select.chunky{ id: 'order.bill_address.country_id', required: false, ng: { init: "order.bill_address.country_id = #{Spree::Config[:default_country_id]}", model: 'order.bill_address.country_id', options: 'c.id as c.name for c in countries' } }
+              = validated_select t(:country), "order.bill_address.country_id", {}, {"ng-init" => "order.bill_address.country_id = order.bill_address.country_id || #{Spree::Config[:default_country_id]}", "ng-options" => "c.id as c.name for c in countries"}
 
       .row
         .small-12.columns.text-right

--- a/app/views/checkout/_billing.html.haml
+++ b/app/views/checkout/_billing.html.haml
@@ -19,25 +19,29 @@
             %input{type: :checkbox, "ng-model" => "Checkout.default_bill_address"}
             = t :checkout_default_bill_address
 
-      = f.fields_for :bill_address, @order.bill_address do |ba|
-        .row
-          .small-12.columns
-            = validated_input t(:address), "order.bill_address.address1", "ofn-focus" => "accordion['billing']"
-        .row
-          .small-12.columns
-            = validated_input t(:address2), "order.bill_address.address2", required: false
-        .row
-          .small-6.columns
-            = validated_input t(:city), "order.bill_address.city"
+      %div{ "ng-controller" => "CountryCtrl" }
+        = f.fields_for :bill_address, @order.bill_address do |ba|
+          .row
+            .small-12.columns
+              = validated_input t(:address), "order.bill_address.address1", "ofn-focus" => "accordion['billing']"
+          .row
+            .small-12.columns
+              = validated_input t(:address2), "order.bill_address.address2", required: false
+          .row
+            .small-6.columns
+              = validated_input t(:city), "order.bill_address.city"
 
-          .small-6.columns
-            = validated_select t(:state), "order.bill_address.state_id", checkout_state_options(:billing)
-        .row
-          .small-6.columns
-            = validated_input t(:postcode), "order.bill_address.zipcode"
+            .small-6.columns
+              %label{ for: 'order.bill_address.state_id' } {{ "state" | t }}
+              %select.chunky{ id: 'order.bill_address.state_id', ng: { model: 'order.bill_address.state_id', options: 's.id as s.abbr for s in countriesById[order.bill_address.country_id].states' } }
 
-          .small-6.columns.right
-            = validated_select t(:country), "order.bill_address.country_id", checkout_country_options
+          .row
+            .small-6.columns
+              = validated_input t(:postcode), "order.bill_address.zipcode"
+
+            .small-6.columns.right
+              %label{ for: 'order.bill_address.country_id' } {{ "country" | t }}
+              %select.chunky{ id: 'order.bill_address.country_id', required: false, ng: { init: "order.bill_address.country_id = #{Spree::Config[:default_country_id]}", model: 'order.bill_address.country_id', options: 'c.id as c.name for c in countries' } }
 
       .row
         .small-12.columns.text-right

--- a/app/views/checkout/_shipping_ship_address.html.haml
+++ b/app/views/checkout/_shipping_ship_address.html.haml
@@ -1,28 +1,32 @@
 .small-12.columns
   #ship_address{"ng-if" => "Checkout.requireShipAddress()"}
     %div.visible{"ng-if" => "!Checkout.ship_address_same_as_billing"}
-      .row
-        .small-6.columns
-          = validated_input t(:first_name), "order.ship_address.firstname", "ofn-focus" => "accordion['shipping']"
-        .small-6.columns
-          = validated_input t(:last_name), "order.ship_address.lastname"
-      .row
-        .small-12.columns
-          = validated_input t(:address), "order.ship_address.address1"
-      .row
-        .small-12.columns
-          = validated_input t(:address2), "order.ship_address.address2", required: false
-      .row
-        .small-6.columns
-          = validated_input t(:city), "order.ship_address.city"
-        .small-6.columns
-          = validated_select t(:state), "order.ship_address.state_id", checkout_state_options(:shipping)
-      .row
-        .small-6.columns
-          = validated_input t(:postcode), "order.ship_address.zipcode"
-        .small-6.columns.right
-          = validated_select t(:country), "order.ship_address.country_id", checkout_country_options
+      %div{ "ng-controller" => "CountryCtrl" }
+        .row
+          .small-6.columns
+            = validated_input t(:first_name), "order.ship_address.firstname", "ofn-focus" => "accordion['shipping']"
+          .small-6.columns
+            = validated_input t(:last_name), "order.ship_address.lastname"
+        .row
+          .small-12.columns
+            = validated_input t(:address), "order.ship_address.address1"
+        .row
+          .small-12.columns
+            = validated_input t(:address2), "order.ship_address.address2", required: false
+        .row
+          .small-6.columns
+            = validated_input t(:city), "order.ship_address.city"
+          .small-6.columns
+            %label{ for: 'order.ship_address.state_id' } {{ "state" | t }}
+            %select.chunky{ id: 'order.ship_address.state_id', ng: { model: 'order.ship_address.state_id', options: 's.id as s.abbr for s in countriesById[order.ship_address.country_id].states' } }
 
-      .row
-        .small-6.columns
-          = validated_input t(:phone), "order.ship_address.phone"
+        .row
+          .small-6.columns
+            = validated_input t(:postcode), "order.ship_address.zipcode"
+          .small-6.columns.right
+            %label{ for: 'order.ship_address.country_id' } {{ "country" | t }}
+            %select.chunky{ id: 'order.ship_address.country_id', required: false, ng: { init: "order.ship_address.country_id = #{Spree::Config[:default_country_id]}", model: 'order.ship_address.country_id', options: 'c.id as c.name for c in countries' } }
+
+        .row
+          .small-6.columns
+            = validated_input t(:phone), "order.ship_address.phone"

--- a/app/views/checkout/_shipping_ship_address.html.haml
+++ b/app/views/checkout/_shipping_ship_address.html.haml
@@ -17,16 +17,12 @@
           .small-6.columns
             = validated_input t(:city), "order.ship_address.city"
           .small-6.columns
-            %label{ for: 'order.ship_address.state_id' } {{ "state" | t }}
-            %select.chunky{ id: 'order.ship_address.state_id', ng: { model: 'order.ship_address.state_id', options: 's.id as s.name for s in countriesById[order.ship_address.country_id].states' } }
-
+            = validated_select t(:state), "order.ship_address.state_id", {}, {"ng-options" => "s.id as s.name for s in countriesById[order.ship_address.country_id].states"}
         .row
           .small-6.columns
             = validated_input t(:postcode), "order.ship_address.zipcode"
           .small-6.columns.right
-            %label{ for: 'order.ship_address.country_id' } {{ "country" | t }}
-            %select.chunky{ id: 'order.ship_address.country_id', required: false, ng: { init: "order.ship_address.country_id = #{Spree::Config[:default_country_id]}", model: 'order.ship_address.country_id', options: 'c.id as c.name for c in countries' } }
-
+            = validated_select t(:country), "order.ship_address.country_id", {}, {"ng-init" => "order.ship_address.country_id = order.ship_address.country_id || #{Spree::Config[:default_country_id]}", "ng-options" => "c.id as c.name for c in countries"}
         .row
           .small-6.columns
             = validated_input t(:phone), "order.ship_address.phone"

--- a/app/views/checkout/_shipping_ship_address.html.haml
+++ b/app/views/checkout/_shipping_ship_address.html.haml
@@ -18,7 +18,7 @@
             = validated_input t(:city), "order.ship_address.city"
           .small-6.columns
             %label{ for: 'order.ship_address.state_id' } {{ "state" | t }}
-            %select.chunky{ id: 'order.ship_address.state_id', ng: { model: 'order.ship_address.state_id', options: 's.id as s.abbr for s in countriesById[order.ship_address.country_id].states' } }
+            %select.chunky{ id: 'order.ship_address.state_id', ng: { model: 'order.ship_address.state_id', options: 's.id as s.name for s in countriesById[order.ship_address.country_id].states' } }
 
         .row
           .small-6.columns

--- a/app/views/checkout/edit.html.haml
+++ b/app/views/checkout/edit.html.haml
@@ -2,6 +2,7 @@
   = t :checkout_title
 
 = inject_enterprise_and_relatives
+= inject_available_countries
 
 .darkswarm.footer-pad
   - content_for :order_cycle_form do


### PR DESCRIPTION
#### What? Why?

Closes #2105 

Functional:
- In the checkout screen, the list of states was not being updated when the country was changed.

Technical Solution:
- I injected country/state data into the browser and created simple country controller to handle the behaviour (inspired by what's done on the enterprise registration process code).

Technical question for review:
- is the div with the controller on the right place on the html or is there a better place?
          %div{ "ng-controller" => "CountryCtrl" }

Issue:
- I run into an issue when doing checkout in the US. Checkout errors out with an message related to adjustments:
- RuntimeError (can't modify frozen Hash):
          app/models/spree/order_decorator.rb:413:in `update_adjustment!'
- git blame around this line of code points to Maikel, Rob and Enrico. Do you guys understand what this error is?
- Do you think we need to fix this now? It only happens in US on my local instance.
Thank you!

#### What should we test?

Checkout process and country state selection on both shipping and billing addresses.
I have tested this quite a bit now. I think it's working correctly. I can checkout in both Portugal and Spain. 

#### Release notes

Fixed country and state selectors on checkout. User can checkout with addresses in multiple countries on the same OFN instance.