### PR TITLE
WIP - Removed unnecessary css_splitter. See #1361

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,6 @@ gem 'foundation_rails_helper', github: 'willrjmarshall/foundation_rails_helper',
 
 gem 'jquery-rails'
 gem 'jquery-migrate-rails'
-gem 'css_splitter'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,9 +243,7 @@ GEM
       safe_yaml (~> 1.0.0)
     css_parser (1.3.5)
       addressable
-    css_splitter (0.4.5)
-      sprockets (>= 2.0.0)
-    daemons (1.2.6)
+    daemons (1.2.2)
     dalli (2.7.2)
     database_cleaner (0.7.1)
     db2fog (0.8.0)
@@ -725,7 +723,6 @@ DEPENDENCIES
   capybara (>= 2.15.4)
   coffee-rails (~> 3.2.1)
   compass-rails
-  css_splitter
   custom_error_message!
   daemons
   dalli

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,6 @@ class ApplicationController < ActionController::Base
   before_filter :set_cache_headers # Issue #1213, prevent cart emptying via cache when using back button
 
   include EnterprisesHelper
-  helper CssSplitter::ApplicationHelper
 
   def redirect_to(options = {}, response_status = {})
     ::Rails.logger.error("Redirected by #{caller(1).first rescue "unknown"}")

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -17,7 +17,7 @@
     = yield :scripts
     %script{:src => "https://js.stripe.com/v3/", :type => "text/javascript"}
     %script{src: "//maps.googleapis.com/maps/api/js?libraries=places,geometry#{ ENV['GOOGLE_MAPS_API_KEY'] ? '&key=' + ENV['GOOGLE_MAPS_API_KEY'] : ''} "}
-    = split_stylesheet_link_tag "darkswarm/all"
+    = stylesheet_link_tag "darkswarm/all"
     = javascript_include_tag "darkswarm/all"
 
     = render "layouts/i18n_script"


### PR DESCRIPTION
Work in Progress.

#### What? Why?

Closes #1361

Removing css_splitter, if it is not necessary, is one solution to #1361.

#### What should we test?
Frontoffice css should remaining the same and the website should look the same.

#### Release notes
Changelog Category: Removed
Removed css splitter.
