### PR TITLE
[Headless Chrome] Fix broken product import spec

### DIFF
--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -166,7 +166,7 @@ feature "Product Import", js: true do
 
       expect(page).to have_selector 'div#s2id_import_date_filter'
       import_time = carrots.import_date.to_date.to_formatted_s(:long).gsub('  ', ' ')
-      select import_time, from: "import_date_filter", visible: false
+      select2_select import_time, from: "import_date_filter"
 
       expect(page).to have_field "product_name", with: carrots.name
       expect(page).to have_field "product_name", with: potatoes.name


### PR DESCRIPTION
#### What? Why?

Fixes a spec in #2469.

I think this previous line was originally a workaround, but anyway... headless doesn't like interacting with hidden elements, so I just switched it to use the proper `select2_select` method.


#### What should we test?

Nothing to test. Reviewers should check that the spec is fixed. :heavy_check_mark: 



