### PR TITLE
Allow fixing and customizing translations for order cancellation and shipment emails

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,14 @@ en:
       subject: "%{enterprise} is now on %{sitename}"
     invite_manager:
       subject: "%{enterprise} has invited you to be a manager"
+  order_mailer:
+    cancel_email:
+      dear_customer: "Dear Customer,"
+      instructions: "Your order has been CANCELED.  Please retain this cancellation information for your records."
+      order_summary_canceled: "Order Summary [CANCELED]"
+      subject: "Cancellation of Order"
+      subtotal: "Subtotal: %{subtotal}"
+      total: "Order Total: %{total}"
   producer_mailer:
     order_cycle:
       subject: "Order cycle report for %{producer}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,15 @@ en:
   producer_mailer:
     order_cycle:
       subject: "Order cycle report for %{producer}"
+  shipment_mailer:
+    shipped_email:
+      dear_customer: "Dear Customer,"
+      instructions: "Your order has been shipped"
+      shipment_summary: "Shipment Summary"
+      subject: "Shipment Notification"
+      thanks: "Thank you for your business."
+      track_information: "Tracking Information: %{tracking}"
+      track_link: "Tracking Link: %{url}"
   subscription_mailer:
     placement_summary_email:
       subject: A summary of recently placed subscription orders


### PR DESCRIPTION
Add translation keys for order cancellation and shipment emails

#### What? Why?

* Closes #2375 
* Closes #2300 

These emails are not correctly translated for some languages. For example, for French, these are still in English.

#### What should we test?

For convenience, you can do all of these as admin.

Order cancellation: (see https://github.com/openfoodfoundation/openfoodnetwork/issues/2375#issue-332185662)

> Go to order, cancel an order you have made, and see the email you receive

Order shipment: (from https://github.com/openfoodfoundation/openfoodnetwork/issues/2300#issue-324616264)

> Make an order, go the "orders" page
> Click on the small "ship" icon on the right of the order line
> Check your mailbox

#### Release notes

- Allow custom translation of order cancellation and shipment emails for customers

Changelog Category: Fixed

#### How is this related to the Spree upgrade?

It is possible that the new emails use new translation keys which are not included here.