### PR TITLE
removed uppercase from state on shops and producers lists in the frontoffice

### DIFF
--- a/app/views/producers/_skinny.html.haml
+++ b/app/views/producers/_skinny.html.haml
@@ -18,7 +18,7 @@
   .columns.small-6.medium-2.large-2
     %span.margin-top{"ng-bind" => "::producer.address.city"}
   .columns.small-4.medium-1.large-1
-    %span.margin-top{"ng-bind" => "::producer.address.state_name | uppercase"}
+    %span.margin-top{"ng-bind" => "::producer.address.state_name"}
   .columns.small-2.medium-1.large-1.text-right
     %span.margin-top
       %i{"ng-class" => "{'ofn-i_005-caret-down' : !open(), 'ofn-i_006-caret-up' : open()}"}

--- a/app/views/shops/_skinny.html.haml
+++ b/app/views/shops/_skinny.html.haml
@@ -7,7 +7,7 @@
   .columns.small-4.medium-2.large-2
     %span.margin-top{"ng-bind" => "::hub.address.city"}
   .columns.small-2.medium-1.large-1
-    %span.margin-top{"ng-bind" => "::hub.address.state_name | uppercase"}
+    %span.margin-top{"ng-bind" => "::hub.address.state_name"}
     %span.margin-top{"ng-if" => "hub.distance != null && hub.distance > 0"} ({{ hub.distance / 1000 | number:0 }} km)
 
   .columns.small-4.medium-3.large-3.text-right{"ng-if" => "::hub.active"}
@@ -39,7 +39,7 @@
   .columns.small-4.medium-2.large-2
     %span.margin-top{"ng-bind" => "::hub.address.city"}
   .columns.small-2.medium-1.large-1
-    %span.margin-top{"ng-bind" => "::hub.address.state_name | uppercase"}
+    %span.margin-top{"ng-bind" => "::hub.address.state_name"}
 
   .columns.small-6.medium-3.large-4.text-right
     %span.margin-top{ ng: { if: "::!current()" } }


### PR DESCRIPTION
#### What? Why?

Complements https://github.com/openfoodfoundation/openfoodnetwork/pull/1969
by removing uppercase from state on shops and producers lists in the frontoffice

#### What should we test?

Verify that state abbreviations are not uppercased in the shops and producers list (frontoffice).

#### Dependencies

This PR depends on (but does not conflict with ) this PR: https://github.com/openfoodfoundation/openfoodnetwork/pull/1969
