### PR TITLE
3332 [Enterprise Fee Summary] Disable report for non-superadmin users

### DIFF
--- a/app/models/feature_flags.rb
+++ b/app/models/feature_flags.rb
@@ -14,6 +14,13 @@ class FeatureFlags
     superadmin?
   end
 
+  # Checks whether the "Enterprise Fee Summary" is enabled for the specified user
+  #
+  # @return [Boolean]
+  def enterprise_fee_summary_enabled?
+    superadmin?
+  end
+
   private
 
   attr_reader :user

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -185,9 +185,9 @@ class AbilityDecorator
 
     # Reports page
     can [:admin, :index, :customers, :orders_and_distributors, :group_buys, :bulk_coop, :payments,
-         :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :packing,
-         :enterprise_fee_summary], :report
-    can [:admin, :new, :create], :enterprise_fee_summary
+         :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :packing],
+         :report
+    add_enterprise_fee_summary_abilities(user)
   end
 
   def add_order_cycle_management_abilities(user)
@@ -261,8 +261,8 @@ class AbilityDecorator
     # Reports page
     can [:admin, :index, :customers, :group_buys, :bulk_coop, :sales_tax, :payments,
          :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory,
-         :order_cycle_management, :xero_invoices, :enterprise_fee_summary], :report
-    can [:admin, :new, :create], :enterprise_fee_summary
+         :order_cycle_management, :xero_invoices], :report
+    add_enterprise_fee_summary_abilities(user)
 
     can [:create], Customer
     can [:admin, :index, :update, :destroy, :show], Customer, enterprise_id: Enterprise.managed_by(user).pluck(:id)
@@ -284,6 +284,16 @@ class AbilityDecorator
     can [:destroy], EnterpriseRelationship do |enterprise_relationship|
       user.enterprises.include? enterprise_relationship.parent
     end
+  end
+
+  def add_enterprise_fee_summary_abilities(user)
+    feature_enabled = FeatureFlags.new(user).enterprise_fee_summary_enabled?
+    return unless feature_enabled
+
+    # Reveal the report link in spree/admin/reports#index
+    can [:enterprise_fee_summary], :report
+    # Allow direct access to the report resource
+    can [:admin, :new, :create], :enterprise_fee_summary
   end
 end
 

--- a/spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb
@@ -3,11 +3,14 @@ require "spec_helper"
 describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :controller do
   let(:report_klass) { OrderManagement::Reports::EnterpriseFeeSummary }
 
-  let!(:admin) { create(:admin_user) }
+  let!(:distributor) { create(:distributor_enterprise) }
 
-  let(:current_user) { admin }
+  let(:current_user) { distributor.owner }
 
   before do
+    feature_flags = instance_double(FeatureFlags, enterprise_fee_summary_enabled?: true)
+    allow(FeatureFlags).to receive(:new).with(current_user) { feature_flags }
+
     allow(controller).to receive(:spree_current_user) { current_user }
   end
 
@@ -17,6 +20,15 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
 
       expect(response).to be_success
       expect(response).to render_template(new_template_path)
+    end
+
+    context "when feature flag is in effect" do
+      before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
+
+      it "is unauthorized" do
+        get :new
+        expect(response).to redirect_to spree.unauthorized_path
+      end
     end
   end
 
@@ -28,6 +40,15 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
         expect(response).to be_success
         expect(response.body).not_to be_blank
         expect(response.header["Content-Type"]).to eq("text/csv")
+      end
+
+      context "when feature flag is in effect" do
+        before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
+
+        it "is unauthorized" do
+          post :create, report: { start_at: "2018-10-09 07:30:00" }, report_format: "csv"
+          expect(response).to redirect_to spree.unauthorized_path
+        end
       end
     end
 

--- a/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
@@ -11,17 +11,41 @@ feature "enterprise fee summaries" do
   let!(:other_order_cycle) { create(:simple_order_cycle, coordinator: other_distributor) }
 
   before do
