### PR TITLE
[Spree upgrade] Update Gemfile.lock to fetch the latest revision

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 1c3dfc7fb48cde32f7dc49a59c1daf65a3ee6974
+  revision: 94b1f395bbf2cffbb1e33cdab5809511150da814
   branch: 2-0-4-stable
   specs:
     spree (2.0.4)


### PR DESCRIPTION
#### What? Why?

Since https://github.com/openfoodfoundation/spree/pull/6 got merged, we need the app to use the latest Spree fork revision to pick up those changes.

#### What should we test?

Nothing yet