### PR TITLE
Favor #public_send over #send using Rubocop's cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19_no_mixed_keys
 
+Style/Send:
+  Enabled: true
+
 Layout/MultilineMethodCallIndentation:
   Enabled: true
   EnforcedStyle: indented

--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -14,7 +14,7 @@ module Admin
     def update
       params.each do |name, value|
         if ContentConfig.has_preference?(name) || ContentConfig.has_attachment?(name)
-          ContentConfig.send("#{name}=", value)
+          ContentConfig.public_send("#{name}=", value)
         end
       end
 

--- a/app/controllers/admin/inventory_items_controller.rb
+++ b/app/controllers/admin/inventory_items_controller.rb
@@ -19,7 +19,7 @@ module Admin
     # we can authorise #create using an object with required attributes
     def build_resource
       if parent_data.present?
-        parent.send(controller_name).build
+        parent.public_send(controller_name).build
       else
         model_class.new(params[object_name]) # This line changed
       end

--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -53,7 +53,7 @@ module Admin
       @importer = ProductImport::ProductImporter.new(File.new(params[:filepath]), spree_current_user, start: params[:start], end: params[:end], settings: params[:settings])
 
       begin
-        @importer.send("#{method}_entries")
+        @importer.public_send("#{method}_entries")
       rescue StandardError => e
         render json: e.message, response: 500
         return false

--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -15,18 +15,18 @@ module Admin
 
     def edit_object_url(object, options = {})
       if parent_data.present?
-        main_app.send "edit_admin_#{model_name}_#{object_name}_url", parent, object, options
+        main_app.public_send "edit_admin_#{model_name}_#{object_name}_url", parent, object, options
       else
-        main_app.send "edit_admin_#{object_name}_url", object, options
+        main_app.public_send "edit_admin_#{object_name}_url", object, options
       end
     end
 
     def object_url(object = nil, options = {})
       target = object ? object : @object
       if parent_data.present?
-        main_app.send "admin_#{model_name}_#{object_name}_url", parent, target, options
+        main_app.public_send "admin_#{model_name}_#{object_name}_url", parent, target, options
       else
-        main_app.send "admin_#{object_name}_url", target, options
+        main_app.public_send "admin_#{object_name}_url", target, options
       end
     end
 

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -77,7 +77,7 @@ class EnterprisesController < BaseController
 
   def reset_user_and_customer(order)
     order.associate_user!(spree_current_user) if order.user.blank? || order.email.blank?
-    order.send(:associate_customer) if order.customer.nil? # Only associates existing customers
+    order.__send__(:associate_customer) if order.customer.nil? # Only associates existing customers
   end
 
   def reset_order_cycle(order, distributor)

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -44,7 +44,7 @@ class ShopController < BaseController
   private
 
   def filtered_json(products_json)
-    if applicator.send(:rules).any?
+    if applicator.rules.any?
       filter(products_json)
     else
       products_json

--- a/app/controllers/spree/admin/general_settings_controller_decorator.rb
+++ b/app/controllers/spree/admin/general_settings_controller_decorator.rb
@@ -10,6 +10,6 @@ module Spree
         @preferences_general << :bugherd_api_key
       end
     end
-    GeneralSettingsController.send(:prepend, GeneralSettingsEditPreferences)
+    GeneralSettingsController.prepend(GeneralSettingsEditPreferences)
   end
 end

--- a/app/controllers/spree/admin/payment_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/payment_methods_controller_decorator.rb
@@ -10,7 +10,7 @@ module Spree
       # Only show payment methods that user has access to and sort by distributor name
       # ! Redundant code copied from Spree::Admin::ResourceController with modifications marked
       def collection
-        return parent.send(controller_name) if parent_data.present?
+        return parent.public_send(controller_name) if parent_data.present?
         collection = if model_class.respond_to?(:accessible_by) &&
                          !current_ability.has_block?(params[:action], model_class)
 

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -10,7 +10,7 @@ Spree::Admin::PaymentsController.class_eval do
 
     # Because we have a transition method also called void, we do this to avoid conflicts.
     event = "void_transaction" if event == "void"
-    if @payment.send("#{event}!")
+    if @payment.public_send("#{event}!")
       flash[:success] = t(:payment_updated)
     else
       flash[:error] = t(:cannot_perform_operation)

--- a/app/controllers/spree/admin/resource_controller_decorator.rb
+++ b/app/controllers/spree/admin/resource_controller_decorator.rb
@@ -13,4 +13,4 @@ module AuthorizeOnLoadResource
   end
 end
 
-Spree::Admin::ResourceController.send(:prepend, AuthorizeOnLoadResource)
+Spree::Admin::ResourceController.prepend(AuthorizeOnLoadResource)

