### PR TITLE
[Defacepocalypse] De-deface payment methods new and form

### DIFF
--- a/app/overrides/spree/admin/payment_methods/_form/remove_clearing_div.deface
+++ b/app/overrides/spree/admin/payment_methods/_form/remove_clearing_div.deface
@@ -1,1 +1,0 @@
-remove "div.clear"

--- a/app/overrides/spree/admin/payment_methods/edit/add_hubs_sidebar.html.haml.deface
+++ b/app/overrides/spree/admin/payment_methods/edit/add_hubs_sidebar.html.haml.deface
@@ -1,5 +1,0 @@
-/ insert_after "code[erb-loud]:contains(\"render :partial => 'form', :locals => { :f => f }\")"
-
-.one.column &nbsp;
-= render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :payment_method }
-.clear

--- a/app/overrides/spree/admin/payment_methods/edit/add_new_payment_method_button.html.haml.deface
+++ b/app/overrides/spree/admin/payment_methods/edit/add_new_payment_method_button.html.haml.deface
@@ -1,4 +1,0 @@
-/ insert_after "code[erb-silent]:contains('content_for :page_actions do')"
-
-%li
-  = button_link_to t(:new), spree.new_admin_payment_method_path, :icon => 'icon-plus' %>

--- a/app/overrides/spree/admin/payment_methods/edit/remove_configuration_sidebar.deface
+++ b/app/overrides/spree/admin/payment_methods/edit/remove_configuration_sidebar.deface
@@ -1,1 +1,0 @@
-remove "code[erb-loud]:contains(\"render :partial => 'spree/admin/shared/configuration_menu'\")"

--- a/app/overrides/spree/admin/payment_methods/new/add_hubs_sidebar.html.haml.deface
+++ b/app/overrides/spree/admin/payment_methods/new/add_hubs_sidebar.html.haml.deface
@@ -1,5 +1,0 @@
-/ insert_after "code[erb-loud]:contains(\"render :partial => 'form', :locals => { :f => f }\")"
-
-.one.column &nbsp;
-= render :partial => 'spree/admin/shared/hubs_sidebar', :locals => { f: f, klass: :payment_method }
-.clear

--- a/app/overrides/spree/admin/payment_methods/new/remove_configuration_sidebar.deface
+++ b/app/overrides/spree/admin/payment_methods/new/remove_configuration_sidebar.deface
@@ -1,1 +1,0 @@
-remove "code[erb-loud]:contains(\"render :partial => 'spree/admin/shared/configuration_menu'\")"

--- a/app/views/spree/admin/payment_methods/_form.html.haml
+++ b/app/views/spree/admin/payment_methods/_form.html.haml
@@ -1,5 +1,3 @@
-/ replace "div[data-hook='admin_payment_method_form_fields']"
-
 = admin_inject_payment_method
 = admin_inject_json_ams_array "admin.paymentMethods", "shops", @hubs, Api::Admin::BasicEnterpriseSerializer
 %div.alpha.eleven.columns{ "ng-app" => "admin.paymentMethods", "ng-controller" => "paymentMethodCtrl" }
@@ -7,23 +5,23 @@
     .alpha.three.columns
       = label_tag nil, t(:name)
     .omega.eight.columns
-      = text_field :payment_method, :name, :class => 'fullwidth'
+      = text_field :payment_method, :name, class: 'fullwidth'
   .row
     .alpha.three.columns
       = label_tag nil, t(:description)
     .omega.eight.columns
-      = text_area :payment_method, :description, {:cols => 60, :rows => 6, :class => 'fullwidth'}
+      = text_area :payment_method, :description, {cols: 60, rows: 6, class: 'fullwidth'}
   - if spree_current_user.admin?
     .row
       .alpha.three.columns
         = label_tag nil, t(:environment)
       .omega.eight.columns
-        = collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {:id => 'gtwy-env', :class => 'select2 fullwidth'})
+        = collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {id: 'gtwy-env', class: 'select2 fullwidth'})
     .row
       .alpha.three.columns
         = label_tag nil, t(:display)
       .omega.eight.columns
-        = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'})
+        = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
   .row
     .alpha.three.columns
       = label_tag nil, t(:active)
@@ -47,4 +45,4 @@
 
   .row
     .omega.eleven.columns
-      = render partial: 'spree/admin/shared/calculator_fields', :locals => { :f => f }
+      = render partial: 'spree/admin/shared/calculator_fields', locals: { f: f }

