### PR TITLE
Admin orders refactor

### DIFF
--- a/app/assets/javascripts/admin/resources/resources/order_resource.js.coffee
+++ b/app/assets/javascripts/admin/resources/resources/order_resource.js.coffee
@@ -1,6 +1,7 @@
 angular.module("admin.resources").factory 'OrderResource', ($resource) ->
   $resource('/admin/orders/:id/:action.json', {}, {
     'index':
+      url: '/api/orders.json'
       method: 'GET'
     'update':
       method: 'PUT'

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  class OrdersController < BaseController
+    def index
+      authorize! :admin, Spree::Order
+
+      search_results = SearchOrders.new(params, spree_current_user)
+
+      render json: {
+        orders: serialized_orders(search_results.orders),
+        pagination: search_results.pagination_data
+      }
+    end
+
+    private
+
+    def serialized_orders(orders)
+      ActiveModel::ArraySerializer.new(
+        orders,
+        each_serializer: Api::Admin::OrderSerializer
+      )
+    end
+  end
+end

--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -23,17 +23,7 @@ Spree::Admin::OrdersController.class_eval do
   respond_to :html, :json
 
   def index
-    @results = SearchOrders.new(params, spree_current_user) if json_request?
-
-    respond_to do |format|
-      format.html
-      format.json do
-        render json: {
-          orders: serialized_orders,
-          pagination: @results.pagination_data
-        }
-      end
-    end
+    # Moved to api. Overriding the action so we only render the page template.
   end
 
   # Overwrite to use confirm_email_for_customer instead of confirm_email.
@@ -95,9 +85,5 @@ Spree::Admin::OrdersController.class_eval do
     unless @order.distribution_set?
       render 'set_distribution', locals: { order: @order }
     end
-  end
-
-  def serialized_orders
-    ActiveModel::ArraySerializer.new(@results.orders, each_serializer: Api::Admin::OrderSerializer)
   end
 end

--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -23,7 +23,8 @@ Spree::Admin::OrdersController.class_eval do
   respond_to :html, :json
 
   def index
-    # Moved to api. Overriding the action so we only render the page template.
+    # Overriding the action so we only render the page template. An angular request
+    # within the page then fetches the data it needs from Api::OrdersController
   end
 
   # Overwrite to use confirm_email_for_customer instead of confirm_email.

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -32,7 +32,7 @@ class SearchOrders
   def paginated_results
     @search.result
       .page(params[:page])
-      .per(params[:per_page] || Spree::Config[:orders_per_page])
+      .per(params[:per_page])
   end
 
   def using_pagination?

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -1,0 +1,41 @@
+class SearchOrders
+  attr_reader :orders
+
+  def initialize(params, current_user)
+    @params = params
+    @current_user = current_user
+
+    @orders = fetch_orders
+  end
+
+  def pagination_data
+    return unless using_pagination?
+    {
+      results: @orders.total_count,
+      pages: @orders.num_pages,
+      page: params[:page].to_i,
+      per_page: params[:per_page].to_i
+    }
+  end
+
+  private
+
+  attr_reader :params, :current_user
+
+  def fetch_orders
+    @search = OpenFoodNetwork::Permissions.new(current_user).editable_orders.ransack(params[:q])
+
+    return paginated_results if using_pagination?
+    @search.result
+  end
+
+  def paginated_results
+    @search.result
+      .page(params[:page])
+      .per(params[:per_page] || Spree::Config[:orders_per_page])
+  end
+
+  def using_pagination?
+    params[:per_page]
+  end
+end

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -1,38 +1,40 @@
 %div{"data-hook" => "admin_orders_index_search"}
-  = search_form_for [:admin, @search], html: { name: "orders_form", "ng-submit" => "fetchResults()"} do |f|
+  = form_tag false, {name: "orders_form", "ng-submit" => "fetchResults()"} do
     .field-block.alpha.four.columns
       .date-range-filter.field
         = label_tag nil, t(:date_range)
         .date-range-fields
-          = f.text_field :created_at_gt, class: 'datepicker', datepicker: 'q.created_at_gt', 'ng-model' => 'q.created_at_gt', :value => params[:q][:created_at_gt], :placeholder => t(:start)
+          = text_field_tag "q[created_at_gt]", nil, class: 'datepicker', datepicker: 'q.created_at_gt', 'ng-model' => 'q.created_at_gt', :placeholder => t(:start)
           %span.range-divider
             %i.icon-arrow-right
-          = f.text_field :created_at_lt, class: 'datepicker', datepicker: 'q.created_at_lt', 'ng-model' => 'q.created_at_lt', :value => params[:q][:created_at_lt], :placeholder => t(:stop)
+          = text_field_tag "q[created_at_lt]", nil, class: 'datepicker', datepicker: 'q.created_at_lt', 'ng-model' => 'q.created_at_lt', :placeholder => t(:stop)
       .field
         = label_tag nil, t(:status)
-        = f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2', 'ng-model' => 'q.state_eq'
+        = select_tag("q[state_eq]",
+            options_for_select(Spree::Order.state_machines[:state].states.collect {|s| [t("order_state.#{s.name}"), s.value]}),
+            {include_blank: true, class: 'select2', 'ng-model' => 'q.state_eq'})
     .four.columns
       .field
         = label_tag nil, t(:order_number)
-        = f.text_field :number_cont, 'ng-model' => 'q.number_cont'
+        = text_field_tag "q[number_cont]", nil, 'ng-model' => 'q.number_cont'
       .field
         = label_tag nil, t(:email)
-        = f.email_field :email_cont, 'ng-model' => 'q.email_cont'
+        = email_field_tag "q[email_cont", nil, 'ng-model' => 'q.email_cont'
     .four.columns
       .field
         = label_tag nil, t(:first_name_begins_with)
-        = f.text_field :bill_address_firstname_start, :size => 25, 'ng-model' => 'q.bill_address_firstname_start'
+        = text_field_tag "q[bill_address_firstname_start]", nil, size: 25, 'ng-model' => 'q.bill_address_firstname_start'
       .field
         = label_tag nil, t(:last_name_begins_with)
-        = f.text_field :bill_address_lastname_start, :size => 25, 'ng-model' => 'q.bill_address_lastname_start'
+        = text_field_tag "q[bill_address_lastname_start]", nil, size: 25, 'ng-model' => 'q.bill_address_lastname_start'
     .omega.four.columns
       .field.checkbox
         %label
-          = f.check_box :completed_at_not_null, {:checked => @show_only_completed, 'ng-model' => 'q.completed_at_not_null'}, '1', ''
+          = check_box_tag "q[completed_at_not_null]", 1, true, {'ng-model' => 'q.completed_at_not_null'}
           = t(:show_only_complete_orders)
       .field.checkbox
         %label
-          = f.check_box :inventory_units_shipment_id_null, {'ng-model' => 'q.inventory_units_shipment_id_null'}, '1', '0'
+          = check_box_tag "q[inventory_units_shipment_id_null]", 1, false, {'ng-model' => 'q.inventory_units_shipment_id_null'}
           = t(:show_only_unfulfilled_orders)
     .field-block.alpha.eight.columns
       = label_tag nil, t(:distributors)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Openfoodnetwork::Application.routes.draw do
       get :accessible, on: :collection
     end
 
+    resources :orders, only: [:index]
+
     resource :status do
       get :job_queue
     end

--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+module Api
+  describe OrdersController, type: :controller do
+    include AuthenticationWorkflow
+    render_views
+
+    describe '#index' do
+      let!(:distributor) { create(:distributor_enterprise) }
+      let!(:order1) { create(:order, distributor: distributor) }
+      let!(:order2) { create(:order, distributor: distributor) }
+      let!(:order3) { create(:order, distributor: distributor) }
+
+      let(:enterprise_user) { distributor.owner }
+      let(:regular_user) { create(:user) }
+
+      context 'as a regular user' do
+        before do
+          allow(controller).to receive(:spree_current_user) { regular_user }
+        end
+
+        it "returns unauthorized" do
+          get :index
+          assert_unauthorized!
+        end
+      end
+
+      context 'as an enterprise user' do
+        before do
+          allow(controller).to receive(:spree_current_user) { enterprise_user }
+        end
+
+        it "returns serialized orders" do
+          get :index
+
+          expect(response.status).to eq 200
+          expect(json_response['orders'].count).to eq 3
+          expect(json_response['orders'].first.keys).to include 'id', 'number', 'email', 'distributor'
+          expect(json_response['pagination']).to be_nil
+        end
+      end
+
+      context 'with pagination' do
+        before do
+          allow(controller).to receive(:spree_current_user) { enterprise_user }
+        end
+
+        it 'returns pagination data when query params contain :per_page]' do
+          get :index, per_page: 15, page: 1
+
+          expect(json_response['pagination']).to eq pagination_data
+        end
+      end
+    end
+
+    def pagination_data
+      {
+        'results' => 3,
+        'pages' => 1,
+        'page' => 1,
+        'per_page' => 15
+      }
+    end
+  end
+end

--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -127,6 +127,13 @@ module Api
         it 'returns pagination data when query params contain :per_page]' do
           get :index, per_page: 15, page: 1
 
+          pagination_data = {
+            'results' => 2,
+            'pages' => 1,
+            'page' => 1,
+            'per_page' => 15
+          }
+
           expect(json_response['pagination']).to eq pagination_data
         end
       end
@@ -146,15 +153,6 @@ module Api
         :payments_path, :shipments_path, :ship_path, :ready_to_ship, :created_at,
         :distributor_name, :special_instructions, :payment_capture_path
       ]
-    end
-
-    def pagination_data
-      {
-        'results' => 2,
-        'pages' => 1,
-        'page' => 1,
-        'per_page' => 15
-      }
     end
   end
 end

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -30,111 +30,24 @@ describe Spree::Admin::OrdersController, type: :controller do
   end
 
   describe "#index" do
-    render_views
-
-    let(:order_attributes) { [:id, :full_name, :email, :phone, :completed_at, :distributor, :order_cycle, :number] }
-
-    def self.make_simple_data!
-      let!(:dist1) { FactoryBot.create(:distributor_enterprise) }
-      let!(:order1) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
-      let!(:order2) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
-      let!(:order3) { FactoryBot.create(:order, state: 'complete', completed_at: Time.zone.now, distributor: dist1, billing_address: FactoryBot.create(:address) ) }
-      let!(:line_item1) { FactoryBot.create(:line_item, order: order1) }
-      let!(:line_item2) { FactoryBot.create(:line_item, order: order2) }
-      let!(:line_item3) { FactoryBot.create(:line_item, order: order2) }
-      let!(:line_item4) { FactoryBot.create(:line_item, order: order3) }
-      let(:line_item_attributes) { [:id, :quantity, :max_quantity, :supplier, :units_product, :units_variant] }
-    end
-
-    context "as a normal user" do
+    context "as a regular user" do
       before { controller.stub spree_current_user: create_enterprise_user }
 
-      make_simple_data!
-
       it "should deny me access to the index action" do
-        spree_get :index, :format => :json
+        spree_get :index
         expect(response).to redirect_to spree.unauthorized_path
       end
     end
 
-    context "as an administrator" do
-      make_simple_data!
+    context "as an enterprise user" do
+      let!(:order) { create(:order_with_distributor) }
 
       before do
-        controller.stub spree_current_user: quick_login_as_admin
-        spree_get :index, :format => :json
+        controller.stub spree_current_user: order.distributor.owner
       end
 
-      it "retrieves a list of orders with appropriate attributes, including line items with appropriate attributes" do
-        keys = json_response['orders'].first.keys.map{ |key| key.to_sym }
-        order_attributes.all?{ |attr| keys.include? attr }.should == true
-      end
-
-      it "sorts orders in ascending id order" do
-        ids = json_response['orders'].map{ |order| order['id'] }
-        expect(ids[0]).to be < ids[1]
-        expect(ids[1]).to be < ids[2]
-      end
-
-      it "formats completed_at to 'yyyy-mm-dd hh:mm'" do
-        json_response['orders'].map{ |order| order['completed_at'] }.all?{ |a| a == order1.completed_at.strftime('%B %d, %Y') }.should == true
-      end
-
-      it "returns distributor object with id key" do
-        json_response['orders'].map{ |order| order['distributor'] }.all?{ |d| d.has_key?('id') }.should == true
-      end
-
-      it "retrieves the order number" do
-        json_response['orders'].map{ |order| order['number'] }.all?{ |number| number.match("^R\\d{5,10}$") }.should == true
-      end
-    end
-
-    context "as an enterprise user" do
-      let(:supplier) { create(:supplier_enterprise) }
-      let(:distributor1) { create(:distributor_enterprise) }
-      let(:distributor2) { create(:distributor_enterprise) }
-      let(:coordinator) { create(:distributor_enterprise) }
-      let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
-      let!(:order1) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryBot.create(:address) ) }
-      let!(:line_item1) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
-      let!(:line_item2) { FactoryBot.create(:line_item, order: order1, product: FactoryBot.create(:product, supplier: supplier)) }
-      let!(:order2) { FactoryBot.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor2, billing_address: FactoryBot.create(:address) ) }
-      let!(:line_item3) { FactoryBot.create(:line_item, order: order2, product: FactoryBot.create(:product, supplier: supplier)) }
-
-      context "producer enterprise" do
-
-        before do
-          controller.stub spree_current_user: supplier.owner
-          spree_get :index, :format => :json
-        end
-
-        it "does not display line items for which my enterprise is a supplier" do
-          expect(response).to redirect_to spree.unauthorized_path
-        end
-      end
-
-      context "coordinator enterprise" do
-        before do
-          controller.stub spree_current_user: coordinator.owner
-          spree_get :index, :format => :json
-        end
-
-        it "retrieves a list of orders" do
-          keys = json_response['orders'].first.keys.map{ |key| key.to_sym }
-          order_attributes.all?{ |attr| keys.include? attr }.should == true
-        end
-      end
-
-      context "hub enterprise" do
-        before do
-          controller.stub spree_current_user: distributor1.owner
-          spree_get :index, :format => :json
-        end
-
-        it "retrieves a list of orders" do
-          keys = json_response['orders'].first.keys.map{ |key| key.to_sym }
-          order_attributes.all?{ |attr| keys.include? attr }.should == true
-        end
+      it "should allow access" do
+        expect(response.status).to eq 200
       end
     end
   end

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -31,7 +31,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
   describe "#index" do
     context "as a regular user" do
