### PR TITLE
[Spree Upgrade] Fix availability validator to include inventory_units in it's validation

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -8,7 +8,7 @@ Spree::LineItem.class_eval do
   # Redefining here to add the inverse_of option
   belongs_to :order, :class_name => "Spree::Order", inverse_of: :line_items
 
-  # Allows manual skipping of stock_availability check
+  # Allows manual skipping of Stock::AvailabilityValidator
   attr_accessor :skip_stock_check
 
   attr_accessible :max_quantity, :final_weight_volume, :price
@@ -132,13 +132,6 @@ Spree::LineItem.class_eval do
     update_inventory_without_scoping
   end
   alias_method_chain :update_inventory, :scoping
-
-  # Override of Spree validation method
-  # Added check for in-memory :skip_stock_check attribute
-  def stock_availability
-    return if skip_stock_check || sufficient_stock?
-    errors.add(:quantity, I18n.t('validation.exceeds_available_stock'))
-  end
 
   def scoper
     @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -1,5 +1,8 @@
 Spree::Stock::AvailabilityValidator.class_eval do
   def validate(line_item)
+    # OFN specific check for in-memory :skip_stock_check attribute
+    return if line_item.skip_stock_check
+
     quantity = adapt_line_item_quantity_to_inventory_units(line_item)
 
     validate_quantity(line_item, quantity)

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -3,10 +3,10 @@ Spree::Stock::AvailabilityValidator.class_eval do
     # OFN specific check for in-memory :skip_stock_check attribute
     return if line_item.skip_stock_check
 
-    quantity = adapt_line_item_quantity_to_inventory_units(line_item)
-    return if quantity == 0
+    quantity_to_validate = line_item.quantity - quantity_in_shipment(line_item)
+    return if quantity_to_validate < 1
 
-    validate_quantity(line_item, quantity)
+    validate_quantity(line_item, quantity_to_validate)
   end
 
   private
@@ -14,12 +14,12 @@ Spree::Stock::AvailabilityValidator.class_eval do
   # This is an adapted version of a fix to the inventory_units not being considered here.
   # See #3090 for details.
   # This can be removed after upgrading to Spree 2.4.
-  def adapt_line_item_quantity_to_inventory_units(line_item)
+  def quantity_in_shipment(line_item)
     shipment = line_item_shipment(line_item)
-    return line_item.quantity unless shipment
+    return 0 unless shipment
 
     units = shipment.inventory_units_for(line_item.variant)
-    line_item.quantity - units.count
+    units.count
   end
 
   def line_item_shipment(line_item)

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -1,0 +1,37 @@
+Spree::Stock::AvailabilityValidator.class_eval do
+  def validate(line_item)
+    quantity = adapt_line_item_quantity_to_inventory_units(line_item)
+
+    validate_quantity(line_item, quantity)
+  end
+
+  private
+
+  # This is an adapted version of a fix to the inventory_units not being considered here.
+  # See #3090 for details.
+  # This can be removed after upgrading to Spree 2.4.
+  def adapt_line_item_quantity_to_inventory_units(line_item)
+    shipment = line_item_shipment(line_item)
+    return line_item.quantity unless shipment
+
+    units = shipment.inventory_units_for(line_item.variant)
+    line_item.quantity - units.count
+  end
+
+  def line_item_shipment(line_item)
+    return line_item.target_shipment if line_item.target_shipment
+    return line_item.order.shipments.first if line_item.order.present? && line_item.order.shipments.any?
+  end
+
+  # This is the spree v2.0.4 implementation of validate
+  # But using the calculated quantity instead of the line_item.quantity.
+  def validate_quantity(line_item, quantity)
+    quantifier = Spree::Stock::Quantifier.new(line_item.variant_id)
+    return if quantifier.can_supply? quantity
+
+    variant = line_item.variant
+    display_name = %Q{#{variant.name}}
+    display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
+    line_item.errors[:quantity] << Spree.t(:out_of_stock, :scope => :order_populator, :item => display_name.inspect)
+  end
+end

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -4,6 +4,7 @@ Spree::Stock::AvailabilityValidator.class_eval do
     return if line_item.skip_stock_check
 
     quantity = adapt_line_item_quantity_to_inventory_units(line_item)
+    return if quantity == 0
 
     validate_quantity(line_item, quantity)
   end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -585,24 +585,5 @@ module Spree
         }.to change(Spree::OptionValue, :count).by(0)
       end
     end
