### PR TITLE
[Spree Upgrade] Fix api orders controller spec broken tests

### DIFF
--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -24,7 +24,7 @@ module Api
         create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now,
                        distributor: distributor, billing_address: create(:address) )
       end
-      let!(:order4) { create(:completed_order_with_fees) }
+      let!(:order4) { create(:completed_order_with_fees, distributor: distributor) }
       let!(:order5) { create(:order, state: 'cart', completed_at: nil) }
       let!(:line_item1) do
         create(:line_item_with_shipment, order: order1,
@@ -130,12 +130,6 @@ module Api
           get :index, format: :json, q: { completed_at_not_null: true, s: 'created_at desc' }
 
           expect(json_response['orders']).to eq serialized_orders([order4, order3, order2, order1])
-        end
-
-        it 'can show only unfulfilled orders' do
-          get :index, format: :json, q: { inventory_units_shipment_id_null: true, s: 'created_at desc' }
-
-          expect(json_response['orders']).to eq serialized_orders([order3, order2, order1])
         end
       end
 


### PR DESCRIPTION
api orders controller spec was broken since last merge from master as it was changed in master.
This PR adapts it to v2.

Two changes:
- remove inventory_units_shipment_id - the unfulfilled orders filter was removed in spree 2
- set the distributor used in the tests on completed_order_with_fees so results for that distributor are correct

#### What should we test?
api orders controller spec should be green.