### PR TITLE
Fix default time zone config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,12 @@ Openfoodnetwork::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = false
 
+  # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
+  # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
+  #
+  # To override this, set the appropriate locale in application.yml
+  config.time_zone = ENV.fetch("TIMEZONE", "UTC")
+
   config.i18n.fallbacks = [:en]
 
   # Show emails using Letter Opener

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,6 +33,8 @@ Openfoodnetwork::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.time_zone = ENV.fetch("TIMEZONE", "Melbourne")
+
   # Tests assume English text on the site.
   config.i18n.default_locale = "en"
   config.i18n.available_locales = ['en', 'es']


### PR DESCRIPTION
#### What? Why?

* Starting the environment, even with just `bundle exec rake`, results
  in the following error:
  ```
  Value assigned to config.time_zone not recognized.Run "rake -D time"
  for a list of tasks for finding appropriate time zone names.
  ```

This change addresses the issue by:

* Adding the time zone setting to environment specific configurations,
  defaulting to UTC in development, and using Melbourne in tests.


#### What should we test?

For devs:

* Running `bundle exec rake` in a clean environment after setting up the project.

For testers:

* Check that order cycles close at the right time.


#### Release notes

* Changed `TIMEZONE` environment variable to be optional in development and test. The system will now default to `UTC` in development when the variable is not present, similar to what happens in Rails when no time zone is assigned.

Changelog Category: Changed