### PR TITLE
[Defacepocalypse] Import product_sub_menu in our codebase and apply overrides

### DIFF
--- a/app/overrides/spree/admin/shared/_product_sub_menu/add_product_import_tab.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_sub_menu/add_product_import_tab.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_sub_tabs']"
-
--# Commenting out for now, until product import is finished
--# = tab :product_import, label: "Import", url: main_app.admin_product_import_path, match_path: '/product_import'

--- a/app/overrides/spree/admin/shared/_product_sub_menu/add_variant_overrides_tab.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_sub_menu/add_variant_overrides_tab.html.haml.deface
@@ -1,3 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_sub_tabs']"
-
-= tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'

--- a/app/views/spree/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_product_sub_menu.html.haml
@@ -1,0 +1,9 @@
+- content_for :sub_menu do
+  %ul#sub_nav.inline-menu{"data-hook" => "admin_product_sub_tabs"}
+    = tab :products, :match_path => '/products'
+    = tab :option_types, :match_path => '/option_types'
+    = tab :properties
+    = tab :prototypes
+    = tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'
+    -# Commenting out for now, until product import is finished
+    -# = tab :product_import, label: "Import", url: main_app.admin_product_import_path, match_path: '/product_import'


### PR DESCRIPTION
#### What? Why?

Part of #3119

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Import Spree's `_product_sub_menu.html.erb` in our codebase and apply overrides.


#### What should we test?
<!-- List which features should be tested and how. -->
Sub menu in Products tab should display correctly, and locales should work.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Imported Spree's `product_sub_menu` in our codebase.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
This is a first step towards #3119 