### PR TITLE
Validation and others for keeping variant override "On Demand" and "Count on Hand" compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ libpeerconnection.log
 node_modules
 vendor/bundle/
 coverage
+/reports/
+!/reports/README.md

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -13,6 +13,10 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
   $scope.RequestMonitor = RequestMonitor
   $scope.selectView = Views.selectView
   $scope.currentView = -> Views.currentView
+  $scope.onDemandOptions = [
+    { description: t('js.yes'), value: true },
+    { description: t('js.no'), value: false }
+  ]
 
   $scope.views = Views.setViews
     inventory:    { name: t('js.variant_overrides.inventory_products'), visible: true }

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -14,8 +14,8 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
   $scope.selectView = Views.selectView
   $scope.currentView = -> Views.currentView
   $scope.onDemandOptions = [
-    { description: t('js.yes'), value: true },
-    { description: t('js.no'), value: false }
+    { description: t('js.variant_overrides.on_demand.yes'), value: true },
+    { description: t('js.variant_overrides.on_demand.no'), value: false }
   ]
 
   $scope.views = Views.setViews

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -110,6 +110,16 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
 
+  $scope.countOnHandPlaceholder = (variant, hubId) ->
+    variantOverride = $scope.variantOverrides[hubId][variant.id]
+
+    if variantOverride.on_demand
+      t('js.variants.on_demand.yes')
+    else if variantOverride.on_demand == false
+      ''
+    else
+      variant.on_hand
+
   $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
     variantOverride = $scope.variantOverrides[hubId][variantId]
     unless variantOverride.on_demand == false && variantOverride.count_on_hand?

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -131,9 +131,9 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
     variantOverride = $scope.variantOverrides[hubId][variant.id]
 
     suggested = $scope.countOnHandSuggestion(variant, hubId)
-    unless suggested == variantOverride.count_on_hand
-      variantOverride.count_on_hand = suggested
-      DirtyVariantOverrides.set hubId, variant.id, variantOverride.id, 'count_on_hand', suggested
+    return if suggested == variantOverride.count_on_hand
+    variantOverride.count_on_hand = suggested
+    DirtyVariantOverrides.set hubId, variant.id, variantOverride.id, 'count_on_hand', suggested
 
   # Suggest producer count_on_hand if variant has limited stock and variant override forces limited
   # stock. Otherwise, clear whatever value is set.

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -110,6 +110,10 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
 
+  # Variant override count_on_hand field placeholder logic:
+  #     on_demand true  -- Show "On Demand"
+  #     on_demand false -- Show empty value to be set by the user
+  #     on_demand nil   -- Show producer on_hand value
   $scope.countOnHandPlaceholder = (variant, hubId) ->
     variantOverride = $scope.variantOverrides[hubId][variant.id]
 

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -110,12 +110,6 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
 
-  $scope.selectLimitedStockIfCountOnHandSet = (hubId, variantId) ->
-    variantOverride = $scope.variantOverrides[hubId][variantId]
-    if variantOverride.count_on_hand? && variantOverride.count_on_hand != '' && variantOverride.on_demand != false
-      variantOverride.on_demand = false
-      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'on_demand', false
-
   $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
     variantOverride = $scope.variantOverrides[hubId][variantId]
     unless variantOverride.on_demand == false && variantOverride.count_on_hand?

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -109,3 +109,15 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
         StatusMessage.display 'success', t('js.variant_overrides.stock_reset')
       .error (data, status) ->
         $timeout -> StatusMessage.display 'failure', $scope.updateError(data, status)
+
+  $scope.selectLimitedStockIfCountOnHandSet = (hubId, variantId) ->
+    variantOverride = $scope.variantOverrides[hubId][variantId]
+    if variantOverride.count_on_hand? && variantOverride.count_on_hand != '' && variantOverride.on_demand != false
+      variantOverride.on_demand = false
+      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'on_demand', false
+
+  $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
+    variantOverride = $scope.variantOverrides[hubId][variantId]
+    unless variantOverride.on_demand == false && variantOverride.count_on_hand?
+      variantOverride.count_on_hand = null
+      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'count_on_hand', null

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -120,8 +120,20 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
     else
       variant.on_hand
 
-  $scope.clearCountOnHandUnlessLimitedStock = (hubId, variantId) ->
-    variantOverride = $scope.variantOverrides[hubId][variantId]
-    unless variantOverride.on_demand == false && variantOverride.count_on_hand?
-      variantOverride.count_on_hand = null
-      DirtyVariantOverrides.set hubId, variantId, variantOverride.id, 'count_on_hand', null
+  # This method should only be used when the variant override on_demand is changed.
+  #
+  # Change the count_on_hand value to a suggested value.
+  $scope.updateCountOnHand = (variant, hubId) ->
+    variantOverride = $scope.variantOverrides[hubId][variant.id]
+
+    suggested = $scope.countOnHandSuggestion(variant, hubId)
+    unless suggested == variantOverride.count_on_hand
+      variantOverride.count_on_hand = suggested
+      DirtyVariantOverrides.set hubId, variant.id, variantOverride.id, 'count_on_hand', suggested
+
+  # Suggest producer count_on_hand if variant has limited stock and variant override forces limited
+  # stock. Otherwise, clear whatever value is set.
+  $scope.countOnHandSuggestion = (variant, hubId) ->
+    variantOverride = $scope.variantOverrides[hubId][variant.id]
+    return null unless !variant.on_demand && variantOverride.on_demand == false
+    variant.on_hand

--- a/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
+++ b/app/assets/javascripts/admin/variant_overrides/controllers/variant_overrides_controller.js.coffee
@@ -14,6 +14,7 @@ angular.module("admin.variantOverrides").controller "AdminVariantOverridesCtrl",
   $scope.selectView = Views.selectView
   $scope.currentView = -> Views.currentView
   $scope.onDemandOptions = [
+    { description: t('js.variant_overrides.on_demand.use_producer_settings'), value: null },
     { description: t('js.variant_overrides.on_demand.yes'), value: true },
     { description: t('js.variant_overrides.on_demand.no'), value: false }
   ]

