### PR TITLE
[Spree Upgrade] Replace allow_backorders with variant.on_demand in the cart

### DIFF
--- a/app/services/cart_service.rb
+++ b/app/services/cart_service.rb
@@ -59,7 +59,7 @@ class CartService
   def quantities_to_add(variant, quantity, max_quantity)
     # If not enough stock is available, add as much as we can to the cart
     on_hand = variant.on_hand
-    on_hand = [quantity, max_quantity].compact.max if Spree::Config.allow_backorders
+    on_hand = [quantity, max_quantity].compact.max if variant.on_demand
     quantity_to_add = [quantity, on_hand].min
     max_quantity_to_add = max_quantity # max_quantity is not capped
 

--- a/spec/services/cart_service_spec.rb
+++ b/spec/services/cart_service_spec.rb
@@ -164,6 +164,7 @@ describe CartService do
       expect(cart_service).to receive(:check_order_cycle_provided_for).with(variant).and_return(true)
       expect(cart_service).to receive(:check_variant_available_under_distribution).with(variant).
         and_return(true)
+      expect(variant).to receive(:on_demand).and_return(false)
       expect(order).to receive(:add_variant).with(variant, quantity, nil, currency)
 
       cart_service.attempt_cart_add(333, quantity.to_s)
@@ -199,6 +200,10 @@ describe CartService do
     let(:v) { double(:variant, on_hand: 10) }
 
     context "when backorders are not allowed" do
+      before do
+        expect(v).to receive(:on_demand).and_return(false)
+      end
+
       context "when max_quantity is not provided" do
         it "returns full amount when available" do
           expect(cart_service.quantities_to_add(v, 5, nil)).to eq([5, nil])
@@ -220,9 +225,9 @@ describe CartService do
       end
     end
 
-    context "when backorders are allowed" do
+    context "when variant is on_demand" do
       before do
-        Spree::Config.allow_backorders = true
+        expect(v).to receive(:on_demand).and_return(true)
       end
 
       it "does not limit quantity" do


### PR DESCRIPTION
#### What? Why?

Closes #2803

We replace the check on Spree::Config.allow_backorders with the check on variant.on_demand in the cart.

#### What should we test?
cart_service_spec is green