### PR TITLE
Fix script/setup by making it less clever

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -40,7 +40,15 @@ Fetch the latest version of `master` from `upstream` (ie. the main repo):
 
 ### Get it running
 
-When ready, run `script/setup`. If the script succeeds you're ready to start developing. If not, take a look at the output as it should be informative enough to help you troubleshoot.
+First, you need to create the database user the app will use by manually typing the following in your terminal:
+
+```sh
+$ sudo -u postgres psql -c "CREATE USER ofn WITH SUPERUSER CREATEDB PASSWORD 'f00d'"
+```
+
+This will create the "ofn" user as superuser and allowing it to create databases.
+
+Once done, run `script/setup`. If the script succeeds you're ready to start developing. If not, take a look at the output as it should be informative enough to help you troubleshoot.
 
 If you run into any other issues getting your local environment up and running please consult [the wiki](wiki).
 

--- a/script/setup
+++ b/script/setup
@@ -1,6 +1,14 @@
 #!/usr/bin/env sh
 
 # Set up Rails app. Run this script immediately after cloning the codebase.
+#
+# First, you need to create the database user the app will use by manually
+# typing the following in your terminal:
+#
+#   $ sudo -u postgres psql -c "CREATE USER ofn WITH SUPERUSER CREATEDB PASSWORD 'f00d'"
+#
+# This will create the "ofn" user as superuser and allowing it to create
+# databases.
 
 # Exit if any command fails
 set -e
@@ -11,10 +19,6 @@ NO_COLOR='\033[0m'
 
 RUBY_VERSION=$(cat .ruby-version)
 NODE_VERSION=$(cat .node-version)
-POSTGRESQL_VERSION='9.5'
-
-DB_USER='ofn'
-DB_PASSWORD='f00d'
 
 # Check ruby version
 if ! ruby --version | grep $RUBY_VERSION > /dev/null; then
@@ -25,12 +29,6 @@ fi
 # Check node version
 if ! node --version | grep $NODE_VERSION > /dev/null; then
   printf "${RED}Open Food Network requires node ${NODE_VERSION}${NO_COLOR}. Have a look at: https://github.com/nodenv/nodenv\n"
-fi
-
-# Check postgresql version
-if ! psql -V | grep $POSTGRESQL_VERSION > /dev/null; then
-  printf "${RED}Open Food Network requires postgresql ${POSTGRESQL_VERSION}${NO_COLOR}\n"
-  exit 1
 fi
 
 # Set up Ruby dependencies via Bundler
@@ -48,11 +46,6 @@ if [ ! -f config/application.yml ]; then
   printf "${YELLOW}Copied config/application.yml Make sure to fill it with the appropriate configuration values.\n\n${NO_COLOR}"
 fi
 
-# Create the development database user
-if ! psql -c '\du' -t | grep $DB_USER > /dev/null; then
-  psql -c "CREATE USER ${DB_USER} WITH SUPERUSER PASSWORD '${DB_PASSWORD}';"
-fi
-
 # Set up the database for both development and test
 # Confirming the default user and password Spree prompts
 printf '\n\n' | bundle exec rake db:setup db:test:prepare
@@ -65,7 +58,7 @@ printf '\n'
 printf "${YELLOW}WELCOME TO OPEN FOOD NETWORK!\n"
 printf '\n'
 
-printf "To login as Spree default user, use:"
+printf "To login as the Spree default user, use:"
 printf '\n'
 printf '\n'
 printf '  email: spree@example.com\n'


### PR DESCRIPTION
#### What? Why?

Closes #2052

Now we ask the dev to create the "ofn" user as precondition. This is way easier than developing a script that fits all possible setups.

It also stops requiring a particlar Postgres version. Although in production we use 9.5 it is very unlikely we will use any version-specific feature in the near future. This should make it a bit easier for new devs to set up their environment.

#### Release notes

Fix setup script by making it less clever

Changelog Category: Fixed