-      before { controller.stub spree_current_user: create_enterprise_user }
+      before { allow(controller).to receive(:spree_current_user) { create_enterprise_user } }
 
       it "should deny me access to the index action" do
         spree_get :index
@@ -42,9 +42,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     context "as an enterprise user" do
       let!(:order) { create(:order_with_distributor) }
 
-      before do
-        controller.stub spree_current_user: order.distributor.owner
-      end
+      before { allow(controller).to receive(:spree_current_user) { order.distributor.owner } }
 
       it "should allow access" do
         expect(response.status).to eq 200
@@ -60,7 +58,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     let(:params) { { id: order.number } }
 
     context "as a normal user" do
-      before { controller.stub spree_current_user: user }
+      before { allow(controller).to receive(:spree_current_user) { user } }
 
       it "should prevent me from sending order invoices" do
         spree_get :invoice, params
@@ -70,7 +68,8 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context "as an enterprise user" do
       context "which is not a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: user }
+        before { allow(controller).to receive(:spree_current_user) { user } }
+
         it "should prevent me from sending order invoices" do
           spree_get :invoice, params
           expect(response).to redirect_to spree.unauthorized_path
@@ -78,7 +77,8 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       context "which is a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: distributor.owner }
+        before { allow(controller).to receive(:spree_current_user) { distributor.owner } }
+
         context "when the distributor's ABN has not been set" do
           before { distributor.update_attribute(:abn, "") }
           it "should allow me to send order invoices" do
