### PR TITLE
Fix multi lingual issue in cart and checkout: the user language selection was not being used

### DIFF
--- a/app/controllers/spree/store_controller_decorator.rb
+++ b/app/controllers/spree/store_controller_decorator.rb
@@ -1,6 +1,9 @@
 class Spree::StoreController
   layout 'darkswarm'
 
+  include I18nHelper
+  before_filter :set_locale
+
   def unauthorized
     render 'shared/unauthorized', :status => 401
   end

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -29,17 +29,15 @@ feature 'Multilingual', js: true do
       visit root_path(locale: 'es')
       expect(get_i18n_locale).to eq 'es'
       expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
-      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+      expect_menu_and_cookie_in_es
       expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
-      expect(page).to have_content 'TIENDAS'
 
       # it is not in the list of available of available_locales
       visit root_path(locale: 'it')
       expect(get_i18n_locale).to eq 'es'
       expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
-      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+      expect_menu_and_cookie_in_es
       expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
-      expect(page).to have_content 'TIENDAS'
     end
 
     context 'with a product in the cart' do
@@ -56,16 +54,14 @@ feature 'Multilingual', js: true do
       scenario "in the cart page" do
         visit spree.cart_path(locale: 'es')
 
-        expect(page).to have_content 'TIENDAS'
-        expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+        expect_menu_and_cookie_in_es
         expect(page).to have_content 'Precio'
       end
 
       scenario "in the checkout page" do
         visit checkout_path(locale: 'es')
 
-        expect(page).to have_content 'TIENDAS'
-        expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+        expect_menu_and_cookie_in_es
         expect(page).to have_content 'Total del carrito'
       end
     end
@@ -77,12 +73,12 @@ feature 'Multilingual', js: true do
     it 'updates user locale from cookie if it is empty' do
       visit root_path(locale: 'es')
 
-      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+      expect_menu_and_cookie_in_es
       expect(user.locale).to be_nil
       quick_login_as user
       visit root_path
 
-      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+      expect_menu_and_cookie_in_es
     end
 
     it 'updates user locale and stays in cookie after logout' do
@@ -94,9 +90,8 @@ feature 'Multilingual', js: true do
 
       logout
 
-      expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+      expect_menu_and_cookie_in_es
       expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
-      expect(page).to have_content 'TIENDAS'
     end
   end
 
@@ -134,9 +129,13 @@ feature 'Multilingual', js: true do
           find('li a[href="?locale=es"]').click
         end
 
-        expect(page.driver.browser.cookies['locale'].value).to eq 'es'
-        expect(page).to have_content 'TIENDAS'
+        expect_menu_and_cookie_in_es
       end
     end
   end
+end
+
+def expect_menu_and_cookie_in_es
+  expect(page.driver.browser.cookies['locale'].value).to eq 'es'
+  expect(page).to have_content 'TIENDAS'
 end


### PR DESCRIPTION
#### What? Why?

Closes #2491 

The function set_locale in the controllers gets the locale variable into the locale cookie, this was only done in:
 - Spree::Admin::BaseController (all OFN backoffice controllers extend this one directly or through ResourceController)
- BaseController (most our frontend controllers extend this one) 

But in the frontoffice, we were missing this set_locale in all controllers that do not extend BaseController, basically, controllers still relying on Spree code:
- controllers/CheckoutController (extends Spree::CheckoutController)
- controllers/spree/Spree::OrdersController.class_eval
- controllers/spree/Spree::UsersController

UsersController already had the set_locale call itself and the other two CheckoutController and OrdersController both extend StoreController, so, that was the destination of the new call to set_locale. See the code.

I have checked backoffice code and some pages and I couldnt find any similar problem there.

#### What should we test?
Cart and checkout process with a non-default language.

#### Release notes
Changelog Category: Fixed
Bug in non-default language: user language selection is no longer jumping to default selection on the cart/checkout process. It keeps the user language through the process.

#### How is this related to the Spree upgrade?
not related.