### PR TITLE
PI: Don't allow save if invalid entries are present

### DIFF
--- a/app/views/admin/product_import/import.html.haml
+++ b/app/views/admin/product_import/import.html.haml
@@ -7,16 +7,16 @@
 
   - if @importer.item_count == 0 #and @importer.invalid_count
     %h5
-      = t('admin.product_import.import.no_valid_entries')
+      = t('.no_valid_entries')
     %p
-      = t('admin.product_import.import.none_to_save')
+      = t('.none_to_save')
     %br
   - else
     .settings-section{ng: {show: 'step == "settings"'}}
       = render 'import_options' if @importer.table_headings
       %br
       %a.button.proceed{href: '', ng: {click: 'confirmSettings()'}}
-        = t('admin.product_import.import.proceed')
+        = t('.proceed')
       %a.button{href: main_app.admin_product_import_path} #{t('admin.cancel')}
 
   .progress-interface{ng: {show: 'step == "import"'}}
@@ -27,9 +27,9 @@
     .progress-bar
       %span.progress-track{class: 'ng-binding', style: "width:{{percentage}}"}
     %button.start_import{ng: {click: 'start()', disabled: 'started', init: "item_count = #{@importer.item_count}; import_url = '#{main_app.admin_product_import_process_async_path}'; filepath = '#{@filepath}'; import_into = '#{@import_into}'"}}
-      = t('admin.product_import.index.import')
+      = t('.import')
     %button.review{ng: {click: 'viewResults()', disabled: '!finished'}}
-      = t('admin.product_import.import.review')
+      = t('.review')
     %p.red
       {{ exception }}
 
@@ -44,13 +44,13 @@
         %p= t('admin.product_import.import.fix_before_import')
       %div{ng: {show: 'count((entries | entriesFilterValid:"invalid")) == 0'}}
         %br
-        %h5= t('admin.product_import.import.no_errors')
-        %p= t('admin.product_import.import.save_all_imported?')
+        %h5= t('.no_errors')
+        %p= t('.save_all_imported?')
       %br
       = hidden_field_tag :filepath, @filepath
       = hidden_field_tag "settings[import_into]", @import_into
 
-      %a.button.proceed{href: '', ng: {show: 'count((entries | entriesFilterValid:"invalid")) == 0', click: 'acceptResults()'}}= t('admin.product_import.import.proceed')
+      %a.button.proceed{href: '', ng: {show: 'count((entries | entriesFilterValid:"invalid")) == 0', click: 'acceptResults()'}}= t('.proceed')
 
       %a.button{href: main_app.admin_product_import_path}= t('admin.cancel')
 
@@ -60,13 +60,13 @@
 
   .progress-interface{ng: {show: 'step == "save"'}}
     %span.filename
-      #{t('admin.product_import.import.save_imported')} ({{ percentage }})
+      #{t('.save_imported')} ({{ percentage }})
     .progress-bar{}
       %span.progress-track{ng: {style: "{'width':percentage}"}}
     %button.start_save{ng: {click: 'start()', disabled: 'started', init: "item_count = #{@importer.item_count}; save_url = '#{main_app.admin_product_import_save_async_path}'; reset_url = '#{main_app.admin_product_import_reset_async_path}'; filepath = '#{@filepath}'; import_into = '#{@import_into}'"}}
-      = t('admin.product_import.import.save')
+      = t('.save')
     %button.view_results{ng: {click: 'finalResults()', disabled: '!finished'}}
-      = t('admin.product_import.import.results')
+      = t('.results')
     %p.red
       {{ exception }}
 

--- a/app/views/admin/product_import/import.html.haml
+++ b/app/views/admin/product_import/import.html.haml
@@ -41,7 +41,7 @@
       %div{ng: {if: 'count((entries | entriesFilterValid:"invalid")) > 0'}}
         %br
         %h5= t('admin.product_import.import.some_invalid_entries')
-        %p= t('admin.product_import.import.save_valid?')
+        %p= t('admin.product_import.import.fix_before_import')
       %div{ng: {show: 'count((entries | entriesFilterValid:"invalid")) == 0'}}
         %br
         %h5= t('admin.product_import.import.no_errors')
