### PR TITLE
[Product Import] Rename enterprise fields and update template

### DIFF
--- a/app/assets/javascripts/admin/product_import/controllers/import_form_controller.js.coffee
+++ b/app/assets/javascripts/admin/product_import/controllers/import_form_controller.js.coffee
@@ -3,7 +3,7 @@ angular.module("admin.productImport").controller "ImportFormCtrl", ($scope, $htt
   $scope.entries = {}
   $scope.update_counts = {}
   $scope.reset_counts = {}
-  $scope.supplier_product_counts = ams_data.supplier_product_counts
+  $scope.enterprise_product_counts = ams_data.enterprise_product_counts
 
   $scope.updates = {}
   $scope.updated_total = 0
@@ -19,7 +19,7 @@ angular.module("admin.productImport").controller "ImportFormCtrl", ($scope, $htt
   }
 
   $scope.countResettable = () ->
-    angular.forEach $scope.supplier_product_counts, (value, key) ->
+    angular.forEach $scope.enterprise_product_counts, (value, key) ->
       $scope.reset_counts[key] = value
       if $scope.update_counts[key]
         $scope.reset_counts[key] -= $scope.update_counts[key]

--- a/app/assets/javascripts/admin/product_import/controllers/import_options_form.js.coffee
+++ b/app/assets/javascripts/admin/product_import/controllers/import_options_form.js.coffee
@@ -17,7 +17,7 @@ angular.module("admin.productImport").controller "ImportOptionsFormCtrl", ($scop
     confirmed = confirm t('js.product_import.confirmation') if checked
 
     if confirmed or !checked
-      ProductImportService.updateResetAbsent($scope.supplierId, $scope.reset_counts[$scope.supplierId], checked)
+      ProductImportService.updateResetAbsent($scope.enterpriseId, $scope.reset_counts[$scope.enterpriseId], checked)
     else
       $scope.settings['reset_all_absent'] = false
 

--- a/app/assets/javascripts/admin/product_import/filters/filter_entries.js.coffee
+++ b/app/assets/javascripts/admin/product_import/filters/filter_entries.js.coffee
@@ -18,15 +18,15 @@ angular.module("admin.productImport").filter 'entriesFilterValid', ->
 
     filtered
 
-angular.module("admin.productImport").filter 'entriesFilterSupplier', ->
-  (entries, supplier) ->
-    if supplier == 'all'
+angular.module("admin.productImport").filter 'entriesFilterEnterprise', ->
+  (entries, enterprise) ->
+    if enterprise == 'all'
       return entries
 
     filtered = {}
 
     angular.forEach entries, (entry, line_number) ->
-      if supplier == entry.attributes['supplier']
+      if enterprise == entry.attributes['enterprise']
         filtered[line_number] = entry
 
     filtered

--- a/app/assets/javascripts/admin/product_import/services/product_import_service.js.coffee
+++ b/app/assets/javascripts/admin/product_import/services/product_import_service.js.coffee
@@ -1,15 +1,15 @@
 angular.module("admin.productImport").factory "ProductImportService", ($rootScope) ->
   new class ProductImportService
-    suppliers: {}
+    enterprises: {}
     resetTotal: 0
     settings: {}
 
-    updateResetAbsent: (supplierId, resetCount, resetAbsent) ->
+    updateResetAbsent: (enterpriseId, resetCount, resetAbsent) ->
       if resetAbsent
-        @suppliers[supplierId] = resetCount
+        @enterprises[enterpriseId] = resetCount
         @resetTotal += resetCount
       else
-        @suppliers[supplierId] = null
+        @enterprises[enterpriseId] = null
         @resetTotal -= resetCount
 
       $rootScope.resetTotal = @resetTotal

--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -90,7 +90,7 @@ module Admin
       {
         filepath: @filepath,
         item_count: @importer.item_count,
-        supplier_product_counts: @importer.supplier_products,
+        enterprise_product_counts: @importer.enterprise_products,
         import_url: main_app.admin_product_import_process_async_path,
         save_url: main_app.admin_product_import_save_async_path,
         reset_url: main_app.admin_product_import_reset_async_path,

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -166,6 +166,7 @@ module ProductImport
 
       product = Spree::Product.new
       product.assign_attributes(entry.attributes.except('id'))
+      product.supplier_id = entry.enterprise_id
       assign_defaults(product, entry)
 
       if product.save

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -29,7 +29,7 @@ module ProductImport
 
     def save_all(entries)
       entries.each do |entry|
-        if import_into_inventory?(entry)
+        if settings.importing_into_inventory?
           save_to_inventory(entry)
         else
           save_to_product_list(entry)
@@ -122,10 +122,6 @@ module ProductImport
       end
 
       @variants_updated += 1
-    end
-
-    def import_into_inventory?(entry)
-      entry.enterprise_id && settings.importing_into_inventory?
     end
 
     def save_new_inventory_item(entry)

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -166,7 +166,7 @@ module ProductImport
 
       product = Spree::Product.new
       product.assign_attributes(entry.attributes.except('id'))
-      product.supplier_id = entry.enterprise_id
+      product.supplier_id = entry.producer_id
       assign_defaults(product, entry)
 
       if product.save

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -46,7 +46,10 @@ module ProductImport
 
         products_count =
           if settings.importing_into_inventory?
-            VariantOverride.where('variant_overrides.hub_id IN (?)', enterprise_id).count
+            VariantOverride.where(
+              'variant_overrides.hub_id IN (?)',
+              enterprise_id
+            ).count
           else
             Spree::Variant.
               not_deleted.
@@ -158,7 +161,9 @@ module ProductImport
       # If we've already added a new product with these attributes
       # from this spreadsheet, mark this entry as a new variant with
       # the new product id, as this is a now variant of that product...
-      if @already_created[entry.enterprise_id] && @already_created[entry.enterprise_id][entry.name]
+      if @already_created[entry.enterprise_id] &&
+         @already_created[entry.enterprise_id][entry.name]
+
         product_id = @already_created[entry.enterprise_id][entry.name]
         @validator.mark_as_new_variant(entry, product_id)
         return
@@ -207,7 +212,10 @@ module ProductImport
         when 'overwrite_all'
           object.assign_attributes(attribute => setting['value'])
         when 'overwrite_empty'
-          if object.public_send(attribute).blank? || ((attribute == 'on_hand' || attribute == 'count_on_hand') && entry.on_hand_nil)
+          if object.public_send(attribute).blank? ||
+             ((attribute == 'on_hand' || attribute == 'count_on_hand') &&
+             entry.on_hand_nil)
+
             object.assign_attributes(attribute => setting['value'])
           end
         end
@@ -216,7 +224,10 @@ module ProductImport
 
     def display_in_inventory(variant_override, is_new = false)
       unless is_new
-        existing_item = InventoryItem.where(variant_id: variant_override.variant_id, enterprise_id: variant_override.hub_id).first
+        existing_item = InventoryItem.where(
+          variant_id: variant_override.variant_id,
+          enterprise_id: variant_override.hub_id
+        ).first
 
         if existing_item
           existing_item.assign_attributes(visible: true)
@@ -225,7 +236,11 @@ module ProductImport
         end
       end
 
-      InventoryItem.new(variant_id: variant_override.variant_id, enterprise_id: variant_override.hub_id, visible: true).save
+      InventoryItem.new(
+        variant_id: variant_override.variant_id,
+        enterprise_id: variant_override.hub_id,
+        visible: true
+      ).save
     end
 
     def ensure_variant_updated(product, entry)

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -46,10 +46,7 @@ module ProductImport
 
         products_count =
           if settings.importing_into_inventory?
-            VariantOverride.where(
-              'variant_overrides.hub_id IN (?)',
-              enterprise_id
-            ).count
+            VariantOverride.for_hubs([enterprise_id]).count
           else
             Spree::Variant.
               not_deleted.

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -27,10 +27,10 @@ module ProductImport
 
     def validate_all(entries)
       entries.each do |entry|
-        supplier_validation(entry)
+        enterprise_validation(entry)
         unit_fields_validation(entry)
 
-        next if entry.supplier_id.blank?
+        next if entry.enterprise_id.blank?
 
         if import_into_inventory?
           producer_validation(entry)
@@ -59,37 +59,37 @@ module ProductImport
 
     private
 
-    def supplier_validation(entry)
+    def enterprise_validation(entry)
       return if name_presence_error entry
       return if enterprise_not_found_error entry
       return if permissions_error entry
       return if primary_producer_error entry
 
-      entry.supplier_id = @spreadsheet_data.suppliers_index[entry.supplier][:id]
+      entry.enterprise_id = @spreadsheet_data.enterprises_index[entry.enterprise][:id]
     end
 
     def name_presence_error(entry)
-      return if entry.supplier.present?
-      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_required))
+      return if entry.enterprise.present?
+      mark_as_invalid(entry, attribute: "enterprise", error: I18n.t(:error_required))
       true
     end
 
     def enterprise_not_found_error(entry)
-      return if @spreadsheet_data.suppliers_index[entry.supplier][:id]
-      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_found_in_database, name: entry.supplier))
+      return if @spreadsheet_data.enterprises_index[entry.enterprise][:id]
+      mark_as_invalid(entry, attribute: "enterprise", error: I18n.t(:error_not_found_in_database, name: entry.enterprise))
       true
     end
 
     def permissions_error(entry)
