### PR TITLE
[Spree Upgrade] Perform mail delivery in spec to make it pass

### DIFF
--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -182,7 +182,9 @@ describe Spree::Admin::OrdersController, type: :controller do
           before { distributor.update_attribute(:abn, "123") }
           before do
             Spree::Config[:mails_from] = "spree@example.com"
+            ActionMailer::Base.perform_deliveries = true
           end
+
           it "should allow me to send order invoices" do
             expect do
               spree_get :invoice, params


### PR DESCRIPTION
#### What? Why?

We need to purposefully enable deliveries for the deliveries array to list this email. Otherwise the delivery logic is not executed and thus the deliveries array never filled.


#### What should we test?
Nothing spree upgrade is not ready yet.