### PR TITLE
Spree 2.0: Fix GET "/"

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -37,7 +37,7 @@ class BaseController < ApplicationController
 
     # And default to the only order cycle if there's only the one
     if @order_cycles.count == 1
-      current_order( create_order_if_necessary: true ).set_order_cycle! @order_cycles.first
+      current_order({ create_order_if_necessary: true }).set_order_cycle! @order_cycles.first
     end
   end
 end

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -37,7 +37,7 @@ class BaseController < ApplicationController
 
     # And default to the only order cycle if there's only the one
     if @order_cycles.count == 1
-      current_order(create_order_if_necessary: true).set_order_cycle! @order_cycles.first
+      current_order( create_order_if_necessary: true ).set_order_cycle! @order_cycles.first
     end
   end
 end

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -37,7 +37,7 @@ class BaseController < ApplicationController
 
     # And default to the only order cycle if there's only the one
     if @order_cycles.count == 1
-      current_order({ create_order_if_necessary: true }).set_order_cycle! @order_cycles.first
+      current_order(true).set_order_cycle! @order_cycles.first
     end
   end
 end

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -49,14 +49,14 @@ class EnterprisesController < BaseController
   end
 
   def check_stock_levels
-    if current_order(create_order_if_necessary: true).insufficient_stock_lines.present?
+    if current_order({ create_order_if_necessary: true }).insufficient_stock_lines.present?
       redirect_to spree.cart_path
     end
   end
 
   def reset_order
     distributor = Enterprise.is_distributor.find_by_permalink(params[:id]) || Enterprise.is_distributor.find(params[:id])
-    order = current_order(create_order_if_necessary: true)
+    order = current_order({ create_order_if_necessary: true })
 
     reset_distributor(order, distributor)
 

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -49,14 +49,14 @@ class EnterprisesController < BaseController
   end
 
   def check_stock_levels
-    if current_order({ create_order_if_necessary: true }).insufficient_stock_lines.present?
+    if current_order(true).insufficient_stock_lines.present?
       redirect_to spree.cart_path
     end
   end
 
   def reset_order
     distributor = Enterprise.is_distributor.find_by_permalink(params[:id]) || Enterprise.is_distributor.find(params[:id])
-    order = current_order({ create_order_if_necessary: true })
+    order = current_order(true)
 
     reset_distributor(order, distributor)
 

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -26,7 +26,7 @@ class ShopController < BaseController
   def order_cycle
     if request.post?
       if oc = OrderCycle.with_distributor(@distributor).active.find_by_id(params[:order_cycle_id])
-        current_order({ create_order_if_necessary: true }).set_order_cycle! oc
+        current_order(true).set_order_cycle! oc
         render partial: "json/order_cycle"
       else
         render status: 404, json: ""

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -26,7 +26,7 @@ class ShopController < BaseController
   def order_cycle
     if request.post?
       if oc = OrderCycle.with_distributor(@distributor).active.find_by_id(params[:order_cycle_id])
-        current_order(create_order_if_necessary: true).set_order_cycle! oc
+        current_order({ create_order_if_necessary: true }).set_order_cycle! oc
         render partial: "json/order_cycle"
       else
         render status: 404, json: ""

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -18,7 +18,7 @@ Spree::OrdersController.class_eval do
 
   # Patching to redirect to shop if order is empty
   def edit
-    @order = current_order( create_order_if_necessary: true )
+    @order = current_order({ create_order_if_necessary: true })
     @insufficient_stock_lines = @order.insufficient_stock_lines
 
     if @order.line_items.empty?
@@ -78,7 +78,7 @@ Spree::OrdersController.class_eval do
     # callbacks on Spree::Adjustment and then manually invoke Spree::Order#update! on success.
 
     Spree::Adjustment.without_callbacks do
-      populator = Spree::OrderPopulator.new(current_order( create_order_if_necessary: true ), current_currency)
+      populator = Spree::OrderPopulator.new(current_order({ create_order_if_necessary: true }), current_currency)
 
       if populator.populate(params.slice(:products, :variants, :quantity), true)
         fire_event('spree.cart.add')
@@ -127,7 +127,7 @@ Spree::OrdersController.class_eval do
   end
 
   def update_distribution
