### PR TITLE
Revert "[Spree Upgrade] Set on_demand default value to false in test factories"

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -647,9 +647,6 @@ FactoryBot.modify do
   factory :stock_location, class: Spree::StockLocation do
     # keeps the test stock_location unique
     initialize_with { Spree::StockLocation.find_or_create_by_name(name)}
-
-    # sets the default value for variant.on_demand
-    backorderable_default false
   end
 
   factory :shipment, class: Spree::Shipment do


### PR DESCRIPTION
PR 3246 got the 2-0-stable build very broken: https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/branches/2-0-stable/builds/158
We should revert this small change and have a look afterwards.
Reverts openfoodfoundation/openfoodnetwork#3246