### PR TITLE
[Spree Upgrade] Fix specs in admin orders spec

### DIFF
--- a/app/views/spree/admin/orders/_line_item.html.haml
+++ b/app/views/spree/admin/orders/_line_item.html.haml
@@ -3,10 +3,10 @@
     = f.object.variant.product.name
     = "(#{f.object.full_name})" unless f.object.variant.option_values.empty?
   %td.price.align-center
-    = f.object.variant.display_amount
+    = f.object.single_display_amount
   %td.qty
     = f.number_field :quantity, min: 0, class: "qty"
   %td.total.align-center
-    = f.object.single_money
+    = f.object.display_amount
   %td.actions
     = link_to_delete f.object, {url: admin_order_line_item_url(@order.number, f.object), no_text: true}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2396,6 +2396,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   payment_methods: "Payment Methods"
   payment_method_fee: "Transaction fee"
   payment_processing_failed: "Payment could not be processed, please check the details you entered"
+  payment_updated: "Payment Updated"
   inventory_settings: "Inventory Settings"
   tag_rules: "Tag Rules"
   shop_preferences: "Shop Preferences"

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -230,10 +230,16 @@ feature %q{
         within('table.index tbody', match: :first) do
           @order.line_items.each do |item|
             expect(page).to have_selector "td", match: :first, text: item.full_name
-            expect(page).to have_selector "td.item-price", text: item.single_display_amount
-            expect(page).to have_selector "td.item-qty-show", text: item.quantity
-            expect(page).to have_selector "td.item-total", text: item.display_amount
+            expect(page).to have_selector "td.price", text: item.single_display_amount
+            expect(page).to have_selector "input.qty[value='#{item.quantity}']"
+            expect(page).to have_selector "td.total", text: item.display_amount
           end
+        end
+      end
+
+      scenario "shows the order subtotal" do
+        within('table.index tbody#subtotal') do
+          expect(page).to have_selector "td.total", text: @order.display_item_total
         end
       end
 
@@ -248,8 +254,8 @@ feature %q{
       end
 
       scenario "shows the order total" do
-        within('fieldset#order-total') do
-          expect(page).to have_selector "span.order-total", text: @order.display_total
+        within('table.index tbody#order-total') do
+          expect(page).to have_selector "td.total", text: @order.display_total
         end
       end
 
@@ -263,11 +269,9 @@ feature %q{
       scenario "shows the dropdown menu" do
         find("#links-dropdown .ofn-drop-down").click
         within "#links-dropdown" do
-          expect(page).to have_link "Edit", href: spree.edit_admin_order_path(@order)
           expect(page).to have_link "Resend Confirmation", href: spree.resend_admin_order_path(@order)
           expect(page).to have_link "Send Invoice", href: spree.invoice_admin_order_path(@order)
           expect(page).to have_link "Print Invoice", href: spree.print_admin_order_path(@order)
-          # expect(page).to have_link "Ship Order", href: spree.fire_admin_order_path(@order, :e => 'ship')
           expect(page).to have_link "Cancel Order", href: spree.fire_admin_order_path(@order, :e => 'cancel')
         end
       end


### PR DESCRIPTION
#### What? Why?

Closes #2941 (also fixes 1 spec in #3103 and moves the spec in #3113 to a new error)

This PR fixes 3 specs:
- order edit page drop down menu #2941 - spec/features/admin/orders_spec.rb:265
- order edit page line items details - the last spec in #3103 - spec/features/admin/orders_spec.rb:230
- order edit page total (no issue) (also re-added subtotal spec) - spec/features/admin/orders_spec.rb:251

And improves one spec in #3113:
- added missing translation for the capture payment spec
        - the payment state is updated correctly but there’s some problem in the order updater because order.update! Is called but the order.payment_state is not updated from the order.payments state (the issue 3113 was updated with this info)

#### What should we test?
spec/features/admin/orders_spec moves from 9 to 6 broken specs (see epic #3110)