### PR TITLE
2013 Remove dead code for Spree upgrade

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -129,12 +129,6 @@ class Enterprise < ActiveRecord::Base
     joins('LEFT OUTER JOIN exchange_variants ON (exchange_variants.exchange_id = exchanges.id)').
     joins('LEFT OUTER JOIN spree_variants ON (spree_variants.id = exchange_variants.variant_id)')
 
-  scope :active_distributors, lambda {
-    with_distributed_products_outer.with_order_cycles_as_distributor_outer.
-      where('(product_distributions.product_id IS NOT NULL AND spree_products.deleted_at IS NULL AND spree_products.available_on <= ? AND spree_products.count_on_hand > 0) OR (order_cycles.id IS NOT NULL AND order_cycles.orders_open_at <= ? AND order_cycles.orders_close_at >= ?)', Time.zone.now, Time.zone.now, Time.zone.now).
-      select('DISTINCT enterprises.*')
-  }
-
   scope :distributors_with_active_order_cycles, lambda {
     with_order_cycles_as_distributor_outer.
       merge(OrderCycle.active).

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -193,10 +193,6 @@ class Enterprise < ActiveRecord::Base
     end
   end
 
-  def has_supplied_products_on_hand?
-    self.supplied_products.where('count_on_hand > 0').present?
-  end
-
   def to_param
     permalink
   end

--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -6,11 +6,7 @@ module OpenFoodNetwork
     render_views
 
     let(:user) { FactoryBot.create(:user) }
-    let(:product1) do
-      p1 = FactoryBot.create(:product)
-      p1.update_column(:count_on_hand, 10)
-      p1
-    end
+    let(:product1) { FactoryBot.create(:product) }
     let(:cart) { Cart.create(user: user) }
     let(:distributor) { FactoryBot.create(:distributor_enterprise) }
 

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -489,26 +489,6 @@ describe Enterprise do
     end
   end
 
-  describe "has_supplied_products_on_hand?" do
-    before :each do
-      @supplier = create(:supplier_enterprise)
-    end
-
-    it "returns false when no products" do
-      @supplier.should_not have_supplied_products_on_hand
-    end
-
-    it "returns false when the product is out of stock" do
-      create(:product, :supplier => @supplier, :on_hand => 0)
-      @supplier.should_not have_supplied_products_on_hand
-    end
-
-    it "returns true when the product is in stock" do
-      create(:product, :supplier => @supplier, :on_hand => 1)
-      @supplier.should have_supplied_products_on_hand
-    end
-  end
-
   describe "finding variants distributed by the enterprise" do
     it "finds master and other variants" do
       d = create(:distributor_enterprise)

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -321,48 +321,6 @@ describe Enterprise do
       end
     end
 
-    describe "active_distributors" do
-      it "finds active distributors by product distributions" do
-        d = create(:distributor_enterprise)
-        create(:product, :distributors => [d])
-        Enterprise.active_distributors.should == [d]
-      end
-
-      it "doesn't show distributors of deleted products" do
-        d = create(:distributor_enterprise)
-        create(:product, :distributors => [d], :deleted_at => Time.zone.now)
-        Enterprise.active_distributors.should be_empty
-      end
-
-      it "doesn't show distributors of unavailable products" do
-        d = create(:distributor_enterprise)
-        create(:product, :distributors => [d], :available_on => 1.week.from_now)
-        Enterprise.active_distributors.should be_empty
-      end
-
-      it "doesn't show distributors of out of stock products" do
-        d = create(:distributor_enterprise)
-        create(:product, :distributors => [d], :on_hand => 0)
-        Enterprise.active_distributors.should be_empty
-      end
-
-      it "finds active distributors by order cycles" do
-        s = create(:supplier_enterprise)
-        d = create(:distributor_enterprise)
-        p = create(:product)
-        create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master])
-        Enterprise.active_distributors.should == [d]
-      end
-
-      it "doesn't show distributors from inactive order cycles" do
-        s = create(:supplier_enterprise)
-        d = create(:distributor_enterprise)
-        p = create(:product)
-        create(:simple_order_cycle, suppliers: [s], distributors: [d], variants: [p.master], orders_open_at: 1.week.from_now, orders_close_at: 2.weeks.from_now)
-        Enterprise.active_distributors.should be_empty
-      end
-    end
-
     describe "supplying_variant_in" do
       it "finds producers by supply of master variant" do
         s = create(:supplier_enterprise)


### PR DESCRIPTION
#### What? Why?

Simplifies #2013. But there is more to do for that issue.

Working on the Spree upgrade, @sauloperez identified the code that is using the soon obsolete column `spree_products.count_on_hand`. Investigating refactoring this code, I found that it can be simply removed. :fire: :fire: :fire: 

#### What should we test?

- Check the list of shops to see that all enterprises are shown correctly as open or closed.

#### Release notes

Removed old, unused code.

#### How is this related to the Spree upgrade?

The removed code was using `spree_products.count_on_hand` which will be removed in Spree.

