### PR TITLE
[Spree Upgrade] Fix admin new order page

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/variant_autocomplete.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/variant_autocomplete.js.coffee
@@ -23,6 +23,7 @@ angular.module("admin.utils").directive "variantAutocomplete", ($timeout) ->
               distributor_id: scope.distributor_id
               order_cycle_id: scope.order_cycle_id
             results: (data, page) ->
+              window.variants = data # this is how spree auto complete JS code picks up variants
               results: data
           formatResult: (variant) ->
             if variant["images"][0] != undefined && variant["images"][0].image != undefined

--- a/app/overrides/spree/admin/orders/customer_details/edit/replace_customer_search.html.haml.deface
+++ b/app/overrides/spree/admin/orders/customer_details/edit/replace_customer_search.html.haml.deface
@@ -1,4 +1,4 @@
-/ replace "code[erb-loud]:contains('hidden_field_tag :customer_search')"
+/ replace "erb[loud]:contains('hidden_field_tag :customer_search')"
 
 - content_for :app_wrapper_attrs do
   = 'ng-app=admin.orders'

--- a/app/views/spree/admin/orders/_add_product.html.haml
+++ b/app/views/spree/admin/orders/_add_product.html.haml
@@ -1,17 +1,11 @@
-= render partial: "spree/admin/variants/autocomplete", formats: :js
-#add-line-item
-  %fieldset
-    %legend{align: "center"}
-      = t(:add_product)
-    .field.eight.columns.alpha
-      = label_tag :add_product_name, t(:name_or_sku)
-      = hidden_field_tag :add_variant_id, "", class: "variant_autocomplete fullwidth"
-    .field.two.columns
-      = label_tag :add_quantity, t(:qty)
-      = number_field_tag :add_quantity,  1, min: 0
-    .actions.two.columns.omega
-      = link_to_with_icon 'icon-plus', t(:add), admin_order_line_items_url(@order),
-        method: :post,
-        id: 'add_line_item_to_order',
-        class: 'button fullwidth',
-        'data-update' => 'order-form-wrapper'
+= render :partial => "spree/admin/variants/autocomplete", :formats => :js
+
+#add-line-item{"data-hook" => ""}
+  %fieldset.no-border-bottom
+    %legend{:align => "center"}= Spree.t(:add_product)
+
+    .field.twelve.columns.alpha{"data-hook" => "add_product_name"}
+      = label_tag :add_variant_id, Spree.t(:name_or_sku)
+      = hidden_field_tag :add_variant_id, "", :class => "variant_autocomplete fullwidth"
+      
+  #stock_details

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -1,68 +1,35 @@
-%div
+%div{"data-hook" => "admin_order_form_fields"}
   - if @line_item.try(:errors).present?
-    = render partial: 'spree/shared/error_messages', locals: { target: @line_item }
-  = form_for @order, url: admin_order_url(@order), method: :put do |f|
-    %fieldset.no-border-top
-      = f.hidden_field :number
-      %table.index{"ng-show" => "distributionChosen()"}
-        %colgroup
-          %col{style: "width: 49%;"}/
-          %col{style: "width: 14%;"}/
-          %col{style: "width: 10%;"}/
-          %col{style: "width: 14%;"}/
-          %col{style: "width: 8%;"}/
-        %thead#line-items
-          %tr
-            %th
-              = t(:item_description)
-            %th.price
-              = t(:price)
-            %th.qty
-              = t(:qty)
-            %th.total
-              %span
-                = t(:total)
-            %th.orders-actions.actions
-        %tbody
-          = f.fields_for :line_items do |li_form|
-            = render partial: 'spree/admin/orders/line_item', locals: { f: li_form }
-        %tbody#subtotal.no-border-top
-          %tr#subtotal-row
-            %td{colspan: "3"}
-              %b
-                = t(:subtotal)
-                \:
-            %td.total.align-center
-              %span
-                = @order.display_item_total.to_html
-            %td.actions
-        %tbody#order-charges.no-border-top
-          - @order.adjustments.eligible.each do |adjustment|
-            %tr
-              %td{colspan: "3"}
+    = render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item }
+
+  = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
+
+  - if order.adjustments.eligible.exists?
+    %fieldset.no-border-bottom
+      %legend= Spree.t('adjustments')
+      %table
+        %thead
+          %th= Spree.t('name')
+          %th= Spree.t('amount')
+        %tbody#order-charges.with-border{"data-hook" => "order_details_adjustments"}
+          - order.adjustments.eligible.each do |adjustment|
+            - next if ((adjustment.originator_type == 'Spree::TaxRate') and (adjustment.amount == 0)) || adjustment.originator_type == 'Spree::ShippingMethod'
+            %tr.total
+              %td
                 %strong
                   = adjustment.label
                   \:
               %td.total.align-center
