### PR TITLE
[Spree Upgrade] Remove dependency to Dash and Jirafe

### DIFF
--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -73,7 +73,6 @@ class AbilityDecorator
 
   def add_group_management_abilities(user)
     can [:admin, :index], :overview
-    can [:admin, :sync], :analytic
     can [:admin, :index], EnterpriseGroup
     can [:read, :edit, :update], EnterpriseGroup do |group|
       user.owned_groups.include? group
@@ -86,7 +85,6 @@ class AbilityDecorator
     can [:create, :search], nil
 
     can [:admin, :index], :overview
-    can [:admin, :sync], :analytic
 
     can [:admin, :index, :read, :create, :edit, :update_positions, :destroy], ProducerProperty
 

--- a/spec/features/admin/overview_spec.rb
+++ b/spec/features/admin/overview_spec.rb
@@ -103,44 +103,5 @@ feature %q{
         end
       end
     end
-
-    context "with the spree dash configured" do
-      let(:d1) { create(:distributor_enterprise) }
-
-      before do
-        stub_jirafe
-        @enterprise_user.enterprise_roles.build(enterprise: d1).save
-      end
-
-      around do |example|
-        with_dash_configured { example.run }
-      end
-
-      it "has permission to sync analytics" do
-        visit '/admin'
-        expect(page).to have_content d1.name
-      end
-    end
-  end
-
-  private
-
-  def stub_jirafe
-    stub_request(:post, "https://api.jirafe.com/v1/applications/abc123/resources?token=").
-      to_return(:status => 200, :body => "", :headers => {})
-  end
-
-  def with_dash_configured(&block)
-    Spree::Dash::Config.preferred_app_id = 'abc123'
-    Spree::Dash::Config.preferred_site_id = 'abc123'
-    Spree::Dash::Config.preferred_token = 'abc123'
-    expect(Spree::Dash::Config.configured?).to be true
-
-    block.call
-  ensure
-    Spree::Dash::Config.preferred_app_id = nil
-    Spree::Dash::Config.preferred_site_id = nil
-    Spree::Dash::Config.preferred_token = nil
-    expect(Spree::Dash::Config.configured?).to be false
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #2434 

As explained in the issue, Dash has been removed in Spree 2.0. Since it is not needed, I removed it from the specs.

#### What should we test?

The build should have more passing tests as references to Dash were causing fails.

#### Release notes

Dash and Jirafe related tests have been removed with Spree Upgrade to 2.0.

Changelog Category: Removed

#### How is this related to the Spree upgrade?

Dash dependencies have been removed in Spree 2.0.
