### PR TITLE
[Spree Upgrade] 2938 Fix Create Order in Admin - missing translation

### DIFF
--- a/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -15,8 +15,8 @@
         <li><strong><%= t('.producer_name') %>:</strong> {{variant.producer_name}}</li>
       </ul>
       <ul class='variant-data'>
-        <li class='variant-sku'><strong>{{t 'sku'}}:</strong> {{variant.sku}}</li>
-        <li class='variant-on_hand'><strong>{{t 'on_hand'}}:</strong> {{variant.count_on_hand}}</li>
+        <li class='variant-sku'><strong><%= t('admin.sku') %>:</strong> {{variant.sku}}</li>
+        <li class='variant-on_hand'><strong><%= t('on_hand') %>:</strong> {{variant.count_on_hand}}</li>
       </ul>
 
       {{#if variant.option_values}}


### PR DESCRIPTION
#### What? Why?

Closes #2938.
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Rendering variants in the order creation form was using Spree's Javascript `t` function which didn't know how to translate `on_hand`. I changed it to use Rails' `I18n.t` method instead.

There is a potential conflict with https://github.com/openfoodfoundation/openfoodnetwork/pull/3194.

#### What should we test?
<!-- List which features should be tested and how. -->

No user testing yet.

Spec ./spec/features/admin/orders_spec.rb:48 still doesn't pass, but progresses a few lines. Now the submission of the form shows a validation error:
![screenshot from 2018-12-07 23-35-48](https://user-images.githubusercontent.com/3524483/49648552-542d2900-fa7a-11e8-8968-c5a2fa793244.png)

And rspec reports:
```
  1) 
    As an administrator
    I want to manage orders
 creating an order with distributor and order cycle
     Failure/Error: expect(page).to have_selector 'h1', text: 'Customer Details'
       expected to find visible css "h1" with text "Customer Details" but there were no matches. Also found "Order # R075812515", which matched the selector but not all filters.
     # ./spec/features/admin/orders_spec.rb:81:in `block (2 levels) in <top (required)>'
```
