### PR TITLE
Do not clean DB twice on feature specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,7 +91,6 @@ RSpec.configure do |config|
   config.after(:each, js:true) do
     Capybara.reset_sessions!
     RackRequestBlocker.wait_for_requests_complete
-    DatabaseCleaner.clean
   end
 
   def restart_phantomjs


### PR DESCRIPTION
#### What? Why?

It turns out that we were executing `DatabaseCleaner.clean` on two `after(:each)` blocks. One for all specs and another one for `js: true` specs. As a result feature specs were hitting both which slows them down considerably.

On my machine this changes consistently saves 2sec on `spec/features/consumer/shops_spec.rb` but chances are it has an accumulative effect when run on the whole test suite.


#### What should we test?
No changes on app code.



#### Release notes

Removed an extra database cleanup for feature specs for the sake of performance.

Changelog Category: Changed