### PR TITLE
[Spree Upgrade] Destroy all shipments when clearing order

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -87,7 +87,7 @@ Spree::Order.class_eval do
   def empty_with_clear_shipping_and_payments!
     empty_without_clear_shipping_and_payments!
     payments.clear
-    update_attributes(shipping_method_id: nil)
+    shipments.destroy_all
   end
   alias_method_chain :empty!, :clear_shipping_and_payments
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -387,18 +387,18 @@ describe Spree::Order do
   end
 
   describe "emptying the order" do
-    it "removes shipping method" do
-      subject.shipments = [create(:shipment)]
+    it "removes shipments" do
+      subject.shipments << create(:shipment)
       subject.save!
       subject.empty!
-      subject.shipping_method.should == nil
+      expect(subject.shipments).to be_empty
     end
 
     it "removes payments" do
       subject.payments << create(:payment)
       subject.save!
       subject.empty!
-      subject.payments.should == []
+      expect(subject.payments).to be_empty
     end
   end
 


### PR DESCRIPTION
Now we only clear the order's shipping_method, and in Spree 2.0 it can have many shipments.

#### What? Why?

Closes #2681 

I think @sauloperez solution is valid. This PR is just cherry picking the commit and resolving conflicts.

#### What should we test?
Fixes order.empty route.