-    @order = current_order( create_order_if_necessary: true )
+    @order = current_order({ create_order_if_necessary: true })
 
     if params[:commit] == 'Choose Hub'
       distributor = Enterprise.is_distributor.find params[:order][:distributor_id]
@@ -159,7 +159,7 @@ Spree::OrdersController.class_eval do
   end
 
   def clear
-    @order = current_order( create_order_if_necessary: true )
+    @order = current_order({ create_order_if_necessary: true })
     @order.empty!
     @order.set_order_cycle! nil
     redirect_to main_app.enterprise_path(@order.distributor.id)

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -18,7 +18,7 @@ Spree::OrdersController.class_eval do
 
   # Patching to redirect to shop if order is empty
   def edit
-    @order = current_order({ create_order_if_necessary: true })
+    @order = current_order(true)
     @insufficient_stock_lines = @order.insufficient_stock_lines
 
     if @order.line_items.empty?
@@ -78,7 +78,7 @@ Spree::OrdersController.class_eval do
     # callbacks on Spree::Adjustment and then manually invoke Spree::Order#update! on success.
 
     Spree::Adjustment.without_callbacks do
-      populator = Spree::OrderPopulator.new(current_order({ create_order_if_necessary: true }), current_currency)
+      populator = Spree::OrderPopulator.new(current_order(true), current_currency)
 
       if populator.populate(params.slice(:products, :variants, :quantity), true)
         fire_event('spree.cart.add')
@@ -127,7 +127,7 @@ Spree::OrdersController.class_eval do
   end
 
   def update_distribution
-    @order = current_order({ create_order_if_necessary: true })
+    @order = current_order(true)
 
     if params[:commit] == 'Choose Hub'
       distributor = Enterprise.is_distributor.find params[:order][:distributor_id]
@@ -159,7 +159,7 @@ Spree::OrdersController.class_eval do
   end
 
   def clear
-    @order = current_order({ create_order_if_necessary: true })
+    @order = current_order(true)
     @order.empty!
     @order.set_order_cycle! nil
     redirect_to main_app.enterprise_path(@order.distributor.id)

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -18,7 +18,7 @@ Spree::OrdersController.class_eval do
 
   # Patching to redirect to shop if order is empty
   def edit
-    @order = current_order(create_order_if_necessary: true)
+    @order = current_order( create_order_if_necessary: true )
     @insufficient_stock_lines = @order.insufficient_stock_lines
 
     if @order.line_items.empty?
@@ -78,7 +78,7 @@ Spree::OrdersController.class_eval do
     # callbacks on Spree::Adjustment and then manually invoke Spree::Order#update! on success.
 
     Spree::Adjustment.without_callbacks do
-      populator = Spree::OrderPopulator.new(current_order(create_order_if_necessary: true), current_currency)
+      populator = Spree::OrderPopulator.new(current_order( create_order_if_necessary: true ), current_currency)
 
       if populator.populate(params.slice(:products, :variants, :quantity), true)
         fire_event('spree.cart.add')
@@ -127,7 +127,7 @@ Spree::OrdersController.class_eval do
   end
 
   def update_distribution
-    @order = current_order(create_order_if_necessary: true)
+    @order = current_order( create_order_if_necessary: true )
 
     if params[:commit] == 'Choose Hub'
       distributor = Enterprise.is_distributor.find params[:order][:distributor_id]
@@ -159,7 +159,7 @@ Spree::OrdersController.class_eval do
   end
 
   def clear
-    @order = current_order(create_order_if_necessary: true)
+    @order = current_order( create_order_if_necessary: true )
     @order.empty!
     @order.set_order_cycle! nil
     redirect_to main_app.enterprise_path(@order.distributor.id)

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -2,7 +2,7 @@ require 'open_food_network/available_payment_method_filter'
 
 module EnterprisesHelper
   def current_distributor
-    @current_distributor ||= current_order(create_order_if_necessary: false).andand.distributor
+    @current_distributor ||= current_order( create_order_if_necessary: false ).andand.distributor
   end
 
   def current_customer

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -2,7 +2,7 @@ require 'open_food_network/available_payment_method_filter'
 
 module EnterprisesHelper
   def current_distributor
