### PR TITLE
[Spree Upgrade] Adapt payment controller spec to spree 2

### DIFF
--- a/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Admin::PaymentsController, type: :controller do
   let!(:shop) { create(:enterprise) }
   let!(:user) { shop.owner }
-  let!(:order) { create(:order, distributor: shop) }
+  let!(:order) { create(:order, distributor: shop, state: 'complete') }
   let!(:line_item) { create(:line_item, order: order, price: 5.0) }
 
   context "as an enterprise user" do


### PR DESCRIPTION
In spree 2, since https://github.com/spree/spree/commit/5ed6015916898c18f81bd121fadbc0b7486444bb, to fire a payment event the order needs to be in either payment or complete state

#### What? Why?

Closes #3033 

#### What should we test?
Fixes the 4 specs in 3033.
