### PR TITLE
[Spree Upgrade] Fix enterprise fees specs in adjustment_spec - enterprise_fee_aplicator

### DIFF
--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -20,6 +20,12 @@ module OpenFoodNetwork
 
     def create_enterprise_fee_adjustment(label, target, calculable)
       adjustment = enterprise_fee.create_adjustment(label, target, calculable, true)
+
+      # This is necessary when source is a line_item
+      #   probably because the association order.adjustments contains "inverse_of :source"
+      #   which overrides the value (the line item) set in calculated_adjustment.create_adjustment
+      adjustment.source = calculable
+      adjustment
     end
 
     def line_item_adjustment_label


### PR DESCRIPTION
#### What? Why?

Continues #2665 

This PR is fixing a problem in enterprise_fees_aplicator caused by calculated_adjustment.create_adjustment where the calculable is the line_item but the adjustment.source is changed to an order.

#### What should we test?
spec/models/spree/adjustment.rb:245 is now green.
spec/lib/open_food_network/enterprise_fee_applicator_spec.rb is still green.