### PR TITLE
[Spree Upgrade] Add missing failed authorization translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1278,7 +1278,7 @@ en:
   no_shipping_or_payment: no shipping or payment methods
   unconfirmed: unconfirmed
   days: days
-
+  authorization_failure: "Authorization Failure"
 
   label_shop: "Shop"
   label_shops: "Shops"


### PR DESCRIPTION
#### What? Why?

Fix one test in the upgrade build.
spec/controllers/spree/admin/payment_methods_controller_spec.rb:115

#### What should we test?
Test should be green now.

#### Documentation updates
I have added a new entry "“Add missing Spree translations”" here: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-(i18n)