### PR TITLE
Encode records with special chars as well

### DIFF
--- a/db/migrate/20181123012635_associate_customers_to_users.rb
+++ b/db/migrate/20181123012635_associate_customers_to_users.rb
@@ -29,11 +29,11 @@ class AssociateCustomersToUsers < ActiveRecord::Migration
       joins("INNER JOIN spree_users ON customers.email = spree_users.email").
       where(user_id: nil).all
 
-    File.write(backup_file, Marshal.dump(customers))
+    File.write(backup_file, YAML.dump(customers))
   end
 
   def backed_up_customers
-    Marshal.load(File.read(backup_file))
+    YAML.load(File.read(backup_file))
   end
 
   def backup_file


### PR DESCRIPTION
Using Marshal.dump on the French production database raised an error:

    Encoding::UndefinedConversionError: "\xC3" from ASCII-8BIT to UTF-8

Replacing Marshal with YAML solves the problem. It is also more reliable
and human readable.

This code was run against the French, Australian and UK production
data successfully.




#### What should we test?
<!-- List which features should be tested and how. -->

Nothing to test on staging.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: Release v1.23.0 can be deployed on servers with non-English data.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed


#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->

https://openfoodnetwork.slack.com/archives/CEBMTRCNS/p1543272844010600