-      return if permission_by_name?(entry.supplier)
-      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_no_permission_for_enterprise, name: entry.supplier))
+      return if permission_by_name?(entry.enterprise)
+      mark_as_invalid(entry, attribute: "enterprise", error: I18n.t(:error_no_permission_for_enterprise, name: entry.enterprise))
       true
     end
 
     def primary_producer_error(entry)
       return if import_into_inventory?
-      return if @spreadsheet_data.suppliers_index[entry.supplier][:is_primary_producer]
-      mark_as_invalid(entry, attribute: "supplier", error: I18n.t(:error_not_primary_producer, name: entry.supplier))
+      return if @spreadsheet_data.enterprises_index[entry.enterprise][:is_primary_producer]
+      mark_as_invalid(entry, attribute: "enterprise", error: I18n.t(:error_not_primary_producer, name: entry.enterprise))
       true
     end
 
@@ -126,7 +126,7 @@ module ProductImport
         return
       end
 
-      unless inventory_permission?(entry.supplier_id, @spreadsheet_data.producers_index[producer_name])
+      unless inventory_permission?(entry.enterprise_id, @spreadsheet_data.producers_index[producer_name])
         mark_as_invalid(entry, attribute: "producer", error: "\"#{producer_name}\": #{I18n.t('admin.product_import.model.inventory_no_permission')}")
         return
       end
@@ -186,7 +186,7 @@ module ProductImport
     end
 
     def product_validation(entry)
-      products = Spree::Product.where(supplier_id: entry.supplier_id, name: entry.name, deleted_at: nil)
+      products = Spree::Product.where(supplier_id: entry.enterprise_id, name: entry.name, deleted_at: nil)
 
       if products.empty?
         mark_as_new_product(entry)
@@ -222,7 +222,7 @@ module ProductImport
       if existing_variant.valid?
         entry.product_object = existing_variant
         entry.validates_as = 'existing_variant' unless entry.errors?
-        updates_count_per_supplier(entry.supplier_id) unless entry.errors?
+        updates_count_per_enterprise(entry.enterprise_id) unless entry.errors?
       else
         mark_as_invalid(entry, product_validations: existing_variant.errors)
       end
@@ -243,16 +243,16 @@ module ProductImport
       existing_product.public_send(attribute).blank? && entry.public_send(attribute).blank?
     end
 
-    def permission_by_name?(supplier_name)
-      @editable_enterprises.key?(supplier_name)
+    def permission_by_name?(enterprise_name)
+      @editable_enterprises.key?(enterprise_name)
     end
 
-    def permission_by_id?(supplier_id)
-      @editable_enterprises.value?(Integer(supplier_id))
+    def permission_by_id?(enterprise_id)
+      @editable_enterprises.value?(Integer(enterprise_id))
     end
 
