### PR TITLE
Import Spree views for orders#edit in our codebase

### DIFF
--- a/app/overrides/spree/admin/orders/_form/add_distribution_fields.html.haml.deface
+++ b/app/overrides/spree/admin/orders/_form/add_distribution_fields.html.haml.deface
@@ -1,3 +1,0 @@
-/ insert_before "[data-hook='admin_order_form_buttons']"
-
-= render partial: 'spree/admin/orders/_form/distribution_fields'

--- a/app/overrides/spree/admin/orders/_form/hide_form_until_distribution.deface
+++ b/app/overrides/spree/admin/orders/_form/hide_form_until_distribution.deface
@@ -1,2 +1,0 @@
-add_to_attributes "table.index, [data-hook='admin_order_form_buttons']"
-attributes "ng-show" => "distributionChosen()"

--- a/app/overrides/spree/admin/orders/_form/relabel_update_button.html.haml.deface
+++ b/app/overrides/spree/admin/orders/_form/relabel_update_button.html.haml.deface
@@ -1,3 +1,0 @@
-/ replace "code[erb-loud]:contains('button t(:update)')"
-
-= button t(:update_and_recalculate_fees), 'icon-refresh'

--- a/app/overrides/spree/admin/orders/_line_item/replace_variant_label.html.haml.deface
+++ b/app/overrides/spree/admin/orders/_line_item/replace_variant_label.html.haml.deface
@@ -1,3 +1,0 @@
-/ replace 'code[erb-loud]:contains(\'"(#{f.object.variant.options_text})"\')'
-
-= "(#{f.object.full_name})"

--- a/app/overrides/spree/admin/orders/_line_item/replace_variant_price.html.haml.deface
+++ b/app/overrides/spree/admin/orders/_line_item/replace_variant_price.html.haml.deface
@@ -1,3 +1,0 @@
-/ replace 'code[erb-loud]:contains(\'f.object.variant.display_amount\')'
-
-= f.object.single_money

--- a/app/overrides/spree/admin/orders/edit/add_action_dropdown.html.haml.deface
+++ b/app/overrides/spree/admin/orders/edit/add_action_dropdown.html.haml.deface
@@ -1,6 +1,0 @@
-/ insert_after "code[erb-loud]:contains('button_link_to t(:resend)')"
-
-%li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
-
-:coffee
-  angular.bootstrap(document.getElementById("links-dropdown"),['admin.dropdown'])

--- a/app/overrides/spree/admin/orders/edit/suppress_errors.html.haml.deface
+++ b/app/overrides/spree/admin/orders/edit/suppress_errors.html.haml.deface
@@ -1,6 +1,0 @@
-/ replace "code[erb-loud]:contains(\'error_messages\')"
-
--# Suppress errors when manually creating a new order - needs to proceed to edit page
--# without having line items (which otherwise gives a validation error)
-- unless params["suppress_error_msg"]
-  = render partial: "spree/shared/error_messages", :locals => { :target => @order }

--- a/app/views/spree/admin/orders/_add_product.html.haml
+++ b/app/views/spree/admin/orders/_add_product.html.haml
@@ -1,15 +1,15 @@
 = render partial: "spree/admin/variants/autocomplete", formats: :js
-#add-line-item{"data-hook" => ""}
+#add-line-item
   %fieldset
     %legend{align: "center"}
       = t(:add_product)
-    .field.eight.columns.alpha{"data-hook" => "add_product_name"}
+    .field.eight.columns.alpha
       = label_tag :add_product_name, t(:name_or_sku)
       = hidden_field_tag :add_variant_id, "", class: "variant_autocomplete fullwidth"
-    .field.two.columns{"data-hook" => "add_quantity"}
+    .field.two.columns
       = label_tag :add_quantity, t(:qty)
       = number_field_tag :add_quantity,  1, min: 0
