### PR TITLE
[Spree Upgrade] Fixed updates of order.shipping_method_id and improved order, stock_location and shipment factories

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -385,6 +385,7 @@ FactoryBot.define do
 
       after(:create) do |shipment, evaluator|
         shipping_method = create(:shipping_method_with, :shipping_fee, shipping_fee: evaluator.shipping_fee)
+        shipment.shipping_rates.destroy_all # remove existing shipping_rates from shipment
         shipment.add_shipping_method(shipping_method, true)
       end
     end
@@ -408,6 +409,9 @@ FactoryBot.define do
       payment_calculator = build(:calculator_per_item, preferred_amount: evaluator.payment_fee)
       payment_method = create(:payment_method, calculator: payment_calculator)
       create(:payment, order: order, amount: order.total, payment_method: payment_method, state: 'checkout')
+
+      # skip the rebuilding of order.shipments from line_items and stock locations (this is enforced in checkout step :address to :delivery)
+      order.stub(:create_proposed_shipments)
       while !order.completed? do break unless order.next! end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -616,3 +616,15 @@ FactoryBot.modify do
     end
   end
 end
+
+FactoryBot.modify do
+  factory :stock_location, class: Spree::StockLocation do
+    # keeps the test stock_location unique
+    initialize_with { Spree::StockLocation.find_or_create_by_name(name)}
+  end
+
+  factory :shipment, class: Spree::Shipment do
+    # keeps test shipments unique per order
+    initialize_with { Spree::Shipment.find_or_create_by_order_id(order.id)}
+  end
+end

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -16,7 +16,7 @@ feature "Order Management", js: true do
 
     before do
       shipping_method.calculator.update_attributes(preferred_amount: 5.0)
-      order.update_attributes(shipping_method_id: shipping_method.id)
+      order.shipments = [create(:shipment_with, :shipping_method, shipping_method: shipping_method)]
       order.reload.save
       quick_login_as user
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -708,7 +708,7 @@ describe Spree::Order do
 
       it "updates shipping fees" do
         # Change the shipping method
-        order.shipment.update_attributes(shipping_method_id: shipping_method.id)
+        order.shipments = [create(:shipment_with, :shipping_method, shipping_method: shipping_method)]
         order.save
 
         # Check if fees got updated


### PR DESCRIPTION
#### What? Why?

Closes #2693

Moving uses of order.shipping_method_id to order.shipments in models/spree/order_spec and features/consumer/shopping/orders_spec.

Also improved factory order_completed_with_fees. It now completes the checkout workflow without errors which moves a few specs to a new state.

#### What should we test?
Only changing specs. Errors on these specs are now mostly related to the calculations not being the values expected.

#### Dependencies
This PR depends on #2680 and will have to be rebase and merged _after_ it.