### PR TITLE
Fix invalid variant creation

### DIFF
--- a/app/models/model_set.rb
+++ b/app/models/model_set.rb
@@ -30,8 +30,11 @@ class ModelSet
 
   def errors
     errors = ActiveModel::Errors.new self
-    full_messages = @collection.map { |ef| ef.errors.full_messages }.flatten
-    full_messages.each { |fm| errors.add(:base, fm) }
+    full_messages = @collection
+      .map { |model| model.errors.full_messages }
+      .flatten
+
+    full_messages.each { |message| errors.add(:base, message) }
     errors
   end
 

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -36,18 +36,17 @@ class Spree::ProductSet < ModelSet
 
   def update_product_only_attributes(product, attributes)
     variant_related_attrs = [:id, :variants_attributes, :master_attributes]
+    product_related_attrs = attributes.except(*variant_related_attrs)
 
-    if attributes.except(*variant_related_attrs).present?
-      product.assign_attributes(attributes.except(*variant_related_attrs))
+    return true if product_related_attrs.blank?
 
-      product.variants.each do |variant|
-        validate_presence_of_unit_value(product, variant)
-      end
+    product.assign_attributes(product_related_attrs)
 
-      product.save if errors.empty?
-    else
-      true
+    product.variants.each do |variant|
+      validate_presence_of_unit_value(product, variant)
     end
+
+    product.save if errors.empty?
   end
 
   def validate_presence_of_unit_value(product, variant)
@@ -58,19 +57,13 @@ class Spree::ProductSet < ModelSet
   end
 
   def update_product_variants(product, attributes)
-    if attributes[:variants_attributes]
-      update_variants_attributes(product, attributes[:variants_attributes])
-    else
-      true
-    end
+    return true unless attributes[:variants_attributes]
+    update_variants_attributes(product, attributes[:variants_attributes])
   end
 
   def update_product_master(product, attributes)
-    if attributes[:master_attributes]
-      update_variant(product, attributes[:master_attributes])
-    else
-      true
-    end
+    return true unless attributes[:master_attributes]
+    update_variant(product, attributes[:master_attributes])
   end
 
   def update_variants_attributes(product, variants_attributes)

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -3,11 +3,19 @@ class Spree::ProductSet < ModelSet
     super(Spree::Product, [], attributes, proc { |attrs| attrs[:product_id].blank? })
   end
 
-  # A separate method of updating products was required due to an issue with the way Rails' assign_attributes and updates_attributes behave when delegated attributes of a nested
-  # object are updated via the parent object (ie. price of variants). Updating such attributes by themselves did not work using:
-  # product.update_attributes( { variants_attributes: [ { id: y, price: xx.x } ] } )
-  # and so an explicit call to update attributes on each individual variant was required. ie:
-  # variant.update_attributes( { price: xx.x } )
+  # A separate method of updating products was required due to an issue with
+  # the way Rails' assign_attributes and updates_attributes behave when
+  # delegated attributes of a nested object are updated via the parent object
+  # (ie. price of variants). Updating such attributes by themselves did not
+  # work using:
+  #
+  #   product.update_attributes(variants_attributes: [{ id: y, price: xx.x }])
+  #
+  # and so an explicit call to update attributes on each individual variant was
+  # required. ie:
+  #
+  #   variant.update_attributes( { price: xx.x } )
+  #
   def update_attributes(attributes)
     attributes[:taxon_ids] = attributes[:taxon_ids].split(',')  if attributes[:taxon_ids].present?
     e = @collection.detect { |e| e.id.to_s == attributes[:id].to_s && !e.id.nil? }

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -18,11 +18,13 @@ Spree::Variant.class_eval do
   attr_accessible :unit_value, :unit_description, :images_attributes, :display_as, :display_name, :import_date
   accepts_nested_attributes_for :images
 
-  validates_presence_of :unit_value,
-    if: -> v { %w(weight volume).include? v.product.andand.variant_unit }
+  validates :unit_value, presence: true, if: -> (variant) {
+    %w(weight volume).include?(variant.product.andand.variant_unit)
+  }
 
-  validates_presence_of :unit_description,
-    if: -> v { v.product.andand.variant_unit.present? && v.unit_value.nil? }
+  validates :unit_description, presence: true, if: -> (variant) {
+    variant.product.andand.variant_unit.present? && variant.unit_value.nil?
+  }
 
   before_validation :update_weight_from_unit_value, if: -> v { v.product.present? }
   after_save :update_units

