### PR TITLE
[Spree Upgrade] Scope variants in line items availability validator

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -125,6 +125,11 @@ module VariantStock
     on_demand || total_on_hand >= quantity
   end
 
+  # We override Spree::Variant.in_stock? to avoid depending on the non-overidable method Spree::Stock::Quantifier.can_supply?
+  def in_stock?(quantity = 1)
+    can_supply?(quantity)
+  end
+
   # We can have this responsibility here in the variant because there is only one stock item per variant
   #
   # This enables us to override this behaviour for variant overrides

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -114,6 +114,17 @@ module VariantStock
     end
   end
 
+  # Moving Spree::Stock::Quantifier.can_supply? to the variant enables us to override this behaviour for variant overrides
+  # We can have this responsibility here in the variant because there is only one stock item per variant
+  #
+  # Here we depend only on variant.total_on_hand and variant.on_demand.
+  #   This way, variant_overrides only need to override variant.total_on_hand and variant.on_demand.
+  def can_supply?(quantity)
+    return true unless Spree::Config[:track_inventory_levels]
+
+    on_demand || total_on_hand >= quantity
+  end
+
   # We can have this responsibility here in the variant because there is only one stock item per variant
   #
   # This enables us to override this behaviour for variant overrides

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -130,6 +130,23 @@ module VariantStock
     can_supply?(quantity)
   end
 
+  # Moving Spree::StockLocation.fill_status to the variant enables us to override this behaviour for variant overrides
+  # We can have this responsibility here in the variant because there is only one stock item per variant
+  #
+  # Here we depend only on variant.total_on_hand and variant.on_demand.
+  #   This way, variant_overrides only need to override variant.total_on_hand and variant.on_demand.
+  def fill_status(quantity)
+    if count_on_hand >= quantity
+      on_hand = quantity
+      backordered = 0
+    else
+      on_hand = [0, total_on_hand].max
+      backordered = on_demand ? (quantity - on_hand) : 0
+    end
+
+    [on_hand, backordered]
+  end
+
   # We can have this responsibility here in the variant because there is only one stock item per variant
   #
   # This enables us to override this behaviour for variant overrides

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -8,7 +8,7 @@ Spree::LineItem.class_eval do
   # Redefining here to add the inverse_of option
   belongs_to :order, :class_name => "Spree::Order", inverse_of: :line_items
 
-  # Allows manual skipping of stock_availability check
+  # Allows manual skipping of Stock::AvailabilityValidator
   attr_accessor :skip_stock_check
 
   attr_accessible :max_quantity, :final_weight_volume, :price
@@ -132,13 +132,6 @@ Spree::LineItem.class_eval do
     update_inventory_without_scoping
   end
   alias_method_chain :update_inventory, :scoping
-
-  # Override of Spree validation method
-  # Added check for in-memory :skip_stock_check attribute
-  def stock_availability
-    return if skip_stock_check || sufficient_stock?
-    errors.add(:quantity, I18n.t('validation.exceeds_available_stock'))
-  end
 
   def scoper
     @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -125,6 +125,10 @@ Spree::LineItem.class_eval do
     end
   end
 
+  def scoper
+    @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)
+  end
+
   private
 
   def update_inventory_with_scoping
@@ -132,10 +136,6 @@ Spree::LineItem.class_eval do
     update_inventory_without_scoping
   end
   alias_method_chain :update_inventory, :scoping
-
-  def scoper
-    @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)
-  end
 
   def calculate_final_weight_volume
     if final_weight_volume.present? && quantity_was > 0

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -1,5 +1,8 @@
 Spree::Stock::AvailabilityValidator.class_eval do
   def validate(line_item)
+    # OFN specific check for in-memory :skip_stock_check attribute
+    return if line_item.skip_stock_check
+
     quantity = adapt_line_item_quantity_to_inventory_units(line_item)
 
     validate_quantity(line_item, quantity)

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -3,10 +3,10 @@ Spree::Stock::AvailabilityValidator.class_eval do
     # OFN specific check for in-memory :skip_stock_check attribute
     return if line_item.skip_stock_check
 
-    quantity = adapt_line_item_quantity_to_inventory_units(line_item)
-    return if quantity == 0
+    quantity_to_validate = line_item.quantity - quantity_in_shipment(line_item)
+    return if quantity_to_validate < 1
 
