### PR TITLE
Ignore `it` in Rubocop BlockLength

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -187,7 +187,7 @@ Metrics/AbcSize:
   Max: 15
 
 Metrics/BlockLength:
-  ExcludedMethods: ["describe", "context"]
+  ExcludedMethods: ["context", "describe", "it"]
 
 Metrics/BlockNesting:
   Max: 3


### PR DESCRIPTION
#### What? Why?

Relates to #3141 which was only partly addressed by PR #3142 

We usually end up with long `it` blocks in Ruby specs because we are explicit, need to do a lot of scenario setup, and have to make many assertions. The current config makes Rubocop complain that the blocks are too long.

In #3142, we already made the cop ignore `context` and `describe` blocks. We should have done the same for `it` blocks.

Like in #3142, that wasn't a problem before because of this config in `.codeclimate.yml`:

```yaml
exclude_patterns:
- "spec/**/*"
```

However, recently, we added domain engines, which are in `engines/`. The above pattern does not exclude files in `engines/*/spec/`.

As I mentioned, we can also simply exclude `engines/*/spec/**/*`, but we should not do this.

#### What should we test?

Nothing to test, but the Code Climate check for this PR should pass.

#### Release notes

- Disable Rubocop check `Metrics/BlockLength` for `it` blocks.

Changelog Category: Changed