### PR TITLE
3283 [Enterprise Fee Summary] Fix values when calculator is order-based

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2697,6 +2697,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         date_end_before_start_error: "must be after start"
         parameter_not_allowed_error: "You are not authorized to use one or more selected filters for this report."
         fee_calculated_on_transfer_through_all: "All"
+        fee_calculated_on_transfer_through_entire_orders: "Entire Orders through %{distributor}"
+        tax_category_various: "Various"
         fee_type:
           payment_method: "Payment Transaction"
           shipping_method: "Shipment"

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/associated_enterprise_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/associated_enterprise_fee.rb
@@ -1,0 +1,31 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        class AssociatedEnterpriseFee
+          attr_reader :context
+
+          def initialize(context)
+            @context = context
+          end
+
+          def fee_type
+            context.data["fee_type"].try(:capitalize)
+          end
+
+          def enterprise_name
+            context.data["enterprise_name"]
+          end
+
+          def fee_name
+            context.data["fee_name"]
+          end
+
+          def fee_placement
+            context.i18n_translate("fee_placements.#{context.data['placement_enterprise_role']}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
@@ -2,7 +2,7 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class CoordinatorFee < AssociatedEnterpriseFee
+        class CoordinatorFee < UsingEnterpriseFee
           def fee_calculated_on_transfer_through_name
             context.i18n_translate("fee_calculated_on_transfer_through_all")
           end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
@@ -9,12 +9,12 @@ module OrderManagement
           include UsingEnterpriseFee
 
           def fee_calculated_on_transfer_through_name
-            context.i18n_translate("fee_calculated_on_transfer_through_all")
+            i18n_translate("fee_calculated_on_transfer_through_all")
           end
 
           def tax_category_name
             return context.data["tax_category_name"] if context.data["tax_category_name"].present?
-            context.i18n_translate("tax_category_various") if inherits_tax_category?
+            i18n_translate("tax_category_various") if inherits_tax_category?
           end
 
           def inherits_tax_category?

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
@@ -1,3 +1,6 @@
+# This module provides EnterpriseFeeSummary::Scope DB result to report mappings for coordinator fees
+# in an order cycle.
+
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
@@ -2,7 +2,9 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class CoordinatorFee < UsingEnterpriseFee
+        class CoordinatorFee
+          include UsingEnterpriseFee
+
           def fee_calculated_on_transfer_through_name
             context.i18n_translate("fee_calculated_on_transfer_through_all")
           end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
@@ -13,12 +13,12 @@ module OrderManagement
           end
 
           def tax_category_name
-            return context.data["tax_category_name"] if context.data["tax_category_name"].present?
+            return data["tax_category_name"] if data["tax_category_name"].present?
             i18n_translate("tax_category_various") if inherits_tax_category?
           end
 
           def inherits_tax_category?
-            context.data["enterprise_fee_inherits_tax_category"] == "t"
+            data["enterprise_fee_inherits_tax_category"] == "t"
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
@@ -1,0 +1,22 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        class CoordinatorFee < AssociatedEnterpriseFee
+          def fee_calculated_on_transfer_through_name
+            context.i18n_translate("fee_calculated_on_transfer_through_all")
+          end
+
+          def tax_category_name
+            return context.data["tax_category_name"] if context.data["tax_category_name"].present?
+            context.i18n_translate("tax_category_various") if inherits_tax_category?
+          end
+
+          def inherits_tax_category?
+            context.data["enterprise_fee_inherits_tax_category"] == "t"
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
@@ -2,7 +2,9 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class ExchangeOrderFee < UsingEnterpriseFee
+        class ExchangeOrderFee
+          include UsingEnterpriseFee
+
           def fee_calculated_on_transfer_through_name
             context.i18n_translate("fee_calculated_on_transfer_through_entire_orders",
                                    distributor: context.data["adjustment_source_distributor_name"])

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
@@ -9,12 +9,12 @@ module OrderManagement
           include UsingEnterpriseFee
 
           def fee_calculated_on_transfer_through_name
-            context.i18n_translate("fee_calculated_on_transfer_through_entire_orders",
-                                   distributor: context.data["adjustment_source_distributor_name"])
+            i18n_translate("fee_calculated_on_transfer_through_entire_orders",
+                           distributor: context.data["adjustment_source_distributor_name"])
           end
 
           def tax_category_name
-            context.data["tax_category_name"] || context.i18n_translate("tax_category_various")
+            context.data["tax_category_name"] || i18n_translate("tax_category_various")
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
@@ -2,7 +2,7 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class ExchangeOrderFee < AssociatedEnterpriseFee
+        class ExchangeOrderFee < UsingEnterpriseFee
           def fee_calculated_on_transfer_through_name
             context.i18n_translate("fee_calculated_on_transfer_through_entire_orders",
                                    distributor: context.data["adjustment_source_distributor_name"])

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
@@ -1,0 +1,18 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        class ExchangeOrderFee < AssociatedEnterpriseFee
+          def fee_calculated_on_transfer_through_name
+            context.i18n_translate("fee_calculated_on_transfer_through_entire_orders",
+                                   distributor: context.data["adjustment_source_distributor_name"])
+          end
+
+          def tax_category_name
+            context.data["tax_category_name"] || context.i18n_translate("tax_category_various")
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
@@ -1,3 +1,6 @@
+# This module provides EnterpriseFeeSummary::Scope DB result to report mappings for exchange fees
+# that use order-based calculators.
+
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/exchange_order_fee.rb
@@ -10,11 +10,11 @@ module OrderManagement
 
           def fee_calculated_on_transfer_through_name
             i18n_translate("fee_calculated_on_transfer_through_entire_orders",
-                           distributor: context.data["adjustment_source_distributor_name"])
+                           distributor: data["adjustment_source_distributor_name"])
           end
 
           def tax_category_name