@@ -50,7 +50,7 @@
       = hidden_field_tag :filepath, @filepath
       = hidden_field_tag "settings[import_into]", @import_into
 
-      %a.button.proceed{href: '', ng: {click: 'acceptResults()'}}= t('admin.product_import.import.proceed')
+      %a.button.proceed{href: '', ng: {show: 'count((entries | entriesFilterValid:"invalid")) == 0', click: 'acceptResults()'}}= t('admin.product_import.import.proceed')
 
       %a.button{href: main_app.admin_product_import_path}= t('admin.cancel')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -478,7 +478,8 @@ en:
         save_imported: Save imported products
         no_valid_entries: No valid entries found
         none_to_save: There are no entries that can be saved
-        some_invalid_entries: Imported file contains some invalid entries
+        some_invalid_entries: Imported file contains invalid entries
+        fix_before_import: Please fix these errors and try importing the file again
         save_valid?: Save valid entries for now and discard the others?
         no_errors: No errors detected!
         save_all_imported?: Save all imported products?

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -107,12 +107,10 @@ feature "Product Import", js: true do
       expect(page).to_not have_selector 'input[type=submit][value="Save"]'
     end
 
-    it "handles validation and saving of named tax and shipping categories" do
+    it "handles saving of named tax and shipping categories" do
       csv_data = CSV.generate do |csv|
         csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "tax_category", "shipping_category"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.name, shipping_category.name]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", "Unknown Tax Category", shipping_category.name]
-        csv << ["Peas", "User Enterprise", "Vegetables", "7", "2.50", "1", "kg", tax_category2.name, "Unknown Shipping Category"]
       end
       File.write('/tmp/test.csv', csv_data)
 
@@ -127,8 +125,7 @@ feature "Product Import", js: true do
 
       import_data
 
-      expect(page).to have_selector '.item-count', text: "3"
-      expect(page).to have_selector '.invalid-count', text: "2"
+      expect(page).to have_selector '.item-count', text: "1"
       expect(page).to have_selector '.create-count', text: "1"
       expect(page).to_not have_selector '.update-count'
 
@@ -267,8 +264,6 @@ feature "Product Import", js: true do
       csv_data = CSV.generate do |csv|
         csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "tax_category", "shipping_category"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.name, shipping_category.name]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", "Unknown Tax Category", shipping_category.name]
-        csv << ["Peas", "User Enterprise", "Vegetables", "7", "2.50", "1", "kg", tax_category2.name, "Unknown Shipping Category"]
         csv << ["Pumpkin", "User Enterprise", "Vegetables", "3", "3.50", "1", "kg", tax_category.name, ""]
         csv << ["Spinach", "User Enterprise", "Vegetables", "7", "3.60", "1", "kg", "", shipping_category.name]
       end
@@ -307,8 +302,7 @@ feature "Product Import", js: true do
 
       import_data
 
-      expect(page).to have_selector '.item-count', text: "5"
-      expect(page).to have_selector '.invalid-count', text: "2"
+      expect(page).to have_selector '.item-count', text: "3"
       expect(page).to have_selector '.create-count', text: "3"
       expect(page).to_not have_selector '.update-count'
 
@@ -403,16 +397,7 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.create-count', text: "1"
 
       expect(page.body).to have_content 'you do not have permission'
-
-      expect(page).to have_selector 'a.button.proceed', visible: true
-      click_link 'Proceed'
-
-      save_data
-
-      expect(page).to have_selector '.created-count', text: '1'
-
-      expect(Spree::Product.find_by_name('My Carrots')).to be_a Spree::Product
-      expect(Spree::Product.find_by_name('Your Potatoes')).to be_nil
+      expect(page).to_not have_selector 'a.button.proceed', visible: true
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #2456.

Changes the Product Import logic so that saving is not possible unless all entries in the spreadsheet are valid. The previous logic allowed the user to save the valid entries and ignore the invalid ones. They will now have to correct their spreadsheet first, and re-import it.

#### What should we test?

Product Import does not allow save unless all entries are valid.

#### Release notes

Product Import: Valid products can not be saved if there are validation errors on other products.

Changelog Category: Changed