### PR TITLE
Fix bad spacing on account settings error page

### DIFF
--- a/app/assets/stylesheets/darkswarm/forms.css.scss
+++ b/app/assets/stylesheets/darkswarm/forms.css.scss
@@ -4,3 +4,11 @@
 fieldset {
   border: 0;
 }
+
+.user-form {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1184px;
+  padding-left: .9375rem;
+  padding-right: .9375rem;
+}

--- a/app/views/spree/users/edit.html.haml
+++ b/app/views/spree/users/edit.html.haml
@@ -1,3 +1,3 @@
 .darkswarm
-  .row
+  .user-form
     = render 'form'


### PR DESCRIPTION
#### What? Why?

Closes #2429 

Whenever an error message was displayed in the user account settings page (e.g. "Invalid email") the padding on the sides of the page's content would disappear. I added some padding to the appropriate stylesheet to fix the problem.



#### What should we test?
Navigate to the account settings page (in a non-maximized window) and submit an invalid email address (e.g. remove ".com" or "@"). The resulting error page should now have padding on the left and right sides.



#### Release notes
Fixed an issue with bad spacing on the account settings error page.

Changelog Category: Fixed
