### PR TITLE
[Spree Upgrade] Replace allow_backorders with variant.on_demand in the line_item_decorator

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -117,7 +117,7 @@ Spree::LineItem.class_eval do
   def sufficient_stock?
     return true if quantity == 0 # This line added
     scoper.scope(variant) # This line added
-    return true if Spree::Config[:allow_backorders]
+    return true if variant.on_demand
     if new_record? || !order.completed?
       variant.on_hand >= quantity
     else

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -103,16 +103,9 @@ feature "full-page cart", js: true do
         add_product_to_cart order, product_tax
       end
 
-      around do |example|
-        original = Spree::Config.allow_backorders
-        Spree::Config.allow_backorders = false
-        example.run
-        Spree::Config.allow_backorders = original
-      end
-
       it "prevents me from entering an invalid value" do
         # Given we have 2 on hand, and we've loaded the page after that fact
-        variant.update_attributes! on_hand: 2
+        variant.update_attributes!({ on_hand: 2, on_demand: false })
         visit spree.cart_path
 
         accept_alert 'Insufficient stock available, only 2 remaining' do
@@ -123,6 +116,7 @@ feature "full-page cart", js: true do
 
       it "shows the quantities saved, not those submitted" do
         # Given we load the page with 3 on hand, then the number available drops to 2
+        variant.update_attributes! on_demand: false
         variant.update_attributes! on_hand: 3
         visit spree.cart_path
         variant.update_attributes! on_hand: 2

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -14,7 +14,6 @@ module Spree
       let(:li1) { create(:line_item, order: o, product: p1) }
       let(:li2) { create(:line_item, order: o, product: p2) }
 
-
       let(:p3) {create(:product, name: 'Clear Honey') }
       let(:p4) {create(:product, name: 'Apricots') }
       let(:v1) {create(:variant, product: p3, unit_value: 500) }
@@ -190,8 +189,6 @@ module Spree
       let!(:li) { create(:line_item, variant: v, order: o, quantity: 5, max_quantity: 5) }
 
       before do
-        Spree::Config.set allow_backorders: false
-
         # li#scoper is memoised, and this makes it difficult to update test conditions
         # so we reset it after the line_item is created for each spec
         li.remove_instance_variable(:@scoper)


### PR DESCRIPTION
#### What? Why?

Closes #2885

Replaces calls to config::allow_backorders with variant.on_demand in line_item decorator.

#### What should we test?
- shopping/cart_spec with only 2 specs broken
In spec/models/spree/line_item_spec.rb, there's still an error but now related to the scoper and variant_overrides. To be addressed in another issue.

