### PR TITLE
[Spree Upgrade] Fix some tests in orders admin spec

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2045,6 +2045,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   ok: OK
   not_visible: not visible
   you_have_no_orders_yet: "You have no orders yet"
+  show_only_complete_orders: "Only show complete orders"
   running_balance: "Running balance"
   outstanding_balance: "Outstanding balance"
   admin_enterprise_relationships: "Enterprise Permissions"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -565,7 +565,7 @@ FactoryBot.modify do
     end
   end
 
-  factory :shipping_method do
+  factory :shipping_method, parent: :base_shipping_method do
     distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
     display_on ''
   end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -223,28 +223,22 @@ feature %q{
                         tax_rate_name: "Tax 1")
         Spree::TaxRate.adjust(@order)
 
-        visit spree.admin_order_path(@order)
+        visit spree.edit_admin_order_path(@order)
       end
 
       scenario "shows a list of line_items" do
         within('table.index tbody', match: :first) do
           @order.line_items.each do |item|
             expect(page).to have_selector "td", match: :first, text: item.full_name
-            expect(page).to have_selector "td.price", text: item.single_display_amount
-            expect(page).to have_selector "td.qty", text: item.quantity
-            expect(page).to have_selector "td.total", text: item.display_amount
+            expect(page).to have_selector "td.item-price", text: item.single_display_amount
+            expect(page).to have_selector "td.item-qty-show", text: item.quantity
+            expect(page).to have_selector "td.item-total", text: item.display_amount
           end
         end
       end
 
-      scenario "shows the order subtotal" do
-        within('table.index tbody#subtotal') do
-          expect(page).to have_selector "td.total", text: @order.display_item_total
-        end
-      end
-
       scenario "shows the order charges (non-tax adjustments)" do
-        within('table.index tbody#order-charges') do
+        within('tbody#order-charges') do
           @order.adjustments.eligible.each do |adjustment|
             next if (adjustment.originator_type == 'Spree::TaxRate') && (adjustment.amount == 0)
             expect(page).to have_selector "td", match: :first, text: adjustment.label
@@ -254,8 +248,8 @@ feature %q{
       end
 
       scenario "shows the order total" do
-        within('table.index tbody#order-total') do
-          expect(page).to have_selector "td.total", text: @order.display_total
+        within('fieldset#order-total') do
+          expect(page).to have_selector "span.order-total", text: @order.display_total
         end
       end
 
@@ -341,9 +335,7 @@ feature %q{
       expect(o.distributor).to eq distributor1
       expect(o.order_cycle).to eq order_cycle1
     end
-
   end
-
 
   # Working around intermittent click failing
   # Possible causes of failure:

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   describe ShippingMethod do
     it "is valid when built from factory" do
-      build(:shipping_method).should be_valid
+      create(:shipping_method).should be_valid
     end
 
     it "can have distributors" do


### PR DESCRIPTION
#### What? Why?

Closes #2933 

Three changes:
- Orders action show is gone in spree 2 since:
https://github.com/spree/spree/commit/4e54ceda35397fe81399c8ca4e951e123d1a63f3
Updated path to edit_admin_order_path to solve the original problem.
Created #2937 to adapt all occurrences of orders.show
-  In order edit page, adapted some class selectors to spree 2. These we introduced in spree 2 here:
https://github.com/spree/spree/commit/72e5d4717d39a1722215f144ef452dfd498a79e5
- In order edit page, removed test of order subtotal, it’s gone in spree 2.

Result:
A few more green tests in the spec.

----
In this process I've found a fix to an unrelated broken spec. I am using this PR (separate commit) to put a very simple fix to the shipping_method_spec. It makes the shipping_method_spec completely green.