--- a/db/migrate/20181010093850_fix_variants_missing_unit_value.rb
+++ b/db/migrate/20181010093850_fix_variants_missing_unit_value.rb
@@ -1,0 +1,49 @@
+# Fixes variants whose product.variant_unit is 'weight' and miss a unit_value,
+# showing 1 unit of the specified weight. That is, if the user chose Kg, it'll
+# display 1 as unit.
+class FixVariantsMissingUnitValue < ActiveRecord::Migration
+  HUMAN_UNIT_VALUE = 1
+
+  def up
+    logger.info "Fixing variants missing unit_value...\n"
+
+    variants_missing_unit_value.find_each do |variant|
+      logger.info "Processing variant #{variant.id}..."
+
+      fix_unit_value(variant)
+    end
+
+    logger.info "Done!"
+  end
+
+  def down
+  end
+
+  private
+
+  def variants_missing_unit_value
+    Spree::Variant
+      .joins(:product)
+      .readonly(false)
+      .where(
+        spree_products: { variant_unit: 'weight' },
+        spree_variants: { unit_value: nil }
+    )
+  end
+
+  def fix_unit_value(variant)
+    variant.unit_value = HUMAN_UNIT_VALUE * variant.product.variant_unit_scale
+
+    if variant.save
+      logger.info "Successfully fixed variant #{variant.id}"
+    else
+      logger.info "Failed fixing variant #{variant.id}"
+    end
+
+    logger.info ""
+  end
+
+  def logger
+    @logger ||= Logger.new('log/migrate.log')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180919102548) do
+ActiveRecord::Schema.define(:version => 20181010093850) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -1,22 +1,75 @@
 require 'spec_helper'
 
 describe Spree::Admin::ProductsController, type: :controller do
-  describe "updating a product we do not have access to" do
-    let(:s_managed) { create(:enterprise) }
-    let(:s_unmanaged) { create(:enterprise) }
-    let(:p) { create(:simple_product, supplier: s_unmanaged, name: 'Peas') }
+  describe 'bulk_update' do
+    context "updating a product we do not have access to" do
+      let(:s_managed) { create(:enterprise) }
+      let(:s_unmanaged) { create(:enterprise) }
+      let(:product) do
+        create(:simple_product, supplier: s_unmanaged, name: 'Peas')
+      end
 
-    before do
-      login_as_enterprise_user [s_managed]
-      spree_post :bulk_update, {"products" => [{"id" => p.id, "name" => "Pine nuts"}]}
+      before do
+        login_as_enterprise_user [s_managed]
+        spree_post :bulk_update, {
+          "products" => [{"id" => product.id, "name" => "Pine nuts"}]
+        }
+      end
+
+      it "denies access" do
+        response.should redirect_to spree.unauthorized_url
+      end
+
+      it "does not update any product" do
+        product.reload.name.should_not == "Pine nuts"
+      end
     end
 
-    it "denies access" do
-      response.should redirect_to spree.unauthorized_url
-    end
+    context "when changing a product's variant_unit" do
+      let(:producer) { create(:enterprise) }
+      let!(:product) do
+        create(
+          :simple_product,
+          supplier: producer,
+          variant_unit: 'items',
+          variant_unit_scale: nil,
+          variant_unit_name: 'bunches',
+          unit_value: nil,
+          unit_description: 'some description'
+        )
+      end
 
-    it "does not update any product" do
-      p.reload.name.should_not == "Pine nuts"
+      before { login_as_enterprise_user([producer]) }
+
+      it 'fails' do
+        spree_post :bulk_update, {
+          "products" => [
+            {
+              "id" => product.id,
+              "variant_unit" => "weight",
+              "variant_unit_scale" => 1
+            }
+          ]
+        }
+
+        expect(response).to have_http_status(400)
+      end
+
+      it 'does not redirect to bulk_products' do
+        spree_post :bulk_update, {
+          "products" => [
+            {
+              "id" => product.id,
+              "variant_unit" => "weight",
+              "variant_unit_scale" => 1
+            }
+          ]
+        }
+
+        expect(response).not_to redirect_to(
+          '/api/products/bulk_products?page=1;per_page=500;'
+        )
+      end
     end
   end
 

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -59,6 +59,36 @@ describe Spree::ProductSet do
             'variant_unit_scale' => 1
           )
         end
+
+        context 'when :master_attributes is passed' do
+          let(:master_attributes) { { sku: '123' } }
+
+          before do
+            collection_hash[0][:master_attributes] = master_attributes
+          end
+
+          context 'and the variant does exist' do
+            let!(:variant) { create(:variant, product: product) }
+
+            before { master_attributes[:id] = variant.id }
+
+            it 'updates the attributes of the master variant' do
+              product_set.save
+              expect(variant.reload.sku).to eq('123')
+            end
+          end
+
+          context 'and the variant does not exist' do
+            let(:master_attributes) do
+              attributes_for(:variant).merge(sku: '123')
+            end
+
+            it 'creates it with the specified attributes' do
+              product_set.save
+              expect(Spree::Variant.last.sku).to eq('123')
+            end
+          end
+        end
       end
     end
   end

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -32,35 +32,50 @@ describe Spree::ProductSet do
       end
 
       context 'when the product does exist' do
