### PR TITLE
Uk/admin orders

### DIFF
--- a/app/assets/javascripts/admin/orders/directives/customer_search_override.js.coffee
+++ b/app/assets/javascripts/admin/orders/directives/customer_search_override.js.coffee
@@ -56,7 +56,4 @@ angular.module("admin.orders").directive 'customerSearchOverride', ->
           return
         $('#order_email').val customer.email
         $('#user_id').val customer.user_id  # modified
-        $('#guest_checkout_true').prop 'checked', false
-        $('#guest_checkout_false').prop 'checked', true
-        $('#guest_checkout_false').prop 'disabled', false
         customer.email

--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -1,7 +1,20 @@
 Spree::Admin::Orders::CustomerDetailsController.class_eval do
+  before_filter :set_guest_checkout_status, only: :update
+
   # Inherit CanCan permissions for the current order
   def model_class
     load_order unless @order
     @order
+  end
+
+  private
+
+  def set_guest_checkout_status
+    registered_user = Spree::User.find_by_email(params[:order][:email])
+
+    params[:order][:guest_checkout] = registered_user.nil?
+
+    return unless registered_user
+    @order.user_id = registered_user.id
   end
 end

--- a/app/overrides/spree/admin/orders/customer_details/_form/make_email_fullwidth.html.haml.deface
+++ b/app/overrides/spree/admin/orders/customer_details/_form/make_email_fullwidth.html.haml.deface
@@ -1,0 +1,2 @@
+/ set_attributes "div[data-hook='customer_fields'] div.alpha"
+/ attributes({class: "fullwidth"})

--- a/app/overrides/spree/admin/orders/customer_details/_form/remove_guest_order_buttons.deface
+++ b/app/overrides/spree/admin/orders/customer_details/_form/remove_guest_order_buttons.deface
@@ -1,0 +1,1 @@
+remove "div[data-hook='customer_fields'] div.omega"

--- a/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
+  include AuthenticationWorkflow
+
+  describe "#update" do
+    context "adding customer details via newly created admin order" do
+      let!(:user) { create(:user) }
+      let(:address) { create(:address) }
+      let!(:distributor) { create(:distributor_enterprise) }
+      let!(:shipping_method) { create(:shipping_method) }
+      let!(:order) {
+        create(
+            :order_with_totals_and_distribution,
+            state: 'cart',
+            shipping_method: shipping_method,
+            distributor: distributor,
+            user: nil,
+            email: nil,
+            bill_address: nil,
+            ship_address: nil,
+        )
+      }
+      let(:address_params) {
+        {
+          firstname: address.firstname,
+          lastname: address.lastname,
+          address1: address.address1,
+          address2: address.address2,
+          city: address.city,
+          zipcode: address.zipcode,
+          country_id: address.country_id,
+          state_id: address.state_id,
+          phone: address.phone
+        }
+      }
+
+      before do
+        login_as_enterprise_user [order.distributor]
+      end
+
+      it "accepts registered users" do
+        spree_post :update, order: { email: user.email, bill_address_attributes: address_params, ship_address_attributes: address_params }, order_id: order.number
+
+        order.reload
+
+        expect(response).to redirect_to spree.edit_admin_order_shipment_path(order, order.shipment)
+        expect(order.email).to eq user.email
+        expect(order.user_id).to eq user.id
+        expect(order.ship_address).to_not be_nil
+      end
+
+      it "accepts unregistered users" do
+        spree_post :update, order: { email: 'unregistered@email.com', bill_address_attributes: address_params, ship_address_attributes: address_params }, order_id: order.number
+
+        order.reload
+
+        expect(response).to redirect_to spree.edit_admin_order_shipment_path(order, order.shipment)
+        expect(order.email).to eq 'unregistered@email.com'
+        expect(order.user_id).to be_nil
+        expect(order.ship_address).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -39,26 +39,24 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
         login_as_enterprise_user [order.distributor]
       end
 
-      it "accepts registered users" do
-        spree_post :update, order: { email: user.email, bill_address_attributes: address_params, ship_address_attributes: address_params }, order_id: order.number
+      context "when adding details of a registered user" do
+        it "redirects to shipments on success" do
+          spree_post :update, order: { email: user.email, bill_address_attributes: address_params, ship_address_attributes: address_params }, order_id: order.number
 
-        order.reload
+          order.reload
 
-        expect(response).to redirect_to spree.edit_admin_order_shipment_path(order, order.shipment)
-        expect(order.email).to eq user.email
-        expect(order.user_id).to eq user.id
-        expect(order.ship_address).to_not be_nil
+          expect(response).to redirect_to spree.edit_admin_order_shipment_path(order, order.shipment)
+        end
       end
 
-      it "accepts unregistered users" do
-        spree_post :update, order: { email: 'unregistered@email.com', bill_address_attributes: address_params, ship_address_attributes: address_params }, order_id: order.number
+      context "when adding details of an unregistered user" do
+        it "redirects to shipments on success" do
+          spree_post :update, order: { email: 'unregistered@email.com', bill_address_attributes: address_params, ship_address_attributes: address_params }, order_id: order.number
 
-        order.reload
+          order.reload
 
-        expect(response).to redirect_to spree.edit_admin_order_shipment_path(order, order.shipment)
-        expect(order.email).to eq 'unregistered@email.com'
-        expect(order.user_id).to be_nil
-        expect(order.ship_address).to_not be_nil
+          expect(response).to redirect_to spree.edit_admin_order_shipment_path(order, order.shipment)
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Fixes part of issue #2354 

Creating orders via admin was throwing errors because #2073 introduced a new validation rule to stop registered customers using the guest checkout, but the old form for manually creating orders hadn't been updated. The snail page was showing when adding a payment during admin order creation due to this validation condition not always being met.

The radio button to manually set a new order to "guest checkout" has been removed, and is now set automatically depending on whether or not the customer is registered.

#### What should we test?

Creating orders as enterprise manager via admin, with registered and unregistered users.

This PR shouldn't need additional testing on mobile.

#### Release notes

Creating orders via admin will now automatically be set to "guest checkout" or not, if the customer is registered or unregistered.
