### PR TITLE
[Spree Upgrade] Phase 2 - Product Import - Adapt product_reset_strategy

### DIFF
--- a/app/models/product_import/products_reset_strategy.rb
+++ b/app/models/product_import/products_reset_strategy.rb
@@ -38,13 +38,8 @@ module ProductImport
     end
 
     def reset_variant_count_on_hand(variant)
-      begin
-        variant.count_on_hand = 0
-        return true if variant.count_on_hand.zero?
-      rescue StandardError => e
-        Rails.logger.info "Could not reset variant count on hand: #{e.message}"
-      end
-      false
+      variant.count_on_hand = 0
+      variant.count_on_hand.zero?
     end
   end
 end

--- a/spec/models/product_import/products_reset_strategy_spec.rb
+++ b/spec/models/product_import/products_reset_strategy_spec.rb
@@ -80,12 +80,11 @@ describe ProductImport::ProductsResetStrategy do
 
         context 'and there is an unresetable variant' do
           before do
-            variant.stock_items = [] # this makes variant.count_on_hand fail
+            variant.stock_items = [] # this makes variant.count_on_hand raise an error
           end
 
           it 'returns correct number of resetted variants' do
-            updated_records_count = products_reset.reset(supplier_ids)
-            expect(updated_records_count).to eq(0) # the variant is not updated
+            expect { products_reset.reset(supplier_ids) }.to raise_error RuntimeError
           end
         end
       end

--- a/spec/models/product_import/products_reset_strategy_spec.rb
+++ b/spec/models/product_import/products_reset_strategy_spec.rb
@@ -1,41 +1,34 @@
 require 'spec_helper'
 
-xdescribe ProductImport::ProductsResetStrategy do
+describe ProductImport::ProductsResetStrategy do
   let(:products_reset) { described_class.new(excluded_items_ids) }
 
   describe '#reset' do
     let(:supplier_ids) { enterprise.id }
-    let(:enterprise) { variant.product.supplier }
-    let(:variant) { create(:variant, count_on_hand: 2) }
+    let(:product) { create(:product) }
+    let(:enterprise) { product.supplier }
+    let(:variant) { product.variants.first }
+
+    before { variant.count_on_hand = 2 }
 
     context 'when there are excluded_items_ids' do
       let(:excluded_items_ids) { [variant.id] }
 
       context 'and supplier_ids is []' do
         let(:supplier_ids) { [] }
-        let(:relation) do
-          instance_double(ActiveRecord::Relation, update_all: true)
-        end
 
-        before { allow(VariantOverride).to receive(:where) { relation } }
-
-        it 'does not update any DB record' do
+        it 'does not reset the variant.count_on_hand' do
           products_reset.reset(supplier_ids)
-          expect(relation).not_to have_received(:update_all)
+          expect(variant.reload.count_on_hand).to eq(2)
         end
       end
 
       context 'and supplier_ids is nil' do
         let(:supplier_ids) { nil }
-        let(:relation) do
-          instance_double(ActiveRecord::Relation, update_all: true)
-        end
 
-        before { allow(VariantOverride).to receive(:where) { relation } }
-
-        it 'does not update any DB record' do
+        it 'does not reset the variant.count_on_hand' do
           products_reset.reset(supplier_ids)
-          expect(relation).not_to have_received(:update_all)
+          expect(variant.reload.count_on_hand).to eq(2)
         end
       end
 
@@ -48,9 +41,9 @@ xdescribe ProductImport::ProductsResetStrategy do
         it 'updates the count_on_hand of the non-excluded items' do
           non_excluded_variant = create(
             :variant,
-            count_on_hand: 3,
             product: variant.product
           )
+          non_excluded_variant.count_on_hand = 3
           products_reset.reset(supplier_ids)
           expect(non_excluded_variant.reload.count_on_hand).to eq(0)
         end
@@ -62,36 +55,38 @@ xdescribe ProductImport::ProductsResetStrategy do
 
       context 'and supplier_ids is []' do
         let(:supplier_ids) { [] }
-        let(:relation) do
-          instance_double(ActiveRecord::Relation, update_all: true)
-        end
 
-        before { allow(VariantOverride).to receive(:where) { relation } }
-
-        it 'does not update any DB record' do
+        it 'does not reset the variant.count_on_hand' do
           products_reset.reset(supplier_ids)
-          expect(relation).not_to have_received(:update_all)
+          expect(variant.reload.count_on_hand).to eq(2)
         end
       end
 
       context 'and supplier_ids is nil' do
         let(:supplier_ids) { nil }
-        let(:relation) do
-          instance_double(ActiveRecord::Relation, update_all: true)
-        end
 
-        before { allow(VariantOverride).to receive(:where) { relation } }
-
-        it 'does not update any DB record' do
+        it 'does not reset the variant.count_on_hand' do
           products_reset.reset(supplier_ids)
-          expect(relation).not_to have_received(:update_all)
+          expect(variant.reload.count_on_hand).to eq(2)
         end
       end
 
-      context 'and supplier_ids is nil' do
+      context 'and supplier_ids is not nil' do
         it 'sets all count_on_hand to 0' do
-          products_reset.reset(supplier_ids)
+          updated_records_count = products_reset.reset(supplier_ids)
           expect(variant.reload.count_on_hand).to eq(0)
+          expect(updated_records_count).to eq(1)
+        end
+
+        context 'and there is an unresetable variant' do
+          before do
+            variant.stock_items = [] # this makes variant.count_on_hand fail
+          end
+
+          it 'returns correct number of resetted variants' do
+            updated_records_count = products_reset.reset(supplier_ids)
+            expect(updated_records_count).to eq(0) # the variant is not updated
+          end
         end
       end
     end
@@ -101,29 +96,18 @@ xdescribe ProductImport::ProductsResetStrategy do
 
       context 'and supplier_ids is []' do
         let(:supplier_ids) { [] }
-        let(:relation) do
-          instance_double(ActiveRecord::Relation, update_all: true)
-        end
 
-        before { allow(VariantOverride).to receive(:where) { relation } }
-
-        it 'does not update any DB record' do
+        it 'does not reset the variant.count_on_hand' do
           products_reset.reset(supplier_ids)
-          expect(relation).not_to have_received(:update_all)
+          expect(variant.reload.count_on_hand).to eq(2)
         end
       end
 
       context 'and supplier_ids is nil' do
         let(:supplier_ids) { nil }
-        let(:relation) do
-          instance_double(ActiveRecord::Relation, update_all: true)
-        end
-
-        before { allow(VariantOverride).to receive(:where) { relation } }
-
-        it 'does not update any DB record' do
+        it 'does not reset the variant.count_on_hand' do
           products_reset.reset(supplier_ids)
-          expect(relation).not_to have_received(:update_all)
+          expect(variant.reload.count_on_hand).to eq(2)
         end
       end
 


### PR DESCRIPTION
#### What? Why?
Change product import's product_reset_strategy from depending on the inexistent variant.count_on_hand DB field and instead make individual calls to variant.count_on_hand= defined in VariantStock.
Closes #2782.

#### What should we test?
Fixes 6 specs in products_reset_strategy_spec, moved to pending in #2791.