### PR TITLE
Extract email setup in specs for easy upgrade

### DIFF
--- a/spec/controllers/admin/manager_invitations_controller_spec.rb
+++ b/spec/controllers/admin/manager_invitations_controller_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 module Admin
   describe ManagerInvitationsController, type: :controller do
+    include OpenFoodNetwork::EmailHelper
+
     let!(:enterprise_owner) { create(:user) }
     let!(:other_enterprise_user) { create(:user) }
     let!(:existing_user) { create(:user) }
@@ -25,7 +27,7 @@ module Admin
 
       context "signing up a new user" do
         before do
-          create(:mail_method)
+          setup_email
           controller.stub spree_current_user: admin
         end
 
@@ -46,7 +48,7 @@ module Admin
     describe "with enterprise permissions" do
       context "as user with proper enterprise permissions" do
         before do
-          create(:mail_method)
+          setup_email
           controller.stub spree_current_user: enterprise_owner
         end
 

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Admin::SubscriptionsController, type: :controller do
   include AuthenticationWorkflow
+  include OpenFoodNetwork::EmailHelper
 
   describe 'index' do
     let!(:user) { create(:user, enterprise_limit: 10) }
@@ -626,10 +627,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
             context "when at least one associate orders is 'canceled'" do
               before do
-                Spree::MailMethod.create!(
-                  environment: Rails.env,
-                  preferred_mails_from: 'spree@example.com'
-                )
+                setup_email
                 proxy_order.cancel
               end
 

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Spree::Admin::OrdersController, type: :controller do
   include AuthenticationWorkflow
+  include OpenFoodNetwork::EmailHelper
 
   context "updating an order with line items" do
     let!(:order) { create(:order) }
@@ -181,10 +182,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         context "when the distributor's ABN has been set" do
           before { distributor.update_attribute(:abn, "123") }
           before do
-            Spree::MailMethod.create!(
-              environment: Rails.env,
-              preferred_mails_from: 'spree@example.com'
-            )
+            setup_email
           end
           it "should allow me to send order invoices" do
             expect do

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::OrdersController, type: :controller do
+  include OpenFoodNetwork::EmailHelper
+
   let(:distributor) { double(:distributor) }
   let(:order) { create(:order) }
   let(:order_cycle) { create(:simple_order_cycle) }
@@ -372,10 +374,7 @@ describe Spree::OrdersController, type: :controller do
         let(:order) { create(:completed_order_with_totals, user: user) }
 
         before do
-          Spree::MailMethod.create!(
-            environment: Rails.env,
-            preferred_mails_from: 'spree@example.com'
-          )
+          setup_email
         end
 
         it "responds with success" do

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe UserConfirmationsController, type: :controller do
   include AuthenticationWorkflow
+  include OpenFoodNetwork::EmailHelper
+
   let!(:user) { create_enterprise_user }
   let!(:confirmed_user) { create_enterprise_user(confirmed_at: nil) }
   let!(:unconfirmed_user) { create_enterprise_user(confirmed_at: nil) }
@@ -57,7 +59,7 @@ describe UserConfirmationsController, type: :controller do
   end
 
   context "requesting confirmation instructions to be resent" do
-    before { create(:mail_method) }
+    before { setup_email }
 
     it "redirects the user to login" do
       spree_post :create, { spree_user: { email: unconfirmed_user.email } }

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'spree/api/testing_support/helpers'
 
 describe UserPasswordsController, type: :controller do
+  include OpenFoodNetwork::EmailHelper
+
   let(:user) { create(:user) }
   let(:unconfirmed_user) { create(:user, confirmed_at: nil) }
 
@@ -32,7 +34,7 @@ describe UserPasswordsController, type: :controller do
   end
 
   it "renders Darkswarm" do
-    Spree::MailMethod.create!(environment: 'test')
+    setup_email
     clear_jobs
 
     user.send_reset_password_instructions

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 require 'spree/api/testing_support/helpers'
 
 describe UserRegistrationsController, type: :controller do
+  include OpenFoodNetwork::EmailHelper
 
   before(:all) do
-    create(:mail_method)
+    setup_email
   end
 
   before do

--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -6,6 +6,7 @@ feature %q{
 }, js: true do
   include AuthenticationWorkflow
   include WebHelper
