### PR TITLE
Subscription emails for customer should not link to order page if customer has no user account

### DIFF
--- a/app/helpers/shop_mail_helper.rb
+++ b/app/helpers/shop_mail_helper.rb
@@ -1,0 +1,8 @@
+module ShopMailHelper
+  # Long datetime format string used in emails to customers
+  #
+  # Example: "Fri Aug 31 @ 11:00PM"
+  def mail_long_datetime_format
+    "%a %b %d @ %l:%M%p"
+  end
+end

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,5 +1,6 @@
 class SubscriptionMailer < Spree::BaseMailer
   helper CheckoutHelper
+  helper ShopMailHelper
 
   def confirmation_email(order)
     @type = 'confirmation'

--- a/app/views/subscription_mailer/confirmation_email.html.haml
+++ b/app/views/subscription_mailer/confirmation_email.html.haml
@@ -4,7 +4,7 @@
 %p.callout
   = t("email_so_confirmation_explainer_html")
   = t("email_so_edit_false_html",
-    orders_close_at: l(@order.order_cycle.orders_close_at, format: "%a %b %d @ %l:%M%p"),
+    orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
     order_url: spree.order_url(@order))
   = t("email_so_contact_distributor_html", distributor: @order.distributor.name, email: @order.distributor.contact.email)
 

--- a/app/views/subscription_mailer/confirmation_email.html.haml
+++ b/app/views/subscription_mailer/confirmation_email.html.haml
@@ -3,9 +3,10 @@
 
 %p.callout
   = t("email_so_confirmation_explainer_html")
-  = t("email_so_edit_false_html",
-    orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
-    order_url: spree.order_url(@order))
+  - if @order.user.present?
+    = t("email_so_edit_false_html",
+      orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
+      order_url: spree.order_url(@order))
   = t("email_so_contact_distributor_html", distributor: @order.distributor.name, email: @order.distributor.contact.email)
 
 %p &nbsp;

--- a/app/views/subscription_mailer/failed_payment_email.html.haml
+++ b/app/views/subscription_mailer/failed_payment_email.html.haml
@@ -2,9 +2,10 @@
 
 %p.callout
   = t("email_so_failed_payment_explainer_html", distributor: @order.distributor.name)
-  = t("email_so_edit_false_html",
-    orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
-    order_url: spree.order_url(@order))
+  - if @order.user.present?
+    = t("email_so_edit_false_html",
+      orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
+      order_url: spree.order_url(@order))
   = t("email_so_contact_distributor_html", distributor: @order.distributor.name, email: @order.distributor.contact.email)
 
 - if @order.errors.any?

--- a/app/views/subscription_mailer/failed_payment_email.html.haml
+++ b/app/views/subscription_mailer/failed_payment_email.html.haml
@@ -3,7 +3,7 @@
 %p.callout
   = t("email_so_failed_payment_explainer_html", distributor: @order.distributor.name)
   = t("email_so_edit_false_html",
-    orders_close_at: l(@order.order_cycle.orders_close_at, format: "%a %b %d @ %l:%M%p"),
+    orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
     order_url: spree.order_url(@order))
   = t("email_so_contact_distributor_html", distributor: @order.distributor.name, email: @order.distributor.contact.email)
 

--- a/app/views/subscription_mailer/placement_email.html.haml
+++ b/app/views/subscription_mailer/placement_email.html.haml
@@ -3,11 +3,18 @@
 
 %p.callout
   = t("email_so_placement_explainer_html")
-  - allow_changes = !!@order.distributor.allow_order_changes?
-  = t("email_so_edit_#{allow_changes}_html",
-    orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
-    order_url: spree.order_url(@order))
-  = t("email_so_contact_distributor_html", distributor: @order.distributor.name, email: @order.distributor.contact.email)
+
+  - if @order.user.present?
+    - allow_changes = !!@order.distributor.allow_order_changes?
+    = t("email_so_edit_#{allow_changes}_html",
+      orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
+      order_url: spree.order_url(@order))
+    = t("email_so_contact_distributor_html", distributor: @order.distributor.name, email: @order.distributor.contact.email)
+  - else
+    = t("email_so_contact_distributor_to_change_order_html",
+      orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
+      distributor: @order.distributor.name,
+      email: @order.distributor.contact.email)
 
 %p &nbsp;
 %h4

