### PR TITLE
Add Portuguese and German to list of momentJS locales

### DIFF
--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -54,12 +54,14 @@
 //= require i18n/translations
 //= require darkswarm/i18n.translate.js
 //= require moment
+//= require moment/de.js
 //= require moment/en-gb.js
 //= require moment/es.js
 //= require moment/fr.js
 //= require moment/it.js
 //= require moment/nb.js
 //= require moment/pt-br.js
+//= require moment/pt.js
 //= require moment/sv.js
 //= require ../shared/mm-foundation-tpls-0.9.0-20180826174721.min.js
 //= require angularjs-file-upload

--- a/app/assets/javascripts/darkswarm/all.js.coffee
+++ b/app/assets/javascripts/darkswarm/all.js.coffee
@@ -25,12 +25,14 @@
 #= require angular-flash.min.js
 #
 #= require moment
+#= require moment/de.js
 #= require moment/en-gb.js
 #= require moment/es.js
 #= require moment/fr.js
 #= require moment/it.js
 #= require moment/nb.js
 #= require moment/pt-br.js
+#= require moment/pt.js
 #= require moment/sv.js
 #
 #= require modernizr


### PR DESCRIPTION
The main usage is in the order cycle closure time in the shopfront.

#### What? Why?

Portuguese katuma shopfronts have the order cycle closure time indication in english. This fixes the problem.
German was also missing. Now fixed:
<img width="461" alt="screen shot 2018-10-23 at 17 57 58" src="https://user-images.githubusercontent.com/1640378/47377461-3e8fba00-d6ed-11e8-8b19-3d563c594350.png">


#### What should we test?
In Portuguese or German, the shopfront message should not display "in x days" but instead a localed message.

#### Release notes
Changelog Category: Fixed
Fixed Portuguese and German translation problem in the shopfront order cycle closure time.

#### How is this related to the Spree upgrade?
not related.
