### PR TITLE
Spree 2 Upgrade - MailMethod - Fix "undefined mail method" error in specs

### DIFF
--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -626,10 +626,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
             context "when at least one associate orders is 'canceled'" do
               before do
-                Spree::MailMethod.create!(
-                  environment: Rails.env,
-                  preferred_mails_from: 'spree@example.com'
-                )
+                Spree::Config[:mails_from] = "spree@example.com"
                 proxy_order.cancel
               end
 

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -180,10 +180,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         context "when the distributor's ABN has been set" do
           before { distributor.update_attribute(:abn, "123") }
           before do
-            Spree::MailMethod.create!(
-              environment: Rails.env,
-              preferred_mails_from: 'spree@example.com'
-            )
+            Spree::Config[:mails_from] = "spree@example.com"
           end
           it "should allow me to send order invoices" do
             expect do

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -398,10 +398,7 @@ describe Spree::OrdersController, type: :controller do
         let(:order) { create(:completed_order_with_totals, user: user) }
 
         before do
-          Spree::MailMethod.create!(
-            environment: Rails.env,
-            preferred_mails_from: 'spree@example.com'
-          )
+          Spree::Config[:mails_from] = "spree@example.com"
         end
 
         it "responds with success" do

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -32,7 +32,6 @@ describe UserPasswordsController, type: :controller do
   end
 
   it "renders Darkswarm" do
-    Spree::MailMethod.create!(environment: 'test')
     clear_jobs
 
     user.send_reset_password_instructions

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -37,10 +37,7 @@ feature "Order Management", js: true do
 
     context "when the distributor allows changes to be made to orders" do
       before do
-        Spree::MailMethod.create!(
-          environment: Rails.env,
-          preferred_mails_from: 'spree@example.com'
-        )
+        Spree::Config[:mails_from] = "spree@example.com"
       end
       before do
         order.distributor.update_attributes(allow_order_changes: true)

--- a/spec/mailers/enterprise_mailer_spec.rb
+++ b/spec/mailers/enterprise_mailer_spec.rb
@@ -6,7 +6,6 @@ describe EnterpriseMailer do
 
   before do
     ActionMailer::Base.deliveries = []
-    Spree::MailMethod.create!(environment: 'test')
   end
 
   describe "#welcome" do

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -3,10 +3,7 @@ require 'yaml'
 
 describe ProducerMailer do
   before do
-    Spree::MailMethod.create!(
-      environment: Rails.env,
-      preferred_mails_from: 'spree@example.com'
-    )
+    Spree::Config[:mails_from] = "spree@example.com"
   end
   let!(:zone) { create(:zone_with_member) }
   let!(:tax_rate) { create(:tax_rate, included_in_price: true, calculator: Spree::Calculator::DefaultTax.new, zone: zone, amount: 0.1) }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -11,8 +11,6 @@ describe Spree::UserMailer do
     ActionMailer::Base.delivery_method = :test
     ActionMailer::Base.perform_deliveries = true
     ActionMailer::Base.deliveries = []
-
-    Spree::MailMethod.create!(environment: 'test')
   end
 
   it "sends an email when given a user" do

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -531,7 +531,7 @@ describe OrderCycle do
 
     it "only returns items from non-cancelled orders in the OC, placed by the user at the shop" do
       items = oc.items_bought_by_user(user, shop)
-      expect(items).to eq order1.reload.line_items
+      expect(items).to match_array order1.reload.line_items
     end
   end
 end

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -525,10 +525,7 @@ describe OrderCycle do
     let!(:order5) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: oc)  }
 
     before do
-      Spree::MailMethod.create!(
-        environment: Rails.env,
-        preferred_mails_from: 'spree@example.com'
-      )
+      Spree::Config[:mails_from] = "spree@example.com"
     end
     before { order5.cancel }
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -495,10 +495,7 @@ describe Spree::Order do
   describe "scopes" do
     describe "not_state" do
       before do
-        Spree::MailMethod.create!(
-          environment: Rails.env,
-          preferred_mails_from: 'spree@example.com'
-        )
+        Spree::Config[:mails_from] = "spree@example.com"
       end
 
       it "finds only orders not in specified state" do


### PR DESCRIPTION
#### What? Why?

Closes #2020 

Doing exactly what's described in #2020.

#### What should we test?
All these specs should now have progressed to green or other errors as described below.

Tests not verifiable right now as tests fail with other errors:
- spec/controllers/admin/subscriptions_controller_spec.rb:627 (2 tests)
- spec/jobs/subscription_confirm_job_spec.rb:104 (3 tests)

Tests with new errors:
- spec/controllers/spree/admin/orders_controller_spec.rb:180
       - other error related to email expectations
- spec/features/consumer/shopping/orders_spec.rb:38
       - other unrelated error
- spec/mailers/producer_mailer_spec.rb:4 (10 tests)
       - other error related to email expectations
- spec/mailers/enterprise_mailer_spec.rb:3
      - other error related to email expectations

Green tests:
- spec/controllers/spree/orders_controller_spec.rb:397
        - green after PR #2587 and PR #2574
- spec/models/order_cycle_spec.rb:517
        - green - I had to add a array sort in this spec expectation
- spec/models/spree/order_spec.rb:495
        - green
- spec/controllers/user_passwords_controller_spec.rb:34
       - green, just removed MailMethod call (this call is no longer needed)
- spec/mailers/user_mailer_spec.rb:4 (5 tests)
       - green, just removed MailMethod call

#### How is this related to the Spree upgrade?
This is part of getting the spree2 branch build to green.

#### Dependencies
This is related to PR #2587 and PR #2574 but can go first.