### PR TITLE
Update Skylight from 1.6.1 to 1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -688,7 +688,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    skylight (1.6.1)
+    skylight (1.7.1)
       activesupport (>= 3.0.0)
     spinjs-rails (1.3)
       rails (>= 3.1)


### PR DESCRIPTION
#### What? Why?

This doesn't bring too many improvements but it's the latest version can
work on our Rails 3.2 version.

You can read the changelog at
https://github.com/skylightio/skylight-ruby/blob/master/CHANGELOG.md#170-april-24-2018.


#### What should we test?
No change in behavior but we should check things work as expected after deploying to production.

#### Release notes

Update Skylight to the latest release supporting our Rails version 3.2.

Changelog Category: Changed