### PR TITLE
Reimplement import date filter as an actual Filter

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -28,7 +28,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     $scope.filterTaxons = [{id: "0", name: ""}].concat $scope.taxons
     $scope.producerFilter = "0"
     $scope.categoryFilter = "0"
-    $scope.importDateFilter = ""
+    $scope.importDateFilter = "0"
     $scope.products = BulkProducts.products
     $scope.filteredProducts = []
     $scope.currentFilters = []

--- a/app/assets/javascripts/admin/filters/import_date_filter.js.coffee
+++ b/app/assets/javascripts/admin/filters/import_date_filter.js.coffee
@@ -1,0 +1,4 @@
+angular.module("ofn.admin").filter "importDate", ($filter) ->
+  return (products, importDate) ->
+    return products if importDate == "0"
+    $filter('filter')( products, { import_date: importDate } )

--- a/app/views/spree/admin/products/bulk_edit/_products.html.haml
+++ b/app/views/spree/admin/products/bulk_edit/_products.html.haml
@@ -8,7 +8,7 @@
 
       = render 'spree/admin/products/bulk_edit/products_head'
 
-      %tbody{ 'ng-repeat' => 'product in filteredProducts = ( products | filter:query | producer: producerFilter | category: categoryFilter | filter: (importDateFilter != 0) && {import_date: importDateFilter} | limitTo:limit )', 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'" }
+      %tbody{ 'ng-repeat' => 'product in filteredProducts = ( products | filter:query | producer: producerFilter | category: categoryFilter | importDate: importDateFilter | limitTo:limit )', 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'" }
 
         = render 'spree/admin/products/bulk_edit/products_product'
         = render 'spree/admin/products/bulk_edit/products_variant'


### PR DESCRIPTION
#### What? Why?

Fixes #2372: Import date filter was causing some products to not be displayed on the bulk product update page. @Matt-Yorkley could you run your eyes over this and check that I haven't completely trashed something? 😬 

I suspect that the filter expression being used:
 ```
... | filter: (importDateFilter != 0) && {import_date: importDateFilter} | ...
```
may not have been working as we thought it should. So I rewrote it as a AngularJS filter service, and it seems to have fixed the issue I was seeing.

#### What should we test?

- [ ] The product import filter should work as per the original spec (see #1492)

#### Release notes

This has not been released yet, but if the #1492 is released before this bug is fixed then maybe use the following:

Fixed a bug which caused some products to be hidden from the bulk product update view in the backend.