### PR TITLE
1667 manage validations emails

### DIFF
--- a/app/assets/stylesheets/mail/email.css.scss
+++ b/app/assets/stylesheets/mail/email.css.scss
@@ -55,6 +55,12 @@ p.callout {
   color: #0096ad;
 }
 
+p.notice {
+  font-style: italic;
+  font-size: 12px;
+  margin-top: 20px;
+}
+
 table.social {
   background-color: #ebebeb;
 

--- a/app/mailers/spree/user_mailer_decorator.rb
+++ b/app/mailers/spree/user_mailer_decorator.rb
@@ -9,6 +9,9 @@ Spree::UserMailer.class_eval do
   # overriding `Devise::Mailer.confirmation_instructions`.
   def confirmation_instructions(user, _opts)
     @user = user
+    @instance = Spree::Config[:site_name]
+    @contact = ContentConfig.footer_email
+
     subject = t('spree.user_mailer.confirmation_instructions.subject')
     mail(to: user.email,
          from: from_address,

--- a/app/views/spree/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/spree/user_mailer/confirmation_instructions.html.haml
@@ -1,7 +1,7 @@
 %h3
   = t :email_signup_greeting
 %p.lead
-  = t :email_signup_welcome, sitename: Spree::Config[:site_name]
+  = t :email_signup_welcome, sitename: @instance
 %p= t :email_confirmation_activate_account
 
 %p.callout
@@ -13,3 +13,6 @@
 = render 'shared/mailers/signoff'
 
 = render 'shared/mailers/social_and_contact'
+
+%p.notice
+  = t :email_confirmation_notice_unexpected, sitename: @instance, contact: @contact

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1354,6 +1354,7 @@ To activate your Profile we need to confirm this email address."
   email_confirmation_link_label: "Confirm this email address »"
   email_confirmation_help_html: "After confirming your email you can access your administration account for this enterprise.
 See the %{link} to find out more about %{sitename}'s features and to start using your profile or online store."
+  email_confirmation_notice_unexpected: "You received this message because you signed up on %{sitename}, or were invited to sign up by someone you probably know. If you don't understand why you are receiving this email, please write to %{contact}." 
   email_social: "Connect with Us:"
   email_contact: "Email us:"
   email_signoff: "Cheers,"


### PR DESCRIPTION
#### What? Why?

This PR extends and replaces @HugsDaniel PR #2355.
Closes #1667 

Adds a bottom comment in signup validation email with sitename and contact address. This comment is put there in case of unexpected validation email.

#### What should we test?

The bottom message is displayed correctly and with correct sitename and contact address.

#### Release notes

Adds a bottom comment in signup validation email with sitename and contact address in case of unexpected email.