### PR TITLE
[Spree Upgrade] Update spree 2-0-4-stable revision used to pick up latest commits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 43950c3689a77a7f493cc6d805a0edccfe75ebc2
+  revision: f55722b38db7e706a8521c9091a0e00119bb4d20
   branch: 2-0-4-stable
   specs:
     spree (2.0.4)


### PR DESCRIPTION
What? Why?
Updating spree revision to be used in 2-0-stable branch.

I updated spree 2-0-4-stable locally and picked the top commit: f55722b38db7e706a8521c9091a0e00119bb4d20

previous similar PR was #2640