### PR TITLE
2545 Link to enterprise fees of enterprise

### DIFF
--- a/app/views/admin/enterprises/form/_enterprise_fees.html.haml
+++ b/app/views/admin/enterprises/form/_enterprise_fees.html.haml
@@ -1,4 +1,4 @@
-- if @enterprise_fees.count > 0
+- if @enterprise_fees.present?
   %table
     %thead
       %tr
@@ -11,7 +11,7 @@
           %td= enterprise_fee.fee_type
   %br
   %div
-    %a.button{ href: "#{main_app.admin_enterprise_fees_path}"}
+    %a.button{href: main_app.admin_enterprise_fees_path(enterprise_id: @enterprise.id)}
       = t('.manage_fees')
       %i.icon-arrow-right
 
@@ -21,6 +21,6 @@
 
   %br
   .text-center
-    %a.button{ href: "#{main_app.admin_enterprise_fees_path}"}
+    %a.button{href: main_app.admin_enterprise_fees_path(enterprise_id: @enterprise.id)}
       = t('.create_button')
       %i.icon-arrow-right

--- a/app/views/admin/enterprises/form/_enterprise_fees.html.haml
+++ b/app/views/admin/enterprises/form/_enterprise_fees.html.haml
@@ -4,15 +4,11 @@
       %tr
         %th= t('.name')
         %th= t('.fee_type')
-        -# %th Calculator
-        -# %th Calculator Values
     %tbody
       - @enterprise_fees.each do |enterprise_fee|
         %tr
           %td= enterprise_fee.name
           %td= enterprise_fee.fee_type
