### PR TITLE
Add missing translation for 'Has Shopfront' in single-enterprise dashboard

### DIFF
--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -55,7 +55,7 @@ module EnterprisesHelper
     if enterprise.sells == 'none'
       enterprise.producer_profile_only ? I18n.t(:profile) : I18n.t(:supplier_only)
     else
-      "Has Shopfront"
+      I18n.t(:has_shopfront)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,7 @@ en:
   admin_and_handling: Admin & Handling
   profile: Profile
   supplier_only: Supplier Only
+  has_shopfront: Has Shopfront
   weight: Weight
   volume: Volume
   items: Items


### PR DESCRIPTION
#### What? Why?

Closes [#3098](https://github.com/openfoodfoundation/openfoodnetwork/issues/3098)

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The single-enterprise dashboard is missing a translation for 'Has Shopfront'.

#### What should we test?
<!-- List which features should be tested and how. -->

This change won't take effect until the next [Transifex PR](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29). To validate the fix beforehand, you can:
1. Add my contribution
2. Change the value of the key-value pair
3. Create a single-enterprise account
4. Navigate to the dashboard
5. Watch as the text changes in English to match your value

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning because you did it for a reason. -->

Fixed a missing translation in the single-enterprise dashboard.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