-    def inventory_permission?(supplier_id, producer_id)
-      @current_user.admin? || ( @inventory_permissions[supplier_id] && @inventory_permissions[supplier_id].include?(producer_id) )
+    def inventory_permission?(enterprise_id, producer_id)
+      @current_user.admin? || ( @inventory_permissions[enterprise_id] && @inventory_permissions[enterprise_id].include?(producer_id) )
     end
 
     def mark_as_invalid(entry, options = {})
@@ -273,9 +273,9 @@ module ProductImport
     end
 
     def create_inventory_item(entry, existing_variant)
-      existing_variant_override = VariantOverride.where(variant_id: existing_variant.id, hub_id: entry.supplier_id).first
+      existing_variant_override = VariantOverride.where(variant_id: existing_variant.id, hub_id: entry.enterprise_id).first
 
-      variant_override = existing_variant_override || VariantOverride.new(variant_id: existing_variant.id, hub_id: entry.supplier_id)
+      variant_override = existing_variant_override || VariantOverride.new(variant_id: existing_variant.id, hub_id: entry.enterprise_id)
       variant_override.assign_attributes(count_on_hand: entry.on_hand, import_date: @import_time)
       check_on_hand_nil(entry, variant_override)
       variant_override.assign_attributes(entry.attributes.slice('price', 'on_demand'))
@@ -287,18 +287,18 @@ module ProductImport
       if variant_override.id
         entry.validates_as = 'existing_inventory_item'
         entry.product_object = variant_override
-        updates_count_per_supplier(entry.supplier_id) unless entry.errors?
+        updates_count_per_enterprise(entry.enterprise_id) unless entry.errors?
       else
         entry.validates_as = 'new_inventory_item'
         entry.product_object = variant_override
       end
     end
 
-    def updates_count_per_supplier(supplier_id)
-      if @reset_counts[supplier_id] && @reset_counts[supplier_id][:updates_count]
-        @reset_counts[supplier_id][:updates_count] += 1
+    def updates_count_per_enterprise(enterprise_id)
+      if @reset_counts[enterprise_id] && @reset_counts[enterprise_id][:updates_count]
+        @reset_counts[enterprise_id][:updates_count] += 1
       else
-        @reset_counts[supplier_id] = { updates_count: 1 }
+        @reset_counts[enterprise_id] = { updates_count: 1 }
       end
     end
 

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -207,6 +207,7 @@ module ProductImport
     def mark_as_new_product(entry)
       new_product = Spree::Product.new
       new_product.assign_attributes(entry.attributes.except('id'))
+      new_product.supplier_id = entry.enterprise_id
 
       if new_product.valid?
         entry.validates_as = 'new_product' unless entry.errors?

--- a/app/models/product_import/inventory_reset_strategy.rb
+++ b/app/models/product_import/inventory_reset_strategy.rb
@@ -4,10 +4,10 @@ module ProductImport
       @excluded_items_ids = excluded_items_ids
     end
 
-    def reset(supplier_ids)
-      @supplier_ids = supplier_ids
+    def reset(enterprise_ids)
+      @enterprise_ids = enterprise_ids
 
-      if supplier_ids.present?
+      if enterprise_ids.present?
         relation.update_all(count_on_hand: 0)
       else
         0
@@ -16,10 +16,10 @@ module ProductImport
 
     private
 
-    attr_reader :excluded_items_ids, :supplier_ids
+    attr_reader :excluded_items_ids, :enterprise_ids
 
     def relation
-      relation = VariantOverride.where(hub_id: supplier_ids)
+      relation = VariantOverride.where(hub_id: enterprise_ids)
       return relation if excluded_items_ids.blank?
 
       relation.where('id NOT IN (?)', excluded_items_ids)

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -180,7 +180,7 @@ module ProductImport
         build_entries
       end
 
-      @spreadsheet_data = SpreadsheetData.new(@entries)
+      @spreadsheet_data = SpreadsheetData.new(@entries, @import_settings)
       @validator = EntryValidator.new(@current_user, @import_time, @spreadsheet_data, @editable_enterprises, @inventory_permissions, @reset_counts, @import_settings)
       @processor = EntryProcessor.new(self, @validator, @import_settings, @spreadsheet_data, @editable_enterprises, @import_time, @updated_ids)
 

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -65,27 +65,27 @@ module ProductImport
     end
 
     def reset_counts
-      # Return indexed data about existing product count, reset count, and updates count per supplier
-      @reset_counts.each do |supplier_id, values|
+      # Return indexed data about existing product count, reset count, and updates count per enterprise
+      @reset_counts.each do |enterprise_id, values|
         values[:updates_count] = 0 if values[:updates_count].blank?
 
         if values[:updates_count] && values[:existing_products]
-          @reset_counts[supplier_id][:reset_count] = values[:existing_products] - values[:updates_count]
+          @reset_counts[enterprise_id][:reset_count] = values[:existing_products] - values[:updates_count]
         end
       end
       @reset_counts
     end
 
-    def suppliers_index
-      @spreadsheet_data.suppliers_index
+    def enterprises_index
+      @spreadsheet_data.enterprises_index
     end
 
-    def supplier_products
-      @processor.andand.supplier_products
+    def enterprise_products
+      @processor.andand.enterprise_products
     end
 
-    def total_supplier_products
-      @processor.total_supplier_products
+    def total_enterprise_products
+      @processor.total_enterprise_products
     end
 
     def all_entries
@@ -165,8 +165,8 @@ module ProductImport
       @processor.reset_absent_items
     end
 
-    def permission_by_id?(supplier_id)
-      @editable_enterprises.value?(Integer(supplier_id))
+    def permission_by_id?(enterprise_id)
+      @editable_enterprises.value?(Integer(enterprise_id))
     end
 
     private

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -65,12 +65,14 @@ module ProductImport
     end
 
     def reset_counts
