### PR TITLE
2655 fix admin payments

### DIFF
--- a/app/controllers/admin/subscription_line_items_controller.rb
+++ b/app/controllers/admin/subscription_line_items_controller.rb
@@ -1,5 +1,6 @@
 require 'open_food_network/permissions'
 require 'open_food_network/order_cycle_permissions'
+require 'open_food_network/scope_variant_to_hub'
 
 module Admin
   class SubscriptionLineItemsController < ResourceController

--- a/app/controllers/spree/admin/line_items_controller_decorator.rb
+++ b/app/controllers/spree/admin/line_items_controller_decorator.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 Spree::Admin::LineItemsController.class_eval do
   prepend_before_filter :load_order, except: :index
   around_filter :apply_enterprise_fees_with_lock, only: :update

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 class OrderCycle < ActiveRecord::Base
   belongs_to :coordinator, :class_name => 'Enterprise'
 

--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 module Spree
   InventoryUnit.class_eval do
     def self.assign_opening_inventory(order)

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,3 +1,4 @@
+require 'open_food_network/scope_variant_to_hub'
 require 'open_food_network/variant_and_line_item_naming'
 
 Spree::LineItem.class_eval do

--- a/app/services/order_factory.rb
+++ b/app/services/order_factory.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 # Builds orders based on a set of attributes
 # There are some idiosyncracies in the order creation process,
 # and it is nice to have them dealt with in one place.

--- a/app/services/subscription_estimator.rb
+++ b/app/services/subscription_estimator.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 # Responsible for estimating prices and fees for subscriptions
 # Used by SubscriptionForm as part of the create/update process
 # The values calculated here are intended to be persisted in the db

--- a/app/views/spree/admin/payments/_form.html.erb
+++ b/app/views/spree/admin/payments/_form.html.erb
@@ -1,5 +1,5 @@
 <%= admin_inject_json "admin.payments", "currentOrderNumber", @order.number %>
-<%= admin_inject_json_ams_array "admin.payments", "paymentMethods", @payment_methods, Api::PaymentMethodSerializer %>
+<%= admin_inject_json_ams_array "admin.payments", "paymentMethods", @payment_methods, Api::PaymentMethodSerializer, current_order: @order %>
 
 <div data-hook="admin_payment_form_fields" class="row">
   <div class="alpha three columns">

--- a/lib/open_food_network/products_and_inventory_report_base.rb
+++ b/lib/open_food_network/products_and_inventory_report_base.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 module OpenFoodNetwork
   class ProductsAndInventoryReportBase
     attr_reader :params

--- a/lib/open_food_network/scope_variants_for_search.rb
+++ b/lib/open_food_network/scope_variants_for_search.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 # Used to return a set of variants which match the criteria provided
 # A query string is required, which will be match to the name and/or SKU of a product
 # Further restrictions on the schedule, order_cycle or distributor through which the

--- a/lib/spree/core/controller_helpers/order_decorator.rb
+++ b/lib/spree/core/controller_helpers/order_decorator.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/scope_variant_to_hub'
+
 Spree::Core::ControllerHelpers::Order.class_eval do
   def current_order_with_scoped_variants(create_order_if_necessary = false)
     order = current_order_without_scoped_variants(create_order_if_necessary)

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -27,7 +27,6 @@ feature '
     end
 
     scenario "visiting the payment form" do
-      pending "fix usage of the PaymentMethodSerializer"
       quick_login_as_admin
 
       visit spree.new_admin_order_payment_path order

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+feature '
+    As an admin
+    I want to manage payments
+' do
+  include AuthenticationWorkflow
+
+  let(:order) { create(:completed_order_with_fees) }
+
+  scenario "visiting the payment form" do
+    quick_login_as_admin
+
+    visit spree.new_admin_order_payment_path order
+
+    expect(page).to have_content "New Payment"
+  end
+
+  context "with sensitive payment fee" do
+    let(:payment_method) { order.distributor.payment_methods.first }
+
+    before do
+      # This calculator doesn't handle a `nil` order well.
+      # That has been useful in finding bugs. ;-)
+      payment_method.calculator = Spree::Calculator::FlatPercentItemTotal.new
+      payment_method.save!
+    end
+
+    scenario "visiting the payment form" do
+      pending "fix usage of the PaymentMethodSerializer"
+      quick_login_as_admin
+
+      visit spree.new_admin_order_payment_path order
+
+      expect(page).to have_content "New Payment"
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #2655.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The new Stripe code is loading payment methods including their calculated fees. But it forgot to pass on the current order to calculate fees on. Trying to create a payment for an order failed if the enterprise had certain payment fees configured.

#### What should we test?
<!-- List which features should be tested and how. -->

Creating a payment from the admin interface.

- Admin -> Orders -> select order -> Payments -> New Payment

Creating a payment should work.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed charging customers from the admin interface which failed when certain payment fees where configured.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
