### PR TITLE
Reference existing translation: closed order cycle

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
@@ -16,7 +16,7 @@ angular.module("admin.subscriptions").controller "OrdersPanelController", ($scop
     oc = OrderCycles.byID[id]
     return t('js.subscriptions.close_date_not_set') unless oc?.orders_close_at?
     closes_at = moment(oc.orders_close_at)
-    text = if closes_at > moment() then t('js.subscriptions.closes') else t('js.subscription.closed')
+    text = if closes_at > moment() then t('js.subscriptions.closes') else t('js.subscriptions.closed')
     "#{text} #{closes_at.fromNow()}"
 
   $scope.stateText = (state) -> t("spree.order_state.#{state}")


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2465

Viewing a customers subscription could display a translation missing
error.

#### What should we test?

View a subscription associated to a closed order cycle. It should display `closed` instead of "missing translation".

#### Release notes

Corrected a typo in the admin interface.

Changelog Category: Fixed

