### PR TITLE
Update gem i18n-js to pick up locale changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,8 +439,8 @@ GEM
       multi_json (~> 1.0)
       multi_xml
     i18n (0.6.11)
-    i18n-js (3.0.0)
-      i18n (~> 0.6, >= 0.6.6)
+    i18n-js (3.0.11)
+      i18n (>= 0.6.6, < 2)
     immigrant (0.1.6)
       activerecord (>= 3.0)
       foreigner (>= 1.2.1)

--- a/app/controllers/spree/admin/search_controller_decorator.rb
+++ b/app/controllers/spree/admin/search_controller_decorator.rb
@@ -10,7 +10,7 @@ Spree::Admin::SearchController.class_eval do
         :ship_address_lastname_start => params[:q],
         :bill_address_firstname_start => params[:q],
         :bill_address_lastname_start => params[:q]
-        }).result.limit(10)
+      }).result.limit(10)
     end
 
     render json: @users, each_serializer: Api::Admin::UserSerializer

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -107,7 +107,7 @@ feature "Using embedded shopfront functionality", js: true do
   end
 
   private
-  
+
   def login_with_modal
     expect(page).to have_selector 'div.login-modal', visible: true
 


### PR DESCRIPTION
We had some problems recently with changes in en.yml not being picked up
by i18n-js to be included in all.js. There have been some patches for
the current version that have an impact on that:

https://github.com/fnando/i18n-js/commit/578555f57ece1cf226ef004118e60738502b859a
https://github.com/fnando/i18n-js/commit/db3cdf82aaa33a0be558214d82e89a27204380a4
https://github.com/fnando/i18n-js/commit/a88b206644a14b0de7bbb58e0ba1baab93737a8e

Trying it out locally, the updated i18n-js gem works while the old
version doesn't update the Javascript translations when new keys are
added. To reproduce the issue, you can add a new key in `en.yml` and
reference it from an Angular template in `app/assets/javascripts/`. The
old version complained about a missing translation until you ran:
```
bundle exec rake tmp:cache:clear
```

We don't need to do that any more.

#### What should we test?

The login modal still displays all text correctly.

Developers can test changing the locale as described above, but that is beyond the scope of testing on staging.

#### Release notes

Updated a language translation module that caused missing translations in the past.

Changelog Category: Fixed

