### PR TITLE
Rewrite user stat query for improved performance of homepage

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,7 +7,7 @@ class HomeController < BaseController
     if ContentConfig.home_show_stats
       @num_distributors = Enterprise.is_distributor.activated.visible.count
       @num_producers = Enterprise.is_primary_producer.activated.visible.count
-      @num_users = Spree::User.joins(:orders).merge(Spree::Order.complete).count('DISTINCT spree_users.*')
+      @num_users = Spree::Order.complete.count('DISTINCT user_id')
       @num_orders = Spree::Order.complete.count
     end
   end


### PR DESCRIPTION
#### What? Why?

We just set up Skylight and it immediately became clear that some of the lowest hanging fruit for performance improvement is the count of active shoppers on the homepage. This PR rewrites the query so that it no longer uses an unnecessary join, which should mean a ~6-8x speed improvement (according to my local testing). If we're lucky this may bring our homepage load time down to <100ms for Aus production.

#### What should we test?

- [ ] The `FOOD SHOPPERS` count on the homepage should continue to work, and should show the same number as it did prior to this change being made

#### Release notes

Made a small technical change to stat calculation to improve the load time of the homepage