### PR TITLE
[Spree Upgrade] Fix checkout_controller_spec

### DIFF
--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -401,7 +401,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
             page.should_not have_content "Your order has been processed successfully"
             page.should have_selector 'closing', text: "Your shopping cart"
-            page.should have_content "Out Of Stock"
+            page.should have_content "An item in your cart has become unavailable."
           end
 
           context "when we are charged a shipping fee" do


### PR DESCRIPTION
Change out of stock message in spec. Now the checkout controller is returning the error message in ensure_sufficient_stock_lines, not the line items validator.

#### What should we test?
shopping/checkout_spec should be green (Ive checked in the build).