### PR TITLE
Added basic integration with Matomo

### DIFF
--- a/app/controllers/admin/matomo_settings_controller.rb
+++ b/app/controllers/admin/matomo_settings_controller.rb
@@ -1,11 +1,11 @@
 module Admin
-  class InvoiceSettingsController < Spree::Admin::BaseController
+  class MatomoSettingsController < Spree::Admin::BaseController
     def update
       Spree::Config.set(params[:preferences])
 
       respond_to do |format|
         format.html {
-          redirect_to main_app.edit_admin_invoice_settings_path
+          redirect_to main_app.edit_admin_matomo_settings_path
         }
       end
     end

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -35,6 +35,8 @@ Spree::AppConfiguration.class_eval do
 
   # External services
   preference :bugherd_api_key, :string, default: nil
+  preference :matomo_url, :string, default: nil
+  preference :matomo_site_id, :string, default: nil
 
   # Invoices & Receipts
   preference :invoice_style2?, :boolean, default: false

--- a/app/overrides/spree/admin/shared/_configuration_menu/add_invoice_settings.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_configuration_menu/add_invoice_settings.html.haml.deface
@@ -1,4 +1,4 @@
 // insert_bottom "[data-hook='admin_configurations_sidebar_menu']"
 
 %li
-  = link_to t('admin.invoice_settings.edit.invoice_settings'), main_app.edit_admin_invoice_settings_path
+  = link_to t('admin.invoice_settings.edit.title'), main_app.edit_admin_invoice_settings_path

--- a/app/overrides/spree/admin/shared/_configuration_menu/add_matomo_settings.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_configuration_menu/add_matomo_settings.html.haml.deface
@@ -1,0 +1,4 @@
+// insert_bottom "[data-hook='admin_configurations_sidebar_menu']"
+
+%li
+  = link_to t('admin.matomo_settings.edit.title'), main_app.edit_admin_matomo_settings_path

--- a/app/overrides/spree/admin/shared/_configuration_menu/add_stripe_connect_settings.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_configuration_menu/add_stripe_connect_settings.html.haml.deface
@@ -1,4 +1,4 @@
 // insert_bottom "[data-hook='admin_configurations_sidebar_menu']"
 
 %li
-  = link_to t('.stripe_connect'), main_app.edit_admin_stripe_connect_settings_path
+  = link_to t('admin.stripe_connect_settings.edit.title'), main_app.edit_admin_stripe_connect_settings_path

--- a/app/views/admin/matomo_settings/edit.html.haml
+++ b/app/views/admin/matomo_settings/edit.html.haml
@@ -1,0 +1,23 @@
+= render :partial => 'spree/admin/shared/configuration_menu'
+
+- content_for :page_title do
+  = t('.title')
+
+= form_tag main_app.admin_matomo_settings_path, :method => :put do
+
+  .div
+    %legend= t('.info_html')
+    = tag(:br)
+    = t('.config_instructions_html')
+
+  .field
+    = label_tag(:matomo_url, t('.matomo_url')) + tag(:br)
+    = preference_field_tag("preferences[#{:matomo_url}]", Spree::Config[:matomo_url], type: Spree::Config.preference_type(:matomo_url))
+
+  .field
+    = label_tag(:matomo_site_id, t('.matomo_site_id')) + tag(:br)
+    = preference_field_tag("preferences[#{:matomo_site_id}]", Spree::Config[:matomo_site_id], type: Spree::Config.preference_type(:matomo_site_id))
+
+
+  .form-buttons{"data-hook" => "buttons"}
+    = button t(:update), 'icon-refresh'

