### PR TITLE
Add specs for cloning a product with image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'nokogiri', '>= 1.6.7.1'
 gem 'web', path: './engines/web'
 
 gem 'pg'
-gem 'spree', github: 'openfoodfoundation/spree', branch: 'step-6a', ref: '69db1c090f3711088d84b524f1b94d25e6d21616'
+gem 'spree', github: 'openfoodfoundation/spree', branch: 'step-6a', ref: '41906362d931695e0616194341a68d2c4c85aaaf'
 gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'
 gem 'spree_auth_devise', github: 'openfoodfoundation/spree_auth_devise', branch: 'spree-upgrade-intermediate'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,8 +31,8 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 69db1c090f3711088d84b524f1b94d25e6d21616
-  ref: 69db1c090f3711088d84b524f1b94d25e6d21616
+  revision: 41906362d931695e0616194341a68d2c4c85aaaf
+  ref: 41906362d931695e0616194341a68d2c4c85aaaf
   branch: step-6a
   specs:
     spree (1.3.99)

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -8,6 +8,7 @@ module Spree
     let(:supplier2) { create(:supplier_enterprise) }
     let!(:product1) { create(:product, supplier: supplier) }
     let(:product_other_supplier) { create(:product, supplier: supplier2) }
+    let(:product_with_image) { create(:product_with_image, supplier: supplier) }
     let(:attributes) { [:id, :name, :supplier, :price, :on_hand, :available_on, :permalink_live] }
 
     let(:current_api_user) { build_stubbed(:user) }
@@ -144,6 +145,12 @@ module Spree
           spree_post :clone, product_id: product1.id, format: :json
           expect(json_response['name']).to eq("COPY OF #{product1.name}")
         end
+
+        it 'clones a product with image' do
+          spree_post :clone, product_id: product_with_image.id, format: :json
+          expect(response.status).to eq(201)
+          expect(json_response['name']).to eq("COPY OF #{product_with_image.name}")
+        end
       end
 
       context 'as an administrator' do
@@ -161,6 +168,12 @@ module Spree
         it 'clones the product' do
           spree_post :clone, product_id: product1.id, format: :json
           expect(json_response['name']).to eq("COPY OF #{product1.name}")
+        end
+
+        it 'clones a product with image' do
+          spree_post :clone, product_id: product_with_image.id, format: :json
+          expect(response.status).to eq(201)
+          expect(json_response['name']).to eq("COPY OF #{product_with_image.name}")
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Part of #2756 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This adds specs for cloning a product with image.
**Blocked by https://github.com/openfoodfoundation/spree/pull/19**

The issue itself is solved in Spree:https://github.com/openfoodfoundation/spree/pull/19
The implementation is from Spree 2-0 and solves the problem we had with product duplication.

#### What should we test?
<!-- List which features should be tested and how. -->
After https://github.com/openfoodfoundation/spree/pull/19 is merged, specs should be green, and it should be possible to duplicate a product with an image.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Fixed product with image duplication.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
https://github.com/openfoodfoundation/spree/pull/19