### PR TITLE
[Spree Upgrade] Fix enterprise fees specs in adjustment_spec - tax_rate

### DIFF
--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -25,9 +25,8 @@ module Spree
     # LineItems or Orders, so we mock out a line item here to fit the interface
     # that our calculator (usually DefaultTax) expects.
     def compute_tax(amount)
-      product = OpenStruct.new tax_category: tax_category
       line_item = LineItem.new quantity: 1
-      line_item.define_singleton_method(:product) { product }
+      line_item.tax_category = tax_category
       line_item.define_singleton_method(:price) { amount }
 
       # Tax on adjustments (represented by the included_tax field) is always inclusive of


### PR DESCRIPTION
#### What? Why?

Continues #2665 

Fixes issue in Tax Rate decorator.

#### What should we test?
spec/models/spree/adjustment.rb:145 is now green.
and spec/models/spree/tax_rate_spec.rb is still green.