### PR TITLE
[Spree Upgrade] Avoiding variantStock raise by creating variant first and then setting `count_on_hand`

### DIFF
--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -22,10 +22,12 @@ describe CartController, type: :controller do
     describe "generating stock levels" do
       let!(:order) { create(:order) }
       let!(:li) { create(:line_item, order: order, variant: v, quantity: 2, max_quantity: 3) }
-      let!(:v) { create(:variant, count_on_hand: 4) }
-      let!(:v2) { create(:variant, count_on_hand: 2) }
+      let!(:v) { create(:variant) }
+      let!(:v2) { create(:variant) }
 
       before do
+        v.count_on_hand = 4
+        v2.count_on_hand = 2
         order.reload
         allow(controller).to receive(:current_order) { order }
       end
@@ -50,9 +52,10 @@ describe CartController, type: :controller do
       end
 
       describe "encoding Infinity" do
-        let!(:v) { create(:variant, on_demand: true, count_on_hand: 0) }
+        let!(:v) { create(:variant, on_demand: true) }
 
         it "encodes Infinity as a large, finite integer" do
+          v.count_on_hand = 0
           expect(controller.stock_levels(order, [v.id])).to eq(
             {v.id => {quantity: 2, max_quantity: 3, on_hand: 2147483647}}
           )


### PR DESCRIPTION
#### What? Why?

Related to VariantStock work done recently.

This progresses 4 specs in cart_controller_spec.

Specs were failing with this error.
```
95) CartController returning stock levels in JSON on success generating stock levels includes all line items, even when the variant_id is not specified
      Failure/Error: raise message if stock_items.empty?
      
      RuntimeError:
        You need to save the variant to create a stock item before you can set stock levels.
      # ./app/models/concerns/variant_stock.rb:124:in `raise_error_if_no_stock_item_available'
      # ./app/models/concerns/variant_stock.rb:76:in `count_on_hand='
      # ./spec/controllers/cart_controller_spec.rb:25:in `block (4 levels) in <top (required)>'
      # ./spec/controllers/cart_controller_spec.rb:24:in `block (4 levels) in <top (required)>'

```

We simply need to create the variant first and set count_on_hand afterwards.

#### What should we test?
cart_controller_spec is not failing with the same error.