### PR TITLE
Pi/producer enabled

### DIFF
--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -34,7 +34,8 @@ module ProductImport
     end
 
     def count_existing_items
-      @spreadsheet_data.suppliers_index.each do |_supplier_name, supplier_id|
+      @spreadsheet_data.suppliers_index.each do |_supplier_name, attrs|
+        supplier_id = attrs[:id]
         next unless supplier_id && permission_by_id?(supplier_id)
 
         products_count =

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -62,6 +62,11 @@ module ProductImport
         return
       end
 
+      unless Enterprise.find_by_name(supplier_name).is_primary_producer?
+        mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_primary_producer, name: supplier_name))
+        return
+      end
+
       entry.supplier_id = @spreadsheet_data.suppliers_index[supplier_name]
     end
 

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -17,7 +17,7 @@ module ProductImport
 
         next if entry.supplier_id.blank?
 
-        if import_into_inventory?(entry)
+        if import_into_inventory?
           producer_validation(entry)
           inventory_validation(entry)
         else
@@ -45,29 +45,37 @@ module ProductImport
     private
 
     def supplier_validation(entry)
-      supplier_name = entry.supplier
+      return if name_presence_error entry
+      return if enterprise_not_found_error entry
+      return if permissions_error entry
+      return if primary_producer_error entry
 
-      if supplier_name.blank?
-        mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_required))
-        return
-      end
+      entry.supplier_id = @spreadsheet_data.suppliers_index[entry.supplier][:id]
+    end
 
-      unless @spreadsheet_data.suppliers_index[supplier_name]
-        mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_found_in_database, name: supplier_name))
-        return
-      end
+    def name_presence_error(entry)
+      return if entry.supplier.present?
+      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_required))
+      true
+    end
 
-      unless permission_by_name?(supplier_name)
-        mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_no_permission_for_enterprise, name: supplier_name))
-        return
-      end
+    def enterprise_not_found_error(entry)
+      return if @spreadsheet_data.suppliers_index[entry.supplier][:id]
+      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_found_in_database, name: entry.supplier))
+      true
+    end
 
-      unless Enterprise.find_by_name(supplier_name).is_primary_producer?
-        mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_primary_producer, name: supplier_name))
-        return
-      end
+    def permissions_error(entry)
+      return if permission_by_name?(entry.supplier)
+      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_no_permission_for_enterprise, name: entry.supplier))
+      true
+    end
 
-      entry.supplier_id = @spreadsheet_data.suppliers_index[supplier_name]
+    def primary_producer_error(entry)
+      return if import_into_inventory?
+      return if @spreadsheet_data.suppliers_index[entry.supplier][:is_primary_producer]
+      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_primary_producer, name: entry.supplier))
+      true
     end
 
     def unit_fields_validation(entry)
@@ -77,7 +85,7 @@ module ProductImport
         mark_as_invalid(entry, attribute: 'units', error: I18n.t('admin.product_import.model.blank'))
       end
 
-      return if import_into_inventory?(entry)
+      return if import_into_inventory?
 
       # unit_type must be valid type
       if entry.unit_type && entry.unit_type.present?
@@ -225,8 +233,8 @@ module ProductImport
       entry.product_validations = options[:product_validations] if options[:product_validations]
     end
 
-    def import_into_inventory?(entry)
-      entry.supplier_id && @import_settings[:settings]['import_into'] == 'inventories'
+    def import_into_inventory?
+      @import_settings[:settings]['import_into'] == 'inventories'
     end
 
     def validate_inventory_item(entry, variant_override)

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -63,8 +63,7 @@ module ProductImport
     end
 
     def suppliers_index
-      index = @spreadsheet_data.suppliers_index
-      index.sort_by{ |_k, v| v.to_i }.reverse.to_h
+      @spreadsheet_data.suppliers_index
     end
 
     def supplier_products

--- a/app/models/product_import/spreadsheet_data.rb
+++ b/app/models/product_import/spreadsheet_data.rb
@@ -30,8 +30,9 @@ module ProductImport
       @suppliers_index = {}
       @entries.each do |entry|
         supplier_name = entry.supplier
-        supplier_id = @suppliers_index[supplier_name] || Enterprise.find_by_name(supplier_name, select: 'id, name').try(:id)
-        @suppliers_index[supplier_name] = supplier_id
+        next if @suppliers_index.key? supplier_name
+        enterprise = Enterprise.find_by_name(supplier_name, select: 'id, name, is_primary_producer')
+        @suppliers_index[supplier_name] = { id: enterprise.try(:id), is_primary_producer: enterprise.try(:is_primary_producer) }
       end
       @suppliers_index
     end

