### PR TITLE
Allow preferred_mails_from and preferred_mail_bcc to be set from configs

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -29,6 +29,10 @@ MAIL_PORT: 25
 SMTP_USERNAME: 'ofn'
 SMTP_PASSWORD: 'f00d'
 
+# Optional mail settings
+# MAILS_FROM: hello@example.com
+# MAIL_BCC: manager@example.com
+
 # SingleSignOn login for Discourse
 #
 # DISCOURSE_SSO_SECRET should be a random string. It must be the same as provided to your Discourse instance.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,8 +43,8 @@ def create_mail_method
     preferred_smtp_username: ENV.fetch('SMTP_USERNAME'),
     preferred_smtp_password: ENV.fetch('SMTP_PASSWORD'),
     preferred_secure_connection_type: 'None',
-    preferred_mails_from: "no-reply@#{ENV.fetch('MAIL_DOMAIN')}",
-    preferred_mail_bcc: '',
+    preferred_mails_from: ENV.fetch('MAILS_FROM', "no-reply@#{ENV.fetch('MAIL_DOMAIN')}"),
+    preferred_mail_bcc: ENV.fetch('MAIL_BCC', ''),
     preferred_intercept_email: ''
   ).call
 end


### PR DESCRIPTION
#### What? Why?

Needed for issue: https://github.com/openfoodfoundation/ofn-install/issues/202

Twinned with PR: https://github.com/openfoodfoundation/ofn-install/pull/203

Mail settings are being wiped out on each deploy and have to be re-set by instance managers. I've added the use of "defaults" as the second argument in the two `ENV.fetch()` calls that I've changed, so there shouldn't be any change for instances where the new ENV vars are not present.

#### What should we test?

Nothing to test for now.

Emails should work and mail settings should be added correctly, but this can't really be tested without some additional ofn-install work and re-deploying.

#### Release notes

Mail Settings: don't delete from_address and bcc settings from mail methods on deployment

Changelog Category: Fixed

