### PR TITLE
Remove taxon when primary taxon is changed

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -38,6 +38,7 @@ Spree::Product.class_eval do
   before_validation :sanitize_permalink
   before_save :add_primary_taxon_to_taxons
   after_touch :touch_distributors
+  after_save :remove_previous_primary_taxon_from_taxons
   after_save :ensure_standard_variant
   after_save :update_units
   after_save :refresh_products_cache
@@ -243,6 +244,11 @@ Spree::Product.class_eval do
 
   def add_primary_taxon_to_taxons
     taxons << primary_taxon unless taxons.include? primary_taxon
+  end
+
+  def remove_previous_primary_taxon_from_taxons
+    return unless primary_taxon_id_changed? && primary_taxon_id_was
+    taxons.destroy(primary_taxon_id_was)
   end
 
   def self.all_variant_unit_option_types

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -193,6 +193,22 @@ module Spree
           expect { product.delete }.to change { distributor.reload.updated_at }
         end
       end
+
+      it "adds the primary taxon to the product's taxon list" do
+        taxon = create(:taxon)
+        product = create(:product, primary_taxon: taxon)
+
+        expect(product.taxons).to include(taxon)
+      end
+
+      it "removes the previous primary taxon from the taxon list" do
+        original_taxon = create(:taxon)
+        product = create(:product, primary_taxon: original_taxon)
+        product.primary_taxon = create(:taxon)
+        product.save!
+
+        expect(product.taxons).not_to include(original_taxon)
+      end
     end
 
     describe "scopes" do


### PR DESCRIPTION
#### What? Why?

Closes #1250 

We are adding taxons to the product as you change the primary taxon.
However we never remove the previous primary taxon so it forces the user
to update the taxons manually. This can be a big problem if you are bulk
updating products.

We now remove the taxon that matches the previously set primary taxon.

#### What should we test?

Updating a product's primary taxon (Category) either through bulk updating or normal update adds the new taxon to the product's taxon list and removes the previous primary taxon from the product's taxon list.

#### Release notes

When changing a product's primary taxon the system now removes the previously set primary taxon from the product's taxon list automatically.