-                %span= adjustment.display_amount.to_html
-              %td.actions
-        %tbody#order-total.grand-total.no-border-top
-          %tr
-            %td{colspan: "3"}
-              %b
-                = t(:order_total)
-                \:
-            %td.total.align-center
-              %span#order_total
-                = @order.display_total.to_html
-            %td.actions
+                %span= adjustment.display_amount
 
-      = render partial: 'spree/admin/orders/_form/distribution_fields'
+  - if order.line_items.exists?
+    %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}
+      %legend= Spree.t(:order_total)
+      %span.order-total= order.display_total
 
-      .filter-actions.actions{"ng-show" => "distributionChosen()"}
-        = button t(:update_and_recalculate_fees), 'icon-refresh'
-        %span.or
-          = t(:or)
-        = link_to_with_icon 'button icon-arrow-left', t(:back), admin_orders_url
   = javascript_tag do
-    = render partial: 'spree/admin/shared/update_order_state', handlers: [:js]
+    var order_number = '#{@order.number}';
+    var shipments = [];
+    - @order.shipments.each do |shipment|
+      shipments.push(#{shipment.to_json(:root => false, :include => [:inventory_units, :stock_location]).html_safe});
+    = render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js]

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -27,6 +27,15 @@
       %legend= Spree.t(:order_total)
       %span.order-total= order.display_total
 
+  = form_for @order, url: admin_order_url(@order), method: :put do |f|
+    = render partial: 'spree/admin/orders/_form/distribution_fields'
+
+    .filter-actions.actions{"ng-show" => "distributionChosen()"}
+      = button t(:update_and_recalculate_fees), 'icon-refresh'
+      %span.or
+        = t(:or)
+      = link_to_with_icon 'button icon-arrow-left', t(:back), admin_orders_url
+
   = javascript_tag do
     var order_number = '#{@order.number}';
     var shipments = [];

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -16,15 +16,19 @@
   - unless params["suppress_error_msg"]
     = render partial: "spree/shared/error_messages", :locals => { :target => @order }
 
-= render :partial => 'add_product' if can?(:update, @order)
+  = admin_inject_shops(module: 'admin.orders')
+  = admin_inject_order_cycles
+  %div{"ng-app" => "admin.orders", "ng-controller" => "orderCtrl", "ofn-distributor-id" => @order.distributor_id, "ofn-order-cycle-id" => @order.order_cycle_id}
 
-- if @order.line_items.empty?
-  .no-objects-found
-    = Spree.t(:your_order_is_empty_add_product)
+    = render :partial => 'add_product' if can?(:update, @order)
 
-%div{"data-hook" => "admin_order_edit_form"}
-  #order-form-wrapper
-    = render :partial => 'form', :locals => { :order => @order }
+    - if @order.line_items.empty?
+      .no-objects-found
+        = Spree.t(:your_order_is_empty_add_product)
+
+    %div{"data-hook" => "admin_order_edit_form"}
+      #order-form-wrapper
+        = render :partial => 'form', :locals => { :order => @order }
 
 - content_for :head do
   = javascript_tag 'var expand_variants = true;'

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -1,27 +1,30 @@
 = csrf_meta_tags
-
 - content_for :page_actions do
-  %li= event_links
-  %li= button_link_to t(:resend), resend_admin_order_url(@order), method: :post, icon: 'icon-email'
+  - if can?(:fire, @order)
+    %li= event_links
+  - if can?(:resend, @order)
+    %li= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'icon-email'
   %li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
+  - if can?(:admin, Spree::Order)
+    %li= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
-  %li= button_link_to t(:back_to_orders_list), admin_orders_path, icon: 'icon-arrow-left'
+= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Order Details' }
 
-= admin_inject_shops(module: 'admin.orders')
-= admin_inject_order_cycles
-
-= render 'spree/admin/shared/order_tabs', current: 'Order Details'
-
-%div
+%div{"data-hook" => "admin_order_edit_header"}
+  -# Suppress errors when manually creating a new order - needs to proceed to edit page
+  -# without having line items (which otherwise gives a validation error)
   - unless params["suppress_error_msg"]
     = render partial: "spree/shared/error_messages", :locals => { :target => @order }
 
