### PR TITLE
Disable hiding of hamburger menu upon resize <= 1024px width

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/off_canvas_wrap.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/off_canvas_wrap.js.coffee
@@ -5,6 +5,9 @@
 # the page. This is not workable if the height of the contents of the off-canvas exceeds the height
 # of the screen, because the latter portion of the contents stays hidden to the user.
 #
+# However, for screens over 1024px width for which the off-canvas is not styled to be visible, we
+# can proceed to hide this.
+#
 # https://github.com/openfoodfoundation/angular-foundation/blob/0.9.0-20180826174721/src/offcanvas/offcanvas.js
 angular.module('mm.foundation.offcanvas').directive 'offCanvasWrap', ($window) ->
   {
@@ -19,4 +22,8 @@ angular.module('mm.foundation.offcanvas').directive 'offCanvasWrap', ($window) -
 
       # Unbind hiding of the off-canvas upon window resize.
       win.unbind('resize.body', isolatedScope.hide)
+
+      # Bind hiding of the off-canvas that only happens when screen width is over 1024px.
+      win.bind 'resize.body', ->
+        isolatedScope.hide() if $(window).width() > 1024
   }

--- a/app/assets/javascripts/darkswarm/directives/off_canvas_wrap.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/off_canvas_wrap.js.coffee
@@ -1,0 +1,22 @@
+# Extend the "offCanvasWrap" directive in "angular-foundation" to disable hiding of the off-canvas
+# upon window resize.
+#
+# In some browsers for mobile devices, the address bar is automatically hidden when scrolling down
+# the page. This is not workable if the height of the contents of the off-canvas exceeds the height
+# of the screen, because the latter portion of the contents stays hidden to the user.
+#
+# https://github.com/openfoodfoundation/angular-foundation/blob/0.9.0-20180826174721/src/offcanvas/offcanvas.js
+angular.module('mm.foundation.offcanvas').directive 'offCanvasWrap', ($window) ->
+  {
+    restrict: 'C'
+    priority: 1
+    link: ($scope, element, attrs) ->
+      win = angular.element($window)
+
+      # Get the scope used by the "offCanvasWrap" directive:
+      # https://github.com/openfoodfoundation/angular-foundation/blob/0.9.0-20180826174721/src/offcanvas/offcanvas.js#L2
+      isolatedScope = element.isolateScope()
+
+      # Unbind hiding of the off-canvas upon window resize.
+      win.unbind('resize.body', isolatedScope.hide)
+  }


### PR DESCRIPTION
#### What? Why?

Closes #2907 

Disable hiding the hamburger menu (off-canvas) upon window resize to less than 1024px width.
    
In some browsers for mobile devices, the address bar is automatically hidden when scrolling down the page. This is not workable if the height of the contents of the hamburger menu exceeds the height of the screen, because the latter portion of the contents stays hidden to the user.

Refer to code of directive: https://github.com/openfoodfoundation/angular-foundation/blob/0.9.020180826174721/src/offcanvas/offcanvas.js

Merely changing the hamburger menu to be scrollable is quite tangly and will need a lot of testing because of how the DOM elements are laid out, which I think this is counter-productive. The behaviour of automatically closing the hamburger menu is introduced by [angular-foundation](https://github.com/openfoodfoundation/angular-foundation/blob/0.9.0-20180826174721/src/offcanvas/offcanvas.js#L2) which has long been unsupported. We should move away from the library rather than work around its features.

#### What should we test?

Test closed and open hamburger menu for different screen sizes, and switching between landscape and portrait for mobile devices.

#### Release notes

- Disable hiding of hamburger menu in screen widths of not more than 1024px.

Changelog Category: Fixed

#### How is this related to the Spree upgrade?

The behaviour should be checked again if the version of Foundation is upgraded.