-    @current_distributor ||= current_order( create_order_if_necessary: false ).andand.distributor
+    @current_distributor ||= current_order({ create_order_if_necessary: false }).andand.distributor
   end
 
   def current_customer

--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -2,7 +2,7 @@ require 'open_food_network/available_payment_method_filter'
 
 module EnterprisesHelper
   def current_distributor
-    @current_distributor ||= current_order({ create_order_if_necessary: false }).andand.distributor
+    @current_distributor ||= current_order(false).andand.distributor
   end
 
   def current_customer

--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -1,6 +1,6 @@
 module OrderCyclesHelper
   def current_order_cycle
-    @current_order_cycle ||= current_order({ create_order_if_necessary: false }).andand.order_cycle
+    @current_order_cycle ||= current_order(false).andand.order_cycle
   end
 
   def permitted_enterprises_for(order_cycle)

--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -1,6 +1,6 @@
 module OrderCyclesHelper
   def current_order_cycle
-    @current_order_cycle ||= current_order(create_order_if_necessary: false).andand.order_cycle
+    @current_order_cycle ||= current_order( create_order_if_necessary: false ).andand.order_cycle
   end
 
   def permitted_enterprises_for(order_cycle)

--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -1,6 +1,6 @@
 module OrderCyclesHelper
   def current_order_cycle
-    @current_order_cycle ||= current_order( create_order_if_necessary: false ).andand.order_cycle
+    @current_order_cycle ||= current_order({ create_order_if_necessary: false }).andand.order_cycle
   end
 
   def permitted_enterprises_for(order_cycle)

--- a/app/helpers/shared_helper.rb
+++ b/app/helpers/shared_helper.rb
@@ -1,6 +1,6 @@
 module SharedHelper
   def distributor_link_class(distributor)
-    cart = current_order( create_order_if_necessary: true )
+    cart = current_order({ create_order_if_necessary: true })
     @active_distributors ||= Enterprise.distributors_with_active_order_cycles
 
     klass = "shop-distributor"

--- a/app/helpers/shared_helper.rb
+++ b/app/helpers/shared_helper.rb
@@ -1,6 +1,6 @@
 module SharedHelper
   def distributor_link_class(distributor)
-    cart = current_order(create_order_if_necessary: true)
+    cart = current_order( create_order_if_necessary: true )
     @active_distributors ||= Enterprise.distributors_with_active_order_cycles
 
     klass = "shop-distributor"

--- a/app/helpers/shared_helper.rb
+++ b/app/helpers/shared_helper.rb
@@ -1,6 +1,6 @@
 module SharedHelper
   def distributor_link_class(distributor)
-    cart = current_order({ create_order_if_necessary: true })
+    cart = current_order(true)
     @active_distributors ||= Enterprise.distributors_with_active_order_cycles
 
     klass = "shop-distributor"

--- a/app/helpers/spree/orders_helper.rb
+++ b/app/helpers/spree/orders_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module OrdersHelper
     def cart_is_empty
-      order = current_order({ create_order_if_necessary: false })
+      order = current_order(false)
       order.nil? || order.line_items.empty?
     end
 

--- a/app/helpers/spree/orders_helper.rb
+++ b/app/helpers/spree/orders_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module OrdersHelper
     def cart_is_empty
-      order = current_order(create_order_if_necessary: false)
+      order = current_order( create_order_if_necessary: false )
       order.nil? || order.line_items.empty?
     end
 

--- a/app/helpers/spree/orders_helper.rb
+++ b/app/helpers/spree/orders_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module OrdersHelper
     def cart_is_empty
-      order = current_order( create_order_if_necessary: false )
+      order = current_order({ create_order_if_necessary: false })
       order.nil? || order.line_items.empty?
     end
 

--- a/app/services/reset_order_service.rb
+++ b/app/services/reset_order_service.rb
@@ -23,7 +23,7 @@ class ResetOrderService
 
   # Builds an order setting the token and distributor of the one specified
   def build_new_order
-    new_order = controller.current_order( create_order_if_necessary: true )
+    new_order = controller.current_order({ create_order_if_necessary: true })
     new_order.set_distributor!(distributor)
     new_order.tokenized_permission.token = token
     new_order.tokenized_permission.save!

