### PR TITLE
[Spree Upgrade] Set on_demand default value to false in test factories

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -647,6 +647,9 @@ FactoryBot.modify do
   factory :stock_location, class: Spree::StockLocation do
     # keeps the test stock_location unique
     initialize_with { Spree::StockLocation.find_or_create_by_name(name)}
+
+    # sets the default value for variant.on_demand
+    backorderable_default false
   end
 
   factory :shipment, class: Spree::Shipment do


### PR DESCRIPTION
#### What? Why?

Closes #3114 

Set on_demand default value to false in the StockLocation factory. This is done here as variant.on_demand is based on stock_item.backorderable and the default value is stored in StockLocation.backorderable_default field.

If the default value is TRUE, the bulk products edit page doesn't work correctly because it gets mixed up between 1. no on_demand value being sent to the server vs 2. nil on_demand value vs 3. on_demand false value. I suggest we create an issue to address this problem. It will not be important as the issue would only happen if we make the system wide on_demand default value = true.

Also (maybe the following belongs in a discourse thread but) I believe:
- we should have a migration to create the single stocklocation in every database (part of the data migration task, to be created) and to set this backorderable_default value to false
- and by the way, this field is editable in Configuration > Stock Locations which is a page we will need to disable in OFN v2 as there will only be one StockLocation in the system.

If reviewers agree with these tasks, I can create issues for these things.

#### What should we test?
Spec in #3114 is green (I have verified in the build)