@@ -117,7 +117,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     let(:params) { { id: order.number } }
 
     context "as a normal user" do
-      before { controller.stub spree_current_user: user }
+      before { allow(controller).to receive(:spree_current_user) { user } }
 
       it "should prevent me from sending order invoices" do
         spree_get :print, params
@@ -127,7 +127,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context "as an enterprise user" do
       context "which is not a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: user }
+        before { allow(controller).to receive(:spree_current_user) { user } }
         it "should prevent me from sending order invoices" do
           spree_get :print, params
           expect(response).to redirect_to spree.unauthorized_path
@@ -135,7 +135,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       context "which is a manager of the distributor for an order" do
-        before { controller.stub spree_current_user: distributor.owner }
+        before { allow(controller).to receive(:spree_current_user) { distributor.owner } }
         it "should allow me to send order invoices" do
           spree_get :print, params
           expect(response).to render_template :invoice

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -70,14 +70,13 @@ describe Spree::Admin::OrdersController, type: :controller do
         order_attributes.all?{ |attr| keys.include? attr }.should == true
       end
 
-      it "sorts orders in descending id order" do
+      it "sorts orders in ascending id order" do
         ids = json_response['orders'].map{ |order| order['id'] }
-        ids[0].should > ids[1]
-        ids[1].should > ids[2]
+        expect(ids[0]).to be < ids[1]
+        expect(ids[1]).to be < ids[2]
       end
 
       it "formats completed_at to 'yyyy-mm-dd hh:mm'" do
