### PR TITLE
Avoid deprecation warnings of momentjs

### DIFF
--- a/app/views/layouts/_i18n_script.html.haml
+++ b/app/views/layouts/_i18n_script.html.haml
@@ -2,4 +2,4 @@
   I18n.default_locale = "#{I18n.default_locale}";
   I18n.locale = "#{I18n.locale}";
   I18n.fallbacks = true;
-  moment.lang([I18n.locale, 'en']);
+  moment.locale([I18n.locale, 'en']);


### PR DESCRIPTION
#### What? Why?

Closes #3279 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We were seeing a lot of these warnings:

> Deprecation warning: moment.lang is deprecated. Use moment.locale instead.                                                                                                                        |  ETA: ??:??:?? 
> Arguments: 
> [0] 0: en, 1: en
> undefined

#### What should we test?
<!-- List which features should be tested and how. -->

- Log in as admin
- Visit the orders page
- Check that the month of the date is in the right language
- Change languages and check again

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Updated our use of the date calculating library momentjs to stay compatible with future versions.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

