### PR TITLE
Removed DatabaseCleaner and configured transactional fixtures in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,6 @@ group :test, :development do
   gem 'shoulda-matchers'
   gem "factory_bot_rails", require: false
   gem 'capybara', '>= 2.15.4'
-  gem 'database_cleaner', '0.7.1', require: false
   gem 'awesome_print'
   gem 'letter_opener', '>= 1.4.1'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,6 @@ GEM
       addressable
     daemons (1.2.2)
     dalli (2.7.2)
-    database_cleaner (0.7.1)
     db2fog (0.9.0)
       activerecord (>= 3.2.0, < 5.0)
       fog (~> 1.0)
@@ -771,7 +770,6 @@ DEPENDENCIES
   custom_error_message!
   daemons
   dalli
-  database_cleaner (= 0.7.1)
   db2fog
   debugger-linecache
   deface!
@@ -854,4 +852,4 @@ RUBY VERSION
    ruby 2.1.5p273
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@ ENV["RAILS_ENV"] ||= 'test'
 require_relative "../config/environment"
 require 'rspec/rails'
 require 'capybara'
-require 'database_cleaner'
 require 'rspec/retry'
 require 'paper_trail/frameworks/rspec'
 
@@ -69,7 +68,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
@@ -82,16 +81,9 @@ RSpec.configure do |config|
   # Retry
   config.verbose_retry = true
 
-  # DatabaseCleaner
-  config.before(:suite)          { DatabaseCleaner.clean_with :deletion, {except: ['spree_countries', 'spree_states']} }
-  config.before(:each)           { DatabaseCleaner.strategy = :transaction }
-  config.before(:each, js: true) { DatabaseCleaner.strategy = :deletion, {except: ['spree_countries', 'spree_states']} }
-  config.before(:each)           { DatabaseCleaner.start }
-  config.after(:each)            { DatabaseCleaner.clean }
   config.after(:each, js:true) do
     Capybara.reset_sessions!
     RackRequestBlocker.wait_for_requests_complete
-    DatabaseCleaner.clean
   end
 
   def restart_phantomjs


### PR DESCRIPTION
#### What? Why?

Just wanted to see if we could get rid of `database_cleaner` since `use_transactional_fixtures` should do the job. I ran the tests in local but I'm not sure if the ones that are failing are due to my configuration or due to this change.

#### What should we test?

Tests 🍏 

#### Release notes

Removed `database_cleaner` gem

Changelog Category: Removed
