### PR TITLE
Reorganize LineItemsController's destroy line item specs

### DIFF
--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -27,70 +27,72 @@ describe LineItemsController, type: :controller do
     end
   end
 
-  describe "destroying a line item on a completed order" do
-    let(:item) do
-      order = create(:completed_order_with_totals)
-      item = create(:line_item, order: order)
-      while !order.completed? do break unless order.next! end
-      item
-    end
-
-    let(:order) { item.order }
-    let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: [order.line_item_variants]) }
-
-    before { controller.stub spree_current_user: item.order.user }
-
-    context "without a line item id" do
-      it "fails and raises an error" do
-        delete :destroy
-        expect(response.status).to eq 404
+  describe "destroying a line item" do
+    context "on a completed order" do
+      let(:item) do
+        order = create(:completed_order_with_totals)
+        item = create(:line_item, order: order)
+        while !order.completed? do break unless order.next! end
+        item
       end
-    end
 
-    context "with a line item id" do
-      let(:params) { { format: :json, id: item } }
+      let(:order) { item.order }
+      let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: [order.line_item_variants]) }
 
-      context "where the item's order is not associated with the user" do
-        it "denies deletion" do
-          delete :destroy, params
-          expect(response.status).to eq 403
+      before { controller.stub spree_current_user: item.order.user }
+
+      context "without a line item id" do
+        it "fails and raises an error" do
+          delete :destroy
+          expect(response.status).to eq 404
         end
       end
 
-      context "where the item's order is associated with the current user" do
-        before { order.update_attributes!(user_id: user.id) }
+      context "with a line item id" do
+        let(:params) { { format: :json, id: item } }
 
-        context "without an order cycle or distributor" do
+        context "where the item's order is not associated with the user" do
           it "denies deletion" do
             delete :destroy, params
             expect(response.status).to eq 403
           end
         end
 
-        context "with an order cycle and distributor" do
-          before { order.update_attributes!(order_cycle_id: order_cycle.id, distributor_id: distributor.id) }
+        context "where the item's order is associated with the current user" do
+          before { order.update_attributes!(user_id: user.id) }
 
-          context "where changes are not allowed" do
+          context "without an order cycle or distributor" do
             it "denies deletion" do
               delete :destroy, params
               expect(response.status).to eq 403
             end
           end
 
-          context "where changes are allowed" do
-            before { distributor.update_attributes!(allow_order_changes: true) }
+          context "with an order cycle and distributor" do
+            before { order.update_attributes!(order_cycle_id: order_cycle.id, distributor_id: distributor.id) }
 
-            it "deletes the line item" do
-              delete :destroy, params
-              expect(response.status).to eq 204
-              expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
+            context "where changes are not allowed" do
+              it "denies deletion" do
+                delete :destroy, params
+                expect(response.status).to eq 403
+              end
+            end
+
+            context "where changes are allowed" do
+              before { distributor.update_attributes!(allow_order_changes: true) }
+
+              it "deletes the line item" do
+                delete :destroy, params
+                expect(response.status).to eq 204
+                expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
+              end
             end
           end
         end
       end
     end
 
-    context "where shipping and payment fees apply" do
+    context "on a completed order with shipping and payment fees" do
       let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true, allow_order_changes: true) }
       let(:shipping_fee) { 3 }
       let(:payment_fee) { 5 }
@@ -125,7 +127,7 @@ describe LineItemsController, type: :controller do
       end
     end
 
-    context "where enterprise fees apply" do
+    context "on a completed order with enterprise fees" do
       let(:user) { create(:user) }
       let(:variant) { create(:variant) }
       let(:distributor) { create(:distributor_enterprise, allow_order_changes: true) }


### PR DESCRIPTION
Separate contexts with different test orders (completed_with_total and completed_with_fees)

#### What? Why?
Doing this in master to avoid merge conflicts in 2-0-stable.

#### What should we test?
No change.

#### How is this related to the Spree upgrade?
This prepares the spec to be refactored for spree 2.
