### PR TITLE
Enable setting a customized user guide link in general settings

### DIFF
--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -24,10 +24,16 @@ module Admin
     private
 
     def preference_sections
-      Dir["app/models/preference_sections/*.rb"].map do |filename|
-        basename = 'PreferenceSections::' + File.basename(filename, '.rb').camelize
-        basename.constantize.new
-      end
+      [
+        PreferenceSections::HeaderSection.new,
+        PreferenceSections::HomePageSection.new,
+        PreferenceSections::ProducerSignupPageSection.new,
+        PreferenceSections::HubSignupPageSection.new,
+        PreferenceSections::GroupSignupPageSection.new,
+        PreferenceSections::MainLinksSection.new,
+        PreferenceSections::FooterAndExternalLinksSection.new,
+        PreferenceSections::UserGuideSection.new
+      ]
     end
   end
 end

--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -1,15 +1,9 @@
 module Admin
   class ContentsController < Spree::Admin::BaseController
     def edit
-      @preference_sections = [{name: I18n.t('admin.contents.edit.header'), preferences: [:logo, :logo_mobile, :logo_mobile_svg]},
-                              {name: I18n.t('admin.contents.edit.home_page'), preferences: [:home_hero, :home_show_stats]},
-                              {name: I18n.t('admin.contents.edit.producer_signup_page'), preferences: [:producer_signup_pricing_table_html, :producer_signup_case_studies_html, :producer_signup_detail_html]},
-                              {name: I18n.t('admin.contents.edit.hub_signup_page'), preferences: [:hub_signup_pricing_table_html, :hub_signup_case_studies_html, :hub_signup_detail_html]},
-                              {name: I18n.t('admin.contents.edit.group_signup_page'), preferences: [:group_signup_pricing_table_html, :group_signup_case_studies_html, :group_signup_detail_html]},
-                              {name: I18n.t('admin.contents.edit.main_links'), preferences: [:menu_1, :menu_1_icon_name, :menu_2, :menu_2_icon_name, :menu_3, :menu_3_icon_name, :menu_4, :menu_4_icon_name, :menu_5, :menu_5_icon_name, :menu_6, :menu_6_icon_name, :menu_7, :menu_7_icon_name]},
-                              {name: I18n.t('admin.contents.edit.footer_and_external_links'), preferences: [:footer_logo,
-                                                             :footer_facebook_url, :footer_twitter_url, :footer_instagram_url, :footer_linkedin_url, :footer_googleplus_url, :footer_pinterest_url,
-                                                             :footer_email, :community_forum_url, :footer_links_md, :footer_about_url]}]
+      @preference_sections = preference_sections.map do |preference_section|
+        { name: preference_section.name, preferences: preference_section.preferences }
+      end
     end
 
     def update
@@ -25,6 +19,15 @@ module Admin
       flash[:success] = t(:successfully_updated, :resource => I18n.t('admin.contents.edit.your_content'))
 
       redirect_to main_app.edit_admin_content_path
+    end
+
+    private
+
+    def preference_sections
+      Dir["app/models/preference_sections/*.rb"].map do |filename|
+        basename = 'PreferenceSections::' + File.basename(filename, '.rb').camelize
+        basename.constantize.new
+      end
     end
   end
 end

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -71,5 +71,5 @@ EOS
   preference :footer_about_url, :string, default: "http://www.openfoodnetwork.org/ofn-local/open-food-network-australia/"
 
   #User Guide
-  preference :user_guide_link, :string, default: 'http://www.openfoodnetwork.org/platform/user-guide/'
+  preference :user_guide_link, :string, default: 'https://guide.openfoodnetwork.org/'
 end

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -69,4 +69,7 @@ class ContentConfiguration < Spree::Preferences::FileConfiguration
 EOS
 
   preference :footer_about_url, :string, default: "http://www.openfoodnetwork.org/ofn-local/open-food-network-australia/"
+
+  #User Guide
+  preference :user_guide_link, :string, default: 'http://www.openfoodnetwork.org/platform/user-guide/'
 end

