### PR TITLE
3127 More robust tax rates report

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -54,7 +54,7 @@ module CheckoutHelper
   end
 
   def display_adjustment_tax_rates(adjustment)
-    tax_rates = adjustment.tax_rates
+    tax_rates = TaxRateFinder.tax_rates_of(adjustment)
     tax_rates.map { |tr| number_to_percentage(tr.amount * 100, :precision => 1) }.join(", ")
   end
 

--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -40,11 +40,6 @@ module Spree
       included_tax > 0
     end
 
-    # @return [Array<Spree::TaxRate>]
-    def tax_rates
-      TaxRateFinder.new.tax_rates(originator, source, amount, included_tax)
-    end
-
     def self.without_callbacks
       skip_callback :save, :after, :update_adjustable
       skip_callback :destroy, :after, :update_adjustable

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -293,7 +293,7 @@ Spree::Order.class_eval do
 
   def tax_adjustment_totals
     tax_adjustments.each_with_object(Hash.new) do |adjustment, hash|
-      tax_rates = adjustment.tax_rates
+      tax_rates = TaxRateFinder.tax_rates_of(adjustment)
       tax_rates_hash = Hash[tax_rates.collect do |tax_rate|
         tax_amount = tax_rates.one? ? adjustment.included_tax : tax_rate.compute_tax(adjustment.amount)
         [tax_rate, tax_amount]

--- a/app/services/tax_rate_finder.rb
+++ b/app/services/tax_rate_finder.rb
@@ -1,0 +1,33 @@
+# Finds tax rates on which an adjustment is based on.
+# For example a packaging fee may contain VAT. This service finds the VAT rate
+# for the tax included in the packaging fee.
+class TaxRateFinder
+  # @return [Array<Spree::TaxRate>]
+  def tax_rates(originator, source, amount, included_tax)
+    case originator
+    when Spree::TaxRate
+      [originator]
+    when EnterpriseFee
+      case source
+      when Spree::LineItem
+        tax_category = originator.inherits_tax_category? ? source.product.tax_category : originator.tax_category
+        tax_category ? tax_category.tax_rates.match(source.order) : []
+      when Spree::Order
+        originator.tax_category ? originator.tax_category.tax_rates.match(source) : []
+      end
+    else
+      find_closest_tax_rates_from_included_tax(amount, included_tax)
+    end
+  end
+
+  private
+
+  # shipping fees and adjustments created from the admin panel have
+  # taxes set at creation in the included_tax field without relation
+  # to the corresponding TaxRate, so we look for the closest one
+  def find_closest_tax_rates_from_included_tax(amount, included_tax)
+    approximation = (included_tax / (amount - included_tax))
+    return [] if approximation.infinite? || approximation.zero?
+    [Spree::TaxRate.order("ABS(amount - #{approximation})").first]
+  end
+end

--- a/app/services/tax_rate_finder.rb
+++ b/app/services/tax_rate_finder.rb
@@ -4,6 +4,13 @@
 class TaxRateFinder
   # @return [Array<Spree::TaxRate>]
   def tax_rates(originator, source, amount, included_tax)
+    find_associated_tax_rate(originator, source) ||
+      find_closest_tax_rates_from_included_tax(amount, included_tax)
+  end
+
+  private
+
+  def find_associated_tax_rate(originator, source)
     case originator
     when Spree::TaxRate
       [originator]
@@ -15,12 +22,8 @@ class TaxRateFinder
       when Spree::Order
         originator.tax_category ? originator.tax_category.tax_rates.match(source) : []
       end
-    else
-      find_closest_tax_rates_from_included_tax(amount, included_tax)
     end
   end
-
-  private
 
   # shipping fees and adjustments created from the admin panel have
   # taxes set at creation in the included_tax field without relation

--- a/app/services/tax_rate_finder.rb
+++ b/app/services/tax_rate_finder.rb
@@ -15,13 +15,25 @@ class TaxRateFinder
     when Spree::TaxRate
       [originator]
     when EnterpriseFee
-      case source
-      when Spree::LineItem
-        tax_category = originator.inherits_tax_category? ? source.product.tax_category : originator.tax_category
-        tax_category ? tax_category.tax_rates.match(source.order) : []
-      when Spree::Order
-        originator.tax_category ? originator.tax_category.tax_rates.match(source) : []
-      end
+      enterprise_fee_tax_rates(originator, source)
+    end
+  end
+
+  def enterprise_fee_tax_rates(enterprise_fee, source)
+    case source
+    when Spree::LineItem
+      tax_category = line_item_tax_category(enterprise_fee, source)
+      tax_category ? tax_category.tax_rates.match(source.order) : []
+    when Spree::Order
+      enterprise_fee.tax_category ? enterprise_fee.tax_category.tax_rates.match(source) : []
+    end
+  end
+
+  def line_item_tax_category(enterprise_fee, line_item)
+    if enterprise_fee.inherits_tax_category?
+      line_item.product.tax_category
+    else
+      enterprise_fee.tax_category
     end
   end
 

--- a/app/services/tax_rate_finder.rb
+++ b/app/services/tax_rate_finder.rb
@@ -3,6 +3,16 @@
 # for the tax included in the packaging fee.
 class TaxRateFinder
   # @return [Array<Spree::TaxRate>]
+  def self.tax_rates_of(adjustment)
+    new.tax_rates(
+      adjustment.originator,
+      adjustment.source,
+      adjustment.amount,
+      adjustment.included_tax
+    )
+  end
+
+  # @return [Array<Spree::TaxRate>]
   def tax_rates(originator, source, amount, included_tax)
     find_associated_tax_rate(originator, source) ||
       find_closest_tax_rates_from_included_tax(amount, included_tax)

--- a/lib/open_food_network/enterprise_fee_applicator.rb
+++ b/lib/open_food_network/enterprise_fee_applicator.rb
@@ -32,7 +32,7 @@ module OpenFoodNetwork
     end
 
     def adjustment_tax(adjustable, adjustment)
-      tax_rates = adjustment.tax_rates
+      tax_rates = TaxRateFinder.tax_rates_of(adjustment)
 
       tax_rates.select(&:included_in_price).sum do |rate|
         rate.compute_tax adjustment.amount

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -281,21 +281,6 @@ module Spree
           adjustment.included_tax.should == 10.00
         end
       end
-
-      describe "getting the corresponding tax rate" do
-        let!(:adjustment_with_tax)    { create(:adjustment, amount: 50, included_tax: 10) }
-        let!(:adjustment_without_tax) { create(:adjustment, amount: 50, included_tax: 0) }
-        let!(:tax_rate)               { create(:tax_rate, calculator: Spree::Calculator::DefaultTax.new, amount: 0.25) }
-        let!(:other_tax_rate)         { create(:tax_rate, calculator: Spree::Calculator::DefaultTax.new, amount: 0.3) }
-
-        it "returns [] if there is no included tax" do
-          adjustment_without_tax.find_closest_tax_rates_from_included_tax.should == []
-        end
-
-        it "returns the most accurate tax rate" do
-          adjustment_with_tax.find_closest_tax_rates_from_included_tax.should == [tax_rate]
-        end
-      end
     end
 
     context "extends LocalizedNumber" do

--- a/spec/services/tax_rate_finder_spec.rb
+++ b/spec/services/tax_rate_finder_spec.rb
@@ -51,7 +51,7 @@ describe TaxRateFinder do
     # There is a bug that leaves orphan adjustments on an order after
     # associated line items have been removed.
     # https://github.com/openfoodfoundation/openfoodnetwork/issues/3127
-    pending "deals with a missing line item" do
+    it "deals with a missing line item" do
       rates = TaxRateFinder.new.tax_rates(
         enterprise_fee,
         nil,

--- a/spec/services/tax_rate_finder_spec.rb
+++ b/spec/services/tax_rate_finder_spec.rb
@@ -2,11 +2,9 @@ require 'spec_helper'
 
 describe TaxRateFinder do
   describe "getting the corresponding tax rate" do
-    let(:amount) { BigDecimal(100) }
+    let(:amount) { BigDecimal(120) }
     let(:included_tax) { BigDecimal(20) }
     let(:tax_rate) { create_rate(0.2) }
-    let(:close_tax_rate) { create_rate(0.25) }
-    let(:other_tax_rate) { create_rate(0.3) }
     let(:tax_category) { create(:tax_category, tax_rates: [tax_rate]) }
     # This zone is used by :order_with_taxes and needs to match it
     let(:zone) { create(:zone, name: "GlobalZone") }
@@ -25,8 +23,11 @@ describe TaxRateFinder do
     end
 
     it "finds a close match" do
-      close_tax_rate
-      other_tax_rate
+      tax_rate.destroy
+      close_tax_rate = create_rate(tax_rate.amount + 0.05)
+      # other tax rates, not as close to the real one
+      create_rate(tax_rate.amount + 0.06)
+      create_rate(tax_rate.amount - 0.06)
 
       rates = TaxRateFinder.new.tax_rates(
         nil,

--- a/spec/services/tax_rate_finder_spec.rb
+++ b/spec/services/tax_rate_finder_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe TaxRateFinder do
+  describe "getting the corresponding tax rate" do
+    let(:amount) { BigDecimal(100) }
+    let(:included_tax) { BigDecimal(20) }
+    let(:tax_rate) { create_rate(0.2) }
+    let(:close_tax_rate) { create_rate(0.25) }
+    let(:other_tax_rate) { create_rate(0.3) }
+    let(:tax_category) { create(:tax_category, tax_rates: [tax_rate]) }
+    # This zone is used by :order_with_taxes and needs to match it
+    let(:zone) { create(:zone, name: "GlobalZone") }
+    let(:shipment) { create(:shipment) }
+    let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_category) }
+    let(:order) { create(:order_with_taxes) }
+
+    it "finds the tax rate of a shipping fee" do
+      rates = TaxRateFinder.new.tax_rates(
+        tax_rate,
+        shipment,
+        amount,
+        included_tax
+      )
+      expect(rates).to eq [tax_rate]
+    end
+
+    it "finds a close match" do
+      close_tax_rate
+      other_tax_rate
+
+      rates = TaxRateFinder.new.tax_rates(
+        nil,
+        shipment,
+        amount,
+        included_tax
+      )
+
+      expect(rates).to eq [close_tax_rate]
+    end
+
+    it "finds the tax rate of an enterprise fee" do
+      rates = TaxRateFinder.new.tax_rates(
+        enterprise_fee,
+        order,
+        amount,
+        included_tax
+      )
+      expect(rates).to eq [tax_rate]
+    end
+
+    # There is a bug that leaves orphan adjustments on an order after
+    # associated line items have been removed.
+    # https://github.com/openfoodfoundation/openfoodnetwork/issues/3127
+    pending "deals with a missing line item" do
+      rates = TaxRateFinder.new.tax_rates(
+        enterprise_fee,
+        nil,
+        amount,
+        included_tax
+      )
+      expect(rates).to eq [tax_rate]
+    end
+
+    def create_rate(amount)
+      create(
+        :tax_rate,
+        amount: amount,
+        calculator: Spree::Calculator::DefaultTax.new,
+        zone: zone
+      )
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #3127

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

It is possible to delete line items without deleting their associated fees which can include tax. Orders containing these orphaned fees broke the tax rates report.

While we should work on keeping our database clean and consistent, this change makes tax rate reporting much more robust and fixes the immediate issue #3127.

It also encapsulates the tax rate finding logic in a new class, not polluting Spree's namespace.

#### What should we test?
<!-- List which features should be tested and how. -->

- Go to Enterprises / Enterprise Fees and add a packing fee with flat percent per item.
- Adjust the percentage to 10%.
- Include that fee in an order cycle.
- Create an order with multiple line items.
- Go to admin / orders / edit order.
- Observer that there is a fee for each item.
- Click the trash icon to delete an item, but don't click "Update And Recalculate Fees".
- Observe that the line item is gone, but the fee is still there.
- Go to the tax rates report.
- Get a report that includes the modified order.
- Observe that the page doesn't crash, but the tax rate of the enterprise fee is displayed.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: The tax rates report is working again. It crashed with orders containing orphaned enterprise fees including tax.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
