### PR TITLE
Improve shops performance take 2

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -114,12 +114,15 @@ class Enterprise < ActiveRecord::Base
   scope :with_distributed_products_outer,
     joins('LEFT OUTER JOIN product_distributions ON product_distributions.distributor_id = enterprises.id').
     joins('LEFT OUTER JOIN spree_products ON spree_products.id = product_distributions.product_id')
+
   scope :with_order_cycles_as_supplier_outer,
     joins("LEFT OUTER JOIN exchanges ON (exchanges.sender_id = enterprises.id AND exchanges.incoming = 't')").
     joins('LEFT OUTER JOIN order_cycles ON (order_cycles.id = exchanges.order_cycle_id)')
+
   scope :with_order_cycles_as_distributor_outer,
     joins("LEFT OUTER JOIN exchanges ON (exchanges.receiver_id = enterprises.id AND exchanges.incoming = 'f')").
     joins('LEFT OUTER JOIN order_cycles ON (order_cycles.id = exchanges.order_cycle_id)')
+
   scope :with_order_cycles_outer,
     joins("LEFT OUTER JOIN exchanges ON (exchanges.receiver_id = enterprises.id OR exchanges.sender_id = enterprises.id)").
     joins('LEFT OUTER JOIN order_cycles ON (order_cycles.id = exchanges.order_cycle_id)')

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -7,7 +7,7 @@ module Api
     cached
 
     def cache_key
-      object.andand.cache_key
+      enterprise.andand.cache_key
     end
 
     attributes :name, :id, :description, :latitude, :longitude,
@@ -24,55 +24,55 @@ module Api
     has_many :distributed_properties, serializer: PropertySerializer
 
     def pickup
-      services = data.shipping_method_services[object.id]
+      services = data.shipping_method_services[enterprise.id]
       services ? services[:pickup] : false
     end
 
     def delivery
-      services = data.shipping_method_services[object.id]
+      services = data.shipping_method_services[enterprise.id]
       services ? services[:delivery] : false
     end
 
     def email_address
-      object.email_address.to_s.reverse
+      enterprise.email_address.to_s.reverse
     end
 
     def hash
-      object.to_param
+      enterprise.to_param
     end
 
     def logo
-      object.logo(:medium) if object.logo?
+      enterprise.logo(:medium) if enterprise.logo?
     end
 
     def promo_image
-      object.promo_image(:large) if object.promo_image?
+      enterprise.promo_image(:large) if enterprise.promo_image?
     end
 
     def path
-      enterprise_shop_path(object)
+      enterprise_shop_path(enterprise)
     end
 
     def producers
-      relatives = data.relatives[object.id]
+      relatives = data.relatives[enterprise.id]
       ids_to_objs(relatives.andand[:producers])
     end
 
     def hubs
-      relatives = data.relatives[object.id]
+      relatives = data.relatives[enterprise.id]
       ids_to_objs(relatives.andand[:distributors])
     end
 
     def taxons
       if active
-        ids_to_objs data.current_distributed_taxons[object.id]
+        ids_to_objs data.current_distributed_taxons[enterprise.id]
       else
-        ids_to_objs data.all_distributed_taxons[object.id]
+        ids_to_objs data.all_distributed_taxons[enterprise.id]
       end
     end
 
     def supplied_taxons
-      ids_to_objs data.supplied_taxons[object.id]
+      ids_to_objs data.supplied_taxons[enterprise.id]
     end
 
     def supplied_properties
@@ -97,7 +97,7 @@ module Api
     end
 
     def active
-      data.active_distributors.andand.include? object
+      data.active_distributors.andand.include? enterprise
     end
 
     # Map svg icons.
@@ -109,7 +109,7 @@ module Api
         producer_shop: "/assets/map_003-producer-shop.svg",
         producer: "/assets/map_001-producer-only.svg",
       }
-      icons[object.category]
+      icons[enterprise.category]
     end
 
     # Choose regular icon font for enterprises.
@@ -121,7 +121,7 @@ module Api
         producer_shop: "ofn-i_059-producer",
         producer: "ofn-i_059-producer",
       }
