### PR TITLE
Set the SSL protocol for secure connections

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 
 Capybara.register_driver :poltergeist do |app|
-  options = {phantomjs_options: ['--load-images=no'], window_size: [1280, 3600], timeout: 2.minutes}
+  options = {phantomjs_options: ['--load-images=no', '--ssl-protocol=any'], window_size: [1280, 3600], timeout: 2.minutes}
   # Extend poltergeist's timeout to allow ample time to use pry in browser thread
   #options.merge! {timeout: 5.minutes}
   # Enable the remote inspector: Use page.driver.debug to open a remote debugger in chrome


### PR DESCRIPTION
#### What? Why?

There are ssl errors when using stripe through phantom js. This allows
other SSL protocols now.