### PR TITLE
Move default_url_options set up to an initializer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,9 +30,6 @@ Openfoodnetwork::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use https when creating links in emails
-  config.action_mailer.default_url_options = { protocol: 'https', host: Spree::Config[:site_url] }
-
   # See everything in the log (default is :info)
   config.log_level = :info
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,9 +30,6 @@ Openfoodnetwork::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use https when creating links in emails
-  config.action_mailer.default_url_options = { protocol: 'https', host: Spree::Config[:site_url] }
-
   # See everything in the log (default is :info)
   # config.log_level = :debug
 

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,0 +1,6 @@
+ActionMailer::Base.configure do |config|
+  if Rails.env.production? || Rails.env.staging?
+    # Use https when creating links in emails
+    config.default_url_options = { protocol: 'https', host: Spree::Config[:site_url] }
+  end
+end


### PR DESCRIPTION
### What? Why?

For some reason running `bundle exec rake db:migrate RAILS_ENV=staging` on a deployment fails with:

```
rake aborted!
NameError: uninitialized constant Spree::Config
```

Running `bundle exec rails server` for instance, does not. There must be a difference on the way a rake task and the rails commands load the app.

Moving this configuration to an initializer, at the end of the initialization process, fixes it. The constant `Spree::Config` is already loaded.

**This is preventing the release v1.22.0 from being staged and tested**

### What should we test?

This should fix the deployment to staging therefore, I can test it myself.