-    validate_quantity(line_item, quantity)
+    validate_quantity(line_item, quantity_to_validate)
   end
 
   private
@@ -14,12 +14,12 @@ Spree::Stock::AvailabilityValidator.class_eval do
   # This is an adapted version of a fix to the inventory_units not being considered here.
   # See #3090 for details.
   # This can be removed after upgrading to Spree 2.4.
-  def adapt_line_item_quantity_to_inventory_units(line_item)
+  def quantity_in_shipment(line_item)
     shipment = line_item_shipment(line_item)
-    return line_item.quantity unless shipment
+    return 0 unless shipment
 
     units = shipment.inventory_units_for(line_item.variant)
-    line_item.quantity - units.count
+    units.count
   end
 
   def line_item_shipment(line_item)

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -1,0 +1,37 @@
+Spree::Stock::AvailabilityValidator.class_eval do
+  def validate(line_item)
+    quantity = adapt_line_item_quantity_to_inventory_units(line_item)
+
+    validate_quantity(line_item, quantity)
+  end
+
+  private
+
+  # This is an adapted version of a fix to the inventory_units not being considered here.
+  # See #3090 for details.
+  # This can be removed after upgrading to Spree 2.4.
+  def adapt_line_item_quantity_to_inventory_units(line_item)
+    shipment = line_item_shipment(line_item)
+    return line_item.quantity unless shipment
+
+    units = shipment.inventory_units_for(line_item.variant)
+    line_item.quantity - units.count
+  end
+
+  def line_item_shipment(line_item)
+    return line_item.target_shipment if line_item.target_shipment
+    return line_item.order.shipments.first if line_item.order.present? && line_item.order.shipments.any?
+  end
+
+  # This is the spree v2.0.4 implementation of validate
+  # But using the calculated quantity instead of the line_item.quantity.
+  def validate_quantity(line_item, quantity)
+    quantifier = Spree::Stock::Quantifier.new(line_item.variant_id)
+    return if quantifier.can_supply? quantity
+
+    variant = line_item.variant
+    display_name = %Q{#{variant.name}}
+    display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
+    line_item.errors[:quantity] << Spree.t(:out_of_stock, :scope => :order_populator, :item => display_name.inspect)
+  end
+end

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -4,6 +4,7 @@ Spree::Stock::AvailabilityValidator.class_eval do
     return if line_item.skip_stock_check
 
     quantity = adapt_line_item_quantity_to_inventory_units(line_item)
+    return if quantity == 0
 
     validate_quantity(line_item, quantity)
   end

--- a/app/models/spree/stock_location_decorator.rb
+++ b/app/models/spree/stock_location_decorator.rb
@@ -2,4 +2,8 @@ Spree::StockLocation.class_eval do
   def move(variant, quantity, originator = nil)
     variant.move(quantity, originator)
   end
+
+  def fill_status(variant, quantity)
+    variant.fill_status(quantity)
+  end
 end

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -20,14 +20,6 @@ module OpenFoodNetwork
         Spree::Price.new(amount: price, currency: currency)
       end
 
-      # Old Spree has the same logic as here and doesn't need this override.
-      # But we need this to use VariantOverrides with Spree 2.0.
-      def in_stock?
-        return true unless Spree::Config[:track_inventory_levels]
-
-        on_demand || (count_on_hand > 0)
-      end
-
       # Uses variant_override.count_on_hand instead of Stock::Quantifier.stock_items.count_on_hand
       def total_on_hand
         @variant_override.andand.count_on_hand || super

--- a/spec/features/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/features/consumer/shopping/variant_overrides_spec.rb
@@ -13,26 +13,26 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
   let(:outgoing_exchange) { oc.exchanges.outgoing.first }
   let(:sm) { hub.shipping_methods.first }
   let(:pm) { hub.payment_methods.first }
-  let(:p1) { create(:simple_product, supplier: producer) }
-  let(:p2) { create(:simple_product, supplier: producer) }
-  let(:p3) { create(:simple_product, supplier: producer, on_demand: true) }
-  let(:v1) { create(:variant, product: p1, price: 11.11, unit_value: 1) }
-  let(:v2) { create(:variant, product: p1, price: 22.22, unit_value: 2) }
-  let(:v3) { create(:variant, product: p2, price: 33.33, unit_value: 3) }
-  let(:v4) { create(:variant, product: p1, price: 44.44, unit_value: 4) }
-  let(:v5) { create(:variant, product: p3, price: 55.55, unit_value: 5, on_demand: true) }
-  let(:v6) { create(:variant, product: p3, price: 66.66, unit_value: 6, on_demand: true) }
-  let!(:vo1) { create(:variant_override, hub: hub, variant: v1, price: 55.55, count_on_hand: nil, default_stock: nil, resettable: false) }
-  let!(:vo2) { create(:variant_override, hub: hub, variant: v2, count_on_hand: 0, default_stock: nil, resettable: false) }
-  let!(:vo3) { create(:variant_override, hub: hub, variant: v3, count_on_hand: 0, default_stock: nil, resettable: false) }
-  let!(:vo4) { create(:variant_override, hub: hub, variant: v4, count_on_hand: 3, default_stock: nil, resettable: false) }
-  let!(:vo5) { create(:variant_override, hub: hub, variant: v5, count_on_hand: 0, default_stock: nil, resettable: false) }
-  let!(:vo6) { create(:variant_override, hub: hub, variant: v6, count_on_hand: 6, default_stock: nil, resettable: false) }
-  let(:ef) { create(:enterprise_fee, enterprise: hub, fee_type: 'packing', calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 10)) }
+  let(:product1) { create(:simple_product, supplier: producer) }
+  let(:product2) { create(:simple_product, supplier: producer) }
+  let(:product3) { create(:simple_product, supplier: producer, on_demand: true) }
+  let(:product1_variant1) { create(:variant, product: product1, price: 11.11, unit_value: 1) }
+  let(:product1_variant2) { create(:variant, product: product1, price: 22.22, unit_value: 2) }
+  let(:product2_variant1) { create(:variant, product: product2, price: 33.33, unit_value: 3) }
+  let(:product1_variant3) { create(:variant, product: product1, price: 44.44, unit_value: 4) }
+  let(:product3_variant1) { create(:variant, product: product3, price: 55.55, unit_value: 5, on_demand: true) }
+  let(:product3_variant2) { create(:variant, product: product3, price: 66.66, unit_value: 6, on_demand: true) }
+  let!(:product1_variant1_override) { create(:variant_override, hub: hub, variant: product1_variant1, price: 55.55, count_on_hand: nil, default_stock: nil, resettable: false) }
+  let!(:product1_variant2_override) { create(:variant_override, hub: hub, variant: product1_variant2, count_on_hand: 0, default_stock: nil, resettable: false) }
+  let!(:product2_variant1_override) { create(:variant_override, hub: hub, variant: product2_variant1, count_on_hand: 0, default_stock: nil, resettable: false) }
+  let!(:product1_variant3_override) { create(:variant_override, hub: hub, variant: product1_variant3, count_on_hand: 3, default_stock: nil, resettable: false) }
+  let!(:product3_variant1_override) { create(:variant_override, hub: hub, variant: product3_variant1, count_on_hand: 0, default_stock: nil, resettable: false) }
+  let!(:product3_variant2_override) { create(:variant_override, hub: hub, variant: product3_variant2, count_on_hand: 6, default_stock: nil, resettable: false) }
+  let(:enterprise_fee) { create(:enterprise_fee, enterprise: hub, fee_type: 'packing', calculator: Calculator::FlatPercentPerItem.new(preferred_flat_percent: 10)) }
 
   before do
