### PR TITLE
Pass on redirect path instead of URL

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -208,7 +208,7 @@ class CheckoutController < Spree::CheckoutController
     payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
     return unless payment_method.kind_of?(Spree::Gateway::PayPalExpress)
 
-    render json: {path: spree.paypal_express_url(payment_method_id: payment_method.id)}, status: 200
+    render json: {path: spree.paypal_express_path(payment_method_id: payment_method.id)}, status: 200
     true
   end
 


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2376

The checkout doesn't deal with absolute URLs since
fc2cc09ea5e6c123243dac27b0f5dff601ac518b.

#### What should we test?

Checking out using Paypal. Nothing else is affected.

#### Release notes

Fixed checkout with Paypal.