--- a/app/views/layouts/_matomo_tag.html.haml
+++ b/app/views/layouts/_matomo_tag.html.haml
@@ -1,0 +1,15 @@
+- if Spree::Config.matomo_url.present?
+  :javascript
+    var _paq = _paq || [];
+    _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+    _paq.push(["setCookieDomain", "*.#{Spree::Config.site_url}"]);
+    _paq.push(["setDomains", ["*.#{Spree::Config.site_url}"]]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="#{Spree::Config.matomo_url}";
+      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setSiteId', '#{Spree::Config.matomo_site_id}']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -22,6 +22,7 @@
 
     = render "layouts/i18n_script"
     = render "layouts/bugherd_script"
+    = render "layouts/matomo_tag"
     = csrf_meta_tags
 
   %body{class: body_classes, ng: {app: "Darkswarm"}}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -354,6 +354,46 @@ en:
         total_monthly_bill_incl_tax: "Total Monthly Bill (Incl. Tax)"
         total_monthly_bill_incl_tax_tip: "The example total monthly bill with tax included, given the settings and the turnover provided."
 
+    cache_settings:
+      show:
+        title: Caching
+        distributor: Distributor
+        order_cycle: Order Cycle
+        status: Status
+        diff: Diff
+        error: Error
+
+    invoice_settings:
+      edit:
+        title: Invoice Settings
+        invoice_style2?: Use the alternative invoice model that includes total tax breakdown per rate and tax rate info per item (not yet suitable for countries displaying prices excluding tax)
+        enable_receipt_printing?: Show options for printing receipts using thermal printers in order dropdown?
+
+    stripe_connect_settings:
+      edit:
+        title: "Stripe Connect"
+        settings: "Settings"
+        stripe_connect_enabled: Enable shops to accept payments using Stripe Connect?
+        no_api_key_msg: No Stripe account exists for this enterprise.
+        configuration_explanation_html: For detailed instructions on configuring the Stripe Connect integration, please <a href='https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance' target='_blank'>consult this guide</a>.
+        status: Status
+        ok: Ok
+        instance_secret_key: Instance Secret Key
+        account_id: Account ID
+        business_name: Business Name
+        charges_enabled: Charges Enabled
+        charges_enabled_warning: "Warning: Charges are not enabled for your account"
+        auth_fail_error: The API key you provided is invalid
+        empty_api_key_error_html: No Stripe API key has been provided. To set your API key, please follow <a href="https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance" target="_blank">these instructions</a>
+
+    matomo_settings:
+      edit:
+        title: "Matomo Settings"
+        matomo_url: "Matomo URL"
+        matomo_site_id: "Matomo Site ID"
+        info_html: "Matomo is a Web and Mobile Analytics. You can either host Matomo on-premises or use a cloud-hosted service. See <a href='http://matomo.org' target='_blank'>matomo.org</a> for more information."
+        config_instructions_html: "Here you can configure the OFN Matomo integration. The Matomo URL below should point to the Matomo instance where the user tracking information will be sent to; if it is left empty, Matomo user tracking will be disabled. The Site ID field is not mandatory but useful if you are tracking more than one website on a single Matomo instance; it can be found on the Matomo instance console."
+
     customers:
       index:
         add_customer: "Add Customer"
@@ -379,15 +419,6 @@ en:
         guest_label: 'Guest checkout'
       destroy:
         has_associated_orders: 'Delete failed: customer has associated orders with his shop'
-
-    cache_settings:
-      show:
-        title: Caching
-        distributor: Distributor
-        order_cycle: Order Cycle
-        status: Status
-        diff: Diff
-        error: Error
 
     contents:
       edit:
@@ -899,12 +930,6 @@ en:
     shared:
       user_guide_link:
         user_guide: User Guide
-
-    invoice_settings:
-      edit:
-        title: Invoice Settings
-        invoice_style2?: Use the alternative invoice model that includes total tax breakdown per rate and tax rate info per item (not yet suitable for countries displaying prices excluding tax)
-        enable_receipt_printing?: Show options for printing receipts using thermal printers in order dropdown?
     overview:
       enterprises_header:
         ofn_with_tip: Enterprises are Producers and/or Hubs and are the basic unit of organisation within the Open Food Network.
@@ -1042,23 +1067,6 @@ en:
     schedules:
       destroy:
         associated_subscriptions_error: This schedule cannot be deleted because it has associated subscriptions
-
-    stripe_connect_settings:
-      edit:
-        title: "Stripe Connect"
-        settings: "Settings"
-        stripe_connect_enabled: Enable shops to accept payments using Stripe Connect?
-        no_api_key_msg: No Stripe account exists for this enterprise.
-        configuration_explanation_html: For detailed instructions on configuring the Stripe Connect integration, please <a href='https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance' target='_blank'>consult this guide</a>.
-        status: Status
-        ok: Ok
-        instance_secret_key: Instance Secret Key
-        account_id: Account ID
-        business_name: Business Name
-        charges_enabled: Charges Enabled
-        charges_enabled_warning: "Warning: Charges are not enabled for your account"
-        auth_fail_error: The API key you provided is invalid
-        empty_api_key_error_html: No Stripe API key has been provided. To set your API key, please follow <a href="https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance" target="_blank">these instructions</a>
 
     # Admin controllers
     controllers:
@@ -2604,9 +2612,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           bulk_coop_allocation: 'Bulk Co-op - Allocation'
           bulk_coop_packing_sheets: 'Bulk Co-op - Packing Sheets'
           bulk_coop_customer_payments: 'Bulk Co-op - Customer Payments'
-      shared:
-        configuration_menu:
-          stripe_connect: Stripe Connect
       users:
         email_confirmation:
           confirmation_pending: "Email confirmation is pending. We've sent a confirmation email to %{address}."

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -91,6 +91,8 @@ Openfoodnetwork::Application.routes.draw do
 
     resource :stripe_connect_settings, only: [:edit, :update]
 
+    resource :matomo_settings, only: [:edit, :update]
+
     resources :stripe_accounts, only: [:destroy] do
       get :connect, on: :collection
       get :status, on: :collection


### PR DESCRIPTION
#### What? Why?

Closes #2404 

Integration with Matomo. The OFN admin user can provide In the global settings the matomo url and site id. That enables the Matomo tracking script.

#### What should we test?

Update matomo URL and site Id, make some interactions with the OFN website under test and check Matomo console to see that visits are being the global settings

Mobile visits should also be recorded.

#### Release notes

New Matomo integration.
Changelog Category: Added
