### PR TITLE
Handle soft deleted products in serializer spec

### DIFF
--- a/app/models/spree/classification_decorator.rb
+++ b/app/models/spree/classification_decorator.rb
@@ -1,14 +1,14 @@
 Spree::Classification.class_eval do
-  belongs_to :product, :class_name => "Spree::Product", touch: true
-  after_save :refresh_products_cache
+  belongs_to :product, class_name: "Spree::Product", touch: true
+
   before_destroy :dont_destroy_if_primary_taxon
   after_destroy :refresh_products_cache
-
+  after_save :refresh_products_cache
 
   private
 
   def refresh_products_cache
-    product.refresh_products_cache
+    Spree::Product.with_deleted.find(product_id).refresh_products_cache
   end
 
   def dont_destroy_if_primary_taxon

--- a/app/models/spree/classification_decorator.rb
+++ b/app/models/spree/classification_decorator.rb
@@ -8,7 +8,8 @@ Spree::Classification.class_eval do
   private
 
   def refresh_products_cache
-    Spree::Product.with_deleted.find(product_id).refresh_products_cache
+    product = Spree::Product.with_deleted.find(product_id) unless product.present?  
+    product.refresh_products_cache
   end
 
   def dont_destroy_if_primary_taxon

--- a/spec/serializers/admin/for_order_cycle/enterprise_serializer_spec.rb
+++ b/spec/serializers/admin/for_order_cycle/enterprise_serializer_spec.rb
@@ -1,16 +1,27 @@
 describe Api::Admin::ForOrderCycle::EnterpriseSerializer do
-  let(:coordinator)         { create(:distributor_enterprise) }
-  let(:order_cycle)         { double(:order_cycle, coordinator: coordinator) }
-  let(:enterprise)          { create(:distributor_enterprise) }
-  let!(:non_inventory_product) { create(:simple_product, supplier: enterprise) }
-  let!(:non_inventory_variant)  { non_inventory_product.variants.first }
-  let!(:inventory_product)  { create(:simple_product, supplier: enterprise) }
-  let!(:inventory_variant)  { inventory_product.variants.first }
-  let!(:deleted_product)    { create(:simple_product, supplier: enterprise, deleted_at: 24.hours.ago ) }
-  let!(:deleted_variant)  { deleted_product.variants.first }
-  let(:serialized_enterprise) { Api::Admin::ForOrderCycle::EnterpriseSerializer.new(enterprise, order_cycle: order_cycle, spree_current_user: enterprise.owner ).to_json }
-  let!(:inventory_item1) { create(:inventory_item, enterprise: coordinator, variant: inventory_variant, visible: true)}
-  let!(:inventory_item2) { create(:inventory_item, enterprise: coordinator, variant: deleted_variant, visible: true)}
+  let(:coordinator) { create(:distributor_enterprise) }
+  let(:order_cycle) { double(:order_cycle, coordinator: coordinator) }
+  let(:enterprise) { create(:distributor_enterprise) }
+
+  let(:non_inventory_product) { create(:simple_product, supplier: enterprise) }
+  let!(:non_inventory_variant) { non_inventory_product.variants.first }
+
+  let(:inventory_product) { create(:simple_product, supplier: enterprise) }
+  let(:inventory_variant) { inventory_product.variants.first }
+
+  let(:deleted_product) { create(:product, supplier: enterprise, deleted_at: 24.hours.ago ) }
+  let(:deleted_variant) { deleted_product.variants.first }
+
+  let(:serialized_enterprise) do
+    Api::Admin::ForOrderCycle::EnterpriseSerializer.new(
+      enterprise,
+      order_cycle: order_cycle,
+      spree_current_user: enterprise.owner
+    ).to_json
+  end
+
+  let!(:inventory_item1) { create(:inventory_item, enterprise: coordinator, variant: inventory_variant, visible: true) }
+  let!(:inventory_item2) { create(:inventory_item, enterprise: coordinator, variant: deleted_variant, visible: true) }
 
   context "when order cycle shows only variants in the coordinator's inventory" do
     before do


### PR DESCRIPTION
#### What? Why?

Closes #3032

Since [cd3add960e](https://github.com/spree/spree/commit/cd3add960e) Spree soft-deletes products and as such the models not
destroyed but updated setting a value for the `deleted_at` field.

This turns what used to be deletes into updates thus triggering AR's
update callbacks instead of the destroy ones. As a result, this bypasses
the logic to refresh the products cache on destroy and hits the
`after_save` callback.

Furthermore, since act_as_paranoid (the soft-delete gem Spree uses) uses
a default scope to avoid retrieving soft-deleted records we need to
purposefully fetch them in order to refresh the cache.

Expect more bugs like this one, even not cached by the test suite.
