### PR TITLE
Spree 2 Upgrade - MailMethod - Delete outdated base_mailer_decorator.from_address

### DIFF
--- a/app/mailers/spree/base_mailer_decorator.rb
+++ b/app/mailers/spree/base_mailer_decorator.rb
@@ -7,13 +7,6 @@ Spree::BaseMailer.class_eval do
 
   protected
 
-  # This method copies the one defined in Spree's mailers. It should be removed
-  # once in Spree v2.0 and Spree's BaseMailer class lands in our codebase.
-  # Then, we'll be able to rely on its #from_address.
-  def from_address
-    Spree::MailMethod.current.preferred_mails_from
-  end
-
   def roadie_options
     # This lets us specify assets using relative paths in email templates
     super.merge(url_options: {host: URI(spree.root_url).host })


### PR DESCRIPTION
#### What? Why?

Closes #2198

Base_mailer_decorator.from_address is outdated as it used old MailMethod.
This way we rely on the correct spree base_mailer.from_address (that gets it from Spree::Config.

#### What should we test?
This PR helps some of the tests in PR #2588 move to green or to new errors.

#### Release notes
Adapter Base Mailer to Spree 2.
Changelog Category: Changed

#### How is this related to the Spree upgrade?
This is part of getting the spree2 branch build to green.

#### Dependencies
Related but not dependent on #2588
