### PR TITLE
Add translation for 'Back to Payments List' button in new payment form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,7 @@ en:
   password_confirmation: Password Confirmation
   reset_password_token: Reset password token
   expired: has expired, please request a new one
+  back_to_payments_list: "Back to Payments List"
 
   actions:
     create_and_add_another: "Create and Add Another"


### PR DESCRIPTION
#### What? Why?

Closes [#2374](https://github.com/openfoodfoundation/openfoodnetwork/issues/2374).

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The back office's new payment form is missing a translation on the "back to payments list" button.
To find the button: 
1. From back office, orders, click on "new order".
2. Follow the steps till you arrive at "payment step" and you'll find the button in the top-right corner.

#### What should we test?
<!-- List which features should be tested and how. -->

This change won't take effect until the next [Transifex PR](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29). To validate the fix beforehand, you can add my translation key/value pair, change the value, and watch as the button's text changes in English. 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed untranslated 'Back to Payments List' button in the new payment form.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed