### PR TITLE
[Spree Upgrade] Mark specs from secondary features as xfeature

### DIFF
--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-xfeature %q{
+feature %q{
   As an Administrator
   I want to be able to manage products in bulk
 } , js: true do

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature %q{
+xfeature %q{
     As an administrator
     I want numbers, all the numbers!
 } do
@@ -118,7 +118,7 @@ feature %q{
 
     end
 
-    xscenario "Pack By Customer" do
+    scenario "Pack By Customer" do
       click_link "Pack By Customer"
       fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
       fill_in 'q_completed_at_lt', with: '2013-04-25 16:00:00'
@@ -133,7 +133,7 @@ feature %q{
       expect(page).to have_selector 'table#listing_orders tbody tr', count: 5 # Totals row per order
     end
 
-    xscenario "Pack By Supplier" do
+    scenario "Pack By Supplier" do
       click_link "Pack By Supplier"
       fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
       fill_in 'q_completed_at_lt', with: '2013-04-25 16:00:00'
@@ -212,7 +212,7 @@ feature %q{
       select("Tax types", from: "report_type")
     end
 
-    xit "reports" do
+    it "reports" do
       # Then it should give me access only to managed enterprises
       expect(page).to     have_select 'q_distributor_id_eq', with_options: [user1.enterprises.first.name]
       expect(page).not_to have_select 'q_distributor_id_eq', with_options: [user2.enterprises.first.name]
@@ -317,7 +317,7 @@ feature %q{
       variant2.option_values = [create(:option_value, :presentation => "Something")]
     end
 
-    xit "shows products and inventory report" do
+    it "shows products and inventory report" do
       quick_login_as_admin
       visit spree.admin_reports_path
 
@@ -332,7 +332,7 @@ feature %q{
       expect(page).to have_table_row [product2.supplier.name, product1.supplier.address.city, "Product 2",    product1.properties.map(&:presentation).join(", "), product2.primary_taxon.name,  "100g",           "99.0",   product1.group_buy_unit_size.to_s, "",       "product_sku"]
     end
 
-    xit "shows the LettuceShare report" do
+    it "shows the LettuceShare report" do
       quick_login_as_admin
       visit spree.admin_reports_path
       click_link 'LettuceShare'
@@ -505,7 +505,7 @@ feature %q{
         visit current_path
       end
 
-      xit "generates a detailed report for account invoices" do
+      it "generates a detailed report for account invoices" do
         select 'Detailed', from: 'report_type'
         select accounts_distributor.name, from: 'q_distributor_id_eq'
         click_button 'Search'

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Subscriptions' do
+xfeature 'Subscriptions' do
   include AuthenticationWorkflow
   include WebHelper
 

--- a/spec/jobs/finalize_account_invoices_spec.rb
+++ b/spec/jobs/finalize_account_invoices_spec.rb
@@ -5,7 +5,7 @@ def travel_to(time)
 end
 
 
-describe FinalizeAccountInvoices do
+xdescribe FinalizeAccountInvoices do
   let!(:year) { Time.zone.now.year }
 
   describe "unit specs" do

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SubscriptionConfirmJob do
+xdescribe SubscriptionConfirmJob do
   let(:job) { SubscriptionConfirmJob.new }
 
   describe "finding proxy_orders that are ready to be confirmed" do

--- a/spec/jobs/update_account_invoices_spec.rb
+++ b/spec/jobs/update_account_invoices_spec.rb
@@ -4,7 +4,7 @@ def travel_to(time)
   around { |example| Timecop.travel(start_of_july + time) { example.run } }
 end
 
-describe UpdateAccountInvoices do
+xdescribe UpdateAccountInvoices do
   let(:year) { Time.zone.now.year }
 
   before do

--- a/spec/models/product_import/products_reset_strategy_spec.rb
+++ b/spec/models/product_import/products_reset_strategy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ProductImport::ProductsResetStrategy do
+xdescribe ProductImport::ProductsResetStrategy do
   let(:products_reset) { described_class.new(excluded_items_ids) }
 
   describe '#reset' do

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'open_food_network/permissions'
 
-describe ProductImport::ProductImporter do
+xdescribe ProductImport::ProductImporter do
   include AuthenticationWorkflow
 
   let!(:admin) { create(:admin_user) }
@@ -63,7 +63,7 @@ describe ProductImport::ProductImporter do
       expect(@importer.item_count).to eq(5)
     end
 
-    xit "validates entries and returns the results as json" do
+    it "validates entries and returns the results as json" do
       @importer.validate_entries
       entries = JSON.parse(@importer.entries_json)
 
@@ -73,7 +73,7 @@ describe ProductImport::ProductImporter do
       expect(filter('update_product', entries)).to eq 0
     end
 
-    xit "saves the results and returns info on updated products" do
+    it "saves the results and returns info on updated products" do
       @importer.save_entries
 
       expect(@importer.products_created_count).to eq 5
@@ -146,7 +146,7 @@ describe ProductImport::ProductImporter do
     end
     after { File.delete('/tmp/test-m.csv') }
 
-    xit "validates entries" do
+    it "validates entries" do
       @importer.validate_entries
       entries = JSON.parse(@importer.entries_json)
 
@@ -156,7 +156,7 @@ describe ProductImport::ProductImporter do
       expect(filter('update_product', entries)).to eq 0
     end
 
-    xit "allows saving of the valid entries" do
+    it "allows saving of the valid entries" do
       @importer.save_entries
 
       expect(@importer.products_created_count).to eq 1
@@ -220,7 +220,7 @@ describe ProductImport::ProductImporter do
       expect(filter('update_product', entries)).to eq 1
     end
 
-    xit "saves and updates" do
+    it "saves and updates" do
       @importer.save_entries
 
       expect(@importer.products_created_count).to eq 1
@@ -256,7 +256,7 @@ describe ProductImport::ProductImporter do
     end
     after { File.delete('/tmp/test-m.csv') }
 
-    xit "validates entries" do
+    it "validates entries" do
       @importer.validate_entries
       entries = JSON.parse(@importer.entries_json)
 
@@ -265,7 +265,7 @@ describe ProductImport::ProductImporter do
       expect(filter('create_product', entries)).to eq 2
     end
 
-    xit "saves and updates" do
+    it "saves and updates" do
       @importer.save_entries
 
       expect(@importer.products_created_count).to eq 2
@@ -310,7 +310,7 @@ describe ProductImport::ProductImporter do
       expect(filter('update_product', entries)).to eq 2
     end
 
-    xit "saves and updates" do
+    it "saves and updates" do
       @importer.save_entries
 
       expect(@importer.products_created_count).to eq 0
@@ -515,7 +515,7 @@ describe ProductImport::ProductImporter do
   describe "handling enterprise permissions" do
     after { File.delete('/tmp/test-m.csv') }
 
-    xit "only allows product import into enterprises the user is permitted to manage" do
+    it "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
         csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
@@ -599,7 +599,7 @@ describe ProductImport::ProductImporter do
   describe "applying settings and defaults on import" do
     after { File.delete('/tmp/test-m.csv') }
 
-    xit "can reset all products for an enterprise that are not present in the uploaded file to zero stock" do
+    it "can reset all products for an enterprise that are not present in the uploaded file to zero stock" do
       csv_data = CSV.generate do |csv|
         csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
@@ -679,7 +679,7 @@ describe ProductImport::ProductImporter do
       expect(lettuce.count_on_hand).to eq 96   # In different enterprise; unchanged
     end
 
-    xit "can overwrite fields with selected defaults when importing to product list" do
+    it "can overwrite fields with selected defaults when importing to product list" do
       csv_data = CSV.generate do |csv|
         csv << ["name", "supplier", "category", "on_hand", "price", "units", "unit_type", "tax_category_id", "available_on"]
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.id, ""]

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ProxyOrder, type: :model do
+xdescribe ProxyOrder, type: :model do
   describe "cancel" do
     let(:order_cycle) { create(:simple_order_cycle) }
     let(:subscription) { create(:subscription) }

--- a/spec/services/subscription_form_spec.rb
+++ b/spec/services/subscription_form_spec.rb
@@ -1,4 +1,4 @@
-describe SubscriptionForm do
+xdescribe SubscriptionForm do
   describe "creating a new subscription" do
     let!(:shop) { create(:distributor_enterprise) }
     let!(:customer) { create(:customer, enterprise: shop) }


### PR DESCRIPTION
This is just the continuation of the previous effort to move broken specs of secondary features to pending so we can first focus on core features.

There are 9 commits in this PR, explanation:

Reports:

1. Moved full reports_spec to pending
     - when this PR is approved, I'll add a new TODO item in this existing issue: https://github.com/openfoodfoundation/openfoodnetwork/issues/2792

Product Import:

2. Moved full product_importer_spec to pending
3. Move all specs in products_reset_strategy_spec to pending
    - 2 new TODOs here: https://github.com/openfoodfoundation/openfoodnetwork/issues/2791

Subscriptions:

4. Move all specs in subscription_form_spec to pending
5. Move all specs in spec/features/admin/subscriptions_spec to pending
6. Move all specs in subscription_confirm_job_spec to pending
   - 3 new TODOs here: https://github.com/openfoodfoundation/openfoodnetwork/issues/2786
7. Move all specs in proxy_order_spec to pending (order syncer and proxy order are specific to subscriptions) 
   - new TODO here: https://github.com/openfoodfoundation/openfoodnetwork/issues/2788

Account Invoices:

8. Move all specs in update_account_invoices_spec and finalize_account_invoices_spec  to pending
     - this feature is the only new scope added to the "pending party", Ill create new issue to fix these specs when this PR is approved

Bulk Product Update

9. Move bulk_product_update_spec back to running (the product list cannot be secondary)
   - I'll close this issue: https://github.com/openfoodfoundation/openfoodnetwork/issues/2790
