### PR TITLE
Remove all database.travis.yml

### DIFF
--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,4 +1,0 @@
-test:
-  adapter: postgresql
-  database: open_food_network_test
-  username: postgres


### PR DESCRIPTION
#### What? Why?

We no longer use this file since we started with Semaphore CI.


#### What should we test?

No change on behavior.


#### Release notes
Removed old and unused database configuration for Travis CI.

Changelog Category: Removed
