### PR TITLE
Add missing 'required field' stars in new product form

### DIFF
--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -22,6 +22,7 @@
         .six.columns.alpha
           = f.field_container :units do
             = f.label :variant_unit_with_scale, t(:units)
+            %span.required *
             %select.select2.fullwidth{ id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options' }
               %option{'value' => '', 'ng-hide' => "hasUnit(product)"}
             %input{ type: 'hidden', 'ng-value' => 'product.variant_unit', name: 'product[variant_unit]' }
@@ -29,6 +30,7 @@
         .three.columns
           = f.field_container :unit_value do
             = f.label :product_unit_value_with_description, t(:value), 'ng-disabled' => "!hasUnit(product)"
+            %span.required *
             %input.fullwidth{ id: 'product_unit_value_with_description', 'ng-model' => 'product.master.unit_value_with_description', :type => 'text', placeholder: "eg. 2", 'ng-disabled' => "!hasUnit(product)" }
             %input{ type: 'hidden', 'ng-value' => 'product.master.unit_value', name: 'product[unit_value]' }
             %input{ type: 'hidden', 'ng-value' => 'product.master.unit_description', name: 'product[unit_description]' }


### PR DESCRIPTION
#### What? Why?

Closes [#3200](https://github.com/openfoodfoundation/openfoodnetwork/issues/3200)

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

In the New Product form, we are missing some stars to denote required fields. This should fix that!

#### What should we test?
<!-- List which features should be tested and how. -->

1. Login and visit Administration.
2. Visit Products and create a new product.
3. Check for "required field" stars on the Unit Size and Value fields.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added missing "required field" stars in New Product form.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed