### PR TITLE
[Spree Upgrade] Remove obsolete Spree 2 backport on Order

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -320,24 +320,6 @@ Spree::Order.class_eval do
     complete? && distributor.andand.allow_order_changes? && order_cycle.andand.open?
   end
 
-  # Override of existing Spree method. Can remove when we reach 2-0-stable
-  # See commit: https://github.com/spree/spree/commit/5fca58f658273451193d5711081d018c317814ed
-  # Allows GatewayError to show useful error messages in checkout
-  def process_payments!
-    pending_payments.each do |payment|
-      break if payment_total >= total
-
-      payment.process!
-
-      if payment.completed?
-        self.payment_total += payment.amount
-      end
-    end
-  rescue Spree::Core::GatewayError => e # This section changed
-    result = !!Spree::Config[:allow_checkout_on_gateway_error]
-    errors.add(:base, e.message) and return result
-  end
-
   # Override or Spree method. Used to prevent payments on subscriptions from being processed in the normal way.
   # ie. they are 'hidden' from processing logic until after the order cycle has closed.
   def pending_payments


### PR DESCRIPTION
#### What? Why?

Closes #2520

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We backported error handling logic for processing payments from Spree 2. We don't need this backport any more.

#### What should we test?
<!-- List which features should be tested and how. -->

Not testable yet.

