### PR TITLE
[Spree Upgrade] Fix variant edit page optiontype deface code

### DIFF
--- a/app/overrides/spree/admin/variants/_form/hide_unit_option_types.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/hide_unit_option_types.html.haml.deface
@@ -1,10 +1,10 @@
 / replace "[data-hook='presentation']"
 
-- unless variant_unit_option_type?(option.option_type)
+- unless variant_unit_option_type?(option_type)
   .field{"data-hook" => "presentation"}
-    = label :new_variant, option.option_type.presentation
+    = label :new_variant, option_type.presentation
     - if @variant.new_record?
-      = select(:new_variant, option.option_type.presentation, option.option_type.option_values.collect {|ov| [ ov.presentation, ov.id ] }, {}, {:class => 'select2 fullwidth'})
+      = select(:new_variant, option_type.presentation, option_type.option_values.collect {|ov| [ ov.presentation, ov.id ] }, {}, {:class => 'select2 fullwidth'})
     - else
-      - if opt = @variant.option_values.detect {|o| o.option_type == option.option_type }.try(:presentation)
-        = text_field(:new_variant,  option.option_type.presentation, :value => opt, :disabled => 'disabled', :class => 'fullwidth')
+      - if opt = @variant.option_values.detect {|o| o.option_type == option_type }.try(:presentation)
+        = text_field(:new_variant, option_type.presentation, :value => opt, :disabled => 'disabled', :class => 'fullwidth')


### PR DESCRIPTION
#### What? Why?

Closes #3091
Adapt to this change in spree 2: https://github.com/openfoodfoundation/spree/commit/2e6c66c49eb54d83acb07675bfafcf1980e5762f#diff-4cc0ba3139a87f563a1faedee946fe6cL4

Not going for the de-deface this time as the fix seems simple enough.

#### What should we test?
The 3 specs in #3091 are passing now (confirmed in the build).