-      # Return indexed data about existing product count, reset count, and updates count per enterprise
+      # Return indexed data about existing product count, reset count, and
+      # updates count per enterprise
       @reset_counts.each do |enterprise_id, values|
         values[:updates_count] = 0 if values[:updates_count].blank?
 
         if values[:updates_count] && values[:existing_products]
-          @reset_counts[enterprise_id][:reset_count] = values[:existing_products] - values[:updates_count]
+          @reset_counts[enterprise_id][:reset_count] =
+            values[:existing_products] - values[:updates_count]
         end
       end
       @reset_counts

--- a/app/models/product_import/products_reset_strategy.rb
+++ b/app/models/product_import/products_reset_strategy.rb
@@ -4,10 +4,10 @@ module ProductImport
       @excluded_items_ids = excluded_items_ids
     end
 
-    def reset(supplier_ids)
-      @supplier_ids = supplier_ids
+    def reset(enterprise_ids)
+      @enterprise_ids = enterprise_ids
 
-      if supplier_ids.present?
+      if enterprise_ids.present?
         relation.update_all(count_on_hand: 0)
       else
         0
@@ -16,13 +16,13 @@ module ProductImport
 
     private
 
-    attr_reader :excluded_items_ids, :supplier_ids
+    attr_reader :excluded_items_ids, :enterprise_ids
 
     def relation
       relation = Spree::Variant
         .joins(:product)
         .where(
-          spree_products: { supplier_id: supplier_ids },
+          spree_products: { supplier_id: enterprise_ids },
           spree_variants: { is_master: false, deleted_at: nil }
         )
 

--- a/app/models/product_import/settings.rb
+++ b/app/models/product_import/settings.rb
@@ -6,8 +6,8 @@ module ProductImport
 
     def defaults(entry)
       @import_settings.key?(:settings) &&
-        settings[entry.supplier_id.to_s] &&
-        settings[entry.supplier_id.to_s]['defaults']
+        settings[entry.enterprise_id.to_s] &&
+        settings[entry.enterprise_id.to_s]['defaults']
     end
 
     def settings

--- a/app/models/product_import/spreadsheet_data.rb
+++ b/app/models/product_import/spreadsheet_data.rb
@@ -7,8 +7,9 @@
 
 module ProductImport
   class SpreadsheetData
-    def initialize(entries)
+    def initialize(entries, import_settings)
       @entries = entries
+      @import_settings = import_settings
     end
 
     def enterprises_index
@@ -33,10 +34,14 @@ module ProductImport
 
     private
 
+    def import_into_inventory?
+      @import_settings[:settings] && @import_settings[:settings]['import_into'] == 'inventories'
+    end
+
     def create_enterprises_index
       @enterprises_index = {}
       @entries.each do |entry|
-        enterprise_name = entry.enterprise
+        enterprise_name = import_into_inventory? ? entry.distributor : entry.producer
         next if @enterprises_index.key? enterprise_name
         enterprise = Enterprise.find_by_name(enterprise_name, select: 'id, name, is_primary_producer')
         @enterprises_index[enterprise_name] = { id: enterprise.try(:id), is_primary_producer: enterprise.try(:is_primary_producer) }

--- a/app/models/product_import/spreadsheet_data.rb
+++ b/app/models/product_import/spreadsheet_data.rb
@@ -35,16 +35,21 @@ module ProductImport
     private
 
     def import_into_inventory?
-      @import_settings[:settings] && @import_settings[:settings]['import_into'] == 'inventories'
+      @import_settings[:settings].andand['import_into'] == 'inventories'
     end
 
     def create_enterprises_index
       @enterprises_index = {}
       @entries.each do |entry|
         enterprise_name = import_into_inventory? ? entry.distributor : entry.producer
+
         next if @enterprises_index.key? enterprise_name
-        enterprise = Enterprise.find_by_name(enterprise_name, select: 'id, name, is_primary_producer')
-        @enterprises_index[enterprise_name] = { id: enterprise.try(:id), is_primary_producer: enterprise.try(:is_primary_producer) }
+
+        enterprise = Enterprise.find_by_name(enterprise_name, select: 'id, is_primary_producer')
+
+        @enterprises_index[enterprise_name] =
+          { id: enterprise.try(:id),
+            is_primary_producer: enterprise.try(:is_primary_producer) }
       end
       @enterprises_index
     end

--- a/app/models/product_import/spreadsheet_data.rb
+++ b/app/models/product_import/spreadsheet_data.rb
@@ -11,8 +11,8 @@ module ProductImport
       @entries = entries
     end
 
-    def suppliers_index
-      @suppliers_index || create_suppliers_index
+    def enterprises_index
+      @enterprises_index || create_enterprises_index
     end
 
     def producers_index
@@ -33,15 +33,15 @@ module ProductImport
 
     private
 
-    def create_suppliers_index
-      @suppliers_index = {}
+    def create_enterprises_index
+      @enterprises_index = {}
       @entries.each do |entry|
-        supplier_name = entry.supplier
-        next if @suppliers_index.key? supplier_name
-        enterprise = Enterprise.find_by_name(supplier_name, select: 'id, name, is_primary_producer')
-        @suppliers_index[supplier_name] = { id: enterprise.try(:id), is_primary_producer: enterprise.try(:is_primary_producer) }
+        enterprise_name = entry.enterprise
+        next if @enterprises_index.key? enterprise_name
+        enterprise = Enterprise.find_by_name(enterprise_name, select: 'id, name, is_primary_producer')
+        @enterprises_index[enterprise_name] = { id: enterprise.try(:id), is_primary_producer: enterprise.try(:is_primary_producer) }
       end
-      @suppliers_index
+      @enterprises_index
     end
 
     def create_producers_index

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -11,10 +11,10 @@ module ProductImport
     attr_accessor :line_number, :valid, :validates_as, :product_object, :product_validations, :on_hand_nil,
                   :has_overrides, :units, :unscaled_units, :unit_type, :tax_category, :shipping_category
 
