### PR TITLE
Add custom footer message in reports section

### DIFF
--- a/app/views/spree/admin/reports/_table.html.haml
+++ b/app/views/spree/admin/reports/_table.html.haml
@@ -20,4 +20,4 @@
           %td{colspan: @header.count}= t(:none)
 - else
   %p.report__message
-    = t(".select_and_search")
+    = t(".select_and_search", option: msg_option.upcase)

--- a/app/views/spree/admin/reports/bulk_coop.html.haml
+++ b/app/views/spree/admin/reports/bulk_coop.html.haml
@@ -16,4 +16,4 @@
   %br
   = button t(:search)
 
-= render "table", id: "listing_orders"
+= render "table", id: "listing_orders", msg_option: t(:search)

--- a/app/views/spree/admin/reports/customers.html.haml
+++ b/app/views/spree/admin/reports/customers.html.haml
@@ -27,6 +27,6 @@
   = check_box_tag :csv
   = label_tag :csv, t(:report_customers_csv)
   %br
-  = button t(:search)
+  = button t(:go)
 
-= render "table", id: "listing_customers"
+= render "table", id: "listing_customers", msg_option: t(:go)

--- a/app/views/spree/admin/reports/order_cycle_management.html.haml
+++ b/app/views/spree/admin/reports/order_cycle_management.html.haml
@@ -29,4 +29,4 @@
   .row
   = button t(:search)
 
-= render "table", id: "listing_ocm_orders"
+= render "table", id: "listing_ocm_orders", msg_option: t(:search)

--- a/app/views/spree/admin/reports/orders_and_distributors.html.haml
+++ b/app/views/spree/admin/reports/orders_and_distributors.html.haml
@@ -6,4 +6,4 @@
   %br
   = button t(:search)
 
-= render "table", id: "listing_orders"
+= render "table", id: "listing_orders", msg_option: t(:search)

--- a/app/views/spree/admin/reports/orders_and_fulfillment.html.haml
+++ b/app/views/spree/admin/reports/orders_and_fulfillment.html.haml
@@ -25,4 +25,4 @@
   .row
   = button t(:search)
 
-= render "table", id: "listing_orders"
+= render "table", id: "listing_orders", msg_option: t(:search)

--- a/app/views/spree/admin/reports/packing.html.haml
+++ b/app/views/spree/admin/reports/packing.html.haml
@@ -25,4 +25,4 @@
   .row
   = button t(:search)
 
-= render "table", id: "listing_orders"
+= render "table", id: "listing_orders", msg_option: t(:search)

--- a/app/views/spree/admin/reports/payments.html.haml
+++ b/app/views/spree/admin/reports/payments.html.haml
@@ -16,4 +16,4 @@
   %br
   = button t(:search)
 
-= render "table", id: "listing_orders"
+= render "table", id: "listing_orders", msg_option: t(:search)

--- a/app/views/spree/admin/reports/products_and_inventory.html.haml
+++ b/app/views/spree/admin/reports/products_and_inventory.html.haml
@@ -30,5 +30,5 @@
   = check_box_tag :csv
   = label_tag :csv, t(:report_customers_csv)
   %br
-  = button t(:search)
-= render "table", id: "listing_products"
+  = button t(:go)
+= render "table", id: "listing_products", msg_option: t(:go)

--- a/app/views/spree/admin/reports/sales_tax.html.haml
+++ b/app/views/spree/admin/reports/sales_tax.html.haml
@@ -16,4 +16,4 @@
   %br
   = button t(:search)
 
-= render "table", id: "listing_orders", column_partials: {0 => "link_order"}
+= render "table", id: "listing_orders", column_partials: {0 => "link_order"}, msg_option: t(:search)

--- a/app/views/spree/admin/reports/users_and_enterprises.html.haml
+++ b/app/views/spree/admin/reports/users_and_enterprises.html.haml
@@ -18,4 +18,4 @@
   .row
     = button t(:search)
 
-= render "table", id: "users_and_enterprises"
+= render "table", id: "users_and_enterprises", msg_option: t(:search)

--- a/app/views/spree/admin/reports/xero_invoices.html.haml
+++ b/app/views/spree/admin/reports/xero_invoices.html.haml
@@ -32,4 +32,4 @@
     .four.columns.alpha= button t(:search)
 
 
-= render "table", id: "listing_invoices"
+= render "table", id: "listing_invoices", msg_option: t(:search)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2772,7 +2772,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           display_as: Display As
       reports:
         table:
-          select_and_search: "Select filters and click on SEARCH to access your data."
+          select_and_search: "Select filters and click on %{option} to access your data."
         bulk_coop:
           bulk_coop_supplier_report: 'Bulk Co-op - Totals by Supplier'
           bulk_coop_allocation: 'Bulk Co-op - Allocation'

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -40,8 +40,8 @@ feature %q{
     scenario "customers report" do
       click_link "Mailing List"
       expect(page).to have_select('report_type', selected: 'Mailing List')
-      expect(page).to have_content "click on SEARCH"
-      click_button "Search"
+      expect(page).to have_content "click on GO"
+      click_button "Go"
 
       rows = find("table#listing_customers").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
@@ -54,7 +54,7 @@ feature %q{
       click_link "Addresses"
       expect(page).to have_select('report_type', selected: 'Addresses')
 
-      click_button "Search"
+      click_button "Go"
       rows = find("table#listing_customers").all("thead tr")
       table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
       expect(table.sort).to eq([
@@ -323,7 +323,7 @@ feature %q{
       expect(page).to have_content "All products"
       expect(page).to have_content "Inventory (on hand)"
       click_link 'Products & Inventory'
-      click_button "Search"
+      click_button "Go"
       expect(page).to have_content "Supplier"
       expect(page).to have_table_row ["Supplier", "Producer Suburb", "Product", "Product Properties", "Taxons", "Variant Value", "Price", "Group Buy Unit Quantity", "Amount", "SKU"].map(&:upcase)
       expect(page).to have_table_row [product1.supplier.name, product1.supplier.address.city, "Product Name", product1.properties.map(&:presentation).join(", "), product1.primary_taxon.name,  "Test",           "100.0",  product1.group_buy_unit_size.to_s, "",       "sku1"]
@@ -335,7 +335,7 @@ feature %q{
       quick_login_as_admin
       visit spree.admin_reports_path
       click_link 'LettuceShare'
-      click_button "Search"
+      click_button "Go"
 
       expect(page).to have_table_row ['PRODUCT', 'Description', 'Qty', 'Pack Size', 'Unit', 'Unit Price', 'Total', 'GST incl.', 'Grower and growing method', 'Taxon'].map(&:upcase)
       expect(page).to have_table_row ['Product 2', '100g', '', '100', 'g', '99.0', '', '0', 'Supplier Name (Organic - NASAA 12345)', 'Taxon Name']


### PR DESCRIPTION
#### What? Why?

Closes #3159 

When accessing all reports, OFN users must click the blue button 'Search'. In some cases this is appropriate as you can select subsets of data to look at.
For other instances (such as when downloading 'addresses') 'Go' or 'Download' would be more appropriate.
Currently the same string is used in each location in the reports section of the user dashboard and in other locations.

My proposal is to send an additional parameter to the partial `_table.html.haml` and modify the locales in order to show either a `SEARCH` or `GO` on the footer message

#### What should we test?
All pages within the Reports Section should be checked to confirm that the appropriate message is shown for all cases.


#### Release notes
- Add custom message `option` to partial `_table.html.haml`
- Send `msg_option` param from all reports to partial `_table.html.haml`


<!-- Please assign one category to your PR and delete the others. 
Changelog Category: Added 

