### PR TITLE
Fix link to Mac setup guide in Getting Started

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -114,7 +114,7 @@ $ createdb open_food_network_test --owner=ofn
 If these commands succeed, you should be able to [continue the setup process](#get-it-running).
 
 [developer-wiki]: https://github.com/openfoodfoundation/openfoodnetwork/wiki
-[sierra]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup:-macOS-(Sierra)
+[sierra]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup%3A-macOS-%28Sierra%2C-HighSierra-and-Mojave%29
 [el-capitan]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup:-OS-X-(El-Capitan)
 [ubuntu]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup:-Ubuntu
 [wiki]: https://github.com/openfoodfoundation/openfoodnetwork/wiki


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

In the Getting Started guide, the link to the Mac setup guide is broken. This fixes things.

#### What should we test?
<!-- List which features should be tested and how. -->

In the Getting Started guide, click the link to the Mac setup guide.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed link to Mac setup guide in Getting Started

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed