### PR TITLE
Removed old files that were used with, now unsupported, heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,0 @@
-worker_processes 2 # amount of unicorn workers to spin up
-timeout 120         # restarts workers that hang for 30 seconds


### PR DESCRIPTION
#### What? Why?

Raised from the review of #238.

These files are no longer required because heroku is no longer supporte.

#### What should we test?
I don't think this needs testing.

#### Release notes
Changelog Category: Removed
Removed old files used in, now unsupported, heroku.