--- a/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/shipping_methods_controller_decorator.rb
@@ -7,7 +7,7 @@ module Spree
       # Sort shipping methods by distributor name
       # ! Code copied from Spree::Admin::ResourceController with two added lines
       def collection
-        return parent.send(controller_name) if parent_data.present?
+        return parent.public_send(controller_name) if parent_data.present?
 
         collection = if model_class.respond_to?(:accessible_by) &&
                          !current_ability.has_block?(params[:action], model_class)

--- a/app/helpers/angular_form_builder.rb
+++ b/app/helpers/angular_form_builder.rb
@@ -7,10 +7,6 @@ class AngularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def ng_text_field(method, options = {})
-    # @object_name --> "enterprise_fee_set"
-    # @fields_for_record_name --> :collection
-    # @object.send(@fields_for_record_name).first.class.to_s.underscore --> enterprise_fee
-
     value = "{{ #{angular_model(method)} }}"
     options.reverse_merge!({'id' => angular_id(method)})
 
@@ -46,6 +42,6 @@ class AngularFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def angular_model(method)
-    "#{@object.send(@fields_for_record_name).first.class.to_s.underscore}.#{method}"
+    "#{@object.public_send(@fields_for_record_name).first.class.to_s.underscore}.#{method}"
   end
 end

--- a/app/helpers/angular_form_helper.rb
+++ b/app/helpers/angular_form_helper.rb
@@ -11,7 +11,7 @@ module AngularFormHelper
 
   def ng_options_from_collection_for_select(collection, value_method, text_method, angular_field)
     options = collection.map do |element|
-      [element.send(text_method), element.send(value_method)]
+      [element.public_send(text_method), element.public_send(value_method)]
     end
 
     ng_options_for_select(options, angular_field)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
   # spree.foo_path in any view rendered from non-spree-namespaced controllers.
   def method_missing(method, *args, &block)
     if (method.to_s.end_with?('_path') || method.to_s.end_with?('_url')) && spree.respond_to?(method)
-      spree.send(method, *args)
+      spree.public_send(method, *args)
     else
       super
     end

--- a/app/models/column_preference.rb
+++ b/app/models/column_preference.rb
@@ -20,7 +20,7 @@ class ColumnPreference < ActiveRecord::Base
 
   def self.for(user, action_name)
     stored_preferences = where(user_id: user.id, action_name: action_name)
-    default_preferences = send("#{action_name}_columns")
+    default_preferences = __send__("#{action_name}_columns")
     filter(default_preferences, user, action_name)
     default_preferences.each_with_object([]) do |(column_name, default_attributes), preferences|
       stored_preference = stored_preferences.find_by_column_name(column_name)
@@ -37,7 +37,7 @@ class ColumnPreference < ActiveRecord::Base
   private
 
   def self.valid_columns_for(action_name)
-    send("#{action_name}_columns").keys.map(&:to_s)
+    __send__("#{action_name}_columns").keys.map(&:to_s)
   end
 
   def self.known_actions

--- a/app/models/model_set.rb
+++ b/app/models/model_set.rb
@@ -12,7 +12,7 @@ class ModelSet
     @collection = attributes[:collection] if attributes[:collection]
 
     attributes.each do |name, value|
-      send("#{name}=", value)
+      public_send("#{name}=", value)
     end
   end
 

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -204,7 +204,7 @@ module ProductImport
         when 'overwrite_all'
           object.assign_attributes(attribute => setting['value'])
         when 'overwrite_empty'
-          if object.send(attribute).blank? || ((attribute == 'on_hand' || attribute == 'count_on_hand') && entry.on_hand_nil)
+          if object.public_send(attribute).blank? || ((attribute == 'on_hand' || attribute == 'count_on_hand') && entry.on_hand_nil)
             object.assign_attributes(attribute => setting['value'])
           end
         end

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -169,7 +169,7 @@ module ProductImport
       return if category.blank?
 
       if index.key? category
-        entry.send("#{type}_category_id=", index[category])
+        entry.public_send("#{type}_category_id=", index[category])
       else
         mark_as_invalid(entry, attribute: "#{type}_category", error: I18n.t('admin.product_import.model.not_found'))
       end

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -71,7 +71,7 @@ module ProductImport
 
       units.converted_attributes.each do |attr, value|
         if respond_to?("#{attr}=")
-          send("#{attr}=", value) unless non_product_attributes.include?(attr)
+          public_send("#{attr}=", value) unless non_product_attributes.include?(attr)
         end
       end
     end