-    outgoing_exchange.variants = [v1, v2, v3, v4, v5, v6]
-    outgoing_exchange.enterprise_fees << ef
+    outgoing_exchange.variants = [product1_variant1, product1_variant2, product2_variant1, product1_variant3, product3_variant1, product3_variant2]
+    outgoing_exchange.enterprise_fees << enterprise_fee
     sm.calculator.preferred_amount = 0
     visit shops_path
     click_link hub.name
@@ -40,24 +40,24 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
 
   describe "viewing products" do
     it "shows the overridden price" do
-      page.should_not have_price with_currency(12.22) # $11.11 + 10% fee
-      page.should have_price with_currency(61.11)
+      page.should_not have_price with_currency(12.22) # product1_variant1.price ($11.11) + 10% fee
+      page.should have_price with_currency(61.11) # product1_variant1_override.price ($55.55) + 10% fee
     end
 
     it "looks up stock from the override" do
       # Product should appear but one of the variants is out of stock
-      page.should_not have_content v2.options_text
+      page.should_not have_content product1_variant2.options_text
 
       # Entire product should not appear - no stock
-      page.should_not have_content p2.name
-      page.should_not have_content v3.options_text
+      page.should_not have_content product2.name
+      page.should_not have_content product2_variant1.options_text
 
       # On-demand product with VO of no stock should NOT appear
