### PR TITLE
Fix bug in inventory management page 

### DIFF
--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -6,7 +6,7 @@ class EnterpriseRelationship < ActiveRecord::Base
   validates_presence_of :parent_id, :child_id
   validates_uniqueness_of :child_id, scope: :parent_id, message: I18n.t('validation_msg_relationship_already_established')
 
-  after_save :apply_variant_override_permissions
+  after_save :update_permissions_of_child_variant_overrides
 
   scope :with_enterprises,
     joins('LEFT JOIN enterprises AS parent_enterprises ON parent_enterprises.id = enterprise_relationships.parent_id').
@@ -25,7 +25,6 @@ class EnterpriseRelationship < ActiveRecord::Base
   }
 
   scope :by_name, with_enterprises.order('child_enterprises.name, parent_enterprises.name')
-
 
   # Load an array of the relatives of each enterprise (ie. any enterprise related to it in
   # either direction). This array is split into distributors and producers, and has the format:
@@ -76,14 +75,24 @@ class EnterpriseRelationship < ActiveRecord::Base
 
   private
 
-  def apply_variant_override_permissions
-    variant_overrides = VariantOverride.unscoped.for_hubs(child)
-      .joins(variant: :product).where("spree_products.supplier_id IN (?)", parent)
-
+  def update_permissions_of_child_variant_overrides
     if has_permission?(:create_variant_overrides)
-      variant_overrides.update_all(permission_revoked_at: nil)
+      allow_all_child_variant_overrides
     else
-      variant_overrides.update_all(permission_revoked_at: Time.now)
+      revoke_all_child_variant_overrides
     end
+  end
+
+  def allow_all_child_variant_overrides
+    child_variant_overrides.update_all(permission_revoked_at: nil)
+  end
+
+  def revoke_all_child_variant_overrides
+    child_variant_overrides.update_all(permission_revoked_at: Time.now)
+  end
+
+  def child_variant_overrides
+    VariantOverride.unscoped.for_hubs(child)
+      .joins(variant: :product).where("spree_products.supplier_id IN (?)", parent)
   end
 end

--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -7,6 +7,7 @@ class EnterpriseRelationship < ActiveRecord::Base
   validates_uniqueness_of :child_id, scope: :parent_id, message: I18n.t('validation_msg_relationship_already_established')
 
   after_save :update_permissions_of_child_variant_overrides
+  before_destroy :revoke_all_child_variant_overrides
 
   scope :with_enterprises,
     joins('LEFT JOIN enterprises AS parent_enterprises ON parent_enterprises.id = enterprise_relationships.parent_id').

--- a/db/migrate/20181020103501_revoke_variant_overrideswithout_permissions.rb
+++ b/db/migrate/20181020103501_revoke_variant_overrideswithout_permissions.rb
@@ -1,0 +1,17 @@
+class RevokeVariantOverrideswithoutPermissions < ActiveRecord::Migration
+  def up
+    # This process was executed when the permission_revoked_at colum was created (see AddPermissionRevokedAtToVariantOverrides)
+    #   It needs to be repeated due to #2739
+    variant_override_hubs = Enterprise.where(id: VariantOverride.all.map(&:hub_id).uniq)
+
+    variant_override_hubs.each do |hub|
+      permitting_producer_ids = hub.relationships_as_child
+        .with_permission(:create_variant_overrides).map(&:parent_id)
+
+      variant_overrides_with_revoked_permissions = VariantOverride.for_hubs(hub)
+        .joins(variant: :product).where("spree_products.supplier_id NOT IN (?)", permitting_producer_ids)
+
+      variant_overrides_with_revoked_permissions.update_all(permission_revoked_at: Time.now)
+    end
+  end
+end

--- a/db/migrate/20181020103501_revoke_variant_overrideswithout_permissions.rb
+++ b/db/migrate/20181020103501_revoke_variant_overrideswithout_permissions.rb
@@ -2,11 +2,11 @@ class RevokeVariantOverrideswithoutPermissions < ActiveRecord::Migration
   def up
     # This process was executed when the permission_revoked_at colum was created (see AddPermissionRevokedAtToVariantOverrides)
     #   It needs to be repeated due to #2739
-    variant_override_hubs = Enterprise.where(id: VariantOverride.all.map(&:hub_id).uniq)
+    variant_override_hubs = Enterprise.where(id: VariantOverride.select(:hub_id).uniq)
 
-    variant_override_hubs.each do |hub|
+    variant_override_hubs.find_each do |hub|
       permitting_producer_ids = hub.relationships_as_child
