### PR TITLE
Fix for instagram links

### DIFF
--- a/app/views/admin/enterprises/form/_social.html.haml
+++ b/app/views/admin/enterprises/form/_social.html.haml
@@ -12,7 +12,7 @@
   .alpha.three.columns
     = f.label :linkedin, 'LinkedIn'
   .omega.eight.columns
-    = f.text_field :linkedin
+    = f.text_field :linkedin, { placeholder: t('.linkedin_placeholder') }
 .row
   .alpha.three.columns
     = f.label :twitter

--- a/app/views/admin/enterprises/form/_social.html.haml
+++ b/app/views/admin/enterprises/form/_social.html.haml
@@ -7,7 +7,7 @@
   .alpha.three.columns
     = f.label :instagram, 'Instagram'
   .omega.eight.columns
-    = f.text_field :instagram
+    = f.text_field :instagram, { placeholder: t('.instagram_placeholder') }
 .row
   .alpha.three.columns
     = f.label :linkedin, 'LinkedIn'

--- a/app/views/admin/enterprises/form/_social.html.haml
+++ b/app/views/admin/enterprises/form/_social.html.haml
@@ -2,7 +2,7 @@
   .alpha.three.columns
     = f.label :facebook, 'Facebook'
   .omega.eight.columns
-    = f.text_field :facebook
+    = f.text_field :facebook, { placeholder: t('.facebook_placeholder') }
 .row
   .alpha.three.columns
     = f.label :instagram, 'Instagram'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -772,8 +772,8 @@ en:
         social:
           twitter_placeholder: eg. @the_prof
           instagram_placeholder: eg. @the_prof
-          facebook_placeholder: "eg. www.facebook.com/PageNameHere"
-          linkedin_placeholder: "eg. www.linkedin.com/in/YourNameHere"
+          facebook_placeholder: eg. www.facebook.com/PageNameHere
+          linkedin_placeholder: eg. www.linkedin.com/in/YourNameHere
         stripe_connect:
           connect_with_stripe: "Connect with Stripe"
           stripe_connect_intro: "To accept payments using credit card, you will need to connect your stripe account to the Open Food Network. Use the button to the right to get started."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,9 +771,15 @@ en:
           close_date: Close Date
         social:
           twitter_placeholder: eg. @the_prof
+<<<<<<< HEAD
           instagram_placeholder: eg. the_prof
           facebook_placeholder: eg. www.facebook.com/PageNameHere
           linkedin_placeholder: eg. www.linkedin.com/in/YourNameHere
+=======
+          instagram_placeholder: eg. @the_prof
+          facebook_placeholder: "eg. www.facebook.com/PageNameHere"
+          linkedin_placeholder: "eg. www.linkedin.com/in/YourNameHere"
+>>>>>>> Add new attribute linkedin_placeholder to local yml
         stripe_connect:
           connect_with_stripe: "Connect with Stripe"
           stripe_connect_intro: "To accept payments using credit card, you will need to connect your stripe account to the Open Food Network. Use the button to the right to get started."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -773,6 +773,7 @@ en:
           twitter_placeholder: eg. @the_prof
           instagram_placeholder: eg. @the_prof
           facebook_placeholder: "eg. www.facebook.com/PageNameHere"
+          linkedin_placeholder: "eg. www.linkedin.com/in/YourNameHere"
         stripe_connect:
           connect_with_stripe: "Connect with Stripe"
           stripe_connect_intro: "To accept payments using credit card, you will need to connect your stripe account to the Open Food Network. Use the button to the right to get started."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,7 +771,7 @@ en:
           close_date: Close Date
         social:
           twitter_placeholder: eg. @the_prof
-          instagram_placeholder: eg. @the_prof
+          instagram_placeholder: eg. the_prof
           facebook_placeholder: eg. www.facebook.com/PageNameHere
           linkedin_placeholder: eg. www.linkedin.com/in/YourNameHere
         stripe_connect:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,15 +771,9 @@ en:
           close_date: Close Date
         social:
           twitter_placeholder: eg. @the_prof
