### PR TITLE
[Spree Upgrade] Replace Spree::ShippingMethods index view by our own and apply overrides

### DIFF
--- a/app/overrides/spree/admin/shipping_methods/index/add_distributor_td.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/index/add_distributor_td.html.haml.deface
@@ -1,6 +1,0 @@
-/ insert_after "[data-hook='admin_shipping_methods_index_rows'] td:first-child"
-
-%td.align-center
-  - shipping_method.distributors.each do |distributor|
-    = distributor.name
-    %br/

--- a/app/overrides/spree/admin/shipping_methods/index/add_distributor_th.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/index/add_distributor_th.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_after "[data-hook='admin_shipping_methods_index_headers'] th:first-child" 
-
-%th
-  = t(:products_distributor)

--- a/app/overrides/spree/admin/shipping_methods/index/rearrange_cols.html.haml.deface
+++ b/app/overrides/spree/admin/shipping_methods/index/rearrange_cols.html.haml.deface
@@ -1,1 +1,0 @@
-/ replace_contents "table#listing_shipping_methods colgroup" 

--- a/app/overrides/spree/admin/shipping_methods/index/remove_configuration_sidebar.deface
+++ b/app/overrides/spree/admin/shipping_methods/index/remove_configuration_sidebar.deface
@@ -1,1 +1,0 @@
-remove "code[erb-loud]:contains(\"render :partial => 'spree/admin/shared/configuration_menu'\")"

--- a/app/views/spree/admin/shipping_methods/index.html.haml
+++ b/app/views/spree/admin/shipping_methods/index.html.haml
@@ -1,0 +1,37 @@
+- content_for :page_title do
+  = Spree.t(:shipping_methods)
+- content_for :page_actions do
+  %li
+    = button_link_to Spree.t(:new_shipping_method), new_object_url,  :icon => 'icon-plus', :id => 'admin_new_shipping_method_link'
+- if @shipping_methods.any?
+  %table#listing_shipping_methods.index
+    %colgroup
+      %col{style: "width: 20%"}/
+      %col{style: "width: 15%"}/
+      %col{style: "width: 40%"}/
+      %col{style: "width: 10%"}/
+      %col{style: "width: 15%"}/
+    %thead
+      %tr
+        %th= Spree.t(:name)
+        %th= t(:products_distributor)
+        %th= Spree.t(:zone)
+        %th= Spree.t(:calculator)
+        %th= Spree.t(:display)
+        %th.actions
+    %tbody
+      - @shipping_methods.each do |shipping_method|
+        %tr{class: "#{cycle('odd', 'even')}", id: "#{spree_dom_id shipping_method}"}
+          %td= shipping_method.name
+          %td.align-center
+            - shipping_method.distributors.each do |distributor|
+              = distributor.name
+              %br/
+          %td= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones
+          %td= shipping_method.calculator.description
+          %td.align-center= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on)
+          %td.actions
+            = link_to_edit shipping_method, :no_text => true
+            = link_to_delete shipping_method, :no_text => true
+- else
+  .alpha.twelve.columns.no-objects-found= Spree.t(:no_shipping_methods_found)

--- a/app/views/spree/admin/shipping_methods/index.html.haml
+++ b/app/views/spree/admin/shipping_methods/index.html.haml
@@ -2,7 +2,7 @@
   = Spree.t(:shipping_methods)
 - content_for :page_actions do
   %li
-    = button_link_to Spree.t(:new_shipping_method), new_object_url,  :icon => 'icon-plus', :id => 'admin_new_shipping_method_link'
+    = button_link_to Spree.t(:new_shipping_method), new_object_url,  icon: 'icon-plus', id: 'admin_new_shipping_method_link'
 - if @shipping_methods.any?
   %table#listing_shipping_methods.index
     %colgroup
@@ -31,7 +31,7 @@
           %td= shipping_method.calculator.description
           %td.align-center= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on)
           %td.actions
-            = link_to_edit shipping_method, :no_text => true
-            = link_to_delete shipping_method, :no_text => true
+            = link_to_edit shipping_method, no_text: true
+            = link_to_delete shipping_method, no_text: true
 - else
   .alpha.twelve.columns.no-objects-found= Spree.t(:no_shipping_methods_found)


### PR DESCRIPTION
#### What? Why?

Part of #2744

Replacing Spree view for Spree:ShippingMethods index by OFN own view and applying Deface overrides.
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
The index shipping method view won't be working right now (because #2744), but all elements should be here and Rails should take our view instead of Spree's.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
No release notes