### PR TITLE
Add "more" translation key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
   free_trial: "free trial"
   plus_tax: "plus GST"
   min_bill_turnover_desc: "once turnover exceeds %{mbt_amount}"
+  more: "More"
   say_no: "No"
   say_yes: "Yes"
   then: then


### PR DESCRIPTION
Add "more" translation key to allow "More" in the admin menu to be customized

#### What? Why?

Closes #2617 

This is used in places such as the adaptive menu in the admin section.

This is actually included in `spree_i18n`, but not correctly translated for `fr` in version `1.3` which we are using. It is translated to "More" until version `2.2` which translates it to "Plus".

And it's probably not a good idea to look into upgrading `spree_i18n` before the big Spree upgrade.

#### What should we test?

In a non-English instance (ideally, France), go to the admin dashboard. Check the "More" dropdown in the main navigation. This should be properly translated in non-English instances, especially for France for which the correct translation will not match the one used before this PR.

#### Release notes

- Fix translation for "More" dropdown in admin adaptive menu for some languages

Changelog Category: Fixed