### PR TITLE
Reimplement Spree's simple_product in OFN factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -530,5 +530,4 @@ FactoryBot.modify do
       user.spree_roles << Spree::Role.find_or_create_by_name!('admin')
     end
   end
-
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -453,6 +453,10 @@ FactoryBot.define do
       Spree::Image.create(attachment: image, viewable_id: product.master.id, viewable_type: 'Spree::Variant')
     end
   end
+
+  factory :simple_product, parent: :base_product do
+    on_hand 5
+  end
 end
 
 
@@ -526,4 +530,5 @@ FactoryBot.modify do
       user.spree_roles << Spree::Role.find_or_create_by_name!('admin')
     end
   end
+
 end


### PR DESCRIPTION
#### What? Why?

Closes #2433 

As explained in the PR, Spree's product factory got rid of `simple_product` in favor of `base_product`, making all of our tests using `simple_product` fail.

I reimplemented the Spree<2.0 `simple_product` factory inside OFN `spec/factories.rb`, inheriting from OFN's override of Spree's `base_product` factory.
As before, a `simple_product` is an extension of a `base_product` with `on_hand 5`.

#### What should we test?

All tests using Spree's `product_factory` don't fail on `simple_product`.

#### Release notes

Spree Upgrade - Reimplementation in OFN of Spree's `simple_product`, inheriting from `base_product`, as a test helper.

Changelog Category: Changed

#### How is this related to the Spree upgrade?

Spree 2.0 removed `simple_product` in their `product_factory`, so it has been reimplemented in OFN factories to enable its use in test suite.
