### PR TITLE
Replace therubyracer with mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,8 +87,7 @@ group :assets do
   gem 'compass-rails'
   gem 'coffee-rails', '~> 3.2.1'
 
-  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-  gem 'therubyracer'
+  gem 'mini_racer'
 
   gem 'uglifier', '>= 1.0.3'
 

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,9 @@ group :assets do
   gem 'coffee-rails', '~> 3.2.1'
 
   gem 'mini_racer'
+  # We found that the following version of libv8 breaks the compilation of mini_racer.
+  # Nothing else depends on libv8.
+  gem 'libv8', '!= 6.7.288.46.1'
 
   gem 'uglifier', '>= 1.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -757,6 +757,7 @@ DEPENDENCIES
   jwt (~> 1.5)
   knapsack
   letter_opener (>= 1.4.1)
+  libv8 (!= 6.7.288.46.1)
   listen (= 3.0.8)
   mini_racer
   momentjs-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,7 +467,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.6.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.19)
+    libv8 (6.3.292.48.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -479,6 +479,8 @@ GEM
     mime-types (1.25.1)
     mini_mime (1.0.1)
     mini_portile2 (2.1.0)
+    mini_racer (0.1.15)
+      libv8 (~> 6.3)
     momentjs-rails (2.5.1)
       railties (>= 3.1)
     money (5.1.0)
@@ -576,7 +578,6 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.2.3)
-    ref (2.0.0)
     representative (1.0.5)
       activesupport (>= 2.2.2)
       builder (>= 2.1.2)
@@ -657,9 +658,6 @@ GEM
     stringex (1.3.3)
     stripe (3.3.2)
       faraday (~> 0.9)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.0)
     tilt (1.4.1)
     timecop (0.9.1)
@@ -760,6 +758,7 @@ DEPENDENCIES
   knapsack
   letter_opener (>= 1.4.1)
   listen (= 3.0.8)
+  mini_racer
   momentjs-rails
   nokogiri (>= 1.6.7.1)
   oauth2 (~> 1.2.0)
@@ -795,7 +794,6 @@ DEPENDENCIES
   spree_i18n!
   spree_paypal_express!
   stripe (~> 3.3.2)
-  therubyracer
   timecop
   truncate_html
   turbo-sprockets-rails3


### PR DESCRIPTION
#### What? Why?

Closes #2100

This is being replaced to increase the reliability and speed of asset
compilation.

#### What should we test?

Assets are compiled in staging.