### PR TITLE
Remove hide class from the hide button in the inventory list

### DIFF
--- a/app/views/admin/variant_overrides/_new_products.html.haml
+++ b/app/views/admin/variant_overrides/_new_products.html.haml
@@ -22,5 +22,5 @@
         %button.fullwidth.icon-plus{ ng: { click: "setVisibility(hub_id,variant.id,true)" } }
           = t('admin.variant_overrides.index.add')
       %td.hide
-        %button.fullwidth.hide.icon-remove{ ng: { click: "setVisibility(hub_id,variant.id,false)" } }
+        %button.fullwidth.icon-remove{ ng: { click: "setVisibility(hub_id,variant.id,false)" } }
           = t('admin.variant_overrides.index.hide')

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -21,7 +21,7 @@
     .tag_watcher{ 'track-tag-list' => true }
       %tags_with_translation{ object: 'variantOverrides[hub_id][variant.id]', form: 'variant_overrides_form' }
   %td.visibility{ ng: { show: 'columns.visibility.visible' } }
-    %button.icon-remove.hide.fullwidth{ :type => 'button', ng: { click: "setVisibility(hub_id,variant.id,false)" } }
+    %button.icon-remove.fullwidth{ :type => 'button', ng: { click: "setVisibility(hub_id,variant.id,false)" } }
       = t('admin.variant_overrides.index.hide')
   %td.import_date{ ng: { show: 'columns.import_date.visible' } }
     %span {{variantOverrides[hub_id][variant.id].import_date | date:"MMMM dd, yyyy HH:mm"}}


### PR DESCRIPTION
The hide button should not be hidden. The hide css class was no active in v1 but it is in v2, so we need to remove it so that hide buttons appear in both new products list as well as in the default inventory view.

#### What? Why?

Fixes 2 of the 3 broken test in #3112

#### What should we test?
Go to inventory page and make sure Hide buttons work on both New products as well as in the default view.