### PR TITLE
Delete representative_view dependency, not used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'aws-sdk'
 gem 'db2fog'
 gem 'andand'
 gem 'truncate_html'
-gem 'representative_view'
 gem 'rabl'
 
 # AMS is pinned to 0.8.4 because 0.9.x is a complete re-write, as is 0.10.x

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -622,14 +622,6 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.2.3)
-    representative (1.0.5)
-      activesupport (>= 2.2.2)
-      builder (>= 2.1.2)
-      i18n (>= 0.4.1)
-      nokogiri (>= 1.4.2)
-    representative_view (1.2.2)
-      actionpack (> 2.3.0, < 4.0.0)
-      representative (~> 1.0.2)
     roadie (3.0.1)
       css_parser (~> 1.3.4)
       nokogiri (~> 1.6.0)
@@ -821,7 +813,6 @@ DEPENDENCIES
   rails (~> 3.2.22)
   rails-i18n (~> 3.0.0)
   redcarpet
-  representative_view
   roadie-rails (~> 1.0.3)
   roo (~> 2.7.0)
   roo-xls (~> 1.1.0)


### PR DESCRIPTION
#### What? Why?

Raised by dependabot here #2800 , introduced here 63ba5d13a303ba91a1e1ac41649fa4ad7125416b
Not used anymore.

#### What should we test?
I don't think we need to test this. If the build is green, this will be fine.

#### Release notes
Changelog Category: Removed
Removed dependency to unused representative_view