### PR TITLE
[Spree Upgrade] Scopes variants on order completion and on changes to completed orders

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -127,6 +127,12 @@ Spree::LineItem.class_eval do
 
   private
 
+  def update_inventory_with_scoping
+    scoper.scope(variant)
+    update_inventory_without_scoping
+  end
+  alias_method_chain :update_inventory, :scoping
+
   # Override of Spree validation method
   # Added check for in-memory :skip_stock_check attribute
   def stock_availability
@@ -135,8 +141,7 @@ Spree::LineItem.class_eval do
   end
 
   def scoper
-	  return @scoper unless @scoper.nil?
-	  @scoper = OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)
+    @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)
   end
 
   def calculate_final_weight_volume

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -15,6 +15,18 @@ module Spree
       end
     end
 
+    # The shipment manifest is built by loading inventory units and variants from the DB
+    # These variants come unscoped
+    # So, we need to scope the variants just after the manifest is built
+    def manifest_with_scoping
+      manifest_without_scoping.each { |item| scoper.scope(item.variant) }
+    end
+    alias_method_chain :manifest, :scoping
+
+    def scoper
+      @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)
+    end
+
     private
 
     # NOTE: This is an override of spree's method, needed to allow orders


### PR DESCRIPTION
#### What? Why?

See twin PR #3147 
Here we scope the variants before they are used for stock management, so that stock management is done on variant overrides (as prepared in #3147)

In terms of places we need to scope variants, there are quite a few:
- on order completion, scoping variants on order.finalize! is not needed, we need to scope variants in shipment.finalize as it reloads inventory_units.variants before moving stock (handled here)
- scoping variants on line_item.update_inventory (it's a before_save hook in line_item) before changes in line items of completed orders are synced with inventory  (handled here)
- there are quite a few more places we need to do this, we may leave that for a follow up PR

This is fixed with alias_method_chain in both cases, in both cases quite easy to understand ... what do you guys think? alternatives?

#### What should we test?
See #3147 