### PR TITLE
Pi/utf8

### DIFF
--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -16,8 +16,7 @@ module Admin
       @original_filename = params[:file].try(:original_filename)
       @non_updatable_fields = ProductImport::EntryValidator.non_updatable_fields
 
-      check_file_errors @importer
-      check_spreadsheet_has_data @importer
+      return if contains_errors? @importer
 
       @ams_data = ams_data
     end
@@ -63,15 +62,19 @@ module Admin
       true
     end
 
-    def check_file_errors(importer)
+    def contains_errors?(importer)
       if importer.errors.present?
         redirect_to '/admin/product_import', notice: @importer.errors.full_messages.to_sentence
+        return true
       end
+
+      check_spreadsheet_has_data importer
     end
 
     def check_spreadsheet_has_data(importer)
       unless importer.item_count
         redirect_to '/admin/product_import', notice: I18n.t(:product_import_no_data_in_spreadsheet_notice)
+        true
       end
     end
 

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -205,7 +205,7 @@ module ProductImport
 
     def open_spreadsheet
       if accepted_mimetype
-        Roo::Spreadsheet.open(@file, extension: accepted_mimetype)
+        Roo::Spreadsheet.open(@file, extension: accepted_mimetype, encoding: Encoding::UTF_8)
       else
         errors.add(:importer, I18n.t(:product_importer_spreadsheet_error))
         delete_uploaded_file

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -226,6 +226,14 @@ module ProductImport
       (2..@sheet.last_row).map do |i|
         @sheet.row(i)
       end
+    rescue ArgumentError => e
+      if e.message.include? 'invalid byte sequence'
+        errors.add(:importer, I18n.t('admin.product_import.model.encoding_error'))
+      else
+        errors.add(:importer, I18n.t('admin.product_import.model.unexpected_error',
+                                     error_message: e.message))
+      end
+      []
     end
 
     def build_entries_in_range

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,6 +524,8 @@ en:
         inventory_no_permission: you do not have permission to create inventory for this producer
         none_saved: did not save any products successfully
         line_number: "Line %{number}:"
+        encoding_error: "Please check the language setting of your source file and ensure it is saved with UTF-8 encoding"
+        unexpected_error: "Product Import encountered an unexpected error whilst opening the file: %{error_message}"
       index:
         select_file: Select a spreadsheet to upload
         spreadsheet: Spreadsheet


### PR DESCRIPTION
#### What? Why?

Closes #2836 

Addresses issues with different encodings in spreadsheets causing errors when reading the file in product import.


#### What should we test?

When a file with unusual encoding is used with product import, an error message is displayed when it is uploaded.

#### Release notes

Added file encoding error messages to product import.

Changelog Category: Added
