### PR TITLE
Moved definition of colors in the cookies modal and banner colors to common darkswarm/base/colors

### DIFF
--- a/app/assets/stylesheets/darkswarm/base/colors.css.scss
+++ b/app/assets/stylesheets/darkswarm/base/colors.css.scss
@@ -1,4 +1,13 @@
+@import '../branding';
+
 $modal-background-color: #efefef;
 $modal-content-background-color: #fff;
 $modal-alert-link-color: #fff;
 $modal-alert-link-hover-color: rgba(255, 255, 255, .7);
+
+$cookies-banner-background-color: $dark-grey;
+$cookies-banner-button-background-color: $clr-turquoise;
+$cookies-banner-text-color: $white;
+$cookies-policy-modal-background-color: $disabled-light;
+$cookies-policy-modal-border-bottom-color: $disabled-light;
+$cookies-policy-modal-table-tr-even-background-color: $disabled-very-light;

--- a/app/assets/stylesheets/darkswarm/base/colors.css.scss
+++ b/app/assets/stylesheets/darkswarm/base/colors.css.scss
@@ -1,4 +1,4 @@
-@import '../branding';
+@import 'darkswarm/branding';
 
 $modal-background-color: #efefef;
 $modal-content-background-color: #fff;

--- a/engines/web/app/assets/stylesheets/web/pages/cookies_banner.css.scss
+++ b/engines/web/app/assets/stylesheets/web/pages/cookies_banner.css.scss
@@ -1,18 +1,18 @@
 @import 'darkswarm/branding';
 
 .cookies-banner {
-  background: $dark-grey;
+  background: $cookies-banner-background-color;
   bottom: 0;
   position: fixed;
   top: 15% !important;
   z-index: 100000;
 
   button {
-    background-color: $clr-turquoise;
+    background-color: $cookies-banner-button-background-color;
   }
 
   p {
-    color: $white;
+    color: $cookies-banner-text-color;
     font-size: .75rem;
   }
 

--- a/engines/web/app/assets/stylesheets/web/pages/cookies_banner.css.scss
+++ b/engines/web/app/assets/stylesheets/web/pages/cookies_banner.css.scss
@@ -1,4 +1,4 @@
-@import 'darkswarm/branding';
+@import 'darkswarm/base/colors';
 
 .cookies-banner {
   background: $cookies-banner-background-color;

--- a/engines/web/app/assets/stylesheets/web/pages/cookies_policy_modal.css.scss
+++ b/engines/web/app/assets/stylesheets/web/pages/cookies_policy_modal.css.scss
@@ -1,4 +1,4 @@
-@import 'darkswarm/branding';
+@import 'darkswarm/base/colors';
 
 .cookies-policy-modal {
   background: $cookies-policy-modal-background-color;

--- a/engines/web/app/assets/stylesheets/web/pages/cookies_policy_modal.css.scss
+++ b/engines/web/app/assets/stylesheets/web/pages/cookies_policy_modal.css.scss
@@ -1,14 +1,14 @@
 @import 'darkswarm/branding';
 
 .cookies-policy-modal {
-  background: $disabled-light;
-  border-bottom-color: $disabled-light;
+  background: $cookies-policy-modal-background-color;
+  border-bottom-color: $cookies-policy-modal-border-bottom-color;
 
   table {
     width: 100%;
 
     tr:nth-of-type(even) {
-      background-color: $disabled-very-light;
+      background-color: $cookies-policy-modal-table-tr-even-background-color;
     }
 
     p {


### PR DESCRIPTION
#### What? Why?

This comes out of this commit from @kristinalim 
https://github.com/luisramos0/openfoodnetwork/pull/2/commits/cdabeda2d9bcb02b331bef3c58c1d049f764f109

Instead of having all css files with references to a color palete defined in branding.css we should have a file with all color definitions colors.css and we should use scss variables for colors in the specific css files.

#### What should we test?
Cookies modal policy page and cookies banner should keep existing colors.

#### Release notes
Changelog Category: Changed
Introduced new color management approach in CSS.

#### Dependencies
This started in the [cookies engines POC](https://github.com/openfoodfoundation/openfoodnetwork/pull/2521) but its now independent from it.

#### Documentation updates
When this PR is approved we should get this approach documented somewhere on the wiki.
