### PR TITLE
[Spree Upgrade] Fix missing translation in User transaction history

### DIFF
--- a/app/views/spree/users/_fat.html.haml
+++ b/app/views/spree/users/_fat.html.haml
@@ -22,7 +22,7 @@
           %td.order7
         %tr.order-row
           %td.order1
-            %a{"ng-href" => "{{::order.path}}", "ng-bind" => "::('order' | t )+ ' ' + order.number"}
+            %a{"ng-href" => "{{::order.path}}", "ng-bind" => "::('js.spree.users.order' | t )+ ' ' + order.number"}
           %td.order2{"ng-bind" => "::order.completed_at"}
           %td.order3.show-for-large-up{"ng-bind" => "::'spree.payment_states.' + order.payment_state | t | capitalize"}
           %td.order4.show-for-large-up{"ng-bind" => "::'spree.shipment_states.' + order.shipment_state | t | capitalize"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2643,6 +2643,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       closes: closes
       closed: closed
       close_date_not_set: Close date not set
+    spree:
+      users:
+        order: "Order"
   producers:
     signup:
       start_free_profile: "Start with a free profile, and expand when you're ready!"


### PR DESCRIPTION
#### What? Why?

Fix this spree upgrade build spec:
spec/features/consumer/account_spec.rb:36

```
 26) 
    As a consumer
    I want to view my order history with each hub
    and view any outstanding balance.
 as a logged in user with completed orders shows all hubs that have been ordered from with balance or credit
      Failure/Error: expect(page).to have_link "Order " + d1o1.number, href:"/orders/#{d1o1.number}"
        expected to find visible link "Order R378065461" but there were no matches
      # ./spec/features/consumer/account_spec.rb:69:in `block (4 levels) in <top (required)>'

```
I could have just added "order" on the root level of en.yml but here I follow the best practice:
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29#javascript-translations-put-translation-key-under-the-js-namespace

#### What should we test?
Spec should be green.
I have double checked and this spec is green on this PR's build.