### PR TITLE
[Spree Upgrade] Fix User Balance Calculator spec

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -286,7 +286,7 @@ FactoryBot.define do
 
     after(:create) do |order|
       p = create(:simple_product, :distributors => [order.distributor])
-      FactoryBot.create(:line_item, :order => order, :product => p)
+      FactoryBot.create(:line_item_with_shipment, :order => order, :product => p)
       order.reload
     end
   end

--- a/spec/lib/open_food_network/user_balance_calculator_spec.rb
+++ b/spec/lib/open_food_network/user_balance_calculator_spec.rb
@@ -11,17 +11,17 @@ module OpenFoodNetwork
 
       let!(:o1) { create(:order_with_totals_and_distribution,
                           user: user1, distributor: hub1,
-                          completed_at: 1.day.ago) 
+                          completed_at: 1.day.ago)
       } #total=10
       let!(:o2) { create(:order_with_totals_and_distribution,
                           user: user1, distributor: hub1,
-                          completed_at: 1.day.ago) 
+                          completed_at: 1.day.ago)
       } #total=10
       let!(:p1) { create(:payment, order: o1, amount: 15.00,
-                          state: "completed") 
+                          state: "completed")
       }
       let!(:p2) { create(:payment, order: o2, amount: 2.00,
-                          state: "completed") 
+                          state: "completed")
       }
 
       it "finds the correct balance for this email and enterprise" do
@@ -32,7 +32,7 @@ module OpenFoodNetwork
         let!(:hub2) { create(:distributor_enterprise) }
         let!(:o3) { create(:order_with_totals_and_distribution,
                             user: user1, distributor: hub2,
-                            completed_at: 1.day.ago) 
+                            completed_at: 1.day.ago)
         } #total=10
         let!(:p3) { create(:payment, order: o3, amount: 15.00,
                             state: "completed") 


### PR DESCRIPTION
#### What? Why?

Fixed user balance calculator by setting missing required target_shipment on line items.

#### What should we test?
User Balance Calculator spec is green.
