### PR TITLE
added directive to make links open in new tab by default in textangul…

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/textangular_links_target_blank.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/textangular_links_target_blank.js.coffee
@@ -1,0 +1,6 @@
+angular.module("admin.utils").directive "textangularLinksTargetBlank", () ->
+  restrict: 'CA'
+  link: (scope, element, attrs) ->
+    setTimeout ->
+      element.find(".ta-editor").scope().defaultTagAttributes.a.target = '_blank'
+    , 500

--- a/app/views/admin/enterprise_groups/_form_about.html.haml
+++ b/app/views/admin/enterprise_groups/_form_about.html.haml
@@ -1,6 +1,6 @@
 %fieldset.alpha.no-border-bottom{ ng: { show: "menu.selected.name=='about'" } }
   %legend {{menu.selected.label}}
   = f.field_container :long_description do
-    %text-angular{'id' => 'enterprise_group_long_description', 'name' => 'enterprise_group[long_description]', 'class' => 'text-angular',
+    %text-angular{'id' => 'enterprise_group_long_description', 'name' => 'enterprise_group[long_description]', 'class' => 'text-angular', "textangular-links-target-blank" => true,
       'ta-toolbar' => "[['h1','h2','h3','h4','p'],['bold','italics','underline','clear'],['insertLink']]"}
       != @enterprise_group[:long_description]

--- a/app/views/admin/enterprises/form/_about_us.html.haml
+++ b/app/views/admin/enterprises/form/_about_us.html.haml
@@ -12,6 +12,6 @@
     -# 	['bold', 'italics', 'underline', 'strikeThrough', 'ul', 'ol', 'redo', 'undo', 'clear'],
     -# 	['justifyLeft','justifyCenter','justifyRight','indent','outdent'],
     -# 	['html', 'insertImage', 'insertLink', 'insertVideo']
-    %text-angular{'ng-model' => 'Enterprise.long_description', 'id' => 'enterprise_long_description', 'name' => 'enterprise[long_description]', 'class' => 'text-angular',
+    %text-angular{'ng-model' => 'Enterprise.long_description', 'id' => 'enterprise_long_description', 'name' => 'enterprise[long_description]', 'class' => 'text-angular', "textangular-links-target-blank" => true,
       'ta-toolbar' => "[['h1','h2','h3','h4','p'],['bold','italics','underline','clear'],['insertLink']]",
       'placeholder' => t('.desc_long_placeholder')}

--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -3,7 +3,7 @@
     .three.columns.alpha
       = f.label "enterprise_preferred_shopfront_message", t('.shopfront_message')
     .eight.columns.omega
-      %text-angular{'ng-model' => 'Enterprise.preferred_shopfront_message', 'id' => 'enterprise_preferred_shopfront_message', 'name' => 'enterprise[preferred_shopfront_message]', 'class' => 'text-angular',
+      %text-angular{'ng-model' => 'Enterprise.preferred_shopfront_message', 'id' => 'enterprise_preferred_shopfront_message', 'name' => 'enterprise[preferred_shopfront_message]', 'class' => 'text-angular', "textangular-links-target-blank" => true,
         'ta-toolbar' => "[['h1','h2','h3','h4','p'],['bold','italics','underline','clear'],['insertLink']]",
         'placeholder' => t('.shopfront_message_placeholder')}
 .row
@@ -11,7 +11,7 @@
     .three.columns.alpha
       = f.label "enterprise_preferred_shopfront_closed_message", t('.shopfront_closed_message')
     .eight.columns.omega
-      %text-angular{'ng-model' => 'Enterprise.preferred_shopfront_closed_message', 'id' => 'enterprise_preferred_shopfront_closed_message', 'name' => 'enterprise[preferred_shopfront_closed_message]', 'class' => 'text-angular',
+      %text-angular{'ng-model' => 'Enterprise.preferred_shopfront_closed_message', 'id' => 'enterprise_preferred_shopfront_closed_message', 'name' => 'enterprise[preferred_shopfront_closed_message]', 'class' => 'text-angular', "textangular-links-target-blank" => true,
         'ta-toolbar' => "[['h1','h2','h3','h4','p'],['bold','italics','underline','clear'],['insertLink']]",
         'placeholder' => t('.shopfront_closed_message_placeholder')}
 .row


### PR DESCRIPTION
…ar text areas

#### What? Why?

Closes #2301

Added a directive to be used with textangular to make links open in new tab by default.

#### What should we test?

Links inserted in enterprise "about us" textarea should open in new tab by default.
Note: the behaviour can still be turned around by clicking on the link in the text area and click "open in new window".

#### Release notes

Links on enterprise "about us" text will open in new tab by default now.