### PR TITLE
Use :user factory instead of build_stubbed to create the current_api_…

### DIFF
--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -10,7 +10,7 @@ module Spree
     let(:product_other_supplier) { create(:product, supplier: supplier2) }
     let(:attributes) { [:id, :name, :supplier, :price, :on_hand, :available_on, :permalink_live] }
 
-    let(:current_api_user) { build_stubbed(:user) }
+    let(:current_api_user) { build(:user) }
 
     before do
       allow(controller).to receive(:spree_current_user) { current_api_user }


### PR DESCRIPTION
#### What? Why?

Closes #3034

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Surprisingly enough, changing `build_stubbed(:user)` to `create(:user)` for the `current_api_user` fixed all the failing specs from #3034.
It was returning an exception with message `stubbed models are not allowed to access the database - Spree::User#save!()\`, which was making all accesses fail, so all specs accessing the database fail as well.


#### What should we test?
<!-- List which features should be tested and how. -->
Specs in `spec/controllers/spree/api/products_controller_spec.rb` pass.
