### PR TITLE
Custom user guide link in enterprise welcome mail

### DIFF
--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -9,7 +9,8 @@ module Admin
                               {name: I18n.t('admin.contents.edit.main_links'), preferences: [:menu_1, :menu_1_icon_name, :menu_2, :menu_2_icon_name, :menu_3, :menu_3_icon_name, :menu_4, :menu_4_icon_name, :menu_5, :menu_5_icon_name, :menu_6, :menu_6_icon_name, :menu_7, :menu_7_icon_name]},
                               {name: I18n.t('admin.contents.edit.footer_and_external_links'), preferences: [:footer_logo,
                                                              :footer_facebook_url, :footer_twitter_url, :footer_instagram_url, :footer_linkedin_url, :footer_googleplus_url, :footer_pinterest_url,
-                                                             :footer_email, :community_forum_url, :footer_links_md, :footer_about_url]}]
+                                                             :footer_email, :community_forum_url, :footer_links_md, :footer_about_url]},
+                              {name: I18n.t('admin.contents.edit.user_guide'), preferences: [:user_guide_link]}]
     end
 
     def update

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -69,4 +69,7 @@ class ContentConfiguration < Spree::Preferences::FileConfiguration
 EOS
 
   preference :footer_about_url, :string, default: "http://www.openfoodnetwork.org/ofn-local/open-food-network-australia/"
+
+  #User Guide
+  preference :user_guide_link, :string, default: 'http://www.openfoodnetwork.org/platform/user-guide/'
 end

--- a/app/views/admin/shared/_user_guide_link.html.haml
+++ b/app/views/admin/shared/_user_guide_link.html.haml
@@ -1,1 +1,1 @@
-= button_link_to t('.user_guide'), "http://www.openfoodnetwork.org/platform/user-guide/", icon: 'icon-external-link', target: '_blank'
+= button_link_to t('.user_guide'), ContentConfig.user_guide_link, icon: 'icon-external-link', target: '_blank'

--- a/app/views/enterprise_mailer/welcome.html.haml
+++ b/app/views/enterprise_mailer/welcome.html.haml
@@ -6,7 +6,7 @@
   = "#{t(:email_registered)} #{ Spree::Config.site_name }!"
 
 %p
-  = t :email_userguide_html, link: link_to('Open Food Network User Guide', 'http://www.openfoodnetwork.org/platform/user-guide/')
+  = t :email_userguide_html, link: link_to('Open Food Network User Guide', ContentConfig.user_guide_link)
 
 %p
   = t :email_admin_html, link: link_to('Admin Panel', spree.admin_url)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,6 +431,7 @@ en:
         main_links: Main Menu Links
         footer_and_external_links: Footer and External Links
         your_content: Your content
+        user_guide: User Guide
 
     enterprise_fees:
       index:
@@ -1199,6 +1200,8 @@ en:
   footer_email: "Email"
   footer_links_md: "Links"
   footer_about_url: "About URL"
+
+  user_guide_link: "User Guide Link"
 
   name: Name
   first_name: First Name

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -18,23 +18,36 @@ feature %q{
     fill_in 'footer_twitter_url', with: 'http://twitter.com/me'
     fill_in 'footer_links_md', with: '[markdown link](/)'
     click_button 'Update'
-    page.should have_content 'Your content has been successfully updated!'
+    expect(page).to have_content 'Your content has been successfully updated!'
 
     visit root_path
 
     # Then social media icons are only shown if they have a value
-    page.should_not have_selector 'i.ofn-i_044-facebook'
-    page.should     have_selector 'i.ofn-i_041-twitter'
+    expect(page).not_to have_selector 'i.ofn-i_044-facebook'
+    expect(page).to     have_selector 'i.ofn-i_041-twitter'
 
     # And markdown is rendered
-    page.should have_link 'markdown link'
+    expect(page).to have_link 'markdown link'
   end
 
   scenario "uploading logos" do
     attach_file 'logo', "#{Rails.root}/app/assets/images/logo-white.png"
     click_button 'Update'
-    page.should have_content 'Your content has been successfully updated!'
+    expect(page).to have_content 'Your content has been successfully updated!'
 
-    ContentConfig.logo.to_s.should include "logo-white"
+    expect(ContentConfig.logo.to_s).to include "logo-white"
+  end
+
+  scenario "setting user guide link" do
+    fill_in 'user_guide_link', with: 'http://www.openfoodnetwork.org/platform/user-guide/'
+    click_button 'Update'
+
+    expect(page).to have_content 'Your content has been successfully updated!'
+    expect(ContentConfig.user_guide_link).to eq 'http://www.openfoodnetwork.org/platform/user-guide/'
+
+    visit spree.admin_path
+
+    expect(page).to have_link('User Guide', href: 'http://www.openfoodnetwork.org/platform/user-guide/')
+    expect(find_link('User Guide')[:target]).to eq('_blank')
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #2631 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Following #2686 
Adding dynamic user guide link to enterprise welcome email.


#### What should we test?
<!-- List which features should be tested and how. -->
In the enterprise welcome email, the custom user guide link should be displayed.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
