### PR TITLE
Hide postcode - not necessary as passed from billing address and wrec…

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/stripe_elements.js.coffee
@@ -10,7 +10,7 @@ Darkswarm.directive "stripeElements", ($injector, StripeElements) ->
       stripe = $injector.get('stripeObject')
 
       card = stripe.elements().create 'card',
-        hidePostalCode: false
+        hidePostalCode: true
         style:
           base:
             fontFamily: "Roboto, Arial, sans-serif"


### PR DESCRIPTION
…ks mobile UX

#### What? Why?

Simple fix to test for:
#2352

The word "Postcode" is too long and overlaps the card number field on small screens. We can just hide the field it as it's not necessary (see issue discussion).

#### What should we test?

Check form is visible and usable

Check Stripe payments still go through ok.

#### Release notes

Removed postcode (ZIP) field from Stripe card form so it now works on small screen mobile devices.