### PR TITLE
Less ambiguous field for "on demand" in the Inventory page

### DIFF
--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -13,6 +13,10 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
   $scope.RequestMonitor = RequestMonitor
   $scope.selectView = Views.selectView
   $scope.currentView = -> Views.currentView
+  $scope.onDemandOptions = [
+    { description: t('js.yes'), value: true },
+    { description: t('js.no'), value: false }
+  ]
 
   $scope.views = Views.setViews
     inventory:    { name: t('js.variant_overrides.inventory_products'), visible: true }

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -14,8 +14,8 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
   $scope.selectView = Views.selectView
   $scope.currentView = -> Views.currentView
   $scope.onDemandOptions = [
-    { description: t('js.yes'), value: true },
-    { description: t('js.no'), value: false }
+    { description: t('js.variant_overrides.on_demand.yes'), value: true },
+    { description: t('js.variant_overrides.on_demand.no'), value: false }
   ]
 
   $scope.views = Views.setViews

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -110,6 +110,16 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
 
+  $scope.countOnHandPlaceholder = (variant, hubId) ->
+    variantOverride = $scope.variantOverrides[hubId][variant.id]
+
+    if variantOverride.on_demand
+      t('js.variants.on_demand.yes')
+    else if variantOverride.on_demand == false
+      ''
+    else
+      variant.on_hand
+
   $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
     variantOverride = $scope.variantOverrides[hubId][variantId]
     unless variantOverride.on_demand == false && variantOverride.count_on_hand?

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -131,9 +131,9 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
     variantOverride = $scope.variantOverrides[hubId][variant.id]
 
     suggested = $scope.countOnHandSuggestion(variant, hubId)
-    unless suggested == variantOverride.count_on_hand
-      variantOverride.count_on_hand = suggested
-      DirtyVariantOverrides.set hubId, variant.id, variantOverride.id, 'count_on_hand', suggested
+    return if suggested == variantOverride.count_on_hand
+    variantOverride.count_on_hand = suggested
+    DirtyVariantOverrides.set hubId, variant.id, variantOverride.id, 'count_on_hand', suggested
 
   # Suggest producer count_on_hand if variant has limited stock and variant override forces limited
   # stock. Otherwise, clear whatever value is set.

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -110,6 +110,10 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
 
+  # Variant override count_on_hand field placeholder logic:
+  #     on_demand true  -- Show "On Demand"
+  #     on_demand false -- Show empty value to be set by the user
+  #     on_demand nil   -- Show producer on_hand value
   $scope.countOnHandPlaceholder = (variant, hubId) ->
     variantOverride = $scope.variantOverrides[hubId][variant.id]
 

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -110,12 +110,6 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
 
-  $scope.selectLimitedStockIfCountOnHandSet = (hubId, variantId) ->
-    variantOverride = $scope.variantOverrides[hubId][variantId]
-    if variantOverride.count_on_hand? && variantOverride.count_on_hand != '' && variantOverride.on_demand != false
-      variantOverride.on_demand = false
-      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'on_demand', false
-
   $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
     variantOverride = $scope.variantOverrides[hubId][variantId]
     unless variantOverride.on_demand == false && variantOverride.count_on_hand?

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -109,3 +109,15 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
         StatusMessage.display 'success', t('js.variant_overrides.stock_reset')
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
+
+  $scope.selectLimitedStockIfCountOnHandSet = (hubId, variantId) ->
+    variantOverride = $scope.variantOverrides[hubId][variantId]
+    if variantOverride.count_on_hand? && variantOverride.count_on_hand != '' && variantOverride.on_demand != false
+      variantOverride.on_demand = false
+      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'on_demand', false
+
+  $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
+    variantOverride = $scope.variantOverrides[hubId][variantId]
+    unless variantOverride.on_demand == false && variantOverride.count_on_hand?
+      variantOverride.count_on_hand = null
+      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'count_on_hand', null

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -120,8 +120,20 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
     else
       variant.on_hand
 
