### PR TITLE
[Spree Upgrade] Fix ProductsRenderer specs

### DIFF
--- a/spec/lib/open_food_network/products_renderer_spec.rb
+++ b/spec/lib/open_food_network/products_renderer_spec.rb
@@ -49,6 +49,7 @@ module OpenFoodNetwork
       end
 
       it "doesn't return products not in stock" do
+        variant.update_attribute(:on_demand, false)
         variant.update_attribute(:count_on_hand, 0)
         pr.products_json.should_not include product.name
       end


### PR DESCRIPTION
#### What? Why?

Closes #3029 

Set `variant.on_demand` to false, so when setting `on_hand` to 0 the JSON response for available products does not include the product related to this variant.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
`spec/lib/open_food_network/products_renderer_spec.rb` should pass.