### PR TITLE
Pi/french issue

### DIFF
--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -100,7 +100,8 @@ module ProductImport
         entries[entry.line_number] = {
           attributes: entry.displayable_attributes,
           validates_as: entry.validates_as,
-          errors: entry.invalid_attributes
+          errors: entry.invalid_attributes,
+          product_validations: entry.product_validations
         }
       end
       entries.to_json

--- a/app/views/admin/product_import/_errors_list.html.haml
+++ b/app/views/admin/product_import/_errors_list.html.haml
@@ -7,3 +7,5 @@
       ( {{entry.attributes.display_name}} )
   %p.error{ng: {repeat: "(attribute, error) in entry.errors", show: "ignore_fields.indexOf(attribute) < 0" }}
     &nbsp;-&nbsp; {{error}}
+  %p.error{ng: {repeat: "(attribute, error) in entry.product_validations"}}
+    &nbsp;-&nbsp; {{error}}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2395,6 +2395,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   validation_msg_relationship_already_established: "^That relationship is already established."
   validation_msg_at_least_one_hub: "^At least one hub must be selected"
   validation_msg_product_category_cant_be_blank: "^Product Category cant be blank"
+  validation_msg_tax: "^Tax Category is required"
   validation_msg_tax_category_cant_be_blank: "^Tax Category can't be blank"
   validation_msg_is_associated_with_an_exising_customer: "is associated with an existing customer"
   content_configuration_pricing_table: "(TODO: Pricing table)"


### PR DESCRIPTION
#### What? Why?

Closes #2951

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

An instance configuration on French production was causing unexpected product validation messages when creating a new product. This setting was forcing all products to require a tax_category to be set, and added an extra validation error into product objects at an unexpected point in the import process.

#### What should we test?
<!-- List which features should be tested and how. -->

Importing products from CSV on an instance with this checkbox checked in the config:
![screenshot from 2018-11-18 20-31-40](https://user-images.githubusercontent.com/9029026/48677853-1328af80-eb73-11e8-942f-c892b8d914b7.png)
should show an error message if there is no tax_category set in the CSV file.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed tax category validations in product import for instances that enforce mandatory tax categories.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

