### PR TITLE
Spree 2 Upgrade - MailMethod - Fixed bug on order_mailer_decorator (only visible in spree 2)

### DIFF
--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -3,43 +3,42 @@ Spree::OrderMailer.class_eval do
   helper CheckoutHelper
   helper SpreeCurrencyHelper
 
-  def cancel_email(order, resend = false)
-    @order = find_order(order)
-    subject = (resend ? "[#{t(:resend).upcase}] " : '')
-    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{@order.number}"
-    mail(to: @order.email, from: from_address, subject: subject)
-  end
-
-  def confirm_email_for_customer(order, resend = false)
-    find_order(order) # Finds an order instance from an id
-    subject = (resend ? "[#{t(:resend).upcase}] " : '')
-    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
+  def confirm_email_for_customer(order_or_order_id, resend = false)
+    @order = find_order(order_or_order_id)
+    subject = build_subject(t('order_mailer.confirm_email.subject'), resend)
     mail(:to => @order.email,
          :from => from_address,
          :subject => subject,
          :reply_to => @order.distributor.contact.email)
   end
 
-  def confirm_email_for_shop(order, resend = false)
-    find_order(order) # Finds an order instance from an id
-    subject = (resend ? "[#{t(:resend).upcase}] " : '')
-    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
+  def confirm_email_for_shop(order_or_order_id, resend = false)
+    @order = find_order(order_or_order_id)
+    subject = build_subject(t('order_mailer.confirm_email.subject'), resend)
     mail(:to => @order.distributor.contact.email,
          :from => from_address,
          :subject => subject)
   end
 
-  def invoice_email(order, pdf)
-    find_order(order) # Finds an order instance from an id
+  def invoice_email(order_or_order_id, pdf)
+    @order = find_order(order_or_order_id)
+    subject = build_subject(t(:invoice))
     attachments["invoice-#{@order.number}.pdf"] = pdf if pdf.present?
-    subject = "#{Spree::Config[:site_name]} #{t(:invoice)} ##{@order.number}"
     mail(:to => @order.email,
          :from => from_address,
          :subject => subject,
          :reply_to => @order.distributor.contact.email)
   end
 
-  def find_order(order)
-    @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
+  private
+
+  # Finds an order instance from an order or from an order id
+  def find_order(order_or_order_id)
+    order_or_order_id.respond_to?(:id) ? order_or_order_id : Spree::Order.find(order_or_order_id)
+  end
+
+  def build_subject( subject_text, resend = false )
+    subject = (resend ? "[#{t(:resend).upcase}] " : "")
+    subject += "#{Spree::Config[:site_name]} #{subject_text} ##{@order.number}"
   end
 end

--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -6,8 +6,8 @@ Spree::OrderMailer.class_eval do
   def cancel_email(order, resend = false)
     @order = find_order(order)
     subject = (resend ? "[#{t(:resend).upcase}] " : '')
-    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{order.number}"
-    mail(to: order.email, from: from_address, subject: subject)
+    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{@order.number}"
+    mail(to: @order.email, from: from_address, subject: subject)
   end
 
   def confirm_email_for_customer(order, resend = false)

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Spree::OrderMailer do
-  let!(:mail_method) { create(:mail_method, preferred_mails_from: 'spree@example.com') }
-
   describe "order confimation" do
     after do
       ActionMailer::Base.deliveries.clear

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -3,8 +3,6 @@ require 'spec_helper'
 describe SubscriptionMailer do
   include ActionView::Helpers::SanitizeHelper
 
-  let!(:mail_method) { create(:mail_method, preferred_mails_from: 'spree@example.com') }
-
   describe "order placement" do
     let(:subscription) { create(:subscription, with_items: true) }
     let(:proxy_order) { create(:proxy_order, subscription: subscription) }


### PR DESCRIPTION
When cancel_email is called with order id in paramater order, order.number will fail. This is only seen in spree 2 because only spree 2 calls this method with order id. Bug introduced here: https://github.com/openfoodfoundation/openfoodnetwork/commit/32d2adc8a24f4352e8c6a0b179fe9ef351295f6d#diff-aa82d768109073ea8ad7858146630be4R9. Spree change introduced here: https://github.com/spree/spree/commit/8d90ae15f807467ffbcc20e779c9ffead577df2a#diff-1e2ba31309f1f1abd2a4b626036d316fR94

We dont need to put this in master because this is not a problem in spree 1 because cancel_email is always called with order (not order id) in spree 1.

#### What? Why?

Related to #2020 

Detected while fixing mailmethod related spec errors.
This error appears in spec/controllers/spree/orders_controller_spec.rb:407 (but only seen after PR #2574 fixes are applied as well).

#### What should we test?
After PR #2574 is applied, this PR gets spec/controllers/spree/orders_controller_spec.rb:404 to green.

#### How is this related to the Spree upgrade?
This is part of getting the spree2 branch build to green.

#### Dependencies
This is related to PR #2574 but can go first.