+    feature_flags = instance_double(FeatureFlags, enterprise_fee_summary_enabled?: true)
+    allow(FeatureFlags).to receive(:new).with(current_user) { feature_flags }
+
     login_as current_user
   end
 
   describe "navigation" do
-    context "when accessing the report as an enterprise user" do
-      let(:current_user) { distributor.owner }
+    context "when accessing the report as an superadmin" do
+      let(:current_user) { create(:admin_user) }
 
-      it "allows access to the report" do
+      it "shows link and allows access to the report" do
         visit spree.admin_reports_path
         click_on I18n.t("admin.reports.enterprise_fee_summary.name")
         expect(page).to have_button(I18n.t("filters.generate_report", scope: i18n_scope))
+      end
+    end
+
+    context "when accessing the report as an admin" do
+      let(:current_user) { distributor.owner }
+
+      it "shows link and allows access to the report" do
+        visit spree.admin_reports_path
+        click_on I18n.t("admin.reports.enterprise_fee_summary.name")
+        expect(page).to have_button(I18n.t("filters.generate_report", scope: i18n_scope))
+      end
+
+      context "when feature flag is in effect" do
+        before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
+
+        it "does not show link now allow direct access to the report" do
+          visit spree.admin_reports_path
+          expect(page).to have_no_link I18n.t("admin.reports.enterprise_fee_summary.name")
+          visit spree.new_admin_reports_enterprise_fee_summary_path
+          expect(page).to have_no_button(I18n.t("filters.generate_report", scope: i18n_scope))
+        end
       end
     end
 
@@ -33,6 +57,17 @@ feature "enterprise fee summaries" do
         expect(page).to have_no_link(I18n.t("admin.reports.enterprise_fee_summary.name"))
         visit spree.new_admin_reports_enterprise_fee_summary_path
         expect(page).to have_content(I18n.t("unauthorized"))
+      end
+
+      context "when feature flag is in effect" do
+        before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
+
+        it "does not show link now allow direct access to the report" do
+          visit spree.admin_reports_path
+          expect(page).to have_no_link I18n.t("admin.reports.enterprise_fee_summary.name")
+          visit spree.new_admin_reports_enterprise_fee_summary_path
+          expect(page).to have_no_button(I18n.t("filters.generate_report", scope: i18n_scope))
+        end
       end
     end
   end

--- a/spec/models/feature_flags_spec.rb
+++ b/spec/models/feature_flags_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe FeatureFlags do
-  describe '.product_import_enabled?' do
-    let(:user) { build_stubbed(:user) }
-    let(:feature_flags) { described_class.new(user) }
+  let(:user) { build_stubbed(:user) }
+  let(:feature_flags) { described_class.new(user) }
 
+  describe '.product_import_enabled?' do
     context 'when the user is superadmin' do
       before do
         allow(user).to receive(:has_spree_role?).with('admin') { true }
@@ -22,6 +22,24 @@ describe FeatureFlags do
 
       it 'returns false' do
         expect(feature_flags.product_import_enabled?).to eq(false)
+      end
+    end
+  end
+
+  describe ".enterprise_fee_summary_enabled?" do
+    context "when the user is superadmin" do
+      let!(:user) { create(:admin_user) }
+
+      it "returns true" do
+        expect(feature_flags).to be_enterprise_fee_summary_enabled
+      end
+    end
+
+    context "when the user is not superadmin" do
+      let!(:user) { create(:user) }
+
+      it "returns false" do
+        expect(feature_flags).not_to be_enterprise_fee_summary_enabled
       end
     end
   end

--- a/spec/models/feature_flags_spec.rb
+++ b/spec/models/feature_flags_spec.rb
@@ -4,7 +4,7 @@ describe FeatureFlags do
   let(:user) { build_stubbed(:user) }
   let(:feature_flags) { described_class.new(user) }
 
