### PR TITLE
[Spree Upgrade] Add VariantStock.on_demand as attribute_accessible

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -105,6 +105,7 @@ module VariantStock
     # unknown reasons, it does not pass the test.
     stock_items.each do |item|
       item.backorderable = new_value
+      item.save
     end
   end
 

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -126,11 +126,8 @@ module VariantStock
   end
 
   # Backwards compatible setting of stock levels in Spree 2.0.
-  # It would be better to use `Spree::StockItem.adjust_count_on_hand` which
-  # takes a value to add to the current stock level and uses proper locking.
-  # But this should work the same as in Spree 1.3.
   def overwrite_stock_levels(new_level)
-    stock_item.__send__(:count_on_hand=, new_level)
+    stock_item.adjust_count_on_hand(new_level - stock_item.count_on_hand)
   end
 
   # There shouldn't be any other stock items, because we should

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -16,7 +16,7 @@ module VariantStock
   extend ActiveSupport::Concern
 
   included do
-    attr_accessible :on_hand
+    attr_accessible :on_hand, :on_demand
     after_update :save_stock
   end
 

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -19,11 +19,11 @@ feature "Product Import", js: true do
   let!(:shipping_category) { create(:shipping_category) }
 
   let!(:product) { create(:simple_product, supplier: enterprise2, name: 'Hypothetical Cake') }
-  let!(:variant) { create(:variant, product_id: product.id, price: '8.50', on_hand: '100', unit_value: '500', display_name: 'Preexisting Banana') }
-  let!(:product2) { create(:simple_product, supplier: enterprise, on_hand: '100', name: 'Beans', unit_value: '500', description: '', primary_taxon_id: category.id) }
-  let!(:product3) { create(:simple_product, supplier: enterprise, on_hand: '100', name: 'Sprouts', unit_value: '500') }
-  let!(:product4) { create(:simple_product, supplier: enterprise, on_hand: '100', name: 'Cabbage', unit_value: '500') }
-  let!(:product5) { create(:simple_product, supplier: enterprise2, on_hand: '100', name: 'Lettuce', unit_value: '500') }
+  let!(:variant) { create(:variant, product_id: product.id, price: '8.50', on_hand: 100, unit_value: '500', display_name: 'Preexisting Banana') }
+  let!(:product2) { create(:simple_product, supplier: enterprise, on_hand: 100, name: 'Beans', unit_value: '500', description: '', primary_taxon_id: category.id) }
+  let!(:product3) { create(:simple_product, supplier: enterprise, on_hand: 100, name: 'Sprouts', unit_value: '500') }
+  let!(:product4) { create(:simple_product, supplier: enterprise, on_hand: 100, name: 'Cabbage', unit_value: '500') }
+  let!(:product5) { create(:simple_product, supplier: enterprise2, on_hand: 100, name: 'Lettuce', unit_value: '500') }
   let!(:variant_override) { create(:variant_override, variant_id: product4.variants.first.id, hub: enterprise2, count_on_hand: 42) }
   let!(:variant_override2) { create(:variant_override, variant_id: product5.variants.first.id, hub: enterprise, count_on_hand: 96) }
 


### PR DESCRIPTION
#### What? Why?

This is required so that it is mass-assigned from product_controller_decorator.bulk_update.
That makes the admin product list on_demand checkboxes work.
That helps the changes in PR #3139 close issue #2804 by fixing two extra tests. 

Also, this closes #3017 by fixing the 3 tests and this also fixes one of the 12 tests in #2943 

#### What should we test?
This PR fixes 6 tests.

Hey, let's stage this one for proper testing!!!!
Product List on_demand checkboxes are now working.
