### PR TITLE
Ignore `describe` and `context` in Rubocop BlockLength

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -186,6 +186,9 @@ Lint/AssignmentInCondition:
 Metrics/AbcSize:
   Max: 15
 
+Metrics/BlockLength:
+  ExcludedMethods: ["describe", "context"]
+
 Metrics/BlockNesting:
   Max: 3
 


### PR DESCRIPTION
#### What? Why?

Closes #3141

We would normally end up with long `describe` and `context` blocks in Ruby specs because we nest them. However, the current config makes Rubocop complain that the blocks are too long.

This wasn't a problem before because of this config in `.codeclimate.yml`:

```yaml
exclude_patterns:
- "spec/**/*"
```

However, recently, we added domain engines, which are in `engines/`. The above pattern does not exclude files in `engines/*/spec/`, because [according to the docs](https://docs.codeclimate.com/docs/excluding-files-and-folders):

> Patterns can be filenames relative to the project root, or shell-style globs relative to the project root.

We can also simply exclude `engines/*/spec/**/*`, but we should not do this unless/until necessary. Luckily, `Metrics/BlockLength` accepts an `ExcludedMethods` option.

#### What should we test?

Nothing to test, but the Code Climate check for this PR should pass.

#### Release notes

- Disable Rubocop check `Metrics/BlockLength` for `describe` and `context` methods.

Changelog Category: Changed