-      page.should_not have_content v5.options_text
+      page.should_not have_content product3_variant1.options_text
     end
 
     it "calculates fees correctly" do
-      page.find("#variant-#{v1.id} .graph-button").click
+      page.find("#variant-#{product1_variant1.id} .graph-button").click
       page.find(".price_breakdown a").click
       page.should have_selector 'li.cost div', text: with_currency(55.55)
       page.should have_selector 'li.packing-fee div', text: with_currency(5.56)
@@ -65,38 +65,38 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
     end
 
     it "shows the correct prices when products are in the cart" do
-      fill_in "variants[#{v1.id}]", with: "2"
+      fill_in "variants[#{product1_variant1.id}]", with: "2"
       show_cart
       wait_until_enabled 'li.cart a.button'
       visit shop_path
-      page.should_not have_price with_currency(12.22)
+      page.should have_price with_currency(61.11)
     end
 
     # The two specs below reveal an unrelated issue with fee calculation. See:
     # https://github.com/openfoodfoundation/openfoodnetwork/issues/312
 
     it "shows the overridden price with fees in the quick cart" do
-      fill_in "variants[#{v1.id}]", with: "2"
+      fill_in "variants[#{product1_variant1.id}]", with: "2"
       show_cart
-      page.should have_selector "#cart-variant-#{v1.id} .quantity", text: '2'
-      page.should have_selector "#cart-variant-#{v1.id} .price", text: with_currency(61.11)
-      page.should have_selector "#cart-variant-#{v1.id} .total-price", text: with_currency(122.22)
+      page.should have_selector "#cart-variant-#{product1_variant1.id} .quantity", text: '2'
+      page.should have_selector "#cart-variant-#{product1_variant1.id} .price", text: with_currency(61.11)
+      page.should have_selector "#cart-variant-#{product1_variant1.id} .total-price", text: with_currency(122.22)
     end
 
     it "shows the correct prices in the shopping cart" do
-      fill_in "variants[#{v1.id}]", with: "2"
+      fill_in "variants[#{product1_variant1.id}]", with: "2"
       add_to_cart
 
-      page.should have_selector "tr.line-item.variant-#{v1.id} .cart-item-price", text: with_currency(61.11)
+      page.should have_selector "tr.line-item.variant-#{product1_variant1.id} .cart-item-price", text: with_currency(61.11)
       page.should have_field "order[line_items_attributes][0][quantity]", with: '2'
-      page.should have_selector "tr.line-item.variant-#{v1.id} .cart-item-total", text: with_currency(122.22)
+      page.should have_selector "tr.line-item.variant-#{product1_variant1.id} .cart-item-total", text: with_currency(122.22)
 
       page.should have_selector "#edit-cart .item-total", text: with_currency(122.22)
       page.should have_selector "#edit-cart .grand-total", text: with_currency(122.22)
     end
 
     it "shows the correct prices in the checkout" do
-      fill_in "variants[#{v1.id}]", with: "2"
+      fill_in "variants[#{product1_variant1.id}]", with: "2"
       click_checkout
 
       page.should have_selector 'form.edit_order .cart-total', text: with_currency(122.22)
@@ -108,7 +108,7 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
 
   describe "creating orders" do
     it "creates the order with the correct prices" do
-      fill_in "variants[#{v1.id}]", with: "2"
+      fill_in "variants[#{product1_variant1.id}]", with: "2"
       click_checkout
 
       complete_checkout
@@ -119,39 +119,39 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
     end
 
     it "subtracts stock from the override" do