-  $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
-    variantOverride = $scope.variantOverrides[hubId][variantId]
-    unless variantOverride.on_demand == false && variantOverride.count_on_hand?
-      variantOverride.count_on_hand = null
-      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'count_on_hand', null
+  # This method should only be used when the variant override on_demand is changed.
+  #
+  # Change the count_on_hand value to a suggested value.
+  $scope.updateCountOnHand = (variant, hubId) ->
+    variantOverride = $scope.variantOverrides[hubId][variant.id]
+
+    suggested = $scope.countOnHandSuggestion(variant, hubId)
+    unless suggested == variantOverride.count_on_hand
+      variantOverride.count_on_hand = suggested
+      DirtyVariantOverrides.set hubId, variant.id, variantOverride.id, 'count_on_hand', suggested
+
+  # Suggest producer count_on_hand if variant has limited stock and variant override forces limited
+  # stock. Otherwise, clear whatever value is set.
+  $scope.countOnHandSuggestion = (variant, hubId) ->
+    variantOverride = $scope.variantOverrides[hubId][variant.id]
+    return null unless !variant.on_demand && variantOverride.on_demand == false
+    variant.on_hand

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -14,6 +14,7 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
   $scope.selectView = Views.selectView
   $scope.currentView = -> Views.currentView
   $scope.onDemandOptions = [
+    { description: t('js.variant_overrides.on_demand.use_producer_settings'), value: null },
     { description: t('js.variant_overrides.on_demand.yes'), value: true },
     { description: t('js.variant_overrides.on_demand.no'), value: false }
   ]

--- a/app/assets/stylesheets/admin/components/input.css.scss
+++ b/app/assets/stylesheets/admin/components/input.css.scss
@@ -1,3 +1,5 @@
+@import '../../darkswarm/branding';
+
 .container {
   input {
     &[readonly] {

--- a/app/assets/stylesheets/admin/components/input.css.scss
+++ b/app/assets/stylesheets/admin/components/input.css.scss
@@ -1,0 +1,8 @@
+.container {
+  input {
+    &[readonly] {
+      background-color: $disabled-light;
+      cursor: default;
+    }
+  }
+}

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -10,7 +10,8 @@
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].count_on_hand'}, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
-    %input.field{ :type => 'checkbox', name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand' }, 'ofn-track-variant-override' => 'on_demand' }
+    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
+      %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}
   %td.reset{ ng: { show: 'columns.reset.visible' } }

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -8,7 +8,7 @@
   %td.price{ ng: { show: 'columns.price.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-price', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].price'}, placeholder: '{{ variant.price }}', 'ofn-track-variant-override' => 'price'}
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
+    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ countOnHandPlaceholder(variant, hub_id) }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
     %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -8,9 +8,9 @@
   %td.price{ ng: { show: 'columns.price.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-price', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].price'}, placeholder: '{{ variant.price }}', 'ofn-track-variant-override' => 'price'}
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].count_on_hand'}, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
+    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', change: 'selectLimitedStockIfCountOnHandSet(hub_id, variant.id)' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
-    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
+    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -8,7 +8,7 @@
   %td.price{ ng: { show: 'columns.price.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-price', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].price'}, placeholder: '{{ variant.price }}', 'ofn-track-variant-override' => 'price'}
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', change: 'selectLimitedStockIfCountOnHandSet(hub_id, variant.id)' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
+    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
     %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -11,7 +11,6 @@
     %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ countOnHandPlaceholder(variant, hub_id) }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
     %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'updateCountOnHand(variant, hub_id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
-      %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}
   %td.reset{ ng: { show: 'columns.reset.visible' } }

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -10,7 +10,7 @@
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ countOnHandPlaceholder(variant, hub_id) }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
-    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
+    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'updateCountOnHand(variant, hub_id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -623,6 +623,9 @@ en:
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
       controls:
         back_to_my_inventory: Back to my inventory
+      products_variants:
+        on_demand:
+          use_producer_settings: "Use producer settings"
     orders:
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
@@ -2445,6 +2448,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     pending: Pending
     shipped: Shipped
   js:
