### PR TITLE
Revert to the ruby racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,10 +88,7 @@ group :assets do
   gem 'compass-rails'
   gem 'coffee-rails', '~> 3.2.1'
 
-  gem 'mini_racer'
-  # We found that the following version of libv8 breaks the compilation of mini_racer.
-  # Nothing else depends on libv8.
-  gem 'libv8', '!= 6.7.288.46.1'
+  gem 'therubyracer', '=0.12.0'
 
   gem 'uglifier', '>= 1.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,7 +511,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.6.0)
       launchy (~> 2.2)
-    libv8 (6.3.292.48.1)
+    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -523,8 +523,6 @@ GEM
     mime-types (1.25.1)
     mini_mime (1.0.1)
     mini_portile2 (2.1.0)
-    mini_racer (0.1.15)
-      libv8 (~> 6.3)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     money (5.1.0)
@@ -627,6 +625,7 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.2.3)
+    ref (2.0.0)
     roadie (3.4.0)
       css_parser (~> 1.4)
       nokogiri (~> 1.5)
@@ -705,6 +704,9 @@ GEM
     stringex (1.3.3)
     stripe (3.3.2)
       faraday (~> 0.9)
+    therubyracer (0.12.0)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.20.3)
     tilt (1.4.1)
     timecop (0.9.1)
@@ -802,9 +804,7 @@ DEPENDENCIES
   jwt (~> 1.5)
   knapsack
   letter_opener (>= 1.4.1)
-  libv8 (!= 6.7.288.46.1)
   listen (= 3.0.8)
-  mini_racer
   momentjs-rails
   nokogiri (>= 1.6.7.1)
   oauth2 (~> 1.2.0)
@@ -840,6 +840,7 @@ DEPENDENCIES
   spree_i18n!
   spree_paypal_express!
   stripe (~> 3.3.2)
+  therubyracer (= 0.12.0)
   timecop
   truncate_html
   turbo-sprockets-rails3
@@ -856,4 +857,4 @@ RUBY VERSION
    ruby 2.1.5p273
 
 BUNDLED WITH
-   1.16.4
+   1.17.2


### PR DESCRIPTION
#### What? Why?

I can't make mini racer work locally (osx mojave) . I cant trace back to the point of failure but it did work at some point.
This is not only my problem as 2 new contributors (I believe all using osx as I am) have also reported this problem.

So, this PR reverts PR #2424.
I suggest we re-open #2100

This PR makes my life (and some new contributors with the same problem) a lot easier but makes the assets compilation move back from 211s to 316s (as noted on #2100).

#### What should we test?
Asset precompilation should still work correctly. We should make a sanity check of the app.

#### Release notes
Moved back to therubyracer for asset compilation to avoid trouble caused by the faster mini racer.
Changelog Category: Changed
