### PR TITLE
Added httponly to cookieConsent cookie, this makes this cookie secure…

### DIFF
--- a/app/services/cookies_consent.rb
+++ b/app/services/cookies_consent.rb
@@ -18,7 +18,8 @@ class CookiesConsent
     cookies[COOKIE_NAME] = {
       value: COOKIE_NAME,
       expires: 1.year.from_now,
-      domain: domain
+      domain: domain,
+      httponly: true
     }
   end
 


### PR DESCRIPTION
…, i.e. the cookie cannot be altered by javascript

#### What? Why?

Closes #2554 

See issue for details.

#### What should we test?
No change in behaviour at all.
The http header, when the cookie with the CookieConsent is set, should include HttpOnly.
Verify that the cookie banner is showing, the user can click "accept cookies" and that the banner disappears on acceptance and doesn't come back on page refresh.

#### Release notes
Changelog Category: Changed

CookiesConsent cookie is now secure (httponly).
