### PR TITLE
[Spree Upgrade] Sets StockLocation.backorderable_default to false in test factories

### DIFF
--- a/app/services/default_stock_location.rb
+++ b/app/services/default_stock_location.rb
@@ -6,7 +6,7 @@ class DefaultStockLocation
   def self.create!
     country = Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
     state = country.states.first
-    Spree::StockLocation.create!(name: NAME, country_id: country.id, state_id: state.id)
+    Spree::StockLocation.create!(name: NAME, country_id: country.id, state_id: state.id, backorderable_default: false)
   end
 
   def self.destroy_all

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -551,19 +551,26 @@ FactoryBot.define do
       on_hand { 5 }
     end
     after(:create) do |product, evaluator|
-      product.variants.first.tap do |variant|
-        variant.on_demand = evaluator.on_demand
-        variant.count_on_hand = evaluator.on_hand
-        variant.save
-      end
+      product.master.on_demand = evaluator.on_demand
+      product.master.on_hand = evaluator.on_hand
+      product.variants.first.on_demand = evaluator.on_demand
+      product.variants.first.on_hand = evaluator.on_hand
     end
   end
 end
 
-
 FactoryBot.modify do
   factory :product do
+    transient do
+      on_hand { 5 }
+    end
+
     primary_taxon { Spree::Taxon.first || FactoryBot.create(:taxon) }
+
+    after(:create) do |product, evaluator|
+      product.master.on_hand = evaluator.on_hand
+      product.variants.first.on_hand = evaluator.on_hand
+    end
   end
 
   factory :base_product do
@@ -661,6 +668,9 @@ FactoryBot.modify do
 
     # Ensures the name attribute is not assigned after instantiating the default location
     transient { name 'default' }
+
+    # sets the default value for variant.on_demand
+    backorderable_default false
   end
 
   factory :shipment, class: Spree::Shipment do

--- a/spec/models/concerns/variant_stock_spec.rb
+++ b/spec/models/concerns/variant_stock_spec.rb
@@ -135,7 +135,7 @@ describe VariantStock do
       let(:variant) { build(:variant) }
 
       it 'returns stock location default' do
-        expect(variant.on_demand).to be_truthy
+        expect(variant.on_demand).to be_falsy
       end
     end
   end

--- a/spec/models/spree/payment_method_spec.rb
+++ b/spec/models/spree/payment_method_spec.rb
@@ -28,16 +28,20 @@ module Spree
     end
 
     it "computes the amount of fees" do
-      pickup = create(:payment_method)
       order = create(:order)
-      expect(pickup.compute_amount(order)).to eq 0
-      transaction = create(:payment_method, calculator: Calculator::FlatRate.new(preferred_amount: 10))
-      expect(transaction.compute_amount(order)).to eq 10
-      transaction = create(:payment_method, calculator: Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10))
-      expect(transaction.compute_amount(order)).to eq 0
+
+      free_payment_method = create(:payment_method) # flat rate calculator with preferred_amount of 0
+      expect(free_payment_method.compute_amount(order)).to eq 0
+
+      flat_rate_payment_method = create(:payment_method, calculator: Calculator::FlatRate.new(preferred_amount: 10))
+      expect(flat_rate_payment_method.compute_amount(order)).to eq 10
+
+      flat_percent_payment_method = create(:payment_method, calculator: Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10))
+      expect(flat_percent_payment_method.compute_amount(order)).to eq 0
+
       product = create(:product)
       order.add_variant(product.master)
-      expect(transaction.compute_amount(order)).to eq 2.0
+      expect(flat_percent_payment_method.compute_amount(order)).to eq 2.0
     end
   end
 end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -711,26 +711,6 @@ module Spree
         e.variants(true).should be_empty
       end
     end
-
-    describe '#on_hand' do
-      let(:product) { create(:product) }
-
-      context 'when the product has variants' do
-        before { create(:variant, product: product) }
-
-        it 'returns the sum of the on_hand of its variants' do
-          expect(product.on_hand).to eq(Float::INFINITY)
-        end
-      end
-
-      context 'when the product has no variants' do
-        before { product.variants.destroy_all }
-
-        it 'returns the on_hand of the master' do
-          expect(product.on_hand).to eq(product.master.on_hand)
-        end
-      end
-    end
   end
 
   describe "product import" do


### PR DESCRIPTION
This makes the default value of variant.on_demand be false

#### What? Why?
Closes #3114
Replaying #3246 but now making the necessary adaptations.

Notes:
I made most changes in one single commit on purpose, these changes are all closely related and are better looked at together.

I had to fix the :product factory modify part and set on_hand default value.
:simple_product is being used in many places and it's property on_demand as well. At some point we have to decide to use either :product or :simple_product. I think we should use :product and delete :simple_product. Something we should do at some point in the future.

#### What should we test?
see 3246 description https://github.com/openfoodfoundation/openfoodnetwork/pull/3246#issue-241033260