### PR TITLE
Setup simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ libpeerconnection.log
 /config/application.yml
 node_modules
 vendor/bundle/
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,7 @@ end
 
 group :test do
   gem 'webmock'
+  gem 'simplecov', require: false
   # See spec/spec_helper.rb for instructions
   #gem 'perftools.rb'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
       devise (>= 2.1.0)
     diff-lcs (1.3)
     diffy (3.1.0)
+    docile (1.3.1)
     dry-inflector (0.1.2)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -688,6 +689,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     skylight (1.6.1)
       activesupport (>= 3.0.0)
     spinjs-rails (1.3)
@@ -832,6 +838,7 @@ DEPENDENCIES
   sass-rails (~> 3.2.3)
   shoulda-matchers
   simple_form!
+  simplecov
   skylight (< 2.0)
   spinjs-rails
   spree!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start 'rails'
+
 require 'rubygems'
 
 # Require pry when we're not inside Travis-CI


### PR DESCRIPTION
#### What? Why?

This enables code coverage analysis when running specs in your dev
environment. Simply run them as usual and you'll see a line like the
following at the end of the output:

```
Coverage report generated for RSpec to /home/pau/dev/openfoodnetwork/coverage
```

Simply browse to coverage/index.html and the results in a web UI.

This is a useful tool that helps you decide if the tests you added are
enough or not.

##### Screenshots

![screenshot from 2018-09-27 15-58-40](https://user-images.githubusercontent.com/762088/46151127-6450ad00-c26e-11e8-97ff-c14200aecd12.png)
![screenshot from 2018-09-27 15-58-30](https://user-images.githubusercontent.com/762088/46151129-64e94380-c26e-11e8-8d71-95d66efcb419.png)


#### What should we test?

Nothing. This is for development only.

#### Release notes

Add SimpleCov to enable code coverage analysis.

Changelog Category: Added