### PR TITLE
Fix Gemfile.lock by running bundle install. Adds missing chromedriver-helper.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
       tilt
     angularjs-file-upload-rails (2.4.1)
     angularjs-rails (1.5.5)
+    archive-zip (0.7.0)
+      io-like (~> 0.3.0)
     arel (3.0.3)
     ast (2.4.0)
     atomic (1.1.101)
@@ -215,6 +217,9 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.1.0)
+      archive-zip (~> 0.7.0)
+      nokogiri (~> 1.6)
     chronic (0.10.2)
     chunky_png (1.3.10)
     climate_control (0.2.0)
@@ -489,6 +494,7 @@ GEM
       i18n (>= 0.6.6, < 2)
     immigrant (0.3.6)
       activerecord (>= 3.0)
+    io-like (0.3.0)
     ipaddress (0.8.3)
     jaro_winkler (1.5.1)
     journey (1.0.4)
@@ -769,6 +775,7 @@ DEPENDENCIES
   bugsnag
   byebug (~> 9.0.0)
   capybara (>= 2.15.4)
+  chromedriver-helper
   coffee-rails (~> 3.2.1)
   compass-rails
   custom_error_message!


### PR DESCRIPTION
#### What? Why?

Fix problem in #3331 adds chrome-helpder to Gemfile.lock

#### What should we test?
Build should not fail on setup as here: https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/branches/headless-chrome/builds/18