+  include OpenFoodNetwork::EmailHelper
 
 
   context "as a site administrator" do
@@ -137,7 +138,7 @@ feature %q{
       end
 
       it "can invite unregistered users to be managers" do
-        create(:mail_method)
+        setup_email
         find('a.button.help-modal').click
         expect(page).to have_css '#invite-manager-modal'
 

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -2,10 +2,11 @@ require "spec_helper"
 
 feature "Managing users" do
   include AuthenticationWorkflow
+  include OpenFoodNetwork::EmailHelper
 
   context "as super-admin" do
     before do
-      create(:mail_method)
+      setup_email
       quick_login_as_admin
     end
 

--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 feature "Account Settings", js: true do
   include AuthenticationWorkflow
+  include OpenFoodNetwork::EmailHelper
 
   describe "as a logged in user" do
     let(:user) do
@@ -12,7 +13,7 @@ feature "Account Settings", js: true do
     end
 
     before do
-      create(:mail_method)
+      setup_email
       quick_login_as user
       visit "/account"
       click_link I18n.t('spree.users.show.tabs.settings')

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 feature "Authentication", js: true, retry: 3 do
   include UIComponentHelper
+  include OpenFoodNetwork::EmailHelper
 
   # Attempt to address intermittent failures in these specs
   around do |example|
@@ -75,7 +76,7 @@ feature "Authentication", js: true, retry: 3 do
           end
 
           scenario "Signing up successfully" do
-            create(:mail_method)
+            setup_email
             fill_in "Email", with: "test@foo.com"
             fill_in "Choose a password", with: "test12345"
             fill_in "Confirm password", with: "test12345"

--- a/spec/features/consumer/confirm_invitation_spec.rb
+++ b/spec/features/consumer/confirm_invitation_spec.rb
@@ -2,13 +2,14 @@ require "spec_helper"
 
 feature "Confirm invitation as manager" do
   include UIComponentHelper # for be_logged_in_as
+  include OpenFoodNetwork::EmailHelper
 
   describe "confirm email and set password" do
     let(:email) { "test@example.org" }
     let(:user) { Spree::User.create(email: email, unconfirmed_email: email, password: "secret") }
 
     before do
-      create(:mail_method)
+      setup_email
       user.reset_password_token = Devise.friendly_token
       user.reset_password_sent_at = Time.now.utc
       user.save!

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 feature "Order Management", js: true do
   include AuthenticationWorkflow
+  include OpenFoodNetwork::EmailHelper
 
   describe "viewing a completed order" do
     let!(:distributor) { create(:distributor_enterprise) }
@@ -115,10 +116,7 @@ feature "Order Management", js: true do
 
     context "when the distributor allows changes to be made to orders" do
       before do
-        Spree::MailMethod.create!(
-          environment: Rails.env,
-          preferred_mails_from: 'spree@example.com'
-        )
+        setup_email
       end
       before do
         order.distributor.update_attributes(allow_order_changes: true)

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe SubscriptionConfirmJob do
+  include OpenFoodNetwork::EmailHelper
+
   let(:job) { SubscriptionConfirmJob.new }
 
   describe "finding proxy_orders that are ready to be confirmed" do
@@ -114,10 +116,7 @@ describe SubscriptionConfirmJob do
       while !order.completed? do break unless order.next! end
       allow(job).to receive(:send_confirm_email).and_call_original
       job.instance_variable_set(:@order, order)
-      Spree::MailMethod.create!(
-        environment: Rails.env,
-        preferred_mails_from: 'spree@example.com'
-      )
+      setup_email
       expect(job).to receive(:record_order).with(order)
     end
 

--- a/spec/mailers/enterprise_mailer_spec.rb
+++ b/spec/mailers/enterprise_mailer_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
 
 describe EnterpriseMailer do
+  include OpenFoodNetwork::EmailHelper
+
   let!(:enterprise) { create(:enterprise) }
   let!(:user) { create(:user) }
 
   before do
     ActionMailer::Base.deliveries = []
-    Spree::MailMethod.create!(environment: 'test')
+    setup_email
   end
 
   describe "#welcome" do

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::OrderMailer do
-  let!(:mail_method) { create(:mail_method, preferred_mails_from: 'spree@example.com') }
+  include OpenFoodNetwork::EmailHelper
 
   describe "order confimation" do
     after do
@@ -9,6 +9,7 @@ describe Spree::OrderMailer do
     end
 
     before do
+      setup_email
       ActionMailer::Base.delivery_method = :test
       ActionMailer::Base.perform_deliveries = true
       ActionMailer::Base.deliveries = []

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -2,11 +2,10 @@ require 'spec_helper'
 require 'yaml'
 
 describe ProducerMailer do
+  include OpenFoodNetwork::EmailHelper
+
   before do
-    Spree::MailMethod.create!(
-      environment: Rails.env,
-      preferred_mails_from: 'spree@example.com'
-    )
+    setup_email
   end
   let!(:zone) { create(:zone_with_member) }
   let!(:tax_rate) { create(:tax_rate, included_in_price: true, calculator: Spree::Calculator::DefaultTax.new, zone: zone, amount: 0.1) }

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe SubscriptionMailer do
   include ActionView::Helpers::SanitizeHelper
+  include OpenFoodNetwork::EmailHelper
 
-  let!(:mail_method) { create(:mail_method, preferred_mails_from: 'spree@example.com') }
+  before { setup_email }
 
   describe "order placement" do
     let(:shop) { create(:enterprise) }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::UserMailer do
+  include OpenFoodNetwork::EmailHelper
+
   let(:user) { build(:user) }
 
   after do
@@ -12,7 +14,7 @@ describe Spree::UserMailer do
     ActionMailer::Base.perform_deliveries = true
     ActionMailer::Base.deliveries = []
 
-    Spree::MailMethod.create!(environment: 'test')
+    setup_email
   end
 
   it "sends an email when given a user" do

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe OrderCycle do
+  include OpenFoodNetwork::EmailHelper
+
   it "should be valid when built from factory" do
     build(:simple_order_cycle).should be_valid
   end
@@ -525,10 +527,7 @@ describe OrderCycle do
     let!(:order5) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: oc)  }
 
     before do
