### PR TITLE
[Headless Chrome] Fix shipping method tests

### DIFF
--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -94,6 +94,9 @@ feature 'shipping methods' do
 
       check "shipping_method_distributor_ids_#{distributor1.id}"
       find(:css, "tags-input .tags input").set "local\n"
+      within(".tags .tag-list") do
+        expect(page).to have_css '.tag-item'
+      end
 
       click_button 'Create'
 

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -42,7 +42,7 @@ module WebHelper
   end
 
   def flash_message
-    find('.flash', visible: false).text.strip
+    find('.flash', visible: false).text(:all).strip
   end
 
   def handle_js_confirm(accept=true)


### PR DESCRIPTION
#### What? Why?

Fixes a test on #2469 

Adjusts the `flash_message` method in spec helper to suit chrome.

#### What should we test?

Nothing to test. `shipping_methods_spec.rb` should be green.


