### PR TITLE
Remove old commented out code

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -65,13 +65,6 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
       DirtyProducts.clear()
       StatusMessage.clear()
 
-    # $scope.matchProducer = (product) ->
-    #   for producer in $scope.producers
-    #     if angular.equals(producer.id, product.producer)
-    #       product.producer = producer
-    #       break
-
-
     $scope.updateOnHand = (product) ->
       on_demand_variants = []
       if product.variants

--- a/app/serializers/api/admin/product_serializer.rb
+++ b/app/serializers/api/admin/product_serializer.rb
@@ -5,7 +5,7 @@ class Api::Admin::ProductSerializer < ActiveModel::Serializer
 
   has_one :supplier, key: :producer_id, embed: :id
   has_one :primary_taxon, key: :category_id, embed: :id
-  has_many :variants, key: :variants, serializer: Api::Admin::VariantSerializer # embed: ids
+  has_many :variants, key: :variants, serializer: Api::Admin::VariantSerializer
   has_one :master, serializer: Api::Admin::VariantSerializer
 
   def image_url


### PR DESCRIPTION
#### What? Why?

You know, git already keeps old code for us. So we don't need it here.

I found this while working on the upgrade.