-    attr_accessor :id, :product_id, :producer, :producer_id, :enterprise, :enterprise_id, :name, :display_name, :sku,
+    attr_accessor :id, :product_id, :producer, :producer_id, :distributor, :distributor_id, :name, :display_name, :sku,
                   :unit_value, :unit_description, :variant_unit, :variant_unit_scale, :variant_unit_name,
                   :display_as, :category, :primary_taxon_id, :price, :on_hand, :count_on_hand, :on_demand,
-                  :tax_category_id, :shipping_category_id, :description, :import_date
+                  :tax_category_id, :shipping_category_id, :description, :import_date, :enterprise, :enterprise_id
 
     def initialize(attrs)
       @validates_as = ''
@@ -77,7 +77,7 @@ module ProductImport
     end
 
     def non_display_attributes
-      ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise_id', 'primary_taxon', 'primary_taxon_id', 'category_id', 'shipping_category_id', 'tax_category_id', 'variant_unit_scale', 'variant_unit', 'unit_value']
+      ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise', 'enterprise_id', 'producer_id', 'distributor_id', 'primary_taxon', 'primary_taxon_id', 'category_id', 'shipping_category_id', 'tax_category_id', 'variant_unit_scale', 'variant_unit', 'unit_value']
     end
 
     def non_product_attributes

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -8,13 +8,17 @@ module ProductImport
     include ActiveModel::Conversion
     include ActiveModel::Validations
 
-    attr_accessor :line_number, :valid, :validates_as, :product_object, :product_validations, :on_hand_nil,
-                  :has_overrides, :units, :unscaled_units, :unit_type, :tax_category, :shipping_category
+    attr_accessor :line_number, :valid, :validates_as, :product_object,
+                  :product_validations, :on_hand_nil, :has_overrides, :units,
+                  :unscaled_units, :unit_type, :tax_category, :shipping_category
 
-    attr_accessor :id, :product_id, :producer, :producer_id, :distributor, :distributor_id, :name, :display_name, :sku,
-                  :unit_value, :unit_description, :variant_unit, :variant_unit_scale, :variant_unit_name,
-                  :display_as, :category, :primary_taxon_id, :price, :on_hand, :count_on_hand, :on_demand,
-                  :tax_category_id, :shipping_category_id, :description, :import_date, :enterprise, :enterprise_id
+    attr_accessor :id, :product_id, :producer, :producer_id, :distributor,
+                  :distributor_id, :name, :display_name, :sku, :unit_value,
+                  :unit_description, :variant_unit, :variant_unit_scale,
+                  :variant_unit_name, :display_as, :category, :primary_taxon_id,
+                  :price, :on_hand, :count_on_hand, :on_demand,
+                  :tax_category_id, :shipping_category_id, :description,
+                  :import_date, :enterprise, :enterprise_id
 
     def initialize(attrs)
       @validates_as = ''
@@ -77,11 +81,16 @@ module ProductImport
     end
 
     def non_display_attributes
-      ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise', 'enterprise_id', 'producer_id', 'distributor_id', 'primary_taxon', 'primary_taxon_id', 'category_id', 'shipping_category_id', 'tax_category_id', 'variant_unit_scale', 'variant_unit', 'unit_value']
+      ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise',
+       'enterprise_id', 'producer_id', 'distributor_id', 'primary_taxon',
+       'primary_taxon_id', 'category_id', 'shipping_category_id',
+       'tax_category_id', 'variant_unit_scale', 'variant_unit', 'unit_value']
     end
 
     def non_product_attributes
-      ['line_number', 'valid', 'errors', 'product_object', 'product_validations', 'inventory_validations', 'validates_as', 'save_type', 'on_hand_nil', 'has_overrides']
+      ['line_number', 'valid', 'errors', 'product_object',
+       'product_validations', 'inventory_validations', 'validates_as',
+       'save_type', 'on_hand_nil', 'has_overrides']
     end
   end
 end

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -11,7 +11,7 @@ module ProductImport
     attr_accessor :line_number, :valid, :validates_as, :product_object, :product_validations, :on_hand_nil,
                   :has_overrides, :units, :unscaled_units, :unit_type, :tax_category, :shipping_category
 
-    attr_accessor :id, :product_id, :producer, :producer_id, :supplier, :supplier_id, :name, :display_name, :sku,
+    attr_accessor :id, :product_id, :producer, :producer_id, :enterprise, :enterprise_id, :name, :display_name, :sku,
                   :unit_value, :unit_description, :variant_unit, :variant_unit_scale, :variant_unit_name,
                   :display_as, :category, :primary_taxon_id, :price, :on_hand, :count_on_hand, :on_demand,
                   :tax_category_id, :shipping_category_id, :description, :import_date
@@ -77,7 +77,7 @@ module ProductImport
     end
 
     def non_display_attributes
-      ['id', 'product_id', 'unscaled_units', 'variant_id', 'supplier_id', 'primary_taxon', 'primary_taxon_id', 'category_id', 'shipping_category_id', 'tax_category_id', 'variant_unit_scale', 'variant_unit', 'unit_value']
+      ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise_id', 'primary_taxon', 'primary_taxon_id', 'category_id', 'shipping_category_id', 'tax_category_id', 'variant_unit_scale', 'variant_unit', 'unit_value']
     end
 
     def non_product_attributes

--- a/app/views/admin/product_import/_import_options.html.haml
+++ b/app/views/admin/product_import/_import_options.html.haml
@@ -1,7 +1,7 @@
 %h5= t('admin.product_import.import.options_and_defaults')
 %br
 
-- @importer.suppliers_index.each do |name, attrs|
+- @importer.enterprises_index.each do |name, attrs|
   - if name and attrs[:id] and @importer.permission_by_id?(attrs[:id])
     %div.panel-section.import-settings
       %div.panel-header{ng: {click: 'togglePanel()', class: '{active: active}'}}
@@ -32,7 +32,7 @@
           %i.fa.fa-warning
         %div.header-description
           = t('admin.product_import.import.no_name')
-          %span.header-error= " - #{t('admin.product_import.import.blank_supplier')}"
+          %span.header-error= " - #{t('admin.product_import.import.blank_enterprise')}"
 
 %br.panels.clearfix
 %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -554,7 +554,7 @@ en:
         no_permission: you do not have permission to manage this enterprise
         not_found: enterprise could not be found in database
         no_name: No name