--- a/app/views/spree/admin/payment_methods/edit.html.haml
+++ b/app/views/spree/admin/payment_methods/edit.html.haml
@@ -1,12 +1,12 @@
 - content_for :page_title do
-  = t(:editing_payment_method)
+  = t('.editing_payment_method')
   %i.icon-arrow-right
   = @payment_method.name
 - content_for :page_actions do
   %li
     = button_link_to t(:new), spree.new_admin_payment_method_path, icon: 'icon-plus'
   %li
-    = button_link_to t(:back_to_payment_methods_list), spree.admin_payment_methods_path, icon: 'icon-arrow-left'
+    = button_link_to t('.back_to_payment_methods_list'), spree.admin_payment_methods_path, icon: 'icon-arrow-left'
 = render partial: 'spree/shared/error_messages', locals: { target: @payment_method }
 = form_for @payment_method, url: admin_payment_method_path(@payment_method) do |f|
   %fieldset.no-border-top

--- a/app/views/spree/admin/payment_methods/edit.html.haml
+++ b/app/views/spree/admin/payment_methods/edit.html.haml
@@ -1,0 +1,18 @@
+- content_for :page_title do
+  = t(:editing_payment_method)
+  %i.icon-arrow-right
+  = @payment_method.name
+- content_for :page_actions do
+  %li
+    = button_link_to t(:new), spree.new_admin_payment_method_path, icon: 'icon-plus'
+  %li
+    = button_link_to t(:back_to_payment_methods_list), spree.admin_payment_methods_path, icon: 'icon-arrow-left'
+= render partial: 'spree/shared/error_messages', locals: { target: @payment_method }
+= form_for @payment_method, url: admin_payment_method_path(@payment_method) do |f|
+  %fieldset.no-border-top
+    = render partial: 'form', locals: { f: f }
+    .one.column &nbsp;
+    = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :payment_method }
+    .clear
+    .filter-actions.actions
+      = button t(:update), 'icon-refresh'

--- a/app/views/spree/admin/payment_methods/new.html.haml
+++ b/app/views/spree/admin/payment_methods/new.html.haml
@@ -1,0 +1,14 @@
+- content_for :page_title do
+  = t(:new_payment_method)
+- content_for :page_actions do
+  %li
+    = button_link_to t(:back_to_payment_methods_list), admin_payment_methods_path, icon: 'icon-arrow-left'
+= render partial: 'spree/shared/error_messages', locals: { target: @payment_method }
+= form_for @payment_method, url: collection_url do |f|
+  %fieldset.no-border-top
+    = render partial: 'form', locals: { f: f }
+    .one.column &nbsp;
+    = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :payment_method }
+    .clear
+    .filter-actions.actions
+      = button t(:create), 'icon-ok'

--- a/app/views/spree/admin/payment_methods/new.html.haml
+++ b/app/views/spree/admin/payment_methods/new.html.haml
@@ -1,8 +1,8 @@
 - content_for :page_title do
-  = t(:new_payment_method)
+  = t('.new_payment_method')
 - content_for :page_actions do
   %li
-    = button_link_to t(:back_to_payment_methods_list), admin_payment_methods_path, icon: 'icon-arrow-left'
+    = button_link_to t('.back_to_payment_methods_list'), admin_payment_methods_path, icon: 'icon-arrow-left'
 = render partial: 'spree/shared/error_messages', locals: { target: @payment_method }
 = form_for @payment_method, url: collection_url do |f|
   %fieldset.no-border-top

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2696,6 +2696,12 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             other: "You have %{count} active order cycles."
           manage_order_cycles: "MANAGE ORDER CYCLES"
       payment_methods:
+        new:
+          new_payment_method: "New Payment Method"
+          back_to_payment_methods_list: "Back To Payment Methods List"
+        edit:
+          editing_payment_method: "Editing Payment Method"
+          back_to_payment_methods_list: "Back To Payment Methods List"
         stripe_connect:
           enterprise_select_placeholder: Choose...
           loading_account_information_msg: Loading account information from stripe, please wait...


### PR DESCRIPTION
#### What? Why?

Part of #3121 

Import payment_methods new view and form partial in our codebase and apply overrides.
I took advantage of this PR to de-deface edit view as well, since it uses the form partial. @luisramos0 @sauloperez what do you think ?

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
In Config -> Payment Methods -> New Payment Method, the form appears as usual.
In Config -> Payment Methods -> Edit, the form appears as usual.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Import Spree views for `payment_methods` new and edit in our codebase.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
This is a first step towards solving #3121.
