### PR TITLE
Fix bug on calculator_decorator line_items_for where input is line_item with a nil order

### DIFF
--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -12,19 +12,5 @@ module Calculator
       total_weight = line_items.sum { |li| ((li.variant.andand.weight || 0) * li.quantity) }
       total_weight * preferred_per_kg
     end
-
-    private
-
-    def line_items_for(object)
-      if object.respond_to? :order
-        object.order.line_items
-      elsif object.respond_to? :line_items
-        object.line_items
-      elsif object.respond_to?(:variant) && object.respond_to?(:quantity)
-        [object]
-      else
-        raise "Unknown object type: #{object.inspect}"
-      end
-    end
   end
 end

--- a/app/models/spree/calculator_decorator.rb
+++ b/app/models/spree/calculator_decorator.rb
@@ -1,18 +1,20 @@
 module Spree
   Calculator.class_eval do
 
-
     private
 
     # Given an object which might be an Order or a LineItem (amongst
     # others), return a collection of line items.
     def line_items_for(object)
-      if object.respond_to? :line_items
+      if object.is_a?(Spree::LineItem)
+        [object]
+      elsif object.respond_to? :line_items
         object.line_items
+      elsif object.order.present?
+        object.order.line_items
       else
         [object]
       end
     end
-
   end
 end

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -10,10 +10,10 @@ feature "full-page cart", js: true do
     let!(:zone) { create(:zone_with_member) }
     let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
     let(:supplier) { create(:supplier_enterprise) }
-    let!(:order_cycle) { create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor], coordinator: create(:distributor_enterprise), variants: [product_tax.variants.first, product_fee.variants.first]) }
-    let(:enterprise_fee) { create(:enterprise_fee, amount: 11.00, tax_category: product_tax.tax_category) }
-    let(:product_tax) { create(:taxed_product, supplier: supplier, zone: zone, price: 110.00, tax_rate_amount: 0.1) }
-    let(:product_fee) { create(:simple_product, supplier: supplier, price: 0.86, on_hand: 100) }
+    let!(:order_cycle) { create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor], coordinator: create(:distributor_enterprise), variants: [product_with_tax.variants.first, product_with_fee.variants.first]) }
+    let(:enterprise_fee) { create(:enterprise_fee, amount: 11.00, tax_category: product_with_tax.tax_category) }
+    let(:product_with_tax) { create(:taxed_product, supplier: supplier, zone: zone, price: 110.00, tax_rate_amount: 0.1) }
+    let(:product_with_fee) { create(:simple_product, supplier: supplier, price: 0.86, on_hand: 100) }
     let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor) }
 
     before do
@@ -22,7 +22,7 @@ feature "full-page cart", js: true do
 
     describe "product description" do
       it "does not link to the product page" do
-        add_product_to_cart order, product_fee, quantity: 2
+        add_product_to_cart order, product_with_fee, quantity: 2
         visit spree.cart_path
         expect(page).to have_no_selector '.item-thumb-image a'
       end
@@ -33,7 +33,7 @@ feature "full-page cart", js: true do
 
       before do
         add_enterprise_fee percentage_fee
-        add_product_to_cart order, product_fee, quantity: 8
+        add_product_to_cart order, product_with_fee, quantity: 8
         visit spree.cart_path
       end
 
@@ -54,7 +54,7 @@ feature "full-page cart", js: true do
 
         before do
           add_enterprise_fee handling_fee
-          add_product_to_cart order, product_fee, quantity: 3
+          add_product_to_cart order, product_with_fee, quantity: 3
           visit spree.cart_path
         end
 
@@ -70,7 +70,7 @@ feature "full-page cart", js: true do
 
       context "when there are no admin and handling fees" do
         before do
-          add_product_to_cart order, product_fee, quantity: 2
+          add_product_to_cart order, product_with_fee, quantity: 2
           visit spree.cart_path
         end
 
@@ -89,13 +89,13 @@ feature "full-page cart", js: true do
           enterprise: order_cycle.coordinator, fee_type: 'admin') }
 
         before do
-          product_fee.variants.first.update_attributes(unit_value: '2000.0')
-          product_tax.variants.first.update_attributes(unit_value: '5000.0')
+          product_with_fee.variants.first.update_attributes(unit_value: '2000.0')
+          product_with_tax.variants.first.update_attributes(unit_value: '5000.0')
 
           add_enterprise_fee admin_fee
 
           cart_service = CartService.new(order)
-          cart_service.populate(variants: { product_fee.variants.first.id => 3, product_tax.variants.first.id => 3 })
+          cart_service.populate(variants: { product_with_fee.variants.first.id => 3, product_with_tax.variants.first.id => 3 })
           order.update_distribution_charge!
 
           visit spree.cart_path
@@ -103,8 +103,8 @@ feature "full-page cart", js: true do
 
         it "shows the correct weight calculations" do
           expect(page).to have_selector('#cart-detail')
-          expect(page).to have_selector '.cart-item-price',                 text: with_currency(2.86) # price + 1 * 2kg
-          expect(page).to have_selector '.cart-item-price',                 text: with_currency(115.0) # price + 1 * 5kg
+          expect(page).to have_selector '.cart-item-price',                 text: with_currency(2.86) # price + (1eur * 2kg)
+          expect(page).to have_selector '.cart-item-price',                 text: with_currency(115.0) # price + (1eur * 5kg)
           expect(page).to have_selector '.order-total.grand-total',         text: with_currency(353.58) # above * 3 items
         end
       end
@@ -113,7 +113,7 @@ feature "full-page cart", js: true do
     describe "tax" do
       before do
         add_enterprise_fee enterprise_fee
