### PR TITLE
[Spree Upgrade] Remove shipments option from orders tab (gone in spree 2)

### DIFF
--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -65,10 +65,6 @@
       %li{ class: payments_classes }
       = link_to_with_icon 'icon-credit-card', t(:payments), admin_order_payments_url(@order)
 
-      - shipments_classes = "active" if current == "Shipments"
-      %li{ class: shipments_classes }
-      = link_to_with_icon 'icon-road', t(:shipments), admin_order_shipments_url(@order)
-
       - if @order.completed?
         - authorizations_classes = "active" if current == "Return Authorizations"
         %li{ class: authorizations_classes }


### PR DESCRIPTION
The admin orders page has been de-defaced and is now on ofn code as haml.
That de-deface work was merged in #3164. We now need to adapt it to spree 2 by removing the shipments tab that is gone in spree 2.

I've checked the build and it's looking good. This PR and #3164 move us from 87 to 84 broken tests.