### PR TITLE
Move query from variant_overrides_controller to its model scope

### DIFF
--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -60,7 +60,9 @@ module Admin
     end
 
     def inventory_import_dates
-      import_dates = VariantOverride.distinct_import_dates.for_hubs(editable_enterprises.collect(&:id))
+      import_dates = VariantOverride.
+        distinct_import_dates.
+        for_hubs(editable_enterprises.collect(&:id))
 
       options = [{ id: '0', name: 'All' }]
       import_dates.collect(&:import_date).map { |i| options.push(id: i.to_date, name: i.to_date.to_formatted_s(:long)) }

--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -60,11 +60,7 @@ module Admin
     end
 
     def inventory_import_dates
-      import_dates = VariantOverride.
-        select('DISTINCT variant_overrides.import_date').
-        where('variant_overrides.hub_id IN (?)
-        AND variant_overrides.import_date IS NOT NULL', editable_enterprises.collect(&:id)).
-        order('import_date DESC')
+      import_dates = VariantOverride.distinct_import_dates.for_hubs(editable_enterprises.collect(&:id))
 
       options = [{ id: '0', name: 'All' }]
       import_dates.collect(&:import_date).map { |i| options.push(id: i.to_date, name: i.to_date.to_formatted_s(:long)) }

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -3,8 +3,6 @@ class VariantOverride < ActiveRecord::Base
 
   acts_as_taggable
 
-  attr_accessor :import_date
-
   belongs_to :hub, class_name: 'Enterprise'
   belongs_to :variant, class_name: 'Spree::Variant'
 
@@ -19,6 +17,12 @@ class VariantOverride < ActiveRecord::Base
 
   scope :for_hubs, lambda { |hubs|
     where(hub_id: hubs)
+  }
+
+  scope :distinct_import_dates, lambda {
+    select('DISTINCT variant_overrides.import_date').
+      where('variant_overrides.import_date IS NOT NULL').
+      order('import_date DESC')
   }
 
   localize_number :price


### PR DESCRIPTION
#### What? Why?

This PR moves query code from `VariantOverrideController` into `VariantOverride` model as a new scope query, in order to extract extra logic from controller and also to reuse an existing scope `for_hubs`

#### What should we test?
The existing rspec tests should pass along with the new one

#### Release notes
Move query code from `VariantOverrideController` into its Model scope and add a spec  

Changelog Category: Changed

