### PR TITLE
Fix broken registration link in footer

### DIFF
--- a/app/views/shared/_register_call.html.haml
+++ b/app/views/shared/_register_call.html.haml
@@ -1,5 +1,9 @@
 .alert-cta
   %h6
+    -# Please forgive the hard-coded link:
+       The more elegant 'registration_path' resolves to /signup due to spree_auth_device > config > routes.rb
+       This is one of several possible fixes. Long-term, we'd like to bring the accounts page into OFN.
+       View the discussion here: https://github.com/openfoodfoundation/openfoodnetwork/pull/3174
     %a{href: "/register", target: "_blank"}
       = t '.selling_on_ofn'
       &nbsp;

--- a/app/views/shared/_register_call.html.haml
+++ b/app/views/shared/_register_call.html.haml
@@ -1,6 +1,6 @@
 .alert-cta
   %h6
-    %a{href: registration_path, target: "_blank"}
+    %a{href: "/register", target: "_blank"}
       = t '.selling_on_ofn'
       &nbsp;
       %strong

--- a/app/views/shared/_register_call.html.haml
+++ b/app/views/shared/_register_call.html.haml
@@ -1,9 +1,9 @@
 .alert-cta
   %h6
     -# Please forgive the hard-coded link:
-       The more elegant 'registration_path' resolves to /signup due to spree_auth_device > config > routes.rb
-       This is one of several possible fixes. Long-term, we'd like to bring the accounts page into OFN.
-       View the discussion here: https://github.com/openfoodfoundation/openfoodnetwork/pull/3174
+    -# The more elegant 'registration_path' resolves to /signup due to spree_auth_device > config > routes.rb
+    -# This is one of several possible fixes. Long-term, we'd like to bring the accounts page into OFN.
+    -# View the discussion here: https://github.com/openfoodfoundation/openfoodnetwork/pull/3174
     %a{href: "/register", target: "_blank"}
       = t '.selling_on_ofn'
       &nbsp;


### PR DESCRIPTION
#### What? Why?

Closes [#3061](https://github.com/openfoodfoundation/openfoodnetwork/issues/3061)

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We have a broken link: In the account page for a buyer account, the footer features a registration call partial that routes the user to /signup instead of /register. 
This fixes things. But I'm not satisfied with it: why would registration_path resolve to /signup on only this page (or at all for that matter)? I'd rather address the root of the problem.

#### What should we test?
<!-- List which features should be tested and how. -->

In a buyer account, navigate to My Account > Orders and click "Register here" in the footer.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a broken registration link in the footer of our My Account page.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed