### PR TITLE
Subs: totals in backend are consistent and include fee breakdown

### DIFF
--- a/app/assets/stylesheets/admin/index_panel_buttons.css.scss
+++ b/app/assets/stylesheets/admin/index_panel_buttons.css.scss
@@ -5,6 +5,7 @@ tbody.panel-ctrl {
     > td {
       a.update {
         cursor: pointer;
+        margin-top: 10px;
         margin-bottom: 10px;
         font-size: 1.3rem;
         background-color: $warning-red;

--- a/app/serializers/api/admin/proxy_order_serializer.rb
+++ b/app/serializers/api/admin/proxy_order_serializer.rb
@@ -5,11 +5,8 @@ module Api
       attributes :update_issues
 
       def total
-        if object.total.present?
-          object.total.to_money.to_s
-        else
-          object.subscription.subscription_line_items.sum(&:total_estimate)
-        end
+        return unless object.total.present?
+        object.total.to_money.to_s
       end
 
       def update_issues

--- a/app/serializers/api/admin/proxy_order_serializer.rb
+++ b/app/serializers/api/admin/proxy_order_serializer.rb
@@ -5,7 +5,7 @@ module Api
       attributes :update_issues
 
       def total
-        return unless object.total.present?
+        return if object.total.blank?
         object.total.to_money.to_s
       end
 

--- a/app/views/admin/subscriptions/_orders_panel.html.haml
+++ b/app/views/admin/subscriptions/_orders_panel.html.haml
@@ -19,7 +19,7 @@
                 %div{ ng: { bind: "::orderCycleCloses(proxyOrder.order_cycle_id)" } }
               %td.text-center
                 %span.state{ ng: { class: "proxyOrder.state", bind: 'stateText(proxyOrder.state)' } }
-              %td.text-center{ ng: { bind: 'proxyOrder.total | currency' } }
+              %td.text-center{ ng: { bind: '(proxyOrder.total || subscription.estimatedTotal()) | currency' } }
               %td.actions
                 %a.edit-order.icon-edit.no-text{ href: '{{::proxyOrder.edit_path}}', target: '_blank', 'ofn-with-tip' => t(:edit_order), confirm_order_edit: true }
                 %a.cancel-order.icon-remove.no-text{ href: 'javascript:void(0)', ng: { hide: "proxyOrder.state == 'canceled'", click: "cancelOrder(proxyOrder)" }, 'ofn-with-tip' => t(:cancel_order) }

--- a/app/views/admin/subscriptions/_review.html.haml
+++ b/app/views/admin/subscriptions/_review.html.haml
@@ -91,3 +91,5 @@
                     \:
                 %td.total.align-center
                   %span#order_form_total {{ subscription.estimatedTotal() | currency }}
+          %p.notice
+            = t "this_is_an_estimate", scope: 'admin.subscriptions.subscription_line_items'

--- a/app/views/admin/subscriptions/_subscription_line_items.html.haml
+++ b/app/views/admin/subscriptions/_subscription_line_items.html.haml
@@ -29,7 +29,16 @@
           = t(:subtotal)
           \:
       %td.total.align-center
-        %span {{ subscription.estimatedSubtotal() | currency }}
+        %span#order_subtotal {{ subscription.estimatedSubtotal() | currency }}
+      %td.actions
+  %tbody#fees.no-border-top{ ng: { show: "subscription.estimatedFees() > 0" } }
+    %tr#fees-row
+      %td{:colspan => "3"}
+        %b
+          = t(:fees)
+          \:
+      %td.total.align-center
+        %span#order_fees {{ subscription.estimatedFees() | currency }}
       %td.actions
   %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
     %tr

--- a/app/views/admin/subscriptions/_subscription_line_items.html.haml
+++ b/app/views/admin/subscriptions/_subscription_line_items.html.haml
@@ -49,3 +49,5 @@
       %td.total.align-center
         %span#order_form_total {{ subscription.estimatedTotal() | currency }}
       %td.actions
+%p.notice
+  = t ".this_is_an_estimate"

--- a/app/views/admin/subscriptions/setup_explanation.html.haml
+++ b/app/views/admin/subscriptions/setup_explanation.html.haml
@@ -14,7 +14,7 @@
         .steps
           %div
             = t('.enable_subscriptions_step_1_html',
-              enterprises_link: link_to(t('admin.enterprises.title'), main_app.admin_enterprises_path, target: '_blank'))
+              enterprises_link: link_to(t('admin.enterprises.index.title'), main_app.admin_enterprises_path, target: '_blank'))
           %div= t('.enable_subscriptions_step_2')
 
     .row.margin-bottom-20.todo{ class: shipping_and_payment_methods_ok?(@shop) ? 'done' : '' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2048,7 +2048,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   edit_profile_details_etc: "Change your profile description, images, etc."
   order_cycle: "Order Cycle"
   order_cycles: "Order Cycles"
-  enterprises: "Enterprises"
   enterprise_relationships: "Enterprise permissions"
   remove_tax: "Remove tax"
   enterprise_terms_of_service: "Enterprise Terms of Service"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -999,6 +999,10 @@ en:
         address: 2. Address
         products: 3. Add Products
         review: 4. Review & Save
+      subscription_line_items:
+        this_is_an_estimate: |
+          The displayed prices are only an estimate and calculated at the time the subscription is changed.
+          If you change prices or fees, orders will be updated, but the subscription will still display the old values.
       details:
         details: Details
         invalid_error: Oops! Please fill in all of the required fields...

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -87,6 +87,7 @@ feature 'Subscriptions' do
 
         within ".subscription-orders" do
           expect(page).to have_selector "tr.proxy_order", count: 1
+          expect(page).to have_content "$18.50" # 3 x $5 items + $3.5 shipping
 
           proxy_order = subscription.proxy_orders.first
           within "tr#po_#{proxy_order.id}" do


### PR DESCRIPTION
#### What? Why?

@myriamboure picked up an issue while testing #2122, whereby the estimated totals for subscriptions that included products or shipping/payment methods with fees were not consistently showing the fees in the backend, and when they were, they were not providing a breakdown.

This PR adds a fee breakdown to the `Items` tab, and makes sure that the totals displayed in the `Orders` tab are consistent with the `Items` tab (ie. they include fees).

#### What should we test?

- [ ] When fees should apply to shipping or payment fees for a subscription, these should be documented in the Items tab on the subscription index
- [ ] When fee should not apply to shipping or payment fees for a subscription, the fees line should not appear in the Items tab on the subscription index
- [ ] Order totals under the `Orders` tab should always match the total shown in the `Items` tab, except when a particular order has been edited 

#### Release notes

This is part of Subscriptions which has not been released yet, so no release notes required.