-        .with_permission(:create_variant_overrides).map(&:parent_id)
+        .with_permission(:create_variant_overrides).pluck(:parent_id)
 
       variant_overrides_with_revoked_permissions = VariantOverride.for_hubs(hub)
         .joins(variant: :product).where("spree_products.supplier_id NOT IN (?)", permitting_producer_ids)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181010093850) do
+ActiveRecord::Schema.define(:version => 20181020103501) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false

--- a/spec/models/enterprise_relationship_spec.rb
+++ b/spec/models/enterprise_relationship_spec.rb
@@ -140,7 +140,7 @@ describe EnterpriseRelationship do
   end
 
   describe "callbacks" do
-    context "applying variant override permissions" do
+    context "updating variant override permissions" do
       let(:hub) { create(:distributor_enterprise) }
       let(:producer) { create(:supplier_enterprise) }
       let(:some_other_producer) { create(:supplier_enterprise) }
@@ -151,6 +151,17 @@ describe EnterpriseRelationship do
         let!(:vo1) { create(:variant_override, hub: hub, variant: create(:variant, product: create(:product, supplier: producer))) }
         let!(:vo2) { create(:variant_override, hub: hub, variant: create(:variant, product: create(:product, supplier: producer))) }
         let!(:vo3) { create(:variant_override, hub: hub, variant: create(:variant, product: create(:product, supplier: some_other_producer))) }
+
+        context "revoking variant override permissions" do
+          context "when the enterprise relationship is destroyed" do
+            before { er.destroy }
+            it "should set permission_revoked_at to the current time for all variant overrides of the relationship" do
+              expect(vo1.reload.permission_revoked_at).to_not be_nil
+              expect(vo2.reload.permission_revoked_at).to_not be_nil
+              expect(vo2.reload.permission_revoked_at).to_not be_nil
+            end
+          end
+        end
 
         context "and is then removed" do
           before { er.permissions_list = [:add_to_order_cycles]; er.save! }


### PR DESCRIPTION
#### What? Why?

Closes #2739 
Initially I thought this happened where permissions to change existing variant overrides of deleted products were checked. The initial commit (now removed from this PR) was making the inventory page ignore variant overrides of deleted products.
After further investigation I concluded the problem was when permissions were deleted but variant overrides were not revoked (after discovering the field variant_override.permission_revoked_at :-)).

This PR is:
- adding a before_destroy function to enterprise_relationships (the enterprise permission) to revoke variant_overrides related to the permission being deleted
- adding a migration to take care of existing broken data

#### What should we test?
Inventory page and permissions.

Test adapted from a comment in #2739:
- I have a producer and hub in my test.
- For this test, there are two distinct users, one manages Hub, the other manages Producer ("Hub does this" should be read "User that manages Hub does this")
- For a base to test, Hub creates some inventory data for their own products or some Other Producer
- Producer creates Product X
- Producer permits Hub to sell their stuff: enterprise permission "Producer permits Hub to add products to inventory".
- Hub adds product X to inventory and sets the inventory data
- Producer removes permission to Hub
   - product X disappears from Hub inventory and Hub CAN update other inventory data (this was broken before the fix)
- Producer adds Hub permission back
   - product X reappears in Hub inventory and Hub CAN update all inventory data including the product X inventory
- Producer deletes product X from their products (permission is still in place)
   - product X disappears from Hub inventory and Hub CAN update all inventory data (except product X that has been deleted)
- At this point, Hub is not selling any Products from Producer and (apparently) there are no inventory items in Hub related to Producer SO:
- Producer removes useless permission to Hub sell their products
   - Hub CAN update its inventory data (this was broken before the fix) note: inventory entry is still in the database but it's permission is now revoked

After this fix is installed in any live instance, the result of this query should be empty (the migration will do this part of the job) and should remain empty forever (the fix will do this part of the job) ;-)
`select distinct hub.id, hub.name, supplier.id, supplier.name from variant_overrides vo, spree_variants v, spree_products p, enterprises hub, enterprises supplier where vo.variant_id = v.id and hub.id = vo.hub_id and supplier.id = p.supplier_id and v.product_id = p.id and vo.hub_id != p.supplier_id and (p.supplier_id, vo.hub_id) not in (select er.parent_id, er.child_id from enterprise_relationships er, enterprise_relationship_permissions erp where er.id = erp.enterprise_relationship_id and erp.name = 'create_variant_overrides') order by hub.id;
`
#### Release notes
Changelog Category: Fixed
Fix broken inventory page. When a producer deletes a permission for a hub to add producer's products to the hub's inventory, the hub's inventory items are now being correctly updated with a revoked stamp that will not break the inventory page anymore.

#### How is this related to the Spree upgrade?
Not related.