-      icon_fonts[object.category]
+      icon_fonts[enterprise.category]
     end
 
     # Choose producer page icon font - yes, sadly its got to be different.
@@ -135,7 +135,7 @@ module Api
         producer_shop: "ofn-i_059-producer",
         producer: "ofn-i_059-producer",
       }
-      icon_fonts[object.category]
+      icon_fonts[enterprise.category]
     end
 
     private

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -83,18 +83,20 @@ module Api
 
     # This results in 3 queries per enterprise
     def distributed_properties
+      (distributed_product_properties + distributed_producer_properties).uniq do |property_object|
+        property_object.property.presentation
+      end
+    end
+
+    def distributed_product_properties
       if active
-        product_properties = Spree::Property.currently_sold_by(enterprise)
+        Spree::Property.currently_sold_by(enterprise)
       else
-        product_properties = Spree::Property
+        Spree::Property
           .joins(products: { variants: { exchanges: :order_cycle } })
           .merge(Exchange.outgoing)
           .merge(Exchange.to_enterprise(enterprise))
           .select('DISTINCT spree_properties.*')
-      end
-
-      (product_properties + distributed_producer_properties).uniq do |property_object|
-        property_object.property.presentation
       end
     end
 

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -89,23 +89,23 @@ module Api
     end
 
     def distributed_product_properties
-      if active
-        Spree::Property.currently_sold_by(enterprise)
-      else
-        Spree::Property
-          .joins(products: { variants: { exchanges: :order_cycle } })
-          .merge(Exchange.outgoing)
-          .merge(Exchange.to_enterprise(enterprise))
-          .select('DISTINCT spree_properties.*')
-      end
+      properties = Spree::Property
+        .joins(products: { variants: { exchanges: :order_cycle } })
+        .merge(Exchange.outgoing)
+        .merge(Exchange.to_enterprise(enterprise))
+        .select('DISTINCT spree_properties.*')
+
+      return properties.merge(OrderCycle.active) if active
+      properties
     end
 
     def distributed_producer_properties
-      properties = Spree::Property.joins(
-        producer_properties: {
-          producer: { supplied_products: { variants: { exchanges: :order_cycle } } }
-        }
-      )
+      properties = Spree::Property
+        .joins(
+          producer_properties: {
+            producer: { supplied_products: { variants: { exchanges: :order_cycle } } }
+          }
+        )
         .merge(Exchange.outgoing)
         .merge(Exchange.to_enterprise(enterprise))
         .select('DISTINCT spree_properties.*')

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -85,13 +85,11 @@ module Api
     def distributed_properties
       if active
         product_properties = Spree::Property.currently_sold_by(enterprise)
-        producer_property_ids = ProducerProperty.currently_sold_by(enterprise).pluck(:property_id)
+        producer_properties = ProducerProperty.currently_sold_by(enterprise)
       else
         product_properties = Spree::Property.ever_sold_by(enterprise)
-        producer_property_ids = ProducerProperty.ever_sold_by(enterprise).pluck(:property_id)
+        producer_properties = ProducerProperty.ever_sold_by(enterprise)
       end
-
-      producer_properties = Spree::Property.where(id: producer_property_ids)
 
       (product_properties + producer_properties).uniq do |property_object|
         property_object.property.presentation

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -81,16 +81,14 @@ module Api
       end
     end
 
+    # This results in 3 queries per enterprise
     def distributed_properties
-      # This results in 3 queries per enterprise
-
       if active
-        product_properties = Spree::Property.currently_sold_by(object)
-        producer_property_ids = ProducerProperty.currently_sold_by(object).pluck(:property_id)
-
+        product_properties = Spree::Property.currently_sold_by(enterprise)
+        producer_property_ids = ProducerProperty.currently_sold_by(enterprise).pluck(:property_id)
       else
