### PR TITLE
Add available_on notes to PI guide

### DIFF
--- a/app/views/admin/product_import/guide/_columns.html.haml
+++ b/app/views/admin/product_import/guide/_columns.html.haml
@@ -91,3 +91,10 @@
       %td (Various, see notes)
       %td Sets the product shipping category
       %td See below for a list of available categories
+    %tr
+      %td
+        %strong available_on
+      %td No
+      %td 2018-05-21
+      %td Sets the date from which the product will be available
+      %td Date format is: YYYY-MM-DD


### PR DESCRIPTION
#### What? Why?

Closes #2320. 

Doesn't add anything to the codebase, just a few extra notes in the Product Import guide about the correct date format for setting the `available_on` attribute.

#### What should we test?

Nothing to test, really. I think it's not worth release notes either at this point as it's not public yet.