--- a/app/assets/stylesheets/admin/components/input.css.scss
+++ b/app/assets/stylesheets/admin/components/input.css.scss
@@ -1,3 +1,5 @@
+@import '../../darkswarm/branding';
+
 .container {
   input {
     &[readonly] {

--- a/app/assets/stylesheets/admin/components/input.css.scss
+++ b/app/assets/stylesheets/admin/components/input.css.scss
@@ -1,0 +1,8 @@
+.container {
+  input {
+    &[readonly] {
+      background-color: $disabled-light;
+      cursor: default;
+    }
+  }
+}

--- a/app/models/concerns/stock_settings_override_validation.rb
+++ b/app/models/concerns/stock_settings_override_validation.rb
@@ -1,0 +1,41 @@
+module StockSettingsOverrideValidation
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :require_compatible_on_demand_and_count_on_hand
+  end
+
+  def require_compatible_on_demand_and_count_on_hand
+    disallow_count_on_hand_if_using_producer_stock_settings
+    disallow_count_on_hand_if_on_demand
+    require_count_on_hand_if_limited_stock
+  end
+
+  def disallow_count_on_hand_if_using_producer_stock_settings
+    return unless on_demand.nil? && count_on_hand.present?
+
+    error_message = I18n.t("count_on_hand.using_producer_stock_settings_but_count_on_hand_set",
+                           scope: i18n_scope_for_stock_settings_override_validation_error)
+    errors.add(:count_on_hand, error_message)
+  end
+
+  def disallow_count_on_hand_if_on_demand
+    return unless on_demand? && count_on_hand.present?
+
+    error_message = I18n.t("count_on_hand.on_demand_but_count_on_hand_set",
+                           scope: i18n_scope_for_stock_settings_override_validation_error)
+    errors.add(:count_on_hand, error_message)
+  end
+
+  def require_count_on_hand_if_limited_stock
+    return unless on_demand == false && count_on_hand.blank?
+
+    error_message = I18n.t("count_on_hand.limited_stock_but_no_count_on_hand",
+                           scope: i18n_scope_for_stock_settings_override_validation_error)
+    errors.add(:count_on_hand, error_message)
+  end
+
+  def i18n_scope_for_stock_settings_override_validation_error
+    "activerecord.errors.models.#{self.class.name.underscore}"
+  end
+end

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -322,14 +322,12 @@ module ProductImport
     end
 
     def create_inventory_item(entry, existing_variant)
-      variant_override = find_or_initialize_variant_override(entry, existing_variant)
+      find_or_initialize_variant_override(entry, existing_variant).tap do |variant_override|
+        check_variant_override_stock_settings(entry, variant_override)
 
-      check_variant_override_stock_settings(entry, variant_override)
-
-      variant_override.assign_attributes(import_date: @import_time)
-      variant_override.assign_attributes(entry.attributes.slice('price', 'on_demand'))
-
-      variant_override
+        variant_override.assign_attributes(import_date: @import_time)
+        variant_override.assign_attributes(entry.attributes.slice('price', 'on_demand'))
+      end
     end
 
     def mark_as_inventory_item(entry, variant_override)

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -68,6 +68,18 @@ module ProductImport
 
     private
 
+    def find_or_initialize_variant_override(entry, existing_variant)
+      existing_variant_override = VariantOverride.where(
+        variant_id: existing_variant.id,
+        hub_id: entry.enterprise_id
+      ).first
+
+      existing_variant_override || VariantOverride.new(
+        variant_id: existing_variant.id,
+        hub_id: entry.enterprise_id
+      )
+    end
+
     def enterprise_validation(entry)
       return if name_presence_error entry
       return if enterprise_not_found_error entry
@@ -310,16 +322,7 @@ module ProductImport
     end
 
     def create_inventory_item(entry, existing_variant)
-      existing_variant_override = VariantOverride.where(
-        variant_id: existing_variant.id,
-        hub_id: entry.enterprise_id
-      ).first
-
-      variant_override = existing_variant_override || VariantOverride.new(
-        variant_id: existing_variant.id,
-        hub_id: entry.enterprise_id
-      )
-
+      variant_override = find_or_initialize_variant_override(entry, existing_variant)
       variant_override.assign_attributes(count_on_hand: entry.on_hand, import_date: @import_time)
       check_on_hand_nil(entry, variant_override)
       variant_override.assign_attributes(entry.attributes.slice('price', 'on_demand'))

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -323,8 +323,10 @@ module ProductImport
 
     def create_inventory_item(entry, existing_variant)
       variant_override = find_or_initialize_variant_override(entry, existing_variant)
-      variant_override.assign_attributes(count_on_hand: entry.on_hand, import_date: @import_time)
-      check_on_hand_nil(entry, variant_override)
+
+      check_variant_override_stock_settings(entry, variant_override)
+
+      variant_override.assign_attributes(import_date: @import_time)
       variant_override.assign_attributes(entry.attributes.slice('price', 'on_demand'))
 
       variant_override
@@ -357,6 +359,12 @@ module ProductImport
       object.on_hand = 0 if object.respond_to?(:on_hand)
       object.count_on_hand = 0 if object.respond_to?(:count_on_hand)
       entry.on_hand_nil = true
+    end
+
+    def check_variant_override_stock_settings(entry, object)
+      object.count_on_hand = entry.on_hand.presence
+      object.on_demand = object.count_on_hand.blank? if entry.on_demand.blank?
+      entry.on_hand_nil = object.count_on_hand.blank?
     end
   end
 end

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -84,7 +84,7 @@ class VariantOverride < ActiveRecord::Base
   def reset_stock!
     if resettable
       if default_stock?
-        self.attributes = { count_on_hand: default_stock }
+        self.attributes = { on_demand: false, count_on_hand: default_stock }
         self.save
       else
         Bugsnag.notify RuntimeError.new "Attempting to reset stock level for a variant with no default stock level."

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -1,5 +1,6 @@
 class VariantOverride < ActiveRecord::Base
   extend Spree::LocalizedNumber
+  include StockSettingsOverrideValidation
 
   acts_as_taggable
 
@@ -9,8 +10,6 @@ class VariantOverride < ActiveRecord::Base
   validates_presence_of :hub_id, :variant_id
   # Default stock can be nil, indicating stock should not be reset or zero, meaning reset to zero. Need to ensure this can be set by the user.
   validates :default_stock, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
-
-  before_validation :require_compatible_on_demand_and_count_on_hand
 
   after_save :refresh_products_cache_from_save
   after_destroy :refresh_products_cache_from_destroy
@@ -105,39 +104,5 @@ class VariantOverride < ActiveRecord::Base
 
   def refresh_products_cache_from_destroy
     OpenFoodNetwork::ProductsCache.variant_override_destroyed self
-  end
-
-  def require_compatible_on_demand_and_count_on_hand
-    disallow_count_on_hand_if_using_producer_stock_settings
-    disallow_count_on_hand_if_on_demand
-    require_count_on_hand_if_limited_stock
-  end
-
-  def disallow_count_on_hand_if_using_producer_stock_settings
-    return unless on_demand.nil? && count_on_hand.present?
-
-    error_message = I18n.t("using_producer_stock_settings_but_count_on_hand_set",
-                           scope: [i18n_scope_for_error, "count_on_hand"])
-    errors.add(:count_on_hand, error_message)
-  end
-
-  def disallow_count_on_hand_if_on_demand
-    return unless on_demand? && count_on_hand.present?
-
-    error_message = I18n.t("on_demand_but_count_on_hand_set",
-                           scope: [i18n_scope_for_error, "count_on_hand"])
-    errors.add(:count_on_hand, error_message)
-  end
-
-  def require_count_on_hand_if_limited_stock
-    return unless on_demand == false && count_on_hand.blank?
-
-    error_message = I18n.t("limited_stock_but_no_count_on_hand",
-                           scope: [i18n_scope_for_error, "count_on_hand"])
-    errors.add(:count_on_hand, error_message)
-  end
-
-  def i18n_scope_for_error
-    "activerecord.errors.models.variant_override"
   end
 end

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -10,7 +10,8 @@
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].count_on_hand'}, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
-    %input.field{ :type => 'checkbox', name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand' }, 'ofn-track-variant-override' => 'on_demand' }
+    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
+      %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}
   %td.reset{ ng: { show: 'columns.reset.visible' } }

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -8,7 +8,7 @@
   %td.price{ ng: { show: 'columns.price.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-price', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].price'}, placeholder: '{{ variant.price }}', 'ofn-track-variant-override' => 'price'}
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
+    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ countOnHandPlaceholder(variant, hub_id) }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
     %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -8,9 +8,9 @@
   %td.price{ ng: { show: 'columns.price.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-price', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].price'}, placeholder: '{{ variant.price }}', 'ofn-track-variant-override' => 'price'}
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].count_on_hand'}, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
+    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', change: 'selectLimitedStockIfCountOnHandSet(hub_id, variant.id)' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
-    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
+    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -8,7 +8,7 @@
   %td.price{ ng: { show: 'columns.price.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-price', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].price'}, placeholder: '{{ variant.price }}', 'ofn-track-variant-override' => 'price'}
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', change: 'selectLimitedStockIfCountOnHandSet(hub_id, variant.id)' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
+    %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ variant.on_hand }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
     %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -11,7 +11,6 @@
     %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ countOnHandPlaceholder(variant, hub_id) }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
     %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'updateCountOnHand(variant, hub_id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
-      %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}
   %td.reset{ ng: { show: 'columns.reset.visible' } }

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -10,7 +10,7 @@
   %td.on_hand{ ng: { show: 'columns.on_hand.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-count_on_hand', type: 'text', ng: { model: 'variantOverrides[hub_id][variant.id].count_on_hand', readonly: 'variantOverrides[hub_id][variant.id].on_demand != false' }, placeholder: '{{ countOnHandPlaceholder(variant, hub_id) }}', 'ofn-track-variant-override' => 'count_on_hand'}
   %td.on_demand{ ng: { show: 'columns.on_demand.visible' } }
-    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'clearCountOnHandUnlessLimitedStock(hub_id, variant.id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
+    %select{ name: 'variant-overrides-{{ variant.id }}-on_demand', ng: { model: 'variantOverrides[hub_id][variant.id].on_demand', change: 'updateCountOnHand(variant, hub_id)', options: 'option.value as option.description for option in onDemandOptions' }, 'ofn-track-variant-override' => 'on_demand' }
       %option{ value: '' }= t(".on_demand.use_producer_settings")
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,7 @@ module Openfoodnetwork
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(
+      #{config.root}/app/models/concerns
       #{config.root}/app/presenters
       #{config.root}/app/jobs
     )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -623,6 +623,9 @@ en:
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
       controls:
         back_to_my_inventory: Back to my inventory
+      products_variants:
+        on_demand:
+          use_producer_settings: "Use producer settings"
     orders:
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
@@ -2445,6 +2448,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     pending: Pending
     shipped: Shipped
   js:
+    "yes": "Yes"
+    "no": "No"
     saving: 'Saving...'
     changes_saved: 'Changes saved.'
     save_changes_first: Save changes first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -625,7 +625,7 @@ en:
         back_to_my_inventory: Back to my inventory
       products_variants:
         on_demand:
-          use_producer_settings: "Use producer settings"
+          use_producer_settings: "Use producer stock settings"
     orders:
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -623,9 +623,6 @@ en:
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
       controls:
         back_to_my_inventory: Back to my inventory
-      products_variants:
-        on_demand:
-          use_producer_settings: "Use producer stock settings"
     orders:
       invoice_email_sent: 'Invoice email has been sent'
       order_email_resent: 'Order email has been resent'
@@ -2598,6 +2595,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         "yes": "On demand"
     variant_overrides:
       on_demand:
+        use_producer_settings: "Use producer stock settings"
         "yes": "Yes"
         "no": "No"
       inventory_products: "Inventory Products"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2595,6 +2595,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         in your cart have reduced. Here's what's changed:
       now_out_of_stock: is now out of stock.
       only_n_remainging: "now only has %{num} remaining."
+    variants:
+      on_demand:
+        "yes": "On demand"
     variant_overrides:
       on_demand:
         "yes": "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2596,6 +2596,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       now_out_of_stock: is now out of stock.
       only_n_remainging: "now only has %{num} remaining."
     variant_overrides:
+      on_demand:
+        "yes": "Yes"
+        "no": "No"
       inventory_products: "Inventory Products"
       hidden_products: "Hidden Products"
       new_products: "New Products"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,11 @@ en:
           attributes:
             orders_close_at:
               after_orders_open_at: must be after open date
+        variant_override:
+          count_on_hand:
+            using_producer_stock_settings_but_count_on_hand_set: "must be blank because using producer stock settings"
+            on_demand_but_count_on_hand_set: "must be blank if on demand"
+            limited_stock_but_no_count_on_hand: "must be specified because forcing limited stock"
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2448,8 +2448,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     pending: Pending
     shipped: Shipped
   js:
-    "yes": "Yes"
-    "no": "No"
     saving: 'Saving...'
     changes_saved: 'Changes saved.'
     save_changes_first: Save changes first.

--- a/db/migrate/20181128054803_simplify_variant_override_on_demand_and_count_on_hand.rb
+++ b/db/migrate/20181128054803_simplify_variant_override_on_demand_and_count_on_hand.rb
@@ -1,0 +1,29 @@
+# This simplifies variant overrides to have only the following combinations:
+#
+#    on_demand | count_on_hand
+#   -----------+---------------
+#    true      | nil
+#    false     | set
+#    nil       | nil
+#
+# Refer to the table {here}[https://github.com/openfoodfoundation/openfoodnetwork/issues/3067] for
+# the effect of different variant and variant override stock configurations.
+#
+# Furthermore, this will allow all existing variant overrides to satisfy the newly added model
+# validation rules.
+class SimplifyVariantOverrideOnDemandAndCountOnHand < ActiveRecord::Migration
+  def up
+    # When on_demand is nil but count_on_hand is set, force limited stock.
+    VariantOverride.where(on_demand: nil).where("count_on_hand IS NOT NULL")
+      .update_all(on_demand: false)
+
+    # Clear count_on_hand if forcing on demand.
+    VariantOverride.where(on_demand: true).update_all(count_on_hand: nil)
+
+    # When on_demand is false but count on hand is not specified, set this to use producer stock
+    # settings.
+    VariantOverride.where(on_demand: false, count_on_hand: nil).update_all(on_demand: nil)
+  end
+
+  def down; end
+end

--- a/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
+++ b/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
@@ -13,42 +13,112 @@
 # validation rules.
 class SimplifyVariantOverrideStockSettings < ActiveRecord::Migration
   class VariantOverride < ActiveRecord::Base
+    belongs_to :variant
+    belongs_to :hub, class_name: "Enterprise"
+
     scope :with_count_on_hand, -> { where("count_on_hand IS NOT NULL") }
     scope :without_count_on_hand, -> { where(count_on_hand: nil) }
   end
 
+  class Variant < ActiveRecord::Base
+    self.table_name = "spree_variants"
+
+    belongs_to :product
+
+    def name
+      namer = OpenFoodNetwork::OptionValueNamer.new(self)
+      namer.name
+    end
+  end
+
+  class Product < ActiveRecord::Base
+    self.table_name = "spree_products"
+
+    belongs_to :supplier, class_name: "Enterprise"
+  end
+
+  class Enterprise < ActiveRecord::Base; end
+
   def up
-    update_use_producer_stock_settings_with_count_on_hand
-    update_on_demand_with_count_on_hand
-    update_limited_stock_without_count_on_hand
+    CSV.open(csv_path, "w") do |csv|
+      csv << csv_header_row
+
+      update_use_producer_stock_settings_with_count_on_hand(csv)
+      update_on_demand_with_count_on_hand(csv)
+      update_limited_stock_without_count_on_hand(csv)
+    end
   end
 
   def down; end
 
   private
 
+  def csv_path
+    Rails.root.join("reports", "SimplifyVariantOverrideStockSettings-changed_variant_overrides.csv")
+  end
+
   # When on_demand is nil but count_on_hand is set, force limited stock.
-  def update_use_producer_stock_settings_with_count_on_hand
+  def update_use_producer_stock_settings_with_count_on_hand(csv)
     variant_overrides = VariantOverride.where(on_demand: nil).with_count_on_hand
-    variant_overrides.find_each do |variant_override|
+    update_variant_overrides_and_log(csv, variant_overrides) do |variant_override|
       variant_override.update_attributes!(on_demand: false)
     end
   end
 
   # Clear count_on_hand if forcing on demand.
-  def update_on_demand_with_count_on_hand
+  def update_on_demand_with_count_on_hand(csv)
     variant_overrides = VariantOverride.where(on_demand: true).with_count_on_hand
-    variant_overrides.find_each do |variant_override|
+    update_variant_overrides_and_log(csv, variant_overrides) do |variant_override|
       variant_override.update_attributes!(count_on_hand: nil)
     end
   end
 
   # When on_demand is false but count on hand is not specified, set this to use producer stock
   # settings.
-  def update_limited_stock_without_count_on_hand
+  def update_limited_stock_without_count_on_hand(csv)
     variant_overrides = VariantOverride.where(on_demand: false).without_count_on_hand
-    variant_overrides.find_each do |variant_override|
+    update_variant_overrides_and_log(csv, variant_overrides) do |variant_override|
       variant_override.update_attributes!(on_demand: nil)
     end
+  end
+
+  def update_variant_overrides_and_log(csv, variant_overrides)
+    variant_overrides.find_each do |variant_override|
+      csv << variant_override_log_row(variant_override) do
+        yield variant_override
+      end
+    end
+  end
+
+  def csv_header_row
+    %w(
+      variant_override_id
+      distributor_name distributor_id
+      producer_name producer_id
+      product_name product_id
+      variant_description variant_id
+      previous_on_demand previous_count_on_hand
+      updated_on_demand updated_count_on_hand
+    )
+  end
+
+  def variant_override_log_row(variant_override)
+    variant = variant_override.variant
+    distributor = variant_override.hub
+    product = variant.andand.product
+    supplier = product.andand.supplier
+
+    row = [
+      variant_override.id,
+      distributor.andand.name, distributor.andand.id,
+      supplier.andand.name, supplier.andand.id,
+      product.andand.name, product.andand.id,
+      variant.andand.name, variant.andand.id,
+      variant_override.on_demand, variant_override.count_on_hand
+    ]
+
+    yield variant_override
+
+    row + [variant_override.on_demand, variant_override.count_on_hand]
   end
 end

--- a/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
+++ b/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
@@ -12,17 +12,27 @@
 # Furthermore, this will allow all existing variant overrides to satisfy the newly added model
 # validation rules.
 class SimplifyVariantOverrideStockSettings < ActiveRecord::Migration
+  class VariantOverride < ActiveRecord::Base
+    scope :with_count_on_hand, -> { where("count_on_hand IS NOT NULL") }
+    scope :without_count_on_hand, -> { where(count_on_hand: nil) }
+  end
+
   def up
     # When on_demand is nil but count_on_hand is set, force limited stock.
-    VariantOverride.where(on_demand: nil).where("count_on_hand IS NOT NULL")
-      .update_all(on_demand: false)
+    VariantOverride.where(on_demand: nil).with_count_on_hand.find_each do |variant_override|
+      variant_override.update_attributes!(on_demand: false)
+    end
 
     # Clear count_on_hand if forcing on demand.
-    VariantOverride.where(on_demand: true).update_all(count_on_hand: nil)
+    VariantOverride.where(on_demand: true).with_count_on_hand.find_each do |variant_override|
+      variant_override.update_attributes!(count_on_hand: nil)
+    end
 
     # When on_demand is false but count on hand is not specified, set this to use producer stock
     # settings.
-    VariantOverride.where(on_demand: false, count_on_hand: nil).update_all(on_demand: nil)
+    VariantOverride.where(on_demand: false).without_count_on_hand.find_each do |variant_override|
+      variant_override.update_attributes!(on_demand: nil)
+    end
   end
 
   def down; end

--- a/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
+++ b/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
@@ -40,6 +40,8 @@ class SimplifyVariantOverrideStockSettings < ActiveRecord::Migration
   class Enterprise < ActiveRecord::Base; end
 
   def up
+    ensure_reports_path_exists
+
     CSV.open(csv_path, "w") do |csv|
       csv << csv_header_row
 
@@ -59,8 +61,16 @@ class SimplifyVariantOverrideStockSettings < ActiveRecord::Migration
 
   private
 
+  def reports_path
+    Rails.root.join("reports", "SimplifyVariantOverrideStockSettings")
+  end
+
+  def ensure_reports_path_exists
+    Dir.mkdir(reports_path) unless File.exist?(reports_path)
+  end
+
   def csv_path
-    Rails.root.join("reports", "SimplifyVariantOverrideStockSettings-changed_variant_overrides.csv")
+    reports_path.join("changed_variant_overrides.csv")
   end
 
   # When on_demand is nil but count_on_hand is set, force limited stock.

--- a/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
+++ b/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
@@ -11,7 +11,7 @@
 #
 # Furthermore, this will allow all existing variant overrides to satisfy the newly added model
 # validation rules.
-class SimplifyVariantOverrideOnDemandAndCountOnHand < ActiveRecord::Migration
+class SimplifyVariantOverrideStockSettings < ActiveRecord::Migration
   def up
     # When on_demand is nil but count_on_hand is set, force limited stock.
     VariantOverride.where(on_demand: nil).where("count_on_hand IS NOT NULL")

--- a/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
+++ b/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
@@ -18,22 +18,37 @@ class SimplifyVariantOverrideStockSettings < ActiveRecord::Migration
   end
 
   def up
-    # When on_demand is nil but count_on_hand is set, force limited stock.
-    VariantOverride.where(on_demand: nil).with_count_on_hand.find_each do |variant_override|
-      variant_override.update_attributes!(on_demand: false)
-    end
-
-    # Clear count_on_hand if forcing on demand.
-    VariantOverride.where(on_demand: true).with_count_on_hand.find_each do |variant_override|
-      variant_override.update_attributes!(count_on_hand: nil)
-    end
-
-    # When on_demand is false but count on hand is not specified, set this to use producer stock
-    # settings.
-    VariantOverride.where(on_demand: false).without_count_on_hand.find_each do |variant_override|
-      variant_override.update_attributes!(on_demand: nil)
-    end
+    update_use_producer_stock_settings_with_count_on_hand
+    update_on_demand_with_count_on_hand
+    update_limited_stock_without_count_on_hand
   end
 
   def down; end
+
+  private
+
+  # When on_demand is nil but count_on_hand is set, force limited stock.
+  def update_use_producer_stock_settings_with_count_on_hand
+    variant_overrides = VariantOverride.where(on_demand: nil).with_count_on_hand
+    variant_overrides.find_each do |variant_override|
+      variant_override.update_attributes!(on_demand: false)
+    end
+  end
+
+  # Clear count_on_hand if forcing on demand.
+  def update_on_demand_with_count_on_hand
+    variant_overrides = VariantOverride.where(on_demand: true).with_count_on_hand
+    variant_overrides.find_each do |variant_override|
+      variant_override.update_attributes!(count_on_hand: nil)
+    end
+  end
+
+  # When on_demand is false but count on hand is not specified, set this to use producer stock
+  # settings.
+  def update_limited_stock_without_count_on_hand
+    variant_overrides = VariantOverride.where(on_demand: false).without_count_on_hand
+    variant_overrides.find_each do |variant_override|
+      variant_override.update_attributes!(on_demand: nil)
+    end
+  end
 end

--- a/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
+++ b/db/migrate/20181128054803_simplify_variant_override_stock_settings.rb
@@ -49,7 +49,13 @@ class SimplifyVariantOverrideStockSettings < ActiveRecord::Migration
     end
   end
 
-  def down; end
+  def down
+    CSV.foreach(csv_path, headers: true) do |row|
+      VariantOverride.where(id: row["variant_override_id"])
+        .update_all(on_demand: row["previous_on_demand"],
+                    count_on_hand: row["previous_count_on_hand"])
+    end
+  end
 
   private
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181123012635) do
+ActiveRecord::Schema.define(:version => 20181128054803) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,4 @@
+## `reports/` Directory
+
+This directory may be used for reports generated for the OFN instance. For example, a database
+migration may save in this directory a spreadsheet of changes it made during execution.

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -189,9 +189,20 @@ FactoryBot.define do
 
   factory :variant_override, :class => VariantOverride do
     price         77.77
