### PR TITLE
Changed require syntax to fit jquery-ui-rails v<5.0

### DIFF
--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -8,7 +8,7 @@
 //= require jquery
 //= require jquery-migrate-min
 //= require jquery_ujs
-//= require jquery-ui
+//= require jquery.ui.all
 //= require shared/jquery-ui-timepicker-addon
 //= require angular
 //= require angular-resource

--- a/app/assets/javascripts/darkswarm/all.js.coffee
+++ b/app/assets/javascripts/darkswarm/all.js.coffee
@@ -1,6 +1,6 @@
 #= require jquery
 #= require jquery_ujs
-#= require jquery-ui
+#= require jquery.ui.all
 #= require spin
 #
 #= require angular


### PR DESCRIPTION
#### What? Why?

Closes #2359 

It seems that the require syntax for jquery-rails is not the one we used before (strange that it worked before with 2.x though). I replaced `require jquery-ui` with `require jquery.ui.all` in `app/assets/javascripts/admin/all.js` and app/assets/javascripts/darkswarm/all.js.coffee` and now it works fine. Also cart dropdown now appears.

#### What should we test?

In the navbar, when clicking `Login`, a modal should appear with the login form.
Also, the cart button should appear in the navbar and when clicking it, the cart dropdown should appear.

#### How is this related to the Spree upgrade?

Syntax for requiring jquery-ui has to be changed in order to have login modal and shopping cart dropdown working properly.