-        blank_supplier: some products have blank supplier name
+        blank_enterprise: some products do not have an enterprise defined
         reset_absent?: Reset absent products
         reset_absent_tip: Set stock to zero for all exiting products not present in the file
         overwrite_all: Overwrite all

--- a/public/inventory_template.csv
+++ b/public/inventory_template.csv
@@ -1,1 +1,1 @@
-producer,supplier,name,display_name,units,unit_type,price,on_hand
+producer,distributor,name,display_name,units,unit_type,price,on_hand

--- a/public/product_list_template.csv
+++ b/public/product_list_template.csv
@@ -1,1 +1,1 @@
-supplier,sku,name,display_name,category,units,unit_type,variant_unit_name,price,on_hand,available_on,on_demand,shipping_category,tax_category
+producer,sku,name,display_name,category,units,unit_type,variant_unit_name,price,on_hand,available_on,on_demand,shipping_category,tax_category

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -33,7 +33,7 @@ feature "Product Import", js: true do
 
     it "validates entries and saves them if they are all valid and allows viewing new items in Bulk Products" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end
@@ -76,7 +76,7 @@ feature "Product Import", js: true do
 
     it "displays info about invalid entries but no save button if all items are invalid" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Bad Carrots", "Unkown Enterprise", "Mouldy vegetables", "666", "3.20", "", "g"]
         csv << ["Bad Potatoes", "", "Vegetables", "6", "6", "6", ""]
       end
@@ -100,7 +100,7 @@ feature "Product Import", js: true do
 
     it "handles saving of named tax and shipping categories" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "tax_category", "shipping_category"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "tax_category", "shipping_category"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.name, shipping_category.name]
       end
       File.write('/tmp/test.csv', csv_data)
@@ -129,7 +129,7 @@ feature "Product Import", js: true do
 
     it "records a timestamp on import that can be viewed and filtered under Bulk Edit Products" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end
@@ -176,7 +176,7 @@ feature "Product Import", js: true do
 
     it "can reset product stock to zero for products not present in the CSV" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "500", "3.20", "500", "g"]
       end
       File.write('/tmp/test.csv', csv_data)
@@ -203,7 +203,7 @@ feature "Product Import", js: true do
 
     it "can save a new product and variant of that product at the same time, add variant to existing product" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag"]
         csv << ["Beans", "User Enterprise", "Vegetables", "7", "2.50", "250", "g", nil]
@@ -241,7 +241,7 @@ feature "Product Import", js: true do
 
     it "can import items into inventory" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "producer", "category", "on_hand", "price", "units"]
+        csv << ["name", "enterprise", "producer", "category", "on_hand", "price", "units"]
         csv << ["Beans", "Another Enterprise", "User Enterprise", "Vegetables", "5", "3.20", "500"]
         csv << ["Sprouts", "Another Enterprise", "User Enterprise", "Vegetables", "6", "6.50", "500"]
         csv << ["Cabbage", "Another Enterprise", "User Enterprise", "Vegetables", "2001", "1.50", "500"]
@@ -338,7 +338,7 @@ feature "Product Import", js: true do
 
     it "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -33,7 +33,7 @@ feature "Product Import", js: true do
 
     it "validates entries and saves them if they are all valid and allows viewing new items in Bulk Products" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end
@@ -76,7 +76,7 @@ feature "Product Import", js: true do
 
     it "displays info about invalid entries but no save button if all items are invalid" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Bad Carrots", "Unkown Enterprise", "Mouldy vegetables", "666", "3.20", "", "g"]
         csv << ["Bad Potatoes", "", "Vegetables", "6", "6", "6", ""]
       end
@@ -100,7 +100,7 @@ feature "Product Import", js: true do
 
     it "handles saving of named tax and shipping categories" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "tax_category", "shipping_category"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "tax_category", "shipping_category"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.name, shipping_category.name]
       end
       File.write('/tmp/test.csv', csv_data)
@@ -129,7 +129,7 @@ feature "Product Import", js: true do
 
     it "records a timestamp on import that can be viewed and filtered under Bulk Edit Products" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end
@@ -176,7 +176,7 @@ feature "Product Import", js: true do
 
     it "can reset product stock to zero for products not present in the CSV" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "500", "3.20", "500", "g"]
       end
       File.write('/tmp/test.csv', csv_data)
@@ -203,7 +203,7 @@ feature "Product Import", js: true do
 
     it "can save a new product and variant of that product at the same time, add variant to existing product" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag"]
         csv << ["Beans", "User Enterprise", "Vegetables", "7", "2.50", "250", "g", nil]
@@ -241,7 +241,7 @@ feature "Product Import", js: true do
 
     it "can import items into inventory" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "producer", "category", "on_hand", "price", "units"]
+        csv << ["name", "distributor", "producer", "category", "on_hand", "price", "units"]
         csv << ["Beans", "Another Enterprise", "User Enterprise", "Vegetables", "5", "3.20", "500"]
         csv << ["Sprouts", "Another Enterprise", "User Enterprise", "Vegetables", "6", "6.50", "500"]
         csv << ["Cabbage", "Another Enterprise", "User Enterprise", "Vegetables", "2001", "1.50", "500"]
@@ -338,7 +338,7 @@ feature "Product Import", js: true do
 
     it "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end

--- a/spec/models/product_import/settings_spec.rb
+++ b/spec/models/product_import/settings_spec.rb
@@ -15,7 +15,7 @@ describe ProductImport::Settings do
 
     context 'when there are settings' do
       let(:entry) do
-        instance_double(ProductImport::SpreadsheetEntry, supplier_id: 1)
+        instance_double(ProductImport::SpreadsheetEntry, enterprise_id: 1)
       end
       let(:import_settings) { { settings: {} } }
 

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -45,7 +45,7 @@ describe ProductImport::ProductImporter do
   describe "importing products from a spreadsheet" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "variant_unit_name", "on_demand"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "variant_unit_name", "on_demand"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", "", ""]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "2", "kg", "", ""]
         csv << ["Pea Soup", "User Enterprise", "Vegetables", "8", "5.50", "750", "ml", "", "0"]
