### PR TITLE
Configure mail TLS or SSL connection when seeding

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -30,6 +30,7 @@ SMTP_USERNAME: 'ofn'
 SMTP_PASSWORD: 'f00d'
 
 # Optional mail settings
+# MAIL_SECURE_CONNECTION: 'TLS' # 'None' (default), 'SSL' or 'TLS'
 # MAILS_FROM: hello@example.com
 # MAIL_BCC: manager@example.com
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,7 +42,7 @@ def create_mail_method
     preferred_mail_auth_type: 'login',
     preferred_smtp_username: ENV.fetch('SMTP_USERNAME'),
     preferred_smtp_password: ENV.fetch('SMTP_PASSWORD'),
-    preferred_secure_connection_type: 'None',
+    preferred_secure_connection_type: ENV.fetch('MAIL_SECURE_CONNECTION', 'None'),
     preferred_mails_from: ENV.fetch('MAILS_FROM', "no-reply@#{ENV.fetch('MAIL_DOMAIN')}"),
     preferred_mail_bcc: ENV.fetch('MAIL_BCC', ''),
     preferred_intercept_email: ''


### PR DESCRIPTION
#### What? Why?

First part of https://github.com/openfoodfoundation/ofn-install/issues/239.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This allows to seed the secure connection type of the default mail
method. Most servers should use transport encryption when sending emails. For example, the new Australian staging server couldn't send email out of the box, because Gmail doesn't except insecure connections.

#### What should we test?
<!-- List which features should be tested and how. -->

No user testing required.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Simplified initial mail configuration.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

