### PR TITLE
Enable rack-mini-profiler in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,4 +150,6 @@ group :development do
   # While we don't require this gem directly, no dependents forced the upgrade to a version
   # greater than 1.0.9, so we just required the latest available version here.
   gem 'eventmachine', '>= 1.2.3'
+
+  gem 'rack-mini-profiler', '< 1.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,6 +584,8 @@ GEM
     rack (1.4.7)
     rack-cache (1.8.0)
       rack (>= 0.4)
+    rack-mini-profiler (0.10.7)
+      rack (>= 1.2.0)
     rack-rewrite (1.5.1)
     rack-ssl (1.3.4)
       rack
@@ -814,6 +816,7 @@ DEPENDENCIES
   poltergeist (>= 1.16.0)
   pry-byebug (>= 3.4.3)
   rabl
+  rack-mini-profiler (< 1.0.0)
   rack-rewrite
   rack-ssl
   rails (~> 3.2.22)


### PR DESCRIPTION
#### What? Why?

Partially solves #3099

This installs [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) profile the performance of the app in development. Although is better to profile in production mode, there's soooo much room for improvement in terms of performance that development mode is more than enough.

This is what I'm using to fully address #3099.

It generates reports like

![captura de pantalla 2018-11-26 a les 19 56 41](https://user-images.githubusercontent.com/762088/49037280-1d256080-f1ba-11e8-9630-bc296eb53a7c.png)

#### Release notes

Add rack-mini-profiler to profile performance in development

Changelog Category: Added