@@ -135,7 +135,7 @@ describe ProductImport::ProductImporter do
   describe "when uploading a spreadsheet with some invalid entries" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Good Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Bad Potatoes", "", "Vegetables", "6", "6.50", "1", ""]
       end
@@ -176,7 +176,7 @@ describe ProductImport::ProductImporter do
   describe "when enterprises are not valid" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Product 1", "Non-existent Enterprise", "Vegetables", "5", "5.50", "500", "g"]
         csv << ["Product 2", "Non-Producer", "Vegetables", "5", "5.50", "500", "g"]
       end
@@ -191,15 +191,15 @@ describe ProductImport::ProductImporter do
       @importer.validate_entries
       entries = JSON.parse(@importer.entries_json)
 
-      expect(entries['2']['errors']['supplier']).to include "not found in database"
-      expect(entries['3']['errors']['supplier']).to include "not enabled as a producer"
+      expect(entries['2']['errors']['enterprise']).to include "not found in database"
+      expect(entries['3']['errors']['enterprise']).to include "not enabled as a producer"
     end
   end
 
   describe "adding new variants to existing products and updating exiting products" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "5", "5.50", "500", "g", "Preexisting Banana"]
         csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "6", "3.50", "500", "g", "Emergent Coffee"]
       end
@@ -245,7 +245,7 @@ describe ProductImport::ProductImporter do
   describe "adding new product and sub-variant at the same time" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag"]
       end
@@ -289,7 +289,7 @@ describe ProductImport::ProductImporter do
   describe "updating various fields" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "on_demand", "sku"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "on_demand", "sku"]
         csv << ["Beetroot", "And Another Enterprise", "Vegetables", "5", "3.50", "500", "g", "0", nil]
         csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "g", "1", "TOMS"]
       end
@@ -331,7 +331,7 @@ describe ProductImport::ProductImporter do
   describe "updating non-updatable fields on existing products" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Beetroot", "And Another Enterprise", "Meat", "5", "3.50", "500", "g"]
         csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "Kg"]
       end
@@ -358,7 +358,7 @@ describe ProductImport::ProductImporter do
   describe "when more than one product of the same name already exists with multiple variants each" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "description", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "enterprise", "category", "description", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Oats", "User Enterprise", "Cereal", "", "50", "3.50", "500", "g", "Rolled Oats"]   # Update
         csv << ["Oats", "User Enterprise", "Cereal", "", "80", "3.75", "500", "g", "Flaked Oats"]   # Update
         csv << ["Oats", "User Enterprise", "Cereal", "", "60", "5.50", "500", "g", "Magic Oats"]    # Add
@@ -398,7 +398,7 @@ describe ProductImport::ProductImporter do
   describe "when importer processes create and update across multiple stages" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Bag of Oats", "User Enterprise", "Cereal", "60", "5.50", "500", "g", "Magic Oats"]     # Add
         csv << ["Bag of Oats", "User Enterprise", "Cereal", "70", "8.50", "500", "g", "French Oats"]    # Add
         csv << ["Bag of Oats", "User Enterprise", "Cereal", "80", "9.50", "500", "g", "Organic Oats"]   # Add
@@ -467,7 +467,7 @@ describe ProductImport::ProductImporter do
   describe "importing items into inventory" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "producer", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "producer", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "Another Enterprise", "User Enterprise", "5", "3.20", "500", "g"]
         csv << ["Sprouts", "Another Enterprise", "User Enterprise", "6", "6.50", "500", "g"]
         csv << ["Cabbage", "Another Enterprise", "User Enterprise", "2001", "1.50", "500", "g"]
@@ -517,7 +517,7 @@ describe ProductImport::ProductImporter do
 
     it "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end
@@ -545,7 +545,7 @@ describe ProductImport::ProductImporter do
 
     it "allows creating inventories for producers that a user's hub has permission for" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "supplier", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "enterprise", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "User Enterprise", "Another Enterprise", "777", "3.20", "500", "g"]
       end
       File.write('/tmp/test-m.csv', csv_data)
@@ -572,7 +572,7 @@ describe ProductImport::ProductImporter do
 
     it "does not allow creating inventories for producers that a user's hubs don't have permission for" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "User Enterprise", "5", "3.20", "500", "g"]
         csv << ["Sprouts", "User Enterprise", "6", "6.50", "500", "g"]
       end
@@ -601,7 +601,7 @@ describe ProductImport::ProductImporter do
 
     it "can reset all products for an enterprise that are not present in the uploaded file to zero stock" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Beans", "User Enterprise", "Vegetables", "6", "6.50", "500", "g"]
       end
@@ -640,7 +640,7 @@ describe ProductImport::ProductImporter do
 
     it "can reset all inventory items for an enterprise that are not present in the uploaded file to zero stock" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "producer", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "enterprise", "producer", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "Another Enterprise", "User Enterprise", "6", "3.20", "500", "g"]
         csv << ["Sprouts", "Another Enterprise", "User Enterprise", "7", "6.50", "500", "g"]
       end
@@ -681,7 +681,7 @@ describe ProductImport::ProductImporter do
 
     it "can overwrite fields with selected defaults when importing to product list" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "tax_category_id", "available_on"]
+        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "tax_category_id", "available_on"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.id, ""]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", "", ""]
       end

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -45,7 +45,7 @@ describe ProductImport::ProductImporter do
   describe "importing products from a spreadsheet" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "variant_unit_name", "on_demand"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "variant_unit_name", "on_demand"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", "", ""]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "2", "kg", "", ""]
         csv << ["Pea Soup", "User Enterprise", "Vegetables", "8", "5.50", "750", "ml", "", "0"]
@@ -135,7 +135,7 @@ describe ProductImport::ProductImporter do
   describe "when uploading a spreadsheet with some invalid entries" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Good Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Bad Potatoes", "", "Vegetables", "6", "6.50", "1", ""]
       end
