### PR TITLE
[Spree Upgrade] Refactored spree/order_details, extracted delivery and pickup details into separate partials

### DIFF
--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -29,60 +29,10 @@
         = order.bill_address.phone
 
   .columns.large-6
-    - if order.shipping_method.andand.delivery?
-      // Delivery option
-      .order-summary.text-small
-        %strong= order.shipping_method.name
-      .pad
-        .text-big
-          = t :order_delivery_time
-          %strong #{order.order_cycle.pickup_time_for(order.distributor)}
-        %p.text-small.text-skinny.pre-line
-          %em= order.shipping_method.description.andand.html_safe || ""
-      .order-summary.text-small
-        %strong
-          = t :order_delivery_address
-      .pad
-        %p.text-small
-          = order.ship_address.firstname + " " + order.ship_address.lastname
-          %br
-          = order.ship_address.full_address
-          %br
-          = order.ship_address.phone
-        - if order.special_instructions.present?
-          %br
-          %p.light.small
-            %strong
-              = t :order_special_instructions
-            %br
-            = order.special_instructions
+    - if order.shipping_method.andand.require_ship_address
+      = render 'spree/shared/shipment_delivery_details', order: order
     - else
-      // Collection option
-      .order-summary.text-small
-        %strong= order.shipping_method.name
-      .pad
-        .text-big
-          = t :order_pickup_time
-          %strong #{order.order_cycle.pickup_time_for(order.distributor)}
-        %p.text-small.text-skinny.pre-line
-          %em= order.shipping_method.description.andand.html_safe || ""
-
-        - if order.order_cycle.pickup_instructions_for(order.distributor).present?
-          %br
-          %p.text-small
-            %strong
-              = t :order_pickup_instructions
-            %br
-            #{order.order_cycle.pickup_instructions_for(order.distributor)}
-
-        - if order.special_instructions.present?
-          %br
-          %p.light.small
-            %strong
-              = t :order_special_instructions
-            %br
-            = order.special_instructions
-
+      = render 'spree/shared/shipment_pickup_details', order: order
 %br
 .row
   .columns.large-12

--- a/app/views/spree/shared/_shipment_delivery_details.html.haml
+++ b/app/views/spree/shared/_shipment_delivery_details.html.haml
@@ -1,0 +1,25 @@
+.order-summary.text-small
+  %strong= order.shipping_method.name
+.pad
+  .text-big
+    = t :order_delivery_time
+    %strong #{order.order_cycle.pickup_time_for(order.distributor)}
+  %p.text-small.text-skinny.pre-line
+    %em= order.shipping_method.description.andand.html_safe || ""
+.order-summary.text-small
+  %strong
+    = t :order_delivery_address
+.pad
+  %p.text-small
+    = order.ship_address.firstname + " " + order.ship_address.lastname
+    %br
+    = order.ship_address.full_address
+    %br
+    = order.ship_address.phone
+  - if order.special_instructions.present?
+    %br
+    %p.light.small
+      %strong
+        = t :order_special_instructions
+      %br
+      = order.special_instructions

--- a/app/views/spree/shared/_shipment_pickup_details.html.haml
+++ b/app/views/spree/shared/_shipment_pickup_details.html.haml
@@ -1,0 +1,25 @@
+.order-summary.text-small
+  %strong= order.shipping_method.name
+.pad
+  .text-big
+    = t :order_pickup_time
+    %strong #{order.order_cycle.pickup_time_for(order.distributor)}
+  %p.text-small.text-skinny.pre-line
+    %em= order.shipping_method.description.andand.html_safe || ""
+
+  - if order.order_cycle.pickup_instructions_for(order.distributor).present?
+    %br
+    %p.text-small
+      %strong
+        = t :order_pickup_instructions
+      %br
+      #{order.order_cycle.pickup_instructions_for(order.distributor)}
+
+  - if order.special_instructions.present?
+    %br
+    %p.light.small
+      %strong
+        = t :order_special_instructions
+      %br
+      = order.special_instructions
+

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -21,6 +21,11 @@ feature "Order Management", js: true do
       quick_login_as user
     end
 
+    it 'shows the name of the shipping method' do
+      visit spree.order_path(order)
+      expect(find('#order')).to have_content(shipping_method.name)
+    end
+
     context "when the distributor doesn't allow changes to be made to orders" do
       before do
         order.distributor.update_attributes(allow_order_changes: false)


### PR DESCRIPTION
This was copied/adapted from 6f7c8bb8b1e174dc67e60effa4a1e57844878a0e

#### What? Why?

Closes #2678 

#### What should we test?
Not really manually testable. But the build is validating the shipping method is there in the page.