### PR TITLE
[Headless Chrome] Add chromedriver-helper to Gemfile for test and development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,7 @@ group :test, :development do
   gem 'letter_opener', '>= 1.4.1'
   gem 'timecop'
   gem 'selenium-webdriver'
+  gem 'chromedriver-helper'
   gem 'rspec-retry'
   gem 'json_spec', '~> 1.1.4'
   gem 'unicorn-rails'


### PR DESCRIPTION
#### What? Why?

Helps development of #2469

Adding `chromedriver-helper` to the Gemfile. Specs don't run on my machine using headless chrome without this. Unless anyone has any tips on making it run on Debian... @mkllnk ?


#### What should we test?

Nothing to test. Only applies to dev and test environments.