+    on_demand false
     count_on_hand 11111
     default_stock 2000
     resettable  false
+
+    trait :on_demand do
+      on_demand true
+      count_on_hand nil
+    end
+
+    trait :use_producer_stock_settings do
+      on_demand nil
+      count_on_hand nil
+    end
   end
 
   factory :inventory_item, :class => InventoryItem do

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -141,7 +141,7 @@ feature %q{
             fill_in "variant-overrides-#{variant.id}-sku", with: 'NEWSKU'
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
-            select I18n.t("js.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
             page.should have_content "Changes to one override remain unsaved."
 
             expect do
@@ -236,7 +236,7 @@ feature %q{
           it "product values are affected by overrides" do
             page.should have_input "variant-overrides-#{variant.id}-price", with: '77.77', placeholder: '1.23'
             page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: '12'
-            expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.yes")
+            expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.variant_overrides.on_demand.yes")
           end
 
           it "updates existing overrides" do
@@ -257,14 +257,14 @@ feature %q{
           end
 
           it "updates on_demand settings" do
-            select I18n.t("js.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
             vo.reload
             expect(vo.on_demand).to eq(false)
 
-            select I18n.t("js.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -434,14 +434,7 @@ feature %q{
   end
 
   def select_on_demand(variant, value_sym)
-    option_label = case value_sym
-                   when :no
-                     I18n.t("js.variant_overrides.on_demand.no")
-                   when :yes
-                     I18n.t("js.variant_overrides.on_demand.yes")
-                   when :use_producer_settings
-                     I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings")
-                   end
+    option_label = I18n.t(value_sym, scope: "js.variant_overrides.on_demand")
     select option_label, from: "variant-overrides-#{variant.id}-on_demand"
   end
 end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -140,7 +140,7 @@ feature %q{
 
             fill_in "variant-overrides-#{variant.id}-sku", with: 'NEWSKU'
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
-            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :no
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
             page.should have_content "Changes to one override remain unsaved."
 
@@ -162,7 +162,7 @@ feature %q{
             it "updates the same override instead of creating a duplicate" do
               # When I create a new override
               fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
-              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
               page.should have_content "Changes to one override remain unsaved."
 
@@ -243,7 +243,7 @@ feature %q{
 
           it "updates existing overrides" do
             fill_in "variant-overrides-#{variant.id}-price", with: '22.22'
-            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :no
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '8888'
             page.should have_content "Changes to one override remain unsaved."
 
@@ -261,21 +261,21 @@ feature %q{
           end
 
           it "updates on_demand settings" do
-            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :no
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
             vo.reload
             expect(vo.on_demand).to eq(false)
 
-            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :yes
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
             vo.reload
             expect(vo.on_demand).to eq(true)
 
-            select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :use_producer_settings
             click_button I18n.t("save_changes")
             expect(page).to have_content I18n.t("js.changes_saved")
 
@@ -299,7 +299,7 @@ feature %q{
             # Clearing values manually
             fill_in "variant-overrides-#{variant.id}-price", with: ''
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: ''
-            select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
+            select_on_demand variant, :use_producer_settings
             fill_in "variant-overrides-#{variant.id}-default_stock", with: ''
             within "tr#v_#{variant.id}" do
               vo.tag_list.each do |tag|
@@ -347,15 +347,15 @@ feature %q{
           describe "ensuring that on demand and count on hand settings are compatible" do
             it "clears count on hand when not limited stock" do
               # It clears count_on_hand when selecting true on_demand.
-              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
-              select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :yes
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It clears count_on_hand when selecting nil on_demand.
-              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :no
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
-              select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
+              select_on_demand variant, :use_producer_settings
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It saves the changes.
@@ -431,5 +431,17 @@ feature %q{
         end
       end
     end
+  end
+
+  def select_on_demand(variant, value_sym)
+    option_label = case value_sym
+                   when :no
+                     I18n.t("js.variant_overrides.on_demand.no")
+                   when :yes
+                     I18n.t("js.variant_overrides.on_demand.yes")
+                   when :use_producer_settings
+                     I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings")
+                   end
+    select option_label, from: "variant-overrides-#{variant.id}-on_demand"
   end
 end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -365,6 +365,27 @@ feature %q{
               expect(vo.count_on_hand).to be_nil
               expect(vo.on_demand).to be_nil
             end
+
+            it "provides explanation when attempting to save variant override with incompatible stock settings" do
+              # Successfully change stock settings.
+              select_on_demand variant, :no
+              fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "1111"
+              click_button I18n.t("save_changes")
+              expect(page).to have_content I18n.t("js.changes_saved")
+
+              # Make stock settings incompatible.
+              select_on_demand variant, :no
+              fill_in "variant-overrides-#{variant.id}-count_on_hand", with: ""
+
+              # It does not save the changes.
+              click_button I18n.t("save_changes")
+              expect(page).to have_content I18n.t("activerecord.errors.models.variant_override.count_on_hand.limited_stock_but_no_count_on_hand")
+              expect(page).to have_no_content I18n.t("js.changes_saved")
+
+              vo.reload
+              expect(vo.count_on_hand).to eq(1111)
+              expect(vo.on_demand).to eq(false)
+            end
           end
         end
       end

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -237,7 +237,7 @@ feature %q{
 
           it "product values are affected by overrides" do
             page.should have_input "variant-overrides-#{variant.id}-price", with: '77.77', placeholder: '1.23'
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: '12'
+            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: I18n.t("js.variants.on_demand.yes")
             expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.variant_overrides.on_demand.yes")
           end
 
@@ -325,7 +325,7 @@ feature %q{
             first("div#bulk-actions-dropdown div.menu div.menu_item", text: "Reset Stock Levels To Defaults").click
             page.should have_content 'Stocks reset to defaults.'
             vo.reload
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '1000', placeholder: '12'
+            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '1000', placeholder: I18n.t("js.variants.on_demand.yes")
             vo.count_on_hand.should == 1000
           end
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -220,7 +220,7 @@ feature %q{
         end
 
         context "with overrides" do
-          let!(:vo) { create(:variant_override, variant: variant, hub: hub, price: 77.77, on_demand: true, count_on_hand: 11111, default_stock: 1000, resettable: true, tag_list: ["tag1","tag2","tag3"]) }
+          let!(:vo) { create(:variant_override, :on_demand, variant: variant, hub: hub, price: 77.77, default_stock: 1000, resettable: true, tag_list: ["tag1","tag2","tag3"]) }
           let!(:vo_no_auth) { create(:variant_override, variant: variant, hub: hub2, price: 1, count_on_hand: 2) }
           let!(:product2) { create(:simple_product, supplier: producer, variant_unit: 'weight', variant_unit_scale: 1) }
           let!(:variant2) { create(:variant, product: product2, unit_value: 8, price: 1.00, on_hand: 12) }
@@ -237,8 +237,10 @@ feature %q{
 
           it "product values are affected by overrides" do
             page.should have_input "variant-overrides-#{variant.id}-price", with: '77.77', placeholder: '1.23'
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '11111', placeholder: I18n.t("js.variants.on_demand.yes")
+            expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: "", placeholder: I18n.t("js.variants.on_demand.yes")
             expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.variant_overrides.on_demand.yes")
+
+            expect(page).to have_input "variant-overrides-#{variant2.id}-count_on_hand", with: "40", placeholder: ""
           end
 
           it "updates existing overrides" do

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -325,7 +325,7 @@ feature %q{
             first("div#bulk-actions-dropdown div.menu div.menu_item", text: "Reset Stock Levels To Defaults").click
             page.should have_content 'Stocks reset to defaults.'
             vo.reload
-            page.should have_input "variant-overrides-#{variant.id}-count_on_hand", with: '1000', placeholder: I18n.t("js.variants.on_demand.yes")
+            expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: "1000", placeholder: ""
             vo.count_on_hand.should == 1000
           end
 
@@ -333,7 +333,7 @@ feature %q{
             first("div#bulk-actions-dropdown").click
             first("div#bulk-actions-dropdown div.menu div.menu_item", text: "Reset Stock Levels To Defaults").click
             vo_no_reset.reload
-            page.should have_input "variant-overrides-#{variant2.id}-count_on_hand", with: '40', placeholder: '12'
+            expect(page).to have_input "variant-overrides-#{variant2.id}-count_on_hand", with: "40", placeholder: ""
             vo_no_reset.count_on_hand.should == 40
           end
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -140,8 +140,8 @@ feature %q{
 
             fill_in "variant-overrides-#{variant.id}-sku", with: 'NEWSKU'
             fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
+            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
-            select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
             page.should have_content "Changes to one override remain unsaved."
 
             expect do
@@ -154,14 +154,15 @@ feature %q{
             vo.hub_id.should == hub.id
             vo.sku.should == "NEWSKU"
             vo.price.should == 777.77
+            expect(vo.on_demand).to eq(false)
             vo.count_on_hand.should == 123
-            vo.on_demand.should == true
           end
 
           describe "creating and then updating the new override" do
             it "updates the same override instead of creating a duplicate" do
               # When I create a new override
               fill_in "variant-overrides-#{variant.id}-price", with: '777.77'
+              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '123'
               page.should have_content "Changes to one override remain unsaved."
 
@@ -186,6 +187,7 @@ feature %q{
               vo.variant_id.should == variant.id
               vo.hub_id.should == hub.id
               vo.price.should == 111.11
+              expect(vo.on_demand).to eq(false)
               vo.count_on_hand.should == 111
             end
           end
@@ -241,6 +243,7 @@ feature %q{
 
           it "updates existing overrides" do
             fill_in "variant-overrides-#{variant.id}-price", with: '22.22'
+            select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
             fill_in "variant-overrides-#{variant.id}-count_on_hand", with: '8888'
             page.should have_content "Changes to one override remain unsaved."
 
@@ -253,6 +256,7 @@ feature %q{
             vo.variant_id.should == variant.id
             vo.hub_id.should == hub.id
             vo.price.should == 22.22
+            expect(vo.on_demand).to eq(false)
             vo.count_on_hand.should == 8888
           end
 
@@ -341,27 +345,15 @@ feature %q{
           end
 
           describe "ensuring that on demand and count on hand settings are compatible" do
-            it "changes to limited stock when count on hand is set" do
-              # It sets on_demand to false when count_on_hand is filled.
-              fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
-              expect(page).to have_select "variant-overrides-#{variant.id}-on_demand", selected: I18n.t("js.variant_overrides.on_demand.no")
-
-              # It saves the changes.
-              click_button I18n.t("save_changes")
-              expect(page).to have_content I18n.t("js.changes_saved")
-
-              vo.reload
-              expect(vo.count_on_hand).to eq(200)
-              expect(vo.on_demand).to eq(false)
-            end
-
             it "clears count on hand when not limited stock" do
               # It clears count_on_hand when selecting true on_demand.
+              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
               select I18n.t("js.variant_overrides.on_demand.yes"), from: "variant-overrides-#{variant.id}-on_demand"
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""
 
               # It clears count_on_hand when selecting nil on_demand.
+              select I18n.t("js.variant_overrides.on_demand.no"), from: "variant-overrides-#{variant.id}-on_demand"
               fill_in "variant-overrides-#{variant.id}-count_on_hand", with: "200"
               select I18n.t("admin.variant_overrides.products_variants.on_demand.use_producer_settings"), from: "variant-overrides-#{variant.id}-on_demand"
               expect(page).to have_input "variant-overrides-#{variant.id}-count_on_hand", with: ""

--- a/spec/features/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/features/consumer/shopping/variant_overrides_spec.rb
@@ -22,7 +22,7 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
   let(:v4) { create(:variant, product: p1, price: 44.44, unit_value: 4) }
   let(:v5) { create(:variant, product: p3, price: 55.55, unit_value: 5, on_demand: true) }
   let(:v6) { create(:variant, product: p3, price: 66.66, unit_value: 6, on_demand: true) }
-  let!(:vo1) { create(:variant_override, hub: hub, variant: v1, price: 55.55, count_on_hand: nil, default_stock: nil, resettable: false) }
+  let!(:vo1) { create(:variant_override, :use_producer_stock_settings, hub: hub, variant: v1, price: 55.55, default_stock: nil, resettable: false) }
   let!(:vo2) { create(:variant_override, hub: hub, variant: v2, count_on_hand: 0, default_stock: nil, resettable: false) }
   let!(:vo3) { create(:variant_override, hub: hub, variant: v3, count_on_hand: 0, default_stock: nil, resettable: false) }
   let!(:vo4) { create(:variant_override, hub: hub, variant: v4, count_on_hand: 3, default_stock: nil, resettable: false) }

--- a/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
@@ -120,3 +120,51 @@ describe "VariantOverridesCtrl", ->
           expect(scope.variantOverrides[123][2].count_on_hand).toBeNull()
           dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
           expect(dirtyVariantOverride.count_on_hand).toBeNull()
+
+  describe "count on hand placeholder", ->
+    beforeEach ->
+      scope.variantOverrides = {123: {}}
+
+    describe "when variant is on demand", ->
+      variant = null
+
+      beforeEach ->
+        # Ideally, count_on_hand is blank when the variant is on demand. However, this rule is not
+        # enforced.
+        variant = {id: 2, on_demand: true, count_on_hand: 20, on_hand: t("on_demand")}
+
+      it "is 'On demand' when variant override uses producer stock settings", ->
+        scope.variantOverrides[123][2] = {on_demand: null, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(t("on_demand"))
+
+      it "is 'On demand' when variant override is on demand", ->
+        scope.variantOverrides[123][2] = {on_demand: true, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(t("js.variants.on_demand.yes"))
+
+      it "is blank when variant override is limited stock", ->
+        scope.variantOverrides[123][2] = {on_demand: false, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe('')
+
+    describe "when variant is limited stock", ->
+      variant = null
+
+      beforeEach ->
+        variant = {id: 2, on_demand: false, count_on_hand: 20, on_hand: 20}
+
+      it "is variant count on hand when variant override uses producer stock settings", ->
+        scope.variantOverrides[123][2] = {on_demand: null, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(20)
+
+      it "is 'On demand' when variant override is on demand", ->
+        scope.variantOverrides[123][2] = {on_demand: true, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe(t("js.variants.on_demand.yes"))
+
+      it "is blank when variant override is limited stock", ->
+        scope.variantOverrides[123][2] = {on_demand: false, count_on_hand: 1}
+        placeholder = scope.countOnHandPlaceholder(variant, 123)
+        expect(placeholder).toBe('')

--- a/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
@@ -89,36 +89,6 @@ describe "VariantOverridesCtrl", ->
       expect(StatusMessage.display).toHaveBeenCalledWith 'success', 'Stocks reset to defaults.'
 
   describe "ensuring that on demand and count on hand settings are compatible", ->
-    describe "changing to limited stock when count on hand is set", ->
-      beforeEach ->
-        scope.variantOverrides = {123: {2: {id: 5, on_demand: true}}}
-
-      describe "when count on hand is set", ->
-        beforeEach ->
-          scope.variantOverrides[123][2].count_on_hand = 1
-
-        it "changes to limited stock and registers dirty attribute", ->
-          scope.selectLimitedStockIfCountOnHandSet(123, 2)
-          expect(scope.variantOverrides[123][2].on_demand).toBe(false)
-          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
-          expect(dirtyVariantOverride.on_demand).toBe(false)
-
-      describe "when count on hand is null", ->
-        beforeEach ->
-          scope.variantOverrides[123][2].count_on_hand = null
-
-        it "does not change to limited stock", ->
-          scope.selectLimitedStockIfCountOnHandSet(123, 2)
-          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
-
-      describe "when count on hand is blank string", ->
-        beforeEach ->
-          scope.variantOverrides[123][2].count_on_hand = ''
-
-        it "does not change to limited stock", ->
-          scope.selectLimitedStockIfCountOnHandSet(123, 2)
-          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
-
     describe "clearing count on hand when not limited stock", ->
       beforeEach ->
         scope.variantOverrides = {123: {2: {id: 5, count_on_hand: 1}}}

--- a/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/controllers/variant_overrides_controller_spec.js.coffee
@@ -87,3 +87,66 @@ describe "VariantOverridesCtrl", ->
       $httpBackend.flush()
       expect(VariantOverrides.updateData).toHaveBeenCalledWith variant_overrides_mock
       expect(StatusMessage.display).toHaveBeenCalledWith 'success', 'Stocks reset to defaults.'
+
+  describe "ensuring that on demand and count on hand settings are compatible", ->
+    describe "changing to limited stock when count on hand is set", ->
+      beforeEach ->
+        scope.variantOverrides = {123: {2: {id: 5, on_demand: true}}}
+
+      describe "when count on hand is set", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].count_on_hand = 1
+
+        it "changes to limited stock and registers dirty attribute", ->
+          scope.selectLimitedStockIfCountOnHandSet(123, 2)
+          expect(scope.variantOverrides[123][2].on_demand).toBe(false)
+          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
+          expect(dirtyVariantOverride.on_demand).toBe(false)
+
+      describe "when count on hand is null", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].count_on_hand = null
+
+        it "does not change to limited stock", ->
+          scope.selectLimitedStockIfCountOnHandSet(123, 2)
+          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
+
+      describe "when count on hand is blank string", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].count_on_hand = ''
+
+        it "does not change to limited stock", ->
+          scope.selectLimitedStockIfCountOnHandSet(123, 2)
+          expect(scope.variantOverrides[123][2].on_demand).toBe(true)
+
+    describe "clearing count on hand when not limited stock", ->
+      beforeEach ->
+        scope.variantOverrides = {123: {2: {id: 5, count_on_hand: 1}}}
+
+      describe "when on demand is false", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].on_demand = false
+
+        it "does not clear count on hand", ->
+          scope.clearCountOnHandUnlessLimitedStock(123, 2)
+          expect(scope.variantOverrides[123][2].count_on_hand).toEqual(1)
+
+      describe "when on demand is true", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].on_demand = true
+
+        it "clears count on hand and registers dirty attribute", ->
+          scope.clearCountOnHandUnlessLimitedStock(123, 2)
+          expect(scope.variantOverrides[123][2].count_on_hand).toBeNull()
+          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
+          expect(dirtyVariantOverride.count_on_hand).toBeNull()
+
+      describe "when on demand is null", ->
+        beforeEach ->
+          scope.variantOverrides[123][2].on_demand = null
+
+        it "clears count on hand and registers dirty attribute", ->
+          scope.clearCountOnHandUnlessLimitedStock(123, 2)
+          expect(scope.variantOverrides[123][2].count_on_hand).toBeNull()
+          dirtyVariantOverride = DirtyVariantOverrides.dirtyVariantOverrides[123][2]
+          expect(dirtyVariantOverride.count_on_hand).toBeNull()

--- a/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
+++ b/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
@@ -5,7 +5,7 @@ module OpenFoodNetwork
     let(:hub) { create(:distributor_enterprise) }
     let(:v)   { create(:variant, price: 11.11, count_on_hand: 1, on_demand: true, sku: "VARIANTSKU") }
     let(:vo)  { create(:variant_override, hub: hub, variant: v, price: 22.22, count_on_hand: 2, on_demand: false, sku: "VOSKU") }
-    let(:vo_price_only) { create(:variant_override, hub: hub, variant: v, price: 22.22, count_on_hand: nil) }
+    let(:vo_price_only) { create(:variant_override, :use_producer_stock_settings, hub: hub, variant: v, price: 22.22) }
     let(:scoper) { ScopeVariantToHub.new(hub) }
 
     describe "overriding price" do


### PR DESCRIPTION
#### What? Why?

Relates to #3066 
Relates to #3067 
Relates to #3104 

This includes changes in #3104, which is a dependency for this PR.

The following changes are included:

1. Require VO "On Demand" and "Count on Hand" to be compatible. Only the following combinations are allowed for VOs now:
    * "Use producer stock settings", with no override value for "Count on Hand"
    * "Yes" on demand, with no override value for "Count on Hand"
    * "No" on demand, with required override value for "Count on Hand"
2. Migrate existing VOs to comply with these new validation rules.
3. Make resetting stock settings for VO change on demand to "No" (force limited stock).
4. Update Inventory data import to set appropriate VO "On Demand" for specified "On Hand" value.

For code review, please pay special attention to the DB migration, which would make the following changes based on the discussion in #3067 for existing VOs:

1. When "On Demand" is "Yes" but "Count on Hand" is not blank, clear "Count on Hand"
2. When "On Demand" is "Use producer stock settings" but "Count on Hand" is not blank, set "On Demand" to "No"
3. When "On Demand" is "No" but "Count on Hand" is blank, change "On Demand" to "Use producer stock settings"

#### What should we test?

Aside from testing the Inventory page UI changed in #3104, here are parts which should be tested:

1. Saving invalid VO should provide an appropriate error. For example, you may try setting "On Demand" to "No" but leaving "Count on Hand" blank.
2. Saving VO with the different allowed stock settings should be successful. Aside from checking the success notice, please reload the "Inventory" page and check the updated values.
3. Resetting stock settings for VOs with different allowed settings should be successful. This should set "On Demand" to "No" aside from updating to the default stock level.
4. Importing of inventory data with different combinations of stock settings, both valid and invalid. Check that the correct VO "Count on Hand" and "On Demand" settings are saved. 

#### Release notes

- Require variant override "On Demand" and "Count on Hand" to be compatible. Only the following combinations are allowed now:
    * On Demand: "Use producer stock settings", Count on Hand: blank
    * On Demand: "Yes", Count on Hand: blank
    * On Demand: "No", Count on Hand: filled
- Migrate existing variant overrides to comply with new validation rules. Changes to the variant overrides are recorded in `reports/SimplifyVariantOverrideStockSettings/` in the application path: `changed_variant_overrides.csv` has the complete list of affected records, and there are CSV files specific to each distributor affected.
- Make resetting stock settings for variant override change "On Demand" to "No" (`false`).
- Update Inventory data import to set appropriate variant override "On Demand" for specified "On Hand" value.

Changelog Category: Changed

#### Dependencies

This needs to be merged together with #3104.