### PR TITLE
Switch feature matcher style from `to_not have` to `to have_no`

### DIFF
--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -132,7 +132,7 @@ feature %q{
       end
 
       it "adds the class 'ng-dirty' to input elements when value is altered" do
-        expect(page).to_not have_css "input[name='quantity'].ng-dirty"
+        expect(page).to have_no_css "input[name='quantity'].ng-dirty"
         fill_in "quantity", :with => 2
         expect(page).to have_css "input[name='quantity'].ng-dirty"
       end

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -770,10 +770,10 @@ feature %q{
 
         # Shows spinner whilst loading
         expect(page).to have_css "img.spinner", visible: true
-        expect(page).to_not have_css "img.spinner", visible: true
+        expect(page).to have_no_css "img.spinner", visible: true
       end
 
-      expect(page).to_not have_selector "div.reveal-modal.product-image-upload"
+      expect(page).to have_no_selector "div.reveal-modal.product-image-upload"
 
       within "table#listing_products tr#p_#{product.id}" do
         # New thumbnail is shown in image column

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -28,9 +28,9 @@ feature 'Customers' do
         select2_select managed_distributor2.name, from: "shop_id"
 
         # Loads the right customers
-        expect(page).to_not have_selector "tr#c_#{customer1.id}"
-        expect(page).to_not have_selector "tr#c_#{customer2.id}"
-        expect(page).to_not have_selector "tr#c_#{customer3.id}"
+        expect(page).to have_no_selector "tr#c_#{customer1.id}"
+        expect(page).to have_no_selector "tr#c_#{customer2.id}"
+        expect(page).to have_no_selector "tr#c_#{customer3.id}"
         expect(page).to have_selector "tr#c_#{customer4.id}"
 
         # Changing Shops
@@ -39,12 +39,12 @@ feature 'Customers' do
         # Loads the right customers
         expect(page).to have_selector "tr#c_#{customer1.id}"
         expect(page).to have_selector "tr#c_#{customer2.id}"
-        expect(page).to_not have_selector "tr#c_#{customer3.id}"
-        expect(page).to_not have_selector "tr#c_#{customer4.id}"
+        expect(page).to have_no_selector "tr#c_#{customer3.id}"
+        expect(page).to have_no_selector "tr#c_#{customer4.id}"
 
         # Searching
         fill_in "quick_search", with: customer2.email
-        expect(page).to_not have_selector "tr#c_#{customer1.id}"
+        expect(page).to have_no_selector "tr#c_#{customer1.id}"
         expect(page).to have_selector "tr#c_#{customer2.id}"
         fill_in "quick_search", with: ""
 
@@ -68,8 +68,8 @@ feature 'Customers' do
         expect(page).to have_content customer1.email
         first("div#columns-dropdown", :text => "COLUMNS").click
         first("div#columns-dropdown div.menu div.menu_item", text: "Email").click
-        expect(page).to_not have_selector "th.email"
-        expect(page).to_not have_content customer1.email
+        expect(page).to have_no_selector "th.email"
+        expect(page).to have_no_content customer1.email
 
         # Deleting
         create(:order, customer: customer1)
@@ -85,7 +85,7 @@ feature 'Customers' do
           within "tr#c_#{customer2.id}" do
             find("a.delete-customer").click
           end
-          expect(page).to_not have_selector "tr#c_#{customer2.id}"
+          expect(page).to have_no_selector "tr#c_#{customer2.id}"
         }.to change{Customer.count}.by(-1)
       end
 

--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -128,7 +128,7 @@ feature %q{
         within 'table.managers' do
           within "tr#manager-#{user1.id}" do
             expect(page).to have_css 'i.owner'
-            expect(page).to_not have_css 'i.contact'
+            expect(page).to have_no_css 'i.contact'
           end
           within "tr#manager-#{user2.id}" do
             expect(page).to have_css 'i.contact'

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -17,8 +17,8 @@ feature 'Enterprises Index' do
         expect(page).to have_select "enterprise_set_collection_attributes_1_sells"
         expect(page).to have_content "Settings"
         expect(page).to have_content "Delete"
-        expect(page).to_not have_content "Payment Methods"
-        expect(page).to_not have_content "Shipping Methods"
+        expect(page).to have_no_content "Payment Methods"
+        expect(page).to have_no_content "Shipping Methods"
         expect(page).to have_content "Enterprise Fees"
       end
 
@@ -131,8 +131,8 @@ feature 'Enterprises Index' do
           expect(page).to have_selector "td.package", text: 'Profile'
         end
 
-        expect(page).to_not have_content "supplier2.name"
-        expect(page).to_not have_content "distributor2.name"
+        expect(page).to have_no_content "supplier2.name"
+        expect(page).to have_no_content "distributor2.name"
 
         expect(find("#content-header")).to have_link "New Enterprise"
       end
@@ -146,12 +146,12 @@ feature 'Enterprises Index' do
           expect(page).to have_selector "a.selector.producer.disabled"
           find("a.selector.producer.disabled").click
           expect(page).to have_selector "a.selector.non-producer.selected.disabled"
-          expect(page).to_not have_selector "a.update"
+          expect(page).to have_no_selector "a.update"
           find("td.package").click
           expect(page).to have_selector "a.selector.hub-profile.disabled"
           find("a.selector.hub-profile.disabled").click
           expect(page).to have_selector "a.selector.hub.selected.disabled"
-          expect(page).to_not have_selector "a.update"
+          expect(page).to have_no_selector "a.update"
         end
       end
     end
@@ -173,13 +173,13 @@ feature 'Enterprises Index' do
           # Open the producer panel
           find("td.producer").click
 
-          expect(page).to_not have_selector "a.selector.producer.selected"
+          expect(page).to have_no_selector "a.selector.producer.selected"
           expect(page).to have_selector "a.selector.non-producer.selected"
 
           # Change to a producer
           find("a.selector.producer").click
 
-          expect(page).to_not have_selector "a.selector.non-producer.selected"
+          expect(page).to have_no_selector "a.selector.non-producer.selected"
           expect(page).to have_selector "a.selector.producer.selected"
           expect(page).to have_selector "a.update", text: "SAVE"
 
@@ -191,16 +191,16 @@ feature 'Enterprises Index' do
           # Open the package panel
           find("td.package").click
 
-          expect(page).to_not have_selector "a.selector.producer-profile.selected"
-          expect(page).to_not have_selector "a.selector.producer-shop.selected"
+          expect(page).to have_no_selector "a.selector.producer-profile.selected"
+          expect(page).to have_no_selector "a.selector.producer-shop.selected"
           expect(page).to have_selector "a.selector.producer-hub.selected"
 
           # Change to a producer-shop
           find("a.selector.producer-shop").click
 
-          expect(page).to_not have_selector "a.selector.producer-profile.selected"
+          expect(page).to have_no_selector "a.selector.producer-profile.selected"
           expect(page).to have_selector "a.selector.producer-shop.selected"
-          expect(page).to_not have_selector "a.selector.producer-hub.selected"
+          expect(page).to have_no_selector "a.selector.producer-hub.selected"
           expect(page).to have_selector "a.update", text: "SAVE"
 
           # Save selection

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -368,7 +368,7 @@ feature %q{
           click_button 'Create'
 
           # Then it should show me an error
-          expect(page).to_not have_content 'Enterprise "zzz" has been successfully created!'
+          expect(page).to have_no_content 'Enterprise "zzz" has been successfully created!'
           expect(page).to have_content "#{enterprise_user.email} is not permitted to own any more enterprises (limit is 1)."
         end
       end

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -48,14 +48,14 @@ feature "Product Import", js: true do
       import_data
 
       expect(page).to have_selector '.item-count', text: "2"
-      expect(page).to_not have_selector '.invalid-count'
+      expect(page).to have_no_selector '.invalid-count'
       expect(page).to have_selector '.create-count', text: "2"
-      expect(page).to_not have_selector '.update-count'
+      expect(page).to have_no_selector '.update-count'
 
       save_data
 
       expect(page).to have_selector '.created-count', text: '2'
-      expect(page).to_not have_selector '.updated-count'
+      expect(page).to have_no_selector '.updated-count'
 
       carrots = Spree::Product.find_by_name('Carrots')
       potatoes = Spree::Product.find_by_name('Potatoes')
@@ -92,10 +92,10 @@ feature "Product Import", js: true do
 
       expect(page).to have_selector '.item-count', text: "2"
       expect(page).to have_selector '.invalid-count', text: "2"
-      expect(page).to_not have_selector '.create-count'
-      expect(page).to_not have_selector '.update-count'
+      expect(page).to have_no_selector '.create-count'
+      expect(page).to have_no_selector '.update-count'
 
-      expect(page).to_not have_selector 'input[type=submit][value="Save"]'
+      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
     end
 
     it "handles saving of named tax and shipping categories" do
@@ -115,12 +115,12 @@ feature "Product Import", js: true do
 
       expect(page).to have_selector '.item-count', text: "1"
       expect(page).to have_selector '.create-count', text: "1"
-      expect(page).to_not have_selector '.update-count'
+      expect(page).to have_no_selector '.update-count'
 
       save_data
 
       expect(page).to have_selector '.created-count', text: '1'
-      expect(page).to_not have_selector '.updated-count'
+      expect(page).to have_no_selector '.updated-count'
 
       carrots = Spree::Product.find_by_name('Carrots')
       expect(carrots.tax_category).to eq tax_category
@@ -170,8 +170,8 @@ feature "Product Import", js: true do
 
       expect(page).to have_field "product_name", with: carrots.name
       expect(page).to have_field "product_name", with: potatoes.name
-      expect(page).to_not have_field "product_name", with: product.name
-      expect(page).to_not have_field "product_name", with: product2.name
+      expect(page).to have_no_field "product_name", with: product.name
+      expect(page).to have_no_field "product_name", with: product2.name
     end
 
     it "can reset product stock to zero for products not present in the CSV" do
@@ -218,16 +218,16 @@ feature "Product Import", js: true do
       import_data
 
       expect(page).to have_selector '.item-count', text: "3"
-      expect(page).to_not have_selector '.invalid-count'
-      expect(page).to_not have_selector '.create-count'
-      expect(page).to_not have_selector '.update-count'
+      expect(page).to have_no_selector '.invalid-count'
+      expect(page).to have_no_selector '.create-count'
+      expect(page).to have_no_selector '.update-count'
       expect(page).to have_selector '.inv-create-count', text: "2"
       expect(page).to have_selector '.inv-update-count', text: "1"
 
       save_data
 
-      expect(page).to_not have_selector '.created-count'
-      expect(page).to_not have_selector '.updated-count'
+      expect(page).to have_no_selector '.created-count'
+      expect(page).to have_no_selector '.updated-count'
       expect(page).to have_selector '.inv-created-count', text: '2'
       expect(page).to have_selector '.inv-updated-count', text: '1'
 
@@ -268,7 +268,7 @@ feature "Product Import", js: true do
       click_button 'Upload'
 
       expect(page).to have_content "Importer could not process file: invalid filetype"
-      expect(page).to_not have_selector 'input[type=submit][value="Save"]'
+      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
       expect(page).to have_content "Select a spreadsheet to upload"
       File.delete('/tmp/test.txt')
     end
@@ -288,9 +288,9 @@ feature "Product Import", js: true do
       attach_file 'file', '/tmp/test.csv'
       click_button 'Upload'
 
-      expect(page).to_not have_selector '.create-count'
-      expect(page).to_not have_selector '.update-count'
-      expect(page).to_not have_selector 'input[type=submit][value="Save"]'
+      expect(page).to have_no_selector '.create-count'
+      expect(page).to have_no_selector '.update-count'
+      expect(page).to have_no_selector 'input[type=submit][value="Save"]'
       File.delete('/tmp/test.csv')
     end
   end
@@ -320,7 +320,7 @@ feature "Product Import", js: true do
       expect(page).to have_selector '.create-count', text: "1"
 
       expect(page.body).to have_content 'you do not have permission'
-      expect(page).to_not have_selector 'a.button.proceed', visible: true
+      expect(page).to have_no_selector 'a.button.proceed', visible: true
     end
   end
 

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -64,8 +64,8 @@ feature 'Subscriptions' do
         expect(page).to have_content subscription.customer.email
         first("div#columns-dropdown", :text => "COLUMNS").click
         first("div#columns-dropdown div.menu div.menu_item", text: "Customer").click
-        expect(page).to_not have_selector "th.customer"
-        expect(page).to_not have_content subscription.customer.email
+        expect(page).to have_no_selector "th.customer"
+        expect(page).to have_no_content subscription.customer.email
 
         # Viewing Products
         within "tr#so_#{subscription.id}" do
@@ -91,7 +91,7 @@ feature 'Subscriptions' do
 
           proxy_order = subscription.proxy_orders.first
           within "tr#po_#{proxy_order.id}" do
-            expect(page).to_not have_content 'CANCELLED'
+            expect(page).to have_no_content 'CANCELLED'
             accept_alert 'Are you sure?' do
               find("a.cancel-order").trigger('click')
             end

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -19,7 +19,7 @@ feature 'Tag Rules', js: true do
       click_link "Tag Rules"
 
       # Creating a new tag
-      expect(page).to_not have_selector '.customer_tag'
+      expect(page).to have_no_selector '.customer_tag'
       expect(page).to have_content 'No tags apply to this enterprise yet'
       click_button '+ Add A New Tag'
       find(:css, "tags-input .tags input").set "volunteer\n"
@@ -241,9 +241,9 @@ feature 'Tag Rules', js: true do
 
       expect do
         within "#tr_1" do first("a.delete-tag-rule").click end
-        expect(page).to_not have_selector "#tr_1"
+        expect(page).to have_no_selector "#tr_1"
         within "#tr_0" do first("a.delete-tag-rule").click end
-        expect(page).to_not have_selector "#tr_0"
+        expect(page).to have_no_selector "#tr_0"
       end.to change{TagRule.count}.by(-2)
     end
   end

--- a/spec/features/admin/variants_spec.rb
+++ b/spec/features/admin/variants_spec.rb
@@ -40,7 +40,7 @@ feature %q{
     page.find('table.index .icon-edit').click
 
     # Then I should not see a traditional option value field for the unit-related option value
-    expect(page).to_not have_selector "div[data-hook='presentation'] input"
+    expect(page).to have_no_selector "div[data-hook='presentation'] input"
 
     # And I should see unit value and description fields for the unit-related option value
     page.should have_field "unit_value_human", with: "1"

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -67,7 +67,7 @@ feature "Credit Cards", js: true do
       end
 
       expect(page).to have_content I18n.t(:card_has_been_removed, number: "x-#{default_card.last_digits}")
-      expect(page).to_not have_selector ".card#card#{default_card.id}"
+      expect(page).to have_no_selector ".card#card#{default_card.id}"
 
       # Allows authorisation of card use by shops
       within "tr#customer#{customer.id}" do

--- a/spec/features/consumer/account_spec.rb
+++ b/spec/features/consumer/account_spec.rb
@@ -38,7 +38,7 @@ feature %q{
         visit "/account"
 
         # No distributors allow changes to orders
-        expect(page).to_not have_content I18n.t('spree.users.orders.open_orders')
+        expect(page).to have_no_content I18n.t('spree.users.orders.open_orders')
 
         expect(page).to have_content I18n.t('spree.users.orders.past_orders')
 

--- a/spec/features/consumer/cookies_spec.rb
+++ b/spec/features/consumer/cookies_spec.rb
@@ -5,7 +5,7 @@ feature "Cookies", js: true do
     describe "in the homepage" do
       before do
         Spree::Config[:cookies_consent_banner_toggle] = true
-        visit root_path       
+        visit root_path
       end
 
       scenario "does not show after cookies are accepted" do
@@ -32,7 +32,7 @@ feature "Cookies", js: true do
       end
 
       scenario "it is showing" do
-        visit "/shops"      
+        visit "/shops"
         expect_visible_cookies_banner
       end
     end
@@ -41,7 +41,7 @@ feature "Cookies", js: true do
       scenario "it is not showing" do
         Spree::Config[:cookies_consent_banner_toggle] = false
         visit root_path
-        expect(page).to_not have_content I18n.t('legal.cookies_banner.cookies_usage')
+        expect(page).to have_no_content I18n.t('legal.cookies_banner.cookies_usage')
       end
     end
   end
@@ -65,7 +65,7 @@ feature "Cookies", js: true do
       scenario "does not show Matomo cookies details" do
         Spree::Config[:cookies_policy_matomo_section] = false
         visit '/#/policies/cookies'
-        expect(page).to_not have_content matomo_description_text
+        expect(page).to have_no_content matomo_description_text
       end
     end
   end
@@ -83,7 +83,7 @@ feature "Cookies", js: true do
   end
 
   def expect_not_visible_cookies_banner
-    expect(page).to_not have_css("button", :text => accept_cookies_button_text, :visible => true)
+    expect(page).to have_no_css("button", :text => accept_cookies_button_text, :visible => true)
   end
 
   def accept_cookies_button_text

--- a/spec/features/consumer/footer_links_spec.rb
+++ b/spec/features/consumer/footer_links_spec.rb
@@ -18,7 +18,7 @@ feature "Footer Links", js: true do
     scenario "not showing if it is empty" do
       Spree::Config[:privacy_policy_url] = nil
       visit root_path
-      expect(page).to_not have_link "privacy policy"
+      expect(page).to have_no_link "privacy policy"
     end
 
     scenario "showing configured privacy policy link" do

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -79,7 +79,7 @@ feature 'Multilingual', js: true do
 
       it "hides the dropdown language menu" do
         visit root_path
-        expect(page).to_not have_css 'ul.right li.language-switcher.has-dropdown'
+        expect(page).to have_no_css 'ul.right li.language-switcher.has-dropdown'
       end
     end
 

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -24,7 +24,7 @@ feature "full-page cart", js: true do
       it "does not link to the product page" do
         add_product_to_cart order, product_fee, quantity: 2
         visit spree.cart_path
-        expect(page).to_not have_selector '.item-thumb-image a'
+        expect(page).to have_no_selector '.item-thumb-image a'
       end
     end
 
@@ -76,7 +76,7 @@ feature "full-page cart", js: true do
 
         it 'hides admin and handlings row' do
           expect(page).to have_selector('#cart-detail')
-          expect(page).to_not have_content('Admin & Handling')
+          expect(page).to have_no_content('Admin & Handling')
           expect(page).to have_selector '.cart-item-price',         text: with_currency(0.86)
           expect(page).to have_selector '.order-total.grand-total', text: with_currency(1.72) # price * 3
         end
@@ -155,8 +155,8 @@ feature "full-page cart", js: true do
         item1 = prev_order1.line_items.first
         item2 = prev_order2.line_items.first
 
-        expect(page).to_not have_content item1.variant.name
-        expect(page).to_not have_content item2.variant.name
+        expect(page).to have_no_content item1.variant.name
+        expect(page).to have_no_content item2.variant.name
 
         expect(page).to have_link I18n.t(:orders_bought_edit_button), href: spree.account_path
         find("td.toggle-bought").click

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -27,7 +27,7 @@ feature "As a consumer I want to check out my cart", js: true do
       quick_login_as user
       visit checkout_path
       within "section[role='main']" do
-        expect(page).to_not have_content "Login"
+        expect(page).to have_no_content "Login"
         expect(page).to have_checkout_details
       end
     end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -121,7 +121,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         end
 
         it "it doesn't tell about previous orders" do
-          expect(page).to_not have_content("You have an order for this order cycle already.")
+          expect(page).to have_no_content("You have an order for this order cycle already.")
         end
       end
 
@@ -200,7 +200,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
           expect(page).to have_content I18n.t("spree.checkout.payment.stripe.used_saved_card")
 
           # default card is selected, form element is not shown
-          expect(page).to_not have_selector "#card-element.StripeElement"
+          expect(page).to have_no_selector "#card-element.StripeElement"
           expect(page).to have_select 'selected_card', selected: "Visa x-1111 Exp:01/2025"
 
           # allows checkout

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -31,7 +31,7 @@ feature "Order Management", js: true do
         expect(find("tr.variant-#{item1.variant.id}")).to have_content item1.product.name
         expect(find("tr.variant-#{item2.variant.id}")).to have_content item2.product.name
         expect(find("tr.variant-#{item3.variant.id}")).to have_content item3.product.name
-        expect(page).to_not have_button I18n.t(:save_changes)
+        expect(page).to have_no_button I18n.t(:save_changes)
       end
     end
 
@@ -50,7 +50,7 @@ feature "Order Management", js: true do
         visit spree.order_path(order)
 
         expect(page).to have_button I18n.t(:order_saved), disabled: true
-        expect(page).to_not have_button I18n.t(:save_changes)
+        expect(page).to have_no_button I18n.t(:save_changes)
 
         # Changing the quantity of an item
         within "tr.variant-#{item1.variant.id}" do


### PR DESCRIPTION
I noticed you're using `to_not have` expectations on some feature tests. I'm pretty sure that you'd be better switching these to Capybara's negative selector, as you'll avoid Capybara waiting the full length of time until it times out for each of these tests.

Check out the Capybara finders section of [this blog post](https://blog.codeship.com/faster-rails-tests/) for more details.