-        product_properties = Spree::Property.ever_sold_by(object)
-        producer_property_ids = ProducerProperty.ever_sold_by(object).pluck(:property_id)
+        product_properties = Spree::Property.ever_sold_by(enterprise)
+        producer_property_ids = ProducerProperty.ever_sold_by(enterprise).pluck(:property_id)
       end
 
       producer_properties = Spree::Property.where(id: producer_property_ids)

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -93,7 +93,9 @@ module Api
 
       producer_properties = Spree::Property.where(id: producer_property_ids)
 
-      OpenFoodNetwork::PropertyMerge.merge product_properties, producer_properties
+      (product_properties + producer_properties).uniq do |property_object|
+        property_object.property.presentation
+      end
     end
 
     def active

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -101,12 +101,11 @@ module Api
     end
 
     def distributed_producer_properties
-      properties = Spree::Property
-        .joins(
-          producer_properties: {
-            producer: { supplied_products: { variants: { exchanges: :order_cycle } } }
-          }
-        )
+      properties = Spree::Property.joins(
+        producer_properties: {
+          producer: { supplied_products: { variants: { exchanges: :order_cycle } } }
+        }
+      )
         .merge(Exchange.outgoing)
         .merge(Exchange.to_enterprise(enterprise))
         .select('DISTINCT spree_properties.*')

--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -16,10 +16,49 @@ describe ShopsController, type: :controller do
     expect(response.body).to have_content(invisible_distributor.name)
   end
 
+  it 'renders distributed product properties' do
+    product_property = create(:property, presentation: 'eggs')
+    product = create(:product, properties: [product_property])
+    producer = create(:supplier_enterprise)
+
+    create(
+      :simple_order_cycle,
+      coordinator: distributor,
+      suppliers: [producer],
+      distributors: [distributor],
+      variants: [product.variants]
+    )
+
+    get :index
+
+    expect(response.body)
+      .to match(/"distributed_properties":\[{"id":\d+,"name":"eggs","presentation":"eggs"}\]/)
+  end
+
+  it 'renders distributed producer properties' do
+    producer_property = create(:property, presentation: 'certified')
+    producer = create(:supplier_enterprise, properties: [producer_property])
+    product = create(:product)
+
+    create(
+      :simple_order_cycle,
+      coordinator: distributor,
+      suppliers: [producer],
+      distributors: [distributor],
+      variants: [product.variants]
+    )
+
+    get :index
+
+    expect(response.body)
+      .to match(/"distributed_properties":\[{"id":\d+,"name":"certified","presentation":"certified"}\]/)
+  end
+
   it 'renders distributed properties' do
     duplicate_property = create(:property, presentation: 'dairy')
     producer = create(:supplier_enterprise, properties: [duplicate_property])
     property = create(:property, presentation: 'dairy')
+
     product = create(:product, properties: [property])
     producer.supplied_products << product
 

--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -15,4 +15,25 @@ describe ShopsController, type: :controller do
     get :index
     expect(response.body).to have_content(invisible_distributor.name)
   end
+
+  it 'renders distributed properties' do
+    duplicate_property = create(:property, presentation: 'dairy')
+    producer = create(:supplier_enterprise, properties: [duplicate_property])
+    property = create(:property, presentation: 'dairy')
+    product = create(:product, properties: [property])
+    producer.supplied_products << product
+
+    create(
+      :simple_order_cycle,
+      coordinator: distributor,
+      suppliers: [producer],
+      distributors: [distributor],
+      variants: [product.variants]
+    )
+
+    get :index
+
+    expect(response.body)
+      .to match(/"distributed_properties":\[{"id":\d+,"name":"dairy","presentation":"dairy"}\]/)
+  end
 end

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -55,15 +55,15 @@ describe Api::CachedEnterpriseSerializer do
 
       it 'does not duplicate properties' do
         properties = cached_enterprise_serializer.distributed_properties
-        expect(properties).to eq([property])
+        expect(properties.map(&:presentation)).to eq([property.presentation])
       end
 
       it 'fetches producer properties' do
         distributed_producer_properties = cached_enterprise_serializer
           .distributed_producer_properties
 
