### PR TITLE
[Spree Upgrade] Add missing translation to admin new order creation page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2659,6 +2659,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     my_account: "My account"
     date: "Date"
     time: "Time"
+    errors:
+      messages:
+        blank: "can't be blank"
     layouts:
       admin:
         header:


### PR DESCRIPTION
#### What? Why?

Error message "cant be blank" is now in OFN en.yml.
Related to #2938

#### What should we test?
It will only change the error message. The error message shows up on spec/features/admin/orders_spec.rb:72. translation_missing should be gone from the error message.
