### PR TITLE
The main menu is now translatable and configurable (per instance)

### DIFF
--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -6,6 +6,7 @@ module Admin
                               {name: I18n.t('admin.contents.edit.producer_signup_page'), preferences: [:producer_signup_pricing_table_html, :producer_signup_case_studies_html, :producer_signup_detail_html]},
                               {name: I18n.t('admin.contents.edit.hub_signup_page'), preferences: [:hub_signup_pricing_table_html, :hub_signup_case_studies_html, :hub_signup_detail_html]},
                               {name: I18n.t('admin.contents.edit.group_signup_page'), preferences: [:group_signup_pricing_table_html, :group_signup_case_studies_html, :group_signup_detail_html]},
+                              {name: I18n.t('admin.contents.edit.main_links'), preferences: [:menu_1, :menu_1_icon_name, :menu_2, :menu_2_icon_name, :menu_3, :menu_3_icon_name, :menu_4, :menu_4_icon_name, :menu_5, :menu_5_icon_name, :menu_6, :menu_6_icon_name, :menu_7, :menu_7_icon_name]},
                               {name: I18n.t('admin.contents.edit.footer_and_external_links'), preferences: [:footer_logo,
                                                              :footer_facebook_url, :footer_twitter_url, :footer_instagram_url, :footer_linkedin_url, :footer_googleplus_url, :footer_pinterest_url,
                                                              :footer_email, :community_forum_url, :footer_links_md, :footer_about_url]}]

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -33,19 +33,19 @@ class ContentConfiguration < Spree::Preferences::FileConfiguration
 
   # Main URLs
   preference :menu_1, :boolean, default: true
-  preference :menu_1_icon_name, :string, default: ""
+  preference :menu_1_icon_name, :string, default: "ofn-i_019-map-pin"
   preference :menu_2, :boolean, default: true
-  preference :menu_2_icon_name, :string, default: ""
+  preference :menu_2_icon_name, :string, default: "ofn-i_037-map"
   preference :menu_3, :boolean, default: true
-  preference :menu_3_icon_name, :string, default: ""
+  preference :menu_3_icon_name, :string, default: "ofn-i_036-producers"
   preference :menu_4, :boolean, default: true
-  preference :menu_4_icon_name, :string, default: ""
+  preference :menu_4_icon_name, :string, default: "ofn-i_035-groups"
   preference :menu_5, :boolean, default: true
-  preference :menu_5_icon_name, :string, default: ""
-  preference :menu_6, :boolean, default: true
-  preference :menu_6_icon_name, :string, default: ""
-  preference :menu_7, :boolean, default: true
-  preference :menu_7_icon_name, :string, default: ""
+  preference :menu_5_icon_name, :string, default: "ofn-i_013-help"
+  preference :menu_6, :boolean, default: false
+  preference :menu_6_icon_name, :string, default: "ofn-i_035-groups"
+  preference :menu_7, :boolean, default: false
+  preference :menu_7_icon_name, :string, default: "ofn-i_013-help"
 
   # Footer
   preference :footer_logo, :file

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -31,6 +31,22 @@ class ContentConfiguration < Spree::Preferences::FileConfiguration
   preference :group_signup_case_studies_html, :text, default: I18n.t(:content_configuration_case_studies)
   preference :group_signup_detail_html, :text, default: I18n.t(:content_configuration_detail)
 
+  # Main URLs
+  preference :menu_1, :boolean, default: true
+  preference :menu_1_icon_name, :string, default: ""
+  preference :menu_2, :boolean, default: true
+  preference :menu_2_icon_name, :string, default: ""
+  preference :menu_3, :boolean, default: true
+  preference :menu_3_icon_name, :string, default: ""
+  preference :menu_4, :boolean, default: true
+  preference :menu_4_icon_name, :string, default: ""
+  preference :menu_5, :boolean, default: true
+  preference :menu_5_icon_name, :string, default: ""
+  preference :menu_6, :boolean, default: true
+  preference :menu_6_icon_name, :string, default: ""
+  preference :menu_7, :boolean, default: true
+  preference :menu_7_icon_name, :string, default: ""
+
   # Footer
   preference :footer_logo, :file
   has_attached_file :footer_logo, default_url: "/assets/ofn-logo-footer.png"

--- a/app/views/admin/contents/_fieldset.html.haml
+++ b/app/views/admin/contents/_fieldset.html.haml
@@ -2,7 +2,11 @@
   %legend{align: "center"}= name
   - preferences.each do |key|
     - type = ContentConfig.preference_type(key)
