### PR TITLE
[Spree Upgrade] Fix delete enterprise fees spec

### DIFF
--- a/app/assets/javascripts/admin/enterprise_fees/directives/delete_resource.js.coffee
+++ b/app/assets/javascripts/admin/enterprise_fees/directives/delete_resource.js.coffee
@@ -1,7 +1,7 @@
 angular.module('admin.enterpriseFees').directive 'spreeDeleteResource', ->
   (scope, element, attrs) ->
     if scope.enterprise_fee.id
-      url = '/admin/enterprise_fees/' + scope.enterprise_fee.id
+      url = '/admin/enterprise_fees/' + scope.enterprise_fee.id + '.js'
       html = '<a href="' + url + '" class="delete-resource icon_link icon-trash no-text" data-action="remove" data-confirm="' + t('are_you_sure') + '" url="' + url + '"></a>'
       #var html = '<a href="'+url+'" class="delete-resource" data-confirm="Are you sure?"><img alt="Delete" src="/assets/admin/icons/delete.png" /> Delete</a>';
       element.append html


### PR DESCRIPTION
#### What? Why?

Closes #2987 

For some reason, the destroy action was processed as HTML and not JS. Putting the format to JS in the delete URL fixed it.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
`spec/features/admin/enterprise_fees_spec.rb:122` should pass.
Job#1 should be green :v:


#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
This is part of fixing Spree 2.0 build.
