### PR TITLE
Removed deprecated spec helper have_select2_option and fixed its last usage

### DIFF
--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -128,7 +128,7 @@ feature %q{
     visit '/admin/orders'
     page.find('td.actions a.icon-edit').click
 
-    expect(page).not_to have_select2_option product.name, from: ".variant_autocomplete", dropdown_css: ".select2-search"
+    expect(page).not_to have_select2 "add_variant_id", with_options: [product.name]
   end
 
   scenario "can't change distributor or order cycle once order has been finalized" do

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -168,15 +168,6 @@ module WebHelper
     select_select2_result(value)
   end
 
-  # Deprecated: Use have_select2 instead (spec/support/matchers/select2_matchers.rb)
-  def have_select2_option(value, options)
-    container = options[:dropdown_css] || ".select2-with-searchbox"
-    page.execute_script %Q{$('#{options[:from]}').select2('open')}
-    page.execute_script "$('#{container} input.select2-input').val('#{value}').trigger('keyup-change');"
-    sleep 1
-    have_selector "div.select2-result-label", text: value
-  end
-
   def open_select2(selector)
     page.execute_script "jQuery('#{selector}').select2('open');"
   end


### PR DESCRIPTION
#### What? Why?

Clean up specs code.

#### What should we test?
features/admin/orders_spec should still be green.