-        let!(:product) do
-          create(
-            :simple_product,
-            variant_unit: 'items',
-            variant_unit_scale: nil,
-            variant_unit_name: 'bunches'
-          )
-        end
+        context 'when a different varian_unit is passed' do
+          let!(:product) do
+            create(
+              :simple_product,
+              variant_unit: 'items',
+              variant_unit_scale: nil,
+              variant_unit_name: 'bunches',
+              unit_value: nil,
+              unit_description: 'some description'
+            )
+          end
 
-        let(:collection_hash) do
-          {
-            0 => {
-              id: product.id,
-              variant_unit: 'weight',
-              variant_unit_scale: 1
+          let(:collection_hash) do
+            {
+              0 => {
+                id: product.id,
+                variant_unit: 'weight',
+                variant_unit_scale: 1
+              }
             }
-          }
-        end
+          end
 
-        it 'updates all the specified product attributes' do
-          product_set.save
+          it 'does not update the product' do
+            product_set.save
 
-          expect(product.reload.attributes).to include(
-            'variant_unit' => 'weight',
-            'variant_unit_scale' => 1
-          )
+            expect(product.reload.attributes).to include(
+              'variant_unit' => 'items'
+            )
+          end
+
+          it 'adds an error' do
+            product_set.save
+            expect(product_set.errors.get(:base))
+              .to include("Unit value can't be blank")
+          end
+
+          it 'returns false' do
+            expect(product_set.save).to eq(false)
+          end
         end
 
         context 'when :master_attributes is passed' do
+          let!(:product) { create(:simple_product) }
+          let(:collection_hash) { { 0 => { id: product.id } } }
           let(:master_attributes) { { sku: '123' } }
 
           before do

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Spree::ProductSet do
+  describe '#save' do
+    context 'when passing :collection_attributes' do
+      let(:product_set) do
+        described_class.new(collection_attributes: collection_hash)
+      end
+
+      context 'when the product does not exist yet' do
+        let(:collection_hash) do
+          {
+            0 => {
+              product_id: 11,
+              name: 'a product',
+              price: 2.0,
+              supplier_id: create(:enterprise).id,
+              primary_taxon_id: create(:taxon).id,
+              unit_description: 'description',
+              variant_unit: 'items',
+              variant_unit_name: 'bunches'
+            }
+          }
+        end
+
+        it 'creates it with the specified attributes' do
+          product_set.save
+
+          expect(Spree::Product.last.attributes)
+            .to include('name' => 'a product')
+        end
+      end
+
+      context 'when the product does exist' do
+        let!(:product) do
+          create(
+            :simple_product,
+            variant_unit: 'items',
+            variant_unit_scale: nil,
+            variant_unit_name: 'bunches'
+          )
+        end
+
+        let(:collection_hash) do
+          {
+            0 => {
+              id: product.id,
+              variant_unit: 'weight',
+              variant_unit_scale: 1
+            }
+          }
+        end
+
+        it 'updates all the specified product attributes' do
+          product_set.save
+
+          expect(product.reload.attributes).to include(
+            'variant_unit' => 'weight',
+            'variant_unit_scale' => 1
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #2776

It's been a bit hard to first understand and untangle `ProductSet`, which is the class responsible for the bulk update of products.

What I did is to check the presence of `variant.unit_value` when updating a product's `variant_unit`. Although there's a validation for that in `variant_decorator.rb`, it does not work when the product is not yet persisted :see_no_evil: (See my comment on the code).

Not only `ProductSet` should be improved, but also this unit related attributes spread between product and variant feels a bit messy. I'm not even sure validating a model checking other's attributes is even a good choice. (Shouldn't this go into a service? isn't too much for a model's responsibility). That's why I chose to:

* Duplicate this validation. Duplication is cheaper than a wrong abstraction.
* I fixed just the exact scenario we found with `variant_unit/unit_value`. I didn't implement a fix for any possible update to a product that may make its variants become invalid.

This will make the world a bit better than it was but it'll require a follow-up. We don't know if there are other possible scenarios.

#### What should we test?
Update products and variants through the "Bulk Edit Products" page, especially the case described in the issue above.


#### Release notes

Forbid changing a product's variant_unit when the variant has no unit_value.

Changelog Category: Fixed
 
#### Still missing :warning: 

- [x] Data migration to fix current cases.