### PR TITLE
Remove impossible route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Openfoodnetwork::Application.routes.draw do
   get "/t/products/:id", to: redirect("/")
   get "/about_us", to: redirect(ContentConfig.footer_about_url)
 
-  get "/#/login", to: "home#index", as: :spree_login
   get "/login", to: redirect("/#/login")
 
   get "/discourse/login", to: "discourse_sso#login"


### PR DESCRIPTION
#### What? Why?

I randomly came across this impossible entry in our routes: `get "/#/login"`

Hash fragments are not part of the http request and not sent to the
server. So the routes will never see a hash fragment which means that
this route is never used.

#### What should we test?

Logging in from a few different screens. Make sure that nothing changed.

#### Release notes

Removed unused code.