### PR TITLE
[Spree Upgrade] Phase 2 - Reports ready - all specs running and green (except enterprise fee report)

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -250,7 +250,7 @@ Spree::Admin::ReportsController.class_eval do
       :xero_invoices,
       :packing
     ]
-    reports = all_reports.select { |action| can? action, :report }
+    reports = all_reports.select { |action| can? action, Spree::Admin::ReportsController }
     reports.map { |report| [report, describe_report(report)] }.to_h
   end
 

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -20,6 +20,7 @@ module Spree
         klass = Spree::Order if klass == :bulk_order_management
         klass = EnterpriseGroup if klass == :group
         klass = VariantOverride if klass == :Inventory
+        klass = Spree::Admin::ReportsController if klass == :report
         klass
       end
       alias_method_chain :klass_for, :sym_fallback

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -187,7 +187,7 @@ class AbilityDecorator
     # Reports page
     can [:admin, :index, :customers, :orders_and_distributors, :group_buys, :bulk_coop, :payments,
          :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :packing],
-        :report
+        Spree::Admin::ReportsController
     add_enterprise_fee_summary_abilities(user)
   end
 
@@ -263,7 +263,7 @@ class AbilityDecorator
     # Reports page
     can [:admin, :index, :customers, :group_buys, :bulk_coop, :sales_tax, :payments,
          :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory,
-         :order_cycle_management, :xero_invoices], :report
+         :order_cycle_management, :xero_invoices], Spree::Admin::ReportsController
     add_enterprise_fee_summary_abilities(user)
 
     can [:create], Customer
@@ -293,7 +293,7 @@ class AbilityDecorator
     return unless feature_enabled
 
     # Reveal the report link in spree/admin/reports#index
-    can [:enterprise_fee_summary], :report
+    can [:enterprise_fee_summary], Spree::Admin::ReportsController
     # Allow direct access to the report resource
     can [:admin, :new, :create], :enterprise_fee_summary
   end

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -63,7 +63,7 @@ describe Spree::Admin::ReportsController, type: :controller do
   let(:resulting_products) { assigns(:report).table_items.map(&:product) }
 
   # As manager of a coordinator (coordinator1)
-  xcontext "Coordinator Enterprise User" do
+  context "Coordinator Enterprise User" do
     let!(:present_objects) { [orderA1, orderA2, orderB1, orderB2] }
 
     before { login_as_enterprise_user [coordinator1] }
@@ -79,7 +79,7 @@ describe Spree::Admin::ReportsController, type: :controller do
   end
 
   # As a Distributor Enterprise user for distributor1
-  xcontext "Distributor Enterprise User" do
+  context "Distributor Enterprise User" do
     before { login_as_enterprise_user [distributor1] }
 
     describe 'Orders and Distributors' do
@@ -148,7 +148,7 @@ describe Spree::Admin::ReportsController, type: :controller do
     before { login_as_enterprise_user [supplier1] }
 
     describe 'index' do
-      xit "loads reports relevant to producers" do
+      it "loads reports relevant to producers" do
         spree_get :index
 
         report_types = assigns(:reports).keys
@@ -157,7 +157,7 @@ describe Spree::Admin::ReportsController, type: :controller do
       end
     end
 
-    xdescribe 'Bulk Coop' do
+    describe 'Bulk Coop' do
       context "where I have granted P-OC to the distributor" do
         let!(:present_objects) { [orderA1, orderA2] }
 
@@ -182,7 +182,7 @@ describe Spree::Admin::ReportsController, type: :controller do
       end
     end
 
