### PR TITLE
[Spree Upgrade] Add missing translations causing a test failure

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,6 +247,8 @@ en:
   pick_up: Pick up
   ok: Ok
   copy: Copy
+  change_my_password: "Change my password"
+  update_password: "Update password"
   password_confirmation: Password Confirmation
   reset_password_token: Reset password token
   expired: has expired, please request a new one

--- a/spec/features/consumer/confirm_invitation_spec.rb
+++ b/spec/features/consumer/confirm_invitation_spec.rb
@@ -19,7 +19,7 @@ feature "Confirm invitation as manager" do
       visit spree.spree_user_confirmation_url(confirmation_token: user.confirmation_token)
 
       expect(user.reload.confirmed?).to be true
-      expect(page).to have_text "Change my password"
+      expect(page).to have_text I18n.t(:change_my_password)
 
       fill_in "Password", with: "my secret"
       fill_in "Password Confirmation", with: "my secret"


### PR DESCRIPTION
#### What? Why?

Closes #3015

These two translations were missing and one of them was causing a test to fail.
