### PR TITLE
[Spree Upgrade] Adapt product_decorator code to spree 2 with new variants_including_master

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -215,7 +215,7 @@ Spree::Product.class_eval do
         self.supplier.touch
         touch_distributors
 
-        ExchangeVariant.where('exchange_variants.variant_id IN (?)', self.variants_including_master_and_deleted).destroy_all
+        ExchangeVariant.where('exchange_variants.variant_id IN (?)', self.variants_including_master.with_deleted).destroy_all
 
         delete_without_delete_from_order_cycles
       end


### PR DESCRIPTION
It now makes use of Paranoia gem

#### What? Why?

Some specs failing on product decorator with error:
```
NoMethodError:
        undefined method `variants_including_master_and_deleted' for #<Spree::Product:0x007fd49d1f2128>

```

Solution in a Spree changelog:
* Removed `variants_including_master_and_deleted`, in favour of using the Paranoia gem. This scope would now be achieved using `variants_including_master.with_deleted`.

#### What should we test?
Mostly fixes some specs in product_spec but also shop_spec and product_cache_spec.