### PR TITLE
Deface/orders#show

### DIFF
--- a/app/overrides/spree/admin/orders/show/add_action_dropdown.html.haml.deface
+++ b/app/overrides/spree/admin/orders/show/add_action_dropdown.html.haml.deface
@@ -1,6 +1,0 @@
-/ insert_after "code[erb-loud]:contains('button_link_to t(:edit)')"
-
-%li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
-
-:coffee
-  angular.bootstrap(document.getElementById("links-dropdown"),['admin.dropdown'])

--- a/app/views/spree/admin/orders/show.html.haml
+++ b/app/views/spree/admin/orders/show.html.haml
@@ -1,8 +1,12 @@
+- content_for :app_wrapper_attrs do
+  = "ng-app='ofn.admin'"
+
 - content_for :page_actions do
   %li
     = button_link_to t(:cancel), fire_admin_order_url(@order.number, { :e => 'cancel' }), :icon => 'icon-trash', :data => { :confirm => t(:are_you_sure) } if @order.can_cancel?
   %li
     = button_link_to t(:edit), edit_admin_order_url(@order.number), :icon => 'icon-edit'
+  %li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
   %li
     = button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 

--- a/app/views/spree/admin/orders/show.html.haml
+++ b/app/views/spree/admin/orders/show.html.haml
@@ -1,0 +1,22 @@
+- content_for :page_actions do
+  %li
+    = button_link_to t(:cancel), fire_admin_order_url(@order.number, { :e => 'cancel' }), :icon => 'icon-trash', :data => { :confirm => t(:are_you_sure) } if @order.can_cancel?
+  %li
+    = button_link_to t(:edit), edit_admin_order_url(@order.number), :icon => 'icon-edit'
+  %li
+    = button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
+
+= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Order Details' }
+
+.row
+  - if @order.bill_address
+    %fieldset.alpha.six.columns.no-border-bottom
+      %legend{:align => "center"}= t(:bill_address)
+      = render :partial => 'spree/shared/address', :locals => { :address => @order.bill_address }
+  - if @order.ship_address
+    %fieldset.omega.six.columns.no-border-bottom
+      %legend{:align => "center"}= t(:ship_address)
+      = render :partial => 'spree/shared/address', :locals => { :address => @order.ship_address }
+
+%div
+  = render :partial => 'spree/admin/shared/order_details', :locals => { :order => @order }


### PR DESCRIPTION
#### What? Why?

Preparation for #2937 and another step in the `#defacepocalypse`.

Reimplements the admin orders#show view with deface overrides applied.

#### What should we test?

The regular orders show page works and is unchanged. Specifically the dropdown in the submenu should also work.
