### PR TITLE
Translate and fix fallback errors when creating or updating OC

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
@@ -156,7 +156,7 @@ angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, S
         if response.data.errors?
           StatusMessage.display('failure', response.data.errors[0])
         else
-          StatusMessage.display('failure', 'Failed to create order cycle')
+          StatusMessage.display('failure', t('js.order_cycles.create_failure'))
 
     update: (destination, form) ->
       return unless @confirmNoDistributors()
@@ -171,7 +171,7 @@ angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, S
         if response.data.errors?
           StatusMessage.display('failure', response.data.errors[0])
         else
-          StatusMessage.display('failure', 'Failed to create order cycle')
+          StatusMessage.display('failure', t('js.order_cycles.update_failure'))
 
 
     confirmNoDistributors: ->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2565,7 +2565,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         This will set stock level to zero on all products for this
         enterprise that are not present in the uploaded file.
     order_cycles:
+      create_failure: "Failed to create order cycle"
       update_success: 'Your order cycle has been updated.'
+      update_failure: "Failed to update order cycle"
       no_distributors: There are no distributors in this order cycle. This order cycle will not be visible to customers until you add one. Would you like to continue saving this order cycle?'
     enterprises:
       producer: "Producer"


### PR DESCRIPTION
#### What? Why?

Closes #2641

This translates the fallback errors when creating or updating an OC fails. _Fallback_, because some errors that we explicitly support in the code (e.g. when close date is set before open date) give a more specific error.

Then, for the error when updating, this was actually saying "Failure to _create_ order cycle" (should be "update"). This has also been addressed.

#### What should we test?

One way I let these errors appear is by removing authorization of a user for an enterprise while the user is filling in the OC form.

@RachL if you know a simpler way, kindly share. It's likely that when you encountered these errors after leaving some fields blank was only because staging [had inconsistent data](https://github.com/openfoodfoundation/openfoodnetwork/pull/2625#issuecomment-418390260) as @luisramos0 found. I couldn't get these errors to appear that way.

1. Browser Session 1: Add test user as manager to an enterprise.
2. Browser Session 2: As test user, open the new OC page and fill in the form, but do not submit.
3. Browser Session 1: Remove test user as manager for the enterprise.
4. Browser Session 2: Being unauthorized for the enterprise now, test user should get the translated error when submitting the form.

Repeat the same for editing an OC.

#### Release notes

- Fix and translate fallback errors when creating and updating an order cycle

Changelog Category: Fixed