### PR TITLE
Fix untranslated buttons at image step of registration modal

### DIFF
--- a/app/views/registration/steps/_images.html.haml
+++ b/app/views/registration/steps/_images.html.haml
@@ -4,8 +4,8 @@
     .row
       .small-12.columns
         %header
-          %h2 {{'registration_images_headline' | t}}
-          %h5 {{'registration_images_description' | t}}
+          %h2= t(".headline")
+          %h5= t(".description")
 
     %form{ name: 'images', novalidate: true, ng: { controller: "RegistrationFormCtrl", submit: "select('social')" } }
       .row{ ng: { repeat: 'image_step in imageSteps', show: "imageStep == image_step" } }
@@ -13,11 +13,11 @@
 
       .row.buttons.pad-top{ ng: { if: "imageStep == 'logo'" } }
         .small-12.columns
-          %input.button.secondary{ type: "button", value: "{{'back' | t}}", ng: { click: "select('about')" } }
+          %input.button.secondary{ type: "button", value: t(".back"), ng: { click: "select('about')" } }
           &nbsp;
-          %input.button.primary.right{ type: "button", value: "{{'continue' | t}}", ng: { click: "imageSelect('promo')" } }
+          %input.button.primary.right{ type: "button", value: t(".continue"), ng: { click: "imageSelect('promo')" } }
 
       .row.buttons.pad-top{ ng: { if: "imageStep == 'promo'" } }
         .small-12.columns
-          %input.button.secondary{ type: "button", value: "{{'back' | t}}", ng: { click: "imageSelect('logo')" } }
-            %input.button.primary.right{ type: "submit", value: "{{'continue' | t}}" }
+          %input.button.secondary{ type: "button", value: t(".back"), ng: { click: "imageSelect('logo')" } }
+            %input.button.primary.right{ type: "submit", value: t(".continue") }

--- a/app/views/registration/steps/_images.html.haml
+++ b/app/views/registration/steps/_images.html.haml
@@ -13,9 +13,9 @@
 
       .row.buttons.pad-top{ ng: { if: "imageStep == 'logo'" } }
         .small-12.columns
-          %input.button.secondary{ type: "button", value: "Back", ng: { click: "select('about')" } }
+          %input.button.secondary{ type: "button", value: "{{'back' | t}}", ng: { click: "select('about')" } }
           &nbsp;
-          %input.button.primary.right{ type: "button", value: "Continue", ng: { click: "imageSelect('promo')" } }
+          %input.button.primary.right{ type: "button", value: "{{'continue' | t}}", ng: { click: "imageSelect('promo')" } }
 
       .row.buttons.pad-top{ ng: { if: "imageStep == 'promo'" } }
         .small-12.columns

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1847,6 +1847,11 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   update_and_recalculate_fees: "Update And Recalculate Fees"
   registration:
     steps:
+      images:
+        continue: "Continue"
+        back: "Back"
+        headline: "Thanks!"
+        description: "Let's upload some pretty pictures so your profile looks great! :)"
       type:
         headline: "Last step to add %{enterprise}!"
         question: "Are you a producer?"
@@ -1986,9 +1991,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   registration_type_producer_help: "Producers make yummy things to eat and/or drink. You're a producer if you grow it, raise it, brew it, bake it, ferment it, milk it or mould it."
   registration_type_no_producer_help: "If you’re not a producer, you’re probably someone who sells and distributes food. You might be a hub, coop, buying group, retailer, wholesaler or other."
   # END
-
-  registration_images_headline: "Thanks!"
-  registration_images_description: "Let's upload some pretty pictures so your profile looks great! :)"
 
 
   # TODO: Remove these once the enterprise.registration.modal keys are translated


### PR DESCRIPTION
#### What? Why?

Closes [#3161](https://github.com/openfoodfoundation/openfoodnetwork/issues/3161)

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This change fixes missing translations on the "back" and "continue" buttons for the Images step of enterprise registration and transitions the form's translations to lazy-loading.

#### What should we test?
<!-- List which features should be tested and how. -->

In the Images step of an enterprise registration, look to the "back" and "continue" buttons at the bottom of the view.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed untranslated buttons at image step of registration modal.
Transitioned the translations in this form to lazy-loading.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed