### PR TITLE
2841  Associate customers with their user records

### DIFF
--- a/db/migrate/20181123012635_associate_customers_to_users.rb
+++ b/db/migrate/20181123012635_associate_customers_to_users.rb
@@ -1,0 +1,42 @@
+# When we introduced the Customer model, we didn't associate any existing
+# customers with users that have the same email address.
+# Later we decided to create that association when users sign up. But we didn't
+# update all the existing customers. We do that now for data consistency and to
+# solve several bugs.
+#
+# - https://github.com/openfoodfoundation/openfoodnetwork/pull/2084
+# - https://github.com/openfoodfoundation/openfoodnetwork/issues/2841
+class AssociateCustomersToUsers < ActiveRecord::Migration
+  class Customer < ActiveRecord::Base
+  end
+
+  def up
+    save_customers
+    execute "UPDATE customers
+              SET user_id = spree_users.id
+              FROM spree_users
+              WHERE customers.email = spree_users.email
+               AND customers.user_id IS NULL;"
+  end
+
+  def down
+    customers = backed_up_customers
+    Customer.where(id: customers).update_all(user_id: nil)
+  end
+
+  def save_customers
+    customers = Customer.
+      joins("INNER JOIN spree_users ON customers.email = spree_users.email").
+      where(user_id: nil).all
+
+    File.write(backup_file, Marshal.dump(customers))
+  end
+
+  def backed_up_customers
+    Marshal.load(File.read(backup_file))
+  end
+
+  def backup_file
+    File.join("log", "customers_without_user_association.log")
+  end
+end

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -13,7 +13,7 @@ module ShopWorkflow
   end
 
   def set_order(order)
-    ApplicationController.any_instance.stub(:session).and_return({order_id: order.id, access_token: order.token})
+    allow_any_instance_of(ApplicationController).to receive(:session).and_return({order_id: order.id, access_token: order.token})
   end
 
   def add_product_to_cart(order, product, quantity: 1)


### PR DESCRIPTION
#### What? Why?

Closes #2841.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
When we introduced the Customer model, we didn't associate any existing
customers with users that have the same email address.
Later we decided to create that association when users sign up. But we didn't
update all the existing customers. We do that now for data consistency and to
solve several bugs.


#### What should we test?
<!-- List which features should be tested and how. -->

Our staging data is too new to contain the legacy records that are fixed with this pull request. Only developers can test this against production data on their local machine.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: Some customer records created before May 2018 caused subscriptions to fail and get repaired with this release.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->

https://community.openfoodnetwork.org/t/subscriptions-and-customers/1512

