### PR TITLE
[Spree Upgrade] Fix features/admin/enterprise_groups_spec by replacing select2_search with select2_select

### DIFF
--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -40,8 +40,8 @@ feature %q{
     fill_in 'enterprise_group_address_attributes_address1', with: 'My Street'
     fill_in 'enterprise_group_address_attributes_city', with: 'Block'
     fill_in 'enterprise_group_address_attributes_zipcode', with: '0000'
-    select2_search 'Australia', :from => 'Country'
-    select2_search 'Victoria', :from => 'State'
+    select2_select 'Australia', :from => 'enterprise_group_address_attributes_country_id'
+    select2_select 'Victoria', :from => 'enterprise_group_address_attributes_state_id'
     click_button 'Create'
 
     page.should have_content 'Enterprise group "EGEGEG" has been successfully created!'


### PR DESCRIPTION
Replacing select2_search with select2_select for country and state in enterprise group address.

Fix spec/features/admin/enterprise_groups_spec error:
```
 16) 
    As an administrator
    I want to manage enterprise groups
 creating a new enterprise group
      Failure/Error: select2_search 'Australia', :from => 'Country'
      
      Capybara::ElementNotFound:
        Unable to find visible css ".select2-container" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/DIV[1]/DIV[1]/DIV[2]/DIV[1]/DIV[1]/DIV[1]/FORM[1]/DIV[2]/DIV[1]/DIV[3]/FIELDSET[5]/DIV[6]/DIV[1]">
      # ./spec/features/admin/enterprise_groups_spec.rb:43:in `block (2 levels) in <top (required)>'
```

Some issue with select2 search, I have used the same solution as in #2760, avoiding search and just selecting.
