### PR TITLE
[Spree Upgrade] Fix order spec restart checkout test and orders controller enterprise with fees test

### DIFF
--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -214,7 +214,7 @@ describe Spree::OrdersController, type: :controller do
       let(:enterprise_fee) { create(:enterprise_fee, calculator: build(:calculator_per_item) ) }
       let!(:exchange) { create(:exchange, incoming: true, sender: variant.product.supplier, receiver: order_cycle.coordinator, variants: [variant], enterprise_fees: [enterprise_fee]) }
       let!(:order) do
-        order = create(:completed_order_with_totals, user: user, distributor: distributor, order_cycle: order_cycle)
+        order = create(:completed_order_with_totals, line_items_count: 1, user: user, distributor: distributor, order_cycle: order_cycle)
         order.reload.line_items.first.update_attributes(variant_id: variant.id)
         while !order.completed? do break unless order.next! end
         order.update_distribution_charge!

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -821,7 +821,7 @@ describe Spree::Order do
   end
 
   describe '#restart_checkout!' do
-    let(:order) { build(:order) }
+    let(:order) { build(:order, line_items: [build(:line_item)]) }
 
     context 'when the order is complete' do
       before { order.completed_at = Time.zone.now }


### PR DESCRIPTION
In order spec, add a required line_item to the order being tested.
In orders_controller spec, set order line items count to 1 (the default in spree 2 order factory is 5).

#### What? Why?

Related to #2685 

#### What should we test?
Errors should be gone:
```
  15) Spree::Order#restart_checkout! when the is not complete transitions to :cart state
      Failure/Error: order.restart_checkout!
      
      StateMachine::InvalidTransition:
        Cannot transition state via :restart_checkout from :cart (Reason(s): There are no items for this order. Please add an item to the order to continue.)
      # ./spec/models/spree/order_spec.rb:839:in `block (4 levels) in <top (required)>'
```
and
```
  33) Spree::OrdersController removing items from a completed order with enterprise fees updates the fees
      Failure/Error: expect(order.reload.adjustment_total).to eq enterprise_fee.calculator.preferred_amount
      
        expected: 1.0 (#<BigDecimal:5618f0f6dd58,'0.1E1',9(18)>)
             got: 5.0 (#<BigDecimal:5618f0f782d0,'0.5E1',9(18)>)
      
        (compared using ==)
      # ./spec/controllers/spree/orders_controller_spec.rb:238:in `block (4 levels) in <top (required)>'

```

I just double checked the build and these errors are gone.