### PR TITLE
Remove spree product navigation override

### DIFF
--- a/app/overrides/spree/admin/shared/_product_sub_menu/add_products_tab.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_sub_menu/add_products_tab.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_sub_tabs']"
-
-- if spree_current_user.admin?
-  = tab :spree_products, url: admin_products_path, :match_path => '/products'


### PR DESCRIPTION
#### What? Why?

Closes #2412 

This was here to override the original spree products navigation link,
but since moving back to the index action this had the side effect of
adding an additional navigation item instead. We can simply remove this
override to get rid of the additional menu item.

#### What should we test?

Ensure when in admin product pages that the additional "Spree Products" sub-menu item is no longer present, but the "Products" sub-menu item still exists.