-    .actions.two.columns.omega{"data-hook" => "add_button"}
+    .actions.two.columns.omega
       = link_to_with_icon 'icon-plus', t(:add), admin_order_line_items_url(@order),
         method: :post,
         id: 'add_line_item_to_order',

--- a/app/views/spree/admin/orders/_add_product.html.haml
+++ b/app/views/spree/admin/orders/_add_product.html.haml
@@ -1,0 +1,17 @@
+= render partial: "spree/admin/variants/autocomplete", formats: :js
+#add-line-item{"data-hook" => ""}
+  %fieldset
+    %legend{align: "center"}
+      = t(:add_product)
+    .field.eight.columns.alpha{"data-hook" => "add_product_name"}
+      = label_tag :add_product_name, t(:name_or_sku)
+      = hidden_field_tag :add_variant_id, "", class: "variant_autocomplete fullwidth"
+    .field.two.columns{"data-hook" => "add_quantity"}
+      = label_tag :add_quantity, t(:qty)
+      = number_field_tag :add_quantity,  1, min: 0
+    .actions.two.columns.omega{"data-hook" => "add_button"}
+      = link_to_with_icon 'icon-plus', t(:add), admin_order_line_items_url(@order),
+        method: :post,
+        id: 'add_line_item_to_order',
+        class: 'button fullwidth',
+        'data-update' => 'order-form-wrapper'

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -1,0 +1,68 @@
+%div{"data-hook" => "admin_order_form_fields"}
+  - if @line_item.try(:errors).present?
+    = render partial: 'spree/shared/error_messages', locals: { target: @line_item }
+  = form_for @order, url: admin_order_url(@order), method: :put do |f|
+    %fieldset.no-border-top
+      = f.hidden_field :number
+      %table.index{"ng-show" => "distributionChosen()"}
+        %colgroup
+          %col{style: "width: 49%;"}/
+          %col{style: "width: 14%;"}/
+          %col{style: "width: 10%;"}/
+          %col{style: "width: 14%;"}/
+          %col{style: "width: 8%;"}/
+        %thead#line-items
+          %tr{"data-hook" => "admin_order_form_line_items_headers"}
+            %th
+              = t(:item_description)
+            %th.price
+              = t(:price)
+            %th.qty
+              = t(:qty)
+            %th.total
+              %span
+                = t(:total)
+            %th.orders-actions.actions{"data-hook" => "admin_order_form_line_items_header_actions"}
+        %tbody{"data-hook" => "admin_order_form_line_items"}
+          = f.fields_for :line_items do |li_form|
+            = render partial: 'spree/admin/orders/line_item', locals: { f: li_form }
+        %tbody#subtotal.no-border-top{"data-hook" => "admin_order_form_subtotal"}
+          %tr#subtotal-row
+            %td{colspan: "3"}
+              %b
+                = t(:subtotal)
+                \:
+            %td.total.align-center
+              %span
+                = @order.display_item_total.to_html
+            %td.actions
+        %tbody#order-charges.no-border-top{"data-hook" => "admin_order_form_adjustments"}
+          - @order.adjustments.eligible.each do |adjustment|
+            %tr
+              %td{colspan: "3"}
+                %strong
+                  = adjustment.label
+                  \:
+              %td.total.align-center
+                %span= adjustment.display_amount.to_html
+              %td.actions
+        %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
+          %tr
+            %td{colspan: "3"}
+              %b
+                = t(:order_total)
+                \:
+            %td.total.align-center
+              %span#order_total
+                = @order.display_total.to_html
+            %td.actions
+
+      = render partial: 'spree/admin/orders/_form/distribution_fields'
+
+      .filter-actions.actions{"data-hook" => "admin_order_form_buttons", "ng-show" => "distributionChosen()"}
+        = button t(:update_and_recalculate_fees), 'icon-refresh'
+        %span.or
+          = t(:or)
+        = link_to_with_icon 'button icon-arrow-left', t(:back), admin_orders_url
+  = javascript_tag do
+    = render partial: 'spree/admin/shared/update_order_state', handlers: [:js]

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -1,4 +1,4 @@
-%div.admin_order_form_fields
+%div
   - if @line_item.try(:errors).present?
     = render partial: 'spree/shared/error_messages', locals: { target: @line_item }
   = form_for @order, url: admin_order_url(@order), method: :put do |f|

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -1,4 +1,4 @@
-%div
+%div.admin_order_form_fields
   - if @line_item.try(:errors).present?
     = render partial: 'spree/shared/error_messages', locals: { target: @line_item }
   = form_for @order, url: admin_order_url(@order), method: :put do |f|

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -1,4 +1,4 @@
-%div{"data-hook" => "admin_order_form_fields"}
+%div
   - if @line_item.try(:errors).present?
     = render partial: 'spree/shared/error_messages', locals: { target: @line_item }
   = form_for @order, url: admin_order_url(@order), method: :put do |f|
