### PR TITLE
changed the country and state selectors to angular on enterprises admin

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/country_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/country_controller.js.coffee
@@ -1,5 +1,5 @@
+# Used in enterprise new and edit forms to reset the state when the country is changed
 angular.module("admin.enterprises").controller 'countryCtrl', ($scope, availableCountries) ->
-
   $scope.countries = availableCountries
 
   $scope.countriesById = $scope.countries.reduce (obj, country) ->
@@ -7,19 +7,12 @@ angular.module("admin.enterprises").controller 'countryCtrl', ($scope, available
     obj
   , {}
 
-  $scope.countryOnChange = (stateSelectElemId) ->
+  $scope.$watch 'Enterprise.address.country_id', (newID, oldID) ->
     $scope.clearState() unless $scope.addressStateMatchesCountry()
-    $scope.refreshStateSelector(stateSelectElemId)
 
   $scope.clearState = ->
-    $scope.enterprise_address_attributes_state = {}
+    $scope.Enterprise.address.state_id = null
 
   $scope.addressStateMatchesCountry = ->
-    $scope.countriesById[$scope.enterprise_address_attributes_country.id].states.some (state) -> state.id == $scope.enterprise_address_attributes_state?.id
-
-  $scope.refreshStateSelector = (stateSelectElemId) ->
-  	# workaround select2 (using jQuery and setTimeout) to force a refresh of the selected value
-    setTimeout ->
-      selectedState = jQuery('#' + stateSelectElemId)
-      jQuery('#' + stateSelectElemId).select2("val", selectedState)
-    , 500
+    $scope.countriesById[$scope.Enterprise.address.country_id].states.some (state) ->
+      state.id == $scope.Enterprise.address.state_id

--- a/app/assets/javascripts/admin/enterprises/controllers/country_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/country_controller.js.coffee
@@ -1,0 +1,25 @@
+angular.module("admin.enterprises").controller 'countryCtrl', ($scope, availableCountries) ->
+
+  $scope.countries = availableCountries
+
+  $scope.countriesById = $scope.countries.reduce (obj, country) ->
+    obj[country.id] = country
+    obj
+  , {}
+
+  $scope.countryOnChange = (stateSelectElemId) ->
+    $scope.clearState() unless $scope.addressStateMatchesCountry()
+    $scope.refreshStateSelector(stateSelectElemId)
+
+  $scope.clearState = ->
+    $scope.enterprise_address_attributes_state = {}
+
+  $scope.addressStateMatchesCountry = ->
+    $scope.countriesById[$scope.enterprise_address_attributes_country.id].states.some (state) -> state.id == $scope.enterprise_address_attributes_state?.id
+
+  $scope.refreshStateSelector = (stateSelectElemId) ->
+  	# workaround select2 (using jQuery and setTimeout) to force a refresh of the selected value
+    setTimeout ->
+      selectedState = jQuery('#' + stateSelectElemId)
+      jQuery('#' + stateSelectElemId).select2("val", selectedState)
+    , 500

--- a/app/assets/javascripts/admin/enterprises/controllers/new_enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/new_enterprise_controller.js.coffee
@@ -1,0 +1,5 @@
+angular.module("admin.enterprises").controller 'NewEnterpriseController', ($scope, defaultCountryID) ->
+  $scope.Enterprise =
+    address:
+      country_id: defaultCountryID
+      state_id: null

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -5,6 +5,7 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
   attributes :preferred_product_selection_from_inventory_only
   attributes :owner, :contact, :users, :tag_groups, :default_tag_group
   attributes :require_login, :allow_guest_orders, :allow_order_changes
+  attributes :address
 
   has_one :owner, serializer: Api::Admin::UserSerializer
   has_many :users, serializer: Api::Admin::UserSerializer

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -5,10 +5,10 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
   attributes :preferred_product_selection_from_inventory_only
   attributes :owner, :contact, :users, :tag_groups, :default_tag_group
   attributes :require_login, :allow_guest_orders, :allow_order_changes
-  attributes :address
 
   has_one :owner, serializer: Api::Admin::UserSerializer
   has_many :users, serializer: Api::Admin::UserSerializer
+  has_one :address, serializer: Api::AddressSerializer
 
   def tag_groups
     object.tag_rules.prioritised.reject(&:is_default).each_with_object([]) do |tag_rule, tag_groups|

--- a/app/views/admin/enterprises/_form_data.html.haml
+++ b/app/views/admin/enterprises/_form_data.html.haml
@@ -3,3 +3,4 @@
 = admin_inject_payment_methods
 = admin_inject_shipping_methods
 = admin_inject_enterprise_permissions
+= admin_inject_available_countries(module: 'admin.enterprises')

--- a/app/views/admin/enterprises/_new_form.html.haml
+++ b/app/views/admin/enterprises/_new_form.html.haml
@@ -87,15 +87,17 @@
       = af.text_field :city, { placeholder: t(:city_placeholder)}
     .five.columns.omega
       = af.text_field :zipcode, { placeholder: t(:postcode_placeholder)}
-  .row
-    .three.columns.alpha
-      = af.label :state_id, t(:state)
-      \/
-      = af.label :country_id, t(:country)
-    .four.columns
-      = af.collection_select :state_id, af.object.country.states, :id, :name, {}, :class => "select2 fullwidth"
-    .five.columns.omega
-      = af.collection_select :country_id, available_countries, :id, :name, {}, :class => "select2 fullwidth"
+  %div{ "ng-controller" => "countryCtrl" }
+    .row
+      .three.columns.alpha
+        = af.label :state_id, t(:state)
+        \/
+        = af.label :country_id, t(:country)
+      .four.columns
+        = af.collection_select :state_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-options" => "s as s.name for s in countriesById[enterprise_address_attributes_country.id].states track by s.id", "ng-model" => "enterprise_address_attributes_state"
+      .five.columns.omega
+        = af.collection_select :country_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-options" => "c as c.name for c in countries track by c.id", "ng-model" => "enterprise_address_attributes_country", "ng-init" => "enterprise_address_attributes_country = { id: \"#{Spree::Config[:default_country_id]}\" }", "ng-change" => "countryOnChange('s2id_enterprise_address_attributes_state_id')"
+
 .row
   .twelve.columns.alpha
     &nbsp;

--- a/app/views/admin/enterprises/_new_form.html.haml
+++ b/app/views/admin/enterprises/_new_form.html.haml
@@ -94,9 +94,9 @@
         \/
         = af.label :country_id, t(:country)
       .four.columns
-        = af.collection_select :state_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-options" => "s as s.name for s in countriesById[enterprise_address_attributes_country.id].states track by s.id", "ng-model" => "enterprise_address_attributes_state"
+        %input.ofn-select2.fullwidth#enterprise_address_attributes_state_id{ name: 'enterprise[address_attributes][state_id]', type: 'number', data: 'countriesById[Enterprise.address.country_id].states', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.state_id' } }
       .five.columns.omega
-        = af.collection_select :country_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-options" => "c as c.name for c in countries track by c.id", "ng-model" => "enterprise_address_attributes_country", "ng-init" => "enterprise_address_attributes_country = { id: \"#{Spree::Config[:default_country_id]}\" }", "ng-change" => "countryOnChange('s2id_enterprise_address_attributes_state_id')"
+        %input.ofn-select2.fullwidth#enterprise_address_attributes_country_id{ name: 'enterprise[address_attributes][country_id]', type: 'number', data: 'countries', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.country_id' } }
 
 .row
   .twelve.columns.alpha

--- a/app/views/admin/enterprises/form/_address.html.haml
+++ b/app/views/admin/enterprises/form/_address.html.haml
@@ -33,6 +33,6 @@
     %span.required *
   %div{ "ng-controller" => "countryCtrl" }
     .four.columns
-      = af.collection_select :state_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-init" => "enterprise_address_attributes_state.id = Enterprise.address.address.state_id", "ng-options" => "s as s.name for s in countriesById[enterprise_address_attributes_country.id || Enterprise.address.address.country_id].states track by s.id", "ng-model" => "enterprise_address_attributes_state"
+      %input.ofn-select2.fullwidth#enterprise_address_attributes_state_id{ name: 'enterprise[address_attributes][state_id]', type: 'number', data: 'countriesById[Enterprise.address.country_id].states', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.state_id' } }
     .four.columns.omega
-      = af.collection_select :country_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-init" => "enterprise_address_attributes_country.id = Enterprise.address.address.country_id", "ng-options" => "c as c.name for c in countries track by c.id", "ng-model" => "enterprise_address_attributes_country", "ng-change" => "countryOnChange('s2id_enterprise_address_attributes_state_id')"
+      %input.ofn-select2.fullwidth#enterprise_address_attributes_country_id{ name: 'enterprise[address_attributes][country_id]', type: 'number', data: 'countries', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.country_id' } }

--- a/app/views/admin/enterprises/form/_address.html.haml
+++ b/app/views/admin/enterprises/form/_address.html.haml
@@ -31,7 +31,8 @@
     \/
     = af.label :country_id, t(:country)
     %span.required *
-  .four.columns
-    = af.collection_select :state_id, af.object.country.states, :id, :name, {}, :class => "select2 fullwidth"
-  .four.columns.omega
-    = af.collection_select :country_id, available_countries, :id, :name, {}, :class => "select2 fullwidth"
+  %div{ "ng-controller" => "countryCtrl" }
+    .four.columns
+      = af.collection_select :state_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-init" => "enterprise_address_attributes_state.id = Enterprise.address.address.state_id", "ng-options" => "s as s.name for s in countriesById[enterprise_address_attributes_country.id || Enterprise.address.address.country_id].states track by s.id", "ng-model" => "enterprise_address_attributes_state"
+    .four.columns.omega
+      = af.collection_select :country_id, {}, :id, :name, {}, :class => "select2 fullwidth", "ng-init" => "enterprise_address_attributes_country.id = Enterprise.address.address.country_id", "ng-options" => "c as c.name for c in countries track by c.id", "ng-model" => "enterprise_address_attributes_country", "ng-change" => "countryOnChange('s2id_enterprise_address_attributes_state_id')"

--- a/app/views/admin/enterprises/new.html.haml
+++ b/app/views/admin/enterprises/new.html.haml
@@ -10,10 +10,11 @@
   = "ng-app='admin.enterprises'"
 
 = admin_inject_available_countries(module: 'admin.enterprises')
+= admin_inject_json "admin.enterprises", "defaultCountryID", Spree::Config[:default_country_id]
 
 -# Form
 
 = form_for [main_app, :admin, @enterprise], html: { "nav-check" => '', "nav-callback" => '' } do |f|
   .row
-    .twelve.columns.fullwidth_inputs{ ng: { app: "admin.users" } }
+    .twelve.columns.fullwidth_inputs{ ng: { controller: "NewEnterpriseController" } }
       = render 'new_form', f: f

--- a/app/views/admin/enterprises/new.html.haml
+++ b/app/views/admin/enterprises/new.html.haml
@@ -6,6 +6,10 @@
 - content_for :page_actions do
   %li= button_link_to t('.back_link'), main_app.admin_enterprises_path, icon: 'icon-arrow-left'
 
+- content_for :app_wrapper_attrs do
+  = "ng-app='admin.enterprises'"
+
+= admin_inject_available_countries(module: 'admin.enterprises')
 
 -# Form
 

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -53,7 +53,7 @@ feature %q{
     fill_in 'enterprise_address_attributes_address1', :with => '35 Ballantyne St'
     fill_in 'enterprise_address_attributes_city', :with => 'Thornbury'
     fill_in 'enterprise_address_attributes_zipcode', :with => '3072'
-    select2_search 'Australia', :from => 'Country'
+    # default country (Australia in this test) should be selected by default
     select2_search 'Victoria', :from => 'State'
 
     click_button 'Create'
@@ -342,6 +342,8 @@ feature %q{
         fill_in 'enterprise_address_attributes_address1', with: 'z'
         fill_in 'enterprise_address_attributes_city', with: 'z'
         fill_in 'enterprise_address_attributes_zipcode', with: 'z'
+        select2_select 'Australia', from: 'enterprise_address_attributes_country_id'
+        select2_select 'Victoria', from: 'enterprise_address_attributes_state_id'
       end
 
       scenario "without violating rules" do


### PR DESCRIPTION
...(new and edit screens) so that states are dynamically updated when country is changed

This PR is ready for review now.

#### What? Why?

Closes #1538 

Changed the country and state selectors on new and edit enterprises to angular so that states becomes dynamic based on country selection.

#### What should we test?

New Enterprise and Edit Enterprise Address should now allow for selection of states of the selected country.

#### Release notes

Create Enterprise and Edit Enterprise Address now allow for selection of states of the selected country.