### PR TITLE
Add script to install required bundler version

### DIFF
--- a/script/install-bundler
+++ b/script/install-bundler
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# This shell script looks for the last used Bundler version in Gemfile.lock and
+# installs exactly that version, removing all other versions.
+
+# Command line arguments are passed on to `gem install`. So you can call this
+# script with with arguments:
+#
+#   ./script/install-bundler --no-ri --no-rdoc
+
+# This script is used by ofn-install and can by handy in your development
+# environment.
+
+# Fail if a single command fails.
+set -e
+
+# `grep -m 1`: find the first occurrence of "BUNDLED WITH"
+# `-A`:        print the next line after "BUNDLED WITH" as well
+# `-x -F`:     find exactly that string without interpreting regex
+# `tail -n 1`: take the last line, the version line
+# `tr -d`:     delete all spaces, the indent before the version
+version="$(grep -m 1 -A 1 -x -F "BUNDLED WITH" Gemfile.lock | tail -n 1  | tr -d '[:space:]')"
+
+# if the length of $version is zero
+if [ -z "$version" ]; then
+  echo >&2 "No bundler version in Gemfile.lock."
+  exit 1
+fi
+
+# Get the currently used bundler version.
+# We ignore all errors with `2>/dev/null || true` in case there is no bundler
+# or only an orphaned shim installed.
+current="$(bundler --version 2>/dev/null || true)"
+
+if [ "$current" = "Bundler version $version" ]; then
+  echo >&2 "Already up-to-date: $current"
+  exit 0
+fi
+
+# Passing on all arguments of this script with "$@".
+gem install bundler -v "$version" "$@"
+gem uninstall bundler -v "!= $version" 2>/dev/null || true

--- a/script/setup
+++ b/script/setup
@@ -33,7 +33,7 @@ fi
 
 # Set up Ruby dependencies via Bundler
 if ! command -v bundle > /dev/null; then
-  gem install bundler
+  ./script/install-bundler
 fi
 
 # Install all dependencies


### PR DESCRIPTION
#### What? Why?

Helps with https://github.com/openfoodfoundation/ofn-install/issues/74.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The newest version of bundler is not compatible with our current version of Ruby. This script helps to install the bundler version defined in Gemfile.lock. It will simplify https://github.com/openfoodfoundation/ofn-install/pull/320.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added: Script to install the right version of our dependency `bundler`.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->

https://openfoodnetwork.slack.com/archives/C0DNLAZC7/p1546618893018000
