### PR TITLE
2376 improve checkout redirects

### DIFF
--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -13,7 +13,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
     submit: =>
       Loading.message = t 'submitting_order'
       $http.put('/checkout.json', {order: @preprocess()}).success (data, status)=>
-        Navigation.goWithoutHashFragments data.path
+        Navigation.go data.path
       .error (response, status)=>
         if response.path
           Navigation.go response.path

--- a/app/assets/javascripts/darkswarm/services/navigation.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/navigation.js.coffee
@@ -21,10 +21,9 @@ Darkswarm.factory 'Navigation', ($location, $window) ->
       $window.location.href = $window.location.origin + path
 
     go: (path)->
-      if path.match /^http/
-        $window.location.href = path
-      else
-        $window.location.pathname = path
+      # The browser treats this like clicking on a link.
+      # It works for absolute paths, relative paths and URLs alike.
+      $window.location.href = path
 
     reload: ->
       $window.location.reload()

--- a/app/assets/javascripts/darkswarm/services/navigation.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/navigation.js.coffee
@@ -16,10 +16,6 @@ Darkswarm.factory 'Navigation', ($location, $window) ->
       else
         @navigate(path)
 
-    goWithoutHashFragments: (path) ->
-      # Redirects to specified path, without Angular hash fragments such as '#/login'
-      $window.location.href = $window.location.origin + path
-
     go: (path)->
       # The browser treats this like clicking on a link.
       # It works for absolute paths, relative paths and URLs alike.

--- a/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
@@ -95,6 +95,12 @@ describe 'Checkout service', ->
       Checkout.submit()
       $httpBackend.flush()
 
+    it "Redirects to the returned path", ->
+      $httpBackend.expectPUT("/checkout.json", {order: Checkout.preprocess()}).respond 200, {path: "/test"}
+      Checkout.submit()
+      $httpBackend.flush()
+      expect(Navigation.go).toHaveBeenCalledWith '/test'
+
     describe "when there is an error", ->
       it "redirects when a redirect is given", ->
         $httpBackend.expectPUT("/checkout.json").respond 400, {path: 'path'}

--- a/spec/javascripts/unit/darkswarm/services/navigation.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/navigation.js.coffee
@@ -3,7 +3,6 @@ describe 'Navigation service', ->
   window =
     location:
       href: null
-      pathname: null
 
   beforeEach ->
     module 'Darkswarm', ($provide) ->
@@ -24,5 +23,4 @@ describe 'Navigation service', ->
 
     it "redirects to paths", ->
       Navigation.go "/woo/yeah"
-      expect(window.location.pathname).toEqual "/woo/yeah"
-    
+      expect(window.location.href).toEqual "/woo/yeah"


### PR DESCRIPTION
#### What? Why?

Addresses #2376 which is already closed. This is another improvement that would have fixed it as well.

A small change in #2337 broke Paypal. But the problem was not with that change, but that other parts of the code didn't behave as expected. We got an absolute URL as `path` from the checkout controller and `Navigation.go` was preserving hash fragments.

While #2377 changed the checkout controller, this pull request makes the Navigation service more robust to prevent bugs like this from happening in the future.

#### What should we test?

The changed code is used during registration, checkout and changing credit card details. We need to check that every click is bringing us to the right page and that modals open correctly. Especially the redirect on checkout should be tested with different payment methods.

The checkout should also be tested on mobile to verify that mobile browser are doing the same thing.

#### Release notes

Code improvements to prevent bugs.