### PR TITLE
Fix bindings on angular orders data

### DIFF
--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -15,7 +15,7 @@
 
 - content_for :table_filter do
   = render partial: 'filters'
-    
+
 %table#listing_orders.index.responsive{width: "100%", 'ng-init' => 'initialise()', 'ng-show' => "!RequestMonitor.loading && orders.length > 0" }
   %colgroup
     %col{style: "width: 10%"}
@@ -39,37 +39,37 @@
   %tbody
     %tr{ng: {repeat: 'order in orders track by $index', class: {even: "'even'", odd: "'odd'"}}, 'ng-class' => "'state-{{order.state}}'"}
       %td.align-center
-        {{::order.distributor_name}}
+        {{order.distributor_name}}
       %td.align-center
-        = @show_only_completed ? '{{::order.completed_at}}' : '{{::order.created_at}}'
+        = @show_only_completed ? '{{order.completed_at}}' : '{{order.created_at}}'
       %td
-        %a{'ng-href' => '{{::order.show_path}}'}
+        %a{'ng-href' => '{{order.show_path}}'}
           {{order.number}}
         %div{'ng-if' => 'order.special_instructions'}
           %br
-          %span.icon-warning-sign{'ofn-with-tip' => "{{::order.special_instructions}}"}
+          %span.icon-warning-sign{'ofn-with-tip' => "{{order.special_instructions}}"}
             = t('.note')
       %td.align-center
         %span.state{'ng-class' => 'order.state'}
           {{'order_state.' + order.state | t}}
       %td.align-center
         %span.state{'ng-class' => 'order.payment_state', 'ng-if' => 'order.payment_state'}
-          %a{'ng-href' => '{{::order.payments_path}}' }
+          %a{'ng-href' => '{{order.payments_path}}' }
             {{'payment_states.' + order.payment_state | t}}
       %td.align-center
         %span.state{'ng-class' => 'order.shipment_state', 'ng-if' => 'order.shipment_state'}
-          %a{'ng-href' => '{{::order.shipments_path}}' }
+          %a{'ng-href' => '{{order.shipments_path}}' }
             {{'shipment_states.' + order.shipment_state | t}}
       %td
-        = mail_to "{{::order.email}}"
+        = mail_to "{{order.email}}"
       %td.align-center
-        %span{'ng-bind-html' => '::order.display_total'}
+        %span{'ng-bind-html' => 'order.display_total'}
       %td.actions
-        %a.icon_link.with-tip.icon-edit.no-text{'ng-href' => '{{::order.edit_path}}', 'data-action' => 'edit', 'ofn-with-tip' => t('.edit')}
+        %a.icon_link.with-tip.icon-edit.no-text{'ng-href' => '{{order.edit_path}}', 'data-action' => 'edit', 'ofn-with-tip' => t('.edit')}
         %div{'ng-if' => 'order.ready_to_ship'}
-          %a.icon-road.icon_link.with-tip.no-text{'ng-href' => '{{::order.ship_path}}', 'data-action' => 'ship', 'data-confirm' => t(:are_you_sure), 'data-method' => 'put', rel: 'nofollow', 'ofn-with-tip' => t('.ship')}
+          %a.icon-road.icon_link.with-tip.no-text{'ng-href' => '{{order.ship_path}}', 'data-action' => 'ship', 'data-confirm' => t(:are_you_sure), 'data-method' => 'put', rel: 'nofollow', 'ofn-with-tip' => t('.ship')}
         %div{'ng-if' => 'order.payment_capture_path'}
-          %a.icon-capture.icon_link.no-text{'ng-href' => '{{::order.payment_capture_path}}', 'data-action' => 'capture', 'data-method' => 'put', rel: 'nofollow', 'ofn-with-tip' => t('.capture')}
+          %a.icon-capture.icon_link.no-text{'ng-href' => '{{order.payment_capture_path}}', 'data-action' => 'capture', 'data-method' => 'put', rel: 'nofollow', 'ofn-with-tip' => t('.capture')}
 
 .orders-loading{'ng-show' => 'RequestMonitor.loading'}
   .row


### PR DESCRIPTION
#### What? Why?

Closes #2843

When changing the page's data via filters or pagination on the new orders page, some of the data was not being updated as it was using one-time bindings with `::`.

#### What should we test?

The new angular orders page updates the data in the table when changing page or filtering data.

#### Release notes

Fixed angular bindings on new orders page

Changelog Category: Fixed
