### PR TITLE
update Skylight to 1.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -690,7 +690,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    skylight (1.7.1)
+    skylight (1.7.2)
       activesupport (>= 3.0.0)
     spinjs-rails (1.3)
       rails (>= 3.1)


### PR DESCRIPTION
#### What? Why?

Closes #3101

The 'spans closed out-of-order' issue was related to treating the Rails router(s) like middleware. We fixed this issue in Skylight v3.1, and recently backported the fix to 1.7.2 (source: I work at Tilde on Skylight)


#### What should we test?
Endpoints in mounted engines should now be instrumented by Skylight correctly

Changelog Category: Fixed