### PR TITLE
Translate "Any Enterprise" and "Any Schedule" in OC filters

### DIFF
--- a/app/views/admin/order_cycles/_filters.html.haml
+++ b/app/views/admin/order_cycles/_filters.html.haml
@@ -6,12 +6,12 @@
   .filter_select.four.columns
     %label{ :for => 'involving_filter' }=t('.involving')
     %br
-    %input.ofn-select2.fullwidth{ :id => 'involving_filter', type: 'number', blank: "{id: 0, name: 'Any Enterprise'}", data: 'enterprises', ng: { model: 'involvingFilter' } }
+    %input.ofn-select2.fullwidth{ id: 'involving_filter', type: 'number', blank: "{id: 0, name: '#{j t(".any_enterprise")}'}", data: 'enterprises', ng: { model: 'involvingFilter' } }
   - if subscriptions_enabled?
     .filter_select.four.columns
       %label{ :for => 'schedule_filter' }=t('admin.order_cycles.index.schedule')
       %br
-      %input.ofn-select2.fullwidth{ :id => 'schedule_filter', type: 'number', blank: "{id: 0, name: 'Any Schedule'}", data: 'schedules', ng: { model: 'scheduleFilter' } }
+      %input.ofn-select2.fullwidth{ id: 'schedule_filter', type: 'number', blank: "{id: 0, name: '#{j t(".any_schedule")}'}", data: 'schedules', ng: { model: 'scheduleFilter' } }
     .two.columns &nbsp;
   - else
     .six.columns &nbsp;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -897,6 +897,8 @@ en:
       filters:
         search_by_order_cycle_name: "Search by Order Cycle name..."
         involving: "Involving"
+        any_enterprise: "Any Enterprise"
+        any_schedule: "Any Schedule"
       form:
         incoming: Incoming
         supplier: Supplier


### PR DESCRIPTION
#### What? Why?

Fixes part of #2414, including translation of the "Any Schedule" option for the "Schedule" filter.

I should have included this #2659, but I was considering whether we should have a helper method for converting a hash in Ruby to a hash used in an HTML tag attribute. This seems risky though and has potential to be misused, so I didn't do that now because for now the risks seem to outweight the benefit.

#### What should we test?

Test this in a non-English instance.

As admin:

1. Go to the OC index.
2. Check the "Involving" filter. The first drop-down option "Any Enterprise" should be translated.
3. Check the "Schedule" filter. The first drop-down option "Any Schedule" should be translated.

#### Release notes

- Translate more text in the order cycle index

Changelog Category: Fixed

#### Dependencies

~This includes changes in #2659. That should be merged first and this could be rebased, or this could be merged into that branch before that branch is merged.~ (**Update**: This is no longer the case.)