### PR TITLE
admin page fetcher is now synchronously fetching all pages before reso…

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -1,5 +1,6 @@
 angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout, $http, $window, BulkProducts, DisplayProperties, dataFetcher, DirtyProducts, VariantUnitManager, StatusMessage, producers, Taxons, SpreeApiAuth, Columns, tax_categories) ->
     $scope.loading = true
+    $scope.loadingAllPages = true
 
     $scope.StatusMessage = StatusMessage
 
@@ -49,7 +50,10 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
 
     $scope.fetchProducts = ->
       $scope.loading = true
-      BulkProducts.fetch($scope.currentFilters).then ->
+      $scope.loadingAllPages = true
+      BulkProducts.fetch($scope.currentFilters, ->
+        $scope.loadingAllPages = false
+      ).then ->
         $scope.resetProducts()
         $scope.loading = false
 

--- a/app/assets/javascripts/admin/index_utils/services/paged_fetcher.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/services/paged_fetcher.js.coffee
@@ -3,14 +3,18 @@ angular.module("admin.indexUtils").factory "PagedFetcher", (dataFetcher) ->
     # Given a URL like http://example.com/foo?page=::page::&per_page=20
     # And the response includes an attribute pages with the number of pages to fetch
     # Fetch each page async, and call the processData callback with the resulting data
-    fetch: (url, processData) ->
+    fetch: (url, processData, onLastPageComplete) ->
       dataFetcher(@urlForPage(url, 1)).then (data) =>
         processData data
 
         if data.pages > 1
           for page in [2..data.pages]
-            dataFetcher(@urlForPage(url, page)).then (data) ->
+            lastPromise = dataFetcher(@urlForPage(url, page)).then (data) ->
               processData data
+          onLastPageComplete && lastPromise.then onLastPageComplete
+          return
+        else
+          onLastPageComplete && onLastPageComplete()
 
     urlForPage: (url, page) ->
       url.replace("::page::", page)

--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -8,7 +8,8 @@ angular.module("ofn.admin").factory "BulkProducts", (PagedFetcher, dataFetcher, 
       , ""
 
       url = "/api/products/bulk_products?page=::page::;per_page=20;#{queryString}"
-      PagedFetcher.fetch url, (data) => @addProducts data.products
+      processData = (data) => @addProducts data.products
+      PagedFetcher.fetch url, processData, onComplete
 
     cloneProduct: (product) ->
       $http.post("/api/products/" + product.id + "/clone").success (data) =>

--- a/app/views/spree/admin/products/index/_indicators.html.haml
+++ b/app/views/spree/admin/products/index/_indicators.html.haml
@@ -5,10 +5,10 @@
   %img.spinner{ src: "/assets/spinning-circles.svg" }
   %h1= t('.title')
 
-%div.sixteen.columns.alpha{ 'ng-show' => '!loading && filteredProducts.length == 0 && query.length==0' }
+%div.sixteen.columns.alpha{ 'ng-show' => '!loadingAllPages && filteredProducts.length == 0 && query.length==0' }
   %h1#no_results= t('.no_products')
 
-%div.sixteen.columns.alpha{ 'ng-show' => '!loading && filteredProducts.length == 0 && query.length!=0' }
+%div.sixteen.columns.alpha{ 'ng-show' => '!loadingAllPages && filteredProducts.length == 0 && query.length!=0' }
   %h1#no_results
     = t('.no_results')
     '


### PR DESCRIPTION
…lving its promise (so that results are not inacurate due to filters)

#### What? Why?

Closes #436

Makes page fetch synchronous so that results are always accurate.

#### What should we test?

Products bulk edit list and filtering.
Inventory (variant overrides).

#### Release notes

Bulk product edit page will now show results only after fetching all results from server.