### PR TITLE
[Spree Upgrade] Adapt variant overrides to spree 2

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -245,7 +245,6 @@ Layout/EmptyLines:
     - 'spec/models/spree/product_spec.rb'
     - 'spec/models/spree/shipping_method_spec.rb'
     - 'spec/models/spree/variant_spec.rb'
-    - 'spec/models/variant_override_spec.rb'
     - 'spec/serializers/admin/exchange_serializer_spec.rb'
     - 'spec/serializers/admin/for_order_cycle/enterprise_serializer_spec.rb'
     - 'spec/serializers/admin/for_order_cycle/supplied_product_serializer_spec.rb'
@@ -389,7 +388,6 @@ Layout/ExtraSpacing:
     - 'spec/models/spree/adjustment_spec.rb'
     - 'spec/models/spree/gateway/stripe_connect_spec.rb'
     - 'spec/models/spree/order_spec.rb'
-    - 'spec/models/variant_override_spec.rb'
     - 'spec/serializers/admin/for_order_cycle/enterprise_serializer_spec.rb'
     - 'spec/serializers/admin/for_order_cycle/supplied_product_serializer_spec.rb'
     - 'spec/spec_helper.rb'
@@ -557,7 +555,6 @@ Layout/SpaceAfterColon:
     - 'spec/features/admin/variants_spec.rb'
     - 'spec/features/consumer/account_spec.rb'
     - 'spec/models/spree/ability_spec.rb'
-    - 'spec/models/variant_override_spec.rb'
     - 'spec/spec_helper.rb'
 
 # Offense count: 83
@@ -870,7 +867,6 @@ Layout/SpaceInsideHashLiteralBraces:
     - 'spec/models/spree/taxon_spec.rb'
     - 'spec/models/spree/variant_spec.rb'
     - 'spec/models/tag_rule/discount_order_spec.rb'
-    - 'spec/models/variant_override_spec.rb'
     - 'spec/performance/orders_controller_spec.rb'
     - 'spec/requests/checkout/failed_checkout_spec.rb'
     - 'spec/requests/checkout/stripe_connect_spec.rb'
@@ -965,7 +961,6 @@ Lint/DuplicateMethods:
 Lint/IneffectiveAccessModifier:
   Exclude:
     - 'app/models/column_preference.rb'
-    - 'app/models/variant_override.rb'
     - 'lib/open_food_network/feature_toggle.rb'
     - 'lib/open_food_network/products_cache.rb'
     - 'lib/open_food_network/property_merge.rb'
@@ -1130,7 +1125,6 @@ Lint/Void:
     - 'spec/models/spree/payment_spec.rb'
     - 'spec/models/spree/product_spec.rb'
     - 'spec/models/spree/variant_spec.rb'
-    - 'spec/models/variant_override_spec.rb'
     - 'spec/serializers/enterprise_serializer_spec.rb'
     - 'spec/support/request/web_helper.rb'
 
@@ -1522,7 +1516,6 @@ Rails/TimeZone:
     - 'spec/lib/open_food_network/products_cache_refreshment_spec.rb'
     - 'spec/lib/open_food_network/products_cache_spec.rb'
     - 'spec/models/enterprise_relationship_spec.rb'
-    - 'spec/models/variant_override_spec.rb'
 
 # Offense count: 1
 # Configuration parameters: Environments.
@@ -1545,7 +1538,6 @@ Rails/Validation:
     - 'app/models/order_cycle.rb'
     - 'app/models/product_distribution.rb'
     - 'app/models/spree/product_decorator.rb'
-    - 'app/models/variant_override.rb'
 
 # Offense count: 18
 # Cop supports --auto-correct.
@@ -2283,7 +2275,6 @@ Style/RedundantSelf:
     - 'app/models/spree/taxon_decorator.rb'
     - 'app/models/spree/user_decorator.rb'
     - 'app/models/spree/variant_decorator.rb'
-    - 'app/models/variant_override.rb'
     - 'lib/open_food_network/locking.rb'
     - 'lib/open_food_network/rack_request_blocker.rb'
     - 'lib/open_food_network/reports/report.rb'

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -115,8 +115,11 @@ module VariantStock
   def move(quantity, originator = nil)
     raise_error_if_no_stock_item_available
 
-    # Creates a stock movement (this is the original spree stock_location.move)
-    # This will update stock_item.count_on_hand and fill backorders
+    # Creates a stock movement: it updates stock_item.count_on_hand and fills backorders
+    #
+    # This is the original Spree::StockLocation#move,
+    #   except that we raise an error if the stock item is missing,
+    #   because, unlike Spree, we should always have exactly one stock item per variant.
     stock_item.stock_movements.create!(quantity: quantity, originator: originator)
   end
 

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -109,6 +109,17 @@ module VariantStock
     end
   end
 
+  # We can have this responsibility here in the variant because there is only one stock item per variant
+  #
+  # This enables us to override this behaviour for variant overrides
+  def move(quantity, originator = nil)
+    raise_error_if_no_stock_item_available
+
+    # Creates a stock movement (this is the original spree stock_location.move)
+    # This will update stock_item.count_on_hand and fill backorders
+    stock_item.stock_movements.create!(quantity: quantity, originator: originator)
+  end
+
   private
 
   # Persists the single stock item associated to this variant. As defined in
