### PR TITLE
[Spree Upgrade] Fix restart checkout spec

### DIFF
--- a/app/services/restart_checkout.rb
+++ b/app/services/restart_checkout.rb
@@ -23,7 +23,6 @@ class RestartCheckout
   end
 
   def clear_shipments
-    order.update_attributes!(shipping_method_id: nil)
     order.shipments.with_state(:pending).destroy_all
   end
 

--- a/spec/services/restart_checkout_spec.rb
+++ b/spec/services/restart_checkout_spec.rb
@@ -17,7 +17,6 @@ describe RestartCheckout do
       let!(:payment_failed) { create(:payment, order: order, state: 'failed') }
 
       before do
-        order.shipping_method_id = shipment_pending.shipping_method_id
         order.update_attribute(:state, "payment")
       end
 
@@ -28,7 +27,6 @@ describe RestartCheckout do
         RestartCheckout.new(order).call
 
         expect(order.state).to eq 'cart'
-        expect(order.shipping_method_id).to eq nil
         expect(order.shipments.count).to eq 0
         expect(order.adjustments.shipping.count).to eq 0
         expect(order.payments.count).to eq 1

--- a/spec/services/restart_checkout_spec.rb
+++ b/spec/services/restart_checkout_spec.rb
@@ -13,8 +13,8 @@ describe RestartCheckout do
 
     context "when the order is in a subsequent state" do
       let!(:shipment_pending) { create(:shipment, order: order, state: 'pending') }
-      let!(:payment_checkout) { create(:payment, order: order, state: 'checkout') }
       let!(:payment_failed) { create(:payment, order: order, state: 'failed') }
+      let!(:payment_checkout) { create(:payment, order: order, state: 'checkout') }
 
       before do
         order.update_attribute(:state, "payment")


### PR DESCRIPTION
#### What? Why?

Follow up from #3016, this PR fixes services/restart_checkout_spec

We remove shipping_method_id as it is not used and we fix order payments order to adapt to new spree logic.

#### What should we test?
services/restart_checkout_spec should be green.