### PR TITLE
Fix missing local variable in EntryProcessor

### DIFF
--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -139,7 +139,8 @@ module ProductImport
         @inventory_created += 1
         @updated_ids.push new_item.id
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} #{line_number}:", new_item.errors.full_messages)
+        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
+          #{entry.line_number}:", new_item.errors.full_messages)
       end
     end
 
@@ -153,7 +154,8 @@ module ProductImport
         @inventory_updated += 1
         @updated_ids.push existing_item.id
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} #{line_number}:", existing_item.errors.full_messages)
+        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
+          #{entry.line_number}:", existing_item.errors.full_messages)
       end
     end
 
@@ -177,7 +179,8 @@ module ProductImport
         @products_created += 1
         @updated_ids.push product.variants.first.id
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} #{line_number}:", product.errors.full_messages)
+        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
+          #{entry.line_number}:", product.errors.full_messages)
       end
 
       @already_created[entry.supplier_id] = { entry.name => product.id }
@@ -192,7 +195,8 @@ module ProductImport
         @updated_ids.push variant.id
         true
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} #{line_number}:", variant.errors.full_messages)
+        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
+          #{entry.line_number}:", variant.errors.full_messages)
         false
       end
     end

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -139,8 +139,7 @@ module ProductImport
         @inventory_created += 1
         @updated_ids.push new_item.id
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
-          #{entry.line_number}:", new_item.errors.full_messages)
+        assign_errors new_item.errors.full_messages, entry.line_number
       end
     end
 
@@ -154,8 +153,7 @@ module ProductImport
         @inventory_updated += 1
         @updated_ids.push existing_item.id
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
-          #{entry.line_number}:", existing_item.errors.full_messages)
+        assign_errors existing_item.errors.full_messages, entry.line_number
       end
     end
 
@@ -179,8 +177,7 @@ module ProductImport
         @products_created += 1
         @updated_ids.push product.variants.first.id
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
-          #{entry.line_number}:", product.errors.full_messages)
+        assign_errors product.errors.full_messages, entry.line_number
       end
 
       @already_created[entry.supplier_id] = { entry.name => product.id }
@@ -195,10 +192,17 @@ module ProductImport
         @updated_ids.push variant.id
         true
       else
-        @importer.errors.add("#{I18n.t('admin.product_import.model.line')} \
-          #{entry.line_number}:", variant.errors.full_messages)
+        assign_errors variant.errors.full_messages, entry.line_number
         false
       end
+    end
+
+    def assign_errors(errors, line_number)
+      @importer.errors.add(
+        I18n.t('admin.product_import.model.line_number',
+               number: line_number),
+        errors
+      )
     end
 
     def assign_defaults(object, entry)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,7 +520,7 @@ en:
         products_no_permission: you do not have permission to manage products for this enterprise
         inventory_no_permission: you do not have permission to create inventory for this producer
         none_saved: did not save any products successfully
-        line: Line
+        line_number: "Line %{number}:"
       index:
         select_file: Select a spreadsheet to upload
         spreadsheet: Spreadsheet


### PR DESCRIPTION
#### What? Why?

Closes #2837

When certain validations fail at the product level, we apply an error based on the line number of an entry in the CSV file, but the `line_number` attribute was being incorrectly fetched from the object.

![screenshot from 2018-10-08 13-33-55](https://user-images.githubusercontent.com/9029026/46611769-a39cba80-cb06-11e8-9045-8f3a59976263.png)


#### What should we test?

Product Import with Kirsten's problematic CSV. 

#### Release notes

Fixed a validation error assignment issue with Product Import.

Changelog Category: Fixed