--- a/app/views/subscription_mailer/placement_email.html.haml
+++ b/app/views/subscription_mailer/placement_email.html.haml
@@ -5,7 +5,7 @@
   = t("email_so_placement_explainer_html")
   - allow_changes = !!@order.distributor.allow_order_changes?
   = t("email_so_edit_#{allow_changes}_html",
-    orders_close_at: l(@order.order_cycle.orders_close_at, format: "%a %b %d @ %l:%M%p"),
+    orders_close_at: l(@order.order_cycle.orders_close_at, format: mail_long_datetime_format),
     order_url: spree.order_url(@order))
   = t("email_so_contact_distributor_html", distributor: @order.distributor.name, email: @order.distributor.contact.email)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1461,6 +1461,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   email_so_edit_true_html: "You can <a href='%{order_url}'>make changes</a> until orders close on %{orders_close_at}."
   email_so_edit_false_html: "You can <a href='%{order_url}'>view details of this order</a> at any time."
   email_so_contact_distributor_html: "If you have any questions you can contact <strong>%{distributor}</strong> via %{email}."
+  email_so_contact_distributor_to_change_order_html: "This order was automatically created for you. You can make changes until orders close on %{orders_close_at} by contacting <strong>%{distributor}</strong> via %{email}."
   email_so_confirmation_intro_html: "Your order with <strong>%{distributor}</strong> is now confirmed"
   email_so_confirmation_explainer_html: "This order was automatically placed for you, and it has now been finalised."
   email_so_confirmation_details_html: "Here's everything you need to know about your order from <strong>%{distributor}</strong>:"

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -6,7 +6,9 @@ describe SubscriptionMailer do
   let!(:mail_method) { create(:mail_method, preferred_mails_from: 'spree@example.com') }
 
   describe "order placement" do
-    let(:subscription) { create(:subscription, with_items: true) }
+    let(:shop) { create(:enterprise) }
+    let(:customer) { create(:customer, enterprise: shop) }
+    let(:subscription) { create(:subscription, shop: shop, customer: customer, with_items: true) }
     let(:proxy_order) { create(:proxy_order, subscription: subscription) }
     let!(:order) { proxy_order.initialise_order! }
 
@@ -24,7 +26,6 @@ describe SubscriptionMailer do
         body = SubscriptionMailer.deliveries.last.body.encoded
         expect(body).to include "This order was automatically created for you."
         expect(body).to include "Unfortunately, not all products that you requested were available."
-        expect(body).to include "href=\"#{spree.order_url(order)}\""
       end
     end
 
@@ -39,7 +40,36 @@ describe SubscriptionMailer do
         body = SubscriptionMailer.deliveries.last.body.encoded
         expect(body).to include "This order was automatically created for you."
         expect(body).to_not include "Unfortunately, not all products that you requested were available."
-        expect(body).to include "href=\"#{spree.order_url(order)}\""
+      end
+    end
+
+    describe "linking to order page" do
+      let(:order_link_href) { "href=\"#{spree.order_url(order)}\"" }
+      let(:order_link_style) { "style='[^']+'" }
+
+      let(:shop) { create(:enterprise, allow_order_changes: true) }
+
+      let(:email) { SubscriptionMailer.deliveries.last }
+      let(:body) { email.body.encoded }
+
+      before do
+        SubscriptionMailer.placement_email(order, {}).deliver
+      end
+
+      let(:customer) { create(:customer, enterprise: shop) }
+
+      it "provides link to make changes" do
+        expect(body).to match /<a #{order_link_href} #{order_link_style}>make changes<\/a>/
+        expect(body).to_not match /<a #{order_link_href} #{order_link_style}>view details of this order<\/a>/
+      end
+
+      context "when the distributor does not allow changes to the order" do
+        let(:shop) { create(:enterprise, allow_order_changes: false) }
+
+        it "provides link to view details" do
+          expect(body).to_not match /<a #{order_link_href} #{order_link_style}>make changes<\/a>/
+          expect(body).to match /<a #{order_link_href} #{order_link_style}>view details of this order<\/a>/
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #2534

