### PR TITLE
Fixed Factory warning while running tests

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -296,7 +296,7 @@ FactoryBot.define do
   end
 
   factory :order_with_taxes, parent: :completed_order_with_totals do
-    ignore do
+    transient do
       product_price 0
       tax_rate_amount 0
       tax_rate_name ""


### PR DESCRIPTION
#### What? Why?

Fixing this DEPRECATION WARNING while running the tests.

<img width="973" alt="screen shot 2018-11-20 at 18 31 42" src="https://user-images.githubusercontent.com/935744/48794730-b2c07c00-ecf2-11e8-9091-29fc065fb6a5.png">

#### What should we test?

Nothing. Tests should pass.

#### Release notes
Fixed Factory deprecation warning while running the tests.

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security