### PR TITLE
2356 report search hint

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -271,7 +271,6 @@ Layout/EmptyLinesAroundArguments:
 Layout/EmptyLinesAroundBlockBody:
   Exclude:
     - 'app/controllers/spree/admin/orders_controller_decorator.rb'
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'app/controllers/spree/api/orders_controller_decorator.rb'
     - 'app/controllers/spree/api/products_controller_decorator.rb'
     - 'app/controllers/spree/checkout_controller_decorator.rb'
@@ -442,7 +441,6 @@ Layout/IndentHash:
 # SupportedStyles: normal, rails
 Layout/IndentationConsistency:
   Exclude:
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'lib/open_food_network/permissions.rb'
     - 'spec/controllers/admin/tag_rules_controller_spec.rb'
     - 'spec/features/consumer/shopping/checkout_spec.rb'
@@ -824,7 +822,6 @@ Layout/SpaceInsideHashLiteralBraces:
     - 'app/controllers/checkout_controller.rb'
     - 'app/controllers/spree/admin/line_items_controller_decorator.rb'
     - 'app/controllers/spree/admin/products_controller_decorator.rb'
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'app/controllers/spree/admin/search_controller_decorator.rb'
     - 'app/controllers/spree/orders_controller_decorator.rb'
     - 'app/helpers/admin/business_model_configuration_helper.rb'
@@ -1274,7 +1271,6 @@ Naming/UncommunicativeMethodParamName:
 # SupportedStyles: snake_case, camelCase
 Naming/VariableName:
   Exclude:
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'app/helpers/admin/injection_helper.rb'
 
 # Offense count: 16
@@ -1554,7 +1550,6 @@ Rails/Presence:
 Rails/Present:
   Exclude:
     - 'app/controllers/spree/admin/orders_controller_decorator.rb'
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'app/models/producer_property.rb'
     - 'lib/open_food_network/products_and_inventory_report.rb'
 
@@ -1856,7 +1851,6 @@ Style/ConditionalAssignment:
     - 'app/controllers/checkout_controller.rb'
     - 'app/controllers/spree/admin/base_controller_decorator.rb'
     - 'app/controllers/spree/admin/payment_methods_controller_decorator.rb'
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'app/controllers/spree/admin/search_controller_decorator.rb'
     - 'app/helpers/spree/admin/orders_helper_decorator.rb'
     - 'app/models/spree/calculator/per_item_decorator.rb'
@@ -1992,7 +1986,6 @@ Style/HashSyntax:
     - 'app/controllers/spree/admin/line_items_controller_decorator.rb'
     - 'app/controllers/spree/admin/orders_controller_decorator.rb'
     - 'app/controllers/spree/admin/products_controller_decorator.rb'
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'app/controllers/spree/admin/search_controller_decorator.rb'
     - 'app/controllers/spree/admin/shipping_methods_controller_decorator.rb'
     - 'app/controllers/spree/api/products_controller_decorator.rb'
@@ -2437,7 +2430,6 @@ Style/RescueModifier:
   Exclude:
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/spree/admin/orders_controller_decorator.rb'
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'lib/tasks/data.rake'
 
 # Offense count: 5
@@ -2528,7 +2520,6 @@ Style/TrivialAccessors:
 # Cop supports --auto-correct.
 Style/UnlessElse:
   Exclude:
-    - 'app/controllers/spree/admin/reports_controller_decorator.rb'
     - 'app/models/enterprise.rb'
     - 'lib/open_food_network/order_grouper.rb'
 

--- a/app/assets/stylesheets/admin/reports.css.scss
+++ b/app/assets/stylesheets/admin/reports.css.scss
@@ -1,3 +1,6 @@
+.report__table {
+  margin-top: 2em;
+}
 .report__message {
   margin-top: 2em;
   border: 1px solid #cee1f4;

--- a/app/assets/stylesheets/admin/reports.css.scss
+++ b/app/assets/stylesheets/admin/reports.css.scss
@@ -1,0 +1,7 @@
+.report__message {
+  margin-top: 2em;
+  border: 1px solid #cee1f4;
+  border-radius: .5em;
+  padding: .5em;
+  text-align: center;
+}

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -17,6 +17,8 @@ require 'open_food_network/orders_and_fulfillments_report'
 Spree::Admin::ReportsController.class_eval do
   include Spree::ReportsHelper
 
+  helper_method :render_content?
+
   before_filter :cache_search_state
   # Fetches user's distributors, suppliers and order_cycles
   before_filter :load_data, only: [:customers, :products_and_inventory, :order_cycle_management, :packing]

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -240,6 +240,8 @@ Spree::Admin::ReportsController.class_eval do
 
   def render_report(header, table, create_csv, csv_file_name)
     send_data csv_report(header, table), filename: csv_file_name if create_csv
+    @header = header
+    @table = table
     # Rendering HTML is the default.
   end
 

--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -15,7 +15,6 @@ require 'open_food_network/payments_report'
 require 'open_food_network/orders_and_fulfillments_report'
 
 Spree::Admin::ReportsController.class_eval do
-
   include Spree::ReportsHelper
 
   before_filter :cache_search_state
@@ -183,11 +182,11 @@ Spree::Admin::ReportsController.class_eval do
 
   def products_and_inventory
     @report_types = report_types[:products_and_inventory]
-    if params[:report_type] != 'lettuce_share'
-      @report = OpenFoodNetwork::ProductsAndInventoryReport.new spree_current_user, params, render_content?
-    else
-      @report = OpenFoodNetwork::LettuceShareReport.new spree_current_user, params, render_content?
-    end
+    @report = if params[:report_type] != 'lettuce_share'
+                OpenFoodNetwork::ProductsAndInventoryReport.new spree_current_user, params, render_content?
+              else
+                OpenFoodNetwork::LettuceShareReport.new spree_current_user, params, render_content?
+              end
     render_report(@report.header, @report.table, params[:csv], "products_and_inventory_#{timestamp}.csv")
   end
 

--- a/app/views/spree/admin/reports/_link_order.html.haml
+++ b/app/views/spree/admin/reports/_link_order.html.haml
@@ -1,0 +1,1 @@
+%a.edit-order{href: "/admin/orders/#{value}"}= value

--- a/app/views/spree/admin/reports/_table.html.haml
+++ b/app/views/spree/admin/reports/_table.html.haml
@@ -1,21 +1,25 @@
 - column_partials ||= {}
-%br
-%br
-%table{id: id}
-  %thead
-    %tr
-      - @header.each do |heading|
-        %th= heading
-  %tbody
-    - @table.each do |row|
+- if render_content?
+  %br
+  %br
+  %table{id: id}
+    %thead
       %tr
-        - row.each_with_index do |cell_value, column_index|
-          %td
-            - partial = column_partials[column_index]
-            - if partial
-              = render partial, value: cell_value
-            - else
-              = cell_value
-    - if @table.empty?
-      %tr
-        %td{colspan: @header.count}= t(:none)
+        - @header.each do |heading|
+          %th= heading
+    %tbody
+      - @table.each do |row|
+        %tr
+          - row.each_with_index do |cell_value, column_index|
+            %td
+              - partial = column_partials[column_index]
+              - if partial
+                = render partial, value: cell_value
+              - else
+                = cell_value
+      - if @table.empty?
+        %tr
+          %td{colspan: @header.count}= t(:none)
+- else
+  %p.report__message
+    = t(".select_and_search")

--- a/app/views/spree/admin/reports/_table.html.haml
+++ b/app/views/spree/admin/reports/_table.html.haml
@@ -1,8 +1,6 @@
 - column_partials ||= {}
 - if render_content?
-  %br
-  %br
-  %table{id: id}
+  %table.report__table{id: id}
     %thead
       %tr
         - @header.each do |heading|

--- a/app/views/spree/admin/reports/_table.html.haml
+++ b/app/views/spree/admin/reports/_table.html.haml
@@ -1,0 +1,15 @@
+%br
+%br
+%table{id: id}
+  %thead
+    %tr
+      - @header.each do |heading|
+        %th=heading
+  %tbody
+    - @table.each do |row|
+      %tr
+        - row.each do |column|
+          %td= column
+    - if @table.empty?
+      %tr
+        %td{:colspan => "2"}= t(:none)

--- a/app/views/spree/admin/reports/_table.html.haml
+++ b/app/views/spree/admin/reports/_table.html.haml
@@ -1,15 +1,21 @@
+- column_partials ||= {}
 %br
 %br
 %table{id: id}
   %thead
     %tr
       - @header.each do |heading|
-        %th=heading
+        %th= heading
   %tbody
     - @table.each do |row|
       %tr
-        - row.each do |column|
-          %td= column
+        - row.each_with_index do |cell_value, column_index|
+          %td
+            - partial = column_partials[column_index]
+            - if partial
+              = render partial, value: cell_value
+            - else
+              = cell_value
     - if @table.empty?
       %tr
-        %td{:colspan => "2"}= t(:none)
+        %td{colspan: @header.count}= t(:none)

--- a/app/views/spree/admin/reports/bulk_coop.html.haml
+++ b/app/views/spree/admin/reports/bulk_coop.html.haml
@@ -15,18 +15,5 @@
   %br
   %br
   = button t(:search)
-%br
-%br
-%table#listing_orders.index
-  %thead
-    %tr{'data-hook' => "orders_header"}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+
+= render "table", id: "listing_orders"

--- a/app/views/spree/admin/reports/customers.html.haml
+++ b/app/views/spree/admin/reports/customers.html.haml
@@ -29,18 +29,4 @@
   %br
   = button t(:search)
 
-%br
-%br
-%table#listing_customers.index
-  %thead
-    %tr{'data-hook' => "orders_header"}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @report.table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @report.table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+= render "table", id: "listing_customers"

--- a/app/views/spree/admin/reports/order_cycle_management.html.haml
+++ b/app/views/spree/admin/reports/order_cycle_management.html.haml
@@ -29,18 +29,4 @@
   .row
   = button t(:search)
 
-%br
-%br
-%table#listing_ocm_orders.index
-  %thead
-    %tr{'data-hook' => "orders_header"}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+= render "table", id: "listing_ocm_orders"

--- a/app/views/spree/admin/reports/orders_and_distributors.html.haml
+++ b/app/views/spree/admin/reports/orders_and_distributors.html.haml
@@ -6,18 +6,4 @@
   %br
   = button t(:search)
 
-%br
-%br
-%table#listing_orders.index
-  %thead
-    %tr{'data-hook' => 'orders_header'}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @report.table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @report.table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+= render "table", id: "listing_orders"

--- a/app/views/spree/admin/reports/orders_and_fulfillment.html.haml
+++ b/app/views/spree/admin/reports/orders_and_fulfillment.html.haml
@@ -25,18 +25,4 @@
   .row
   = button t(:search)
 
-%br
-%br
-%table#listing_orders.index
-  %thead
-    %tr{'data-hook' => "orders_header"}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+= render "table", id: "listing_orders"

--- a/app/views/spree/admin/reports/packing.html.haml
+++ b/app/views/spree/admin/reports/packing.html.haml
@@ -25,18 +25,4 @@
   .row
   = button t(:search)
 
-%br
-%br
-%table#listing_orders.index
-  %thead
-    %tr{'data-hook' => "orders_header"}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+= render "table", id: "listing_orders"

--- a/app/views/spree/admin/reports/payments.html.haml
+++ b/app/views/spree/admin/reports/payments.html.haml
@@ -15,18 +15,5 @@
   %br
   %br
   = button t(:search)
-%br
-%br
-%table#listing_orders.index
-  %thead
-    %tr{'data-hook' => "orders_header"}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+
+= render "table", id: "listing_orders"

--- a/app/views/spree/admin/reports/products_and_inventory.html.haml
+++ b/app/views/spree/admin/reports/products_and_inventory.html.haml
@@ -31,18 +31,4 @@
   = label_tag :csv, t(:report_customers_csv)
   %br
   = button t(:search)
-%br
-%br
-%table#listing_products.index
-  %thead
-    %tr{'data-hook' => "products_header"}
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @report.table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @report.table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+= render "table", id: "listing_products"

--- a/app/views/spree/admin/reports/sales_tax.html.haml
+++ b/app/views/spree/admin/reports/sales_tax.html.haml
@@ -16,22 +16,4 @@
   %br
   = button t(:search)
 
-%br
-%br
-%table#listing_orders.index
-  %thead
-    %tr{'data-hook' => "orders_header"}
-      - @report.header.each do |heading|
-        %th= heading
-  %tbody
-    - @report.table.each do |row|
-      %tr
-        - row.each_with_index do |column, i|
-          - if i == 0
-            %td
-              %a.edit-order{'href' => "/admin/orders/#{column}"}= column
-          - else
-            %td= column
-    - if @report.table.empty?
-      %tr
-        %td{:colspan => @report.header.count}= t(:none)
+= render "table", id: "listing_orders", column_partials: {0 => "link_order"}

--- a/app/views/spree/admin/reports/users_and_enterprises.html.haml
+++ b/app/views/spree/admin/reports/users_and_enterprises.html.haml
@@ -17,18 +17,5 @@
     = label_tag :csv, t(:report_customers_csv)
   .row
     = button t(:search)
-%br
-%br
-%table#users_and_enterprises
-  %thead
-    %tr
-      - @report.header.each do |heading|
-        %th=heading
-  %tbody
-    - @report.table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @report.table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+
+= render "table", id: "users_and_enterprises"

--- a/app/views/spree/admin/reports/xero_invoices.html.haml
+++ b/app/views/spree/admin/reports/xero_invoices.html.haml
@@ -32,16 +32,4 @@
     .four.columns.alpha= button t(:search)
 
 
-%table#listing_invoices.index
-  %thead
-    %tr
-      - @report.header.each do |header|
-        %th= header
-  %tbody
-    - @report.table.each do |row|
-      %tr
-        - row.each do |column|
-          %td= column
-    - if @report.table.empty?
-      %tr
-        %td{:colspan => "2"}= t(:none)
+= render "table", id: "listing_invoices"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2598,6 +2598,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         display_as:
           display_as: Display As
       reports:
+        table:
+          select_and_search: "Select filters and click on SEARCH to access your data."
         bulk_coop:
           bulk_coop_supplier_report: 'Bulk Co-op - Totals by Supplier'
           bulk_coop_allocation: 'Bulk Co-op - Allocation'

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -39,6 +39,8 @@ feature %q{
     scenario "customers report" do
       click_link "Mailing List"
       expect(page).to have_select('report_type', selected: 'Mailing List')
+      expect(page).to have_content "click on SEARCH"
+      click_button "Search"
 
       rows = find("table#listing_customers").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
@@ -51,6 +53,7 @@ feature %q{
       click_link "Addresses"
       expect(page).to have_select('report_type', selected: 'Addresses')
 
+      click_button "Search"
       rows = find("table#listing_customers").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
       expect(table.sort).to eq([
@@ -67,6 +70,7 @@ feature %q{
 
     scenario "payment method report" do
       click_link "Payment Methods Report"
+      click_button "Search"
       rows = find("table#listing_ocm_orders").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
       expect(table.sort).to eq([
@@ -76,6 +80,7 @@ feature %q{
 
     scenario "delivery report" do
       click_link "Delivery Report"
+      click_button "Search"
       rows = find("table#listing_ocm_orders").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
       expect(table.sort).to eq([
@@ -148,6 +153,7 @@ feature %q{
     login_to_admin_section
     click_link 'Reports'
     click_link 'Orders And Distributors'
+    click_button 'Search'
 
     expect(page).to have_content 'Order date'
   end
@@ -156,6 +162,7 @@ feature %q{
     login_to_admin_section
     click_link 'Reports'
     click_link 'Bulk Co-Op'
+    click_button 'Search'
 
     expect(page).to have_content 'Supplier'
   end
@@ -164,6 +171,7 @@ feature %q{
     login_to_admin_section
     click_link 'Reports'
     click_link 'Payment Reports'
+    click_button 'Search'
 
     expect(page).to have_content 'Payment State'
   end

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -119,7 +119,7 @@ feature %q{
       #select 'Pack By Customer', from: 'report_type'
       click_button 'Search'
 
-      rows = find("table#listing_orders.index").all("thead tr")
+      rows = find("table#listing_orders").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
       expect(table.sort).to eq([
         ["Hub", "Code", "First Name", "Last Name", "Supplier", "Product", "Variant", "Quantity", "TempControlled?"]


### PR DESCRIPTION
#### What? Why?

Closes #2356.

We changed the reports logic to not load any data before searching (#2210). But now some enterprise customers could panic if they look at reports and see that there are none, for example no sales. :scream: 

So we show a friendly message to explain what to do.

#### What should we test?

Clicking on any report should show a friendly message to click on search. Only the Sales Total report has not been modified since it comes from Spree (and is probably not used by enterprise users?).

#### Release notes

Nothing to mention here. The release notes of other pull requests related to reports should be enough.

#### How is this related to the Spree upgrade?

Not.