### PR TITLE
Fix ask anonymous users to login for order page

### DIFF
--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -1,4 +1,5 @@
 require 'spree/core/controller_helpers/order_decorator'
+require 'spree/core/controller_helpers/auth_decorator'
 
 Spree::OrdersController.class_eval do
   before_filter :update_distribution, only: :update
@@ -133,7 +134,7 @@ Spree::OrdersController.class_eval do
     return if session[:access_token] || params[:token] || spree_current_user
 
     flash[:error] = I18n.t("spree.orders.edit.login_to_view_order")
-    redirect_to root_path(anchor: "login?after_login=#{request.env['PATH_INFO']}")
+    require_login_then_redirect_to request.env['PATH_INFO']
   end
 
   def order_to_update

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -5,6 +5,7 @@ Spree::OrdersController.class_eval do
   before_filter :filter_order_params, only: :update
   before_filter :enable_embedded_shopfront
 
+  prepend_before_filter :require_order_authentication, only: :show
   prepend_before_filter :require_order_cycle, only: :edit
   prepend_before_filter :require_distributor_chosen, only: :edit
   before_filter :check_hub_ready_for_checkout, only: :edit
@@ -127,6 +128,13 @@ Spree::OrdersController.class_eval do
 
 
   private
+
+  def require_order_authentication
+    return if session[:access_token] || params[:token] || spree_current_user
+
+    flash[:error] = I18n.t("spree.orders.edit.login_to_view_order")
+    redirect_to root_path(anchor: "login?after_login=#{request.env['PATH_INFO']}")
+  end
 
   def order_to_update
     return @order_to_update if defined? @order_to_update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2699,6 +2699,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     inventory: Inventory
     zipcode: Postcode
     orders:
+      edit:
+        login_to_view_order: "Please log in to view your order."
       bought:
         item: "Already ordered in this order cycle"
     shipment_states:

--- a/lib/spree/core/controller_helpers/auth_decorator.rb
+++ b/lib/spree/core/controller_helpers/auth_decorator.rb
@@ -1,0 +1,5 @@
+Spree::Core::ControllerHelpers::Auth.class_eval do
+  def require_login_then_redirect_to(url)
+    redirect_to root_path(anchor: "login?after_login=#{url}")
+  end
+end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -63,9 +63,14 @@ describe Spree::OrdersController, type: :controller do
     context "when neither checked out as an anonymous guest nor logged in" do
       let(:current_user) { nil }
 
+      before do
+        request.env["PATH_INFO"] = spree.order_path(order)
+      end
+
       it "redirects to unauthorized" do
         spree_get :show, id: order.number
-        expect(response.status).to eq(401)
+        expect(response).to redirect_to(root_path(anchor: "login?after_login=#{spree.order_path(order)}"))
+        expect(flash[:error]).to eq("Please log in to view your order.")
       end
     end
   end

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -69,9 +69,14 @@ feature "Order Management", js: true do
     context "when not logged in" do
       let(:user) { create(:user) }
 
-      it "does not allow the user to see order details" do
+      it "allows the user to see order details after login" do
+        # Cannot load the page without signing in
         visit spree.order_path(order)
         expect(page).to_not be_confirmed_order_page
+
+        # Can load the page after signing in
+        fill_in_and_submit_login_form user
+        expect(page).to be_confirmed_order_page
       end
     end
   end

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -54,9 +54,13 @@ module AuthenticationWorkflow
     user.spree_roles << user_role
 
     visit spree.login_path
-    fill_in 'email', :with => 'someone@ofn.org'
-    fill_in 'password', :with => 'passw0rd'
-    click_button 'Login'
+    fill_in_and_submit_login_form user
+  end
+
+  def fill_in_and_submit_login_form(user)
+    fill_in "email", with: user.email
+    fill_in "password", with: user.password
+    click_button "Login"
   end
 end
 


### PR DESCRIPTION
#### What? Why?

Closes #2506

Subscription emails link to the order page if the order is associated with a user. But if the user is not yet logged in the OFN website and clicks on the link, they get an HTTP 401 (Unauthorized).

This redirects the user to the login page instead. After logging in, the user is redirected back to the order page for which they are now authorized to view.

This also adds automated tests for other scenarios for the order page.

#### What should we test?

As guest:

1. Place an order.
2. After that, you should be redirected to the order details page. It should load.
3. Load the URL in another window (same browser session). It should load.

As signed up user:

1. Place an order.
2. After that, you should be redirected to the order details page. It should load.
3. Load the URL in another window (same browser session). It should load.
4. Copy the URL.
5. Open the URL in a new browser session (through incognito window). This should redirect you to the login page.
6. Sign in as the user. This should redirect you to the order page, which should load.

#### Release notes

- Fix order page for anonymous users - The user is now redirected to the login page, then redirected back to the order page after login.

Changelog Category: Fixed

#### How is this related to the Spree upgrade?

Authorization for the order page could have changed, so this might no longer be necessary or there could be a more straightforward solution.