### PR TITLE
Make all mailers use appropriate locale when sending emails

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -845,7 +845,6 @@ Layout/SpaceInsideHashLiteralBraces:
     - 'spec/features/admin/reports_spec.rb'
     - 'spec/features/consumer/shopping/checkout_spec.rb'
     - 'spec/helpers/checkout_helper_spec.rb'
-    - 'spec/helpers/i18n_helper_spec.rb'
     - 'spec/helpers/order_cycles_helper_spec.rb'
     - 'spec/lib/open_food_network/enterprise_fee_calculator_spec.rb'
     - 'spec/lib/open_food_network/feature_toggle_spec.rb'

--- a/app/controllers/user_registrations_controller.rb
+++ b/app/controllers/user_registrations_controller.rb
@@ -8,22 +8,22 @@ class UserRegistrationsController < Spree::UserRegistrationsController
   # POST /resource/sign_up
   def create
     @user = build_resource(params[:spree_user])
-    if resource.save
-      session[:spree_user_signup] = true
-      session[:confirmation_return_url] = params[:return_url]
-      associate_user
+    unless resource.save
+      return render_error(@user.errors)
+    end
 
-      respond_to do |format|
-        format.html do
-          set_flash_message(:success, :signed_up_but_unconfirmed)
-          redirect_to after_sign_in_path_for(@user)
-        end
-        format.js do
-          render json: { email: @user.email }
-        end
+    session[:spree_user_signup] = true
+    session[:confirmation_return_url] = params[:return_url]
+    associate_user
+
+    respond_to do |format|
+      format.html do
+        set_flash_message(:success, :signed_up_but_unconfirmed)
+        redirect_to after_sign_in_path_for(@user)
       end
-    else
-      render_error(@user.errors)
+      format.js do
+        render json: { email: @user.email }
+      end
     end
   rescue StandardError => error
     OpenFoodNetwork::ErrorLogger.notify(error)

--- a/app/controllers/user_registrations_controller.rb
+++ b/app/controllers/user_registrations_controller.rb
@@ -5,9 +5,13 @@ class UserRegistrationsController < Spree::UserRegistrationsController
 
   before_filter :set_checkout_redirect, only: :create
 
+  include I18nHelper
+  before_filter :set_locale
+
   # POST /resource/sign_up
   def create
     @user = build_resource(params[:spree_user])
+    @user.locale = I18n.locale.to_s
     unless resource.save
       return render_error(@user.errors)
     end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,7 +1,7 @@
 module I18nHelper
   def set_locale
     # Save a given locale
-    if params[:locale] && Rails.application.config.i18n.available_locales.include?(params[:locale])
+    if params[:locale] && available_locale?(params[:locale])
       spree_current_user.update_attributes!(locale: params[:locale]) if spree_current_user
       cookies[:locale] = params[:locale]
     end
@@ -12,5 +12,19 @@ module I18nHelper
     end
 
     I18n.locale = spree_current_user.andand.locale || cookies[:locale] || I18n.default_locale
+  end
+
+  def valid_locale(locale)
+    if available_locale?(locale)
+      locale
+    else
+      I18n.default_locale
+    end
+  end
+
+  private
+
+  def available_locale?(locale)
+    Rails.application.config.i18n.available_locales.include?(locale)
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -15,7 +15,9 @@ module I18nHelper
   end
 
   def valid_locale(object_with_locale)
-    if object_with_locale.present? && object_with_locale.locale.present? && available_locale?(object_with_locale.locale)
+    if object_with_locale.present? &&
+       object_with_locale.locale.present? &&
+       available_locale?(object_with_locale.locale)
       object_with_locale.locale
     else
       I18n.default_locale

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -14,9 +14,9 @@ module I18nHelper
     I18n.locale = spree_current_user.andand.locale || cookies[:locale] || I18n.default_locale
   end
 
-  def valid_locale(locale)
-    if available_locale?(locale)
-      locale
+  def valid_locale(object_with_locale)
+    if object_with_locale.present? && object_with_locale.locale.present? && available_locale?(object_with_locale.locale)
+      object_with_locale.locale
     else
       I18n.default_locale
     end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -14,11 +14,11 @@ module I18nHelper
     I18n.locale = spree_current_user.andand.locale || cookies[:locale] || I18n.default_locale
   end
 
