### PR TITLE
[Spree Upgrade] Subs - Extend Order cleanly for subscriptions

### DIFF
--- a/app/models/extensions/order_subscriptions_extensions.rb
+++ b/app/models/extensions/order_subscriptions_extensions.rb
@@ -1,0 +1,14 @@
+# Used to prevent payments on subscriptions from being processed in the normal way.
+# Payments are skipped until after the order cycle has closed.
+module OrderSubscriptionsExtensions
+  # Override Spree method.
+  def payment_required?
+    super && !skip_payment_for_subscription?
+  end
+
+  private
+
+  def skip_payment_for_subscription?
+    subscription.present? && order_cycle.orders_close_at.andand > Time.zone.now
+  end
+end

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -127,6 +127,7 @@ describe SubscriptionConfirmJob do
       before do
         allow(order).to receive(:payment_total) { 0 }
         allow(order).to receive(:total) { 10 }
+        allow(order).to receive(:payment_required?) { true }
         allow(order).to receive(:pending_payments) { [payment] }
       end
 


### PR DESCRIPTION
#### What? Why?

Part of #2520. It unblocks https://github.com/openfoodfoundation/openfoodnetwork/pull/2771.

Orders belonging to subscriptions get completed without payment. That
requires overriding Spree's functionality. Here we move this
customisation into its own file and override a different method to make
it less invasive and compatible with Spree 2.

In Spree 2, an order in payment state without pending payments is invalid.
Instead we skip the payment state by not requiring a payment for
automatically generated orders until the order cycle is closed.

This is the change that comes with Spree 2:
```diff
diff --git a/app/models/spree/order_decorator.rb b/app/models/spree/order_decorator.rb
index fb5cea69b..25c91568a 100644
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -336,6 +336,9 @@ Spree::Order.class_eval do
   # See commit: https://github.com/spree/spree/commit/5fca58f658273451193d5711081d018c317814ed
   # Allows GatewayError to show useful error messages in checkout
     def process_payments!
+      if pending_payments.empty?
+        raise Core::GatewayError.new Spree.t(:no_pending_payments)
+      else
         pending_payments.each do |payment|
           break if payment_total >= total
 
@@ -345,6 +348,7 @@ Spree::Order.class_eval do
             self.payment_total += payment.amount
           end
         end
+      end
     rescue Spree::Core::GatewayError => e # This section changed
       result = !!Spree::Config[:allow_checkout_on_gateway_error]
       errors.add(:base, e.message) and return result
```
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

- Checkout with several payment methods.
- Create a subscription.
- Let the order cycle close by passing the close-by date.
- Make sure the payment is triggered and a confirmation is sent.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Payment processing logic has been prepared for future software updates.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

It makes our code more compatible with Spree 2.

