### PR TITLE
Specify only email link protocol setting

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,9 @@ Openfoodnetwork::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Use https in email links
+  config.action_mailer.default_url_options = { protocol: 'https' }
+
   # See everything in the log (default is :info)
   config.log_level = :info
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,6 +30,9 @@ Openfoodnetwork::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Use https in email links
+  config.action_mailer.default_url_options = { protocol: 'https' }
+
   # See everything in the log (default is :info)
   # config.log_level = :debug
 

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,6 +1,0 @@
-ActionMailer::Base.configure do |config|
-  if Rails.env.production? || Rails.env.staging?
-    # Use https when creating links in emails
-    config.default_url_options = { protocol: 'https', host: Spree::Config[:site_url] }
-  end
-end


### PR DESCRIPTION
#### What? Why?

Closes #2895 

There has been some back and forth with this bugfix in #2896, where it seemed to work on staging but was patched at the last minute in #2959 due to an Ansible/deployment issue. This PR removes the patch in #2959.

I've tested this on UK staging before and after deploying the PR and it seems to be working correctly with these adjustments.

#### What should we test?

Email links should use https

#### Release notes

Patched a previous fix for https links in emails.

Changelog Category: Fixed
