### PR TITLE
Add spring, a rails preloader alternative to zeus, to our gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ vendor/bundle/
 coverage
 /reports/
 !/reports/README.md
+bin/

--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,8 @@ group :development do
   gem 'guard-rails'
   gem 'guard-rspec', '~> 4.7.3'
   gem 'rubocop', '>= 0.49.1'
+  gem 'spring', '=1.1.3'
+  gem 'spring-commands-rspec'
 
   # 1.0.9 fixed openssl issues on macOS https://github.com/eventmachine/eventmachine/issues/602
   # While we don't require this gem directly, no dependents forced the upgrade to a version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -696,6 +696,9 @@ GEM
       rails (>= 3.1)
     spreadsheet (1.1.4)
       ruby-ole (>= 1.0)
+    spring (1.1.3)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (2.2.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -839,6 +842,8 @@ DEPENDENCIES
   spree_auth_devise!
   spree_i18n!
   spree_paypal_express!
+  spring (= 1.1.3)
+  spring-commands-rspec
   stripe (~> 3.3.2)
   timecop
   truncate_html


### PR DESCRIPTION
Also added /bin to gitignore, bin is used by spring.

#### What? Why?

zeus is not working on my osx mojave, this PR adds spring to the gemfile so that it can be used instead of zeus. I didnt manage to make it work without adding it to the gemfile. Is it acceptable for you guys to have this in the gemfile? any hints on how to make this work without changing the gemfile? Thanks!

#### What should we test?
Spring 1.1.3 should work with OFN.

Can be used locally:
```
bundle install
spring binstub rspec     (generates new rspec binary under /bin)
spring stop
time bin/rspec spec/models/order_cycle_spec.rb:154
time bin/rspec spec/models/order_cycle_spec.rb:154

```
The second run should be a lot faster.

#### Release notes
Changelog Category: Added
Added support for spring rails app preloader.