### PR TITLE
[Spree Upgrade] Fix translation issue in settings spec

### DIFF
--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -30,7 +30,7 @@ feature "Account Settings", js: true do
       sent_mail = ActionMailer::Base.deliveries.last
       expect(sent_mail.to).to eq ['new@email.com']
 
-      expect(find(".alert-box.success").text.strip).to eq "#{I18n.t(:account_updated)} ×"
+      expect(find(".alert-box.success").text.strip).to eq "#{I18n.t('spree.account_updated')} ×"
       user.reload
       expect(user.email).to eq 'old@email.com'
       expect(user.unconfirmed_email).to eq 'new@email.com'
@@ -45,7 +45,7 @@ feature "Account Settings", js: true do
       fill_in 'user_password_confirmation', with: 'NewPassword'
 
       click_button I18n.t(:update)
-      expect(find(".alert-box.success").text.strip).to eq "#{I18n.t(:account_updated)} ×"
+      expect(find(".alert-box.success").text.strip).to eq "#{I18n.t('spree.account_updated')} ×"
 
       expect(user.reload.encrypted_password).to_not eq initial_password
     end


### PR DESCRIPTION
Fix this spec in the spree upgrade build:
```
 64) Account Settings as a logged in user allows the user to change their password
      Failure/Error: expect(find(".alert-box.success").text.strip).to eq "#{I18n.t(:account_updated)} ×"
      
        expected: "translation missing: en.account_updated ×"
             got: "Account updated! ×"
      
        (compared using ==)
      # ./spec/features/consumer/account/settings_spec.rb:48:in `block (3 levels) in <top (required)>'
```

Devise uses Spree.t so we need to use spree namespace here.

#### What should we test?
Referred spec should be green.
