### PR TITLE
Instagram pattern

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -333,8 +333,7 @@ class Enterprise < ActiveRecord::Base
   end
 
   def instagram=(value)
-    regex = %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._]{1,30})/?\z}
-    write_attribute(:instagram, value.try(:gsub, regex, '@\1'))
+    write_attribute(:instagram, value.try(:gsub, instagram_regex, '@\1'))
   end
 
   protected
@@ -344,6 +343,10 @@ class Enterprise < ActiveRecord::Base
   end
 
   private
+
+  def instagram_regex
+    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._]{1,30})/?\z}
+  end
 
   def name_is_unique
     dups = Enterprise.where(name: name)

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -80,6 +80,8 @@ class Enterprise < ActiveRecord::Base
   before_validation :set_unused_address_fields
   after_validation :geocode_address
 
+  before_save :check_instagram_pattern
+
   after_touch :touch_distributors
   after_create :set_default_contact
   after_create :relate_to_owners_enterprises
@@ -424,5 +426,10 @@ class Enterprise < ActiveRecord::Base
     Enterprise.distributing_products(self.supplied_products).
       where('enterprises.id != ?', self.id).
       each(&:touch)
+  end
+
+  def check_instagram_pattern
+    return if self.instagram.blank? || self.instagram.exclude?('www.instagram.com')
+    self.instagram = "@#{self.instagram.split('/').last}"
   end
 end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -80,7 +80,7 @@ class Enterprise < ActiveRecord::Base
   before_validation :set_unused_address_fields
   after_validation :geocode_address
 
-  before_save :check_instagram_pattern
+  validates :instagram, format: /\A@[a-zA-Z0-9._]{1,30}\z/, :allow_blank => true
 
   after_touch :touch_distributors
   after_create :set_default_contact
@@ -332,6 +332,10 @@ class Enterprise < ActiveRecord::Base
     abn.present?
   end
 
+  def instagram=(value)
+    write_attribute(:instagram, value.try(:gsub, %r{\Ahttps?://(?:www.)?instagram.com/([a-zA-Z0-9._]{1,30})/?\z}, '@\1'))
+  end
+
   protected
 
   def devise_mailer
@@ -426,10 +430,5 @@ class Enterprise < ActiveRecord::Base
     Enterprise.distributing_products(self.supplied_products).
       where('enterprises.id != ?', self.id).
       each(&:touch)
-  end
-
-  def check_instagram_pattern
-    return if self.instagram.blank? || self.instagram.exclude?('instagram.com')
-    self.instagram = "@#{self.instagram.split('/').last}"
   end
 end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -429,7 +429,7 @@ class Enterprise < ActiveRecord::Base
   end
 
   def check_instagram_pattern
-    return if self.instagram.blank?
+    return if self.instagram.blank? || self.instagram.exclude?('instagram.com')
     self.instagram = "@#{self.instagram.split('/').last}"
   end
 end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -80,7 +80,7 @@ class Enterprise < ActiveRecord::Base
   before_validation :set_unused_address_fields
   after_validation :geocode_address
 
-  validates :instagram, format: /\A@[a-zA-Z0-9._]{1,30}\z/, :allow_blank => true
+  validates :instagram, format: /\A@[a-zA-Z0-9._]{1,30}\z/, allow_blank: true
 
   after_touch :touch_distributors
   after_create :set_default_contact
@@ -333,7 +333,8 @@ class Enterprise < ActiveRecord::Base
   end
 
   def instagram=(value)
-    write_attribute(:instagram, value.try(:gsub, %r{\Ahttps?://(?:www.)?instagram.com/([a-zA-Z0-9._]{1,30})/?\z}, '@\1'))
+    regex = %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._]{1,30})/?\z}
+    write_attribute(:instagram, value.try(:gsub, regex, '@\1'))
   end
 
   protected

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -429,7 +429,7 @@ class Enterprise < ActiveRecord::Base
   end
 
   def check_instagram_pattern
-    return if self.instagram.blank? || self.instagram.exclude?('www.instagram.com')
+    return if self.instagram.blank?
     self.instagram = "@#{self.instagram.split('/').last}"
   end
 end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -149,10 +149,66 @@ describe Enterprise do
       end
 
       context "prevent an wrong instagram link pattern" do
-        let(:e) { build(:enterprise, instagram: 'instagram.com/my_user') }
-
-        it "expects the instagram attribute to not be valid" do
+        it "expects to be invalid the instagram attribute @my-user" do
+          e = build(:enterprise, instagram: '@my-user')
           expect(e).to_not be_valid
+        end
+
+        it "expects to be invalid the instagram attribute https://facebook.com/user" do
+          e = build(:enterprise, instagram: 'https://facebook.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "expects to be invalid the instagram attribute tagram.com/user" do
+          e = build(:enterprise, instagram: 'tagram.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "expects to be invalid the instagram attribute https://instagram.com/user/preferences" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/preferences')
+          expect(e).to_not be_valid
+        end
+      end
+
+      context "accepted pattern" do
+        it "expects to be valid empty instagram attribute" do
+          e = build(:enterprise)
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute @user" do
+          e = build(:enterprise, instagram: '@user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute @my_www5.example" do
+          e = build(:enterprise, instagram: '@my_www5.example')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute http://instagram.com/user" do
+          e = build(:enterprise, instagram: 'http://instagram.com/user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute https://instagram.com/user/" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute https://www.instagram.com/user" do
+          e = build(:enterprise, instagram: 'https://www.instagram.com/user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute instagram.com/user" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e).to be_valid
+        end
+
+        it "renders the expected pattern" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e.instagram).to eq('@user')
         end
       end
     end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -147,6 +147,14 @@ describe Enterprise do
       it "sets the enterprise contact to the owner by default" do
         enterprise.contact.should eq enterprise.owner
       end
+
+      context "prevent an wrong instagram link pattern" do
+        let!(:e) { create(:enterprise, instagram: 'www.instagram.com/my_user') }
+
+        it "expects the instagram attribute to be in the correct pattern" do
+          expect(e.instagram).to eq('@my_user')
+        end
+      end
     end
 
     describe "preferred_shopfront_taxon_order" do

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -149,10 +149,10 @@ describe Enterprise do
       end
 
       context "prevent an wrong instagram link pattern" do
-        let!(:e) { create(:enterprise, instagram: 'www.instagram.com/my_user') }
+        let(:e) { build(:enterprise, instagram: 'instagram.com/my_user') }
 
-        it "expects the instagram attribute to be in the correct pattern" do
-          expect(e.instagram).to eq('@my_user')
+        it "expects the instagram attribute to not be valid" do
+          expect(e).to_not be_valid
         end
       end
     end


### PR DESCRIPTION
#### Issue: #1760 

There is no suggestion in the Instagram empty field in enterprise profile setup menu. Some users copy-paste the full URL on their page. That doesn't work because what is expected is only their Instagram user pseudo.

![image](https://user-images.githubusercontent.com/20689519/46632963-b3c29300-cb22-11e8-8099-ef1e576ca413.png)

#### FIX

Add an before save to check if the user enter the whole URL, and extract and store just the handle.

So, if the user enter "www.instagram.com/my_user", we store just "@my_user".