### PR TITLE
fixed UX problem in the state selector in customers admin

### DIFF
--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -179,21 +179,28 @@ feature 'Customers' do
 
         it 'updates the existing billing address' do
           expect(page).to have_content 'BILLING ADDRESS'
-
           first('#bill-address-link').click
 
           expect(page).to have_content 'Edit Billing Address'
-
           expect(page).to have_select2 'country_id', selected: 'Australia'
           expect(page).to have_select2 'state_id', selected: 'Victoria'
+
+          fill_in 'address1', with: ""
+          click_button 'Update Address'
+
+          expect(page).to have_content 'Please input all of the required fields'
 
           fill_in 'address1', with: "New Address1"
           click_button 'Update Address'
 
           expect(page).to have_content 'Address updated successfully.'
           expect(page).to have_link 'New Address1'
-
           expect(customer4.reload.bill_address.address1).to eq 'New Address1'
+
+          first('#bill-address-link').click
+          
+          expect(page).to have_content 'Edit Billing Address'
+          expect(page).to_not have_content 'Please input all of the required fields'
         end
 
         it 'creates a new shipping address' do


### PR DESCRIPTION
#### What? Why?

Closes #2106

We needed to clear the state selector when a new country is selected.
The list of states was being updated but the states select box was not being cleared. Code to clear the selector was added whenever the country select is updated.

#### What should we test?

Verify that the issue is solved.

#### Release notes

Fixed UX problem in the state selector in customers admin.