### PR TITLE
Emails/validation

### DIFF
--- a/app/mailers/spree/user_mailer_decorator.rb
+++ b/app/mailers/spree/user_mailer_decorator.rb
@@ -13,8 +13,14 @@ Spree::UserMailer.class_eval do
     @contact = ContentConfig.footer_email
 
     subject = t('spree.user_mailer.confirmation_instructions.subject')
-    mail(to: user.email,
+    mail(to: confirmation_email_address,
          from: from_address,
          subject: subject)
+  end
+
+  private
+
+  def confirmation_email_address
+    @user.pending_reconfirmation? ? @user.unconfirmed_email : @user.email
   end
 end

--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -18,7 +18,12 @@ feature "Account Settings", js: true do
       expect(page).to have_content I18n.t('spree.users.form.account_settings')
       fill_in 'user_email', with: 'new@email.com'
 
-      click_button I18n.t(:update)
+      expect do
+        click_button I18n.t(:update)
+      end.to send_confirmation_instructions
+
+      sent_mail = ActionMailer::Base.deliveries.last
+      expect(sent_mail.to).to eq ['new@email.com']
 
       expect(find(".alert-box.success").text.strip).to eq "#{I18n.t(:account_updated)} ×"
       user.reload

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -75,8 +75,11 @@ describe Spree.user_class do
       create(:mail_method)
 
       expect do
-        create(:user, confirmation_sent_at: nil, confirmed_at: nil)
+        create(:user, email: 'new_user@example.com', confirmation_sent_at: nil, confirmed_at: nil)
       end.to send_confirmation_instructions
+
+      sent_mail = ActionMailer::Base.deliveries.last
+      expect(sent_mail.to).to eq ['new_user@example.com']
     end
 
     context "with the the same email as existing customers" do


### PR DESCRIPTION
#### What? Why?

Closes #2840

Confirmation emails for users who are changing their password were being sent to `user.email` instead of `user.unconfirmed_email`, which is where the new pending email gets set on a user that is already confirmed.

#### What should we test?

Confirmation emails when changing email should now be delivered to the correct email. Confirmation emails for new users should also be sent to the correct email.

#### Release notes

Fixed confirmation emails being sent to the old address when changing to a new email address.

Changelog Category: Fixed