--- a/app/models/proxy_order.rb
+++ b/app/models/proxy_order.rb
@@ -19,7 +19,7 @@ class ProxyOrder < ActiveRecord::Base
   def state
     # NOTE: the order is important here
     %w(canceled paused pending cart).each do |state|
-      return state if send("#{state}?")
+      return state if __send__("#{state}?")
     end
     order.state
   end
@@ -32,7 +32,7 @@ class ProxyOrder < ActiveRecord::Base
     return false unless order_cycle.orders_close_at.andand > Time.zone.now
     transaction do
       update_column(:canceled_at, Time.zone.now)
-      order.send('cancel') if order
+      order.cancel if order
       true
     end
   end
@@ -41,7 +41,7 @@ class ProxyOrder < ActiveRecord::Base
     return false unless order_cycle.orders_close_at.andand > Time.zone.now
     transaction do
       update_column(:canceled_at, nil)
-      order.send('resume') if order
+      order.resume if order
       true
     end
   end

--- a/app/models/spree/calculator/default_tax_decorator.rb
+++ b/app/models/spree/calculator/default_tax_decorator.rb
@@ -18,15 +18,15 @@ Spree::Calculator::DefaultTax.class_eval do
 
     # Added this block, finds relevant fees for each line_item, calculates the tax on them, and returns the total tax
     per_item_fees_total = order.line_items.sum do |line_item|
-      calculator.send(:per_item_enterprise_fee_applicators_for, line_item.variant)
+      calculator.per_item_enterprise_fee_applicators_for(line_item.variant)
         .select { |applicator| (!applicator.enterprise_fee.inherits_tax_category && applicator.enterprise_fee.tax_category == rate.tax_category) ||
-          (applicator.enterprise_fee.inherits_tax_category && line_item.product.tax_category == rate.tax_category) 
+          (applicator.enterprise_fee.inherits_tax_category && line_item.product.tax_category == rate.tax_category)
         }
         .sum { |applicator| applicator.enterprise_fee.compute_amount(line_item) }
     end
 
     # Added this block, finds relevant fees for whole order, calculates the tax on them, and returns the total tax
-    per_order_fees_total = calculator.send(:per_order_enterprise_fee_applicators_for, order)
+    per_order_fees_total = calculator.per_order_enterprise_fee_applicators_for(order)
       .select { |applicator| applicator.enterprise_fee.tax_category == rate.tax_category }
       .sum { |applicator| applicator.enterprise_fee.compute_amount(order) }
 

--- a/app/models/spree/preferences/file_configuration.rb
+++ b/app/models/spree/preferences/file_configuration.rb
@@ -15,7 +15,7 @@ module Spree::Preferences
 
     def get_preference(key)
       if !has_preference?(key) && has_attachment?(key)
-        send key
+        public_send key
       else
         super key
       end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -51,7 +51,7 @@ class Subscription < ActiveRecord::Base
   def state
     # NOTE: the order is important here
     %w(canceled paused pending ended).each do |state|
-      return state if send("#{state}?")
+      return state if __send__("#{state}?")
     end
     "active"
   end

--- a/app/serializers/api/admin/enterprise_fee_serializer.rb
+++ b/app/serializers/api/admin/enterprise_fee_serializer.rb
@@ -15,7 +15,7 @@ class Api::Admin::EnterpriseFeeSerializer < ActiveModel::Serializer
 
     result = nil
 
-    options[:controller].send(:with_format, :html) do
+    options[:controller].__send__(:with_format, :html) do
       result = options[:controller].render_to_string :partial => 'admin/enterprise_fees/calculator_settings', :locals => {:enterprise_fee => object}
     end
 

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -83,7 +83,7 @@ class OrderSyncer
 
   def addresses_match?(order_address, subscription_address)
     relevant_address_attrs.all? do |attr|
-      order_address[attr] == subscription_address.send("#{attr}_was") ||
+      order_address[attr] == subscription_address.public_send("#{attr}_was") ||
         order_address[attr] == subscription_address[attr]
     end
   end
@@ -101,7 +101,7 @@ class OrderSyncer
   # address on the order matches the shop's address
   def force_ship_address_required?(order)
     return false unless shipping_method.require_ship_address?
-    distributor_address = order.send(:address_from_distributor)
+    distributor_address = order.__send__(:address_from_distributor)
     relevant_address_attrs.all? do |attr|
       order.ship_address[attr] == distributor_address[attr]
     end

--- a/lib/discourse/single_sign_on.rb
+++ b/lib/discourse/single_sign_on.rb
@@ -42,7 +42,7 @@ module Discourse
         if BOOLS.include? k
           val = ["true", "false"].include?(val) ? val == "true" : nil
         end
