### PR TITLE
Use https on all links in emails in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Openfoodnetwork::Application.configure do
   config.force_ssl = true
 
   # Use https when creating links in emails
-  config.action_mailer.default_url_options = { protocol: 'https' }
+  config.action_mailer.default_url_options = { protocol: 'https', host: Spree::Config[:site_url] }
 
   # See everything in the log (default is :info)
   config.log_level = :info

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,9 @@ Openfoodnetwork::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Use https when creating links in emails
+  config.action_mailer.default_url_options = { protocol: 'https' }
+
   # See everything in the log (default is :info)
   config.log_level = :info
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,6 +30,9 @@ Openfoodnetwork::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Use https when creating links in emails
+  config.action_mailer.default_url_options = { protocol: 'https' }
+
   # See everything in the log (default is :info)
   # config.log_level = :debug
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -31,7 +31,7 @@ Openfoodnetwork::Application.configure do
   config.force_ssl = true
 
   # Use https when creating links in emails
-  config.action_mailer.default_url_options = { protocol: 'https' }
+  config.action_mailer.default_url_options = { protocol: 'https', host: Spree::Config[:site_url] }
 
   # See everything in the log (default is :info)
   # config.log_level = :debug


### PR DESCRIPTION
#### What? Why?

Closes #2895

Links created by devise in emails were being built with http instead of https. Aside form this not being good practice in general, it seemed to be causing some issues on UK prod where certain user's browsers were complaining, and causing support issues to pile up.


#### What should we test?

Links in emails should now use https on staging and production.

- sign up
- sign up confirmation
- password reset
- order confirmation
- new enterprise
- enterprise manager invitation
- order cycle report for producer
- subscription emails: (testing one of the following should be enough)
  - confirmation
  - empty order
  - placement
  - failed payment
  - placement summary
  - confirmation summary

#### Release notes

Ensure links in emails use https. #2896 

Changelog Category: Changed