-
-    describe "checking stock availability" do
-      let(:line_item) { LineItem.new }
-
-      context "when skip_stock_check is not set" do
-        it "checks stock" do
-          expect(line_item).to receive(:sufficient_stock?) { true }
-          line_item.send(:stock_availability)
-        end
-      end
-
-      context "when skip_stock_check is set to true" do
-        before { line_item.skip_stock_check = true }
-        it "does not check stock" do
-          expect(line_item).to_not receive(:sufficient_stock?)
-          line_item.send(:stock_availability)
-        end
-      end
-    end
   end
 end

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -9,16 +9,11 @@ module Spree
         let(:order) { create(:order_with_line_items) }
         let(:line_item) { order.line_items.first }
 
-        before do
-          expect(order.shipment.inventory_units).to be_empty
-          expect(line_item.target_shipment).to be_nil
-        end
-
         context "available quantity when variant.on_hand > line_item.quantity" do
           it "suceeds" do
             line_item.quantity = line_item.variant.on_hand - 1
             validator.validate(line_item)
-            expect(line_item.errors[:quantity].size).to eq(0)
+            expect(line_item).to be_valid
           end
         end
 
@@ -26,14 +21,14 @@ module Spree
           it "fails" do
             line_item.quantity = line_item.variant.on_hand + 1
             validator.validate(line_item)
-            expect_product_out_of_stock_error
+            expect(line_item).not_to be_valid
           end
 
           it "succeeds with line_item skip_stock_check" do
             line_item.skip_stock_check = true
             line_item.quantity = line_item.variant.on_hand + 1
             validator.validate(line_item)
-            expect(line_item.errors[:quantity].size).to eq(0)
+            expect(line_item).to be_valid
           end
         end
       end
@@ -42,33 +37,19 @@ module Spree
         let(:order) { create(:completed_order_with_totals) }
         let(:line_item) { order.line_items.first }
 
-        before do
-          expect(line_item.quantity).to eq(1)
-          expect(line_item.variant.on_hand).to eq(4)
-
-          expect(order.shipment.inventory_units).to_not be_empty
-          expect(order.shipment.inventory_units_for(line_item.variant).size).to eq(1)
-        end
-
         context "when adding all variant.on_hand quantity to existing line_item quantity" do
           it "succeeds because it excludes existing inventory units from the validation" do
             line_item.quantity += line_item.variant.on_hand
             validator.validate(line_item)
-            expect(line_item.errors[:quantity].size).to eq(0)
+            expect(line_item).to be_valid
           end
 
           it "fails if one more item is added" do
             line_item.quantity += line_item.variant.on_hand + 1
             validator.validate(line_item)
-            expect_product_out_of_stock_error
+            expect(line_item).not_to be_valid
           end
         end
