### PR TITLE
Use progress formatter on Travis to avoid timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
 
 script:
   - 'if [ "$KARMA" = "true" ]; then bundle exec rake karma:run; else echo "Skipping karma run"; fi'
-  - "bundle exec rake 'knapsack:rspec[--tag ~performance]'"
+  - "bundle exec rake 'knapsack:rspec[--format progress --tag ~performance]'"
 
 after_success:
   - >


### PR DESCRIPTION

#### What? Why?

We had a few Travis builds lately that timed out, because no output was
received. Even though our standard formatter Fuubar should detect Travis
and print the right output, nothing was visible in our builds.
https://github.com/travis-ci/travis-ci/issues/1337

In this patch, I tell Travis to use Rspec's default formatter to print
dots for every passed test.

#### What should we test?

No manual testing required.

#### Release notes

Improved test output and stability.

Changelog Category: Changed

