### PR TITLE
Ignore Rake and routes DSL methods in Rubocop BlockLength

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -187,7 +187,7 @@ Metrics/AbcSize:
   Max: 15
 
 Metrics/BlockLength:
-  ExcludedMethods: ["describe", "context"]
+  ExcludedMethods: ["context", "describe", "it"]
 
 Metrics/BlockNesting:
   Max: 3

--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -187,7 +187,7 @@ Metrics/AbcSize:
   Max: 15
 
 Metrics/BlockLength:
-  ExcludedMethods: ["context", "describe", "it"]
+  ExcludedMethods: ["collection", "context", "describe", "it", "member", "namespace", "resource", "resources"]
 
 Metrics/BlockNesting:
   Max: 3


### PR DESCRIPTION
#### What? Why?

Relates to #3141 

Built on top of #3213 which already has two approvals and might get merged before this PR.

This ignores the following additional methods:

* `namespace` - Rake, routes
* `collection` - routes
* `member` - routes
* `resource` - routes
* `resources` - routes

Note that I did not add the Rake method `task` to the list.

#### What should we test?

Nothing to test, but the Code Climate check for this PR should pass.

#### Release notes

* Disable Rubocop check `Metrics/BlockLength` for `collection`, `member`, `namespace`, `resource`, `resources` blocks.

Changelog Category: Changed

#### Dependencies

This includes commits in #3213.