### PR TITLE
Fix/incorrect order dates

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -26,8 +26,19 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
       $scope.startDate = moment(OrderCycles.byID[$scope.orderCycleFilter].orders_open_at).format('YYYY-MM-DD')
       $scope.endDate = moment(OrderCycles.byID[$scope.orderCycleFilter].orders_close_at).startOf('day').format('YYYY-MM-DD')
 
-    RequestMonitor.load $scope.orders = Orders.index("q[state_not_eq]": "canceled", "q[completed_at_not_null]": "true", "q[completed_at_gteq]": "#{moment($scope.startDate).format()}", "q[completed_at_lt]": "#{moment($scope.endDate).add(1,'day').format()}")
-    RequestMonitor.load $scope.lineItems = LineItems.index("q[order][state_not_eq]": "canceled", "q[order][completed_at_not_null]": "true", "q[order][completed_at_gteq]": "#{moment($scope.startDate).format()}", "q[order][completed_at_lt]": "#{moment($scope.endDate).add(1,'day').format()}")
+    RequestMonitor.load $scope.orders = Orders.index(
+      "q[state_not_eq]": "canceled",
+      "q[completed_at_not_null]": "true",
+      "q[completed_at_gteq]": "#{moment($scope.startDate).format()}",
+      "q[completed_at_lt]": "#{moment($scope.endDate).add(1,'day').format()}"
+    )
+
+    RequestMonitor.load $scope.lineItems = LineItems.index(
+      "q[order][state_not_eq]": "canceled",
+      "q[order][completed_at_not_null]": "true",
+      "q[order][completed_at_gteq]": "#{moment($scope.startDate).format()}",
+      "q[order][completed_at_lt]": "#{moment($scope.endDate).add(1,'day').format()}"
+    )
 
     unless $scope.initialized
       RequestMonitor.load $scope.distributors = Enterprises.index(action: "visible", ams_prefix: "basic", "q[sells_in][]": ["own", "any"])

--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -30,7 +30,7 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, RequestMonitor,
       'q[distributor_id_in]': $scope['q']['distributor_id_in'],
       'q[order_cycle_id_in]': $scope['q']['order_cycle_id_in'],
       'q[order_cycle_id_in]': $scope['q']['order_cycle_id_in'],
-      'q[s]': $scope.sorting || 'id desc',
+      'q[s]': $scope.sorting || 'completed_at desc',
       per_page: $scope.per_page,
       page: page
     })

