### PR TITLE
Run RSpec tests in custom engines (and some fixes, cleanup)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ addons:
 
 # Set the timezone for phantomjs with TZ
 # Set the timezone for karma with TIMEZONE
-#
-# The test cases are roughly split according to their test times.
-# It would be better to use https://github.com/ArturT/knapsack.
 env:
   global:
     - TZ="Australia/Melbourne"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - CI_NODE_INDEX=0
     - CI_NODE_INDEX=1
     - CI_NODE_INDEX=2
-    - CI_NODE_INDEX=3
+    - CI_NODE_INDEX=3 RSPEC_ENGINES="true"
     - CI_NODE_INDEX=4 KARMA="true" GITHUB_DEPLOY="true"
 
 before_script:
@@ -39,6 +39,7 @@ before_script:
 
 script:
   - 'if [ "$KARMA" = "true" ]; then bundle exec rake karma:run; else echo "Skipping karma run"; fi'
+  - 'if [ "$RSPEC_ENGINES" = "true" ]; then bundle exec rake openfoodnetwork:specs:engines:rspec; else echo "Skipping RSpec run in engines"; fi'
   - "bundle exec rake 'knapsack:rspec[--format progress --tag ~performance]'"
 
 after_success:

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -69,9 +69,13 @@ Tests, both unit and integration, are based on RSpec. To run the test suite, fir
 
     bundle exec rake db:test:prepare
 
-Then the tests can be run with:
+Then the main application tests can be run with:
 
     bundle exec rspec spec
