### PR TITLE
[Headless Chrome] Fix embedded_shopfront_spec unhandled alert

### DIFF
--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -115,13 +115,15 @@ feature "Using embedded shopfront functionality", js: true do
   end
 
   def login_with_modal
-    expect(page).to have_selector 'div.login-modal', visible: true
+    page.has_selector? 'div.login-modal', visible: true
 
     within 'div.login-modal' do
       fill_in "Email", with: user.email
       fill_in "Password", with: user.password
       find('input[type="submit"]').click
     end
+
+    page.has_no_selector? 'div.login-modal', visible: true
   end
 
   def logout_via_navigation


### PR DESCRIPTION
#### What? Why?

Fixes a test in #2469 
Closes #2674 

This looks like it could be another flakey one that pops up occasionally based on timing. `Selenium::WebDriver::Error::UnhandledAlertError: unexpected alert open`.

#### What should we test?

No testing. `embedded_shopfront_spec` should be green.
