### PR TITLE
Include admin users as managers on new enterprises

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -374,7 +374,7 @@ class Enterprise < ActiveRecord::Base
   end
 
   def ensure_owner_is_manager
-    users << owner unless users.include?(owner) || owner.admin?
+    users << owner unless users.include?(owner)
   end
 
   def enforce_ownership_limit


### PR DESCRIPTION
#### What? Why?

Closes #2257 .

When a superadmin user created a new enterprise via admin and added themselves as the owner, the user was not being explicitly included in the list of managers (superadmins can usually "manage" all enterprises anyway). This meant subsequent setting of the contact user for the enterprise was not happening properly, as the EnterpriseRole record was not there, which in turn meant this was missing and causing a weird Angular glitch in the enterprise users form after creation.

#### What should we test?

Creating an enterprise via admin with a superadmin account, and a superadmin as the enterprise owner. After saving, go to the users tab on the enterprise page and the "Notifications" field should be set to the same user and not be blank. 

![screenshot from 2018-06-14 13-41-42](https://user-images.githubusercontent.com/9029026/41412756-edfcd274-6fd8-11e8-9fe9-1feaf827c41d.png)

Changing other properties on the enterprise and then saving should be successful and not show an error.

#### Release notes

Bugfix for #2257 for superadmin accounts where enterprises owned by a superadmin user where not setting manager roles and contact user correctly.