-        expect(distributed_producer_properties)
-          .to eq(producer.producer_properties.map(&:property))
+        expect(distributed_producer_properties.map(&:presentation))
+          .to eq(producer.producer_properties.map(&:property).map(&:presentation))
       end
     end
 
@@ -74,15 +74,15 @@ describe Api::CachedEnterpriseSerializer do
 
       it 'does not duplicate properties' do
         properties = cached_enterprise_serializer.distributed_properties
-        expect(properties).to eq([property])
+        expect(properties.map(&:presentation)).to eq([property.presentation])
       end
 
       it 'fetches producer properties' do
         distributed_producer_properties = cached_enterprise_serializer
           .distributed_producer_properties
 
-        expect(distributed_producer_properties)
-          .to eq(producer.producer_properties.map(&:property))
+        expect(distributed_producer_properties.map(&:presentation))
+          .to eq(producer.producer_properties.map(&:property).map(&:presentation))
       end
     end
   end

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -44,7 +44,7 @@ describe Api::CachedEnterpriseSerializer do
         coordinator: shop,
         suppliers: [producer],
         distributors: [shop],
-        variants: [product.variants]
+        variants: product.variants
       )
     end
 

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -33,10 +33,10 @@ describe Api::CachedEnterpriseSerializer do
 
     let(:property) { create(:property, presentation: 'One') }
     let(:duplicate_property) { create(:property, presentation: 'One') }
+    let(:producer) { create(:supplier_enterprise, properties: [duplicate_property]) }
 
     before do
       product = create(:product, properties: [property])
-      producer = create(:supplier_enterprise, properties: [duplicate_property])
       producer.supplied_products << product
 
       create(
@@ -57,6 +57,14 @@ describe Api::CachedEnterpriseSerializer do
         properties = cached_enterprise_serializer.distributed_properties
         expect(properties).to eq([property])
       end
+
+      it 'fetches producer properties' do
+        distributed_producer_properties = cached_enterprise_serializer
+          .distributed_producer_properties
+
+        expect(distributed_producer_properties)
+          .to eq(producer.producer_properties.map(&:property))
+      end
     end
 
     context 'when the enterprise is an active distributor' do
@@ -67,6 +75,14 @@ describe Api::CachedEnterpriseSerializer do
       it 'does not duplicate properties' do
         properties = cached_enterprise_serializer.distributed_properties
         expect(properties).to eq([property])
+      end
+
+      it 'fetches producer properties' do
+        distributed_producer_properties = cached_enterprise_serializer
+          .distributed_producer_properties
+
+        expect(distributed_producer_properties)
+          .to eq(producer.producer_properties.map(&:property))
       end
     end
   end

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -35,10 +35,12 @@ describe Api::CachedEnterpriseSerializer do
     end
 
     let(:property) { create(:property, presentation: 'One') }
+    let(:duplicate_property) { create(:property, presentation: 'One') }
 
     before do
-      producer = create(:supplier_enterprise)
-      product = create(:product, supplier: producer, properties: [property])
+      product = create(:product, properties: [property])
+      producer = create(:supplier_enterprise, properties: [duplicate_property])
+      producer.supplied_products << product
 
       create(
         :simple_order_cycle,

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -23,4 +23,37 @@ describe Api::CachedEnterpriseSerializer do
       expect(properties).to eq([property, different_property])
     end
   end
+
+  describe '#distributed_properties' do
+    let(:cached_enterprise_serializer) { described_class.new(shop, options) }
+
+    let(:enterprise_injection_data) do
+      instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributors: [])
+    end
+    let(:options) { { data: enterprise_injection_data } }
+    let(:shop) { create(:distributor_enterprise, name: 'Distributor') }
+
+    let(:property) { create(:property, presentation: 'One') }
+
+    before do
+      producer = create(:supplier_enterprise, name: 'Supplier')
+      product = create(:product, supplier: producer, properties: [property])
+
+      order_cycle = build(:simple_order_cycle, coordinator: shop)
+
+      incoming_exchange = build(:exchange, sender: producer, receiver: shop, incoming: true)
+      outgoing_exchange = build(:exchange, sender: shop, receiver: shop, incoming: false)
+      outgoing_exchange.variants << product.variants.first
+
+      order_cycle.exchanges << incoming_exchange
+      order_cycle.exchanges << outgoing_exchange
+
+      order_cycle.save
+    end
+
+    it 'does not duplicate properties' do
+      properties = cached_enterprise_serializer.distributed_properties
+      expect(properties).to eq([property])
+    end
+  end
 end

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -30,9 +30,6 @@ describe Api::CachedEnterpriseSerializer do
     let(:shop) { create(:distributor_enterprise) }
 
     let(:options) { { data: enterprise_injection_data } }
-    let(:enterprise_injection_data) do
-      instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributors: [])
-    end
 
     let(:property) { create(:property, presentation: 'One') }
     let(:duplicate_property) { create(:property, presentation: 'One') }
