### PR TITLE
Add changelog category to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,11 @@ context for others to understand it]
 [In case this should be present in the release notes, please write them or
 remove this section otherwise]
 
+[To streamline the release process, please designate your PR with ONE of the following 
+categories, based on the specification from keepachangelog.com (and delete the others):]
+
+Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security
+
 #### How is this related to the Spree upgrade?
 
 [Any known conflicts with the Spree Upgrade? explain them or remove this section


### PR DESCRIPTION
#### What? Why?

Adds a line to the PR template asking the person submitting it to assign it a changleog category in order to speed up the process of building a release and make the process much less painful for the person building it.

The specification we use is defined here: http://keepachangelog.com

#### What should we test?

No testing required.

#### Obligatory GIF

![](https://media.giphy.com/media/11djX62aIGdONy/giphy-downsized.gif)


