### PR TITLE
[Spree Upgrade] Fix admin payments spec

### DIFF
--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -17,9 +17,9 @@ feature '
   end
 
   context "with sensitive payment fee" do
-    let(:payment_method) { order.distributor.payment_methods.first }
-
     before do
+      payment_method = create(:payment_method, distributors: [order.distributor])
+
       # This calculator doesn't handle a `nil` order well.
       # That has been useful in finding bugs. ;-)
       payment_method.calculator = Spree::Calculator::FlatPercentItemTotal.new


### PR DESCRIPTION
#### What? Why?

Fix admin/payments_spec error:
```
2) 
    As an admin
    I want to manage payments
 with sensitive payment fee visiting the payment form
     Failure/Error: payment_method.calculator = Spree::Calculator::FlatPercentItemTotal.new
     
     NoMethodError:
       undefined method `calculator=' for nil:NilClass
     # ./spec/features/admin/payments_spec.rb:25:in `block (3 levels) in <top (required)>'
```
Add missing payment method to order.distributor.

Note: I dont understand how is this working in master... if I follow the factory chain of completed_order_with_fees I dont see a payment_method being set on the distributor.

#### What should we test?
The spec should be green (I have confirmed it's green in the build).