-%div{"ng-app" => "admin.orders", "ng-controller" => "orderCtrl", "ofn-distributor-id" => @order.distributor_id, "ofn-order-cycle-id" => @order.order_cycle_id}
-  = render 'add_product'
+= render :partial => 'add_product' if can?(:update, @order)
 
-  %div
-    #order-form-wrapper
-      = render 'form', order: @order
+- if @order.line_items.empty?
+  .no-objects-found
+    = Spree.t(:your_order_is_empty_add_product)
+
+%div{"data-hook" => "admin_order_edit_form"}
+  #order-form-wrapper
+    = render :partial => 'form', :locals => { :order => @order }
 
 - content_for :head do
   = javascript_tag 'var expand_variants = true;'

--- a/app/views/spree/admin/shared/_routes.html.erb
+++ b/app/views/spree/admin/shared/_routes.html.erb
@@ -1,10 +1,13 @@
 <script>
   Spree.routes = <%== {
-    :variants_search       => admin_search_variants_path(:format => 'json'),
+    :variants_search       => spree.admin_search_variants_path(:format => 'json'),
     :taxons_search         => spree.api_taxons_path(:format => 'json'),
     :user_search           => spree.admin_search_users_path(:format => 'json'),
     :product_search        => spree.api_products_path(:format => 'json'),
     :option_type_search    => spree.api_option_types_path(:format => 'json'),
-    :states_search         => spree.api_states_path(:format => 'json')
+    :states_search         => spree.api_states_path(:format => 'json'),
+    :orders_api            => spree.api_orders_path(:format => 'json'),
+    :stock_locations_api   => spree.api_stock_locations_path(:format => 'json'),
+    :variants_api          => spree.api_variants_path(:format => 'json')
   }.to_json %>;
 </script>

--- a/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -29,3 +29,43 @@
     </div>
   </div>
 </script>
