### PR TITLE
[Headless Chrome] Make subscriptions spec and shop_workflow work with selenium

### DIFF
--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -70,7 +70,7 @@ feature 'Subscriptions' do
         # Viewing Products
         within "tr#so_#{subscription.id}" do
           expect(page).to have_selector "td.items.panel-toggle", text: 3
-          page.find("td.items.panel-toggle").trigger('click')
+          page.find("td.items.panel-toggle").click
         end
 
         within "#subscription-line-items" do

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -25,7 +25,7 @@ module ShopWorkflow
   end
 
   def toggle_accordion(name)
-    find("dd a", text: name).trigger "click"
+    find("dd a", text: name).click
   end
 
   def add_variant_to_order_cycle(exchange, variant)

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -105,10 +105,6 @@ module WebHelper
     click_link 'redirected' if response.status == 302
   end
 
-  def trigger_manual_event(field_selector, event = 'change')
-    page.execute_script("$('#{field_selector}').trigger('#{event}');")
-  end
-
   def dirty_form_dialog
     DirtyFormDialog.new(page)
   end


### PR DESCRIPTION
What? Why?

Fixes 1 of 10 broken tests in #2469

I thought the change on shop_workflow would fix spec/features/consumer/shopping/checkout_spec.rb:149
but it doesnt, must be some other problem. I am leaving the change in shop_workflow has it removes all occurrences of .trigger.

What should we test?
This spec should be green:
spec/features/admin/subscriptions_spec.rb:27