@@ -12,7 +12,7 @@
           %col{style: "width: 14%;"}/
           %col{style: "width: 8%;"}/
         %thead#line-items
-          %tr{"data-hook" => "admin_order_form_line_items_headers"}
+          %tr
             %th
               = t(:item_description)
             %th.price
@@ -22,11 +22,11 @@
             %th.total
               %span
                 = t(:total)
-            %th.orders-actions.actions{"data-hook" => "admin_order_form_line_items_header_actions"}
-        %tbody{"data-hook" => "admin_order_form_line_items"}
+            %th.orders-actions.actions
+        %tbody
           = f.fields_for :line_items do |li_form|
             = render partial: 'spree/admin/orders/line_item', locals: { f: li_form }
-        %tbody#subtotal.no-border-top{"data-hook" => "admin_order_form_subtotal"}
+        %tbody#subtotal.no-border-top
           %tr#subtotal-row
             %td{colspan: "3"}
               %b
@@ -36,7 +36,7 @@
               %span
                 = @order.display_item_total.to_html
             %td.actions
-        %tbody#order-charges.no-border-top{"data-hook" => "admin_order_form_adjustments"}
+        %tbody#order-charges.no-border-top
           - @order.adjustments.eligible.each do |adjustment|
             %tr
               %td{colspan: "3"}
@@ -46,7 +46,7 @@
               %td.total.align-center
                 %span= adjustment.display_amount.to_html
               %td.actions
-        %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
+        %tbody#order-total.grand-total.no-border-top
           %tr
             %td{colspan: "3"}
               %b
@@ -59,7 +59,7 @@
 
       = render partial: 'spree/admin/orders/_form/distribution_fields'
 
-      .filter-actions.actions{"data-hook" => "admin_order_form_buttons", "ng-show" => "distributionChosen()"}
+      .filter-actions.actions{"ng-show" => "distributionChosen()"}
         = button t(:update_and_recalculate_fees), 'icon-refresh'
         %span.or
           = t(:or)

--- a/app/views/spree/admin/orders/_line_item.html.haml
+++ b/app/views/spree/admin/orders/_line_item.html.haml
@@ -1,0 +1,12 @@
+%tr{"data-hook" => "admin_order_form_line_item_row", id: "#{spree_dom_id(f.object)}", class: "#{cycle('odd', 'even')}"}
+  %td
+    = f.object.variant.product.name
+    = "(#{f.object.full_name})" unless f.object.variant.option_values.empty?
+  %td.price.align-center
+    = f.object.variant.display_amount
+  %td.qty
+    = f.number_field :quantity, min: 0, class: "qty"
+  %td.total.align-center
+    = f.object.single_money
+  %td.actions{"data-hook" => "admin_order_form_line_item_actions"}
+    = link_to_delete f.object, {url: admin_order_line_item_url(@order.number, f.object), no_text: true}

