### PR TITLE
Make OC name editable from the OC index

### DIFF
--- a/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
@@ -66,7 +66,7 @@ angular.module("admin.resources").factory 'OrderCycles', ($q, $injector, OrderCy
       changes
 
     attrsToSave: ->
-      ['orders_open_at','orders_close_at']
+      ['name', 'orders_open_at','orders_close_at']
 
     resetAttribute: (order_cycle, attribute) ->
       order_cycle[attribute] = @pristineByID[order_cycle.id][attribute]

--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -1,7 +1,6 @@
 %tr{ class: "order-cycle-{{orderCycle.id}} {{orderCycle.status}}", ng: { repeat: 'orderCycle in orderCycles | schedule:scheduleFilter | involving:involvingFilter | filter:{name: query} track by orderCycle.id' } }
   %td.name{ ng: { show: 'columns.name.visible' } }
-    %a{ ng: { href: '{{orderCycle.edit_path}}' } }
-      {{ orderCycle.name }}
+    %input{ id: 'oc{{::orderCycle.id}}_name', name: 'oc{{::orderCycle.id}}[name]', type: 'text', ng: { model: 'orderCycle.name', disabled: '!orderCycle.viewing_as_coordinator' } }
   %td.schedules{ ng: { show: 'columns.schedules.visible' } }
     %span{ ng: { repeat: 'schedule in orderCycle.schedules'} }
       %a{ 'schedule-dialog' => true, 'schedule-id' => '{{schedule.id}}' }

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -220,6 +220,7 @@ module Admin
         let(:params) do
           { format: :json, order_cycle_set: { collection_attributes: { '0' => {
             id: oc.id,
+            name: "Updated Order Cycle",
             orders_open_at: Date.current - 21.days,
             orders_close_at: Date.current + 21.days,
           } } } }
@@ -230,6 +231,7 @@ module Admin
         it "updates order cycle properties" do
           spree_put :bulk_update, params
           oc.reload
+          expect(oc.name).to eq "Updated Order Cycle"
           expect(oc.orders_open_at.to_date).to eq Date.current - 21.days
           expect(oc.orders_close_at.to_date).to eq Date.current + 21.days
         end
@@ -262,11 +264,13 @@ module Admin
         it "doesn't update order cycle properties" do
           spree_put :bulk_update, format: :json, order_cycle_set: { collection_attributes: { '0' => {
             id: oc.id,
+            name: "Updated Order Cycle",
             orders_open_at: Date.current - 21.days,
             orders_close_at: Date.current + 21.days,
           } } }
 
           oc.reload
+          expect(oc.name).to_not eq "Updated Order Cycle"
           expect(oc.orders_open_at.to_date).to_not eq Date.current - 21.days
           expect(oc.orders_close_at.to_date).to_not eq Date.current + 21.days
         end

--- a/spec/javascripts/unit/admin/order_cycles/services/order_cycles_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/services/order_cycles_spec.js.coffee
@@ -106,8 +106,8 @@ describe "OrderCycles service", ->
       OrderCycles.pristineByID = { 23: { id: 23, name: "orderCycle321", orders_open_at: '123' } }
 
     it "returns a list of properties that have been altered, if they are in attrsToSave()", ->
-      spyOn(OrderCycles, "attrsToSave").and.returnValue(["orders_open_at"])
-      expect(OrderCycles.diff({ id: 23, name: "orderCycle123", orders_open_at: '321' })).toEqual ["orders_open_at"]
+      spyOn(OrderCycles, "attrsToSave").and.returnValue(["name", "orders_open_at"])
+      expect(OrderCycles.diff({ id: 23, name: "orderCycle123", orders_open_at: '321' })).toEqual ["name", "orders_open_at"]
 
 
   describe "resetAttribute", ->


### PR DESCRIPTION
#### What? Why?

Closes #2430 

When creating a series of order cycles (OC), the user normally duplicates the first OC and then edits the OC name and dates of these subsequent OCs.

The OC dates can already be edited in bulk from the OC index, but the name cannot.

Before this change, the user has to go to the edit page of each OC and change the name. To save users time, the OC name has been made editable from the OC index as well. 

#### What should we test?

**As admin:**

1. Go to the OC index.
2. Duplicate an order cycle.
3. Still in the OC index, find the newly created order cycle.
4. Change the name, and open and close dates of this OC, and click "Save Changes".
5. Check that you received the/ following success alert: "Order cycles have been updated."
6. Without reloading the page yet, check that the name of the OC is still the updated name.
7. Reload the page.
8. Check that the name of the OC is still the updated name.
9. Repeat Items 2 to 8, but only updating the OC name, not the open and close dates.

**As enterprise manager:**

Repeat steps for admin above.

**As user with particular limited permissions for the enterprise:**
(User account that has an "Enterprise Permission" for the enterprise, as long as _add to order cycle_ was not granted)

1. Go to the OC index.
2. Check that the name, open date, and close date fields for the OC are not editable.

#### Release notes

- Add ability to bulk update order cycle name from the order cycle index

Changelog Category: Added