### PR TITLE
[Spree Upgrade] Replace Spree::ShippingMethods new view by our own and apply overrides

### DIFF
--- a/app/overrides/spree/admin/shipping_methods/new/add_hubs_sidebar.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/new/add_hubs_sidebar.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_after "code[erb-loud]:contains(\"render :partial => 'form', :locals => { :f => f }\")"
-
-.one.column &nbsp;
-= render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :shipping_method }

--- a/app/overrides/spree/admin/shipping_methods/new/remove_configuration_sidebar.deface
+++ b/app/overrides/spree/admin/shipping_methods/new/remove_configuration_sidebar.deface
@@ -1,1 +1,0 @@
-remove "code[erb-loud]:contains(\"render :partial => 'spree/admin/shared/configuration_menu'\")"

--- a/app/views/spree/admin/shipping_methods/new.html.haml
+++ b/app/views/spree/admin/shipping_methods/new.html.haml
@@ -2,15 +2,15 @@
   = Spree.t(:new_shipping_method)
 - content_for :page_actions do
   %li
-    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, :icon => 'icon-arrow-left'
+    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, icon: 'icon-arrow-left'
 %div
-  = render :partial => 'spree/shared/error_messages', :locals => { :target => @shipping_method }
+  = render partial: 'spree/shared/error_messages', locals: { target: @shipping_method }
 %div
   = form_for [:admin, @shipping_method] do |f|
     %fieldset.no-border-top
-      = render :partial => 'form', :locals => { :f => f }
+      = render partial: 'form', locals: { f: f }
       .one.column &nbsp;
-      = render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :shipping_method }
+      = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :shipping_method }
       .clear
       %div
-        = render :partial => 'spree/admin/shared/new_resource_links'
+        = render partial: 'spree/admin/shared/new_resource_links'

--- a/app/views/spree/admin/shipping_methods/new.html.haml
+++ b/app/views/spree/admin/shipping_methods/new.html.haml
@@ -1,0 +1,16 @@
+- content_for :page_title do
+  = Spree.t(:new_shipping_method)
+- content_for :page_actions do
+  %li
+    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, :icon => 'icon-arrow-left'
+%div
+  = render :partial => 'spree/shared/error_messages', :locals => { :target => @shipping_method }
+%div
+  = form_for [:admin, @shipping_method] do |f|
+    %fieldset.no-border-top
+      = render :partial => 'form', :locals => { :f => f }
+      .one.column &nbsp;
+      = render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :shipping_method }
+      .clear
+      %div
+        = render :partial => 'spree/admin/shared/new_resource_links'


### PR DESCRIPTION
#### What? Why?

Part of #2744 

Replacing Spree view for Spree:ShippingMethods new by OFN own view and applying Deface overrides.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
The new shipping method view won't be working right now (because #2744), but all elemnts should be here and Rails should take our view instead of Spree's.



#### Release notes
<!-- Write a line or two to be included in the release notes. -->
No release notes



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