@@ -176,7 +176,7 @@ describe ProductImport::ProductImporter do
   describe "when enterprises are not valid" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Product 1", "Non-existent Enterprise", "Vegetables", "5", "5.50", "500", "g"]
         csv << ["Product 2", "Non-Producer", "Vegetables", "5", "5.50", "500", "g"]
       end
@@ -191,15 +191,15 @@ describe ProductImport::ProductImporter do
       @importer.validate_entries
       entries = JSON.parse(@importer.entries_json)
 
-      expect(entries['2']['errors']['enterprise']).to include "not found in database"
-      expect(entries['3']['errors']['enterprise']).to include "not enabled as a producer"
+      expect(entries['2']['errors']['producer']).to include "not found in database"
+      expect(entries['3']['errors']['producer']).to include "not enabled as a producer"
     end
   end
 
   describe "adding new variants to existing products and updating exiting products" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "5", "5.50", "500", "g", "Preexisting Banana"]
         csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "6", "3.50", "500", "g", "Emergent Coffee"]
       end
@@ -245,7 +245,7 @@ describe ProductImport::ProductImporter do
   describe "adding new product and sub-variant at the same time" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag"]
       end
@@ -289,7 +289,7 @@ describe ProductImport::ProductImporter do
   describe "updating various fields" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "on_demand", "sku"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "on_demand", "sku"]
         csv << ["Beetroot", "And Another Enterprise", "Vegetables", "5", "3.50", "500", "g", "0", nil]
         csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "g", "1", "TOMS"]
       end
@@ -331,7 +331,7 @@ describe ProductImport::ProductImporter do
   describe "updating non-updatable fields on existing products" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Beetroot", "And Another Enterprise", "Meat", "5", "3.50", "500", "g"]
         csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "Kg"]
       end
@@ -358,7 +358,7 @@ describe ProductImport::ProductImporter do
   describe "when more than one product of the same name already exists with multiple variants each" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "description", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "producer", "category", "description", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Oats", "User Enterprise", "Cereal", "", "50", "3.50", "500", "g", "Rolled Oats"]   # Update
         csv << ["Oats", "User Enterprise", "Cereal", "", "80", "3.75", "500", "g", "Flaked Oats"]   # Update
         csv << ["Oats", "User Enterprise", "Cereal", "", "60", "5.50", "500", "g", "Magic Oats"]    # Add
@@ -398,7 +398,7 @@ describe ProductImport::ProductImporter do
   describe "when importer processes create and update across multiple stages" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "display_name"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Bag of Oats", "User Enterprise", "Cereal", "60", "5.50", "500", "g", "Magic Oats"]     # Add
         csv << ["Bag of Oats", "User Enterprise", "Cereal", "70", "8.50", "500", "g", "French Oats"]    # Add
         csv << ["Bag of Oats", "User Enterprise", "Cereal", "80", "9.50", "500", "g", "Organic Oats"]   # Add
@@ -467,7 +467,7 @@ describe ProductImport::ProductImporter do
   describe "importing items into inventory" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "producer", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "distributor", "producer", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "Another Enterprise", "User Enterprise", "5", "3.20", "500", "g"]
         csv << ["Sprouts", "Another Enterprise", "User Enterprise", "6", "6.50", "500", "g"]
         csv << ["Cabbage", "Another Enterprise", "User Enterprise", "2001", "1.50", "500", "g"]
@@ -517,7 +517,7 @@ describe ProductImport::ProductImporter do
 
     it "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
       end
@@ -545,7 +545,7 @@ describe ProductImport::ProductImporter do
 
     it "allows creating inventories for producers that a user's hub has permission for" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "enterprise", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "distributor", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "User Enterprise", "Another Enterprise", "777", "3.20", "500", "g"]
       end
       File.write('/tmp/test-m.csv', csv_data)
@@ -572,7 +572,7 @@ describe ProductImport::ProductImporter do
 
     it "does not allow creating inventories for producers that a user's hubs don't have permission for" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "User Enterprise", "5", "3.20", "500", "g"]
         csv << ["Sprouts", "User Enterprise", "6", "6.50", "500", "g"]
       end
@@ -601,7 +601,7 @@ describe ProductImport::ProductImporter do
 
     it "can reset all products for an enterprise that are not present in the uploaded file to zero stock" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
         csv << ["Beans", "User Enterprise", "Vegetables", "6", "6.50", "500", "g"]
       end
@@ -640,7 +640,7 @@ describe ProductImport::ProductImporter do
 
     it "can reset all inventory items for an enterprise that are not present in the uploaded file to zero stock" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "producer", "on_hand", "price", "units", "unit_type"]
+        csv << ["name", "distributor", "producer", "on_hand", "price", "units", "unit_type"]
         csv << ["Beans", "Another Enterprise", "User Enterprise", "6", "3.20", "500", "g"]
         csv << ["Sprouts", "Another Enterprise", "User Enterprise", "7", "6.50", "500", "g"]
       end
@@ -681,7 +681,7 @@ describe ProductImport::ProductImporter do
 
     it "can overwrite fields with selected defaults when importing to product list" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "enterprise", "category", "on_hand", "price", "units", "unit_type", "tax_category_id", "available_on"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "tax_category_id", "available_on"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.id, ""]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", "", ""]
       end


### PR DESCRIPTION
#### What? Why?

Closes #2481

As part of #2481 it was decided to rename the names of the fields used in the CSV import. For importing to product list, the enterprise field has changed form "supplier" to "producer", and for inventory the fields "supplier" and "producer" are now "producer" and "distributor".

I've tried to make some of the naming more generic in the codebase, using "enterprise" where possible for lists such as "enterprise_ids" which will now be used either to check the "producer" for product list, or "distributor" for inventory.

#### What should we test?

Product Import generally, using the new names, and the downloadabe CSV templates.

#### Release notes

Renamed CSV fields in product import for clarity and updated CSV template.

Changelog Category: Changed


#### Documentation updates

Product Import guide will need to be updated to reflect the new field names.