@@ -51,9 +48,26 @@ describe Api::CachedEnterpriseSerializer do
       )
     end
 
-    it 'does not duplicate properties' do
-      properties = cached_enterprise_serializer.distributed_properties
-      expect(properties).to eq([property])
+    context 'when the enterprise is not an active distributor' do
+      let(:enterprise_injection_data) do
+        instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributors: [])
+      end
+
+      it 'does not duplicate properties' do
+        properties = cached_enterprise_serializer.distributed_properties
+        expect(properties).to eq([property])
+      end
+    end
+
+    context 'when the enterprise is an active distributor' do
+      let(:enterprise_injection_data) do
+        instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributors: [shop])
+      end
+
+      it 'does not duplicate properties' do
+        properties = cached_enterprise_serializer.distributed_properties
+        expect(properties).to eq([property])
+      end
     end
   end
 end

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -27,28 +27,26 @@ describe Api::CachedEnterpriseSerializer do
   describe '#distributed_properties' do
     let(:cached_enterprise_serializer) { described_class.new(shop, options) }
 
+    let(:shop) { create(:distributor_enterprise) }
+
+    let(:options) { { data: enterprise_injection_data } }
     let(:enterprise_injection_data) do
       instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributors: [])
     end
-    let(:options) { { data: enterprise_injection_data } }
-    let(:shop) { create(:distributor_enterprise, name: 'Distributor') }
 
     let(:property) { create(:property, presentation: 'One') }
 
     before do
-      producer = create(:supplier_enterprise, name: 'Supplier')
+      producer = create(:supplier_enterprise)
       product = create(:product, supplier: producer, properties: [property])
 
-      order_cycle = build(:simple_order_cycle, coordinator: shop)
-
-      incoming_exchange = build(:exchange, sender: producer, receiver: shop, incoming: true)
-      outgoing_exchange = build(:exchange, sender: shop, receiver: shop, incoming: false)
-      outgoing_exchange.variants << product.variants.first
-
-      order_cycle.exchanges << incoming_exchange
-      order_cycle.exchanges << outgoing_exchange
-
-      order_cycle.save
+      create(
+        :simple_order_cycle,
+        coordinator: shop,
+        suppliers: [producer],
+        distributors: [shop],
+        variants: [product.variants]
+      )
     end
 
     it 'does not duplicate properties' do


### PR DESCRIPTION
#### What? Why?

Moves #3099 forward.

This is most of the stuff I had on my stash since last time I worked on #3099. It's just part of the refactoring needed to remove another one of the various N+1s that take place in `GET /shops`.

This is aligned with what I did in #3151, where an N+1 is removed by moving the data loading to the controller, or #3257 where moving the data loading brings some clarity.

Unlike #3151, here loading product and producer properties in a single query turns to be tougher. I had to stop at `#active` and give it some more thought. There's more on the backstage, but this is what it's shippable for now.

There won't be much performance improvement if any.

#### What should we test?

The distributed properties shown in `/shops` should keep working as expected. That is, those that belong to producers or products that belong or belonged to an order cycle.

#### Release notes

Refactor CachedEnterpriseSerializer's `#distributed_properties` to make it easier to remove an N+1 on the properties table in the future.

Changelog Category: Changed