### PR TITLE
[Spree Upgrade] Add an API key for admin user

### DIFF
--- a/lib/spree/api/testing_support/setup.rb
+++ b/lib/spree/api/testing_support/setup.rb
@@ -37,6 +37,7 @@ module Spree
             user.stub(:enterprises) { [] }
             user.stub(:owned_groups) { [] }
 
+            user.stub(:spree_api_key) { "admin_spree_api_key" }
             user
           end
         end


### PR DESCRIPTION
#### What? Why?

Closes #2985 

This is a fix proposal for #2985, failing on the fact that the admin logged in the spec has no API key, and since it is a LegacyUser, `generate_spree_api_key!` is undefined for him.

Defining any API key for this admin will avoid calling `generate_spree_api_key!`, making the specs pass.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
`spec/controllers/api/product_images_controller_spec.rb` specs pass


#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
This is part of fixing the Spree build.