### PR TITLE
Fix new preferences migration

### DIFF
--- a/db/migrate/20120327000645_new_preferences.rb
+++ b/db/migrate/20120327000645_new_preferences.rb
@@ -1,4 +1,37 @@
-require 'spree/core/preference_rescue'
+# Spree 1.3.6.beta preference rescue implementation, required for the new
+# preferences migration, which is broken since commit ab707cf due to the
+# absence of this file.
+#
+# Migration: db/migrate/20120327000645_new_preferences.rb
+# Source: https://raw.githubusercontent.com/spree/spree/1-3-stable/core/lib/spree/core/preference_rescue.rb
+#
+# rubocop:disable all
+module Spree
+  class OldPrefs < ActiveRecord::Base
+    self.table_name = "spree_preferences"
+    belongs_to  :owner, :polymorphic => true
+    attr_accessor :owner_klass
+  end
+
+  class PreferenceRescue
+    def self.try
+      OldPrefs.where(:key => nil).each do |old_pref|
+        next unless owner = (old_pref.owner rescue nil)
+        unless old_pref.owner_type == "Spree::Activator" || old_pref.owner_type == "Spree::Configuration"
+          begin
+            old_pref.key = [owner.class.name, old_pref.name, owner.id].join('::').underscore
+            old_pref.value_type = owner.preference_type(old_pref.name)
+            puts "Migrating Preference: #{old_pref.key}"
+            old_pref.save
+          rescue NoMethodError => ex
+            puts ex.message
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable all
 
 class NewPreferences < ActiveRecord::Migration
 


### PR DESCRIPTION
#### What? Why?

* In a clean environment, running the new preferences migration fails,
  due to a missing file from Spree core being manually required. This
  file has now been missing since ab707cf.

This change addresses the issue by:

* Copying the missing file from Spree Core 1.3.6.beta into the codebase.
  This fixes the issue for now, but also means that a migration merge
  and/or rewrite might be in order for the future.


#### What should we test?

* Running the migrations from scratch in a clean system. Before this change `rake db:migrate` fails with
  ```
  rake aborted!
  LoadError: cannot load such file -- spree/core/preference_rescue
  .../db/migrate/20120327000645_new_preferences.rb:1:in  `<top (required)>'
  .../ruby/2.1.5/bin/bundle:23:in `load'
  .../ruby/2.1.5/bin/bundle:23:in `<main>'
  
  Caused by:
  Polyglot::PolyglotLoadError: Failed to load 
  .../db/migrate/20120327000645_new_preferences.rb using extensions deface, rb
  .../ruby/2.1.5/bin/bundle:23:in `load'
  .../ruby/2.1.5/bin/bundle:23:in `<main>'
  Tasks: TOP => db:migrate
  ```

  After this change `db/migrate/20120327000645_new_preferences.rb:1` should work.


#### Release notes

* Fixed the new preferences migration, which was broken since ab707cf due to the Spree upgrade.

Changelog Category: Fixed


#### How is this related to the Spree upgrade?

* This does not present a direct conflict with the Spree upgrade, but was caused by its first steps, and should be revised afterwards.