-      fill_in "variants[#{v4.id}]", with: "2"
+      fill_in "variants[#{product1_variant3.id}]", with: "2"
       click_checkout
 
       expect do
         expect do
           complete_checkout
-        end.to change { v4.reload.count_on_hand }.by(0)
-      end.to change { vo4.reload.count_on_hand }.by(-2)
+        end.to change { product1_variant3.reload.count_on_hand }.by(0)
+      end.to change { product1_variant3_override.reload.count_on_hand }.by(-2)
     end
 
     it "subtracts stock from stock-overridden on_demand variants" do
-      fill_in "variants[#{v6.id}]", with: "2"
+      fill_in "variants[#{product3_variant2.id}]", with: "2"
       click_checkout
 
       expect do
         expect do
           complete_checkout
-        end.to change { v6.reload.count_on_hand }.by(0)
-      end.to change { vo6.reload.count_on_hand }.by(-2)
+        end.to change { product3_variant2.reload.count_on_hand }.by(0)
+      end.to change { product3_variant2_override.reload.count_on_hand }.by(-2)
     end
 
     it "does not subtract stock from overrides that do not override count_on_hand" do
-      fill_in "variants[#{v1.id}]", with: "2"
+      fill_in "variants[#{product1_variant1.id}]", with: "2"
       click_checkout
       expect do
         complete_checkout
-      end.to change { v1.reload.count_on_hand }.by(-2)
-      vo1.reload.count_on_hand.should be_nil
+      end.to change { product1_variant1.reload.count_on_hand }.by(-2)
+      product1_variant1_override.reload.count_on_hand.should be_nil
     end
 
     it "does not show out of stock flags on order confirmation page" do
-      v4.update_attribute :count_on_hand, 0
-      fill_in "variants[#{v4.id}]", with: "2"
+      product1_variant3.update_attribute :count_on_hand, 0
+      fill_in "variants[#{product1_variant3.id}]", with: "2"
       click_checkout
 
       complete_checkout

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -585,24 +585,5 @@ module Spree
         }.to change(Spree::OptionValue, :count).by(0)
       end
     end
-
-    describe "checking stock availability" do
-      let(:line_item) { LineItem.new }
-
-      context "when skip_stock_check is not set" do
-        it "checks stock" do
-          expect(line_item).to receive(:sufficient_stock?) { true }
-          line_item.send(:stock_availability)
-        end
-      end
-
-      context "when skip_stock_check is set to true" do
-        before { line_item.skip_stock_check = true }
-        it "does not check stock" do
-          expect(line_item).to_not receive(:sufficient_stock?)
-          line_item.send(:stock_availability)
-        end
-      end
-    end
   end
 end

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -9,16 +9,11 @@ module Spree
         let(:order) { create(:order_with_line_items) }
         let(:line_item) { order.line_items.first }
 
-        before do
-          expect(order.shipment.inventory_units).to be_empty
-          expect(line_item.target_shipment).to be_nil
-        end
-
         context "available quantity when variant.on_hand > line_item.quantity" do
           it "suceeds" do
             line_item.quantity = line_item.variant.on_hand - 1
             validator.validate(line_item)
-            expect(line_item.errors[:quantity].size).to eq(0)
+            expect(line_item).to be_valid
           end
         end
 
@@ -26,14 +21,14 @@ module Spree
           it "fails" do
             line_item.quantity = line_item.variant.on_hand + 1
             validator.validate(line_item)
-            expect_product_out_of_stock_error
+            expect(line_item).not_to be_valid
           end
 
           it "succeeds with line_item skip_stock_check" do
             line_item.skip_stock_check = true
             line_item.quantity = line_item.variant.on_hand + 1
             validator.validate(line_item)
-            expect(line_item.errors[:quantity].size).to eq(0)
+            expect(line_item).to be_valid
           end
         end
       end
@@ -42,33 +37,19 @@ module Spree
         let(:order) { create(:completed_order_with_totals) }
         let(:line_item) { order.line_items.first }
 
