### PR TITLE
In admin/users, convert Spree.t calls to t calls and use lazy lookup

### DIFF
--- a/app/views/spree/admin/users/_form.html.haml
+++ b/app/views/spree/admin/users/_form.html.haml
@@ -1,11 +1,11 @@
 .row
   .alpha.five.columns
     = f.field_container :email do
-      = f.label :email, Spree.t(:email)
+      = f.label :email, t(".email")
       = f.email_field :email, class: "fullwidth"
       = error_message_on :user, :email
     .field
-      = label_tag nil, Spree.t(:roles)
+      = label_tag nil, t(".roles")
       %ul
         - @roles.each do |role|
           %li
@@ -13,14 +13,14 @@
             = label_tag role.name
       = hidden_field_tag "user[spree_role_ids][]", ""
     = f.field_container :enterprise_limit do
-      = f.label :enterprise_limit, t(:enterprise_limit)
+      = f.label :enterprise_limit, t(".enterprise_limit")
       = f.text_field :enterprise_limit, class: "fullwidth"
   .omega.five.columns
     = f.field_container :password do
-      = f.label :password, Spree.t(:password)
+      = f.label :password, t(".password")
       = f.password_field :password, class: "fullwidth"
       = f.error_message_on :password
     = f.field_container :password do
-      = f.label :password_confirmation, Spree.t(:confirm_password)
+      = f.label :password_confirmation, t(".confirm_password")
       = f.password_field :password_confirmation, class: "fullwidth"
       = f.error_message_on :password_confirmation

--- a/app/views/spree/admin/users/edit.html.haml
+++ b/app/views/spree/admin/users/edit.html.haml
@@ -1,10 +1,10 @@
 - content_for :page_title do
-  = Spree.t(:editing_user)
+  = t(".editing_user")
 - content_for :page_actions do
   %li
-    = button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, icon: "icon-arrow-left"
+    = button_link_to t(".back_to_users_list"), spree.admin_users_path, icon: "icon-arrow-left"
 %fieldset.alpha.ten.columns{"data-hook" => "admin_user_edit_general_settings"}
-  %legend= Spree.t(:general_settings)
+  %legend= t(".general_settings")
   %div{"data-hook" => "admin_user_edit_form_header"}
     = render partial: "spree/shared/error_messages", locals: { target: @user }
   %div{"data-hook" => "admin_user_edit_form"}

--- a/app/views/spree/admin/users/index.html.haml
+++ b/app/views/spree/admin/users/index.html.haml
@@ -1,8 +1,8 @@
 - content_for :page_title do
-  = Spree.t(:listing_users)
+  = t(".listing_users")
 - content_for :page_actions do
   %li
-    = button_link_to Spree.t(:new_user), new_object_url, icon: "icon-plus", id: "admin_new_user_link"
+    = button_link_to t(".new_user"), new_object_url, icon: "icon-plus", id: "admin_new_user_link"
 
 = render "admin/shared/users_sub_menu"
 
@@ -13,8 +13,8 @@
     %col{ style: "width: 15%" }
   %thead
     %tr
-      %th= sort_link @search,:email, Spree.t(:user), {}, {title: "users_email_title"}
-      %th= sort_link @search,:enterprise_limit, t(:enterprise_limit)
+      %th= sort_link @search,:email, t(".user"), {}, {title: "users_email_title"}
+      %th= sort_link @search,:enterprise_limit, t(".enterprise_limit")
       %th.actions
   %tbody
     - @users.each do |user|
@@ -28,13 +28,13 @@
           = link_to_delete user, no_text: true
 = paginate @users
 - content_for :sidebar_title do
-  = Spree.t(:search)
+  = t(".search")
 - content_for :sidebar do
   .box.align-center
     = search_form_for [:admin, @search] do |f|
       .field
-        = f.label Spree.t(:email)
+        = f.label t(".email")
         %br
         = f.text_field :email_cont, class: "fullwidth"
       %div
-        = button Spree.t(:search), "icon-search"
+        = button t(".search"), "icon-search"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,7 +209,6 @@ en:
   distributors: Distributors
   distribution: Distribution
   order_cycles: Order Cycles
-  enterprise_limit: Enterprise Limit
   bulk_order_management: Bulk Order Management
   enterprises: Enterprises
   enterprise_groups: Groups
@@ -1939,7 +1938,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   enterprise_long_desc: "Long Description"
   enterprise_long_desc_placeholder: "This is your opportunity to tell the story of your enterprise - what makes you different and wonderful? We'd suggest keeping your description to under 600 characters or 150 words."
   enterprise_long_desc_length: "%{num} characters / up to 600 recommended"
-  enterprise_limit: Enterprise Limit
   enterprise_abn: "ABN"
   enterprise_abn_placeholder: "eg. 99 123 456 789"
   enterprise_acn: "ACN"
@@ -2755,6 +2753,23 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           bulk_coop_packing_sheets: 'Bulk Co-op - Packing Sheets'
           bulk_coop_customer_payments: 'Bulk Co-op - Customer Payments'
       users:
+        index:
+          listing_users: "Listing Users"
+          new_user: "New User"
+          user: "User"
+          enterprise_limit: "Enterprise Limit"
+          search: "Search"
+          email: "Email"
+        edit:
+          editing_user: "Editing User"
+          back_to_users_list: "Back To Users List"
+          general_settings: "General Settings"
+        form:
+          email: "Email"
+          roles: "Roles"
+          enterprise_limit: "Enterprise Limit"
+          confirm_password: "Confirm Password"
+          password: "Password"
         email_confirmation:
           confirmation_pending: "Email confirmation is pending. We've sent a confirmation email to %{address}."
       variants:


### PR DESCRIPTION
Moved translations from spree to ofn's en.yml

This originated in a broken test in Spree Upgrade related to translations.

#### What should we test?
The translations in admin users screens: mostly list and edit. Only visible in other languages after merge and transifex. So, the best test we can do here is to verify the functionality of the page.

#### Release notes
Changelog Category: Fixed
Admin users screen are now using OFN's translations, not spree translations.

#### How is this related to the Spree upgrade?
This will fix spec/features/admin/users_spec.rb:23 in the upgrade build.