--- a/app/models/preference_sections/footer_and_external_links_section.rb
+++ b/app/models/preference_sections/footer_and_external_links_section.rb
@@ -1,0 +1,23 @@
+module PreferenceSections
+  class FooterAndExternalLinksSection
+    def name
+      I18n.t('admin.contents.edit.footer_and_external_links')
+    end
+
+    def preferences
+      [
+        :footer_logo,
+        :footer_facebook_url,
+        :footer_twitter_url,
+        :footer_instagram_url,
+        :footer_linkedin_url,
+        :footer_googleplus_url,
+        :footer_pinterest_url,
+        :footer_email,
+        :community_forum_url,
+        :footer_links_md,
+        :footer_about_url
+      ]
+    end
+  end
+end

--- a/app/models/preference_sections/group_signup_page_section.rb
+++ b/app/models/preference_sections/group_signup_page_section.rb
@@ -1,0 +1,15 @@
+module PreferenceSections
+  class GroupSignupPageSection
+    def name
+      I18n.t('admin.contents.edit.group_signup_page')
+    end
+
+    def preferences
+      [
+        :group_signup_pricing_table_html,
+        :group_signup_case_studies_html,
+        :group_signup_detail_html
+      ]
+    end
+  end
+end

--- a/app/models/preference_sections/header_section.rb
+++ b/app/models/preference_sections/header_section.rb
@@ -1,0 +1,15 @@
+module PreferenceSections
+  class HeaderSection
+    def name
+      I18n.t('admin.contents.edit.header')
+    end
+
+    def preferences
+      [
+        :logo,
+        :logo_mobile,
+        :logo_mobile_svg
+      ]
+    end
+  end
+end

--- a/app/models/preference_sections/home_page_section.rb
+++ b/app/models/preference_sections/home_page_section.rb
@@ -1,0 +1,14 @@
+module PreferenceSections
+  class HomePageSection
+    def name
+      I18n.t('admin.contents.edit.home_page')
+    end
+
+    def preferences
+      [
+        :home_hero,
+        :home_show_stats
+      ]
+    end
+  end
+end

--- a/app/models/preference_sections/hub_signup_page_section.rb
+++ b/app/models/preference_sections/hub_signup_page_section.rb
@@ -1,0 +1,15 @@
+module PreferenceSections
+  class HubSignupPageSection
+    def name
+      I18n.t('admin.contents.edit.hub_signup_page')
+    end
+
+    def preferences
+      [
+        :hub_signup_pricing_table_html,
+        :hub_signup_case_studies_html,
+        :hub_signup_detail_html
+      ]
+    end
+  end
+end

--- a/app/models/preference_sections/main_links_section.rb
+++ b/app/models/preference_sections/main_links_section.rb
@@ -1,0 +1,26 @@
+module PreferenceSections
+  class MainLinksSection
+    def name
+      I18n.t('admin.contents.edit.main_links')
+    end
+
+    def preferences
+      [
+        :menu_1,
+        :menu_1_icon_name,
+        :menu_2,
+        :menu_2_icon_name,
+        :menu_3,
+        :menu_3_icon_name,
+        :menu_4,
+        :menu_4_icon_name,
+        :menu_5,
+        :menu_5_icon_name,
+        :menu_6,
+        :menu_6_icon_name,
+        :menu_7,
+        :menu_7_icon_name
+      ]
+    end
+  end
+end

--- a/app/models/preference_sections/producer_signup_page_section.rb
+++ b/app/models/preference_sections/producer_signup_page_section.rb
@@ -1,0 +1,15 @@
+module PreferenceSections
+  class ProducerSignupPageSection
+    def name
+      I18n.t('admin.contents.edit.producer_signup_page')
+    end
+
+    def preferences
+      [
+        :producer_signup_pricing_table_html,
+        :producer_signup_case_studies_html,
+        :producer_signup_detail_html
+      ]
+    end
+  end
+end

