### PR TITLE
[Spree Upgrade] Fix redirection on admin products specs

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -275,19 +275,23 @@ Spree::Product.class_eval do
   # This fixes any problems arising from failing master saves, without the need for a validates_associated on
   # master, while giving us more specific errors as to why saving failed
   def save_master
-    begin
-      if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
-        master.save!
-      end
+    if master && (
+        master.changed? || master.new_record? || (
+          master.default_price && (
+            master.default_price.changed? || master.default_price.new_record?
+          )
+        )
+      )
+      master.save!
+    end
 
     # If the master cannot be saved, the Product object will get its errors
     # and will be destroyed
-    rescue ActiveRecord::RecordInvalid
-      master.errors.each do |att, error|
-        self.errors.add(att, error)
-      end
-      raise
+  rescue ActiveRecord::RecordInvalid
+    master.errors.each do |att, error|
+      self.errors.add(att, error)
     end
+    raise
   end
 
   def sanitize_permalink

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -74,46 +74,31 @@ describe Spree::Admin::ProductsController, type: :controller do
   end
 
   context "creating a new product" do
-    before { login_as_admin }
+    let(:supplier) { create(:supplier_enterprise) }
+    let(:taxon) { create(:taxon) }
+    let(:shipping_category) { create(:shipping_category) }
+
+    let(:product_attrs) {
+      attributes_for(:product).merge(
+        shipping_category_id: shipping_category.id,
+        supplier_id: supplier.id,
+        primary_taxon_id: taxon.id
+      )
+    }
+
+    before do
+      login_as_admin
+      create(:stock_location)
+    end
 
     it "redirects to products when the user hits 'create'" do
-      s = create(:supplier_enterprise)
-      t = create(:taxon)
-      spree_post :create, {
-        product: {
-          name: "Product1",
-          supplier_id: s.id,
-          price: 5.0,
-          on_hand: 5,
-          variant_unit: 'weight',
-          variant_unit_scale: 1000,
-          unit_value: 10,
-          unit_description: "",
-          primary_taxon_id: t.id
-        },
-        button: 'create'
-      }
+      spree_post :create, { product: product_attrs, button: 'create' }
       response.should redirect_to spree.admin_products_path
     end
 
     it "redirects to new when the user hits 'add_another'" do
-      s = create(:supplier_enterprise)
-      t = create(:taxon)
-      spree_post :create, {
-        product: {
-          name: "Product1",
-          supplier_id: s.id,
-          price: 5.0,
-          on_hand: 5,
-          variant_unit: 'weight',
-          variant_unit_scale: 1000,
-          unit_value: 10,
-          unit_description: "",
-          primary_taxon_id: t.id
-        },
-        button: 'add_another'
-      }
-      response.should redirect_to "/admin/products/new"
+      spree_post :create, { product: product_attrs, button: 'add_another' }
+      response.should redirect_to spree.new_admin_product_path
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #3031 

In Spree v2.0 the product attributes being sent were no longer valid. Providing a shipping category and setting a stock location on the DB so that a stock item can be created fixes them.

Remember `Variant#create_stock_item`, which is defined as an `after_create` callback, relies on `StockLocation` to create the item.

#### What should we test?

This two tests should get green.
