### PR TITLE
[Spree Upgrade] Import missing translations from Spree 2 to fix some tests

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2046,6 +2046,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   not_visible: not visible
   you_have_no_orders_yet: "You have no orders yet"
   show_only_complete_orders: "Only show complete orders"
+  successfully_created: ! '%{resource} has been successfully created!'
+  successfully_removed: ! '%{resource} has been successfully removed!'
+  successfully_updated: ! '%{resource} has been successfully updated!'
   running_balance: "Running balance"
   outstanding_balance: "Outstanding balance"
   admin_enterprise_relationships: "Enterprise Permissions"


### PR DESCRIPTION
#### What? Why?

Fixes a couple of errors in `Job #3` that look like this:

```
Failure/Error: expect(page).to have_content 'Your content has been successfully updated!'
    expected to find text "Your content has been successfully updated!" in "translation missing: en.successfully_updated Loading... 
```
