### PR TITLE
Rename edit enterprise page to "Settings"

### DIFF
--- a/app/assets/stylesheets/admin/enterprises.css.scss
+++ b/app/assets/stylesheets/admin/enterprises.css.scss
@@ -29,3 +29,11 @@ form[name="enterprise_form"] {
     }
   }
 }
+
+.admin-enterprises-index-admin-actions-divider {
+  background-color: $admin-table-border;
+  border-width: 0;
+  height: 1px;
+  margin-bottom: 1em;
+  margin-top: 1em;
+}

--- a/app/assets/stylesheets/admin/variables.css.scss
+++ b/app/assets/stylesheets/admin/variables.css.scss
@@ -8,3 +8,5 @@ $warning-red: #da5354;
 $warning-orange: #da7f52;
 $medium-grey: #919191;
 $pale-blue: #cee1f4;
+
+$admin-table-border: $pale-blue;

--- a/app/views/admin/enterprises/_actions.html.haml
+++ b/app/views/admin/enterprises/_actions.html.haml
@@ -5,6 +5,8 @@
   = link_to_delete_enterprise enterprise
   %br/
 
+%hr.admin-enterprises-index-admin-actions-divider
+
 - if enterprise.is_primary_producer
   = link_to_with_icon 'icon-dashboard', t('.properties'), main_app.admin_enterprise_producer_properties_path(enterprise_id: enterprise)
   (#{enterprise.producer_properties.count})

--- a/app/views/admin/enterprises/_enterprise_user_index.html.haml
+++ b/app/views/admin/enterprises/_enterprise_user_index.html.haml
@@ -40,7 +40,7 @@
             %i.icon-status{ ng: { class: "enterprise.status" } }
           %td.manage{ ng: { show: 'columns.manage.visible' } }
             %a.button.fullwidth{ ng: { href: '{{::enterprise.edit_path}}' } }
-              = t('.manage')
+              = t('.manage_link')
               %i.icon-arrow-right
 
         %tr.panel-row{ object: "enterprise", panels: "{producer: 'enterprise_producer', package: 'enterprise_package', status: 'enterprise_status'}" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -795,7 +795,7 @@ en:
         i_am_producer: I am a Producer
         contact_name: Contact Name
       edit:
-        editing: 'Editing:'
+        editing: 'Settings:'
         back_link: Back to enterprises list
       new:
         title: New Enterprise

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -788,6 +788,7 @@ en:
         no_enterprises_found: No enterprises found.
         search_placeholder: Search By Name
         manage: Manage
+        manage_link: Manage
       new_form:
         owner: Owner
         owner_tip: The primary user responsible for this enterprise.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -748,7 +748,7 @@ en:
           email_confirmed: "Email confirmed"
           email_not_confirmed: "Email not confirmed"
       actions:
-        edit_profile: Edit Profile
+        edit_profile: Settings
         properties: Properties
         payment_methods: Payment Methods
         payment_methods_tip: This enterprise has no payment methods

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -788,7 +788,7 @@ en:
         no_enterprises_found: No enterprises found.
         search_placeholder: Search By Name
         manage: Manage
-        manage_link: Manage
+        manage_link: Settings
       new_form:
         owner: Owner
         owner_tip: The primary user responsible for this enterprise.

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -145,7 +145,7 @@ feature %q{
       ef2
 
       click_link 'Enterprises'
-      within("#e_#{distributor1.id}") { click_link 'Manage' }
+      within("#e_#{distributor1.id}") { click_link 'Settings' }
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Create One Now"
 
@@ -169,16 +169,16 @@ feature %q{
       ef2
 
       click_link 'Enterprises'
-      within("#e_#{distributor1.id}") { click_link 'Manage' }
+      within("#e_#{distributor1.id}") { click_link 'Settings' }
       within(".side_menu") { click_link 'Enterprise Fees' }
-      click_link "Manage Enterprise Fees"
+      click_link "Settings Enterprise Fees"
       page.should     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
       page.should_not have_field 'enterprise_fee_set_collection_attributes_1_name', with: 'Two'
 
       click_link 'Enterprises'
-      within("#e_#{distributor2.id}") { click_link 'Manage' }
+      within("#e_#{distributor2.id}") { click_link 'Settings' }
       within(".side_menu") { click_link 'Enterprise Fees' }
-      click_link "Manage Enterprise Fees"
+      click_link "Settings Enterprise Fees"
       page.should_not have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
       page.should     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'Two'
     end
@@ -189,7 +189,7 @@ feature %q{
       distributor3
 
       click_link 'Enterprises'
-      within("#e_#{distributor2.id}") { click_link 'Manage' }
+      within("#e_#{distributor2.id}") { click_link 'Settings' }
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
       page.should have_select('enterprise_fee_set_collection_attributes_1_enterprise_id',

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -15,7 +15,7 @@ feature 'Enterprises Index' do
       within("tr.enterprise-#{s.id}") do
         expect(page).to have_content s.name
         expect(page).to have_select "enterprise_set_collection_attributes_1_sells"
-        expect(page).to have_content "Edit Profile"
+        expect(page).to have_content "Settings"
         expect(page).to have_content "Delete"
         expect(page).to_not have_content "Payment Methods"
         expect(page).to_not have_content "Shipping Methods"
@@ -25,7 +25,7 @@ feature 'Enterprises Index' do
       within("tr.enterprise-#{d.id}") do
         expect(page).to have_content d.name
         expect(page).to have_select "enterprise_set_collection_attributes_0_sells"
-        expect(page).to have_content "Edit Profile"
+        expect(page).to have_content "Settings"
         expect(page).to have_content "Delete"
         expect(page).to have_content "Payment Methods"
         expect(page).to have_content "Shipping Methods"

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -77,7 +77,7 @@ feature %q{
 
     visit '/admin/enterprises'
     within "tr.enterprise-#{@enterprise.id}" do
-      first("a", text: 'Edit Profile').trigger 'click'
+      first("a", text: 'Settings').trigger 'click'
     end
 
     fill_in 'enterprise_name', :with => 'Eaterprises'

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -376,7 +376,7 @@ feature %q{
 
     scenario "editing enterprises I manage" do
       visit admin_enterprises_path
-      within("tbody#e_#{distributor1.id}") { click_link 'Manage' }
+      within("tbody#e_#{distributor1.id}") { click_link 'Settings' }
 
       fill_in 'enterprise_name', :with => 'Eaterprises'
 
@@ -392,7 +392,7 @@ feature %q{
     describe "enterprises I have edit permission for, but do not manage" do
       it "allows me to edit them" do
         visit admin_enterprises_path
-        within("tbody#e_#{distributor3.id}") { click_link 'Manage' }
+        within("tbody#e_#{distributor3.id}") { click_link 'Settings' }
 
         fill_in 'enterprise_name', :with => 'Eaterprises'
 
@@ -407,7 +407,7 @@ feature %q{
 
       it "does not show links to manage shipping methods, payment methods or enterprise fees on the edit page" do
         visit admin_enterprises_path
-        within("tbody#e_#{distributor3.id}") { click_link 'Manage' }
+        within("tbody#e_#{distributor3.id}") { click_link 'Settings' }
 
         within(".side_menu") do
           page.should_not have_link 'Shipping Methods'
@@ -419,7 +419,7 @@ feature %q{
 
     scenario "editing images for an enterprise" do
       visit admin_enterprises_path
-      within("tbody#e_#{distributor1.id}") { click_link 'Manage' }
+      within("tbody#e_#{distributor1.id}") { click_link 'Settings' }
 
       within(".side_menu") do
         click_link "Images"
@@ -432,7 +432,7 @@ feature %q{
     scenario "managing producer properties" do
       create(:property, name: "Certified Organic")
       visit admin_enterprises_path
-      within("#e_#{supplier1.id}") { click_link 'Manage' }
+      within("#e_#{supplier1.id}") { click_link 'Settings' }
       within(".side_menu") do
         click_link "Properties"
       end

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -132,7 +132,7 @@ feature %q{
 
     it "I can get to the new enterprise page" do
       visit admin_enterprises_path
-      within("#e_#{distributor1.id}") { click_link 'Manage' }
+      within("#e_#{distributor1.id}") { click_link 'Settings' }
       within(".side_menu") do
         click_link "Payment Methods"
       end
@@ -182,7 +182,7 @@ feature %q{
       pm2
 
       visit admin_enterprises_path
-      within("#e_#{distributor1.id}") { click_link 'Manage' }
+      within("#e_#{distributor1.id}") { click_link 'Settings' }
       within(".side_menu") do
         click_link "Payment Methods"
       end
@@ -191,7 +191,7 @@ feature %q{
       page.should     have_content pm2.name
 
       click_link 'Enterprises'
-      within("#e_#{distributor2.id}") { click_link 'Manage' }
+      within("#e_#{distributor2.id}") { click_link 'Settings' }
       within(".side_menu") do
         click_link "Payment Methods"
       end

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -78,7 +78,7 @@ feature 'shipping methods' do
 
     it "creating a shipping method" do
       visit admin_enterprises_path
-      within("#e_#{distributor1.id}") { click_link 'Manage' }
+      within("#e_#{distributor1.id}") { click_link 'Settings' }
       within(".side_menu") do
         click_link "Shipping Methods"
       end
@@ -131,7 +131,7 @@ feature 'shipping methods' do
       sm2
 
       visit admin_enterprises_path
-      within("#e_#{distributor1.id}") { click_link 'Manage' }
+      within("#e_#{distributor1.id}") { click_link 'Settings' }
       within(".side_menu") do
         click_link "Shipping Methods"
       end
@@ -139,7 +139,7 @@ feature 'shipping methods' do
       page.should     have_content sm2.name
 
       click_link 'Enterprises'
-      within("#e_#{distributor2.id}") { click_link 'Manage' }
+      within("#e_#{distributor2.id}") { click_link 'Settings' }
       within(".side_menu") do
         click_link "Shipping Methods"
       end


### PR DESCRIPTION
#### What? Why?

Closes #1535 

This improves and standardizes the name of the page for editing an enterprise. This will make communication internally and with users easier. Please see related issue for more details.

#### What should we test?

As enterprise owner:

* In the admin section, go to "Enterprises".
* Check the "Manage" column. It should have "Settings" buttons instead of "Manage". See the following image:
![20180803195337-enterprise-owner-settings-button](https://user-images.githubusercontent.com/2243/43641592-e38e7fd6-9756-11e8-99bd-02c14ba56e06.png)
* Click on "Settings". This should lead to the main section of the page for editing the enterprise.
* Check the heading of the page. It should start with "Settings:" instead of "Editing:".

As admin user:

* In the admin section, go to "Enterprises".
* See the list of actions for an enterprise. It should have a "Settings" link instead of "Edit Profile". There should also be a separator below the "Delete" link. It should look like the following image:
![20180803194801-admin-enterprise-actions](https://user-images.githubusercontent.com/2243/43641471-689ae8aa-9756-11e8-99b8-ed0dc0519d23.png)
* Click on "Settings". This should lead to the main section of the page for editing the enterprise.
* Check the heading of the page. It should start with "Settings:" instead of "Editing:".

#### Release notes

- Standardize name of page for editing enterprise to "Settings".

Changelog Category: Changed