### PR TITLE
[Headless Chrome] Make embedded_shopfronts_spec work with selenium

### DIFF
--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -78,12 +78,12 @@ feature "Using embedded shopfront functionality", js: true do
 
         toggle_shipping
         within "#shipping" do
-          find('input[type="radio"]').trigger 'click'
+          find('input[type="radio"]').click
         end
 
         toggle_payment
         within "#payment" do
-          find('input[type="radio"]').trigger 'click'
+          find('input[type="radio"]').click
         end
 
         place_order


### PR DESCRIPTION
#### What? Why?

Fixes 1 of 10 broken tests in #2469 

#### What should we test?
spec/features/consumer/shopping/embedded_shopfronts_spec.rb should be green now.