-<<<<<<< HEAD
           instagram_placeholder: eg. the_prof
           facebook_placeholder: eg. www.facebook.com/PageNameHere
           linkedin_placeholder: eg. www.linkedin.com/in/YourNameHere
-=======
-          instagram_placeholder: eg. @the_prof
-          facebook_placeholder: "eg. www.facebook.com/PageNameHere"
-          linkedin_placeholder: "eg. www.linkedin.com/in/YourNameHere"
->>>>>>> Add new attribute linkedin_placeholder to local yml
         stripe_connect:
           connect_with_stripe: "Connect with Stripe"
           stripe_connect_intro: "To accept payments using credit card, you will need to connect your stripe account to the Open Food Network. Use the button to the right to get started."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -772,6 +772,7 @@ en:
         social:
           twitter_placeholder: eg. @the_prof
           instagram_placeholder: eg. @the_prof
+          facebook_placeholder: "eg. www.facebook.com/PageNameHere"
         stripe_connect:
           connect_with_stripe: "Connect with Stripe"
           stripe_connect_intro: "To accept payments using credit card, you will need to connect your stripe account to the Open Food Network. Use the button to the right to get started."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,6 +771,7 @@ en:
           close_date: Close Date
         social:
           twitter_placeholder: eg. @the_prof
+          instagram_placeholder: eg. @the_prof
         stripe_connect:
           connect_with_stripe: "Connect with Stripe"
           stripe_connect_intro: "To accept payments using credit card, you will need to connect your stripe account to the Open Food Network. Use the button to the right to get started."

--- a/db/migrate/20181008201815_update_instagram_data.rb
+++ b/db/migrate/20181008201815_update_instagram_data.rb
@@ -1,0 +1,9 @@
+class UpdateInstagramData < ActiveRecord::Migration
+  def change
+    enterprises = Enterprise.where("instagram like ?", "%instagram.com%")
+    enterprises.each do |e|
+      e.instagram = "@#{e.instagram.split('/').last}"
+      e.save
+    end
+  end
+end

--- a/db/migrate/20181008201815_update_instagram_data.rb
+++ b/db/migrate/20181008201815_update_instagram_data.rb
@@ -1,7 +1,6 @@
 class UpdateInstagramData < ActiveRecord::Migration
   def change
-    enterprises = Enterprise.where("instagram like ?", "%instagram.com%")
-    enterprises.each do |e|
+    Enterprise.where("instagram like ?", "%instagram.com%").find_each do |e|
       e.instagram = "@#{e.instagram.split('/').last}"
       e.save
     end

--- a/db/migrate/20181008201815_update_instagram_data.rb
+++ b/db/migrate/20181008201815_update_instagram_data.rb
@@ -1,7 +1,7 @@
 class UpdateInstagramData < ActiveRecord::Migration
   def change
     Enterprise.where("instagram like ?", "%instagram.com%").find_each do |e|
-      e.instagram = "@#{e.instagram.split('/').last}"
+      e.instagram = e.instagram.split('/').last
       e.save
     end
   end


### PR DESCRIPTION
#### Issue: #1760 

#### Problem

There is no suggestion in the Instagram empty field in enterprise profile setup menu. Some users copy-paste the full URL on their page. That doesn't work because what is expected is only their Instagram user pseudo.

![image](https://user-images.githubusercontent.com/20689519/46632963-b3c29300-cb22-11e8-8099-ef1e576ca413.png)

#### FIX

Add a suggestion/model in the empty field that guides the user so that he enter the Instagram info at the expected format (as it is done for Twitter for instance).

Add migration to fix the wrong links already inputted, from "http://instagram.com/myUser" to "@myUser"

![image](https://user-images.githubusercontent.com/20689519/46633110-1ddb3800-cb23-11e8-9199-291c30c5c5f2.png)

