### PR TITLE
Add per_page controls to admin orders index

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -3,8 +3,14 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, RequestMonitor,
   $scope.pagination = Orders.pagination
   $scope.orders = Orders.all
   $scope.sortOptions = SortOptions
+  $scope.per_page_options = [
+    {id: 15, name: t('js.admin.orders.index.per_page', results: 15)},
+    {id: 50, name: t('js.admin.orders.index.per_page', results: 50)},
+    {id: 100, name: t('js.admin.orders.index.per_page', results: 100)}
+  ]
 
   $scope.initialise = ->
+    $scope.per_page = 15
     $scope.q = {
       completed_at_not_null: true
     }
@@ -25,7 +31,7 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, RequestMonitor,
       'q[order_cycle_id_in]': $scope['q']['order_cycle_id_in'],
       'q[order_cycle_id_in]': $scope['q']['order_cycle_id_in'],
       'q[s]': $scope.sorting || 'id desc',
-      per_page: $scope.per_page || 15,
+      per_page: $scope.per_page,
       page: page
     })
 

--- a/app/assets/stylesheets/admin/components/per_page_controls.scss
+++ b/app/assets/stylesheets/admin/components/per_page_controls.scss
@@ -1,0 +1,7 @@
+.per-page {
+  float: left;
+
+  .per-page-feedback {
+    margin-left: 1em;
+  }
+}

--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -65,8 +65,9 @@ Spree::Admin::OrdersController.class_eval do
           orders: ActiveModel::ArraySerializer.new(@orders, each_serializer: Api::Admin::OrderSerializer),
           pagination: {
             results: @orders.total_count,
-            pages: @orders.num_pages,
-            page: params[:page].to_i
+            pages: @orders.num_pages.to_i,
+            page: params[:page].to_i,
+            per_page: params[:per_page].to_i
           }
         }
       end

--- a/app/views/spree/admin/orders/_per_page_controls.html.haml
+++ b/app/views/spree/admin/orders/_per_page_controls.html.haml
@@ -1,5 +1,5 @@
 .per-page{'ng-show' => '!RequestMonitor.loading && orders.length > 0'}
-  %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'ng-model' => 'per_page'}
+  %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
 
   %span.per-page-feedback
     {{ 'spree.admin.orders.index.results_found' | t:{number: pagination.results} }}

--- a/app/views/spree/admin/orders/_per_page_controls.html.haml
+++ b/app/views/spree/admin/orders/_per_page_controls.html.haml
@@ -1,0 +1,6 @@
+.per-page{'ng-show' => '!RequestMonitor.loading && orders.length > 0'}
+  %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'ng-model' => 'per_page'}
+
+  %span.per-page-feedback
+    {{ 'spree.admin.orders.index.results_found' | t:{number: pagination.results} }}
+    {{ 'spree.admin.orders.index.viewing' | t:{start: ((pagination.page -1) * pagination.per_page) +1, end: ((pagination.page -1) * pagination.per_page) + orders.length} }}

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -16,6 +16,9 @@
 - content_for :table_filter do
   = render partial: 'filters'
 
+.row
+  = render partial: 'per_page_controls'
+
 %table#listing_orders.index.responsive{width: "100%", 'ng-init' => 'initialise()', 'ng-show' => "!RequestMonitor.loading && orders.length > 0" }
   %colgroup
     %col{style: "width: 10%"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2571,6 +2571,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           resolve: Resolve
       new_tag_rule_dialog:
         select_rule_type: "Select a rule type:"
+      orders:
+        index:
+          per_page: "%{results} per page"
       resend_user_email_confirmation:
         resend: "Resend"
         sending: "Resend..."
@@ -2667,6 +2670,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           next: "Next"
           loading: "Loading"
           no_orders_found: "No Orders Found"
+          results_found: "%{number} Results found."
+          viewing: "Viewing %{start} to %{end}."
         invoice:
           issued_on: Issued on
           tax_invoice: TAX INVOICE


### PR DESCRIPTION
#### What? Why?

Closes #2527

Adds a "results per page" dropdown to the orders page, with option to view 15, 50, or 100 results per page.

![screenshot from 2018-10-05 11-27-27](https://user-images.githubusercontent.com/9029026/46530682-78aa3080-c892-11e8-9a73-b5e250ebe223.png)

#### What should we test?

Results per page dropdown is working on admin order index page.

#### Release notes

Added an option to choose the number of results per page shown when viewing orders in the backend.

Changelog Category: Added 

