### PR TITLE
Increase rubocop line limit to 100

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -188,7 +188,7 @@ Metrics/CyclomaticComplexity:
   Max: 6
 
 Metrics/LineLength:
-  Max: 80
+  Max: 100
 
 Metrics/MethodLength:
   Max: 10


### PR DESCRIPTION
#### What? Why?

Increases the Rubocop characters per line limit from 80 to 100. 

#### What should we test?

Nothing to test.

#### Release notes

Increased the Rubocop characters per line limit from 80 to 100.

Changelog Category: Changed