-        sso.send("#{k}=", val)
+        sso.public_send("#{k}=", val)
       end
 
       decoded_hash.each do |k,v|
@@ -87,9 +87,9 @@ module Discourse
     def unsigned_payload
       payload = {}
       ACCESSORS.each do |k|
-       next if (val = send k) == nil
+        next if (val = public_send k) == nil
 
-       payload[k] = val
+        payload[k] = val
       end
 
       if @custom_fields

--- a/lib/open_food_network/address_finder.rb
+++ b/lib/open_food_network/address_finder.rb
@@ -12,7 +12,7 @@ module OpenFoodNetwork
       args.each do |arg|
         type = types[arg.class]
         next unless type
-        send("#{type}=", arg)
+        public_send("#{type}=", arg)
       end
     end
 
@@ -22,16 +22,6 @@ module OpenFoodNetwork
 
     def ship_address
       customer_preferred_ship_address || user_preferred_ship_address || fallback_ship_address
-    end
-
-    private
-
-    def types
-      {
-        String      => "email",
-        Customer    => "customer",
-        Spree::User => "user"
-      }
     end
 
     def email=(arg)
@@ -44,6 +34,16 @@ module OpenFoodNetwork
 
     def user=(arg)
       @user ||= arg
+    end
+
+    private
+
+    def types
+      {
+        String      => "email",
+        Customer    => "customer",
+        Spree::User => "user"
+      }
     end
 
     def customer_preferred_bill_address

--- a/lib/open_food_network/enterprise_fee_calculator.rb
+++ b/lib/open_food_network/enterprise_fee_calculator.rb
@@ -58,6 +58,41 @@ module OpenFoodNetwork
       end
     end
 
+    def per_item_enterprise_fee_applicators_for(variant)
+      fees = []
+
+      return [] unless @order_cycle && @distributor
+
+      @order_cycle.exchanges_carrying(variant, @distributor).each do |exchange|
+        exchange.enterprise_fees.per_item.each do |enterprise_fee|
+          fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, variant, exchange.role)
+        end
+      end
+
+      @order_cycle.coordinator_fees.per_item.each do |enterprise_fee|
+        fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, variant, 'coordinator')
+      end
+
+      fees
+    end
+
+    def per_order_enterprise_fee_applicators_for(order)
+      fees = []
+
+      return fees unless @order_cycle && order.distributor
+
+      @order_cycle.exchanges_supplying(order).each do |exchange|
+        exchange.enterprise_fees.per_order.each do |enterprise_fee|
+          fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, nil, exchange.role)
+        end
+      end
+
+      @order_cycle.coordinator_fees.per_order.each do |enterprise_fee|
+        fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, nil, 'coordinator')
+      end
+
+      fees
+    end
 
     private
 
@@ -103,42 +138,6 @@ module OpenFoodNetwork
       # so we meet that interface with a struct.
       line_item = OpenStruct.new variant: variant, quantity: 1, price: variant.price, amount: variant.price
       enterprise_fee.compute_amount(line_item)
-    end
-
-    def per_item_enterprise_fee_applicators_for(variant)
-      fees = []
-
-      return [] unless @order_cycle && @distributor
-
-      @order_cycle.exchanges_carrying(variant, @distributor).each do |exchange|
-        exchange.enterprise_fees.per_item.each do |enterprise_fee|
-          fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, variant, exchange.role)
-        end
-      end
-
-      @order_cycle.coordinator_fees.per_item.each do |enterprise_fee|
-        fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, variant, 'coordinator')
-      end
-
-      fees
-    end
-
-    def per_order_enterprise_fee_applicators_for(order)
-      fees = []
-
-      return fees unless @order_cycle && order.distributor
-
-      @order_cycle.exchanges_supplying(order).each do |exchange|
-        exchange.enterprise_fees.per_order.each do |enterprise_fee|
-          fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, nil, exchange.role)
-        end
-      end
-
-      @order_cycle.coordinator_fees.per_order.each do |enterprise_fee|
-        fees << OpenFoodNetwork::EnterpriseFeeApplicator.new(enterprise_fee, nil, 'coordinator')
-      end
-
-      fees
     end
   end
 end

--- a/lib/open_food_network/paperclippable.rb
+++ b/lib/open_food_network/paperclippable.rb
@@ -4,18 +4,18 @@
 module OpenFoodNetwork
   module Paperclippable
     def self.included(base)
