### PR TITLE
Translate "COPY OF" when cloning an OC

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -121,7 +121,7 @@ class OrderCycle < ActiveRecord::Base
 
   def clone!
     oc = self.dup
-    oc.name = "COPY OF #{oc.name}"
+    oc.name = I18n.t("models.order_cycle.cloned_order_cycle_name", order_cycle: oc.name)
     oc.orders_open_at = oc.orders_close_at = nil
     oc.coordinator_fee_ids = self.coordinator_fee_ids
     oc.preferred_product_selection_from_coordinator_inventory_only = self.preferred_product_selection_from_coordinator_inventory_only

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,11 @@ en:
     user_passwords:
       spree_user:
         updated_not_active: "Your password has been reset, but your email has not been confirmed yet."
+
+  models:
+    order_cycle:
+      cloned_order_cycle_name: "COPY OF %{order_cycle}"
+
   enterprise_mailer:
     confirmation_instructions:
       subject: "Please confirm the email address for %{enterprise}"


### PR DESCRIPTION
#### What? Why?

Addresses part of #2414

An OC is cloned as "COPY OF original_oc_name" even in non-English instances.

#### What should we test?

Test cloning an OC in a non-English instance. The name of the new OC should be translated.

#### Release notes

- Translate name of the new order cycle when duplicating an order cycle

Changelog Category: Fixed