-        before do
-          expect(line_item.quantity).to eq(1)
-          expect(line_item.variant.on_hand).to eq(4)
-
-          expect(order.shipment.inventory_units).to_not be_empty
-          expect(order.shipment.inventory_units_for(line_item.variant).size).to eq(1)
-        end
-
         context "when adding all variant.on_hand quantity to existing line_item quantity" do
           it "succeeds because it excludes existing inventory units from the validation" do
             line_item.quantity += line_item.variant.on_hand
             validator.validate(line_item)
-            expect(line_item.errors[:quantity].size).to eq(0)
+            expect(line_item).to be_valid
           end
 
           it "fails if one more item is added" do
             line_item.quantity += line_item.variant.on_hand + 1
             validator.validate(line_item)
-            expect_product_out_of_stock_error
+            expect(line_item).not_to be_valid
           end
         end
-      end
-
-      def expect_product_out_of_stock_error
-        quantity_error = line_item.errors[:quantity].first
-        expect(quantity_error).to include(line_item.variant.product.name)
-        expect(quantity_error).to include("out of stock")
       end
     end
   end

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+module Spree
+  module Stock
+    describe AvailabilityValidator do
+      let(:validator) { AvailabilityValidator.new({}) }
+
+      context "line item without existing inventory units" do
+        let(:order) { create(:order_with_line_items) }
+        let(:line_item) { order.line_items.first }
+
+        before do
+          expect(order.shipment.inventory_units).to be_empty
+          expect(line_item.target_shipment).to be_nil
+        end
+
+        context "available quantity when variant.on_hand > line_item.quantity" do
+          it "suceeds" do
+            line_item.quantity = line_item.variant.on_hand - 1
+            validator.validate(line_item)
+            expect(line_item.errors[:quantity].size).to eq(0)
+          end
+        end
+
+        context "unavailable quantity when variant.on_hand < line_item.quantity" do
+          it "fails" do
+            line_item.quantity = line_item.variant.on_hand + 1
+            validator.validate(line_item)
+            expect_product_out_of_stock_error
+          end
+
+          it "succeeds with line_item skip_stock_check" do
+            line_item.skip_stock_check = true
+            line_item.quantity = line_item.variant.on_hand + 1
+            validator.validate(line_item)
+            expect(line_item.errors[:quantity].size).to eq(0)
+          end
+        end
+      end
+
+      describe "line item with existing inventory units" do
+        let(:order) { create(:completed_order_with_totals) }
+        let(:line_item) { order.line_items.first }
+
+        before do
+          expect(line_item.quantity).to eq(1)
+          expect(line_item.variant.on_hand).to eq(4)
+
+          expect(order.shipment.inventory_units).to_not be_empty
+          expect(order.shipment.inventory_units_for(line_item.variant).size).to eq(1)
+        end
+
+        context "when adding all variant.on_hand quantity to existing line_item quantity" do
+          it "succeeds because it excludes existing inventory units from the validation" do
+            line_item.quantity += line_item.variant.on_hand
+            validator.validate(line_item)
+            expect(line_item.errors[:quantity].size).to eq(0)
+          end
+
+          it "fails if one more item is added" do
+            line_item.quantity += line_item.variant.on_hand + 1
+            validator.validate(line_item)
+            expect_product_out_of_stock_error
+          end
+        end
+      end
+
+      def expect_product_out_of_stock_error
+        quantity_error = line_item.errors[:quantity].first
+        expect(quantity_error).to include(line_item.variant.product.name)
+        expect(quantity_error).to include("out of stock")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR includes all 5 commits from #3210, this PRs commits are the last 5.
#### What? Why?

Closes #3118 

When validating line_item.variant stock levels in stock/availability_validator we need to scope variants so that variant overrides stock levels are used instead. Here we re-use the the line_item.scoper so that the variant_overrides are not loaded several times in the handling fo line_items in the same request.

Additional problems solved:
- adapting line_item.sufficient_stock? to spree 2 by using the new variant.can_supply?
- fix variant.in_stock? by also using the new variant.can_supply?
- move stock_location.fill_status to VariantStock and fix it, it was totally dependent on stock_item methods and is not using already overridden variant methods (on_demand and total_on_hand)

#### What should we test?
This is one of the final steps in making cart and checkout handle stock levels correctly in v2!
the spec in 3118 (spec/features/consumer/shopping/variant_overrides_spec.rb:152) should be green.

#### Dependencies
This PR goes after #3210 