### PR TITLE
[Spree 2 Upgrade] Fixed models/order_spec issues related to order.shipping_method

### DIFF
--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -91,10 +91,9 @@ describe LineItemsController, type: :controller do
     end
 
     context "where shipping and payment fees apply" do
-      let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true, allow_order_changes: true) }
       let(:shipping_fee) { 3 }
       let(:payment_fee) { 5 }
-      let(:order) { create(:completed_order_with_fees, distributor: distributor, shipping_fee: shipping_fee, payment_fee: payment_fee) }
+      let(:order) { create(:completed_order_with_fees, shipping_fee: shipping_fee, payment_fee: payment_fee) }
 
       before do
         Spree::Config.shipment_inc_vat = true

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -94,8 +94,7 @@ describe Spree::OrdersController, type: :controller do
 
   describe "removing items from a completed order" do
     context "with shipping and transaction fees" do
-      let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true, allow_order_changes: true) }
-      let(:order) { create(:completed_order_with_fees, distributor: distributor, shipping_fee: shipping_fee, payment_fee: payment_fee) }
+      let(:order) { create(:completed_order_with_fees, shipping_fee: shipping_fee, payment_fee: payment_fee) }
       let(:line_item1) { order.line_items.first }
       let(:line_item2) { order.line_items.second }
       let(:shipping_fee) { 3 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -348,7 +348,6 @@ FactoryBot.define do
 
     after(:create) do |order, evaluator|
       create(:line_item, order: order)
-      order.create_shipment!
       payment_calculator = build(:calculator_per_item, preferred_amount: evaluator.payment_fee)
       payment_method = create(:payment_method, calculator: payment_calculator)
       create(:payment, order: order, amount: order.total, payment_method: payment_method, state: 'checkout')

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -335,16 +335,49 @@ FactoryBot.define do
     end
   end
 
+  factory :shipping_method_with_flat_rate, parent: :shipping_method do
+    calculator { Spree::Calculator::FlatRate.new(preferred_amount: 50.0) }
+  end
+
+  factory :shipment_with_flat_rate, parent: :shipment do
+    after(:create) do |shipment|
+      shipment.add_shipping_method(create(:shipping_method_with_flat_rate), true)
+    end
+  end
+
+  factory :distributor_enterprise_with_tax, parent: :distributor_enterprise do
+    charges_sales_tax { true }
+    allow_order_changes { true }
+  end
+
+  factory :shipping_method_with_shipping_fee, parent: :shipping_method do
+    transient do
+      shipping_fee 3
+    end
+
+    calculator { build(:calculator_per_item, preferred_amount: shipping_fee) }
+    require_ship_address { false }
+    distributors { [create(:distributor_enterprise_with_tax)] }
+  end
+
+  factory :shipment_with_shipping_fee, parent: :shipment do
+    transient do
+      shipping_fee 3
+    end
+
+    after(:create) do |shipment, evaluator|
+      shipping_method = create(:shipping_method_with_shipping_fee, shipping_fee: evaluator.shipping_fee)
+      shipment.add_shipping_method(shipping_method, true)
+    end
+  end
+
   factory :completed_order_with_fees, parent: :order_with_totals_and_distribution do
     transient do
       shipping_fee 3
       payment_fee 5
     end
 
-    shipping_method do
-      shipping_calculator = build(:calculator_per_item, preferred_amount: shipping_fee)
-      create(:shipping_method, calculator: shipping_calculator, require_ship_address: false, distributors: [distributor])
-    end
+    shipments { [ create(:shipment_with_shipping_fee, shipping_fee: shipping_fee) ] }
 
     after(:create) do |order, evaluator|
       create(:line_item, order: order)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -185,7 +185,6 @@ describe Spree::Order do
     let(:shipping_method) { create(:shipping_method) }
 
     before do
-      order.create_shipment!
       order.reload
       order.state = 'complete'
       order.shipment.update!(order)
@@ -214,7 +213,6 @@ describe Spree::Order do
     let(:shipping_method) { create(:shipping_method) }
 
     before do
-      order.create_shipment!
       order.payment_state = 'paid'
       order.state = 'complete'
       order.shipment.update!(order)
@@ -233,7 +231,6 @@ describe Spree::Order do
       before do
         Spree::Config.shipment_inc_vat = true
         Spree::Config.shipping_tax_rate = 0.25
-        order.create_shipment!
       end
 
       it "returns the shipping tax" do
@@ -267,7 +264,6 @@ describe Spree::Order do
     before do
       Spree::Config.shipment_inc_vat = true
       Spree::Config.shipping_tax_rate = 0.25
-      order.create_shipment!
       order.reload
     end
 
@@ -301,7 +297,6 @@ describe Spree::Order do
     before do
       Spree::Config.shipment_inc_vat = true
       Spree::Config.shipping_tax_rate = tax_rate15.amount
-      order.create_shipment!
       Spree::TaxRate.adjust(order)
       order.reload.update_distribution_charge!
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -634,7 +634,7 @@ describe Spree::Order do
   end
 
   describe "when a guest order is placed with a registered email" do
-    let(:order) { create(:order_with_totals_and_distribution, user: nil) }
+    let(:order) { create(:order_with_totals_and_distribution, user: user) }
     let(:payment_method) { create(:payment_method, distributors: [order.distributor]) }
     let(:shipping_method) { create(:shipping_method, distributors: [order.distributor]) }
     let(:user) { create(:user, email: 'registered@email.com') }
@@ -642,7 +642,6 @@ describe Spree::Order do
     before do
       order.bill_address = create(:address)
       order.ship_address = create(:address)
-      order.shipping_method = shipping_method
       order.email = user.email
       order.user = nil
       order.state = 'cart'


### PR DESCRIPTION
#### What? Why?

Closes #2664 

#### What should we test?
Fixes tests in models/order_spec.

#### How is this related to the Spree upgrade?
Adapts order_spec to spree 2 - order multi shipments.