-            context.data["tax_category_name"] || i18n_translate("tax_category_various")
+            data["tax_category_name"] || i18n_translate("tax_category_various")
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
@@ -2,7 +2,7 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class IncomingExchangeLineItemFee < AssociatedEnterpriseFee
+        class IncomingExchangeLineItemFee < UsingEnterpriseFee
           def fee_calculated_on_transfer_through_name
             context.data["incoming_exchange_enterprise_name"]
           end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
@@ -9,11 +9,11 @@ module OrderManagement
           include UsingEnterpriseFee
 
           def fee_calculated_on_transfer_through_name
-            context.data["incoming_exchange_enterprise_name"]
+            data["incoming_exchange_enterprise_name"]
           end
 
           def tax_category_name
-            context.data["tax_category_name"] || context.data["product_tax_category_name"]
+            data["tax_category_name"] || data["product_tax_category_name"]
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
@@ -1,0 +1,17 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        class IncomingExchangeLineItemFee < AssociatedEnterpriseFee
+          def fee_calculated_on_transfer_through_name
+            context.data["incoming_exchange_enterprise_name"]
+          end
+
+          def tax_category_name
+            context.data["tax_category_name"] || context.data["product_tax_category_name"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
@@ -2,7 +2,9 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class IncomingExchangeLineItemFee < UsingEnterpriseFee
+        class IncomingExchangeLineItemFee
+          include UsingEnterpriseFee
+
           def fee_calculated_on_transfer_through_name
             context.data["incoming_exchange_enterprise_name"]
           end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/incoming_exchange_line_item_fee.rb
@@ -1,3 +1,6 @@
+# This module provides EnterpriseFeeSummary::Scope DB result to report mappings for incoming
+# exchange fees that use line item -based calculators.
+
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
@@ -9,11 +9,11 @@ module OrderManagement
           include UsingEnterpriseFee
 
           def fee_calculated_on_transfer_through_name
-            context.data["outgoing_exchange_enterprise_name"]
+            data["outgoing_exchange_enterprise_name"]
           end
 
           def tax_category_name
-            context.data["tax_category_name"] || context.data["product_tax_category_name"]
+            data["tax_category_name"] || data["product_tax_category_name"]
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
@@ -1,0 +1,17 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        class OutgoingExchangeLineItemFee < AssociatedEnterpriseFee
+          def fee_calculated_on_transfer_through_name
+            context.data["outgoing_exchange_enterprise_name"]
+          end
+
+          def tax_category_name
+            context.data["tax_category_name"] || context.data["product_tax_category_name"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
@@ -1,3 +1,6 @@
+# This module provides EnterpriseFeeSummary::Scope DB result to report mappings for outgoing
+# exchange fees that use line item -based calculators.
+
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
@@ -2,7 +2,9 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class OutgoingExchangeLineItemFee < UsingEnterpriseFee
+        class OutgoingExchangeLineItemFee
+          include UsingEnterpriseFee
+
           def fee_calculated_on_transfer_through_name
             context.data["outgoing_exchange_enterprise_name"]
           end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/outgoing_exchange_line_item_fee.rb
@@ -2,7 +2,7 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class OutgoingExchangeLineItemFee < AssociatedEnterpriseFee
+        class OutgoingExchangeLineItemFee < UsingEnterpriseFee
           def fee_calculated_on_transfer_through_name
             context.data["outgoing_exchange_enterprise_name"]
           end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
@@ -1,0 +1,33 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        class PaymentMethodFee
+          attr_reader :context
+
+          def initialize(context)
+            @context = context
+          end
+
+          def fee_type
+            context.i18n_translate("fee_type.payment_method")
+          end
+
+          def enterprise_name
+            context.data["hub_name"]
+          end
+
+          def fee_name
+            context.data["payment_method_name"]
+          end
+
+          def fee_placement; end
+
+          def fee_calculated_on_transfer_through_name; end
+
+          def tax_category_name; end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
@@ -6,6 +6,8 @@ module OrderManagement
     module EnterpriseFeeSummary
       module DataRepresentations
         class PaymentMethodFee
+          include WithI18n
+
           attr_reader :context
 
           def initialize(context)
@@ -13,7 +15,7 @@ module OrderManagement
           end
 
           def fee_type
-            context.i18n_translate("fee_type.payment_method")
+            i18n_translate("fee_type.payment_method")
           end
 
           def enterprise_name

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
@@ -8,10 +8,10 @@ module OrderManagement
         class PaymentMethodFee
           include WithI18n
 
-          attr_reader :context
+          attr_reader :data
 
-          def initialize(context)
-            @context = context
+          def initialize(data)
+            @data = data
           end
 
           def fee_type
@@ -19,11 +19,11 @@ module OrderManagement
           end
 
           def enterprise_name
-            context.data["hub_name"]
+            data["hub_name"]
           end
 
           def fee_name
-            context.data["payment_method_name"]
+            data["payment_method_name"]
           end
 
           def fee_placement; end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/payment_method_fee.rb
@@ -1,3 +1,6 @@
+# This module provides EnterpriseFeeSummary::Scope DB result to report mappings for payment method
+# fees.
+
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
@@ -1,0 +1,35 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        class ShippingMethodFee
+          attr_reader :context
+
+          def initialize(context)
+            @context = context
+          end
+
+          def fee_type
+            context.i18n_translate("fee_type.shipping_method")
+          end
+
+          def enterprise_name
+            context.data["hub_name"]
+          end
+
+          def fee_name
+            context.data["shipping_method_name"]
+          end
+
+          def fee_placement; end
+
+          def fee_calculated_on_transfer_through_name; end
+
+          def tax_category_name
+            context.i18n_translate("tax_category_name.shipping_instance_rate")
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
@@ -6,6 +6,8 @@ module OrderManagement
     module EnterpriseFeeSummary
       module DataRepresentations
         class ShippingMethodFee
+          include WithI18n
+
           attr_reader :context
 
           def initialize(context)
@@ -13,7 +15,7 @@ module OrderManagement
           end
 
           def fee_type
-            context.i18n_translate("fee_type.shipping_method")
+            i18n_translate("fee_type.shipping_method")
           end
 
           def enterprise_name
@@ -29,7 +31,7 @@ module OrderManagement
           def fee_calculated_on_transfer_through_name; end
 
           def tax_category_name
-            context.i18n_translate("tax_category_name.shipping_instance_rate")
+            i18n_translate("tax_category_name.shipping_instance_rate")
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
@@ -8,10 +8,10 @@ module OrderManagement
         class ShippingMethodFee
           include WithI18n
 
-          attr_reader :context
+          attr_reader :data
 
-          def initialize(context)
-            @context = context
+          def initialize(data)
+            @data = data
           end
 
           def fee_type
@@ -19,11 +19,11 @@ module OrderManagement
           end
 
           def enterprise_name
-            context.data["hub_name"]
+            data["hub_name"]
           end
 
           def fee_name
-            context.data["shipping_method_name"]
+            data["shipping_method_name"]
           end
 
           def fee_placement; end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/shipping_method_fee.rb
@@ -1,3 +1,6 @@
+# This module provides EnterpriseFeeSummary::Scope DB result to report mappings for shipping method
+# fees.
+
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
@@ -1,3 +1,10 @@
+# Different EnterpriseFeeSummary::Scope DB result attributes are checked when dealing with
+# enterprise fees that are attached to an order cycle in different ways.
+#
+# This module provides DB result to report mappings that are common among all rows for enterprise
+# fees. These mappings are not complete and should be supplemented with mappings that are specific
+# to the way that the enterprise fee is attached to the order cycle.
+
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
@@ -10,6 +10,8 @@ module OrderManagement
     module EnterpriseFeeSummary
       module DataRepresentations
         module UsingEnterpriseFee
+          include WithI18n
+
           attr_reader :context
 
           def initialize(context)
@@ -29,7 +31,7 @@ module OrderManagement
           end
 
           def fee_placement
-            context.i18n_translate("fee_placements.#{context.data['placement_enterprise_role']}")
+            i18n_translate("fee_placements.#{context.data['placement_enterprise_role']}")
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
@@ -2,7 +2,7 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class AssociatedEnterpriseFee
+        class UsingEnterpriseFee
           attr_reader :context
 
           def initialize(context)

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
@@ -2,7 +2,7 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       module DataRepresentations
-        class UsingEnterpriseFee
+        module UsingEnterpriseFee
           attr_reader :context
 
           def initialize(context)

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/using_enterprise_fee.rb
@@ -12,26 +12,26 @@ module OrderManagement
         module UsingEnterpriseFee
           include WithI18n
 
-          attr_reader :context
+          attr_reader :data
 
-          def initialize(context)
-            @context = context
+          def initialize(data)
+            @data = data
           end
 
           def fee_type
-            context.data["fee_type"].try(:capitalize)
+            data["fee_type"].try(:capitalize)
           end
 
           def enterprise_name
-            context.data["enterprise_name"]
+            data["enterprise_name"]
           end
 
           def fee_name
-            context.data["fee_name"]
+            data["fee_name"]
           end
 
           def fee_placement
-            i18n_translate("fee_placements.#{context.data['placement_enterprise_role']}")
+            i18n_translate("fee_placements.#{data['placement_enterprise_role']}")
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/with_i18n.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/with_i18n.rb
@@ -1,0 +1,15 @@
+module OrderManagement
+  module Reports
+    module EnterpriseFeeSummary
+      module DataRepresentations
+        module WithI18n
+          private
+
+          def i18n_translate(translation_key, options = {})
+            I18n.t("order_management.reports.enterprise_fee_summary.#{translation_key}", options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/enterprise_fee_type_total_summarizer.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/enterprise_fee_type_total_summarizer.rb
@@ -2,108 +2,45 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       class EnterpriseFeeTypeTotalSummarizer
-        PAYMENT_METHOD_SOURCE_TYPE = 1
-        SHIPPING_METHOD_SOURCE_TYPE = 2
-        COORDINATOR_FEE_SOURCE_TYPE = 3
-        INCOMING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE = 4
-        OUTGOING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE = 5
-        INCOMING_EXCHANGE_ORDER_FEE_SOURCE_TYPE = 6
-        OUTGOING_EXCHANGE_ORDER_FEE_SOURCE_TYPE = 7
+        attr_reader :data
 
-        attr_accessor :data
+        delegate :fee_type, :enterprise_name, :fee_name, :fee_placement,
+                 :fee_calculated_on_transfer_through_name, :tax_category_name, to: :representation
 
         def initialize(data)
           @data = data
-        end
-
-        def fee_type
-          case adjustment_source_type
-            when PAYMENT_METHOD_SOURCE_TYPE
-              i18n_translate("fee_type.payment_method")
-            when SHIPPING_METHOD_SOURCE_TYPE
-              i18n_translate("fee_type.shipping_method")
-            else
-              data["fee_type"].try(:capitalize)
-            end
-        end
-
-        def enterprise_name
-          case adjustment_source_type
-            when PAYMENT_METHOD_SOURCE_TYPE, SHIPPING_METHOD_SOURCE_TYPE
-              data["hub_name"]
-            else
-              data["enterprise_name"]
-            end
-        end
-
-        def fee_name
-          case adjustment_source_type
-            when PAYMENT_METHOD_SOURCE_TYPE
-              data["payment_method_name"]
-            when SHIPPING_METHOD_SOURCE_TYPE
-              data["shipping_method_name"]
-            else
-              data["fee_name"]
-            end
         end
 
         def customer_name
           data["customer_name"]
         end
 
-        def fee_placement
-          case adjustment_source_type
-            when PAYMENT_METHOD_SOURCE_TYPE, SHIPPING_METHOD_SOURCE_TYPE
-              nil
-            else
-              i18n_translate("fee_placements.#{data['placement_enterprise_role']}")
-            end
-        end
-
-        def fee_calculated_on_transfer_through_name
-          case adjustment_source_type
-            when COORDINATOR_FEE_SOURCE_TYPE
-              i18n_translate("fee_calculated_on_transfer_through_all")
-            when INCOMING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE
-              data["incoming_exchange_enterprise_name"]
-            when OUTGOING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE
-              data["outgoing_exchange_enterprise_name"]
-            when INCOMING_EXCHANGE_ORDER_FEE_SOURCE_TYPE, OUTGOING_EXCHANGE_ORDER_FEE_SOURCE_TYPE
-              i18n_translate("fee_calculated_on_transfer_through_entire_orders",
-                             distributor: data["adjustment_source_distributor_name"])
-            end
-        end
-
-        def tax_category_name
-          case adjustment_source_type
-            when PAYMENT_METHOD_SOURCE_TYPE
-              nil
-            when SHIPPING_METHOD_SOURCE_TYPE
-              i18n_translate("tax_category_name.shipping_instance_rate")
-            when COORDINATOR_FEE_SOURCE_TYPE
-              data["tax_category_name"] \
-                || (i18n_translate("tax_category_various") if enterprise_fee_inherits_tax_category?)
-            when INCOMING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE, OUTGOING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE
-              data["tax_category_name"] || data["product_tax_category_name"]
-            when INCOMING_EXCHANGE_ORDER_FEE_SOURCE_TYPE, OUTGOING_EXCHANGE_ORDER_FEE_SOURCE_TYPE
-              data["tax_category_name"] || i18n_translate("tax_category_various")
-            end
-        end
-
         def total_amount
           data["total_amount"]
         end
 
+        def i18n_translate(translation_key, options = {})
+          I18n.t("order_management.reports.enterprise_fee_summary.#{translation_key}", options)
+        end
+
         private
 
-        def adjustment_source_type
-          return PAYMENT_METHOD_SOURCE_TYPE if for_payment_method?
-          return SHIPPING_METHOD_SOURCE_TYPE if for_shipping_method?
-          return COORDINATOR_FEE_SOURCE_TYPE if for_coordinator_fee?
-          return INCOMING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE if for_incoming_exchange? && for_line_item_adjustment_source?
-          return OUTGOING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE if for_outgoing_exchange? && for_line_item_adjustment_source?
-          return INCOMING_EXCHANGE_ORDER_FEE_SOURCE_TYPE if for_incoming_exchange? && for_order_adjustment_source?
-          return OUTGOING_EXCHANGE_ORDER_FEE_SOURCE_TYPE if for_outgoing_exchange? && for_order_adjustment_source?
+        def representation
+          @representation ||= representation_klass.new(self)
+        end
+
+        def representation_klass
+          return DataRepresentations::PaymentMethodFee if for_payment_method?
+          return DataRepresentations::ShippingMethodFee if for_shipping_method?
+          enterprise_fee_adjustment_presentation_klass if for_enterprise_fee?
+        end
+
+        def enterprise_fee_adjustment_presentation_klass
+          return DataRepresentations::CoordinatorFee if for_coordinator_fee?
+          return DataRepresentations::ExchangeOrderFee if for_order_adjustment_source?
+          return unless for_line_item_adjustment_source?
+          return DataRepresentations::IncomingExchangeLineItemFee if for_incoming_exchange?
+          return DataRepresentations::OutgoingExchangeLineItemFee if for_outgoing_exchange?
         end
 
         def for_payment_method?
@@ -136,15 +73,6 @@ module OrderManagement
 
         def for_line_item_adjustment_source?
           data["adjustment_source_type"] == "Spree::LineItem"
-        end
-
-        def enterprise_fee_inherits_tax_category?
-          for_enterprise_fee? && data["tax_category_name"].blank? \
-            && data["enterprise_fee_inherits_tax_category"] == "t"
-        end
-
-        def i18n_translate(translation_key, options = {})
-          I18n.t("order_management.reports.enterprise_fee_summary.#{translation_key}", options)
         end
       end
     end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/enterprise_fee_type_total_summarizer.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/enterprise_fee_type_total_summarizer.rb
@@ -2,6 +2,12 @@ module OrderManagement
   module Reports
     module EnterpriseFeeSummary
       class EnterpriseFeeTypeTotalSummarizer
+        PAYMENT_METHOD_SOURCE_TYPE = 1
+        SHIPPING_METHOD_SOURCE_TYPE = 2
+        COORDINATOR_FEE_SOURCE_TYPE = 3
+        INCOMING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE = 4
+        OUTGOING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE = 5
+
         attr_accessor :data
 
         def initialize(data)
@@ -9,33 +15,34 @@ module OrderManagement
         end
 
         def fee_type
-          if for_payment_method?
-            i18n_translate("fee_type.payment_method")
-          elsif for_shipping_method?
-            i18n_translate("fee_type.shipping_method")
-          else
-            data["fee_type"].try(:capitalize)
-          end
+          case adjustment_source_type
+            when PAYMENT_METHOD_SOURCE_TYPE
+              i18n_translate("fee_type.payment_method")
+            when SHIPPING_METHOD_SOURCE_TYPE
+              i18n_translate("fee_type.shipping_method")
+            else
+              data["fee_type"].try(:capitalize)
+            end
         end
 
         def enterprise_name
-          if for_payment_method?
-            data["hub_name"]
-          elsif for_shipping_method?
-            data["hub_name"]
-          else
-            data["enterprise_name"]
-          end
+          case adjustment_source_type
+            when PAYMENT_METHOD_SOURCE_TYPE, SHIPPING_METHOD_SOURCE_TYPE
+              data["hub_name"]
+            else
+              data["enterprise_name"]
+            end
         end
 
         def fee_name
-          if for_payment_method?
-            data["payment_method_name"]
-          elsif for_shipping_method?
-            data["shipping_method_name"]
-          else
-            data["fee_name"]
-          end
+          case adjustment_source_type
+            when PAYMENT_METHOD_SOURCE_TYPE
+              data["payment_method_name"]
+            when SHIPPING_METHOD_SOURCE_TYPE
+              data["shipping_method_name"]
+            else
+              data["fee_name"]
+            end
         end
 
         def customer_name
@@ -43,25 +50,34 @@ module OrderManagement
         end
 
         def fee_placement
-          return if for_payment_method? || for_shipping_method?
-
-          i18n_translate("fee_placements.#{data['placement_enterprise_role']}")
+          case adjustment_source_type
+            when PAYMENT_METHOD_SOURCE_TYPE, SHIPPING_METHOD_SOURCE_TYPE
+              nil
+            else
+              i18n_translate("fee_placements.#{data['placement_enterprise_role']}")
+            end
         end
 
         def fee_calculated_on_transfer_through_name
-          return if for_payment_method? || for_shipping_method?
-
-          transfer_through_all_string = i18n_translate("fee_calculated_on_transfer_through_all")
-
-          data["incoming_exchange_enterprise_name"] || data["outgoing_exchange_enterprise_name"] ||
-            (transfer_through_all_string if data["placement_enterprise_role"] == "coordinator")
+          case adjustment_source_type
+            when COORDINATOR_FEE_SOURCE_TYPE
+              i18n_translate("fee_calculated_on_transfer_through_all")
+            when INCOMING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE
+              data["incoming_exchange_enterprise_name"]
+            when OUTGOING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE
+              data["outgoing_exchange_enterprise_name"]
+            end
         end
 
         def tax_category_name
-          return if for_payment_method?
-          return i18n_translate("tax_category_name.shipping_instance_rate") if for_shipping_method?
-
-          data["tax_category_name"] || data["product_tax_category_name"]
+          case adjustment_source_type
+            when PAYMENT_METHOD_SOURCE_TYPE
+              nil
+            when SHIPPING_METHOD_SOURCE_TYPE
+              i18n_translate("tax_category_name.shipping_instance_rate")
+            else
+              data["tax_category_name"] || data["product_tax_category_name"]
+            end
         end
 
         def total_amount
@@ -70,12 +86,32 @@ module OrderManagement
 
         private
 
+        def adjustment_source_type
+          return PAYMENT_METHOD_SOURCE_TYPE if for_payment_method?
+          return SHIPPING_METHOD_SOURCE_TYPE if for_shipping_method?
+          return COORDINATOR_FEE_SOURCE_TYPE if for_coordinator_fee?
+          return INCOMING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE if for_incoming_exchange?
+          return OUTGOING_EXCHANGE_LINE_ITEM_FEE_SOURCE_TYPE if for_outgoing_exchange?
+        end
+
         def for_payment_method?
           data["payment_method_name"].present?
         end
 
         def for_shipping_method?
           data["shipping_method_name"].present?
+        end
+
+        def for_coordinator_fee?
+          data["placement_enterprise_role"] == "coordinator"
+        end
+
+        def for_incoming_exchange?
+          data["placement_enterprise_role"] == "supplier"
+        end
+
+        def for_outgoing_exchange?
+          data["placement_enterprise_role"] == "distributor"
         end
 
         def i18n_translate(translation_key)

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/report_service.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/report_service.rb
@@ -25,7 +25,7 @@ module OrderManagement
 
         def enterprise_fee_type_total_list
           enterprise_fees_by_customer.map do |total_data|
-            summarizer = EnterpriseFeeTypeTotalSummarizer.new(total_data)
+            summarizer = Summarizer.new(total_data)
 
             ReportData::EnterpriseFeeTypeTotal.new.tap do |total|
               enterprise_fee_type_summarizer_to_total_attributes.each do |attribute|

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
@@ -31,7 +31,7 @@ module OrderManagement
           include_payment_fee_details
           include_shipping_fee_details
           include_enterprise_fee_details
-          include_line_item_details
+          include_line_item_source_details
           include_incoming_exchange_details
           include_outgoing_exchange_details
 
@@ -169,14 +169,14 @@ module OrderManagement
           )
         end
 
-        # If for line item - Use data only if spree_line_items.id is present
+        # If for line item source - Use data only if spree_line_items.id is present
         #
         # Includes:
         # * Line item
         # * Variant
         # * Product
         # * Tax category of product, if enterprise fee tells to inherit
-        def include_line_item_details
+        def include_line_item_source_details
           join_scope(
             <<-JOIN_STRING.strip_heredoc
               LEFT OUTER JOIN spree_line_items

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
@@ -31,6 +31,7 @@ module OrderManagement
           include_payment_fee_details
           include_shipping_fee_details
           include_enterprise_fee_details
+          include_order_source_details
           include_line_item_source_details
           include_incoming_exchange_details
           include_outgoing_exchange_details
@@ -165,6 +166,30 @@ module OrderManagement
             <<-JOIN_STRING.strip_heredoc
               LEFT OUTER JOIN spree_tax_categories
                 ON (spree_tax_categories.id = enterprise_fees.tax_category_id)
+            JOIN_STRING
+          )
+        end
+
+        # If for order source
+        #
+        # Includes:
+        # * Source order
+        # * Distributor
+        def include_order_source_details
+          join_scope(
+            <<-JOIN_STRING.strip_heredoc
+              LEFT OUTER JOIN spree_orders AS adjustment_source_orders
+                ON (
+                  spree_adjustments.source_type = 'Spree::Order'
+                    AND adjustment_source_orders.id = spree_adjustments.source_id
+                )
+            JOIN_STRING
+          )
+
+          join_scope(
+            <<-JOIN_STRING.strip_heredoc
+              LEFT OUTER JOIN enterprises AS adjustment_source_distributors
+                ON (adjustment_source_distributors.id = adjustment_source_orders.distributor_id)
             JOIN_STRING
           )
         end
@@ -316,7 +341,8 @@ module OrderManagement
             group("enterprise_fees.id", "enterprises.id", "customers.id", "hubs.id",
                   "spree_payment_methods.id", "spree_shipping_methods.id",
                   "adjustment_metadata.enterprise_role", "spree_tax_categories.id",
-                  "product_tax_categories.id", "incoming_exchange_enterprises.id",
+                  "product_tax_categories.id", "spree_adjustments.source_type",
+                  "adjustment_source_distributors.id", "incoming_exchange_enterprises.id",
                   "outgoing_exchange_enterprises.id")
           end
         end
@@ -331,8 +357,11 @@ module OrderManagement
                   enterprise_fees.fee_type AS fee_type, customers.name AS customer_name,
                   customers.email AS customer_email, enterprise_fees.fee_type AS fee_type,
                   enterprise_fees.name AS fee_name, spree_tax_categories.name AS tax_category_name,
+                  enterprise_fees.inherits_tax_category AS enterprise_fee_inherits_tax_category,
                   product_tax_categories.name AS product_tax_category_name,
                   adjustment_metadata.enterprise_role AS placement_enterprise_role,
+                  spree_adjustments.source_type AS adjustment_source_type,
+                  adjustment_source_distributors.name AS adjustment_source_distributor_name,
                   incoming_exchange_enterprises.name AS incoming_exchange_enterprise_name,
                   outgoing_exchange_enterprises.name AS outgoing_exchange_enterprise_name
               JOIN_STRING

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/summarizer.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/summarizer.rb
@@ -19,10 +19,6 @@ module OrderManagement
           data["total_amount"]
         end
 
-        def i18n_translate(translation_key, options = {})
-          I18n.t("order_management.reports.enterprise_fee_summary.#{translation_key}", options)
-        end
-
         private
 
         def representation

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/summarizer.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/summarizer.rb
@@ -1,7 +1,7 @@
 module OrderManagement
   module Reports
     module EnterpriseFeeSummary
-      class EnterpriseFeeTypeTotalSummarizer
+      class Summarizer
         attr_reader :data
 
         delegate :fee_type, :enterprise_name, :fee_name, :fee_placement,

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/summarizer.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/summarizer.rb
@@ -22,7 +22,7 @@ module OrderManagement
         private
 
         def representation
-          @representation ||= representation_klass.new(self)
+          @representation ||= representation_klass.new(data)
         end
 
         def representation_klass

--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
@@ -124,9 +124,9 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
         ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
          nil, nil, nil, "4.00"],
         ["Sales", "Sample Coordinator", "Coordinator Fee 2", "Another Customer",
-         "Coordinator", "All", "Sample Product Tax", "1024.00"],
+         "Coordinator", "All", "Various", "1024.00"],
         ["Sales", "Sample Coordinator", "Coordinator Fee 2", "Sample Customer",
-         "Coordinator", "All", "Sample Product Tax", "2048.00"],
+         "Coordinator", "All", "Various", "2048.00"],
         ["Sales", "Sample Distributor", "Distributor Fee 2", "Another Customer",
          "Outgoing", "Sample Distributor", "Sample Product Tax", "8.00"],
         ["Sales", "Sample Distributor", "Distributor Fee 2", "Sample Customer",
@@ -208,35 +208,53 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
     end
 
     context "with order-based enterprise fee calculator" do
-      let!(:order_cycle) do
-        create(:simple_order_cycle, coordinator: coordinator,
-                                    coordinator_fees: [coordinator_fee])
-      end
-
-      let!(:variant) do
-        prepare_variant(incoming_exchange_fees: variant_incoming_exchange_fees,
-                        outgoing_exchange_fees: variant_outgoing_exchange_fees)
-      end
-      let!(:variant_incoming_exchange_fees) { [producer_fee, coordinator_fee, distributor_fee] }
-      let!(:variant_outgoing_exchange_fees) { [producer_fee, coordinator_fee, distributor_fee] }
-
       let!(:producer_fee) do
-        tax_category = create(:tax_category, name: "Sample Producer Tax")
-        create(:enterprise_fee, :flat_rate, name: "Sample Producer Fee", enterprise: producer,
+        tax_category = create(:tax_category, name: "Producer Tax A")
+        create(:enterprise_fee, :flat_rate, name: "Producer Fee A", enterprise: producer,
                                             fee_type: "sales", tax_category: tax_category,
                                             amount: 10)
       end
       let!(:coordinator_fee) do
-        tax_category = create(:tax_category, name: "Sample Coordinator Tax")
-        create(:enterprise_fee, :flat_rate, name: "Sample Coordinator Fee", enterprise: coordinator,
+        tax_category = create(:tax_category, name: "Coordinator Tax A")
+        create(:enterprise_fee, :flat_rate, name: "Coordinator Fee A", enterprise: coordinator,
                                             fee_type: "admin", tax_category: tax_category,
                                             amount: 15)
       end
-      let!(:distributor_fee) do
-        tax_category = create(:tax_category, name: "Sample Distributor Tax")
-        create(:enterprise_fee, :flat_rate, name: "Sample Distributor Fee", enterprise: distributor,
-                                            fee_type: "admin", tax_category: tax_category,
+      let!(:coordinator_fee_inheriting_product_tax_category) do
+        create(:enterprise_fee, :flat_rate, name: "Coordinator Fee B", enterprise: coordinator,
+                                            fee_type: "admin", inherits_tax_category: true,
                                             amount: 20)
+      end
+      let!(:coordinator_fee_without_tax) do
+        create(:enterprise_fee, :flat_rate, name: "Coordinator Fee C", enterprise: coordinator,
+                                            fee_type: "admin", inherits_tax_category: false,
+                                            amount: 25)
+      end
+      let!(:distributor_fee) do
+        tax_category = create(:tax_category, name: "Distributor Tax A")
+        create(:enterprise_fee, :flat_rate, name: "Distributor Fee A", enterprise: distributor,
+                                            fee_type: "admin", inherits_tax_category: false,
+                                            amount: 30)
+      end
+
+      let!(:coordinator_fees) do
+        [
+          coordinator_fee,
+          coordinator_fee_inheriting_product_tax_category,
+          coordinator_fee_without_tax
+        ]
+      end
+
+      let!(:order_cycle) do
+        create(:simple_order_cycle, coordinator: coordinator, coordinator_fees: coordinator_fees)
+      end
+
+      let!(:variant_incoming_exchange_fees) { [producer_fee, coordinator_fee, distributor_fee] }
+      let!(:variant_outgoing_exchange_fees) { [producer_fee, coordinator_fee, distributor_fee] }
+
+      let!(:variant) do
+        prepare_variant(incoming_exchange_fees: variant_incoming_exchange_fees,
+                        outgoing_exchange_fees: variant_outgoing_exchange_fees)
       end
 
       let!(:customer_order) { prepare_order(customer: customer) }
@@ -244,25 +262,33 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
       it "fetches data correctly" do
         totals = service.list
 
-        expect(totals.length).to eq(9)
+        expect(totals.length).to eq(11)
+
+        entire_orders_text = i18n_translate("fee_calculated_on_transfer_through_entire_orders",
+                                             distributor: "Sample Distributor")
+        various_tax_categories_text = i18n_translate("tax_category_various")
 
         expected_result = [
-          ["Admin", "Sample Coordinator", "Sample Coordinator Fee", "Sample Customer",
-           "Coordinator", "All", "Sample Coordinator Tax", "15.00"],
-          ["Admin", "Sample Coordinator", "Sample Coordinator Fee", "Sample Customer",
-           "Incoming", nil, "Sample Coordinator Tax", "15.00"],
-          ["Admin", "Sample Coordinator", "Sample Coordinator Fee", "Sample Customer",
-           "Outgoing", nil, "Sample Coordinator Tax", "15.00"],
-          ["Admin", "Sample Distributor", "Sample Distributor Fee", "Sample Customer",
-           "Incoming", nil, "Sample Distributor Tax", "20.00"],
-          ["Admin", "Sample Distributor", "Sample Distributor Fee", "Sample Customer",
-           "Outgoing", nil, "Sample Distributor Tax", "20.00"],
+          ["Admin", "Sample Coordinator", "Coordinator Fee A", "Sample Customer",
+           "Coordinator", "All", "Coordinator Tax A", "15.00"],
+          ["Admin", "Sample Coordinator", "Coordinator Fee A", "Sample Customer",
+           "Incoming", entire_orders_text, "Coordinator Tax A", "15.00"],
+          ["Admin", "Sample Coordinator", "Coordinator Fee A", "Sample Customer",
+           "Outgoing", entire_orders_text, "Coordinator Tax A", "15.00"],
+          ["Admin", "Sample Coordinator", "Coordinator Fee B", "Sample Customer",
+           "Coordinator", "All", various_tax_categories_text, "20.00"],
+          ["Admin", "Sample Coordinator", "Coordinator Fee C", "Sample Customer",
+           "Coordinator", "All", nil, "25.00"],
+          ["Admin", "Sample Distributor", "Distributor Fee A", "Sample Customer",
+           "Incoming", entire_orders_text, various_tax_categories_text, "30.00"],
+          ["Admin", "Sample Distributor", "Distributor Fee A", "Sample Customer",
+           "Outgoing", entire_orders_text, various_tax_categories_text, "30.00"],
           ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
            nil, nil, nil, "2.00"],
-          ["Sales", "Sample Producer", "Sample Producer Fee", "Sample Customer",
-           "Incoming", nil, "Sample Producer Tax", "10.00"],
-          ["Sales", "Sample Producer", "Sample Producer Fee", "Sample Customer",
-           "Outgoing", nil, "Sample Producer Tax", "10.00"],
+          ["Sales", "Sample Producer", "Producer Fee A", "Sample Customer",
+           "Incoming", entire_orders_text, "Producer Tax A", "10.00"],
+          ["Sales", "Sample Producer", "Producer Fee A", "Sample Customer",
+           "Outgoing", entire_orders_text, "Producer Tax A", "10.00"],
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
            nil, nil, "Platform Rate", "1.00"]
         ]
@@ -553,6 +579,10 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
   end
 
   # Helper methods for example group
+
+  def i18n_translate(translation_key, options = {})
+    I18n.t("order_management.reports.enterprise_fee_summary.#{translation_key}", options)
+  end
 
   def expect_total_attributes(total, expected_attribute_list)
     actual_attribute_list = [total.fee_type, total.enterprise_name, total.fee_name,

--- a/spec/factories/calculated_adjustment_factory.rb
+++ b/spec/factories/calculated_adjustment_factory.rb
@@ -1,12 +1,23 @@
-attach_per_item_trait = proc do
-  trait :per_item do
-    transient { amount 1 }
-    calculator { build(:calculator_per_item, preferred_amount: amount) }
+FactoryBot.define do
+  factory :calculator_flat_rate, class: Spree::Calculator::FlatRate do
+    preferred_amount { generate(:calculator_amount) }
   end
 end
 
 FactoryBot.modify do
-  factory :payment_method, &attach_per_item_trait
-  factory :shipping_method, &attach_per_item_trait
-  factory :enterprise_fee, &attach_per_item_trait
+  attach_calculator_traits = proc do
+    trait :flat_rate do
+      transient { amount 1 }
+      calculator { build(:calculator_flat_rate, preferred_amount: amount) }
+    end
+
+    trait :per_item do
+      transient { amount 1 }
+      calculator { build(:calculator_per_item, preferred_amount: amount) }
+    end
+  end
+
+  factory :payment_method, &attach_calculator_traits
+  factory :shipping_method, &attach_calculator_traits
+  factory :enterprise_fee, &attach_calculator_traits
 end


### PR DESCRIPTION
#### What? Why?

Relates to #3283 
Closes #2616

Because of constraints in the way we compute and store calculations for order-based calculators, there is no way currently to track the exchange to which an order-based exchange fee is associated, and to break down this fee per line item/variant/supplier.

So, we do not have an existing way to get "Fee Calc on Transfer Through" and "Tax Category" (when the Enterprise Fee itself does not have an associated tax category) for these exchange fees.

As proposed in #3283, we could use "Entire Orders through DISTRIBUTOR_NAME" for these order-absed exchange fees. For "Tax Category", we could use "Various" when there is no associated tax category to the enterprise fee.

#### What should we test?

1. Set up an OC with different enterprises for producer, coordinator, and distributor.
2. Set up an incoming and outgoing exchange for a variant with stock.
3. **Fees for exchanges**: For the incoming exchange and also for the outgoing exchange, add one enterprise fee with order-based calculator (such as "Flat Rate (per order)") for each of the producer, coordinator, and distributor. For testing purposes, one of these enterprise fees should assign a tax category, one should inherit the product's tax category, and one should have no tax category.
4. **Coordinator fees**: Add two "coordinator fees" with order-based calculator to the OC, not to an exchange. For testing purposes, one of these enterprise fees should assign a tax category, one should inherit the product's tax category, and one should have no tax category.
4. Create and complete an order for the variant.
5. Check the Enterprise Fee Summary.
6. For the 6 rows marked "Incoming" / "Outgoing":
    - "Fee Calc on Transfer Through" for the exchange fees should show "Entire Orders through DISTRIBUTOR_NAME".
    - For tax category:
        a. If the enterprise fee itself has a tax category, this should be used.
        b. If the enterprise fee inherits the product's tax category, this should be "Various".
        c. If the enterprise fee has no tax category, this should be blank.
7. For the rows marked "Coordinator":
    - "Fee Calc on Transfer Through" should be "All". For tax category.
    - For tax category: Same as in Step 6.

#### Release notes

No release notes needed as this would be packaged with the rest of the initial changes for the Enterprise Fee Summary.

Changelog Category: -

#### Dependencies

This requires #3319 to be merged to the transitional branch first.