### PR TITLE
Fix product import date error when some but not all variants have import date

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -177,10 +177,7 @@ Spree::Product.class_eval do
 
   # Get the most recent import_date of a product's variants
   def import_date
-    variants.map do |variant|
-      next if variant.import_date.blank?
-      variant.import_date
-    end.sort.last
+    variants.map(&:import_date).compact.max
   end
 
   # Build a product distribution for each distributor

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -714,4 +714,45 @@ module Spree
       end
     end
   end
+
+  describe "product import" do
+    describe "finding the most recent import date of the variants" do
+      let!(:product) { create(:product) }
+
+      let(:reference_time) { Time.zone.now.beginning_of_day }
+
+      before do
+        product.reload
+      end
+
+      context "when the variants do not have an import date" do
+        let!(:variant_a) { create(:variant, product: product, import_date: nil) }
+        let!(:variant_b) { create(:variant, product: product, import_date: nil) }
+
+        it "returns nil" do
+          expect(product.import_date).to be_nil
+        end
+      end
+
+      context "when some variants have import date and some do not" do
+        let!(:variant_a) { create(:variant, product: product, import_date: nil) }
+        let!(:variant_b) { create(:variant, product: product, import_date: reference_time - 1.hour) }
+        let!(:variant_c) { create(:variant, product: product, import_date: reference_time - 2.hour) }
+
+        it "returns the most recent import date" do
+          expect(product.import_date).to eq(variant_b.import_date)
+        end
+      end
+
+      context "when all variants have import date" do
+        let!(:variant_a) { create(:variant, product: product, import_date: reference_time - 2.hour) }
+        let!(:variant_b) { create(:variant, product: product, import_date: reference_time - 1.hour) }
+        let!(:variant_c) { create(:variant, product: product, import_date: reference_time - 3.hour) }
+
+        it "returns the most recent import date" do
+          expect(product.import_date).to eq(variant_b.import_date)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Addresses #2769 and #2799  (Verify before closing issues)

The product import date is used when loading product data for the "Bulk Update Products" page. This however raises an error when some but not all variants have import date.

#### What should we test?

1. Log in as manager of an enterprise that manages some products that were imported and some products that were manually created.
2. Go to the "Bulk Update Products" page.
3. Enable the "Import Date" column.
4. Check that both types of products are listed, and that the import date of imported products are visible.
 
#### Release notes

- Fix listing of a product when some variants have import date and some do not.

Changelog Category: Fixed