+    "yes": "Yes"
+    "no": "No"
     saving: 'Saving...'
     changes_saved: 'Changes saved.'
     save_changes_first: Save changes first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -625,7 +625,7 @@ en:
         back_to_my_inventory: Back to my inventory
       products_variants:
         on_demand:
-          use_producer_settings: "Use producer settings"
+          use_producer_settings: "Use producer stock settings"
     orders:
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -623,9 +623,6 @@ en:
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
       controls:
         back_to_my_inventory: Back to my inventory
-      products_variants:
-        on_demand:
-          use_producer_settings: "Use producer stock settings"
     orders:
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
@@ -2598,6 +2595,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         "yes": "On demand"
     variant_overrides:
       on_demand:
+        use_producer_settings: "Use producer stock settings"
         "yes": "Yes"
         "no": "No"
       inventory_products: "Inventory Products"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2595,6 +2595,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         in your cart have reduced. Here's what's changed:
       now_out_of_stock: is now out of stock.
       only_n_remainging: "now only has %{num} remaining."
+    variants:
+      on_demand:
+        "yes": "On demand"
     variant_overrides:
       on_demand:
         "yes": "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2596,6 +2596,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       now_out_of_stock: is now out of stock.
       only_n_remainging: "now only has %{num} remaining."
     variant_overrides:
+      on_demand:
+        "yes": "Yes"
+        "no": "No"
       inventory_products: "Inventory Products"
       hidden_products: "Hidden Products"
       new_products: "New Products"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2448,8 +2448,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     pending: Pending
     shipped: Shipped
   js:
