### PR TITLE
Clone oc copy schedule #2439

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -122,7 +122,8 @@ class OrderCycle < ActiveRecord::Base
   def clone!
     oc = self.dup
     oc.name = "COPY OF #{oc.name}"
-    oc.orders_open_at = oc.orders_close_at = nil
+    oc.orders_open_at = self.orders_open_at
+    oc.orders_close_at = self.orders_close_at
     oc.coordinator_fee_ids = self.coordinator_fee_ids
     oc.preferred_product_selection_from_coordinator_inventory_only = self.preferred_product_selection_from_coordinator_inventory_only
     oc.save!

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -591,6 +591,17 @@ feature %q{
     # Then I should have clone of the order cycle
     occ = OrderCycle.last
     expect(occ.name).to eq "COPY OF #{oc.name}"
+    expect(occ.products).to eq oc.products
+    expect(occ.schedules).to eq oc.schedules
+
+    # On the page, expect the clone to have the same values as the original
+    within "tr.order-cycle-#{occ.id}" do
+      page.should have_input "oc#{occ.id}[orders_open_at]", value: oc.orders_open_at
+      page.should have_input "oc#{occ.id}[orders_close_at]", value: oc.orders_close_at
+      page.should have_selector 'td.schedules', text: 'None'
+      page.should have_selector 'td.coordinator', text: "#{oc.coordinator.name}"
+      page.should have_selector 'td.products', text: '0 variants'
+    end
   end
 
 

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -440,8 +440,8 @@ describe OrderCycle do
 
     occ = OrderCycle.last
     occ.name.should == "COPY OF #{oc.name}"
-    occ.orders_open_at.should be_nil
-    occ.orders_close_at.should be_nil
+    occ.orders_open_at.should == oc.orders_open_at
+    occ.orders_close_at.should == oc.orders_close_at
     occ.coordinator.should_not be_nil
     occ.preferred_product_selection_from_coordinator_inventory_only.should be true
     occ.coordinator.should == oc.coordinator


### PR DESCRIPTION
#### What? Why?

Closes #2439: Cloning button within admin/order cycles created a clone that did not copy orders open and orders close values. This issue is referenced in #2463. 

I believe this issue stems from the way that clone! was defined at the OrderCycle model. Previous behavior was to set both the orders_open_at and orders_closed_at to nil.

#### What should we test?

From path admin/order_cycles, confirm that the clone button now creates a copy where the open and close values match the original.

Changelog Category:  Changed

#### How is this related to the Spree upgrade?

No known relation
