### PR TITLE
[Spree Upgrade] Adapt Address_Finder.last_used_ship_address to spree 2

### DIFF
--- a/lib/open_food_network/address_finder.rb
+++ b/lib/open_food_network/address_finder.rb
@@ -79,7 +79,7 @@ module OpenFoodNetwork
 
     def last_used_ship_address
       return nil unless allow_search_by_email?
-      Spree::Order.complete.joins(:ship_address, :shipping_method).order('id DESC')
+      Spree::Order.complete.joins(:ship_address, shipments: :shipping_methods).order('id DESC')
         .where(email: email, spree_shipping_methods: { require_ship_address: true })
         .first.andand.ship_address
     end


### PR DESCRIPTION
#### What? Why?

Closes #2663 

Finding last used address now uses the relation order#shipments and not order#shipping_method
Also, fixed respective spec by replacing reference to order.shipping_method_id with order.shipping_method (the new adapter to get to order.shipments).

#### What should we test?
Together with #2727, this makes address_finder_spec green and fixes quite a few tests in models/order_spec and others.