-    "yes": "Yes"
-    "no": "No"
     saving: 'Saving...'
     changes_saved: 'Changes saved.'
     save_changes_first: Save changes first.

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -141,7 +141,7 @@ feature %q{
             fill_in "variant-overrides-#{variant.id}-sku", with: 'NEWSKU'
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
-            select I18n.t("js.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
             page.should have_content "Changes to one override remain unsaved."
 
             expect do
@@ -236,7 +236,7 @@ feature %q{
           it "product values are affected by overrides" do
             page.should have_input "variant-overrides-#{variant.id}-price", with: '77.77', placeholder: '1.23'
             page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: '12'
-            expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.yes")
+            expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.variant_overrides.on_demand.yes")
           end
 
           it "updates existing overrides" do
@@ -257,14 +257,14 @@ feature %q{
           end
 
           it "updates on_demand settings" do
-            select I18n.t("js.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
             vo.reload
             expect(vo.on_demand).to eq(false)
 
-            select I18n.t("js.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -434,14 +434,7 @@ feature %q{
   end
 
   def select_on_demand(variant, value_sym)
-    option_label = case value_sym
-                   when :no
-                     I18n.t("js.variant_overrides.on_demand.no")
-                   when :yes
-                     I18n.t("js.variant_overrides.on_demand.yes")
-                   when :use_producer_settings
-                     I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings")
-                   end
+    option_label = I18n.t(value_sym, scope: "js.variant_overrides.on_demand")
     select option_label, from: "variant-overrides-#{variant.id}-on_demand"
   end
 end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -140,7 +140,7 @@ feature %q{
 
             fill_in "variant-overrides-#{variant.id}-sku", with: 'NEWSKU'
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
-            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :no
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
             page.should have_content "Changes to one override remain unsaved."
 
@@ -162,7 +162,7 @@ feature %q{
             it "updates the same override instead of creating a duplicate" do
               # When I create a new override
               fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
-              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
               page.should have_content "Changes to one override remain unsaved."
 
@@ -243,7 +243,7 @@ feature %q{
 
           it "updates existing overrides" do
             fill_in "variant-overrides-#{variant.id}-price", with: '22.22'
-            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :no
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '8888'
             page.should have_content "Changes to one override remain unsaved."
 
@@ -261,21 +261,21 @@ feature %q{
           end
 
           it "updates on_demand settings" do
-            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :no
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
             vo.reload
             expect(vo.on_demand).to eq(false)
 
-            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :yes
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
             vo.reload
             expect(vo.on_demand).to eq(true)
 
-            select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :use_producer_settings
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
@@ -299,7 +299,7 @@ feature %q{
             # Clearing values manually
             fill_in "variant-overrides-#{variant.id}-price", with: ''
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: ''
-            select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :use_producer_settings
             fill_in "variant-overrides-#{variant.id}-default_stock", with: ''
             within "tr#v_#{variant.id}" do
               vo.tag_list.each do |tag|
@@ -347,15 +347,15 @@ feature %q{
           describe "ensuring that on demand and count on hand settings are compatible" do
             it "clears count on hand when not limited stock" do
               # It clears count_on_hand when selecting true on_demand.
-              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
-              select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :yes
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It clears count_on_hand when selecting nil on_demand.
-              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
-              select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :use_producer_settings
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It saves the changes.
@@ -431,5 +431,17 @@ feature %q{
         end
       end
     end
+  end
+
+  def select_on_demand(variant, value_sym)
+    option_label = case value_sym
+                   when :no
+                     I18n.t("js.variant_overrides.on_demand.no")
+                   when :yes
+                     I18n.t("js.variant_overrides.on_demand.yes")
+                   when :use_producer_settings
+                     I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings")
+                   end
+    select option_label, from: "variant-overrides-#{variant.id}-on_demand"
   end
 end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -237,7 +237,7 @@ feature %q{
 
           it "product values are affected by overrides" do
             page.should have_input "variant-overrides-#{variant.id}-price", with: '77.77', placeholder: '1.23'
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: '12'
+            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: I18n.t("js.variants.on_demand.yes")
             expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.variant_overrides.on_demand.yes")
           end
 
@@ -325,7 +325,7 @@ feature %q{
             first("div#bulk-actions-dropdown div.menu div.menu_item", text: "Reset Stock Levels To Defaults").click
             page.should have_content 'Stocks reset to defaults.'
             vo.reload
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '1000', placeholder: '12'
+            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '1000', placeholder: I18n.t("js.variants.on_demand.yes")
             vo.count_on_hand.should == 1000
           end
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -140,8 +140,8 @@ feature %q{
 
             fill_in "variant-overrides-#{variant.id}-sku", with: 'NEWSKU'
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
+            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
-            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
             page.should have_content "Changes to one override remain unsaved."
 
             expect do
@@ -154,14 +154,15 @@ feature %q{
             vo.hub_id.should == hub.id
             vo.sku.should == "NEWSKU"
             vo.price.should == 777.77
+            expect(vo.on_demand).to eq(false)
             vo.count_on_hand.should == 123
-            vo.on_demand.should == true
           end
 
           describe "creating and then updating the new override" do
             it "updates the same override instead of creating a duplicate" do
               # When I create a new override
               fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
+              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
               page.should have_content "Changes to one override remain unsaved."
 
@@ -186,6 +187,7 @@ feature %q{
               vo.variant_id.should == variant.id
               vo.hub_id.should == hub.id
               vo.price.should == 111.11
+              expect(vo.on_demand).to eq(false)
               vo.count_on_hand.should == 111
             end
           end
@@ -241,6 +243,7 @@ feature %q{
 
           it "updates existing overrides" do
             fill_in "variant-overrides-#{variant.id}-price", with: '22.22'
+            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '8888'
             page.should have_content "Changes to one override remain unsaved."
 
@@ -253,6 +256,7 @@ feature %q{
             vo.variant_id.should == variant.id
             vo.hub_id.should == hub.id
             vo.price.should == 22.22
+            expect(vo.on_demand).to eq(false)
             vo.count_on_hand.should == 8888
           end
 
@@ -341,27 +345,15 @@ feature %q{
           end
 
           describe "ensuring that on demand and count on hand settings are compatible" do
-            it "changes to limited stock when count on hand is set" do
-              # It sets on_demand to false when count_on_hand is filled.
-              fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
-              expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.variant_overrides.on_demand.no")
-
-              # It saves the changes.
-              click_button I18n.t("save_changes")
-              expect(page).to have_content I18n.t("js.changes_saved")
-
-              vo.reload
-              expect(vo.count_on_hand).to eq(200)
-              expect(vo.on_demand).to eq(false)
-            end
-
             it "clears count on hand when not limited stock" do
               # It clears count_on_hand when selecting true on_demand.
+              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
               select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It clears count_on_hand when selecting nil on_demand.
+              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
               select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""

--- a/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
@@ -120,3 +120,51 @@ describe "VariantOverridesCtrl", ->
           expect(scope.variantOverrides[123][2].count_on_hand).toBeNull()
           dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
           expect(dirtyVariantOverride.count_on_hand).toBeNull()
+
+  describe "count on hand placeholder", ->
+    beforeEach ->
+      scope.variantOverrides = {123: {}}
+
+    describe "when variant is on demand", ->
+      variant = null
+
+      beforeEach ->
+        # Ideally, count_on_hand is blank when the variant is on demand. However, this rule is not
+        # enforced.
+        variant = {id: 2, on_demand: true, count_on_hand: 20, on_hand: t("on_demand")}
+
+      it "is 'On demand' when variant override uses producer stock settings", ->
+        scope.variantOverrides[123][2] = {on_demand: null, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(t("on_demand"))
+
+      it "is 'On demand' when variant override is on demand", ->
+        scope.variantOverrides[123][2] = {on_demand: true, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(t("js.variants.on_demand.yes"))
+
+      it "is blank when variant override is limited stock", ->
+        scope.variantOverrides[123][2] = {on_demand: false, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe('')
+
+    describe "when variant is limited stock", ->
+      variant = null
+
+      beforeEach ->
+        variant = {id: 2, on_demand: false, count_on_hand: 20, on_hand: 20}
+
+      it "is variant count on hand when variant override uses producer stock settings", ->
+        scope.variantOverrides[123][2] = {on_demand: null, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(20)
+
+      it "is 'On demand' when variant override is on demand", ->
+        scope.variantOverrides[123][2] = {on_demand: true, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(t("js.variants.on_demand.yes"))
+
+      it "is blank when variant override is limited stock", ->
+        scope.variantOverrides[123][2] = {on_demand: false, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe('')

--- a/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
@@ -89,36 +89,6 @@ describe "VariantOverridesCtrl", ->
       expect(StatusMessage.display).toHaveBeenCalledWith 'success', 'Stocks reset to defaults.'
 
   describe "ensuring that on demand and count on hand settings are compatible", ->
-    describe "changing to limited stock when count on hand is set", ->
-      beforeEach ->
-        scope.variantOverrides = {123: {2: {id: 5, on_demand: true}}}
-
-      describe "when count on hand is set", ->
-        beforeEach ->
-          scope.variantOverrides[123][2].count_on_hand = 1
-
-        it "changes to limited stock and registers dirty attribute", ->
-          scope.selectLimitedStockIfCountOnHandSet(123, 2)
-          expect(scope.variantOverrides[123][2].on_demand).toBe(false)
-          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
-          expect(dirtyVariantOverride.on_demand).toBe(false)
-
-      describe "when count on hand is null", ->
-        beforeEach ->
-          scope.variantOverrides[123][2].count_on_hand = null
-
-        it "does not change to limited stock", ->
-          scope.selectLimitedStockIfCountOnHandSet(123, 2)
-          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
-
-      describe "when count on hand is blank string", ->
-        beforeEach ->
-          scope.variantOverrides[123][2].count_on_hand = ''
-
-        it "does not change to limited stock", ->
-          scope.selectLimitedStockIfCountOnHandSet(123, 2)
-          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
-
     describe "clearing count on hand when not limited stock", ->
       beforeEach ->
         scope.variantOverrides = {123: {2: {id: 5, count_on_hand: 1}}}

--- a/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
@@ -87,3 +87,66 @@ describe "VariantOverridesCtrl", ->
       $httpBackend.flush()
       expect(VariantOverrides.updateData).toHaveBeenCalledWith variant_overrides_mock
       expect(StatusMessage.display).toHaveBeenCalledWith 'success', 'Stocks reset to defaults.'
+
+  describe "ensuring that on demand and count on hand settings are compatible", ->
+    describe "changing to limited stock when count on hand is set", ->
+      beforeEach ->
+        scope.variantOverrides = {123: {2: {id: 5, on_demand: true}}}
+
+      describe "when count on hand is set", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].count_on_hand = 1
+
+        it "changes to limited stock and registers dirty attribute", ->
+          scope.selectLimitedStockIfCountOnHandSet(123, 2)
+          expect(scope.variantOverrides[123][2].on_demand).toBe(false)
+          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
+          expect(dirtyVariantOverride.on_demand).toBe(false)
+
+      describe "when count on hand is null", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].count_on_hand = null
+
+        it "does not change to limited stock", ->
+          scope.selectLimitedStockIfCountOnHandSet(123, 2)
+          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
+
+      describe "when count on hand is blank string", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].count_on_hand = ''
+
+        it "does not change to limited stock", ->
+          scope.selectLimitedStockIfCountOnHandSet(123, 2)
+          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
+
+    describe "clearing count on hand when not limited stock", ->
+      beforeEach ->
+        scope.variantOverrides = {123: {2: {id: 5, count_on_hand: 1}}}
+
+      describe "when on demand is false", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].on_demand = false
+
+        it "does not clear count on hand", ->
+          scope.clearCountOnHandUnlessLimitedStock(123, 2)
+          expect(scope.variantOverrides[123][2].count_on_hand).toEqual(1)
+
+      describe "when on demand is true", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].on_demand = true
+
+        it "clears count on hand and registers dirty attribute", ->
+          scope.clearCountOnHandUnlessLimitedStock(123, 2)
+          expect(scope.variantOverrides[123][2].count_on_hand).toBeNull()
+          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
+          expect(dirtyVariantOverride.count_on_hand).toBeNull()
+
+      describe "when on demand is null", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].on_demand = null
+
+        it "clears count on hand and registers dirty attribute", ->
+          scope.clearCountOnHandUnlessLimitedStock(123, 2)
+          expect(scope.variantOverrides[123][2].count_on_hand).toBeNull()
+          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
+          expect(dirtyVariantOverride.count_on_hand).toBeNull()


### PR DESCRIPTION
Change the UI control for "on demand" in the Inventory page from a checkbox to a SELECT field with three options: `nil`, `true`, and `false`.

#### What? Why?

Closes #3066

As discussed in the issue, this addresses the following problems:
* There is no way to tell between `nil` and `false` - both are represented by an unticked checkbox.
* There is no way to go back to `nil` from a `true` or `false` value.

#### What should we test?

Signed in as producer:

1. Create a product with first variant.
2. Grant distributor permission "to add products to inventory".

Signed in as the distributor, already with payment and shipping methods:

1. Add the variant to the inventory:
    a. Go to Products > Inventory.
    b. Click "Review Now" to see the list of products that can be added.
    c. Click "Add" for the variant.
2. Back in the Inventory page, under "On Demand", check that the selected value is ~blank~ "Use producer settings".
3. Select ~"On Demand"~ "Yes" and save. After that is successful, check that the selected value is still ~"On Demand"~ "Yes", both on the current page and when loading the Inventory page in another browser tab.
4. Repeat Step 3, but for ~"Limited Stock"~ "No".
5. Repeat Step 3, but for ~the blank~ "Use producer settings" option.

#### Release notes

- Update the UI for "On Demand" and "Count on Hand" in the Inventory page to allow display and selection of "Use producer stock settings", and to encourage compatible "On Demand" and "Count on Hand".

Changelog Category: Fixed

#### Dependencies

This is best merged together with #3198.