-      end
-
-      def expect_product_out_of_stock_error
-        quantity_error = line_item.errors[:quantity].first
-        expect(quantity_error).to include(line_item.variant.product.name)
-        expect(quantity_error).to include("out of stock")
       end
     end
   end

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+module Spree
+  module Stock
+    describe AvailabilityValidator do
+      let(:validator) { AvailabilityValidator.new({}) }
+
+      context "line item without existing inventory units" do
+        let(:order) { create(:order_with_line_items) }
+        let(:line_item) { order.line_items.first }
+
+        before do
+          expect(order.shipment.inventory_units).to be_empty
+          expect(line_item.target_shipment).to be_nil
+        end
+
+        context "available quantity when variant.on_hand > line_item.quantity" do
+          it "suceeds" do
+            line_item.quantity = line_item.variant.on_hand - 1
+            validator.validate(line_item)
+            expect(line_item.errors[:quantity].size).to eq(0)
+          end
+        end
+
+        context "unavailable quantity when variant.on_hand < line_item.quantity" do
+          it "fails" do
+            line_item.quantity = line_item.variant.on_hand + 1
+            validator.validate(line_item)
+            expect_product_out_of_stock_error
+          end
+
+          it "succeeds with line_item skip_stock_check" do
+            line_item.skip_stock_check = true
+            line_item.quantity = line_item.variant.on_hand + 1
+            validator.validate(line_item)
+            expect(line_item.errors[:quantity].size).to eq(0)
+          end
+        end
+      end
+
+      describe "line item with existing inventory units" do
+        let(:order) { create(:completed_order_with_totals) }
+        let(:line_item) { order.line_items.first }
+
+        before do
+          expect(line_item.quantity).to eq(1)
+          expect(line_item.variant.on_hand).to eq(4)
+
+          expect(order.shipment.inventory_units).to_not be_empty
+          expect(order.shipment.inventory_units_for(line_item.variant).size).to eq(1)
+        end
+
+        context "when adding all variant.on_hand quantity to existing line_item quantity" do
+          it "succeeds because it excludes existing inventory units from the validation" do
+            line_item.quantity += line_item.variant.on_hand
+            validator.validate(line_item)
+            expect(line_item.errors[:quantity].size).to eq(0)
+          end
+
+          it "fails if one more item is added" do
+            line_item.quantity += line_item.variant.on_hand + 1
+            validator.validate(line_item)
+            expect_product_out_of_stock_error
+          end
+        end
+      end
+
+      def expect_product_out_of_stock_error
+        quantity_error = line_item.errors[:quantity].first
+        expect(quantity_error).to include(line_item.variant.product.name)
+        expect(quantity_error).to include("out of stock")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #3090 and #3037 (see skip_stock_check below) and #3204 (cap line item quantity at stock level).

As described in #3090 ([here](https://github.com/openfoodfoundation/openfoodnetwork/issues/3090#issuecomment-446777857)) this is a spree bug fixed in spree 2.4 that these OFN specs detect.

We could adapt the specs and ignore the spree bug, I dont think that's a valid alternative, specially because the bug is on a basic feature: changing line items quantity on a completed order.

Plain english explanation of the bug: in a completed order with a line_item with quantity 5, when you change the quantity from 5 to 4 on that completed order, because the 5 items were already removed from available stock on order completion, the stock availability check should check the inventory_units of the order (the 5 items) and succeed. From spree v2.0.4 to spree 2.4 the validator is checking if there are 4 (extra) available items in stock...


Bringing the commits from the fix in spree 2.4 to the current ofn spree fork would be painful, they include DB changes.
So, this PR, adapts the availability_validator to fix the bug.

One extra reason to do this is that we can introduce OFN specific stuff like:
- skip_stock_check condition (by including it in this validator we fix #3037), see commit "Fix order factory"
- capping line_item.quantity at zero (we fix #3204 with this fix), see commit "Fix capping quantity"

AND, we still need to handle scoping in this context.

#### What should we test?
2 specs from #3090, 2 from #3037 and 2 from #3204 are green:
- rspec ./spec/features/admin/bulk_order_management_spec.rb:151 - #3090
- rspec ./spec/features/admin/bulk_order_management_spec.rb:163 - #3090
- rspec ./spec/services/order_factory_spec.rb:73 - #3037
- rspec ./spec/services/order_factory_spec.rb:96 - #3037 
- rspec ./spec/models/spree/line_item_spec.rb:100 - #3204
- rspec ./spec/models/spree/line_item_spec.rb:126  - #3204

re bulk_order_management_spec, the test order was changed so that it includes inventory_units that can be checked by the validator.