### PR TITLE
[Spree Upgrade] Fixed db:load_sample_data

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -184,13 +184,12 @@ namespace :openfoodnetwork do
 
       enterprise2 = Enterprise.find_by_name('Enterprise 2')
       enterprise2.sells = 'any'
-      enterprise2.shipping_methods.build(
-        name: 'Pickup',
-        zone_id: 3,
-        require_ship_address: true,
-        calculator_type: 'OpenFoodNetwork::Calculator::Weight',
-        distributor_ids: [enterprise2.id]
-      )
+      enterprise2.shipping_methods << FactoryBot.create(:shipping_method,
+                             name: 'Pickup',
+                             zone: zone,
+                             require_ship_address: true,
+                             calculator_type: 'OpenFoodNetwork::Calculator::Weight',
+                             distributors: [enterprise2])
       enterprise2.payment_methods << Spree::PaymentMethod.last
       enterprise2.save!
 
@@ -200,7 +199,9 @@ namespace :openfoodnetwork do
 
       CreateOrderCycle.new(enterprise2, variants).call
 
-      EnterpriseRole.create!(user: Spree::User.first, enterprise: enterprise2)
+      unless EnterpriseRole.where( user_id: Spree::User.first, enterprise_id: enterprise2 ).any?
+        EnterpriseRole.create!(user: Spree::User.first, enterprise: enterprise2)
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Related to #2009 

Refactored the distributor.shipping_method builder. Basically, shipping_method has no zone_id in spree 2.

#### What should we test?
We can now run

`bundle exec rake openfoodnetwork:dev:load_sample_data RAILS_ENV=development`
