### PR TITLE
Simple translation fixes for admin area and profile page

### DIFF
--- a/app/overrides/spree/admin/product_properties/index/add_producer_properties_warning_and_table.html.haml.deface
+++ b/app/overrides/spree/admin/product_properties/index/add_producer_properties_warning_and_table.html.haml.deface
@@ -1,7 +1,7 @@
 / insert_after 'table.index.sortable'
 
 =f.check_box :inherits_properties
-=f.label :inherits_properties, "Inherit properties from #{@product.supplier.name}? (unless overridden above)"
+=f.label :inherits_properties, t(".inherits_properties_checkbox_hint", supplier: @product.supplier.name)
 %br
 %br
 

--- a/app/views/admin/order_cycles/_filters.html.haml
+++ b/app/views/admin/order_cycles/_filters.html.haml
@@ -2,7 +2,7 @@
   .filter.four.columns.alpha
     %label{ :for => 'query' }=t('admin.quick_search')
     %br
-    %input.fullwidth{ :type => "text", :id => 'query', ng: { model: 'query' }, placeholder: "Search by Order Cycle name..." }
+    %input.fullwidth{ :type => "text", :id => 'query', ng: { model: 'query' }, placeholder: t(".search_by_order_cycle_name") }
   .filter_select.four.columns
     %label{ :for => 'involving_filter' }=t('.involving')
     %br

--- a/app/views/spree/users/_authorised_shops.html.haml
+++ b/app/views/spree/users/_authorised_shops.html.haml
@@ -1,7 +1,7 @@
 %table
   %tr
-    %th= t(:shop_title)
-    %th= t(:allow_charges?)
+    %th= t(".shop_name")
+    %th= t(".allow_charges?")
   %tr.customer{ id: "customer{{ customer.id }}", ng: { repeat: "customer in customers" } }
     %td.shop{ ng: { bind: 'shopsByID[customer.enterprise_id].name' } }
     %td.allow_charges

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2595,6 +2595,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     date: "Date"
     time: "Time"
     admin:
+      product_properties:
+        index:
+          inherits_properties_checkbox_hint: "Inherit properties from %{supplier}? (unless overridden above)"
       orders:
         invoice:
           issued_on: Issued on

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -821,6 +821,9 @@ en:
         search_placeholder: Search By Name
         manage: Manage
         manage_link: Settings
+        producer?: "Producer?"
+        package: "Package"
+        status: "Status"
       new_form:
         owner: Owner
         owner_tip: The primary user responsible for this enterprise.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -867,6 +867,8 @@ en:
         save_reload: Save and Reload Page
       coordinator_fees:
         add: Add coordinator fee
+      filters:
+        search_by_order_cycle_name: "Search by Order Cycle name..."
       form:
         incoming: Incoming
         supplier: Supplier

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2819,5 +2819,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         authorised_shops: Authorised Shops
         authorised_shops_popover: This is the list of shops which are permitted to charge your default credit card for any subscriptions (ie. repeating orders) you may have. Your card details will be kept secure and will not be shared with shop owners. You will always be notified when you are charged.
         saved_cards_popover: This is the list of cards you have opted to save for later use. Your 'default' will be selected automatically when you checkout an order, and can be charged by any shops you have allowed to do so (see right).
+      authorised_shops:
+        shop_name: "Shop Name"
+        allow_charges?: "Allow Charges?"
     localized_number:
       invalid_format: has an invalid format. Please enter a number.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -869,6 +869,7 @@ en:
         add: Add coordinator fee
       filters:
         search_by_order_cycle_name: "Search by Order Cycle name..."
+        involving: "Involving"
       form:
         incoming: Incoming
         supplier: Supplier
@@ -883,7 +884,6 @@ en:
         delivery_details: Pickup / Delivery details
         debug_info: Debug information
       index:
-        involving: Involving
         schedule: Schedule
         schedules: Schedules
         adding_a_new_schedule: Adding A New Schedule


### PR DESCRIPTION
#### What? Why?

- Closes #2630 - Additionally, translates the "Package" and "Status" column headers.
- Closes #2629
- Some work for #2414 - Fixes the placeholder for the OC name search field and also the "Involving" filter label. "Any Enterprise" and "COPY OF" are more complicated in nature, and belong to another pull request.
- Related to #2646 - That issue seems to be fixed already. However, I noticed "Shop Title" and "Allow Charges" are not translated - these have been addressed in this PR.

Please also note that I changed "Shop Title" to "Shop Name". It seems more appropriate.

#### What should we test?

Do below in a translated, non-English OFN instance. For convenience, you can log in as enterprise manager when checking these.

- Enterprise index: Check the "Producer?", "Package", and "Status" column headers.
- Product form: Go to "Properties". Check the checkbox label for inheriting properties from supplier.
- OC index: Check the place holder for OC name search field and the "Involving" filter label.
- "Credit Cards" section in customer account page: Check the table heading for "Authorised Shops" and its tooltip popover. Check the column headers for "Authorised Shops".

#### Release notes

- Translate more text in the enterprise index, order cycle index, product form, and customer account page.

Changelog Category: Fixed