### PR TITLE
[Headless Chrome] Fix failing enterprise images tests

### DIFF
--- a/spec/features/admin/enterprises/images_spec.rb
+++ b/spec/features/admin/enterprises/images_spec.rb
@@ -54,6 +54,7 @@ feature "Managing enterprise images" do
         # Removing image
         within ".page-admin-enterprises-form__logo-field-group" do
           click_on "Remove Image"
+          accept_js_alert
         end
 
         expect(page).to have_content("Logo removed successfully")
@@ -91,6 +92,7 @@ feature "Managing enterprise images" do
         # Removing image
         within ".page-admin-enterprises-form__promo-image-field-group" do
           click_on "Remove Image"
+          accept_js_alert
         end
 
         expect(page).to have_content("Promo image removed successfully")

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -192,6 +192,10 @@ module WebHelper
     page.execute_script(%Q{$("div.select2-result-label:contains('#{value}')").mouseup()})
   end
 
+  def accept_js_alert
+    page.driver.browser.switch_to.alert.accept
+  end
+
   private
 
   def wait_for_ajax


### PR DESCRIPTION
#### What? Why?

Fixes two tests for #2469

Added a helper method for dealing with alert popups and used it in the failing tests where the chrome driver didn't want to proceed without dealing with the unhandled alert box.

#### What should we test?

Nothing to test. The two enterprise images tests should be green now.