-      Spree::MailMethod.create!(
-        environment: Rails.env,
-        preferred_mails_from: 'spree@example.com'
-      )
+      setup_email
     end
     before { order5.cancel }
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Order do
+  include OpenFoodNetwork::EmailHelper
+
   describe "setting variant attributes" do
     it "sets attributes on line items for variants" do
       d = create(:distributor_enterprise)
@@ -495,10 +497,7 @@ describe Spree::Order do
   describe "scopes" do
     describe "not_state" do
       before do
-        Spree::MailMethod.create!(
-          environment: Rails.env,
-          preferred_mails_from: 'spree@example.com'
-        )
+        setup_email
       end
 
       it "finds only orders not in specified state" do

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree.user_class do
+  include OpenFoodNetwork::EmailHelper
+
   describe "associations" do
     it { should have_many(:owned_enterprises) }
 
@@ -72,7 +74,7 @@ describe Spree.user_class do
 
   context "#create" do
     it "should send a confirmation email" do
-      create(:mail_method)
+      setup_email
 
       expect do
         create(:user, email: 'new_user@example.com', confirmation_sent_at: nil, confirmed_at: nil)
@@ -100,7 +102,7 @@ describe Spree.user_class do
 
   context "confirming email" do
     it "should send a welcome email" do
-      create(:mail_method)
+      setup_email
 
       expect do
         create(:user, confirmed_at: nil).confirm!

--- a/spec/support/email_helper.rb
+++ b/spec/support/email_helper.rb
@@ -1,0 +1,11 @@
+module OpenFoodNetwork
+  module EmailHelper
+    # Some specs trigger actions that send emails, for example creating an order.
+    # But sending emails doesn't work out-of-the-box. This code sets it up.
+    # It's here in a single place to allow an easy upgrade to Spree 2 which
+    # needs a different implementation of this method.
+    def setup_email
+      create(:mail_method)
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

First part of #2882.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The way we set up email sending completely changes with Spree 2. This
change encapsulates that code in a single method so that it can be
changed easily and doesn't create further merge conflicts while we are
still working on the master branch and the Spree upgrade.



#### What should we test?
<!-- List which features should be tested and how. -->

No test, passing automated tests should be enough.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

No change of production code.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->



#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

This change should avoid merge conflicts with the Spree upgrade in the future. After this is merged to master, we need to merge master into 2-0-stable. We can then change the `setup_email` method and should not have another merge conflict because of this.