### PR TITLE
[Spree Upgrade] Fix credit card spec that was depending on current year

### DIFF
--- a/spec/serializers/credit_card_serializer_spec.rb
+++ b/spec/serializers/credit_card_serializer_spec.rb
@@ -10,6 +10,6 @@ describe Api::CreditCardSerializer do
   end
 
   it "formats an identifying string with the card number masked" do
-    expect(serializer.formatted).to eq "Visa x-1111 Exp:12/2019"
+    expect(serializer.formatted).to eq "Visa x-1111 Exp:#{card.month}/#{card.year}"
   end
 end


### PR DESCRIPTION
With this commit https://github.com/openfoodfoundation/spree/commit/5d93d1dedb0c727c9a78770d35a4363a16fa1691, this static fix was meant to fail https://github.com/openfoodfoundation/openfoodnetwork/commit/3f33e28839cc60dd28175becad8ed590bc51bb6e

#### What? Why?

Fixes spec/serializers/credit_card_serializer_spec.rb:13

#### What should we test?
Spec should be green. I confirmed in the build that it is green.
