### PR TITLE
[Spree Upgrade] Remove shipping_method_id from order factory

### DIFF
--- a/app/services/order_factory.rb
+++ b/app/services/order_factory.rb
@@ -36,7 +36,7 @@ class OrderFactory
   end
 
   def create_attrs
-    create_attrs = attrs.slice(:customer_id, :order_cycle_id, :distributor_id, :shipping_method_id)
+    create_attrs = attrs.slice(:customer_id, :order_cycle_id, :distributor_id)
     create_attrs[:email] = customer.email
     create_attrs
   end

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe OrderFactory do
   let(:variant1) { create(:variant, price: 5.0) }
   let(:variant2) { create(:variant, price: 7.0) }
@@ -5,7 +7,6 @@ describe OrderFactory do
   let(:customer) { create(:customer, user: user) }
   let(:shop) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle) }
-  let(:shipping_method) { create(:shipping_method, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 5.0)) }
   let(:payment_method) { create(:payment_method) }
   let(:ship_address) { create(:address) }
   let(:bill_address) { create(:address) }
@@ -20,7 +21,6 @@ describe OrderFactory do
       attrs[:customer_id] = customer.id
       attrs[:distributor_id] = shop.id
       attrs[:order_cycle_id] = order_cycle.id
-      attrs[:shipping_method_id] = shipping_method.id
       attrs[:payment_method_id] = payment_method.id
       attrs[:bill_address_attributes] = bill_address.attributes.except("id")
       attrs[:ship_address_attributes] = ship_address.attributes.except("id")
@@ -35,12 +35,10 @@ describe OrderFactory do
       expect(order.user).to eq user
       expect(order.distributor).to eq shop
       expect(order.order_cycle).to eq order_cycle
-      expect(order.shipping_method).to eq shipping_method
-      expect(order.shipments.reload.first.shipping_method).to eq shipping_method
       expect(order.payments.first.payment_method).to eq payment_method
       expect(order.bill_address).to eq bill_address
       expect(order.ship_address).to eq ship_address
-      expect(order.total).to eq 43.0
+      expect(order.total).to eq 38.0
       expect(order.complete?).to be false
     end
 
@@ -109,7 +107,7 @@ describe OrderFactory do
         it "uses the price from the variant" do
           expect{ order }.to change{ Spree::Order.count }.by(1)
           expect(order.line_items.find_by_variant_id(variant1.id).price).to eq 5.0
-          expect(order.total).to eq 43.0
+          expect(order.total).to eq 38.0
         end
       end
 
@@ -119,7 +117,7 @@ describe OrderFactory do
         it "uses the price from the override" do
           expect{ order }.to change{ Spree::Order.count }.by(1)
           expect(order.line_items.find_by_variant_id(variant1.id).price).to eq 3.0
-          expect(order.total).to eq 39.0
+          expect(order.total).to eq 34.0
         end
       end
     end


### PR DESCRIPTION
This attribute is gone in spree 2 and doesn't need to be the responsibility of the order factory to handle order shipping method. The shipping method is selected only when the order workflow is progressed on checkout.

#### What? Why?

Part of #3037, fixes one of the errors.

#### What should we test?
Both failing specs should have the same error, the second one on #3037