--- a/app/views/spree/admin/orders/_line_item.html.haml
+++ b/app/views/spree/admin/orders/_line_item.html.haml
@@ -1,4 +1,4 @@
-%tr{"data-hook" => "admin_order_form_line_item_row", id: "#{spree_dom_id(f.object)}", class: "#{cycle('odd', 'even')}"}
+%tr{id: "#{spree_dom_id(f.object)}", class: "#{cycle('odd', 'even')}"}
   %td
     = f.object.variant.product.name
     = "(#{f.object.full_name})" unless f.object.variant.option_values.empty?
@@ -8,5 +8,5 @@
     = f.number_field :quantity, min: 0, class: "qty"
   %td.total.align-center
     = f.object.single_money
-  %td.actions{"data-hook" => "admin_order_form_line_item_actions"}
+  %td.actions
     = link_to_delete f.object, {url: admin_order_line_item_url(@order.number, f.object), no_text: true}

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -3,6 +3,8 @@
 - content_for :page_actions do
   %li= event_links
   %li= button_link_to t(:resend), resend_admin_order_url(@order), method: :post, icon: 'icon-email'
+  %li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
+
   %li= button_link_to t(:back_to_orders_list), admin_orders_path, icon: 'icon-arrow-left'
 
 = admin_inject_shops(module: 'admin.orders')
@@ -11,7 +13,8 @@
 = render 'spree/admin/shared/order_tabs', current: 'Order Details'
 
 %div{"data-hook" => "admin_order_edit_header"}
-  = render 'spree/shared/error_messages', target: @order
+  - unless params["suppress_error_msg"]
+    = render partial: "spree/shared/error_messages", :locals => { :target => @order }
 
 %div{"ng-app" => "admin.orders", "ng-controller" => "orderCtrl", "ofn-distributor-id" => @order.distributor_id, "ofn-order-cycle-id" => @order.order_cycle_id}
   = render 'add_product'
@@ -22,3 +25,6 @@
 
 - content_for :head do
   = javascript_tag 'var expand_variants = true;'
+  
+:coffee
+  angular.bootstrap(document.getElementById("links-dropdown"),['admin.dropdown'])

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -12,19 +12,19 @@
 
 = render 'spree/admin/shared/order_tabs', current: 'Order Details'
 
-%div{"data-hook" => "admin_order_edit_header"}
+%div
   - unless params["suppress_error_msg"]
     = render partial: "spree/shared/error_messages", :locals => { :target => @order }
 
 %div{"ng-app" => "admin.orders", "ng-controller" => "orderCtrl", "ofn-distributor-id" => @order.distributor_id, "ofn-order-cycle-id" => @order.order_cycle_id}
   = render 'add_product'
 
-  %div{"data-hook" => "admin_order_edit_form"}
+  %div
     #order-form-wrapper
       = render 'form', order: @order
 
 - content_for :head do
   = javascript_tag 'var expand_variants = true;'
-  
+
 :coffee
   angular.bootstrap(document.getElementById("links-dropdown"),['admin.dropdown'])

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -30,16 +30,14 @@
           = t(:shipment)
           \:
         %dd#shipment_status
-          %span.state
-            = @order.shipment_state
-          = t(@order.shipment_state, scope: :shipment_states, default: [:missing, none])
+          %span{class: "state #{@order.shipment_state}"}
+            = t(@order.shipment_state, scope: :shipment_states, default: [:missing, "none"])
         %dt
           = t(:payment)
           \:
         %dd#payment_status