-  describe '.product_import_enabled?' do
+  describe '#product_import_enabled?' do
     context 'when the user is superadmin' do
       before do
         allow(user).to receive(:has_spree_role?).with('admin') { true }
@@ -26,7 +26,7 @@ describe FeatureFlags do
     end
   end
 
-  describe ".enterprise_fee_summary_enabled?" do
+  describe "#enterprise_fee_summary_enabled?" do
     context "when the user is superadmin" do
       let!(:user) { create(:admin_user) }
 

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -4,9 +4,11 @@ require 'support/cancan_helper'
 
 module Spree
   describe User do
-
     describe "broad permissions" do
       subject { AbilityDecorator.new(user) }
+
+      include ::AbilityHelper
+
       let(:user) { create(:user) }
       let(:enterprise_any) { create(:enterprise, sells: 'any') }
       let(:enterprise_own) { create(:enterprise, sells: 'own') }
@@ -215,6 +217,8 @@ module Spree
           should have_ability([:admin, :index, :customers, :bulk_coop, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management], for: :report)
         end
 
+        include_examples "allows access to Enterprise Fee Summary only if feature flag enabled"
+
         it "should not be able to read other reports" do
           should_not have_ability([:sales_total, :group_buys, :payments, :orders_and_distributors, :users_and_enterprises, :xero_invoices], for: :report)
         end
@@ -405,6 +409,8 @@ module Spree
         it "should be able to read some reports" do
           should have_ability([:admin, :index, :customers, :sales_tax, :group_buys, :bulk_coop, :payments, :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :xero_invoices], for: :report)
         end
+
+        include_examples "allows access to Enterprise Fee Summary only if feature flag enabled"
 
         it "should not be able to read other reports" do
           should_not have_ability([:sales_total, :users_and_enterprises], for: :report)

--- a/spec/support/ability_helper.rb
+++ b/spec/support/ability_helper.rb
@@ -1,0 +1,28 @@
+module AbilityHelper
+  shared_examples "allows access to Enterprise Fee Summary only if feature flag enabled" do
+    it "should not be able to read Enterprise Fee Summary" do
+      is_expected.not_to have_link_to_enterprise_fee_summary
+      is_expected.not_to have_direct_access_to_enterprise_fee_summary
+    end
+
+    context "when feature flag for Enterprise Fee Summary is enabled absolutely" do
+      before do
+        feature_flags = instance_double(FeatureFlags, enterprise_fee_summary_enabled?: true)
+        allow(FeatureFlags).to receive(:new).with(user) { feature_flags }
+      end
+
+      it "should be able to see link and read report" do
+        is_expected.to have_link_to_enterprise_fee_summary
+        is_expected.to have_direct_access_to_enterprise_fee_summary
+      end
+    end
+
+    def have_link_to_enterprise_fee_summary
+      have_ability([:enterprise_fee_summary], for: :report)
+    end
+
+    def have_direct_access_to_enterprise_fee_summary
+      have_ability([:admin, :new, :create], for: :enterprise_fee_summary)
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #3332

This exposes the "Enterprise Fee Summary" link and resource to only superadmins. This will allow us to merge existing changes for the report to master even if there are still bugs.

This doesn't enable the feature for non-production environments. Note that this limits permission testing that can be done, so a thorough round of permission testing needs to be done before the feature toggle is enabled for all enterprise users.

#### What should we test?

As superadmin:

1. Go to "Reports". There should be a link to "Enterprise Fee Summary".
2. Click on the link. There should be no permission issues.
3. Generate a report that is expected to provide data. Data should be provided.

As manager of an enterprise with orders:

1. Go to "Reports". There should be no link to "Enterprise Fee Summary".
2. Go directly to URL path `/admin/reports/enterprise_fee_summary/new`. There should be a permissions issue.

#### Release notes

- Expose "Enterprise Fee Summary" only to superadmin users.

Changelog Category: Changed

#### Dependencies

This would be merged into the transitional branch "feature/enterprise_fee_summary", not "master".