### PR TITLE
[Spree Upgrade] Provide anonymous user instead of nil

### DIFF
--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -36,7 +36,7 @@ feature "Order Management", js: true do
     end
 
     context "when checking out as an anonymous guest" do
-      let(:user) { nil }
+      let(:user) { Spree::User.anonymous! }
 
       it "allows the user to see the details" do
         # Cannot load the page without token


### PR DESCRIPTION
#### What? Why?

Closes #3078 

As explained in https://github.com/openfoodfoundation/spree_auth_devise/blob/0181835fb6ac77a05191d26f6f32a0f4a548d851/app/models/spree/user.rb#L26-L32, all orders have a user so checking out as a guest is just using an automatically generated user by means of `.anonymous!`.



#### What should we test?
spec/features/consumer/shopping/orders_spec.rb:17 should be fixed.