--- a/app/services/reset_order_service.rb
+++ b/app/services/reset_order_service.rb
@@ -23,7 +23,7 @@ class ResetOrderService
 
   # Builds an order setting the token and distributor of the one specified
   def build_new_order
-    new_order = controller.current_order({ create_order_if_necessary: true })
+    new_order = controller.current_order(true)
     new_order.set_distributor!(distributor)
     new_order.tokenized_permission.token = token
     new_order.tokenized_permission.save!

--- a/app/services/reset_order_service.rb
+++ b/app/services/reset_order_service.rb
@@ -23,7 +23,7 @@ class ResetOrderService
 
   # Builds an order setting the token and distributor of the one specified
   def build_new_order
-    new_order = controller.current_order(create_order_if_necessary: true)
+    new_order = controller.current_order( create_order_if_necessary: true )
     new_order.set_distributor!(distributor)
     new_order.tokenized_permission.token = token
     new_order.tokenized_permission.save!

--- a/app/views/spree/products/_add_to_cart.html.haml
+++ b/app/views/spree/products/_add_to_cart.html.haml
@@ -1,5 +1,5 @@
 .add-to-cart
-  - order = current_order({ create_order_if_necessary: false })
+  - order = current_order(false)
 
   - if product_out_of_stock
     = content_tag('strong', t(:out_of_stock))

--- a/app/views/spree/products/_add_to_cart.html.haml
+++ b/app/views/spree/products/_add_to_cart.html.haml
@@ -1,5 +1,5 @@
 .add-to-cart
-  - order = current_order(create_order_if_necessary: false)
+  - order = current_order( create_order_if_necessary: false )
 
   - if product_out_of_stock
     = content_tag('strong', t(:out_of_stock))

--- a/app/views/spree/products/_add_to_cart.html.haml
+++ b/app/views/spree/products/_add_to_cart.html.haml
@@ -1,5 +1,5 @@
 .add-to-cart
-  - order = current_order( create_order_if_necessary: false )
+  - order = current_order({ create_order_if_necessary: false })
 
   - if product_out_of_stock
     = content_tag('strong', t(:out_of_stock))

--- a/app/views/spree/products/_distributor_details.html.haml
+++ b/app/views/spree/products/_distributor_details.html.haml
@@ -2,7 +2,7 @@
   %legend
     = t :products_distributor
   .distributor-details
-    - order = current_order({ create_order_if_necessary: false })
+    - order = current_order(false)
     - if order.andand.distributor.present?
       = render 'enterprises/distributor_details', :distributor => order.distributor
     - else

--- a/app/views/spree/products/_distributor_details.html.haml
+++ b/app/views/spree/products/_distributor_details.html.haml
@@ -2,7 +2,7 @@
   %legend
     = t :products_distributor
   .distributor-details
-    - order = current_order( create_order_if_necessary: false )
+    - order = current_order({ create_order_if_necessary: false })
     - if order.andand.distributor.present?
       = render 'enterprises/distributor_details', :distributor => order.distributor
     - else

--- a/app/views/spree/products/_distributor_details.html.haml
+++ b/app/views/spree/products/_distributor_details.html.haml
@@ -2,7 +2,7 @@
   %legend
     = t :products_distributor
   .distributor-details
-    - order = current_order(create_order_if_necessary: false)
+    - order = current_order( create_order_if_necessary: false )
     - if order.andand.distributor.present?
       = render 'enterprises/distributor_details', :distributor => order.distributor
     - else

--- a/app/views/spree/products/_source.html.haml
+++ b/app/views/spree/products/_source.html.haml
@@ -10,7 +10,7 @@
     %h6.product-section-title= t(:distributors)
     %table#product-source.table-display{:width => "100%"}
       %tbody
-        - order = current_order(create_order_if_necessary: false)
+        - order = current_order( create_order_if_necessary: false )
         - validator = DistributionChangeValidator.new(order)
         - Enterprise.distributing_products(@product).each do |distributor|
           - if !order.nil? && distributor == order.distributor

