### PR TITLE
Remove gem rack-livereload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,7 +136,6 @@ group :development do
   gem 'guard'
   gem 'listen', '3.0.8' # 3.1.0 requires ruby 2.2
   gem 'guard-livereload'
-  gem 'rack-livereload'
   gem 'guard-rails'
   gem 'guard-rspec', '~> 4.7.3'
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -541,8 +541,6 @@ GEM
     rack (1.4.7)
     rack-cache (1.7.1)
       rack (>= 0.4)
-    rack-livereload (0.3.17)
-      rack
     rack-rewrite (1.5.1)
     rack-ssl (1.3.4)
       rack
@@ -775,7 +773,6 @@ DEPENDENCIES
   poltergeist (>= 1.16.0)
   pry-byebug (>= 3.4.3)
   rabl
-  rack-livereload
   rack-rewrite
   rack-ssl
   rails (~> 3.2.22)


### PR DESCRIPTION
#### What? Why?

I don't think that anybody is using it. I asked on Slack and people
didn't know what it was. I kept guard-livereload which is probably
offering the same, maybe even better.



#### What should we test?


No manual tests needed.



#### Release notes

Removed outdated and unused development tool rack-livereload.



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Removed

#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->


https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1534985553000100

This came up in https://github.com/openfoodfoundation/openfoodnetwork/pull/2569.