### PR TITLE
[Spree Upgrade] Adapt order_decorator.shipments.adjustments to spree 2

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -153,7 +153,7 @@ Spree::Order.class_eval do
   def update_shipping_fees!
     shipments.each do |shipment|
       next if shipment.shipped?
-      update_adjustment! shipment.adjustment
+      update_adjustment! shipment.adjustment if shipment.adjustment
       shipment.save # updates included tax
     end
   end
@@ -164,7 +164,7 @@ Spree::Order.class_eval do
   def update_payment_fees!
     payments.each do |payment|
       next if payment.completed?
-      update_adjustment! payment.adjustment
+      update_adjustment! payment.adjustment if payment.adjustment
       payment.save
     end
   end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -386,7 +386,7 @@ Spree::Order.class_eval do
     return if adjustment.finalized?
     state = adjustment.state
     adjustment.state = 'open'
-    adjustment.update!(self)
+    adjustment.update!
     adjustment.state = state
   end
 


### PR DESCRIPTION
Adapted order_decorator to spree 2 by:
1 - In order_decorator.update_shipping_fees! and order_decorator.update_payment_fees!, only update adjustment if it exists
2 - in order_decorator.update_adjustment!, fixed call to adjustment.update!

#### What? Why?

Closes #2726 