### PR TITLE
Pi/submenu link

### DIFF
--- a/app/overrides/spree/admin/shared/_product_sub_menu/add_product_import_tab.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_sub_menu/add_product_import_tab.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_sub_tabs']"
-
--# Commenting out for now, until product import is finished
--# = tab :product_import, label: "Import", url: main_app.admin_product_import_path, match_path: '/product_import'

--- a/app/overrides/spree/admin/shared/_product_sub_menu/add_variant_overrides_tab.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_sub_menu/add_variant_overrides_tab.html.haml.deface
@@ -1,3 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_sub_tabs']"
-
-= tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'

--- a/app/views/admin/product_import/import.html.haml
+++ b/app/views/admin/product_import/import.html.haml
@@ -2,7 +2,7 @@
   #{t('admin.product_import.title')}
 
 = render partial: 'ams_data'
-= render partial: 'spree/admin/shared/product_sub_menu'
+= render partial: 'admin/shared/product_sub_menu'
 
 .import-wrapper{ng: {app: 'admin.productImport', controller: 'ImportFormCtrl'}}
 

--- a/app/views/admin/product_import/index.html.haml
+++ b/app/views/admin/product_import/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   #{t('admin.product_import.title')}
 
-= render partial: 'spree/admin/shared/product_sub_menu'
+= render partial: 'admin/shared/product_sub_menu'
 
 = render 'upload_sidebar'
 

--- a/app/views/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/admin/shared/_product_sub_menu.html.haml
@@ -1,0 +1,6 @@
+= content_for :sub_menu do
+  %ul#sub_nav.inline-menu
+    = tab :products, match_path: '/products'
+    = tab :option_types, match_path: '/option_types'
+    = tab :properties
+    = tab :prototypes

--- a/app/views/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/admin/shared/_product_sub_menu.html.haml
@@ -4,3 +4,5 @@
     = tab :option_types, match_path: '/option_types'
     = tab :properties
     = tab :prototypes
+    = tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'
+    = tab :import, url: main_app.admin_product_import_path, match_path: '/product_import'

--- a/app/views/admin/variant_overrides/_header.html.haml
+++ b/app/views/admin/variant_overrides/_header.html.haml
@@ -5,4 +5,4 @@
   %h1.page-title= t("admin.variant_overrides.index.title")
   %a.with-tip{ 'data-powertip' => "#{t("admin.variant_overrides.index.description")}" }=t('admin.whats_this')
 
-= render :partial => 'spree/admin/shared/product_sub_menu'
+= render partial: 'admin/shared/product_sub_menu'

--- a/app/views/spree/admin/products/group_buy_options.html.haml
+++ b/app/views/spree/admin/products/group_buy_options.html.haml
@@ -1,4 +1,4 @@
-= render :partial => 'spree/admin/shared/product_sub_menu'
+= render partial: 'admin/shared/product_sub_menu'
 = render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Group Buy Options' }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 

--- a/app/views/spree/admin/products/index/_header.html.haml
+++ b/app/views/spree/admin/products/index/_header.html.haml
@@ -7,6 +7,6 @@
       %li#new_product_link
         = button_link_to t(:new_product), new_object_url, { :remote => true, :icon => 'icon-plus', :id => 'admin_new_product' }
 
-= render :partial => 'spree/admin/shared/product_sub_menu'
+= render partial: 'admin/shared/product_sub_menu'
 
 %div#new_product(data-hook)

--- a/app/views/spree/admin/products/product_distributions.html.haml
+++ b/app/views/spree/admin/products/product_distributions.html.haml
@@ -1,4 +1,4 @@
-= render :partial => 'spree/admin/shared/product_sub_menu'
+= render partial: 'admin/shared/product_sub_menu'
 = render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Distributions' }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 

--- a/app/views/spree/admin/products/seo.html.haml
+++ b/app/views/spree/admin/products/seo.html.haml
@@ -1,4 +1,4 @@
-= render :partial => 'spree/admin/shared/product_sub_menu'
+= render partial: 'admin/shared/product_sub_menu'
 = render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => t(:Search) }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,7 @@ en:
   enterprise_groups: Groups
   reports: Reports
   variant_overrides: Inventory
+  import: Import
   spree_products: Spree Products
   all: All
   current: Current

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -460,7 +460,7 @@ feature "Product Import", js: true do
 
   def proceed_to_validation
     expect(page).to have_selector 'a.button.proceed', visible: true
-    click_link I18n.t('admin.product_import.import.import')
+    within("#content") { click_link I18n.t('admin.product_import.import.import') }
     expect(page).to have_selector 'form.product-import', visible: true
     expect(page).to have_content I18n.t('admin.product_import.import.validation_overview')
   end


### PR DESCRIPTION
#### What? Why?

Closes #2603

Shows the product import menu item in the backend for superadmin users. Includes recreating the Spree view for product submenu.

#### What should we test?

Product import menu item is visible for admins.

#### Release notes

Product Import is now available for admin users.

Changelog Category: Added 


