### PR TITLE
[Spree Upgrade] Remove on_demand from Product serializers

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -128,6 +128,14 @@ Spree::Product.class_eval do
 
   # -- Methods
 
+  def on_hand
+    if has_variants?
+      variants.map(&:on_hand).reduce(:+)
+    else
+      master.on_hand
+    end
+  end
+
   # Called by Spree::Product::duplicate before saving.
   def duplicate_extra(parent)
     # Spree sets the SKU to "COPY OF #{parent sku}".

--- a/app/serializers/api/admin/product_serializer.rb
+++ b/app/serializers/api/admin/product_serializer.rb
@@ -1,5 +1,5 @@
 class Api::Admin::ProductSerializer < ActiveModel::Serializer
-  attributes :id, :name, :sku, :variant_unit, :variant_unit_scale, :variant_unit_name, :on_demand, :inherits_properties
+  attributes :id, :name, :sku, :variant_unit, :variant_unit_scale, :variant_unit_name, :inherits_properties
 
   attributes :on_hand, :price, :available_on, :permalink_live, :tax_category_id, :import_date, :image_url, :thumb_url
 

--- a/app/serializers/api/product_serializer.rb
+++ b/app/serializers/api/product_serializer.rb
@@ -4,7 +4,7 @@ class Api::ProductSerializer < ActiveModel::Serializer
   # TODO
   # Prices can't be cached? How?
   def serializable_hash
-    cached_serializer_hash.merge uncached_serializer_hash
+    cached_serializer_hash.merge(uncached_serializer_hash)
   end
 
   private
@@ -36,7 +36,7 @@ class Api::CachedProductSerializer < ActiveModel::Serializer
   include ActionView::Helpers::SanitizeHelper
 
   attributes :id, :name, :permalink, :meta_keywords
-  attributes :on_demand, :group_buy, :notes, :description, :description_html
+  attributes :group_buy, :notes, :description, :description_html
   attributes :properties_with_values
 
   has_many :variants, serializer: Api::VariantSerializer

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -542,7 +542,6 @@ module Spree
       end
     end
 
-
     describe "variant units" do
       context "when the product already has a variant unit set (and all required option types exist)" do
         let!(:p) { create(:simple_product,
@@ -711,6 +710,26 @@ module Spree
         e.variants << v
         p.delete
         e.variants(true).should be_empty
+      end
+    end
+
+    describe '#on_hand' do
+      let(:product) { create(:product) }
+
+      context 'when the product has variants' do
+        before { create(:variant, product: product) }
+
+        it 'returns the sum of the on_hand of its variants' do
+          expect(product.on_hand).to eq(Float::INFINITY)
+        end
+      end
+
+      context 'when the product has no variants' do
+        before { product.variants.destroy_all }
+
+        it 'returns the on_hand of the master' do
+          expect(product.on_hand).to eq(product.master.on_hand)
+        end
       end
     end
   end

--- a/spec/serializers/api/admin/product_serializer_spec.rb
+++ b/spec/serializers/api/admin/product_serializer_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Api::Admin::ProductSerializer do
+  let(:product) { create(:simple_product) }
+  let(:serializer) { described_class.new(product) }
+
+  it "serializes a product" do
+    expect(serializer.to_json).to match(product.name)
+  end
+end

--- a/spec/serializers/spree/product_serializer_spec.rb
+++ b/spec/serializers/spree/product_serializer_spec.rb
@@ -1,7 +1,0 @@
-describe Api::Admin::ProductSerializer do
-  let(:product) { create(:simple_product) }
-  it "serializes a product" do
-    serializer = Api::Admin::ProductSerializer.new product
-    serializer.to_json.should match product.name
-  end
-end


### PR DESCRIPTION
#### What? Why?

Closes #2802

`on_demand` is removed from Product. There's no apparent way to provide an adapter as we did with `VariantStock` because the feature is simply removed from Spree (and so it is its DB column).

This change also moves the spec file to its appropriate place for the sake of consistency and RSpec3-izes the test example.

##### `on_demand's` future

This PR just makes it possible to fix lots of failures from the test suite. It is a temporal solution while we figure out how we implement `on_demand` from OFN side so that the following holds true:

> I don't really care about the use of backlorders in replacement of on_demand, but what I care for is the UX, as most users actually do check the box "on demand" on product as they don't manage stock levels within OFN.
My concern is that today backorder is setup at instance level, whereas every hub, for every product, should be able to decide if their customer can order more than stocked / order as much as they want without specified stock info. So the "allow backorder" info should be at product level. Is it the case?

Check out the discussion on https://github.com/openfoodfoundation/openfoodnetwork/issues/2435#issuecomment-426635995 for details.

#### What should we test?
The upgrade is not ready yet