### PR TITLE
Password change logout

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -22,6 +22,9 @@ Spree.config do |config|
   #config.override_actionmailer_config = false
 end
 
+# Don't log users out when setting a new password
+Spree::Auth::Config[:signout_after_password_change] = false
+
 # TODO Work out why this is necessary
 # Seems like classes within OFN module become 'uninitialized' when server reloads
 # unless the empty module is explicity 'registered' here. Something to do with autoloading?

--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -33,7 +33,6 @@ feature "Account Settings", js: true do
     end
 
     it "allows the user to change their password" do
-      allow(Spree::Auth::Config).to receive(:[]).with(:signout_after_password_change).and_return(false)
       initial_password = user.encrypted_password
 
       fill_in 'user_password', with: 'NewPassword'

--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -4,18 +4,22 @@ feature "Account Settings", js: true do
   include AuthenticationWorkflow
 
   describe "as a logged in user" do
-    let(:user) { create(:user, email: 'old@email.com') }
+    let(:user) do
+      create(:user,
+             email: 'old@email.com',
+             password: 'OriginalPassword',
+             password_confirmation: 'OriginalPassword')
+    end
 
     before do
       create(:mail_method)
       quick_login_as user
-    end
-
-    it "allows me to update my account details" do
       visit "/account"
-
       click_link I18n.t('spree.users.show.tabs.settings')
       expect(page).to have_content I18n.t('spree.users.form.account_settings')
+    end
+
+    it "allows the user to update their email address" do
       fill_in 'user_email', with: 'new@email.com'
 
       click_button I18n.t(:update)
@@ -26,6 +30,19 @@ feature "Account Settings", js: true do
       expect(user.unconfirmed_email).to eq 'new@email.com'
       click_link I18n.t('spree.users.show.tabs.settings')
       expect(page).to have_content I18n.t('spree.users.show.unconfirmed_email', unconfirmed_email: 'new@email.com')
+    end
+
+    it "allows the user to change their password" do
+      allow(Spree::Auth::Config).to receive(:[]).with(:signout_after_password_change).and_return(false)
+      initial_password = user.encrypted_password
+
+      fill_in 'user_password', with: 'NewPassword'
+      fill_in 'user_password_confirmation', with: 'NewPassword'
+
+      click_button I18n.t(:update)
+      expect(find(".alert-box.success").text.strip).to eq "#{I18n.t(:account_updated)} ×"
+
+      expect(user.reload.encrypted_password).to_not eq initial_password
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,6 +120,7 @@ RSpec.configure do |config|
       spree_config.allow_backorders = false
     end
 
+    Spree::Auth::Config[:signout_after_password_change] = false
     Spree::Api::Config[:requires_authentication] = true
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #2848

Adjusts a config setting so that users are not logged out when updating their password.

#### What should we test?

Users can change password via /account page without being logged out.

#### Release notes

Users will not be logged out whilst changing their password.

Changelog Category: Changed