--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -18,8 +18,8 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, RequestMonitor,
 
   $scope.fetchResults = (page=1) ->
     Orders.index({
-      'q[completed_at_lt]': $scope['q']['created_at_lt'],
-      'q[completed_at_gt]': $scope['q']['created_at_gt'],
+      'q[completed_at_lt]': $scope['q']['completed_at_lt'],
+      'q[completed_at_gt]': $scope['q']['completed_at_gt'],
       'q[state_eq]': $scope['q']['state_eq'],
       'q[number_cont]': $scope['q']['number_cont'],
       'q[email_cont]': $scope['q']['email_cont'],

--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -18,8 +18,8 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, RequestMonitor,
 
   $scope.fetchResults = (page=1) ->
     Orders.index({
-      'q[created_at_lt]': $scope['q']['created_at_lt'],
-      'q[created_at_gt]': $scope['q']['created_at_gt'],
+      'q[completed_at_lt]': $scope['q']['created_at_lt'],
+      'q[completed_at_gt]': $scope['q']['created_at_gt'],
       'q[state_eq]': $scope['q']['state_eq'],
       'q[number_cont]': $scope['q']['number_cont'],
       'q[email_cont]': $scope['q']['email_cont'],

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -4,10 +4,10 @@
       .date-range-filter.field
         = label_tag nil, t(:date_range)
         .date-range-fields
-          = text_field_tag "q[created_at_gt]", nil, class: 'datepicker', datepicker: 'q.created_at_gt', 'ng-model' => 'q.created_at_gt', :placeholder => t(:start)
+          = text_field_tag "q[completed_at_gt]", nil, class: 'datepicker', datepicker: 'q.completed_at_gt', 'ng-model' => 'q.completed_at_gt', :placeholder => t(:start)
           %span.range-divider
             %i.icon-arrow-right
-          = text_field_tag "q[created_at_lt]", nil, class: 'datepicker', datepicker: 'q.created_at_lt', 'ng-model' => 'q.created_at_lt', :placeholder => t(:stop)
+          = text_field_tag "q[completed_at_lt]", nil, class: 'datepicker', datepicker: 'q.completed_at_lt', 'ng-model' => 'q.completed_at_lt', :placeholder => t(:stop)
       .field
         = label_tag nil, t(:status)
         = select_tag("q[state_eq]",

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -26,19 +26,16 @@
     %tr
       %th
         = t(:products_distributor)
-      - if @show_only_completed
         %th
           %a{'ng-click' => "sortOptions.toggle('completed_at')"}
             = t(:completed_at, scope: 'activerecord.attributes.spree/order')
             %span{'ng-show' => "sorting == 'completed_at asc'"}= "&#x25B2;".html_safe
             %span{'ng-show' => "sorting == 'completed_at desc' || sorting === undefined"}= "&#x25BC;".html_safe
-      - else
-        %th
-          = render partial: 'sortable_header', locals: {column_name: 'completed_at'}
 
       - ['number', 'state', 'payment_state', 'shipment_state', 'email', 'total'].each do |column_name|
         %th
           = render partial: 'sortable_header', locals: {column_name: column_name}
+
       %th.actions
   %tbody
     %tr{ng: {repeat: 'order in orders track by $index', class: {even: "'even'", odd: "'odd'"}}, 'ng-class' => "'state-{{order.state}}'"}

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -34,7 +34,8 @@
             %span{'ng-show' => "sorting == 'completed_at desc' || sorting === undefined"}= "&#x25BC;".html_safe
       - else
         %th
-          = render partial: 'sortable_header', locals: {column_name: 'created_at'}
+          = render partial: 'sortable_header', locals: {column_name: 'completed_at'}
+
       - ['number', 'state', 'payment_state', 'shipment_state', 'email', 'total'].each do |column_name|
         %th
           = render partial: 'sortable_header', locals: {column_name: column_name}
@@ -44,7 +45,7 @@
       %td.align-center
         {{order.distributor_name}}
       %td.align-center
-        = @show_only_completed ? '{{order.completed_at}}' : '{{order.created_at}}'
+        {{order.completed_at}}
       %td
         %a{'ng-href' => '{{order.show_path}}'}
           {{order.number}}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -629,7 +629,7 @@ en:
         tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
         shared: "Shared Resource?"
         order_no: "Order No."
-        order_date: "Order Date"
+        order_date: "Completed at"
         max: "Max"
         product_unit: "Product: Unit"
         weight_volume: "Weight/Volume"

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -53,9 +53,9 @@ feature %q{
       end
 
       it "displays a column for order date" do
-        expect(page).to have_selector "th.date", text: "ORDER DATE", :visible => true
-        expect(page).to have_selector "td.date", text: o1.completed_at.strftime('%B %d, %Y'), :visible => true
-        expect(page).to have_selector "td.date", text: o2.completed_at.strftime('%B %d, %Y'), :visible => true
+        expect(page).to have_selector "th.date", text: I18n.t("admin.orders.bulk_management.order_date").upcase, visible: true
+        expect(page).to have_selector "td.date", text: o1.completed_at.strftime('%B %d, %Y'), visible: true
+        expect(page).to have_selector "td.date", text: o2.completed_at.strftime('%B %d, %Y'), visible: true
       end
 
       it "displays a column for producer" do
@@ -240,7 +240,7 @@ feature %q{
         visit '/admin/orders/bulk_management'
 
         expect(page).to have_selector "th", :text => "NAME"
-        expect(page).to have_selector "th", :text => "ORDER DATE"
+        expect(page).to have_selector "th", text: I18n.t("admin.orders.bulk_management.order_date").upcase
         expect(page).to have_selector "th", :text => "PRODUCER"
         expect(page).to have_selector "th", :text => "PRODUCT: UNIT"
         expect(page).to have_selector "th", :text => "QUANTITY"
@@ -252,7 +252,7 @@ feature %q{
 
         expect(page).to have_no_selector "th", :text => "PRODUCER"
         expect(page).to have_selector "th", :text => "NAME"
-        expect(page).to have_selector "th", :text => "ORDER DATE"
+        expect(page).to have_selector "th", text: I18n.t("admin.orders.bulk_management.order_date").upcase
         expect(page).to have_selector "th", :text => "PRODUCT: UNIT"
         expect(page).to have_selector "th", :text => "QUANTITY"
         expect(page).to have_selector "th", :text => "MAX"

--- a/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
@@ -30,6 +30,13 @@ describe "ordersCtrl", ->
       expect(Orders.index).toHaveBeenCalled()
       expect($scope.orders).toEqual orders
 
+    it "fetches them sorted by completed_at by default", ->
+      $scope.initialise()
+      expect(Orders.index).toHaveBeenCalledWith(jasmine.objectContaining({
+        'q[s]': 'completed_at desc'
+      }))
+
+
   describe "using pagination", ->
     it "changes the page", ->
       $scope.changePage(2)


### PR DESCRIPTION
#### What? Why?

Closes #3045.

As agreed in the issue, I changed the orders page to use `completed_at` instead of `created_at`. As a result, that same page now shows `COMPLETED AT` in the table header instead of `ORDER DATE`. 

To make things consistent I also change BOM page to also show `COMPLETED AT`.

As we are now using always `completed_at` when "ONLY SHOW COMPLETE ORDERS" is not checked we show the following:

![screenshot from 2018-11-15 16-04-31](https://user-images.githubusercontent.com/762088/48561437-3b54ac00-e8f0-11e8-9103-2c89d6a489fe.png)

IMO this clearly conveys the order is not yet finished. There's little value on showing the creation date even in this case.

#### What should we test?

The ordering in `/admin/orders` and `/admin/orders/bulk_management` pages involving the following cases (at least):

* An order that got created in the past, while an old OC was open, but completed now
* An order that got created now, in the current OC, and also completed now

Also using the "ONLY SHOW COMPLETE ORDERS" checbox:

* An order in cart state (the one that gets created after completing an order)


#### Release notes

Orders now display their completion date in the admin section so that orders started long ago are listed together with the orders of the same order cycle.

Changelog Category: Fixed

