### PR TITLE
Fix menu_1_url translation for fr_BE

### DIFF
--- a/config/locales/fr_BE.yml
+++ b/config/locales/fr_BE.yml
@@ -1144,7 +1144,7 @@ fr_BE:
   ticket_column_unit_price: "Prix unitaire"
   ticket_column_total_price: "Prix total"
   menu_1_title: "Comptoir"
-  menu_1_url: "/Comptoir"
+  menu_1_url: "/shops"
   menu_2_title: "Carte"
   menu_2_url: "/map"
   menu_3_title: "Producteurs"


### PR DESCRIPTION
#### What? Why?

The first menu item in OFN BE is currently broken.