-          -# %td= enterprise_fee.calculator.preferred_flat_percent
-          -# %td= enterprise_fee.fee_type
   %br
   %div
     %a.button{ href: "#{main_app.admin_enterprise_fees_path}"}

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -142,13 +142,12 @@ feature %q{
     end
 
     it "creates enterprise fees" do
-      ef2
-
       visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Create One Now"
 
       select distributor1.name, from: 'enterprise_fee_set_collection_attributes_0_enterprise_id'
+      select 'Packing', from: 'enterprise_fee_set_collection_attributes_0_fee_type'
       fill_in 'enterprise_fee_set_collection_attributes_0_name', with: 'foo'
       select 'GST', from: 'enterprise_fee_set_collection_attributes_0_tax_category_id'
       select 'Flat Percent', from: 'enterprise_fee_set_collection_attributes_0_calculator_type'

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -148,10 +148,10 @@ feature %q{
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Create One Now"
 
-      select distributor1.name, :from => 'enterprise_fee_set_collection_attributes_0_enterprise_id'
-      fill_in 'enterprise_fee_set_collection_attributes_0_name', :with => 'foo'
+      select distributor1.name, from: 'enterprise_fee_set_collection_attributes_0_enterprise_id'
+      fill_in 'enterprise_fee_set_collection_attributes_0_name', with: 'foo'
       select 'GST', from: 'enterprise_fee_set_collection_attributes_0_tax_category_id'
-      select 'Flat Percent', :from => 'enterprise_fee_set_collection_attributes_0_calculator_type'
+      select 'Flat Percent', from: 'enterprise_fee_set_collection_attributes_0_calculator_type'
       click_button 'Update'
 
       expect(flash_message).to eq('Your enterprise fees have been updated.')

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -17,12 +17,12 @@ feature %q{
     click_link 'Configuration'
     click_link 'Enterprise Fees'
 
-    page.should have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"
-    page.should have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Packing'
-    page.should have_selector "input[value='$0.50 / kg']"
-    page.should have_select "enterprise_fee_set_collection_attributes_0_tax_category_id", selected: 'GST'
-    page.should have_select "enterprise_fee_set_collection_attributes_0_calculator_type", selected: 'Flat Rate (per item)'
-    page.should have_selector "input[value='#{amount}']"
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Packing'
+    expect(page).to have_selector "input[value='$0.50 / kg']"
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_tax_category_id", selected: 'GST'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_calculator_type", selected: 'Flat Rate (per item)'
+    expect(page).to have_selector "input[value='#{amount}']"
   end
 
   scenario "creating an enterprise fee" do
@@ -42,15 +42,15 @@ feature %q{
     click_button 'Update'
 
     # Then I should see my fee and fields for the calculator
-    page.should have_content "Your enterprise fees have been updated."
-    page.should have_selector "input[value='Hello!']"
+    expect(page).to have_content "Your enterprise fees have been updated."
+    expect(page).to have_selector "input[value='Hello!']"
 
     # When I fill in the calculator fields and click update
     fill_in 'enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent', with: '12.34'
     click_button 'Update'
 
     # Then I should see the correct values in my calculator fields
-    page.should have_selector "#enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent[value='12.34']"
+    expect(page).to have_selector "#enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent[value='12.34']"
   end
 
   scenario "editing an enterprise fee" do
@@ -71,21 +71,21 @@ feature %q{
     click_button 'Update'
 
     # Then I should see the updated fields for my fee
-    page.should have_select "enterprise_fee_set_collection_attributes_0_enterprise_id", selected: 'Foo'
-    page.should have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Admin'
-    page.should have_selector "input[value='Greetings!']"
-    page.should have_select 'enterprise_fee_set_collection_attributes_0_tax_category_id', selected: 'Inherit From Product'
-    page.should have_selector "option[selected]", text: 'Flat Percent (per item)'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id", selected: 'Foo'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Admin'
+    expect(page).to have_selector "input[value='Greetings!']"
+    expect(page).to have_select 'enterprise_fee_set_collection_attributes_0_tax_category_id', selected: 'Inherit From Product'
+    expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'
 
     fee.reload
-    fee.enterprise.should == enterprise
-    fee.name.should == 'Greetings!'
-    fee.fee_type.should == 'admin'
-    fee.calculator_type.should == "Calculator::FlatPercentPerItem"
+    expect(fee.enterprise).to eq(enterprise)
+    expect(fee.name).to eq('Greetings!')
+    expect(fee.fee_type).to eq('admin')
+    expect(fee.calculator_type).to eq("Calculator::FlatPercentPerItem")
 
     # Sets tax_category and inherits_tax_category
-    fee.tax_category.should == nil
-    fee.inherits_tax_category.should == true
+    expect(fee.tax_category).to eq(nil)
+    expect(fee.inherits_tax_category).to eq(true)
   end
 
   scenario "deleting an enterprise fee" do
@@ -119,12 +119,12 @@ feature %q{
     find("a.delete-resource").click
 
     # Then I should see an error
-    page.should have_content "That enterprise fee cannot be deleted as it is referenced by a product distribution: #{p.id} - #{p.name}."
+    expect(page).to have_content "That enterprise fee cannot be deleted as it is referenced by a product distribution: #{p.id} - #{p.name}."
 
     # And my enterprise fee should not have been deleted
     visit admin_enterprise_fees_path
-    page.should have_selector "input[value='#{fee.name}']"
-    EnterpriseFee.find(fee.id).should_not be_nil
+    expect(page).to have_selector "input[value='#{fee.name}']"
+    expect(EnterpriseFee.find(fee.id)).not_to be_nil
   end
 
   context "as an enterprise manager" do
@@ -154,13 +154,13 @@ feature %q{
       select 'Flat Percent', :from => 'enterprise_fee_set_collection_attributes_0_calculator_type'
       click_button 'Update'
 
-      flash_message.should == 'Your enterprise fees have been updated.'
+      expect(flash_message).to eq('Your enterprise fees have been updated.')
 
       # After saving, we should be redirected to the fees for our chosen enterprise
-      page.should_not have_select 'enterprise_fee_set_collection_attributes_1_enterprise_id', selected: 'Second Distributor'
+      expect(page).not_to have_select 'enterprise_fee_set_collection_attributes_1_enterprise_id', selected: 'Second Distributor'
 
       enterprise_fee = EnterpriseFee.find_by_name 'foo'
-      enterprise_fee.enterprise.should == distributor1
+      expect(enterprise_fee.enterprise).to eq(distributor1)
     end
 
     pending "shows me only enterprise fees for the enterprise I select" do
@@ -170,15 +170,15 @@ feature %q{
       visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Settings Enterprise Fees"
-      page.should     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
-      page.should_not have_field 'enterprise_fee_set_collection_attributes_1_name', with: 'Two'
+      expect(page).to     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
+      expect(page).not_to have_field 'enterprise_fee_set_collection_attributes_1_name', with: 'Two'
 
       click_link 'Enterprises'
       within("#e_#{distributor2.id}") { click_link 'Settings' }
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Settings Enterprise Fees"
-      page.should_not have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
-      page.should     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'Two'
+      expect(page).not_to have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
+      expect(page).to     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'Two'
     end
 
     it "only allows me to select enterprises I have access to" do
@@ -189,7 +189,7 @@ feature %q{
       visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      page.should have_select('enterprise_fee_set_collection_attributes_1_enterprise_id',
+      expect(page).to have_select('enterprise_fee_set_collection_attributes_1_enterprise_id',
                               selected: 'Second Distributor',
                               options: ['', 'First Distributor', 'Second Distributor'])
     end

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -162,20 +162,19 @@ feature %q{
       expect(enterprise_fee.enterprise).to eq(distributor1)
     end
 
-    pending "shows me only enterprise fees for the enterprise I select" do
+    it "shows me only enterprise fees for the enterprise I select" do
       ef1
       ef2
 
       visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
-      click_link "Settings Enterprise Fees"
+      click_link "Manage Enterprise Fees"
       expect(page).to     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
       expect(page).not_to have_field 'enterprise_fee_set_collection_attributes_1_name', with: 'Two'
 
-      click_link 'Enterprises'
-      within("#e_#{distributor2.id}") { click_link 'Settings' }
+      visit edit_admin_enterprise_path(distributor2)
       within(".side_menu") { click_link 'Enterprise Fees' }
-      click_link "Settings Enterprise Fees"
+      click_link "Manage Enterprise Fees"
       expect(page).not_to have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
       expect(page).to     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'Two'
     end
@@ -185,10 +184,10 @@ feature %q{
       ef2
       distributor3
 
-      visit edit_admin_enterprise_path(distributor1)
+      visit edit_admin_enterprise_path(distributor2)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
-      expect(page).to have_select('enterprise_fee_set_collection_attributes_1_enterprise_id',
+      expect(page).to have_select('enterprise_fee_set_collection_attributes_0_enterprise_id',
                               selected: 'Second Distributor',
                               options: ['', 'First Distributor', 'Second Distributor'])
     end

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -138,14 +138,13 @@ feature %q{
     before(:each) do
       enterprise_user.enterprise_roles.build(enterprise: distributor1).save
       enterprise_user.enterprise_roles.build(enterprise: distributor2).save
-      login_to_admin_as enterprise_user
+      quick_login_as enterprise_user
     end
 
     it "creates enterprise fees" do
       ef2
 
-      click_link 'Enterprises'
-      within("#e_#{distributor1.id}") { click_link 'Settings' }
+      visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Create One Now"
 
@@ -168,8 +167,7 @@ feature %q{
       ef1
       ef2
 
-      click_link 'Enterprises'
-      within("#e_#{distributor1.id}") { click_link 'Settings' }
+      visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Settings Enterprise Fees"
       page.should     have_field 'enterprise_fee_set_collection_attributes_0_name', with: 'One'
@@ -188,8 +186,7 @@ feature %q{
       ef2
       distributor3
 
-      click_link 'Enterprises'
-      within("#e_#{distributor2.id}") { click_link 'Settings' }
+      visit edit_admin_enterprise_path(distributor1)
       within(".side_menu") { click_link 'Enterprise Fees' }
       click_link "Manage Enterprise Fees"
       page.should have_select('enterprise_fee_set_collection_attributes_1_enterprise_id',


### PR DESCRIPTION
#### What? Why?

Eases #2545.

When you want to manage enterprise fees of one enterprise, you should see only the fees of that enterprise. Instead, you are shown the fees of all your enterprises which is confusing. It can also prevent you from seeing the empty form elements at the bottom of the list to create new enterprise fees.

#### What should we test?

As super admin:

- Go to Enterprises.
- Click on Enterprise fees of one of the enterprises in the list.
- Check that you see only the fees for that enterprise.
- Check that you can edit existing and create new fees.

As enterprise user:

- Go to Enterprises.
- Click Manage on one enterprise in the list.
- Click on Enterprise fees in the menu.
- Click on *Create one now* or *Manage* depending on the existence of fees.
- Check that you see only the fees for that enterprise.
- Check that you can edit existing and create new fees.

#### Release notes

Editing enterprise fees now shows only the fees of that enterprise.

Changelog Category: Fixed