-      base.send :extend, ActiveModel::Naming
-      base.send :extend, ActiveModel::Callbacks
-      base.send :include, ActiveModel::Validations
-      base.send :include, Paperclip::Glue
+      base.extend(ActiveModel::Naming)
+      base.extend(ActiveModel::Callbacks)
+      base.include(ActiveModel::Validations)
+      base.include(Paperclip::Glue)
 
       # Paperclip required callbacks
-      base.send :define_model_callbacks, :save, only: [:after]
-      base.send :define_model_callbacks, :commit, only: [:after]
-      base.send :define_model_callbacks, :destroy, only: [:before, :after]
+      base.define_model_callbacks(:save, only: [:after])
+      base.define_model_callbacks(:commit, only: [:after])
+      base.define_model_callbacks(:destroy, only: [:before, :after])
 
       # Initialise an ID
-      base.send :attr_accessor, :id
+      base.__send__(:attr_accessor, :id)
       base.instance_variable_set :@id, 1
     end
 

--- a/lib/open_food_network/scope_product_to_hub.rb
+++ b/lib/open_food_network/scope_product_to_hub.rb
@@ -8,7 +8,7 @@ module OpenFoodNetwork
     end
 
     def scope(product)
-      product.send :extend, OpenFoodNetwork::ScopeProductToHub::ScopeProductToHub
+      product.extend(OpenFoodNetwork::ScopeProductToHub::ScopeProductToHub)
       product.instance_variable_set :@hub, @hub
       product.instance_variable_set :@variant_overrides, @variant_overrides
     end

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -6,7 +6,7 @@ module OpenFoodNetwork
     end
 
     def scope(variant)
-      variant.send :extend, OpenFoodNetwork::ScopeVariantToHub::ScopeVariantToHub
+      variant.extend(OpenFoodNetwork::ScopeVariantToHub::ScopeVariantToHub)
       variant.instance_variable_set :@hub, @hub
       variant.instance_variable_set :@variant_override, @variant_overrides[variant]
     end

--- a/lib/open_food_network/tag_rule_applicator.rb
+++ b/lib/open_food_network/tag_rule_applicator.rb
@@ -24,6 +24,11 @@ module OpenFoodNetwork
       end
     end
 
+    def rules
+      return @rules unless @rules.nil?
+      @rules = rule_class.prioritised.for(enterprise)
+    end
+
     private
 
     def reject?(element)
@@ -36,11 +41,6 @@ module OpenFoodNetwork
       end
 
       false
-    end
-
-    def rules
-      return @rules unless @rules.nil?
-      @rules = rule_class.prioritised.for(enterprise)
     end
 
     def customer_rules

--- a/lib/spree/api/testing_support/setup.rb
+++ b/lib/spree/api/testing_support/setup.rb
@@ -20,7 +20,9 @@ module Spree
           let!(:current_api_user) do
             user = create(:user)
             user.spree_roles = []
-            enterprises.each { |e| user.enterprise_roles.create(enterprise: send(e)) }
+            enterprises.each do |enterprise|
+              user.enterprise_roles.create(enterprise: public_send(enterprise))
+            end
             user.save!
             user
           end

--- a/lib/stripe/profile_storer.rb
+++ b/lib/stripe/profile_storer.rb
@@ -17,7 +17,7 @@ module Stripe
         attrs = source_attrs_from(response)
         @payment.source.update_attributes!(attrs)
       else
-        @payment.send(:gateway_error, response.message)
+        @payment.__send__(:gateway_error, response.message)
       end
     end
 

--- a/lib/stripe/webhook_handler.rb
+++ b/lib/stripe/webhook_handler.rb
@@ -6,7 +6,7 @@ module Stripe
 
     def handle
       return :unknown unless known_event?
-      send(event_mappings[@event.type])
+      __send__(event_mappings[@event.type])
     end
 
     private


### PR DESCRIPTION
#### What? Why?

Devs keep using `#send` although that method does not preserve
private/protected visibility. Watching after this turned out to be quite
time-consuming while doing code review.

Currently, the Style/Send cop doesn't enforce `#public_send` however
(that's what we want). It simply discourages the use of #send. See
https://github.com/rubocop-hq/rubocop/pull/2081#issuecomment-292251650
for details. So a new entry on the Code Conventions doc has been added
to overcome this limitation:
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Code-Conventions#prefer-public_send-over-send



#### What should we test?
A smoke test, including:

* Product import
* Subscriptions
* Uploading a new logo from Configuration > Contents
* Inventory items (from `admin/variant_overrides` URL)
* Capture (or any other modification to the payment) an order's payment (from `admin/orders/:order_id/payments` URL)
* Enterprise fees

Although very little, these features are affected by this change.

#### Release notes
Ensure devs use `#public_send` over `#send` by enabling a Rubocop cop.

Changelog Category: Added