### PR TITLE
2007 Skip shipment creation for payment step

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -30,20 +30,14 @@ Spree::Order.class_eval do
   checkout_flow do
     go_to_state :address
     go_to_state :delivery
-    go_to_state :payment, :if => lambda { |order|
-      # Fix for #2191
-      if order.shipping_method.andand.delivery?
-        if order.ship_address.andand.valid?
-          order.create_shipment!
-          order.update_totals
-        end
-      end
+    go_to_state :payment, if: ->(order) {
+      order.update_totals
       order.payment_required?
     }
     # NOTE: :confirm step was removed because we were not actually using it
     # go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
     go_to_state :complete
-    remove_transition :from => :delivery, :to => :confirm
+    remove_transition from: :delivery, to: :confirm
   end
 
   # -- Scopes

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -27,18 +27,10 @@ Spree::Order.class_eval do
   before_save :update_shipping_fees!, if: :complete?
   before_save :update_payment_fees!, if: :complete?
 
-  checkout_flow do
-    go_to_state :address
-    go_to_state :delivery
-    go_to_state :payment, if: ->(order) {
-      order.update_totals
-      order.payment_required?
-    }
-    # NOTE: :confirm step was removed because we were not actually using it
-    # go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
-    go_to_state :complete
-    remove_transition from: :delivery, to: :confirm
-  end
+  # Orders are confirmed with their payment, we don't use the confirm step.
+  # Here we remove that step from Spree's checkout state machine.
+  # See: https://guides.spreecommerce.org/developer/checkout.html#modifying-the-checkout-flow
+  remove_checkout_step :confirm
 
   # -- Scopes
   scope :managed_by, lambda { |user|


### PR DESCRIPTION
#### What? Why?

Closes #2007 and closes #2432.

Spree 2.0.4 creates in-memory shipments for the payment step. That means
we don't need to create a shipment in that transition. This change
does not override the whole `checkout_flow` from the Spree code, but still removes the confirm state.


#### What should we test?

I don't think we can test this yet. But once we can, we should test the checkout with fees on shipping methods. Some methods should require a shipping address and others not.

#### Release notes

Spree upgrade.

#### How is this related to the Spree upgrade?

It is part of it.

#### Discourse thread

https://community.openfoodnetwork.org/t/order-model-step7/979