-          %span.state
-            = @order.payment_state
-          = t(@order.payment_state, scope: :payment_states, default: [:missing, none])
+          %span{class: "state #{@order.payment_state}"}
+            = t(@order.payment_state, scope: :payment_states, default: [:missing, "none"])
         %dt
           = t(:date_completed)
           \:

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -1,0 +1,65 @@
+- content_for :page_title do
+  = t(:order)
+  \#
+  = @order.number
+
+- if @order.bill_address.present?
+  = @order.bill_address.firstname
+  = @order.bill_address.lastname
+  \-
+
+- content_for :sidebar_title do
+  = t(:order_information)
+
+- content_for :sidebar do
+  %header#order_tab_summary
+    %dl.additional-info
+      %dt#order_status
+        = t(:status)
+      %dd
+        %span{:class => "state #{@order.state}"}
+        = t(@order.state, scope: :order_state)
+      %dt
+        = t(:total)
+        \:
+      %dd#order_total
+        = @order.display_total.to_html
+
+      - if @order.completed?
+        %dt
+          = t(:shipment)
+          \:
+        %dd#shipment_status
+          %span.state
+            = @order.shipment_state
+          = t(@order.shipment_state, scope: :shipment_states, default: [:missing, none])
+        %dt
+          = t(:payment)
+          \:
+        %dd#payment_status
+          %span.state
+            = @order.payment_state
+          = t(@order.payment_state, scope: :payment_states, default: [:missing, none])
+        %dt
+          = t(:date_completed)
+          \:
+        %dd#date_complete
+          = pretty_time(@order.completed_at)
+
+  %nav.menu
+    %ul{"data-hook" => "admin_order_tabs"}
+      %li{ class: "#{'active' if true}" }
+      = link_to_with_icon 'icon-edit', t(:order_details), edit_admin_order_url(@order)
+      %li{"#{'class=active' if current == 'Customer Details'}"}
+      = link_to_with_icon 'icon-user', t(:customer_details), admin_order_customer_url(@order)
+      %li{"#{'class=active' if current == 'Adjustments Details'}"}
+      = link_to_with_icon 'icon-cogs', t(:adjustments), admin_order_adjustments_url(@order)
+
+      %li{"#{'class=active' if current == 'Payments'}"}
+      = link_to_with_icon 'icon-credit-card', t(:payments), admin_order_payments_url(@order)
+
+      %li{"#{'class=active' if current == 'Shipments'}"}
+      = link_to_with_icon 'icon-road', t(:shipments), admin_order_shipments_url(@order)
+      - if @order.completed?
+        %li{"#{'class=active' if current == 'Return Authorizations'}"}
+        = link_to_with_icon 'icon-share-alt', t(:return_authorizations), admin_order_return_authorizations_url(@order)

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -17,8 +17,9 @@
       %dt#order_status
         = t(:status)
       %dd
-        %span{:class => "state #{@order.state}"}
-        = t(@order.state, scope: :order_state)
+        - order_state_classes = "state #{@order.state}"
+        %span{ class: order_state_classes }
+          = t(@order.state, scope: :order_state)
       %dt
         = t(:total)
         \:
@@ -30,13 +31,15 @@
           = t(:shipment)
           \:
         %dd#shipment_status
-          %span{class: "state #{@order.shipment_state}"}
+          - shipment_state_classes = "state #{@order.shipment_state}"
+          %span{ class: shipment_state_classes }
             = t(@order.shipment_state, scope: :shipment_states, default: [:missing, "none"])
         %dt
           = t(:payment)
           \:
         %dd#payment_status
-          %span{class: "state #{@order.payment_state}"}
+          - payment_state_classes = "state #{@order.payment_state}"
+          %span{ class: payment_state_classes }
             = t(@order.payment_state, scope: :payment_states, default: [:missing, "none"])
         %dt
           = t(:date_completed)
@@ -46,18 +49,27 @@
 
   %nav.menu
     %ul
-      %li{ class: "#{'active' if true}" }
+      - order_details_classes = "active" if current == "Order Details"
+      %li{ class: order_details_classes }
       = link_to_with_icon 'icon-edit', t(:order_details), edit_admin_order_url(@order)
-      %li{"#{'class=active' if current == 'Customer Details'}"}
+
+      - customer_details_classes = "active" if current == "Customer Details"
+      %li{ class: customer_details_classes }
       = link_to_with_icon 'icon-user', t(:customer_details), admin_order_customer_url(@order)
