### PR TITLE
Update schema for latest migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181106162211) do
+ActiveRecord::Schema.define(:version => 20181123012635) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false


### PR DESCRIPTION
#### What? Why?

I feel embarrased that this is the second follow up of my last
migration: https://github.com/openfoodfoundation/openfoodnetwork/pull/3126

The last migration didn't change any database structure, but the schema
still needs the latest migration version. Otherwise it will display
pending migrations when setting up the database.

This commit allows to run `bundle exec rake db:reset` in development
without the following message:

>   Run `rake db:migrate` to update your database then try again.
>   You have 1 pending migrations:
>     20181123012635 AssociateCustomersToUsers

The next pull request with a migration would have solved this problem as
well.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

No user testing can cover this. In development I ran `bundle exec rake db:reset` and it was successful.

