### PR TITLE
[Spree Upgrade] Bring Spree changes on admin/products/new.js.erb

### DIFF
--- a/app/views/spree/admin/products/new.js.erb
+++ b/app/views/spree/admin/products/new.js.erb
@@ -1,5 +1,5 @@
-<%# This chunk is just a copy of Spree's core/app/views/spree/admin/products/new.js.erb %>
-$("#new_product").html('<%= escape_javascript(render :template => "spree/admin/products/new", :formats => [:html], :handlers => [:erb]) %>');
+<%# This chunk is just a copy of Spree's backend/app/views/spree/admin/products/new.js.erb %>
+$("#new_product_wrapper").html('<%= escape_javascript(render :template => "spree/admin/products/new", :formats => [:html], :handlers => [:erb]) %>');
 handle_date_picker_fields();
 <% unless Rails.env.test? %>
   $('.select2').select2();


### PR DESCRIPTION
#### What? Why?

This is a very first step for #2982. 


This brings Spree changes on `admin/products/new.js.erb`. We copied that template from Spree to then append a little change on it. Since the original version changed in Spree 2.0 we need to update our copy.

You can check out Spree's template in https://github.com/openfoodfoundation/spree/blob/2-0-4-stable/backend/app/views/spree/admin/products/new.js.erb


#### What should we test?

Nothing. The upgrade is not ready yet.