@@ -126,7 +137,10 @@ module VariantStock
     raise message if stock_items.empty?
   end
 
-  # Backwards compatible setting of stock levels in Spree 2.0.
+  # Overwrites stock_item.count_on_hand
+  #
+  # Calling stock_item.adjust_count_on_hand will bypass filling backorders and creating stock movements
+  # If that was required we could call self.move
   def overwrite_stock_levels(new_level)
     stock_item.adjust_count_on_hand(new_level - stock_item.count_on_hand)
   end

--- a/app/models/spree/stock_location_decorator.rb
+++ b/app/models/spree/stock_location_decorator.rb
@@ -1,0 +1,5 @@
+Spree::StockLocation.class_eval do
+  def move(variant, quantity, originator = nil)
+    variant.move(quantity, originator)
+  end
+end

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -6,7 +6,8 @@ class VariantOverride < ActiveRecord::Base
   belongs_to :hub, class_name: 'Enterprise'
   belongs_to :variant, class_name: 'Spree::Variant'
 
-  validates_presence_of :hub_id, :variant_id
+  validates :hub_id, presence: true
+  validates :variant_id, presence: true
   # Default stock can be nil, indicating stock should not be reset or zero, meaning reset to zero. Need to ensure this can be set by the user.
   validates :default_stock, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
@@ -58,7 +59,7 @@ class VariantOverride < ActiveRecord::Base
     if resettable
       if default_stock?
         self.attributes = { count_on_hand: default_stock }
-        self.save
+        save
       else
         Bugsnag.notify RuntimeError.new "Attempting to reset stock level for a variant with no default stock level."
       end

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -59,6 +59,14 @@ class VariantOverride < ActiveRecord::Base
     count_on_hand.present?
   end
 
+  def move_stock!(quantity)
+    if quantity > 0
+      increment_stock! quantity
+    elsif quantity < 0
+      decrement_stock! -quantity
+    end
+  end
+
   def decrement_stock!(quantity)
     if stock_overridden?
       decrement! :count_on_hand, quantity

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -28,7 +28,8 @@ module OpenFoodNetwork
         on_demand || (count_on_hand > 0)
       end
 
-      def count_on_hand
+      # Uses variant_override.count_on_hand instead of Stock::Quantifier.stock_items.count_on_hand
+      def total_on_hand
         @variant_override.andand.count_on_hand || super
       end
 
@@ -46,17 +47,13 @@ module OpenFoodNetwork
         end
       end
 
-      def decrement!(attribute, by = 1)
-        if attribute == :count_on_hand && @variant_override.andand.stock_overridden?
-          @variant_override.decrement_stock! by
-        else
-          super
-        end
-      end
-
-      def increment!(attribute, by = 1)
-        if attribute == :count_on_hand && @variant_override.andand.stock_overridden?
-          @variant_override.increment_stock! by
+      # If it is an variant override with a count_on_hand value:
+      #   - updates variant_override.count_on_hand
+      #   - does not create stock_movement
+      #   - does not update stock_item.count_on_hand
+      def move(quantity, originator = nil)
+        if @variant_override.andand.stock_overridden?
+          @variant_override.move_stock! quantity
         else
           super
         end


### PR DESCRIPTION
#### What? Why?

Closes #2559
And relates to #3118 (fixes 2 of 3 broken tests) and #2943 (fixes 6 of 10 broken tests) and #2929 (doesn't fix any spec, it will need PR #2930 for that).

This is simplest solution we could think of: **for variant overrides we shortcut all stock_items and stock_movements code and just manage changes on variant_overrides.count_on_hand**.
We conclude this is the best way to go because any other approach (creating stock_items for variant overrides or creating a stock_items_overrides table) would be a lot of trouble for a solution (variant_overrides) that is **already not nice**.

This is what we need to do:
- scoping variants in appropriate places, this is the biggest challenge (handled in separate PR, see #3158 )
- replacing stock_location.move for variant overrides by a simple version that just updates variant_overrides.count_on_hand
- adapting variant overrides scope (methods injected in the variant object) to the variant_stock methods

#### What should we test?
##### Specs
The current version of this PR (together with #3158) is not breaking any new tests and it is fixing 8 tests:
- spec/features/consumer/shopping/variant_overrides_spec.rb:121 and spec/features/consumer/shopping/variant_overrides_spec.rb:132 re #3118
- 6 tests in spec/models/spree/line_item_spec.rb:126 re #2943

Re #3118, I currently do not understand the only broken test (and it could be related to this PR)
spec/features/consumer/shopping/variant_overrides_spec.rb:155
where variant is made out of stock and cart/checkout are expected to work but not show the out of stock variant in the confirmation page, but the actual result (which currently makes sense to me) is that the cart page shows a "out of stock" message.

Re #2943, 6 specs are fixed in this PR and 4 remaining ones are related to other things, see #2943 comments for details.

Re #2929, line item controller tests are related to this PR but not fixed here yet. They probably need a combination of this PR and PR #2930.

##### Functional tests
Further functional testing needs to be done here:
- making sure inventory management page works properly
- check out with variants and variant overrides and making sure stock levels are updated correctly
- updating completed orders and checking stock levels were updated correctly
- investigate different inventory config options (for example, different on_demand configurations between producer and hub) and test that stock management works correctly on both checkout and when updating completed orders

#### How is this related to the Spree upgrade?
This is the last key change in the upgrade!