### PR TITLE
Remove unused gem newrelic-rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ public/stylesheets
 public/images
 public/spree
 config/abr.yml
-config/newrelic.yml
 config/initializers/feature_toggle.rb
 config/initializers/db2fog.rb
 NERD_tree*

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'simple_form', github: 'RohanM/simple_form'
 gem 'unicorn'
 gem 'angularjs-rails', '1.5.5'
 gem 'bugsnag'
-gem 'newrelic_rpm'
 gem 'haml'
 gem 'sass', "~> 3.3"
 gem 'sass-rails', '~> 3.2.3', groups: [:default, :assets]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,7 +487,6 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    newrelic_rpm (3.12.0.288)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
@@ -763,7 +762,6 @@ DEPENDENCIES
   letter_opener (>= 1.4.1)
   listen (= 3.0.8)
   momentjs-rails
-  newrelic_rpm
   nokogiri (>= 1.6.7.1)
   oauth2 (~> 1.2.0)
   ofn-qz!
@@ -815,4 +813,4 @@ RUBY VERSION
    ruby 2.1.5p273
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
#### What? Why?

Closes #2486.

Nobody uses New Relic any more. So let's remove it.

#### What should we test?

Just a basic sanity check that the checkout is still working. Nothing should have changed.

#### Release notes

Removed unused support for New Relic. It got replaced by Sky Light.

Changelog Category: Removed