+    - if name == t('admin.contents.edit.main_links') && type == :boolean
+      - text = t("#{key}_title") + " - " + t("#{key}_url")
+    - else
+      - text = t(key)
     .field
-      = label_tag(key, t(key) + ': ') + tag(:br) if type != :boolean
+      = label_tag(key, text + ': ') + tag(:br) if type != :boolean
       = preference_field_tag(key, ContentConfig[key], :type => type)
-      = label_tag(key, t(key)) + tag(:br) if type == :boolean
+      = label_tag(key, text) + tag(:br) if type == :boolean

--- a/app/views/shared/menu/_large_menu.html.haml
+++ b/app/views/shared/menu/_large_menu.html.haml
@@ -11,54 +11,13 @@
           %a{href: '/'}
             = t 'title'
     %ul.center
-      %li
-        %a{href: main_app.shops_path}
-          %span.nav-primary
-            = t 'label_shops'
-      %li
-        %a{href: main_app.map_path}
-          %span.nav-primary
-            = t 'label_map'
-      %li
-        %a{href: main_app.producers_path}
-          %span.nav-primary
-            = t 'label_producers'
-      - if feature? :connect_learn_homepage
-        %li
-          %a{href: "https://openfoodnetwork.org/au/connect/"}
-            %span.nav-primary
-              = t 'label_connect'
-        %li
-          %a{href: "https://openfoodnetwork.org/au/learn/"}
-            %span.nav-primary
-              = t 'label_learn'
-      - elsif feature? :about_blog_homepage
-        %li
-          %a{href: main_app.groups_path}
-            %span.nav-primary
-              = t 'label_groups'
-        %li
-          %a{href: "http://about.openfoodnetwork.org.uk/"}
-            %span.nav-primary
-              = t 'label_about'
-        %li
-          %a{href: "http://about.openfoodnetwork.org.uk/blog/"}
-            %span.nav-primary
-              = t 'label_blog'
-        %li
-          %a{href: "http://about.openfoodnetwork.org.uk/support/"}
-            %span.nav-primary
-              = t 'label_support'
-      - else
-        %li
-          %a{href: main_app.groups_path}
-            %span.nav-primary
-              = t 'label_groups'
-        %li
-          %a{href: ContentConfig.footer_about_url}
-            %span.nav-primary
-              = t 'label_about'
-
+      - [*1..7].each do |menu_number|
+        - menu_name = "menu_#{menu_number}"
+        - if ContentConfig[menu_name].present?
+          %li
+            %a{href: t("#{menu_name}_url") }
+              %span.nav-primary
+                = t "#{menu_name}_title"
     %ul.right
       - if OpenFoodNetwork::I18nConfig.selectable_locales.count > 1
         %li.language-switcher.has-dropdown

--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -19,27 +19,14 @@
     %li.ofn-logo
       %a{href: root_path}
         %img{src: ContentConfig.logo_mobile.url, srcset: ContentConfig.logo_mobile_svg.url, width: "75", height: "26"}
-    %li.li-menu
-      - if current_page? main_app.shops_path
-        %a{"ofn-scroll-to" => "hubs"}
-          %span.nav-primary
-            %i.ofn-i_019-map-pin
-            = t 'label_shops'
-      - else
-        %a{href: main_app.shops_path}
-          %span.nav-primary
-            %i.ofn-i_019-map-pin
-            = t 'label_shops'
-    %li.li-menu
-      %a{href: main_app.map_path}
-        %span.nav-primary
-          %i.ofn-i_037-map
-          = t 'label_map'
-    %li.li-menu
-      %a{href: main_app.producers_path}
-        %span.nav-primary
-          %i.ofn-i_036-producers
-          = t 'label_producers'
+    - [*1..7].each do |menu_number|
+      - menu_name = "menu_#{menu_number}"
+      - if ContentConfig[menu_name].present?
+        %li.li-menu
+          %a{href: t("#{menu_name}_url") }
+            %span.nav-primary
+              %i{class: ContentConfig["#{menu_name}_icon_name"]}
+                = t "#{menu_name}_title"
     - if OpenFoodNetwork::I18nConfig.selectable_locales.count > 1
       %li.language-switcher.li-menu
         %a
@@ -50,50 +37,6 @@
             - if I18n.locale != l
               %li
                 %a{href: "?locale=#{l.to_s}" }= t('language_name', locale: l)
