### PR TITLE
Add guard clause on variant overrides filter in case hub id is not present in the hubPermissions

### DIFF
--- a/app/assets/javascripts/admin/variant_overrides/filters/hub_permissions_filter.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/filters/hub_permissions_filter.js.coffee
@@ -1,4 +1,5 @@
 angular.module("admin.variantOverrides").filter "hubPermissions", ($filter) ->
   return (products, hubPermissions, hub_id) ->
     return [] if !hub_id
+    return [] if !hubPermissions[hub_id]
     return $filter('filter')(products, ((product) -> hubPermissions[hub_id].indexOf(product.producer_id) > -1), true)


### PR DESCRIPTION
#### What? Why?

Closes #2502 
I am not sure what's the cause of the #2502 but this fix is correct, will not cause any trouble, and we will not see #2502 again. I think we should go ahead with this small fix.

#### What should we test?
I am not sure someone can replicate #2502 in master in some environment. If not, we need to validate inventory page is still working correctly.

#### Release notes
Changelog Category: Fixed
Fixed edge case on inventory page where permissions for hub are not available.

#### How is this related to the Spree upgrade?
This is happening on spree 2 as well.