--- a/app/views/admin/product_import/_import_options.html.haml
+++ b/app/views/admin/product_import/_import_options.html.haml
@@ -1,15 +1,15 @@
 %h5= t('admin.product_import.import.options_and_defaults')
 %br
 
-- @importer.suppliers_index.each do |name, supplier_id|
-  - if name and supplier_id and @importer.permission_by_id?(supplier_id)
+- @importer.suppliers_index.each do |name, attrs|
+  - if name and attrs[:id] and @importer.permission_by_id?(attrs[:id])
     %div.panel-section.import-settings
       %div.panel-header{ng: {click: 'togglePanel()', class: '{active: active}'}}
         %div.header-icon.success
           %i.fa.fa-check-circle
         %div.header-description
           = name
-  - elsif name and supplier_id
+  - elsif name and attrs[:id]
     %div.panel-section.import-settings
       %div.panel-header
         %div.header-icon.error

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1739,6 +1739,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   error_number: "must be number"
   error_email: "must be email address"
   error_not_found_in_database: "%{name} not found in database"
+  error_not_primary_producer: "%{name} is not enabled as a producer"
   error_no_permission_for_enterprise: "\"%{name}\": you do not have permission to manage products for this enterprise"
   item_handling_fees: "Item Handling Fees (included in item totals)"
   january: "January"

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -8,9 +8,10 @@ describe ProductImport::ProductImporter do
   let!(:user) { create_enterprise_user }
   let!(:user2) { create_enterprise_user }
   let!(:user3) { create_enterprise_user }
-  let!(:enterprise) { create(:enterprise, owner: user, name: "User Enterprise") }
-  let!(:enterprise2) { create(:distributor_enterprise, owner: user2, name: "Another Enterprise") }
-  let!(:enterprise3) { create(:distributor_enterprise, owner: user3, name: "And Another Enterprise") }
+  let!(:enterprise) { create(:enterprise, is_primary_producer: true, owner: user, name: "User Enterprise") }
+  let!(:enterprise2) { create(:distributor_enterprise, is_primary_producer: true, owner: user2, name: "Another Enterprise") }
+  let!(:enterprise3) { create(:distributor_enterprise, is_primary_producer: true, owner: user3, name: "And Another Enterprise") }
+  let!(:enterprise4) { create(:enterprise, is_primary_producer: false, owner: user, name: "Non-Producer") }
   let!(:relationship) { create(:enterprise_relationship, parent: enterprise, child: enterprise2, permissions_list: [:create_variant_overrides]) }
 
   let!(:category) { create(:taxon, name: 'Vegetables') }
@@ -160,6 +161,29 @@ describe ProductImport::ProductImporter do
       expect(carrots.variants.first.import_date).to be_within(1.minute).of Time.zone.now
 
       expect(Spree::Product.find_by_name('Bad Potatoes')).to eq nil
+    end
+  end
+
+  describe "when enterprises are not valid" do
+    before do
+      csv_data = CSV.generate do |csv|
+        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["Product 1", "Non-existent Enterprise", "Vegetables", "5", "5.50", "500", "g"]
+        csv << ["Product 2", "Non-Producer", "Vegetables", "5", "5.50", "500", "g"]
+      end
+      File.write('/tmp/test-m.csv', csv_data)
+      file = File.new('/tmp/test-m.csv')
+      settings = {'import_into' => 'product_list'}
+      @importer = ProductImport::ProductImporter.new(file, admin, start: 1, end: 100, settings: settings)
+    end
+    after { File.delete('/tmp/test-m.csv') }
+
+    it "adds enterprise errors" do
+      @importer.validate_entries
+      entries = JSON.parse(@importer.entries_json)
+
+      expect(entries['2']['errors']['supplier']).to include "not found in database"
+      expect(entries['3']['errors']['supplier']).to include "not enabled as a producer"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #2490

Adds an additional validation check to see if an enterprise is enabled as a producer with the `is_primary_producer` property, and doesn't allow importing products for that enterprise if not.

#### What should we test?

Product cannot be imported for an enterprise that is not set to `is_primary_producer`.


#### Release notes

Product Import: Added a validation check to make sure enterprise is enabled as a producer.

Changelog Category: Added


#### Documentation updates

This should be noted in the product import user guide.