-        pp json_response
         json_response['orders'].map{ |order| order['completed_at'] }.all?{ |a| a == order1.completed_at.strftime('%B %d, %Y') }.should == true
       end
 

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -37,7 +37,7 @@ describe "LineItemsCtrl", ->
     order = { id: 9, order_cycle: { id: 4 }, distributor: { id: 5 }, number: "R123456" }
     lineItem = { id: 7, quantity: 3, order: { id: 9 }, supplier: { id: 1 } }
 
-    httpBackend.expectGET("/admin/orders.json?q%5Bcompleted_at_gteq%5D=SomeDate&q%5Bcompleted_at_lt%5D=SomeDate&q%5Bcompleted_at_not_null%5D=true&q%5Bstate_not_eq%5D=canceled").respond {orders: [order], pagination: {page: 1, pages: 1, results: 1}}
+    httpBackend.expectGET("/api/orders.json?q%5Bcompleted_at_gteq%5D=SomeDate&q%5Bcompleted_at_lt%5D=SomeDate&q%5Bcompleted_at_not_null%5D=true&q%5Bstate_not_eq%5D=canceled").respond {orders: [order], pagination: {page: 1, pages: 1, results: 1}}
     httpBackend.expectGET("/admin/bulk_line_items.json?q%5Border%5D%5Bcompleted_at_gteq%5D=SomeDate&q%5Border%5D%5Bcompleted_at_lt%5D=SomeDate&q%5Border%5D%5Bcompleted_at_not_null%5D=true&q%5Border%5D%5Bstate_not_eq%5D=canceled").respond [lineItem]
     httpBackend.expectGET("/admin/enterprises/visible.json?ams_prefix=basic&q%5Bsells_in%5D%5B%5D=own&q%5Bsells_in%5D%5B%5D=any").respond [distributor]
     httpBackend.expectGET("/admin/order_cycles.json?ams_prefix=basic&as=distributor&q%5Borders_close_at_gt%5D=SomeDate").respond [orderCycle]

