### PR TITLE
[Spree Upgrade] Fix line item destroy by forcing quantity to zero and update_inventory

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -132,6 +132,10 @@ Spree::LineItem.class_eval do
   def update_inventory_with_scoping
     scoper.scope(variant)
     update_inventory_without_scoping
+
+    # This is required because update_inventory may delete the last shipment in the order
+    #   and that makes update_order fail if we don't reload the shipments relation here
+    order.shipments.reload
   end
   alias_method_chain :update_inventory, :scoping
 

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -17,6 +17,7 @@ Spree::LineItem.class_eval do
 
   before_save :calculate_final_weight_volume, if: :quantity_changed?, unless: :final_weight_volume_changed?
   after_save :update_units
+  before_destroy :make_quantity_zero, :update_inventory
 
   delegate :unit_description, to: :variant
 
@@ -133,6 +134,12 @@ Spree::LineItem.class_eval do
     update_inventory_without_scoping
   end
   alias_method_chain :update_inventory, :scoping
+
+  # This is necessary before destroying the line item
+  #   so that update_inventory will restore stock to the variant
+  def make_quantity_zero
+    self.quantity = 0
+  end
 
   def calculate_final_weight_volume
     if final_weight_volume.present? && quantity_was > 0


### PR DESCRIPTION
Fix line item destroy by forcing quantity to zero and update_inventory. This is done as a before_destroy hook so that the variant is restocked.
We move quantity to zero and then line_item.update_inventory through OrderInventory.verify compares quantity with inventory_units and, because there's a difference, it will destroy the inventory_unit and restock the variant.

Additionally we need to reload order.shipments after update_inventory to cover the case where the shipment in the order is deleted (when there are no more items in the order).

#### What? Why?

Closes #3205

The update_inventory part is done in spree 2.2: https://github.com/spree/spree/commit/607b87df63bebc735e748d96d95a6adaa7c138df
But forcing the quantity to zero is never done, so I am not sure if latest spree actually has this problem or not...

inventory_units are added to line_items in spree 2.2 here
https://github.com/spree/spree/commit/dcbd5deae87f046f147b394730b8ee277e0e50df

And in spree 2.4 there's a new before_destroy hook after the "before_destroy :update_inventory" hook to destroy inventory_units:
https://github.com/spree/spree/commit/ea5d4e2de9c2270231960405bd8e62da1c7b6999
But as far as I can see that does not restore stock as inventory_units dont have any destroy related hook...

re the shipments.reload instruction (the 2nd, 3rd and 4th commits in this PR), it is necessary to make 6 other specs pass (in bulk_line_items_controller and bulk_order_management).
I left the 3 commits so reviewers can see different options for this. The 2nd and 3rd options are better as they only impact the line_item destroy  process (the reload in the second commit will happen every time a line_item is saved as well).
Another approach would be to change order_inventory and adapt this line:
https://github.com/openfoodfoundation/spree/blob/f55722b38db7e706a8521c9091a0e00119bb4d20/core/app/models/spree/order_inventory.rb#L103
but I dont know if that would work and also that would mean a new decorated spree class: order_inventory_decorator

#### What should we test?
The 2 broken specs in #3205 are green.