### PR TITLE
Logo sizing to css

### DIFF
--- a/app/assets/stylesheets/darkswarm/footer.scss
+++ b/app/assets/stylesheets/darkswarm/footer.scss
@@ -36,6 +36,7 @@ footer {
 
       img {
         margin-top: 36px;
+        width: 120px;
       }
     }
 

--- a/app/assets/stylesheets/darkswarm/home_tagline.css.scss
+++ b/app/assets/stylesheets/darkswarm/home_tagline.css.scss
@@ -34,7 +34,7 @@
       max-width: 45%;
 
       @media all and (min-height: 500px) {
-        max-width: 80%;
+        max-width: 250px;
       }
 
       margin-bottom: 2rem;

--- a/app/views/home/_tagline.html.haml
+++ b/app/views/home/_tagline.html.haml
@@ -3,7 +3,7 @@
     .small-12.text-center.columns
       %h1
         / TODO: Rohan - logo asset & width is content manageable:
-        %img{src: "/assets/logo-white-notext.png", width: "250", title: Spree::Config.site_name}
+        %img{src: "/assets/logo-white-notext.png", title: Spree::Config.site_name}
         %br/
         %a.button.transparent{href: "/shops"}
           = t :home_shop

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -3,7 +3,7 @@
     .row
       .small-12.columns.text-center
         .logo
-          %img{src: "/assets/logo-white-notext.png", width: "120px"}
+          %img{src: "/assets/logo-white-notext.png"}
     .row
       .small-12.medium-8.medium-offset-2.columns.text-center
         .alert-box


### PR DESCRIPTION
#### What? Why?

Closes #2470

The logo height in width were in some cases set directly in the HTML rather than in CSS. This prevented the logo from scaling on mobile, as style could not be written over by CSS. I moved the formatting over to CSS.

#### What should we test?

Confirm home page logos (center and in footer) are now optimized for mobile. 

#### Release notes

Changelog Category: Fixed

