### PR TITLE
Updated spree 2-0-4 revision used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 94b1f395bbf2cffbb1e33cdab5809511150da814
+  revision: 43950c3689a77a7f493cc6d805a0edccfe75ebc2
   branch: 2-0-4-stable
   specs:
     spree (2.0.4)


### PR DESCRIPTION
#### What? Why?

Updating spree revision to be used in 2-0-stable branch.

I updated spree 2-0-4-stable locally and picked the top commit: 43950c3689a77a7f493cc6d805a0edccfe75ebc2