### PR TITLE
Fix variant_overrides permissions for overrides that belong to the supplier herself

### DIFF
--- a/db/migrate/20181031105158_allow_all_suppliers_own_variant_overrides.rb
+++ b/db/migrate/20181031105158_allow_all_suppliers_own_variant_overrides.rb
@@ -1,0 +1,12 @@
+class AllowAllSuppliersOwnVariantOverrides < ActiveRecord::Migration
+  def up
+    # This migration is fixing a detail of previous migration RevokeVariantOverrideswithoutPermissions
+    #   Here we allow all variant_overrides where hub_id is the products supplier_id
+    #   This is needed when the supplier herself uses the inventory to manage stock and not the catalog
+    owned_variant_overrides = VariantOverride.unscoped
+      .joins(variant: :product).where("spree_products.supplier_id = variant_overrides.hub_id")
+
+    owned_variant_overrides.update_all(permission_revoked_at: nil)
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181020103501) do
+ActiveRecord::Schema.define(:version => 20181031105158) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false


### PR DESCRIPTION
#### What? Why?

Closes #2960 

This PR sets all variant_overrides.permission_revoked_at to nil when variant_override.hub_id is the products supplier_id. Basically allowing all suppliers to manage their own inventory without having to set explicit permission to do so.

#### What should we test?
This should be empty:
```
select distinct vo.hub_id from spree_products p, spree_variants v, variant_overrides vo
openfoodnetwork-> where p.supplier_id = vo.hub_id
openfoodnetwork-> and p.id = v.product_id and vo.variant_id = v.id and vo.permission_revoked_at is not null;
```

#### Release notes
Changelog Category: Fixed
Fixed previous data migration by not revoking access to inventory management for suppliers who manage their own inventory but that do not have explicit enterprise permissions to do so.

#### How is this related to the Spree upgrade?
not related.

#### Dependencies
Fixes problem in the migration in #2893 
