### PR TITLE
Fix failing spec due to wrong attribute

### DIFF
--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -59,7 +59,7 @@ describe VariantOverride do
 
   describe "looking up count on hand" do
     it "returns the numeric stock level when present" do
-      VariantOverride.create!(variant: variant, hub: hub, on_hand: 12)
+      VariantOverride.create!(variant: variant, hub: hub, count_on_hand: 12)
       VariantOverride.count_on_hand_for(hub, variant).should == 12
     end
 


### PR DESCRIPTION
#### What? Why?

It fixes the spec that got broken in https://github.com/openfoodfoundation/openfoodnetwork/commit/cebcdea40cdf0584e59af9af38f634a685e93a60. We mistakenly changed the attribute name for a variant override when doing a replace for variants.


#### What should we test?
Nothing yet. The upgrade is not ready yet.



#### Release notes
Fix broken spec for variant overrides. (This is only in `2-0-stable` branch though).

Changelog Category: Fixed