-        add_product_to_cart order, product_tax
+        add_product_to_cart order, product_with_tax
         visit spree.cart_path
       end
 
@@ -124,10 +124,10 @@ feature "full-page cart", js: true do
 
     describe "updating quantities with insufficient stock available" do
       let(:li) { order.line_items(true).last }
-      let(:variant) { product_tax.variants.first }
+      let(:variant) { product_with_tax.variants.first }
 
       before do
-        add_product_to_cart order, product_tax
+        add_product_to_cart order, product_with_tax
       end
 
       around do |example|
@@ -173,7 +173,7 @@ feature "full-page cart", js: true do
         order.save
         order.distributor.allow_order_changes = true
         order.distributor.save
-        add_product_to_cart order, product_tax
+        add_product_to_cart order, product_with_tax
         quick_login_as user
         visit spree.cart_path
       end

--- a/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_fee_calculator_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'open_food_network/enterprise_fee_calculator'
 
 module OpenFoodNetwork

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Calculator::Weight do
   it "computes shipping cost for an order by total weight" do
-    variant1 = double(:variant, weight: 10)
-    variant2 = double(:variant, weight: 20)
-    variant3 = double(:variant, weight: nil)
+    variant1 = build(:variant, weight: 10)
+    variant2 = build(:variant, weight: 20)
+    variant3 = build(:variant, weight: nil)
 
-    line_item1 = double(:line_item, variant: variant1, quantity: 1)
-    line_item2 = double(:line_item, variant: variant2, quantity: 3)
-    line_item3 = double(:line_item, variant: variant3, quantity: 5)
+    line_item1 = build(:line_item, variant: variant1, quantity: 1)
+    line_item2 = build(:line_item, variant: variant2, quantity: 3)
+    line_item3 = build(:line_item, variant: variant3, quantity: 5)
 
     order = double(:order, line_items: [line_item1, line_item2, line_item3])
 
@@ -17,20 +17,20 @@ describe Calculator::Weight do
   end
 
   it "computes shipping cost for a line item" do
-    variant = double(:variant, weight: 10)
+    variant = build(:variant, weight: 10)
 
-    line_item = double(:line_item, variant: variant, quantity: 2)
+    line_item = build(:line_item, variant: variant, quantity: 2)
 
     subject.set_preference(:per_kg, 10)
     expect(subject.compute(line_item)).to eq(10 * 2 * 10)
   end
 
   it "computes shipping cost for an object with an order" do
-    variant1 = double(:variant, weight: 10)
-    variant2 = double(:variant, weight: 5)
+    variant1 = build(:variant, weight: 10)
+    variant2 = build(:variant, weight: 5)
 
-    line_item1 = double(:line_item, variant: variant1, quantity: 1)
-    line_item2 = double(:line_item, variant: variant2, quantity: 2)
+    line_item1 = build(:line_item, variant: variant1, quantity: 1)
+    line_item2 = build(:line_item, variant: variant2, quantity: 2)
 
     order = double(:order, line_items: [line_item1, line_item2])
     object_with_order = double(:object_with_order, order: order)

--- a/spec/models/spree/calculator/flat_percent_item_total_spec.rb
+++ b/spec/models/spree/calculator/flat_percent_item_total_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::Calculator::FlatPercentItemTotal do
   let(:calculator) { Spree::Calculator::FlatPercentItemTotal.new }
-  let(:line_item) { instance_double(Spree::LineItem, amount: 10) }
+  let(:line_item) { build(:line_item, price: 10, quantity: 1) }
 
   before { calculator.stub :preferred_flat_percent => 10 }
 

--- a/spec/models/spree/calculator/flexi_rate_spec.rb
+++ b/spec/models/spree/calculator/flexi_rate_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Calculator::FlexiRate do
-  let(:line_item) { instance_double(Spree::LineItem, amount: 10, quantity: quantity) }
+  let(:line_item) { build(:line_item, quantity: quantity) }
   let(:calculator) do
     Spree::Calculator::FlexiRate.new(
       preferred_first_item: 2,

--- a/spec/models/spree/calculator/per_item_spec.rb
+++ b/spec/models/spree/calculator/per_item_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Calculator::PerItem do
   let(:calculator) { Spree::Calculator::PerItem.new(preferred_amount: 10) }
   let(:shipping_calculable) { double(:calculable) }
-  let(:line_item) { double(:line_item, quantity: 5, product: double(:product)) }
+  let(:line_item) { build(:line_item, quantity: 5) }
 
   it "correctly calculates on a single line item object" do
     calculator.stub(calculable: shipping_calculable)


### PR DESCRIPTION
#### What? Why?

Take 2 on weight calculator (#2932), this time for a more fundamental change (remove line_items_for method all together).

The specific issue we address in the calculator is that the passed "object" could be a line_item that would "respond? :order" but with a nil order. In this case, the option to return [line_item] is the correct option.

#### What should we test?

Functional: we changed the way calculators work internally so we need to review all the points where calculators are used, not just weight. We need to review shipping fees, enterprise fees, and weight line items. I dont think it's possible these changes will break the calculations (the numbers), if something is wrong, things will just not work, no fees calculated, for example.

Tech: there could be a class loading issue with this PR, we need to watch in staging if there are any class loading error messages.

Specs: All specs related to calculators are green in the 2-0 branch. Fixes tests in spree upgrade issue #3025

#### Release Notes
Changelog Category: Fixed
Fixed bug in fees calculated based on weight. Bug introduced in previous release (#3072). This bug was applicable to orders with multiple line items with weight in order cycles with enterprise fees that use a weight calculator (this was validated in live environments and we didn't detect any case where this was applicable)