+<script type='text/template' id='variant_autocomplete_stock_template'>
+  <fieldset>
+    <legend align="center"><%= Spree.t(:select_stock) %></legend>
+      <table class="stock-levels" data-hook="stock-levels">
+        <colgroup>
+          <col style="width: 30%;" />
+          <col style="width: 40%;" />
+          <col style="width: 20%;" />
+          <col style="width: 10%;" />
+        </colgroup>
+        <thead>
+          <th><%= Spree.t(:location) %></th>
+          <th><%= Spree.t(:count_on_hand) %></th>
+          <th><%= Spree.t(:quantity) %></th>
+          <th class="actions"></th>
+        </thead>
+        <tbody>
+          {{#each variant.stock_items}}
+            <tr>
+              <td>{{this.stock_location_name}}</td>
+              {{#if this.available}}
+                <td>
+                  {{this.count_on_hand}}
+                  {{#if this.backorderable}} (backorders allowed) {{/if}}
+                </td>
+                <td>
+                  <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
+                </td>
+                <td class="actions">
+                  <button class="add_variant no-text icon-plus icon_link with-tip" data-stock-location-id="{{this.stock_location_id}}" title="Add" data-action="add"></button>
+                </td>
+              {{else}}
+                <td><%= Spree.t(:out_of_stock) %></td>
+                <td>0</td>
+              {{/if}}
+            </tr>
+          {{/each}}
+        </tbody>
+  </fieldset>
+</script>

--- a/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -46,26 +46,27 @@
           <th class="actions"></th>
         </thead>
         <tbody>
-          {{#each variant.stock_items}}
-            <tr>
-              <td>{{this.stock_location_name}}</td>
-              {{#if this.available}}
-                <td>
-                  {{this.count_on_hand}}
-                  {{#if this.backorderable}} (backorders allowed) {{/if}}
-                </td>
-                <td>
-                  <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
-                </td>
-                <td class="actions">
-                  <button class="add_variant no-text icon-plus icon_link with-tip" data-stock-location-id="{{this.stock_location_id}}" title="Add" data-action="add"></button>
-                </td>
+          <tr>
+            <td>{{variant.stock_location_name}}</td>
+            {{#if variant.[in_stock?]}}
+              {{#if variant.on_demand}}
+                <td>Spree.t(:on_demand)</td>
               {{else}}
-                <td><%= Spree.t(:out_of_stock) %></td>
-                <td>0</td>
-              {{/if}}
-            </tr>
-          {{/each}}
+                <td>
+                  {{variant.count_on_hand}}
+                </td>
+              {{/if}}                  
+              <td>
+                <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{variant.stock_location_id}}" type="number" min="1" value="1">
+              </td>
+              <td class="actions">
+                <button class="add_variant no-text icon-plus icon_link with-tip" data-stock-location-id="{{variant.stock_location_id}}" title="Add" data-action="add"></button>
+              </td>
+            {{else}}
+              <td><%= Spree.t(:out_of_stock) %></td>
+              <td>0</td>
+            {{/if}}
+          </tr>
         </tbody>
   </fieldset>
 </script>

--- a/app/views/spree/admin/variants/search.rabl
+++ b/app/views/spree/admin/variants/search.rabl
@@ -2,7 +2,7 @@
 # overriding spree/core/app/views/spree/admin/variants/search.rabl
 #
 collection @variants
-attributes :sku, :options_text, :count_on_hand, :id, :cost_price
+attributes :sku, :options_text, :in_stock?, :on_demand, :count_on_hand, :id, :cost_price
 
 node(:name) do |v|
   # TODO: when products must have a unit, full_name will always be present
@@ -20,6 +20,14 @@ end
 
 node(:producer_name) do |v|
   v.product.supplier.name
+end
+
+node(:stock_location_id) do |v|
+  v.stock_items.first.stock_location.id
+end
+
+node(:stock_location_name) do |v|
+  v.stock_items.first.stock_location.name
 end
 
 child(:images => :images) do

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -72,7 +72,7 @@ feature %q{
     expect(page).not_to have_selector '#errorExplanation'
     expect(page).to have_content 'ADD PRODUCT'
     targetted_select2_search @product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
-    click_link 'Add'
+    find('button.add_variant').click
     page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr"  # Wait for JS
     expect(page).to have_selector 'td', text: @product.name
 
@@ -92,7 +92,7 @@ feature %q{
 
     targetted_select2_search @product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
 
-    click_link 'Add'
+    find('button.add_variant').click
 
     expect(page).to have_selector 'td', text: @product.name
     expect(@order.line_items(true).map(&:product)).to include @product
@@ -112,7 +112,6 @@ feature %q{
     page.find('a.icon-search').click
 
     click_icon :edit
-
     select2_select d.name, from: 'order_distributor_id'
     select2_select oc.name, from: 'order_order_cycle_id'
 
@@ -157,14 +156,14 @@ feature %q{
     quick_login_as @user
     new_order_with_distribution(@distributor, @order_cycle)
     targetted_select2_search @product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
-    click_link 'Add'
+    find('button.add_variant').click
     page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr"  # Wait for JS
     click_button 'Update'
     expect(page).to have_selector 'h1.page-title', text: "Customer Details"
 
     # And I select that customer's email address and save the order
     targetted_select2_search @customer.email, from: '#customer_search_override', dropdown_css: '.select2-drop'
-    click_button 'Continue'
+    click_button 'Update'
     expect(page).to have_selector "h1.page-title", text: "Shipments"
 
     # Then their addresses should be associated with the order
@@ -230,16 +229,16 @@ feature %q{
         within('table.index tbody', match: :first) do
           @order.line_items.each do |item|
             expect(page).to have_selector "td", match: :first, text: item.full_name
-            expect(page).to have_selector "td.price", text: item.single_display_amount
-            expect(page).to have_selector "input.qty[value='#{item.quantity}']"
-            expect(page).to have_selector "td.total", text: item.display_amount
+            expect(page).to have_selector "td.item-price", text: item.single_display_amount
+            expect(page).to have_selector "input#quantity[value='#{item.quantity}']", visible: false
+            expect(page).to have_selector "td.item-total", text: item.display_amount
           end
         end
       end
 
-      scenario "shows the order subtotal" do
-        within('table.index tbody#subtotal') do
-          expect(page).to have_selector "td.total", text: @order.display_item_total
+      scenario "shows the order items total" do
+        within('fieldset#order-total') do
+          expect(page).to have_selector "span.order-total", text: @order.display_item_total
         end
       end
 
@@ -254,13 +253,11 @@ feature %q{
       end
 
       scenario "shows the order total" do
-        within('table.index tbody#order-total') do
-          expect(page).to have_selector "td.total", text: @order.display_total
-        end
+        expect(page).to have_selector "fieldset#order-total", text: @order.display_total
       end
 
       scenario "shows the order taxes" do
-        within('table.index tbody#price-adjustments') do
+        within('tbody#order-charges') do
           expect(page).to have_selector "td", match: :first, text: "Tax 1"
           expect(page).to have_selector "td.total", text: Spree::Money.new(10)
         end
@@ -324,7 +321,7 @@ feature %q{
       expect(page).to have_content 'ADD PRODUCT'
       targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
 
-      click_link 'Add'
+      find('button.add_variant').click
       page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr"  # Wait for JS
       expect(page).to have_selector 'td', text: product.name
 

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -101,10 +101,11 @@ feature %q{
   scenario "displays error when incorrect distribution for products is chosen" do
     d = create(:distributor_enterprise)
     oc = create(:simple_order_cycle, distributors: [d])
-    puts d.name
-    puts @distributor.name
 
-    @order.state = 'cart'; @order.completed_at = nil; @order.save
+    # Moves the order back to the cart state
+    #   A nil user keeps the order in the cart state
+    #   Even if the edit page tries to automatically progress the order workflow
+    @order.state = 'cart'; @order.user = nil; @order.completed_at = nil; @order.save
 
     quick_login_as_admin
     visit '/admin/orders'

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -102,10 +102,13 @@ feature %q{
     d = create(:distributor_enterprise)
     oc = create(:simple_order_cycle, distributors: [d])
 
-    # Moves the order back to the cart state
-    #   A nil user keeps the order in the cart state
+    # Move the order back to the cart state
+    @order.state = 'cart'
+    @order.completed_at = nil
+    # A nil user keeps the order in the cart state
     #   Even if the edit page tries to automatically progress the order workflow
-    @order.state = 'cart'; @order.user = nil; @order.completed_at = nil; @order.save
+    @order.user = nil
+    @order.save
 
     quick_login_as_admin
     visit '/admin/orders'

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -242,8 +242,8 @@ feature %q{
         end
       end
 
-      scenario "shows the order charges (non-tax adjustments)" do
-        within('tbody#order-charges') do
+      scenario "shows the order non-tax adjustments" do
+        within('table.index tbody') do
           @order.adjustments.eligible.each do |adjustment|
             next if (adjustment.originator_type == 'Spree::TaxRate') && (adjustment.amount == 0)
             expect(page).to have_selector "td", match: :first, text: adjustment.label
@@ -256,7 +256,7 @@ feature %q{
         expect(page).to have_selector "fieldset#order-total", text: @order.display_total
       end
 
-      scenario "shows the order taxes" do
+      scenario "shows the order tax adjustments" do
         within('tbody#order-charges') do
           expect(page).to have_selector "td", match: :first, text: "Tax 1"
           expect(page).to have_selector "td.total", text: Spree::Money.new(10)

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -407,7 +407,7 @@ feature %q{
       # Reproducing a bug, issue #1446
       it "shows the overridden price" do
         targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
-        click_link 'Add'
+        find('button.add_variant').click
         expect(page).to have_selector("table.index tbody tr") # Wait for JS
         expect(page).to have_content(product.variants.first.variant_overrides.first.price)
       end


### PR DESCRIPTION
#### What? Why?

Closes #3109 and #3107 and #2416
The spec in #3107 should be green.

@HugsDaniel said: 
New new/edit order page in back office! Upgraded Spree views to 2.0 and applied overrides.
There's no error anymore for blank line_items (it was added with deface), and line items can be added.
I used Spree default routes for these actions (see in `_routes.html.erb` to make this work. 

@luisramos0 said:
Regarding the fix to #2416 by adapting app/views/spree/admin/variants/_autocomplete.js.erb and the respective search.rabl file: this is a quick fix to the problem, there's plenty we could improve here, I suggest we leave for after the upgrade, I created this tech debt issue #3440

Remaining work to be done in follow up PRs:
- the display of order adjustments needs to be reviewed (adjustments included in price are not showing) #2940 (fixed in PR #3445)
- fix the flow between order details page and customer details page #3103 (fixed in PR #3436)
- scope variants when adding them to the order api/shipments (and probably get rid of admin/line_items_controller) #3422 (fixed in PR #3441)

**For the review, I recommend reviewers to follow the commits in order.**