### PR TITLE
Fix NoMethodError in order cycles index

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -6,7 +6,7 @@ module Admin
   class OrderCyclesController < ResourceController
     include OrderCyclesHelper
 
-    prepend_before_filter :load_data_for_index, :only => :index
+    before_filter :load_data_for_index, only: :index
     before_filter :require_coordinator, only: :new
     before_filter :remove_protected_attrs, only: [:update]
     before_filter :check_editable_schedule_ids, only: [:create, :update]


### PR DESCRIPTION
#### What? Why?

Closes #2271 

When a user's session has timed out and they try to load new data on the
order cycles page by changing filters, the application throws a
`NoMethodError` because we are prepending the load data method before
checking the user's session.

We can fix this by removing the prepend on this action.

#### What should we test?

Loading and filtering the order cycles page. (Show 30 more days or Show 90 more days)