-  def valid_locale(object_with_locale)
-    if object_with_locale.present? &&
-       object_with_locale.locale.present? &&
-       available_locale?(object_with_locale.locale)
-      object_with_locale.locale
+  def valid_locale(user)
+    if user.present? &&
+       user.locale.present? &&
+       available_locale?(user.locale)
+      user.locale
     else
       I18n.default_locale
     end

--- a/app/mailers/enterprise_mailer.rb
+++ b/app/mailers/enterprise_mailer.rb
@@ -5,7 +5,7 @@ class EnterpriseMailer < Spree::BaseMailer
 
   def welcome(enterprise)
     @enterprise = enterprise
-    I18n.with_locale valid_locale(@enterprise.owner.locale) do
+    I18n.with_locale valid_locale(@enterprise.owner) do
       subject = t('enterprise_mailer.welcome.subject',
                   enterprise: @enterprise.name,
                   sitename: Spree::Config[:site_name])
@@ -20,7 +20,7 @@ class EnterpriseMailer < Spree::BaseMailer
     @instance = Spree::Config[:site_name]
     @instance_email = from_address
 
-    I18n.with_locale valid_locale(@enterprise.owner.locale) do
+    I18n.with_locale valid_locale(@enterprise.owner) do
       subject = t('enterprise_mailer.invite_manager.subject', enterprise: @enterprise.name)
       mail(to: user.email,
            from: from_address,

--- a/app/mailers/enterprise_mailer.rb
+++ b/app/mailers/enterprise_mailer.rb
@@ -1,15 +1,18 @@
 require 'devise/mailers/helpers'
 class EnterpriseMailer < Spree::BaseMailer
   include Devise::Mailers::Helpers
+  include I18nHelper
 
   def welcome(enterprise)
     @enterprise = enterprise
-    subject = t('enterprise_mailer.welcome.subject',
-                enterprise: @enterprise.name,
-                sitename: Spree::Config[:site_name])
-    mail(:to => enterprise.contact.email,
-         :from => from_address,
-         :subject => subject)
+    I18n.with_locale valid_locale(@enterprise.owner.locale) do
+      subject = t('enterprise_mailer.welcome.subject',
+                  enterprise: @enterprise.name,
+                  sitename: Spree::Config[:site_name])
+      mail(:to => enterprise.contact.email,
+           :from => from_address,
+           :subject => subject)
+    end
   end
 
   def manager_invitation(enterprise, user)
@@ -17,11 +20,12 @@ class EnterpriseMailer < Spree::BaseMailer
     @instance = Spree::Config[:site_name]
     @instance_email = from_address
 
-    subject = t('enterprise_mailer.invite_manager.subject', enterprise: @enterprise.name)
-
-    mail(to: user.email,
-         from: from_address,
-         subject: subject)
+    I18n.with_locale valid_locale(@enterprise.owner.locale) do
+      subject = t('enterprise_mailer.invite_manager.subject', enterprise: @enterprise.name)
+      mail(to: user.email,
+           from: from_address,
+           subject: subject)
+    end
   end
 
   private

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -1,4 +1,5 @@
 class ProducerMailer < Spree::BaseMailer
+  include I18nHelper
 
   def order_cycle_report(producer, order_cycle)
     @producer = producer
@@ -10,9 +11,10 @@ class ProducerMailer < Spree::BaseMailer
     @total = total_from_line_items(line_items)
     @tax_total = tax_total_from_line_items(line_items)
 
-    subject = "[#{Spree::Config.site_name}] #{I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)}"
+    I18n.with_locale valid_locale(@producer.owner.locale) do
+      subject = "[#{Spree::Config.site_name}] #{I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)}"
 
-    if has_orders?(order_cycle, producer)
+      return unless has_orders?(order_cycle, producer)
       mail(
         to: @producer.contact.email,
         from: from_address,
@@ -22,7 +24,6 @@ class ProducerMailer < Spree::BaseMailer
       )
     end
   end
-
 
   private
 

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -11,7 +11,7 @@ class ProducerMailer < Spree::BaseMailer
     @total = total_from_line_items(line_items)
     @tax_total = tax_total_from_line_items(line_items)
 
-    I18n.with_locale valid_locale(@producer.owner.locale) do
+    I18n.with_locale valid_locale(@producer.owner) do
       subject = "[#{Spree::Config.site_name}] #{I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)}"
 
       return unless has_orders?(order_cycle, producer)

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -12,7 +12,8 @@ class ProducerMailer < Spree::BaseMailer
     @tax_total = tax_total_from_line_items(line_items)
 
     I18n.with_locale valid_locale(@producer.owner) do
-      subject = "[#{Spree::Config.site_name}] #{I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)}"
+      order_cycle_subject = I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)
+      subject = "[#{Spree::Config.site_name}] #{order_cycle_subject}"
 
       return unless has_orders?(order_cycle, producer)
       mail(

--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -2,41 +2,50 @@ Spree::OrderMailer.class_eval do
   helper HtmlHelper
   helper CheckoutHelper
   helper SpreeCurrencyHelper
+  include I18nHelper
 
   def cancel_email(order, resend = false)
     @order = find_order(order)
-    subject = (resend ? "[#{t(:resend).upcase}] " : '')
-    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{order.number}"
-    mail(to: order.email, from: from_address, subject: subject)
+    I18n.with_locale valid_locale(@order.user.locale) do
+      subject = (resend ? "[#{t(:resend).upcase}] " : '')
+      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{order.number}"
+      mail(to: order.email, from: from_address, subject: subject)
+    end
   end
 
   def confirm_email_for_customer(order, resend = false)
     find_order(order) # Finds an order instance from an id
-    subject = (resend ? "[#{t(:resend).upcase}] " : '')
-    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
-    mail(:to => @order.email,
-         :from => from_address,
-         :subject => subject,
-         :reply_to => @order.distributor.contact.email)
+    I18n.with_locale valid_locale(@order.user.locale) do
+      subject = (resend ? "[#{t(:resend).upcase}] " : '')
+      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
+      mail(:to => @order.email,
+           :from => from_address,
+           :subject => subject,
+           :reply_to => @order.distributor.contact.email)
+    end
   end
 
   def confirm_email_for_shop(order, resend = false)
     find_order(order) # Finds an order instance from an id
-    subject = (resend ? "[#{t(:resend).upcase}] " : '')
-    subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
-    mail(:to => @order.distributor.contact.email,
-         :from => from_address,
-         :subject => subject)
+    I18n.with_locale valid_locale(@order.user.locale) do
+      subject = (resend ? "[#{t(:resend).upcase}] " : '')
+      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
+      mail(:to => @order.distributor.contact.email,
+           :from => from_address,
+           :subject => subject)
+    end
   end
 
   def invoice_email(order, pdf)
     find_order(order) # Finds an order instance from an id
-    attachments["invoice-#{@order.number}.pdf"] = pdf if pdf.present?
-    subject = "#{Spree::Config[:site_name]} #{t(:invoice)} ##{@order.number}"
-    mail(:to => @order.email,
-         :from => from_address,
-         :subject => subject,
-         :reply_to => @order.distributor.contact.email)
+    I18n.with_locale valid_locale(@order.user.locale) do
+      attachments["invoice-#{@order.number}.pdf"] = pdf if pdf.present?
+      subject = "#{Spree::Config[:site_name]} #{t(:invoice)} ##{@order.number}"
+      mail(:to => @order.email,
+           :from => from_address,
+           :subject => subject,
+          :reply_to => @order.distributor.contact.email)
+    end
   end
 
   def find_order(order)

--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -7,48 +7,54 @@ Spree::OrderMailer.class_eval do
   def cancel_email(order, resend = false)
     @order = find_order(order)
     I18n.with_locale valid_locale(@order.user) do
-      subject = (resend ? "[#{t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{order.number}"
-      mail(to: order.email, from: from_address, subject: subject)
+      mail(to: order.email,
+           from: from_address,
+           subject: mail_subject(t('order_mailer.cancel_email.subject'), resend))
     end
   end
 
   def confirm_email_for_customer(order, resend = false)
     find_order(order) # Finds an order instance from an id
     I18n.with_locale valid_locale(@order.user) do
-      subject = (resend ? "[#{t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
-      mail(:to => @order.email,
-           :from => from_address,
-           :subject => subject,
-           :reply_to => @order.distributor.contact.email)
+      mail(to: @order.email,
+           from: from_address,
+           subject: mail_subject(t('order_mailer.confirm_email.subject'), resend),
+           reply_to: @order.distributor.contact.email)
     end
   end
 
   def confirm_email_for_shop(order, resend = false)
     find_order(order) # Finds an order instance from an id
     I18n.with_locale valid_locale(@order.user) do
-      subject = (resend ? "[#{t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
-      mail(:to => @order.distributor.contact.email,
-           :from => from_address,
-           :subject => subject)
+      mail(to: @order.distributor.contact.email,
+           from: from_address,
+           subject: mail_subject(t('order_mailer.confirm_email.subject'), resend))
     end
   end
 
   def invoice_email(order, pdf)
     find_order(order) # Finds an order instance from an id
+    attach_file("invoice-#{@order.number}.pdf", pdf)
     I18n.with_locale valid_locale(@order.user) do
-      attachments["invoice-#{@order.number}.pdf"] = pdf if pdf.present?
-      subject = "#{Spree::Config[:site_name]} #{t(:invoice)} ##{@order.number}"
-      mail(:to => @order.email,
-           :from => from_address,
-           :subject => subject,
-          :reply_to => @order.distributor.contact.email)
+      mail(to: @order.email,
+           from: from_address,
+           subject: mail_subject(t(:invoice), false),
+           reply_to: @order.distributor.contact.email)
     end
   end
 
   def find_order(order)
     @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
+  end
+
+  private
+
+  def mail_subject(base_subject, resend)
+    resend_prefix = (resend ? "[#{t(:resend).upcase}] " : '')
+    "#{resend_prefix}#{Spree::Config[:site_name]} #{base_subject} ##{@order.number}"
+  end
+
+  def attach_file(filename, file)
+    attachments[filename] = file if file.present?
   end
 end

--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -6,7 +6,7 @@ Spree::OrderMailer.class_eval do
 
   def cancel_email(order, resend = false)
     @order = find_order(order)
-    I18n.with_locale valid_locale(@order.user.locale) do
+    I18n.with_locale valid_locale(@order.user) do
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('order_mailer.cancel_email.subject')} ##{order.number}"
       mail(to: order.email, from: from_address, subject: subject)
@@ -15,7 +15,7 @@ Spree::OrderMailer.class_eval do
 
   def confirm_email_for_customer(order, resend = false)
     find_order(order) # Finds an order instance from an id
-    I18n.with_locale valid_locale(@order.user.locale) do
+    I18n.with_locale valid_locale(@order.user) do
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
       mail(:to => @order.email,
@@ -27,7 +27,7 @@ Spree::OrderMailer.class_eval do
 
   def confirm_email_for_shop(order, resend = false)
     find_order(order) # Finds an order instance from an id
-    I18n.with_locale valid_locale(@order.user.locale) do
+    I18n.with_locale valid_locale(@order.user) do
       subject = (resend ? "[#{t(:resend).upcase}] " : '')
       subject += "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{@order.number}"
       mail(:to => @order.distributor.contact.email,
@@ -38,7 +38,7 @@ Spree::OrderMailer.class_eval do
 
   def invoice_email(order, pdf)
     find_order(order) # Finds an order instance from an id
-    I18n.with_locale valid_locale(@order.user.locale) do
+    I18n.with_locale valid_locale(@order.user) do
       attachments["invoice-#{@order.number}.pdf"] = pdf if pdf.present?
       subject = "#{Spree::Config[:site_name]} #{t(:invoice)} ##{@order.number}"
       mail(:to => @order.email,

--- a/app/mailers/spree/user_mailer_decorator.rb
+++ b/app/mailers/spree/user_mailer_decorator.rb
@@ -3,7 +3,7 @@ Spree::UserMailer.class_eval do
 
   def signup_confirmation(user)
     @user = user
-    I18n.with_locale valid_locale(@user.locale) do
+    I18n.with_locale valid_locale(@user) do
       mail(:to => user.email, :from => from_address,
            :subject => t(:welcome_to) + Spree::Config[:site_name])
     end
@@ -16,7 +16,7 @@ Spree::UserMailer.class_eval do
     @instance = Spree::Config[:site_name]
     @contact = ContentConfig.footer_email
 
-    I18n.with_locale valid_locale(@user.locale) do
+    I18n.with_locale valid_locale(@user) do
       subject = t('spree.user_mailer.confirmation_instructions.subject')
       mail(to: confirmation_email_address,
            from: from_address,

--- a/app/mailers/spree/user_mailer_decorator.rb
+++ b/app/mailers/spree/user_mailer_decorator.rb
@@ -1,8 +1,12 @@
 Spree::UserMailer.class_eval do
+  include I18nHelper
+
   def signup_confirmation(user)
     @user = user
-    mail(:to => user.email, :from => from_address,
-         :subject => t(:welcome_to) + Spree::Config[:site_name])
+    I18n.with_locale valid_locale(@user.locale) do
+      mail(:to => user.email, :from => from_address,
+           :subject => t(:welcome_to) + Spree::Config[:site_name])
+    end
   end
 
   # Overriding `Spree::UserMailer.confirmation_instructions` which is
@@ -12,10 +16,12 @@ Spree::UserMailer.class_eval do
     @instance = Spree::Config[:site_name]
     @contact = ContentConfig.footer_email
 
-    subject = t('spree.user_mailer.confirmation_instructions.subject')
-    mail(to: confirmation_email_address,
-         from: from_address,
-         subject: subject)
+    I18n.with_locale valid_locale(@user.locale) do
+      subject = t('spree.user_mailer.confirmation_instructions.subject')
+      mail(to: confirmation_email_address,
+           from: from_address,
+           subject: subject)
+    end
   end
 
   private

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -48,7 +48,8 @@ class SubscriptionMailer < Spree::BaseMailer
 
   def send_mail(order)
     I18n.with_locale valid_locale(order.user) do
-      subject = "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{order.number}"
+      confirm_email_subject = t('order_mailer.confirm_email.subject')
+      subject = "#{Spree::Config[:site_name]} #{confirm_email_subject} ##{order.number}"
       mail(to: order.email,
            from: from_address,
            subject: subject,

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -47,7 +47,7 @@ class SubscriptionMailer < Spree::BaseMailer
   private
 
   def send_mail(order)
-    I18n.with_locale valid_locale(order.user.locale) do
+    I18n.with_locale valid_locale(order.user) do
       subject = "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{order.number}"
       mail(to: order.email,
            from: from_address,

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,6 +1,7 @@
 class SubscriptionMailer < Spree::BaseMailer
   helper CheckoutHelper
   helper ShopMailHelper
+  include I18nHelper
 
   def confirmation_email(order)
     @type = 'confirmation'
@@ -46,10 +47,12 @@ class SubscriptionMailer < Spree::BaseMailer
   private
 
   def send_mail(order)
-    subject = "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{order.number}"
-    mail(to: order.email,
-         from: from_address,
-         subject: subject,
-         reply_to: order.distributor.contact.email)
+    I18n.with_locale valid_locale(order.user.locale) do
+      subject = "#{Spree::Config[:site_name]} #{t('order_mailer.confirm_email.subject')} ##{order.number}"
+      mail(to: order.email,
+           from: from_address,
+           subject: subject,
+           reply_to: order.distributor.contact.email)
+    end
   end
 end

--- a/spec/controllers/user_registrations_controller_spec.rb
+++ b/spec/controllers/user_registrations_controller_spec.rb
@@ -48,6 +48,16 @@ describe UserRegistrationsController, type: :controller do
       expect(json).to eq({"email" => "test@test.com"})
       expect(controller.spree_current_user).to be_nil
     end
+
+    it "sets user.locale from cookie on create" do
+      original_locale_cookie = cookies[:locale]
+      cookies[:locale] = "pt"
+
+      xhr :post, :create, spree_user: user_params, use_route: :spree
+
+      expect(assigns[:user].locale).to eq("pt")
+      cookies[:locale] = original_locale_cookie
+    end
   end
 
   context "when registration fails" do

--- a/spec/helpers/i18n_helper_spec.rb
+++ b/spec/helpers/i18n_helper_spec.rb
@@ -24,13 +24,13 @@ describe I18nHelper, type: :helper do
     end
 
     it "sets the chosen locale" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
       expect(I18n.locale).to eq :es
     end
 
     it "remembers the chosen locale" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
 
       allow(helper).to receive(:params) { {} }
@@ -39,16 +39,16 @@ describe I18nHelper, type: :helper do
     end
 
     it "ignores unavailable locales" do
-      allow(helper).to receive(:params) { {locale: "xx"} }
+      allow(helper).to receive(:params) { { locale: "xx" } }
       helper.set_locale
       expect(I18n.locale).to eq :en
     end
 
     it "remembers the last chosen locale" do
-      allow(helper).to receive(:params) { {locale: "en"} }
+      allow(helper).to receive(:params) { { locale: "en" } }
       helper.set_locale
 
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
 
       allow(helper).to receive(:params) { {} }
@@ -57,7 +57,7 @@ describe I18nHelper, type: :helper do
     end
 
     it "remembers the chosen locale after logging in" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
 
       # log in
@@ -68,7 +68,7 @@ describe I18nHelper, type: :helper do
     end
 
     it "forgets the chosen locale without cookies" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
 
       # clean up cookies
@@ -91,14 +91,14 @@ describe I18nHelper, type: :helper do
     end
 
     it "sets the chosen locale" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
       expect(I18n.locale).to eq :es
       expect(user.locale).to eq "es"
     end
 
     it "remembers the chosen locale" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
 
       allow(helper).to receive(:params) { {} }
@@ -107,10 +107,10 @@ describe I18nHelper, type: :helper do
     end
 
     it "remembers the last chosen locale" do
-      allow(helper).to receive(:params) { {locale: "en"} }
+      allow(helper).to receive(:params) { { locale: "en" } }
       helper.set_locale
 
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
 
       allow(helper).to receive(:params) { {} }
@@ -119,7 +119,7 @@ describe I18nHelper, type: :helper do
     end
 
     it "remembers the chosen locale after logging out" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
 
       # log out
@@ -130,7 +130,7 @@ describe I18nHelper, type: :helper do
     end
 
     it "remembers the chosen locale on another computer" do
-      allow(helper).to receive(:params) { {locale: "es"} }
+      allow(helper).to receive(:params) { { locale: "es" } }
       helper.set_locale
       expect(cookies[:locale]).to eq "es"
 
@@ -140,6 +140,38 @@ describe I18nHelper, type: :helper do
       allow(helper).to receive(:params) { {} }
       helper.set_locale
       expect(I18n.locale).to eq :es
+    end
+  end
+
+  context "#valid_locale" do
+    around do |example|
+      original_default_locale = I18n.default_locale
+      original_available_locales = Rails.application.config.i18n.available_locales
+      I18n.default_locale = "es"
+      Rails.application.config.i18n.available_locales = ["es", "pt"]
+      example.run
+      I18n.default_locale = original_default_locale
+      Rails.application.config.i18n.available_locales = original_available_locales
+    end
+
+    let(:user) { build(:user) }
+
+    it "returns default locale if given user is nil" do
+      expect(helper.valid_locale(nil)).to eq I18n.default_locale
+    end
+
+    it "returns default locale if locale of given user is nil" do
+      expect(helper.valid_locale(user)).to eq I18n.default_locale
+    end
+
+    it "returns default locale if locale of given user is not available" do
+      user.locale = "cn"
+      expect(helper.valid_locale(user)).to eq I18n.default_locale
+    end
+
+    it "returns the locale of the given user if available" do
+      user.locale = "pt"
+      expect(helper.valid_locale(user)).to eq "pt"
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -17,9 +17,32 @@ describe Spree::UserMailer do
     setup_email
   end
 
-  it "sends an email when given a user" do
-    Spree::UserMailer.signup_confirmation(user).deliver
-    ActionMailer::Base.deliveries.count.should == 1
+  describe '#signup_confirmation' do
+    it "sends email when given a user" do
+      Spree::UserMailer.signup_confirmation(user).deliver
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
+
+    describe "user locale" do
+      around do |example|
+        original_default_locale = I18n.default_locale
+        I18n.default_locale = 'pt'
+        example.run
+        I18n.default_locale = original_default_locale
+      end
+
+      it "sends email in user locale when user locale is defined" do
+        user.locale = 'es'
+        Spree::UserMailer.signup_confirmation(user).deliver
+        expect(ActionMailer::Base.deliveries.first.body).to include "Gracias por unirte"
+      end
+
+      it "sends email in default locale when user locale is not available" do
+        user.locale = 'cn'
+        Spree::UserMailer.signup_confirmation(user).deliver
+        expect(ActionMailer::Base.deliveries.first.body).to include "Obrigada por juntar-se"
+      end
+    end
   end
 
   # adapted from https://github.com/spree/spree_auth_devise/blob/70737af/spec/mailers/user_mailer_spec.rb


### PR DESCRIPTION
#### What? Why?

Closes #3043 

In order to send emails in the correct locale we need to select the appropriate locale for each email type, for example, order confirmation should come from the user of the order.

Note for reviewers:
- I am happy to try a different approach. I could not extract/abstract I18n.with_locale because it's needed for both mail _and_ for the t calls in subject.
- I could test this locale change in all mailers (not just user mailer). It would be too much noise?

#### What should we test?
All emails need to be tested. In the default language of the instance used for testing and also in a  language different from the instance default.

#### Release notes
Changelog Category: Added

Emails all now sent in specific locales related to the users, not the instance default language.