-    xdescribe 'Orders & Fulfillment' do
+    describe 'Orders & Fulfillment' do
       let!(:present_objects) { [orderA1, orderA2] }
 
       context "where I have granted P-OC to the distributor" do

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-xfeature %q{
+feature %q{
     As an administrator
     I want numbers, all the numbers!
 } do

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -419,6 +419,7 @@ feature %q{
       let!(:line_item1) { create(:line_item, variant: product1.master, price: 12.54, quantity: 1, order: order1) }
       let!(:line_item2) { create(:line_item, variant: product2.master, price: 500.15, quantity: 3, order: order1) }
 
+      let!(:adj_shipping) { create(:adjustment, adjustable: order1, label: "Shipping", originator: shipping_method, amount: 100.55, included_tax: 10.06) }
       let!(:adj_fee1) { create(:adjustment, adjustable: order1, originator: enterprise_fee1, label: "Enterprise fee untaxed", amount: 10, included_tax: 0) }
       let!(:adj_fee2) { create(:adjustment, adjustable: order1, originator: enterprise_fee2, label: "Enterprise fee taxed", amount: 20, included_tax: 2) }
       let!(:adj_manual1) { create(:adjustment, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 30, included_tax: 0) }

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -9,7 +9,11 @@ module Spree
         end
 
         it "returns a symbol when there's no available class" do
-          helper.klass_for('reports').should == :report
+          helper.klass_for('lions').should == :lion
+        end
+
+        it "returns Spree::Admin::ReportsController for reports" do
+          helper.klass_for('reports').should == Spree::Admin::ReportsController
         end
 
         it "returns :overview for the dashboard" do

--- a/spec/lib/open_food_network/lettuce_share_report_spec.rb
+++ b/spec/lib/open_food_network/lettuce_share_report_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'open_food_network/lettuce_share_report'
 
 module OpenFoodNetwork
-  xdescribe LettuceShareReport do
+  describe LettuceShareReport do
     let(:user) { create(:user) }
     let(:report) { LettuceShareReport.new user, {}, true }
     let(:variant) { create(:variant) }

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 include AuthenticationWorkflow
 
 module OpenFoodNetwork
-  xdescribe OrderCycleManagementReport do
+  describe OrderCycleManagementReport do
     context "as a site admin" do
       let(:user) do
         user = create(:user)

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -214,13 +214,13 @@ module Spree
         end
 
         it "should be able to read some reports" do
-          should have_ability([:admin, :index, :customers, :bulk_coop, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management], for: :report)
+          should have_ability([:admin, :index, :customers, :bulk_coop, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management], for: Spree::Admin::ReportsController)
         end
 
         include_examples "allows access to Enterprise Fee Summary only if feature flag enabled"
 
         it "should not be able to read other reports" do
-          should_not have_ability([:sales_total, :group_buys, :payments, :orders_and_distributors, :users_and_enterprises, :xero_invoices], for: :report)
+          should_not have_ability([:sales_total, :group_buys, :payments, :orders_and_distributors, :users_and_enterprises, :xero_invoices], for: Spree::Admin::ReportsController)
         end
 
         it "should not be able to access customer actions" do
@@ -407,13 +407,13 @@ module Spree
         end
 
         it "should be able to read some reports" do
-          should have_ability([:admin, :index, :customers, :sales_tax, :group_buys, :bulk_coop, :payments, :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :xero_invoices], for: :report)
+          should have_ability([:admin, :index, :customers, :sales_tax, :group_buys, :bulk_coop, :payments, :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :xero_invoices], for: Spree::Admin::ReportsController)
         end
 
         include_examples "allows access to Enterprise Fee Summary only if feature flag enabled"
 
         it "should not be able to read other reports" do
-          should_not have_ability([:sales_total, :users_and_enterprises], for: :report)
+          should_not have_ability([:sales_total, :users_and_enterprises], for: Spree::Admin::ReportsController)
         end
 
         it "should be able to access customer actions" do

--- a/spec/support/ability_helper.rb
+++ b/spec/support/ability_helper.rb
@@ -18,7 +18,7 @@ module AbilityHelper
     end
 
     def have_link_to_enterprise_fee_summary
-      have_ability([:enterprise_fee_summary], for: :report)
+      have_ability([:enterprise_fee_summary], for: Spree::Admin::ReportsController)
     end
 
     def have_direct_access_to_enterprise_fee_summary


### PR DESCRIPTION
#### What? Why?

Closes #3373
All specs related to reports are green now.

There was [a change](https://github.com/openfoodfoundation/spree/commit/3685569db4dd0890faef1e08fb40f099c66cdc0b) in the model_class of the ReportsController that broke the ability_decorator. Here I adapt the ability decorator and the navigation helper.

#### What should we test?
All reports need to be validated as this is the first time we say reports are ready in v2.

Enterprise Fee Summary report is the only report that still needs to be fixed, that's in #3483 and is out of scope for this PR.
