### PR TITLE
Make cookies tests more stable

### DIFF
--- a/spec/features/consumer/cookies_spec.rb
+++ b/spec/features/consumer/cookies_spec.rb
@@ -9,7 +9,9 @@ feature "Cookies", js: true do
       end
 
       scenario "does not show after cookies are accepted" do
+        sleep 1
         click_button I18n.t('legal.cookies_banner.cookies_accept_button')
+        sleep 2
         expect_not_visible_cookies_banner
 
         visit root_path
@@ -18,6 +20,7 @@ feature "Cookies", js: true do
 
       scenario "banner contains cookies policy link that opens coookies policy page and closes banner" do
         find("p.ng-binding > a", :text => "cookies policy").click
+        sleep 1
         expect_visible_cookies_policy_page
         expect_not_visible_cookies_banner
 

--- a/spec/features/consumer/cookies_spec.rb
+++ b/spec/features/consumer/cookies_spec.rb
@@ -15,12 +15,14 @@ feature "Cookies", js: true do
         expect_not_visible_cookies_banner
 
         visit root_path
+        sleep 1
         expect_not_visible_cookies_banner
       end
 
       scenario "banner contains cookies policy link that opens coookies policy page and closes banner" do
-        find("p.ng-binding > a", :text => "cookies policy").click
         sleep 1
+        find("p.ng-binding > a", :text => "cookies policy").click
+        sleep 2
         expect_visible_cookies_policy_page
         expect_not_visible_cookies_banner
 


### PR DESCRIPTION
#### What? Why?

Attempt to close #2553

Fixing cookies spec intermittent fails.
I think I just need a 1 sec sleep before the policy page opens.

#### What should we test?
Build doesn't intermittently fail with cookies_spec errors.