### PR TITLE
[Spree Upgrade] orders#show

### DIFF
--- a/app/helpers/spree/admin/orders_helper_decorator.rb
+++ b/app/helpers/spree/admin/orders_helper_decorator.rb
@@ -3,7 +3,6 @@ module Spree
     module OrdersHelper
       def order_links(order)
         links = []
-        links << { name: t(:view_order), url: admin_order_path(order), icon: 'icon-eye-open' } unless action_name == "show"
         links << { name: t(:edit_order), url: edit_admin_order_path(order), icon: 'icon-edit' } unless action_name == "edit"
         if @order.complete?
           links << { name: t(:resend_confirmation), url: resend_admin_order_path(order), icon: 'icon-email', method: 'post', confirm: t(:confirm_resend_order_confirmation) }

--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -1,6 +1,6 @@
 class Api::Admin::OrderSerializer < ActiveModel::Serializer
   attributes :id, :number, :full_name, :email, :phone, :completed_at, :display_total
-  attributes :show_path, :edit_path, :state, :payment_state, :shipment_state
+  attributes :edit_path, :state, :payment_state, :shipment_state
   attributes :payments_path, :ship_path, :ready_to_ship, :created_at
   attributes :distributor_name, :special_instructions, :payment_capture_path
 
@@ -13,11 +13,6 @@ class Api::Admin::OrderSerializer < ActiveModel::Serializer
 
   def distributor_name
     object.distributor.andand.name
-  end
-
-  def show_path
-    return '' unless object.id
-    spree_routes_helper.admin_order_path(object)
   end
 
   def edit_path

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -46,7 +46,7 @@
       %td.align-center
         = @show_only_completed ? '{{order.completed_at}}' : '{{order.created_at}}'
       %td
-        %a{'ng-href' => '{{order.show_path}}'}
+        %a{'ng-href' => '{{order.edit_path}}'}
           {{order.number}}
         %div{'ng-if' => 'order.special_instructions'}
           %br


### PR DESCRIPTION
#### What? Why?

Closes #2937 

Spree::Admin::OrdersController#show has been removed in 2.0. This PR deals with the remaining references to admin_order_path and either removes these links, or replaces them with the edit path instead.
