### PR TITLE
Bump active_model_serializer to 0.8.4, and pin it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,10 @@ gem 'andand'
 gem 'truncate_html'
 gem 'representative_view'
 gem 'rabl'
-gem "active_model_serializers"
+
+# AMS is pinned to 0.8.4 because 0.9.x is a complete re-write, as is 0.10.x
+# Once Rails is updated to 5.x we should bump directly to 0.10.x
+gem "active_model_serializers", "0.8.4"
 gem 'oj'
 gem 'deface', github: 'spree/deface', ref: '1110a13'
 gem 'paperclip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
-    active_model_serializers (0.8.3)
+    active_model_serializers (0.8.4)
       activemodel (>= 3.0)
     activemerchant (1.78.0)
       activesupport (>= 3.2.14, < 6.x)
@@ -468,7 +468,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.6.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.11)
+    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -484,7 +484,7 @@ GEM
       railties (>= 3.1)
     money (5.1.0)
       i18n (~> 0.6.0)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
@@ -579,7 +579,7 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.2.3)
-    ref (1.0.5)
+    ref (2.0.0)
     representative (1.0.5)
       activesupport (>= 2.2.2)
       builder (>= 2.1.2)
@@ -660,8 +660,8 @@ GEM
     stringex (1.3.3)
     stripe (3.3.1)
       faraday (~> 0.9)
-    therubyracer (0.12.0)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.20.0)
     tilt (1.4.1)
@@ -712,7 +712,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers
+  active_model_serializers (= 0.8.4)
   activemerchant (~> 1.78)
   acts-as-taggable-on (~> 3.4)
   andand
@@ -815,4 +815,4 @@ RUBY VERSION
    ruby 2.1.5p273
 
 BUNDLED WITH
-   1.16.2
+   1.16.4


### PR DESCRIPTION
Also bump `therubyracer` from `0.12.0` to `0.12.3`, because I was finding `0.12.0` impossible to install!

See https://github.com/rails-api/active_model_serializers#status-of-ams for details of what's happening with AMS. At some point (after a Rails update) it may make sense to update to the `0.10.x` branch, but it *doesn't* make sense to go to `0.9.x` first. When the time comes for that there's a guide [here](https://github.com/rails-api/active_model_serializers/blob/v0.10.6/docs/howto/upgrade_from_0_8_to_0_10.md).

Changelog for this release is at https://github.com/rails-api/active_model_serializers/blob/v0.8.4/CHANGELOG.md.