### PR TITLE
[Spree Upgrade] Replace Spree::ShippingMethods edit view by our own and apply overrides

### DIFF
--- a/app/overrides/spree/admin/shipping_methods/edit/add_hubs_sidebar.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/edit/add_hubs_sidebar.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_after "code[erb-loud]:contains(\"render :partial => 'form', :locals => { :f => f }\")"
-
-.one.column &nbsp;
-= render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :shipping_method }

--- a/app/overrides/spree/admin/shipping_methods/edit/add_new_shipping_method_buttton.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/edit/add_new_shipping_method_buttton.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_after "code[erb-silent]:contains('content_for :page_actions do')"
-
-%li
-  = button_link_to t(:new), spree.new_admin_shipping_method_path, :icon => 'icon-plus' %>

--- a/app/overrides/spree/admin/shipping_methods/edit/remove_configuration_sidebar.deface
+++ b/app/overrides/spree/admin/shipping_methods/edit/remove_configuration_sidebar.deface
@@ -1,1 +1,0 @@
-remove "code[erb-loud]:contains(\"render :partial => 'spree/admin/shared/configuration_menu'\")"

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -2,17 +2,17 @@
   = Spree.t(:editing_shipping_method)
 - content_for :page_actions do
   %li
-    = button_link_to t(:new), spree.new_admin_shipping_method_path, :icon => 'icon-plus'
+    = button_link_to t(:new), spree.new_admin_shipping_method_path, icon: 'icon-plus'
   %li
-    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, :icon => 'icon-arrow-left'
+    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, icon: 'icon-arrow-left'
 %div
-  = render :partial => 'spree/shared/error_messages', :locals => { :target => @shipping_method }
+  = render partial: 'spree/shared/error_messages', locals: { target: @shipping_method }
 %div
   = form_for [:admin, @shipping_method] do |f|
     %fieldset.no-border-top
-      = render :partial => 'form', :locals => { :f => f }
+      = render partial: 'form', locals: { f: f }
       .one.column &nbsp;
-      = render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :shipping_method }
+      = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :shipping_method }
       .clear
       %div
-        = render :partial => 'spree/admin/shared/edit_resource_links'
+        = render partial: 'spree/admin/shared/edit_resource_links'

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -1,0 +1,18 @@
+- content_for :page_title do
+  = Spree.t(:editing_shipping_method)
+- content_for :page_actions do
+  %li
+    = button_link_to t(:new), spree.new_admin_shipping_method_path, :icon => 'icon-plus'
+  %li
+    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, :icon => 'icon-arrow-left'
+%div
+  = render :partial => 'spree/shared/error_messages', :locals => { :target => @shipping_method }
+%div
+  = form_for [:admin, @shipping_method] do |f|
+    %fieldset.no-border-top
+      = render :partial => 'form', :locals => { :f => f }
+      .one.column &nbsp;
+      = render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :shipping_method }
+      .clear
+      %div
+        = render :partial => 'spree/admin/shared/edit_resource_links'


### PR DESCRIPTION
#### What? Why?

Part of #2744

Replacing Spree view for Spree:ShippingMethods edit by OFN own view and applying Deface overrides.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
The edit shipping method view won't be working right now (because #2744), but all elements should be here and Rails should take our view instead of Spree's.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
No release notes