### PR TITLE
Remove show_only_unfulfilled_orders filter field

### DIFF
--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -30,10 +30,6 @@
         %label
           = f.check_box :completed_at_not_null, {:checked => @show_only_completed, 'ng-model' => 'q.completed_at_not_null'}, '1', ''
           = t(:show_only_complete_orders)
-      .field.checkbox
-        %label
-          = f.check_box :inventory_units_shipment_id_null, {'ng-model' => 'q.inventory_units_shipment_id_null'}, '1', '0'
-          = t(:show_only_unfulfilled_orders)
     .field-block.alpha.eight.columns
       = label_tag nil, t(:distributors)
       = select_tag("q[distributor_id_in]",


### PR DESCRIPTION
#### What? Why?

Closes #2898 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Removing show_only_unfulfilled_orders field that is gone in Spree 2.0 [here](https://github.com/spree/spree/commit/2d8cd38e704b765345e75a5ea61aaf79a399af92#diff-a49b505b614b2659d9eae6c90d79f698R67)

It is good enough like this ? That's the only thing that was removed from Spree, the params stay in the controller (as seen [here](https://github.com/spree/spree/blob/3c46d141c5cb2bedced63596178a0a79df3f0c9e/backend/app/controllers/spree/admin/orders_controller.rb#L22))
#### What should we test?
<!-- List which features should be tested and how. -->
The orders index page is working properly


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Removed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
This is an update of Spree views.