-    - if feature? :connect_learn_homepage
-      %li.li-menu
-        %a{href: "https://openfoodnetwork.org/au/connect/"}
-          %span.nav-primary
-            %i.ofn-i_035-groups
-            = t 'label_connect'
-      %li.li-menu
-        %a{href: "https://openfoodnetwork.org/au/learn/"}
-          %span.nav-primary
-            %i.ofn-i_013-help
-            = t 'label_learn'
-    - elsif feature? :about_blog_homepage
-      %li.li-menu
-        %a{href: "http://about.openfoodnetwork.org.uk/"}
-          %span.nav-primary
-            %i.ofn-i_019-map-pin
-            = t 'label_about'
-      %li.li-menu
-        %a{href: "http://about.openfoodnetwork.org.uk/blog"}
-          %span.nav-primary
-            %i.ofn-i_037-map
-            = t 'label_blog'
-      %li.li-menu
-        %a{href: "http://about.openfoodnetwork.org.uk/support"}
-          %span.nav-primary
-            %i.ofn-i_013-help
-            = t 'label_support'
-      %li.li-menu
-        %a{href: main_app.groups_path}
-          %span.nav-primary
-            %i.ofn-i_035-groups
-            = t 'label_groups'
-    - else
-      %li.li-menu
-        %a{href: main_app.groups_path}
-          %span.nav-primary
-            %i.ofn-i_035-groups
-            = t 'label_groups'
-      %li.li-menu
-        %a{href: ContentConfig.footer_about_url}
-          %span.nav-primary
-            %i.ofn-i_013-help
-            = t 'label_about'
-
     %li
     - if spree_current_user.nil?
       = render 'shared/signed_out'

--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -26,7 +26,7 @@
           %a{href: t("#{menu_name}_url") }
             %span.nav-primary
               %i{class: ContentConfig["#{menu_name}_icon_name"]}
-                = t "#{menu_name}_title"
+              = t "#{menu_name}_title"
     - if OpenFoodNetwork::I18nConfig.selectable_locales.count > 1
       %li.language-switcher.li-menu
         %a

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1175,14 +1175,14 @@ en:
   menu_2_url: "/map"
   menu_3_title: "Producers"
   menu_3_url: "/producers"
-  menu_4_title: "Connect"
-  menu_4_url: "https://openfoodnetwork.org/au/connect/"
-  menu_5_title: "Learn"
-  menu_5_url: "https://openfoodnetwork.org/au/learn/"
-  menu_6_title: "Blog"
-  menu_6_url: ""
-  menu_7_title: "Groups"
-  menu_7_url: ""
+  menu_4_title: "Groups"
+  menu_4_url: "/groups"
+  menu_5_title: "About"
+  menu_5_url: "http://www.openfoodnetwork.org/"
+  menu_6_title: "Connect"
+  menu_6_url: "https://openfoodnetwork.org/au/connect/"
+  menu_7_title: "Learn"
+  menu_7_url: "https://openfoodnetwork.org/au/learn/"
 
   logo: "Logo (640x130)" #FIXME
   logo_mobile: "Mobile logo (75x26)" #FIXME

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,6 +428,7 @@ en:
         producer_signup_page: Producer signup page
         hub_signup_page: Hub signup page
         group_signup_page: Group signup page
+        main_links: Main Menu Links
         footer_and_external_links: Footer and External Links
         your_content: Your content
 
@@ -1167,6 +1168,21 @@ en:
   ticket_column_item: "Item"
   ticket_column_unit_price: "Unit Price"
   ticket_column_total_price: "Total Price"
+
+  menu_1_title: "Shops"
+  menu_1_url: "/shops"
+  menu_2_title: "Map"
+  menu_2_url: "/map"
+  menu_3_title: "Producers"
+  menu_3_url: "/producers"
+  menu_4_title: "Connect"
+  menu_4_url: "https://openfoodnetwork.org/au/connect/"
+  menu_5_title: "Learn"
+  menu_5_url: "https://openfoodnetwork.org/au/learn/"
+  menu_6_title: "Blog"
+  menu_6_url: ""
+  menu_7_title: "Groups"
+  menu_7_url: ""
 
   logo: "Logo (640x130)" #FIXME
   logo_mobile: "Mobile logo (75x26)" #FIXME


### PR DESCRIPTION
Added 7 menu entries to the translations file (each with text and url) and 7 content configuration points to enable/disable these. The mobile menu icons can also be configured.

#### What? Why?

Closes #2410 

#### What should we test?
See #2410 for screenshots.
We need to set a few variations on the translations files and then activate/deactivate different menu entries and see if both large menu and mobile menu work properly with different type of links.

#### Release notes
The main menu is now translatable and configurable (per instance).

Changelog Category: Added