--- a/app/views/spree/products/_source.html.haml
+++ b/app/views/spree/products/_source.html.haml
@@ -10,7 +10,7 @@
     %h6.product-section-title= t(:distributors)
     %table#product-source.table-display{:width => "100%"}
       %tbody
-        - order = current_order({ create_order_if_necessary: false })
+        - order = current_order(false)
         - validator = DistributionChangeValidator.new(order)
         - Enterprise.distributing_products(@product).each do |distributor|
           - if !order.nil? && distributor == order.distributor

--- a/app/views/spree/products/_source.html.haml
+++ b/app/views/spree/products/_source.html.haml
@@ -10,7 +10,7 @@
     %h6.product-section-title= t(:distributors)
     %table#product-source.table-display{:width => "100%"}
       %tbody
-        - order = current_order( create_order_if_necessary: false )
+        - order = current_order({ create_order_if_necessary: false })
         - validator = DistributionChangeValidator.new(order)
         - Enterprise.distributing_products(@product).each do |distributor|
           - if !order.nil? && distributor == order.distributor

--- a/lib/spree/core/controller_helpers/order_decorator.rb
+++ b/lib/spree/core/controller_helpers/order_decorator.rb
@@ -1,6 +1,6 @@
 Spree::Core::ControllerHelpers::Order.class_eval do
-  def current_order_with_scoped_variants(options = {})
-    order = current_order_without_scoped_variants(options)
+  def current_order_with_scoped_variants(create_order_if_necessary = false)
+    order = current_order_without_scoped_variants(create_order_if_necessary)
 
     if order
       scoper = OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -94,7 +94,7 @@ describe CheckoutController, type: :controller do
       end
 
       it "sets the new order's token to the same as the old order" do
-        order = controller.current_order({ create_order_if_necessary: true })
+        order = controller.current_order(true)
         spree_post :update, order: {}
         expect(controller.current_order.token).to eq order.token
       end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -94,7 +94,7 @@ describe CheckoutController, type: :controller do
       end
 
       it "sets the new order's token to the same as the old order" do
-        order = controller.current_order( create_order_if_necessary: true )
+        order = controller.current_order({ create_order_if_necessary: true })
         spree_post :update, order: {}
         expect(controller.current_order.token).to eq order.token
       end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -94,7 +94,7 @@ describe CheckoutController, type: :controller do
       end
 
       it "sets the new order's token to the same as the old order" do
-        order = controller.current_order(create_order_if_necessary: true)
+        order = controller.current_order( create_order_if_necessary: true )
         spree_post :update, order: {}
         expect(controller.current_order.token).to eq order.token
       end

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe EnterprisesController, type: :controller do
   describe "shopping for a distributor" do
