### PR TITLE
[Spree 2 Upgrade] Removed unused shipping_method.within_zone, customization not needed

### DIFF
--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -42,14 +42,6 @@ Spree::ShippingMethod.class_eval do
     ]
   end
 
-  def within_zone?(order)
-    if order.ship_address
-      zone && zone.include?(order.ship_address)
-    else
-      true # Shipping methods are available before we've selected an address
-    end
-  end
-
   def has_distributor?(distributor)
     self.distributors.include?(distributor)
   end


### PR DESCRIPTION
#### What? Why?

This is the same as PR #1627 but now against the spree upgrade branch 2-0-stable.

Part of #2008 

We need to remove this customization in shipping_method.
This was verifying if a shipping_method is within the zone of the address selected. This is not done here in spree 2.
Next step is to clarify and fix:
- where this is done in spree 2 by default
- where will that be done in ofn2 (including ofn customization/filtering of methods per enterprise)

#### What should we test?
Cant be tested right now.

#### How is this related to the Spree upgrade?
Part of adapting to the new multi shipments of spree 2. See issue and its epic.