### PR TITLE
Modify English tool tip text in yml file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -846,7 +846,7 @@ en:
         add_distributor: 'Add distributor'
       advanced_settings:
         title: Advanced Settings
-        choose_product_tip: You can opt to restrict all available products (both incoming and outgoing), to only those in %{inventory}'s inventory.
+        choose_product_tip: You can restrict products incoming and outgoing to only %{inventory}'s inventory.
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -624,7 +624,7 @@ en_GB:
         add_distributor: 'Add distributor'
       advanced_settings:
         title: Advanced Settings
-        choose_product_tip: You can opt to restrict all available products (both incoming and outgoing), to only those in %{inventory}'s inventory.
+        choose_product_tip: You can restrict products incoming and outgoing to only %{inventory}'s inventory.
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -679,7 +679,7 @@ en_US:
         add_distributor: 'Add distributor'
       advanced_settings:
         title: Advanced Settings
-        choose_product_tip: You can opt to restrict all available products (both incoming and outgoing), to only those in %{inventory}'s inventory.
+        choose_product_tip: You can restrict products incoming and outgoing to only %{inventory}'s inventory.
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page


### PR DESCRIPTION
#### What? Why?

Closes #1848

Before:
![before img](https://user-images.githubusercontent.com/10843056/30726477-611a37a4-9f8e-11e7-8f8c-2181ca980282.png)

After:
![after img](https://user-images.githubusercontent.com/34175382/42330277-08b6ad9e-8030-11e8-9c14-3cb3834fcfa7.png)

Attempted to edit the styling properties of PowerTip but current value used for positioning is `smartPlacement: true` which is supposed to keep the tooltip within the viewport. We believe the text of the tooltip being a long continual string is causing the issue. We decided to shorten the verbiage of the tooltip to allow PowerTip to better handle the placement. Styling still isn't ideal but we believe this is a decent fix without rework of the PowerTip implementation.

As our only available language in our group is English we only applied the shortened tooltip text to the English yml files. We did not want to provide incorrect translations, but we recommend the other language tooltips be changed as well.

#### What should we test?

These changes only modify display text, the test suite we ran had no broken tests.