### PR TITLE
[Spree Upgrade] Fix occurrences of order.shipping_method= by replacing with order.shipments

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2383,6 +2383,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   shipping_methods: "Shipping Methods"
   payment_methods: "Payment Methods"
   payment_method_fee: "Transaction fee"
+  payment_processing_failed: "Payment could not be processed, please check the details you entered"
   inventory_settings: "Inventory Settings"
   tag_rules: "Tag Rules"
   shop_preferences: "Shop Preferences"

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -842,7 +842,8 @@ describe Spree::Order do
 
   describe '#charge_shipping_and_payment_fees!' do
     let(:order) do
-      build(:order, shipping_method: build(:shipping_method))
+      shipment = build(:shipment_with, :shipping_method, shipping_method: build(:shipping_method))
+      build(:order, shipments: [shipment] )
     end
 
     context 'after transitioning to payment' do

--- a/spec/requests/checkout/failed_checkout_spec.rb
+++ b/spec/requests/checkout/failed_checkout_spec.rb
@@ -7,12 +7,12 @@ describe "checking out an order that initially fails", type: :request do
   let!(:order_cycle) { create(:simple_order_cycle) }
   let!(:exchange) { create(:exchange, order_cycle: order_cycle, sender: order_cycle.coordinator, receiver: shop, incoming: false, pickup_time: "Monday") }
   let!(:address) { create(:address) }
-  let!(:order) { create(:order, distributor: shop, order_cycle: order_cycle) }
   let!(:line_item) { create(:line_item, order: order, quantity: 3, price: 5.00) }
   let!(:payment_method) { create(:bogus_payment_method, distributor_ids: [shop.id], environment: Rails.env) }
   let!(:check_payment_method) { create(:payment_method, distributor_ids: [shop.id], environment: Rails.env) }
   let!(:shipping_method) { create(:shipping_method, distributor_ids: [shop.id]) }
-  let!(:shipment) { create(:shipment, order: order, shipping_method: shipping_method) }
+  let!(:shipment) { create(:shipment_with, :shipping_method, shipping_method: shipping_method) }
+  let!(:order) { create(:order, shipments: [shipment], distributor: shop, order_cycle: order_cycle) }
   let(:params) do
     { format: :json, order: {
       shipping_method_id: shipping_method.id,

--- a/spec/requests/checkout/paypal_spec.rb
+++ b/spec/requests/checkout/paypal_spec.rb
@@ -26,7 +26,6 @@ describe "checking out an order with a paypal express payment method", type: :re
 
   before do
     order.reload.update_totals
-    order.shipping_method = shipping_method
     expect(order.next).to be true # => address
     expect(order.next).to be true # => delivery
     expect(order.next).to be true # => payment


### PR DESCRIPTION
#### What? Why?

Do the same as in #2680 
These errors must have been covered up by other errors when 2680 was done.

Fix errors in paypal_spec, order_spec and failed_checkout_spec:
```
NoMethodError:
        undefined method `shipping_method=' for #<Spree::Order:0x0055b7eca7b288>

```

#### What should we test?
A few more green specs.
Paypal_spec is still broken with some shipping_method adjustment problem I couldnt figure out yet. I will open a new issue for it under #2927 

I have also added a missing translation from spree to ofn to make the failed_checkout spec move further.

#### How is this related to the Spree upgrade?
Making the build green!