--- a/spec/javascripts/unit/admin/orders/services/orders_spec.js.coffee
+++ b/spec/javascripts/unit/admin/orders/services/orders_spec.js.coffee
@@ -19,7 +19,7 @@ describe "Orders service", ->
 
     beforeEach ->
       response = { orders: [{ id: 5, name: 'Order 1'}], pagination: {page: 1, pages: 1, results: 1} }
-      $httpBackend.expectGET('/admin/orders.json').respond 200, response
+      $httpBackend.expectGET('/api/orders.json').respond 200, response
       result = Orders.index()
       $httpBackend.flush()
 

--- a/spec/services/search_orders_spec.rb
+++ b/spec/services/search_orders_spec.rb
@@ -22,16 +22,14 @@ describe SearchOrders do
     let(:service) { SearchOrders.new(params, enterprise_user) }
 
     it 'returns pagination data' do
+      pagination_data = {
+        results: 3,
+        pages: 1,
+        page: 1,
+        per_page: 15
+      }
+
       expect(service.pagination_data).to eq pagination_data
     end
-  end
-
-  def pagination_data
-    {
-      results: 3,
-      pages: 1,
-      page: 1,
-      per_page: 15
-    }
   end
 end

--- a/spec/services/search_orders_spec.rb
+++ b/spec/services/search_orders_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe SearchOrders do
+  let!(:distributor) { create(:distributor_enterprise) }
+  let!(:order1) { create(:order, distributor: distributor) }
+  let!(:order2) { create(:order, distributor: distributor) }
+  let!(:order3) { create(:order, distributor: distributor) }
+
+  let(:enterprise_user) { distributor.owner }
+
+  describe '#orders' do
+    let(:params) { {} }
+    let(:service) { SearchOrders.new(params, enterprise_user) }
+
+    it 'returns orders' do
+      expect(service.orders.count).to eq 3
+    end
+  end
+
+  describe '#pagination_data' do
+    let(:params) { { per_page: 15, page: 1 } }
+    let(:service) { SearchOrders.new(params, enterprise_user) }
+
+    it 'returns pagination data' do
+      expect(service.pagination_data).to eq pagination_data
+    end
+  end
+
+  def pagination_data
+    {
+      results: 3,
+      pages: 1,
+      page: 1,
+      per_page: 15
+    }
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #2911

Following up on a refactor prompted by #2908

Tidying up the Admin::OrdersController and related endpoints after the recent changes have made lots of the legacy code there redundant. :fire:

#### What should we test?

Admin orders and BOM pages should work as before.

#### Release notes

Refactor admin orders controller and related code.

Changelog Category: Changed
