### PR TITLE
[Spree Upgrade] Failing credit card spec

### DIFF
--- a/spec/serializers/credit_card_serializer_spec.rb
+++ b/spec/serializers/credit_card_serializer_spec.rb
@@ -10,6 +10,6 @@ describe Api::CreditCardSerializer do
   end
 
   it "formats an identifying string with the card number masked" do
-    expect(serializer.formatted).to eq "Visa x-1111 Exp:12/2013"
+    expect(serializer.formatted).to eq "Visa x-1111 Exp:12/2019"
   end
 end


### PR DESCRIPTION
#### What? Why?

Fixes a small test in `Job #4` by updating a credit card spec to use the new value.

```
Failure/Error: expect(serializer.formatted).to eq "Visa x-1111 Exp:12/2013"
        expected: "Visa x-1111 Exp:12/2013"
             got: "Visa x-1111 Exp:12/2019"
```