+
+The tests of all custom engines can be run with:
+
+    bundle exec rake openfoodnetwork:specs:engines:rspec
 
 Note: If your OS is not explicitly supported in the setup guides then not all tests may pass. However, you may still be able to develop. Get in touch with the [#dev][slack-dev] channel on Slack to troubleshoot issues and determine if they will preclude you from contributing to OFN.
 

--- a/engines/web/spec/spec_helper.rb
+++ b/engines/web/spec/spec_helper.rb
@@ -1,8 +1,3 @@
-ENV["RAILS_ENV"] = "test"
-
-require File.expand_path("dummy/config/environment.rb", __dir__)
-require "rails/test_help"
-
-Rails.backtrace_cleaner.remove_silencers!
+require "../../spec/spec_helper.rb"
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/lib/tasks/specs.rake
+++ b/lib/tasks/specs.rake
@@ -10,7 +10,7 @@ namespace :openfoodnetwork do
       end
 
       def execute_rspec_for_engine(engine_path)
-        system "cd #{engine_path.expand_path} && bundle exec rspec"
+        system "cd #{engine_path.expand_path} && DISABLE_KNAPSACK=true bundle exec rspec"
       end
 
       engine_paths = detect_engine_paths

--- a/lib/tasks/specs.rake
+++ b/lib/tasks/specs.rake
@@ -25,6 +25,20 @@ namespace :openfoodnetwork do
           end
         end
       end
+
+      namespace :all do
+        task :rspec do
+          success = true
+
+          engine_paths.each do |engine_path|
+            success = !!execute_rspec_for_engine(engine_path) && success
+          end
+
+          abort "Failure encountered when running tests for engines" unless success
+        end
+      end
+
+      task rspec: "all:rspec"
     end
   end
 end

--- a/lib/tasks/specs.rake
+++ b/lib/tasks/specs.rake
@@ -19,6 +19,7 @@ namespace :openfoodnetwork do
         engine_name = engine_name_for_engine(engine_path)
 
         namespace engine_name do
+          desc "Run RSpec tests for engine \"#{engine_name}\""
           task :rspec do
             success = execute_rspec_for_engine(engine_path)
             abort "Failure when running tests for engine \"#{engine_name}\"" unless success
@@ -27,6 +28,7 @@ namespace :openfoodnetwork do
       end
 
       namespace :all do
+        desc "Run RSpec tests for all engines"
         task :rspec do
           success = true
 
@@ -38,6 +40,7 @@ namespace :openfoodnetwork do
         end
       end
 
+      desc "Alias for openfoodnetwork:specs:engines:all:rspec"
       task rspec: "all:rspec"
     end
   end

--- a/lib/tasks/specs.rake
+++ b/lib/tasks/specs.rake
@@ -1,0 +1,30 @@
+namespace :openfoodnetwork do
+  namespace :specs do
+    namespace :engines do
+      def detect_engine_paths
+        Pathname("engines/").children.select(&:directory?)
+      end
+
+      def engine_name_for_engine(engine_path)
+        engine_path.basename.to_path
+      end
+
+      def execute_rspec_for_engine(engine_path)
+        system "cd #{engine_path.expand_path} && bundle exec rspec"
+      end
+
+      engine_paths = detect_engine_paths
+
+      engine_paths.each do |engine_path|
+        engine_name = engine_name_for_engine(engine_path)
+
+        namespace engine_name do
+          task :rspec do
+            success = execute_rspec_for_engine(engine_path)
+            abort "Failure when running tests for engine \"#{engine_name}\"" unless success
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,13 @@ require 'rubygems'
 # Require pry when we're not inside Travis-CI
 require 'pry' unless ENV['CI']
 
-require 'knapsack'
-Knapsack.tracker.config({enable_time_offset_warning: false}) unless ENV['CI']
-Knapsack::Adapters::RSpecAdapter.bind
+# This spec_helper.rb is being used by the custom engines in engines/. The engines are not set up to
+# use Knapsack, and this provides the option to disable it when running the tests in CI services.
+unless ENV['DISABLE_KNAPSACK']
+  require 'knapsack'
+  Knapsack.tracker.config({enable_time_offset_warning: false}) unless ENV['CI']
+  Knapsack::Adapters::RSpecAdapter.bind
+end
 
 ENV["RAILS_ENV"] ||= 'test'
 require_relative "../config/environment"


### PR DESCRIPTION
#### What? Why?

Closes #3085 

RSpec tests of the engine "web" are not being run by the commands we use.

This PR includes the following changes:

1. Allow tests in "web" engine to be run separately. Using the main app's `spec_helper.rb` for now, while we are still slowly moving to Rails engines.
2. Add Rake task `openfoodnetwork:specs:engines:rspec` to run RSpec tests for all engines.
3. Add Rake tasks `openfoodnetwork:specs:engines:ENGINE_NAME:rspec` to run RSpec tests of a specific engine.

For your reference, here are Semaphore builds which already run the engine tests on my fork:

- `cleanup-test_scripts` - https://semaphoreci.com/kristinalim/openfoodnetwork/branches/cleanup-test_scripts/builds/14
- `cleanup-test_scripts-failure` which adds a failing engine test - https://semaphoreci.com/kristinalim/openfoodnetwork/branches/cleanup-test_scripts-failure/builds/5

#### What should we test?

Only for developers:

1. Introduce a failing test in `engines/web/spec/`.
2. The failure should reflect in Semaphore.

The `.travis.yml` configuration file currently [does not build successfully](https://github.com/openfoodfoundation/openfoodnetwork/pull/3082#pullrequestreview-176609809).

#### Release notes

- Allow tests in "web" engine to be run with `bundle exec rspec` from the engine path.
- Add Rake task `openfoodnetwork:specs:engines:rspec` to run RSpec tests for all engines.
- Add Rake tasks `openfoodnetwork:specs:engines:ENGINE_NAME:rspec` to run RSpec tests of a specific engine.

Changelog Category: Fixed

#### Documentation updates

1. [Continuous Integration](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Continuous-Integration) - One of the jobs should be updated to run the Rake task `openfoodnetwork:specs:engines:rspec`.

#### After merge

1. Communicate this in `#dev` Slack channel.
2. Update project settings in Semaphore official account to run the Rake task `openfoodnetwork:specs:engines:rspec`.