### PR TITLE
[Spree Upgrade] In order list page, the shipment state is now a label, not a link. The shipments page is gone in spree 2.

### DIFF
--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -1,7 +1,7 @@
 class Api::Admin::OrderSerializer < ActiveModel::Serializer
   attributes :id, :number, :full_name, :email, :phone, :completed_at, :display_total
   attributes :show_path, :edit_path, :state, :payment_state, :shipment_state
-  attributes :payments_path, :shipments_path, :ship_path, :ready_to_ship, :created_at
+  attributes :payments_path, :ship_path, :ready_to_ship, :created_at
   attributes :distributor_name, :special_instructions, :payment_capture_path
 
   has_one :distributor, serializer: Api::Admin::IdSerializer
@@ -28,11 +28,6 @@ class Api::Admin::OrderSerializer < ActiveModel::Serializer
   def payments_path
     return '' unless object.payment_state
     spree_routes_helper.admin_order_payments_path(object)
-  end
-
-  def shipments_path
-    return '' unless object.shipment_state
-    spree_routes_helper.admin_order_shipments_path(object)
   end
 
   def ship_path

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -61,8 +61,7 @@
             {{'payment_states.' + order.payment_state | t}}
       %td.align-center
         %span.state{'ng-class' => 'order.shipment_state', 'ng-if' => 'order.shipment_state'}
-          %a{'ng-href' => '{{order.shipments_path}}' }
-            {{'shipment_states.' + order.shipment_state | t}}
+          {{'shipment_states.' + order.shipment_state | t}}
       %td
         = mail_to "{{order.email}}"
       %td.align-center


### PR DESCRIPTION
Also, the shipments_path can now be removed from the order serializer.

#### What? Why?

Closes #2884 

#### What should we test?
We are almost able to checkout or create new orders in the backoffice, but not yet! So, order list is still empty.

For example, /spec/controllers/spree/admin/orders_controller_spec.rb:120 is passing now.