Updates subscription-related emails for customers, removing link to order page for customers who do not have a user account. Adds custom text for placement emails for this scenario.

#### What should we test?

For below, make sure that the OFN instance is already [configured for Stripe integration](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance).

The following should also be set up for the shop:

1. Subscriptions are enabled (Shop Preferences > Subscriptions)
2. Stripe payment method (Shop Preferences > Payment Methods)

There are three types of subscription emails affected by this PR:

1. Placement of order
2. Confirmation of order
3. Failure to automatically charge payment

And three scenarios that should be tested:

1. Customer has no associated user account
2. Customer has user account, and shop is configured to allow customer to edit placed orders
3. Customer has user account, but shop is configured to restrict customer from editing placed orders

**Scenario 1: Customer has no associated user account**

1. Create a new ongoing order cycle (OC).
2. Create the customer. Make sure there is no user account for this email yet.
3. Create a subscription that starts before current time. Select Cheque payment method.
4. Wait approximately 5 minutes. Find the order placement email, and check that it does not contain a link to the order. _"This order was automatically created for you. This order was automatically created for you. You can make changes until orders close on Fri Aug 31 @ 11:00PM by contacting Amazing Shop via shop@example.com."_
5. To simulate the OC closing, :warning: set its close time to a couple of minutes before current time.
6. Wait approximately 5 minutes. Find the order confirmation email, and check that it does not contain a link to the order. _"This order was automatically placed for you, and it has now been finalised. If you have any questions you can contact Amazing Shop via shop@example.com."_

(AFAIK, there is no way for a customer with no user account to receive the SO failed payment for the subscription. I will ask and will update this when I get info.)

**Scenario 2: Customer has user account, and shop is configured to allow customer to edit placed orders**

(Change enterprise setting: Shop Preferences > Change Orders > "Customers can change / cancel orders while OC is open")

1. :warning: Open the OC again by updating its close date.
2. Create the customer.
3. **As customer:** Sign up with the customer email.
4. **As customer:** Save [credit card details that would charge successfully](https://stripe.com/docs/testing#cards), and give the shop permission to charge you.
5. Create a subscription that starts before current time. Select Stripe payment method.
6. Wait approximately 5 minutes. Find the order placement email, and check that it contains a link to "make changes" to the order. _"This order was automatically created for you. You can make changes until orders close on Fri Aug 31 @ 11:00PM. If you have any questions you can contact Amazing Shop via shop@example.com."_
7. To simulate the OC closing, :warning: set its close time to a couple of minutes before current time.
8. Wait approximately 5 minutes. Find the order confirmation email, and check that it contains a link to "view details" of the order. _"This order was automatically placed for you, and it has now been finalised. You can view details of this order at any time. If you have any questions you can contact Amazing Shop via shop@example.com."_
9. :warning: Open the OC again by updating its close date.
10. **As customer:** Change the saved credit card details to a one that would fail when attempting to charge.
11. Create a subscription that starts before current time. Select Stripe payment method.
12. Wait approximately 5 minutes. Find the order placement email, and check that it contains a link to "view details" of the order. _"The payment for your subscription with Amazing Shop failed because of a problem with your credit card. Amazing Shop has been notified of this failed payment. You can view details of this order at any time. If you have any questions you can contact Amazing Shop via shop@example.com."_

**Scenario 3: Customer has user account, but shop is configured to restrict customer from editing placed orders**

(Change enterprise setting: Shop Preferences > Change Orders > "Placed orders cannot be changed / cancelled")

1. :warning: Open the OC again by updating its close date.
2. Create a subscription that starts before current time. Select Stripe payment method.
3. Wait approximately 5 minutes. Find the Order placement email, and check that it contains a link to "view details" of the order. _"This order was automatically created for you. You can view details of this order at any time. If you have any questions you can contact Amazing Shop via shop@example.com."_

#### Release notes

- Remove link to Order page from Subscription emails for Customers that do not have associated User.

Changelog Category: Fixed