-      %li{"#{'class=active' if current == 'Adjustments Details'}"}
+
+      - adjustments_classes = "active" if current == "Adjustments"
+      %li{ class: adjustments_classes }
       = link_to_with_icon 'icon-cogs', t(:adjustments), admin_order_adjustments_url(@order)
 
-      %li{"#{'class=active' if current == 'Payments'}"}
+      - payments_classes = "active" if current == "Payments"
+      %li{ class: payments_classes }
       = link_to_with_icon 'icon-credit-card', t(:payments), admin_order_payments_url(@order)
 
-      %li{"#{'class=active' if current == 'Shipments'}"}
+      - shipments_classes = "active" if current == "Shipments"
+      %li{ class: shipments_classes }
       = link_to_with_icon 'icon-road', t(:shipments), admin_order_shipments_url(@order)
+
       - if @order.completed?
-        %li{"#{'class=active' if current == 'Return Authorizations'}"}
+        - authorizations_classes = "active" if current == "Return Authorizations"
+        %li{ class: authorizations_classes }
         = link_to_with_icon 'icon-share-alt', t(:return_authorizations), admin_order_return_authorizations_url(@order)

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -45,7 +45,7 @@
           = pretty_time(@order.completed_at)
 
   %nav.menu
-    %ul{"data-hook" => "admin_order_tabs"}
+    %ul
       %li{ class: "#{'active' if true}" }
       = link_to_with_icon 'icon-edit', t(:order_details), edit_admin_order_url(@order)
       %li{"#{'class=active' if current == 'Customer Details'}"}

--- a/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -90,7 +90,7 @@ describe Spree::Admin::LineItemsController, type: :controller do
 
           it 'returns an HTML response with the order form' do
             spree_put :update, params
-            expect(response.body).to match(/admin_order_form_fields/)
+            expect(response.body).to match(/edit_order/)
           end
         end
       end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -16,10 +16,10 @@ feature %q{
   let!(:producer_related) { create(:supplier_enterprise) }
   let!(:producer_unrelated) { create(:supplier_enterprise) }
   let!(:er1) { create(:enterprise_relationship, parent: producer, child: hub,
-                      permissions_list: [:create_variant_overrides]) 
+                      permissions_list: [:create_variant_overrides])
   }
   let!(:er2) { create(:enterprise_relationship, parent: producer_related, child: hub,
-                      permissions_list: [:create_variant_overrides]) 
+                      permissions_list: [:create_variant_overrides])
   }
 
   context "as an enterprise user" do
@@ -28,7 +28,7 @@ feature %q{
 
     describe "selecting a hub" do
       let!(:er1) { create(:enterprise_relationship, parent: hub2, child: producer_managed,
-                          permissions_list: [:add_to_order_cycle]) 
+                          permissions_list: [:add_to_order_cycle])
       } # This er should not confer ability to create VOs for hub2
 
       it "displays a list of hub choices (ie. only those managed by the user)" do
@@ -338,7 +338,7 @@ feature %q{
       it "shows the overridden price" do
         targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
         click_link 'Add'
-        expect(page).to have_selector("table.index tbody[data-hook='admin_order_form_line_items'] tr") # Wait for JS
+        expect(page).to have_selector("table.index tbody tr") # Wait for JS
         expect(page).to have_content(product.variants.first.variant_overrides.first.price)
       end
     end


### PR DESCRIPTION
#### What? Why?
**WIP**

Closes #2956 
Related to #2416, this is the first step to move towards Spree 2.0 for orders edit page.

I imported Spree views from step-6a and integrated Deface modifications.

What remains to be done : 
- [x] Have dynamic classes work in _order_tabs.html.haml
- [x] Remove `data-hook` tags

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
The orders edit page is working properly. Also check the different screens in the workflow of editing orders, like choosing the distributor etc.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
This is the first step before changing to the Spree 2.0 views
