### PR TITLE
[Spree Upgrade] Fix Product model spec and small refactoring in VariantStock

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -2,7 +2,7 @@ require 'active_support/concern'
 
 # These methods were available in Spree 1, but were removed in Spree 2.  We
 # would still like to use them so that we still give support to the consumers
-# of this methods, making the upgrade backward compatible.
+# of these methods, making the upgrade backward compatible.
 #
 # Therefore we use only a single stock item per variant, which is associated to
 # a single stock location per instance (default stock location) and use it to
@@ -85,7 +85,7 @@ module VariantStock
   # https://github.com/openfoodfoundation/spree/commit/20b5ad9835dca7f41a40ad16c7b45f987eea6dcc
   def on_demand
     warn_deprecation(__method__, 'StockItem#backorderable?')
-    stock_items.first.backorderable?
+    stock_item.backorderable?
   end
 
   # Sets whether the variant can be ordered on demand or not. Note that
@@ -117,7 +117,7 @@ module VariantStock
   # https://github.com/openfoodfoundation/spree/blob/43950c3689a77a7f493cc6d805a0edccfe75ebc2/core/app/models/spree/stock_item.rb#L3-L4
   # for details.
   def save_stock
-    stock_items.first.save
+    stock_item.save
   end
 
   def raise_error_if_no_stock_item_available
@@ -130,9 +130,13 @@ module VariantStock
   # takes a value to add to the current stock level and uses proper locking.
   # But this should work the same as in Spree 1.3.
   def overwrite_stock_levels(new_level)
-    # There shouldn't be any other stock items, because we should
-    # have only one stock location.
-    stock_items.first.__send__(:count_on_hand=, new_level)
+    stock_item.__send__(:count_on_hand=, new_level)
+  end
+
+  # There shouldn't be any other stock items, because we should
+  # have only one stock location.
+  def stock_item
+    stock_items.first
   end
 
   def warn_deprecation(method_name, new_method_name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2659,7 +2659,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     my_account: "My account"
     date: "Date"
     time: "Time"
-    inventory_error_flash_for_insufficient_quantity: "An item in your cart has become unavailable"
+    inventory_error_flash_for_insufficient_quantity: "An item in your cart has become unavailable."
     errors:
       messages:
         blank: "can't be blank"

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -100,14 +100,15 @@ module Spree
           let!(:product){ Spree::Product.new }
 
           before do
+            create(:stock_location)
             product.primary_taxon = create(:taxon)
             product.supplier = create(:supplier_enterprise)
             product.name = "Product1"
             product.variant_unit = "weight"
             product.variant_unit_scale = 1000
             product.unit_value = 1
-            product.on_hand = 3
             product.price = 4.27
+            product.shipping_category = create(:shipping_category)
             product.save!
           end
 


### PR DESCRIPTION
#### What? Why?

Part of #2804 (fixes 2 of the 10 tests)
See commit messages.
Also, closes #3036 by fixing a typo in #3100

#### What should we test?
spec/controllers/spree/orders_controller_spec.rb:135 and product_spec.rb:120, product_spec:126  should be green now.
