### PR TITLE
Make 'Clear All' button work on order cycle page

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
@@ -3,8 +3,12 @@ angular.module("admin.orderCycles").controller "OrderCyclesCtrl", ($scope, $q, C
   $scope.columns = Columns.columns
   $scope.saveAll = -> OrderCycles.saveChanges($scope.order_cycles_form)
   $scope.ordersCloseAtLimit = -31 # days
-  $scope.involvingFilter = 0
-  $scope.scheduleFilter = 0
+
+  $scope.resetSelectFilters = ->
+    $scope.scheduleFilter = 0
+    $scope.involvingFilter = 0
+    $scope.query = ''
+  $scope.resetSelectFilters()
 
   compileData = ->
     for schedule in $scope.schedules

--- a/spec/javascripts/unit/admin/order_cycles/controllers/order_cycles_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/controllers/order_cycles_controller_spec.js.coffee
@@ -72,3 +72,13 @@ describe "OrderCyclesCtrl", ->
 
       it "the RequestMonitor will not longer have a state of loading", ->
         expect(scope.RequestMonitor.loading).toBe false
+
+  describe "filtering order cycles", ->
+    it "filters by and resets filter variables", ->
+      scope.query = "test"
+      scope.scheduleFilter = 1
+      scope.involvingFilter = 1
+      scope.resetSelectFilters()
+      expect(scope.query).toBe ""
+      expect(scope.scheduleFilter).toBe 0
+      expect(scope.involvingFilter).toBe 0


### PR DESCRIPTION
#### What? Why?

Closes #2362 
The expected functionality (clearing filters) didn't work because there was no corresponding function in the controller.

#### What should we test?  

- Navigate to `/admin/order_cycles`  
- Apply some filters
- Click on 'Clear all' 
The filters should be reset to initial state

#### Release notes

Make 'Clear All' button work on admin order cycles page