-    let(:order) { controller.current_order(create_order_if_necessary: true) }
+    let(:order) { controller.current_order( create_order_if_necessary: true ) }
 
 
     let!(:current_distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe EnterprisesController, type: :controller do
   describe "shopping for a distributor" do
-    let(:order) { controller.current_order( create_order_if_necessary: true ) }
+    let(:order) { controller.current_order({ create_order_if_necessary: true }) }
 
 
     let!(:current_distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe EnterprisesController, type: :controller do
   describe "shopping for a distributor" do
-    let(:order) { controller.current_order({ create_order_if_necessary: true }) }
+    let(:order) { controller.current_order(true) }
 
 
     let!(:current_distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -5,7 +5,7 @@ require 'support/request/authentication_workflow'
 
 describe Spree::CheckoutController, type: :controller do
   context 'rendering edit from within spree for the current checkout state' do
-    let(:order) { controller.current_order( create_order_if_necessary: true ) }
+    let(:order) { controller.current_order({ create_order_if_necessary: true }) }
     let(:user) { create(:user) }
 
     before do

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -5,7 +5,7 @@ require 'support/request/authentication_workflow'
 
 describe Spree::CheckoutController, type: :controller do
   context 'rendering edit from within spree for the current checkout state' do
-    let(:order) { controller.current_order({ create_order_if_necessary: true }) }
+    let(:order) { controller.current_order(true) }
     let(:user) { create(:user) }
 
     before do

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -5,7 +5,7 @@ require 'support/request/authentication_workflow'
 
 describe Spree::CheckoutController, type: :controller do
   context 'rendering edit from within spree for the current checkout state' do
-    let(:order) { controller.current_order(create_order_if_necessary: true) }
+    let(:order) { controller.current_order( create_order_if_necessary: true ) }
     let(:user) { create(:user) }
 
     before do

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -30,7 +30,7 @@ describe Spree::OrdersController, type: :controller do
   it "redirects home with message if hub is not ready for checkout" do
     VariantOverride.stub(:indexed).and_return({})
 
-    order = subject.current_order(create_order_if_necessary: true)
+    order = subject.current_order( create_order_if_necessary: true )
     distributor.stub(:ready_for_checkout?) { false }
     order.stub(distributor: distributor, order_cycle: order_cycle)
 
@@ -44,7 +44,7 @@ describe Spree::OrdersController, type: :controller do
   end
 
   describe "when an item has insufficient stock" do
-    let(:order) { subject.current_order(create_order_if_necessary: true) }
+    let(:order) { subject.current_order( create_order_if_necessary: true ) }
     let(:oc) { create(:simple_order_cycle, distributors: [d], variants: [variant]) }
     let(:d) { create(:distributor_enterprise, shipping_methods: [create(:shipping_method)], payment_methods: [create(:payment_method)]) }
     let(:variant) { create(:variant, on_demand: false, on_hand: 5) }
@@ -129,7 +129,7 @@ describe Spree::OrdersController, type: :controller do
       distributor_product = create(:distributor_enterprise)
       p = create(:product, :distributors => [distributor_product], :group_buy => true)
 
-      order = subject.current_order(create_order_if_necessary: true)
+      order = subject.current_order( create_order_if_necessary: true )
       order.stub(:distributor) { distributor_product }
       order.should_receive(:set_variant_attributes).with(p.master, {'max_quantity' => '3'})
       controller.stub(:current_order).and_return(order)
@@ -164,7 +164,7 @@ describe Spree::OrdersController, type: :controller do
   describe "removing line items from cart" do
     describe "when I pass params that includes a line item no longer in our cart" do
       it "should silently ignore the missing line item" do
-        order = subject.current_order(create_order_if_necessary: true)
+        order = subject.current_order( create_order_if_necessary: true )
         li = order.add_variant(create(:simple_product, on_hand: 110).variants.first)
         spree_get :update, order: { line_items_attributes: {
           "0" => {quantity: "0", id: "9999"},
@@ -176,7 +176,7 @@ describe Spree::OrdersController, type: :controller do
     end
 
     it "filters line items that are missing from params" do
-      order = subject.current_order(create_order_if_necessary: true)
+      order = subject.current_order( create_order_if_necessary: true )
       li = order.add_variant(create(:simple_product).master)
 
       attrs = {

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -30,7 +30,7 @@ describe Spree::OrdersController, type: :controller do
   it "redirects home with message if hub is not ready for checkout" do
     VariantOverride.stub(:indexed).and_return({})
 
-    order = subject.current_order({ create_order_if_necessary: true })
+    order = subject.current_order(true)
     distributor.stub(:ready_for_checkout?) { false }
     order.stub(distributor: distributor, order_cycle: order_cycle)
 
@@ -44,7 +44,7 @@ describe Spree::OrdersController, type: :controller do
   end
 
   describe "when an item has insufficient stock" do
-    let(:order) { subject.current_order({ create_order_if_necessary: true }) }
+    let(:order) { subject.current_order(true) }
     let(:oc) { create(:simple_order_cycle, distributors: [d], variants: [variant]) }
     let(:d) { create(:distributor_enterprise, shipping_methods: [create(:shipping_method)], payment_methods: [create(:payment_method)]) }
     let(:variant) { create(:variant, on_demand: false, on_hand: 5) }
@@ -129,7 +129,7 @@ describe Spree::OrdersController, type: :controller do
       distributor_product = create(:distributor_enterprise)
       p = create(:product, :distributors => [distributor_product], :group_buy => true)
 
-      order = subject.current_order({ create_order_if_necessary: true })
+      order = subject.current_order(true)
       order.stub(:distributor) { distributor_product }
       order.should_receive(:set_variant_attributes).with(p.master, {'max_quantity' => '3'})
       controller.stub(:current_order).and_return(order)
@@ -164,7 +164,7 @@ describe Spree::OrdersController, type: :controller do
   describe "removing line items from cart" do
     describe "when I pass params that includes a line item no longer in our cart" do
       it "should silently ignore the missing line item" do
-        order = subject.current_order({ create_order_if_necessary: true })
+        order = subject.current_order(true)
         li = order.add_variant(create(:simple_product, on_hand: 110).variants.first)
         spree_get :update, order: { line_items_attributes: {
           "0" => {quantity: "0", id: "9999"},
@@ -176,7 +176,7 @@ describe Spree::OrdersController, type: :controller do
     end
 
     it "filters line items that are missing from params" do
-      order = subject.current_order({ create_order_if_necessary: true })
+      order = subject.current_order(true)
       li = order.add_variant(create(:simple_product).master)
 
       attrs = {

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -30,7 +30,7 @@ describe Spree::OrdersController, type: :controller do
   it "redirects home with message if hub is not ready for checkout" do
     VariantOverride.stub(:indexed).and_return({})
 
-    order = subject.current_order( create_order_if_necessary: true )
+    order = subject.current_order({ create_order_if_necessary: true })
     distributor.stub(:ready_for_checkout?) { false }
     order.stub(distributor: distributor, order_cycle: order_cycle)
 
@@ -44,7 +44,7 @@ describe Spree::OrdersController, type: :controller do
   end
 
   describe "when an item has insufficient stock" do
-    let(:order) { subject.current_order( create_order_if_necessary: true ) }
+    let(:order) { subject.current_order({ create_order_if_necessary: true }) }
     let(:oc) { create(:simple_order_cycle, distributors: [d], variants: [variant]) }
     let(:d) { create(:distributor_enterprise, shipping_methods: [create(:shipping_method)], payment_methods: [create(:payment_method)]) }
     let(:variant) { create(:variant, on_demand: false, on_hand: 5) }
@@ -129,7 +129,7 @@ describe Spree::OrdersController, type: :controller do
       distributor_product = create(:distributor_enterprise)
       p = create(:product, :distributors => [distributor_product], :group_buy => true)
 
-      order = subject.current_order( create_order_if_necessary: true )
+      order = subject.current_order({ create_order_if_necessary: true })
       order.stub(:distributor) { distributor_product }
       order.should_receive(:set_variant_attributes).with(p.master, {'max_quantity' => '3'})
       controller.stub(:current_order).and_return(order)
@@ -164,7 +164,7 @@ describe Spree::OrdersController, type: :controller do
   describe "removing line items from cart" do
     describe "when I pass params that includes a line item no longer in our cart" do
       it "should silently ignore the missing line item" do
-        order = subject.current_order( create_order_if_necessary: true )
+        order = subject.current_order({ create_order_if_necessary: true })
         li = order.add_variant(create(:simple_product, on_hand: 110).variants.first)
         spree_get :update, order: { line_items_attributes: {
           "0" => {quantity: "0", id: "9999"},
@@ -176,7 +176,7 @@ describe Spree::OrdersController, type: :controller do
     end
 
     it "filters line items that are missing from params" do
-      order = subject.current_order( create_order_if_necessary: true )
+      order = subject.current_order({ create_order_if_necessary: true })
       li = order.add_variant(create(:simple_product).master)
 
       attrs = {

--- a/spec/controllers/spree/paypal_controller_spec.rb
+++ b/spec/controllers/spree/paypal_controller_spec.rb
@@ -9,7 +9,7 @@ module Spree
     end
 
     context 'when confirming' do
-      let(:previous_order) { controller.current_order(create_order_if_necessary: true) }
+      let(:previous_order) { controller.current_order( create_order_if_necessary: true ) }
       let(:payment_method) { create(:payment_method) }
 
       before do

--- a/spec/controllers/spree/paypal_controller_spec.rb
+++ b/spec/controllers/spree/paypal_controller_spec.rb
@@ -9,7 +9,7 @@ module Spree
     end
 
     context 'when confirming' do
-      let(:previous_order) { controller.current_order( create_order_if_necessary: true ) }
+      let(:previous_order) { controller.current_order({ create_order_if_necessary: true }) }
       let(:payment_method) { create(:payment_method) }
 
       before do

--- a/spec/controllers/spree/paypal_controller_spec.rb
+++ b/spec/controllers/spree/paypal_controller_spec.rb
@@ -9,7 +9,7 @@ module Spree
     end
 
     context 'when confirming' do
-      let(:previous_order) { controller.current_order({ create_order_if_necessary: true }) }
+      let(:previous_order) { controller.current_order(true) }
       let(:payment_method) { create(:payment_method) }
 
       before do

--- a/spec/performance/orders_controller_spec.rb
+++ b/spec/performance/orders_controller_spec.rb
@@ -4,7 +4,7 @@ describe Spree::OrdersController, type: :controller, performance: true do
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: products.map { |p| p.variants.first }) }
   let(:products) { (0...num_products).map { create(:product) } }
-  let(:order) { subject.current_order({ create_order_if_necessary: true }) }
+  let(:order) { subject.current_order(true) }
   let(:num_products) { 20 }
 
   before do

--- a/spec/performance/orders_controller_spec.rb
+++ b/spec/performance/orders_controller_spec.rb
@@ -4,7 +4,7 @@ describe Spree::OrdersController, type: :controller, performance: true do
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: products.map { |p| p.variants.first }) }
   let(:products) { (0...num_products).map { create(:product) } }
-  let(:order) { subject.current_order( create_order_if_necessary: true ) }
+  let(:order) { subject.current_order({ create_order_if_necessary: true }) }
   let(:num_products) { 20 }
 
   before do

--- a/spec/performance/orders_controller_spec.rb
+++ b/spec/performance/orders_controller_spec.rb
@@ -4,7 +4,7 @@ describe Spree::OrdersController, type: :controller, performance: true do
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: products.map { |p| p.variants.first }) }
   let(:products) { (0...num_products).map { create(:product) } }
-  let(:order) { subject.current_order(create_order_if_necessary: true) }
+  let(:order) { subject.current_order( create_order_if_necessary: true ) }
   let(:num_products) { 20 }
 
   before do


### PR DESCRIPTION
#### What? Why?

This fixes the following error when accessing the app:

```sh
Started GET "/" for 127.0.0.1 at 2018-06-05 18:48:25 +0200
Creating scope :deleted. Overwriting existing method Spree::Variant.deleted.
Creating scope :available. Overwriting existing method Spree::PaymentMethod.available.
Processing by HomeController#index as HTML
   (0.2ms)  BEGIN
  Spree::Order Load (0.8ms)  SELECT "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."number" = 'R175461258' LIMIT 1
   (14.1ms)  SELECT COUNT(*) FROM "spree_orders" WHERE (spree_orders.number LIKE 'R175461258%')
  Customer Load (7.8ms)  SELECT "customers".* FROM "customers" WHERE "customers"."enterprise_id" IS NULL AND "customers"."email" IS NULL LIMIT 1
   (21.7ms)  ROLLBACK
Completed 500 Internal Server Error in 171.3ms (ActiveRecord: 47.8ms)
** [Bugsnag] No API key configured, couldn't notify

NoMethodError (undefined method `shipping_method' for #<Spree::Order:0x007fc2d43ec800>):
  app/models/spree/order_decorator.rb:34:in `block (3 levels) in <top (required)>'
  app/helpers/order_cycles_helper.rb:3:in `current_order_cycle'
  app/controllers/application_controller.rb:134:in `check_order_cycle_expiry'


  Rendered /usr/local/opt/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/templates/rescues/_trace.erb (2.4ms)
  Rendered /usr/local/opt/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb (1.3ms)
  Rendered /usr/local/opt/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/templates/rescues/diagnostics.erb within rescues/layout (223.8ms)
  Rendered /usr/local/opt/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/actionpack-3.2.21/lib/action_dispatch/middleware/templates/rescues/layout.erb (226.7ms)
```

We have changed our target Spree 2.0 version to 2.0.4 since we merged #2209 and said version doesn't change `#current_order`'s signature yet. Reverting the commit related to this method fixed it. Now it is possible to access the app's root path again.

I found it while working on https://github.com/openfoodfoundation/openfoodnetwork/issues/2287.