### PR TITLE
Move i18n locale doc to wiki and reference that

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,58 +1,25 @@
 # English language file
 # ---------------------
 #
-# This is the source language file maintained by the Australian OFN team.
+# This is the source language file maintained by the global OFN team and used
+# by the Australian OFN instance.
+#
 # Visit Transifex to translate this file into other languages:
 #
 #   https://www.transifex.com/open-food-foundation/open-food-network/
 #
-# If you translate this file in a text editor, please share your results with us by
+# Read more about it at:
 #
-# - uploading the file to Transifex or
-# - opening a pull request at GitHub.
-#
-#
-# See http://community.openfoodnetwork.org/t/localisation-ofn-in-your-language/397
+#   https://github.com/openfoodfoundation/openfoodnetwork/wiki/i18n
 #
 # Changing this file
 # ==================
 #
 # You are welcome to fix typos, add missing translations and remove unused ones.
-# Here are some guidelines to make sure that this file is becoming more beautiful
-# with every change we do.
+# But read our guidelines first:
 #
-# * Change text: No problem. Fix the typo. And please enclose the text in quotes
-#   to avoid any accidents.
+#   https://github.com/openfoodfoundation/openfoodnetwork/wiki/i18n#development
 #
-#   Example 1: "When you're using double quotes, they look like \"this\""
-#   Example 2: "When you’re using double quotes, they look like “this”"
-#
-#   The second example uses unicode to make it look prettier and avoid backslashes.
-#
-# * Add translations: Cool, every bit of text in the application should be here.
-#   If you add a translation for a view or mailer, please make use of the nested
-#   structure. Use the "lazy" lookup. See: http://guides.rubyonrails.org/i18n.html#looking-up-translations
-#
-#   Avoid global keys. There are a lot already. And some are okay, for example
-#   "enterprises" should be the same everywhere on the page. But in doubt,
-#   create a new translation and give it a meaningful scope.
-#
-#   Don't worry about duplication. We may use the same word in different contexts,
-#   but another language could use different words. So don't try to re-use
-#   translations between files.
-#
-#   Don't move big parts around or rename scopes with a lot of entries without
-#   a really good reason. In some cases that causes a lot of translations in
-#   other languages to be lost. That causes more work for translators.
-#
-# * Remove translations: If you are sure that they are not used anywhere,
-#   please remove them. Be aware that some translations are looked up with
-#   variables. For example app/views/admin/contents/_fieldset.html.haml looks
-#   up labels for preferences. Unfortunately, they don't have a scope.
-#
-# * Participate in the community discussions:
-#   - https://community.openfoodnetwork.org/t/workflow-to-structure-translations/932
-
 en:
   # Overridden here due to a bug in spree i18n (Issue #870, and issue #1800)
   language_name: "English" # Localised name of this language


### PR DESCRIPTION
#### What? Why?

Helps to prevent unnecessary work as in https://github.com/openfoodfoundation/openfoodnetwork/pull/2437#issuecomment-403774344.

We regularly receive pull requests with changes to translation files. This change moves the documentation into the wiki and makes clear that you shouldn't work on other files than `en.yml`.

#### What should we test?

No code change, no testing needed.

#### Release notes

Improved documentation for contributors.

#### How is this related to the Spree upgrade?

Not.