### PR TITLE
[Cookies] Increased cookies banner font size for med/large screens to improve readability

### DIFF
--- a/app/assets/stylesheets/darkswarm/cookies_banner.css.scss
+++ b/app/assets/stylesheets/darkswarm/cookies_banner.css.scss
@@ -4,20 +4,8 @@
   background: $dark-grey;
   bottom: 0;
   position: fixed;
-  top: 20vh !important;
+  top: 15% !important;
   z-index: 100000;
-
-  @media only screen and (min-width: 640px) {
-    top: 20vh !important;
-  }
-
-  @media only screen and (min-width: 800px) and (min-height: 400px) {
-    top: 40vh !important;
-  }
-
-  @media only screen and (min-width: 1024px) and (min-height: 500px) {
-    top: 60vh !important;
-  }
 
   button {
     background-color: $clr-turquoise;
@@ -26,5 +14,21 @@
   p {
     color: $white;
     font-size: .75rem;
+  }
+
+  @media only screen and (min-width: 800px) and (min-height: 560px) {
+    top: 40% !important;
+
+    p {
+      font-size: 1rem;
+    }
+  }
+
+  @media only screen and (min-width: 1024px) and (min-height: 660px) {
+    top: 60% !important;
+
+    p {
+      font-size: 1rem;
+    }
   }
 }

--- a/spec/features/consumer/cookies_spec.rb
+++ b/spec/features/consumer/cookies_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 
 feature "Cookies", js: true do
   describe "banner" do
+    
+    # keeps banner toggle config unchanged
+    around do |example|
+      original_banner_toggle = Spree::Config[:cookies_consent_banner_toggle]
+      example.run
+      Spree::Config[:cookies_consent_banner_toggle] = original_banner_toggle
+    end
+
     describe "in the homepage" do
       before do
         Spree::Config[:cookies_consent_banner_toggle] = true
@@ -52,6 +60,14 @@ feature "Cookies", js: true do
   end
 
   describe "policy page" do
+
+    # keeps config unchanged
+    around do |example|
+      original_config_value = Spree::Config[:cookies_policy_matomo_section]
+      example.run
+      Spree::Config[:cookies_policy_matomo_section] = original_config_value
+    end
+
     scenario "showing session_id cookies description with correct instance domain" do
       visit '/#/policies/cookies'
       expect(page).to have_content('_session_id')


### PR DESCRIPTION
#### What? Why?

Closes #2597 

Increased font size for med/large screens and adapted CSS to keep the text and button visible in all screen sizes.

#### What should we test?
The cookies banner should be tested in terms of UX in different screen sizes. Functionality was not changed.

#### Release notes
Changelog Category: Changed

Cookies banner font size increased.