### PR TITLE
Adds filter clearing logic to button on order cycle admin page

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
@@ -6,6 +6,13 @@ angular.module("admin.orderCycles").controller "OrderCyclesCtrl", ($scope, $q, C
   $scope.involvingFilter = 0
   $scope.scheduleFilter = 0
 
+  $scope.resetSelectFilters = ->
+    $scope.query = ''
+    $scope.involvingFilter = 0
+    $scope.scheduleFilter = 0
+
+  $scope.resetSelectFilters()
+
   compileData = ->
     for schedule in $scope.schedules
       Dereferencer.dereference(schedule.order_cycles, OrderCycles.byID)

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -113,6 +113,20 @@ feature %q{
     page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
     page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
 
+    # I can also clear filters using the 'clear all' button
+    select2_select schedule1.name, from: "schedule_filter"
+    select2_select oc1.suppliers.first.name, from: "involving_filter"
+    fill_in "query", with: oc0.name
+    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    page.should have_no_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
+    click_on "Clear All"
+    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc0.id}"
+    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc1.id}"
+    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc2.id}"
+    page.should have_selector "#listing_order_cycles tr.order-cycle-#{oc3.id}"
+
     # Attempting to edit dates of an open order cycle with active subscriptions
     find("#oc#{oc1.id}_orders_open_at").click
     expect(page).to have_selector "#confirm-dialog .message", text: I18n.t('admin.order_cycles.date_warning.msg', n: 1)


### PR DESCRIPTION
#### What? Why?

Closes #2362

On the admin order cycles page (/admin/order_cycles) there is a 'Clear All' button that doesn't currently do anything. This PR adds a method in the angular file to clear all of the filters when this button is clicked.

#### What should we test?

We should test that it does in fact clear all the filters if they've been set and all available order cycles show in the list.

#### Release notes

Fixes the clear all button on the admin order cycles page
Changelog Category: Fixed
