### PR TITLE
[Spree Upgrade] Fix Stripe connect factory

### DIFF
--- a/app/models/spree/concerns/payment_method_distributors.rb
+++ b/app/models/spree/concerns/payment_method_distributors.rb
@@ -1,0 +1,15 @@
+require 'active_support/concern'
+
+# This concern is used to duplicate the associations distributors and distributor_ids
+#   across payment method and gateway
+#   this fixes the inheritance problem https://github.com/openfoodfoundation/openfoodnetwork/issues/2781
+module Spree::PaymentMethodDistributors
+  extend ActiveSupport::Concern
+
+  def self.included(base)
+    base.class_eval do
+      attr_accessible :distributor_ids
+      has_and_belongs_to_many :distributors, join_table: 'distributors_payment_methods', class_name: 'Enterprise', foreign_key: 'payment_method_id', association_foreign_key: 'distributor_id'
+    end
+  end
+end

--- a/app/models/spree/gateway_decorator.rb
+++ b/app/models/spree/gateway_decorator.rb
@@ -2,4 +2,7 @@ Spree::Gateway.class_eval do
   # Default to live
   preference :server, :string, :default => 'live'
   preference :test_mode, :boolean, :default => false
+
+  attr_accessible :distributor_ids
+  has_and_belongs_to_many :distributors, join_table: 'distributors_payment_methods', :class_name => 'Enterprise', foreign_key: 'payment_method_id', association_foreign_key: 'distributor_id'
 end

--- a/app/models/spree/gateway_decorator.rb
+++ b/app/models/spree/gateway_decorator.rb
@@ -1,8 +1,9 @@
+require 'spree/concerns/payment_method_distributors'
+
 Spree::Gateway.class_eval do
+  include Spree::PaymentMethodDistributors
+
   # Default to live
   preference :server, :string, :default => 'live'
   preference :test_mode, :boolean, :default => false
-
-  attr_accessible :distributor_ids
-  has_and_belongs_to_many :distributors, join_table: 'distributors_payment_methods', :class_name => 'Enterprise', foreign_key: 'payment_method_id', association_foreign_key: 'distributor_id'
 end

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -1,12 +1,14 @@
+require 'spree/concerns/payment_method_distributors'
+
 Spree::PaymentMethod.class_eval do
   include Spree::Core::CalculatedAdjustments
+  include Spree::PaymentMethodDistributors
 
   acts_as_taggable
 
-  has_and_belongs_to_many :distributors, join_table: 'distributors_payment_methods', :class_name => 'Enterprise', association_foreign_key: 'distributor_id'
   has_many :credit_cards, class_name: "Spree::CreditCard" # from Spree v.2.3.0 d470b31798f37
 
-  attr_accessible :distributor_ids, :tag_list
+  attr_accessible :tag_list
 
   after_initialize :init
 


### PR DESCRIPTION
EDITED (ready for review now)

#### What? Why?

Closes #2781 
Fix the issue by copying distributors and distributors_ids from payment_method decorator to gateway decorator (a subclass of PaymentMethod, see issue for image) and then extract it to a concern.

This is not perfect but looks like it does solve the problem. I can't find a better solution.

#### What should we test?
This PR moves ~30 tests to different stages: ~10 are now passing, ~10 are now failing with errors related to "allow_backorders" and 10~ are now failing with other errors.