### PR TITLE
[Spree Upgrade] Fix api/orders_controller_spec

### DIFF
--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -25,19 +25,19 @@ module Api
                        distributor: distributor, billing_address: create(:address) )
       end
       let!(:line_item1) do
-        create(:line_item, order: order1,
+        create(:line_item_with_shipment, order: order1,
                            product: create(:product, supplier: supplier))
       end
       let!(:line_item2) do
-        create(:line_item, order: order2,
+        create(:line_item_with_shipment, order: order2,
                            product: create(:product, supplier: supplier))
       end
       let!(:line_item3) do
-        create(:line_item, order: order2,
+        create(:line_item_with_shipment, order: order2,
                            product: create(:product, supplier: supplier))
       end
       let!(:line_item4) do
-        create(:line_item, order: order3,
+        create(:line_item_with_shipment, order: order3,
                            product: create(:product, supplier: supplier))
       end
       let!(:regular_user) { create(:user) }

--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -149,8 +149,8 @@ module Api
     def order_attributes
       [
         :id, :number, :full_name, :email, :phone, :completed_at, :display_total,
-        :show_path, :edit_path, :state, :payment_state, :shipment_state,
-        :payments_path, :shipments_path, :ship_path, :ready_to_ship, :created_at,
+        :edit_path, :state, :payment_state, :shipment_state,
+        :payments_path, :ship_path, :ready_to_ship, :created_at,
         :distributor_name, :special_instructions, :payment_capture_path
       ]
     end


### PR DESCRIPTION
#### What? Why?

Two fixes required here:
- use line_items with shipment to make order workflow work
- fix spec problem missed in #2978 (another simple example of why a green build is fundamental)

#### What should we test?
api/orders_controller_spec should be green now

#### How is this related to the Spree upgrade?
Part of making the build green.