### PR TITLE
Remove empty SKU values if empty

### DIFF
--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -14,6 +14,7 @@ module ProductImport
 
     def initialize(attrs)
       @validates_as = ''
+      remove_empty_skus attrs
       assign_units attrs
     end
 
@@ -56,6 +57,10 @@ module ProductImport
     end
 
     private
+
+    def remove_empty_skus(attrs)
+      attrs.delete('sku') if attrs.key?('sku') && attrs['sku'].blank?
+    end
 
     def assign_units(attrs)
       units = UnitConverter.new(attrs)

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -254,9 +254,9 @@ describe ProductImport::ProductImporter do
   describe "updating various fields" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "on_demand"]
-        csv << ["Beetroot", "And Another Enterprise", "Vegetables", "5", "3.50", "500", "g", "0"]
-        csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "g", "1"]
+        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "on_demand", "sku"]
+        csv << ["Beetroot", "And Another Enterprise", "Vegetables", "5", "3.50", "500", "g", "0", nil]
+        csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "g", "1", "TOMS"]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')


### PR DESCRIPTION
#### What? Why?

Closes #2501

Fixes a bug where validation of the SKU field when saving a product would cause import to fail if some of the entries in the spreadsheet were present and some were `nil`.

#### What should we test?

Product import works when the spreadsheet has an `sku` column present, and some values in the column are empty. 

#### Release notes

Product Import: fixed an issue with empty SKU fields causing products to not be saved. 

Changelog Category: Fixed