--- a/app/models/preference_sections/user_guide_section.rb
+++ b/app/models/preference_sections/user_guide_section.rb
@@ -1,0 +1,11 @@
+module PreferenceSections
+  class UserGuideSection
+    def name
+      I18n.t('admin.contents.edit.user_guide')
+    end
+
+    def preferences
+      [:user_guide_link]
+    end
+  end
+end

--- a/app/views/admin/shared/_user_guide_link.html.haml
+++ b/app/views/admin/shared/_user_guide_link.html.haml
@@ -1,1 +1,1 @@
-= button_link_to t('.user_guide'), "http://www.openfoodnetwork.org/platform/user-guide/", icon: 'icon-external-link', target: '_blank'
+= button_link_to t('.user_guide'), ContentConfig.user_guide_link, icon: 'icon-external-link', target: '_blank'

--- a/app/views/enterprise_mailer/welcome.html.haml
+++ b/app/views/enterprise_mailer/welcome.html.haml
@@ -6,7 +6,7 @@
   = "#{t(:email_registered)} #{ Spree::Config.site_name }!"
 
 %p
-  = t :email_userguide_html, link: link_to('Open Food Network User Guide', 'http://www.openfoodnetwork.org/platform/user-guide/')
+  = t :email_userguide_html, link: link_to('Open Food Network User Guide', ContentConfig.user_guide_link)
 
 %p
   = t :email_admin_html, link: link_to('Admin Panel', spree.admin_url)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,6 +431,7 @@ en:
         main_links: Main Menu Links
         footer_and_external_links: Footer and External Links
         your_content: Your content
+        user_guide: User Guide
 
     enterprise_fees:
       index:
@@ -1199,6 +1200,8 @@ en:
   footer_email: "Email"
   footer_links_md: "Links"
   footer_about_url: "About URL"
+
+  user_guide_link: "User Guide Link"
 
   name: Name
   first_name: First Name

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -18,23 +18,35 @@ feature %q{
     fill_in 'footer_twitter_url', with: 'http://twitter.com/me'
     fill_in 'footer_links_md', with: '[markdown link](/)'
     click_button 'Update'
-    page.should have_content 'Your content has been successfully updated!'
+    expect(page).to have_content 'Your content has been successfully updated!'
 
     visit root_path
 
     # Then social media icons are only shown if they have a value
-    page.should_not have_selector 'i.ofn-i_044-facebook'
-    page.should     have_selector 'i.ofn-i_041-twitter'
+    expect(page).not_to have_selector 'i.ofn-i_044-facebook'
+    expect(page).to     have_selector 'i.ofn-i_041-twitter'
 
     # And markdown is rendered
-    page.should have_link 'markdown link'
+    expect(page).to have_link 'markdown link'
   end
 
   scenario "uploading logos" do
     attach_file 'logo', "#{Rails.root}/app/assets/images/logo-white.png"
     click_button 'Update'
-    page.should have_content 'Your content has been successfully updated!'
+    expect(page).to have_content 'Your content has been successfully updated!'
 
-    ContentConfig.logo.to_s.should include "logo-white"
+    expect(ContentConfig.logo.to_s).to include "logo-white"
+  end
+
+  scenario "setting user guide link" do
+    fill_in 'user_guide_link', with: 'http://www.openfoodnetwork.org/platform/user-guide/'
+    click_button 'Update'
+
+    expect(page).to have_content 'Your content has been successfully updated!'
+
+    visit spree.admin_path
+
+    expect(page).to have_link('User Guide', href: 'http://www.openfoodnetwork.org/platform/user-guide/')
+    expect(find_link('User Guide')[:target]).to eq('_blank')
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #2593 #2631 

In configuration > general settings, a field is available to add an external link for the user guide.


![screenshot from 2018-09-12 09-50-02](https://user-images.githubusercontent.com/28786869/45410179-64975880-b671-11e8-80f7-8d9f32ccafef.png)

#### What should we test?
<!-- List which features should be tested and how. -->
A superadmin can add a custom user guide link.
Non superadmins can't.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
An admin can now add a custom user guide link in Configuration > General Settings.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
This adds customizations to Spree::Config.


#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
There could be a line added where this new feature is mentioned but I'm not sure where to put it.
