### PR TITLE
Fix shipment without fee

### DIFF
--- a/app/models/concerns/order_shipment.rb
+++ b/app/models/concerns/order_shipment.rb
@@ -8,8 +8,12 @@ require 'active_support/concern'
 # for details.
 #
 # Methods in this module may become deprecated.
-module OrderShippingMethod
+module OrderShipment
   extend ActiveSupport::Concern
+
+  def shipment
+    shipments.first
+  end
 
   # Returns the shipping method of the first and only shipment in the order
   #

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -2,14 +2,14 @@ require 'open_food_network/enterprise_fee_calculator'
 require 'open_food_network/distribution_change_validator'
 require 'open_food_network/feature_toggle'
 require 'open_food_network/tag_rule_applicator'
-require 'concerns/order_shipping_method'
+require 'concerns/order_shipment'
 
 ActiveSupport::Notifications.subscribe('spree.order.contents_changed') do |name, start, finish, id, payload|
   payload[:order].reload.update_distribution_charge!
 end
 
 Spree::Order.class_eval do
-  include OrderShippingMethod
+  prepend OrderShipment
 
   belongs_to :order_cycle
   belongs_to :distributor, class_name: 'Enterprise'

--- a/spec/models/concerns/order_shipment_spec.rb
+++ b/spec/models/concerns/order_shipment_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe OrderShippingMethod do
+describe OrderShipment do
   let(:order) { create(:order) }
 
   describe "#shipping_method" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -711,12 +711,9 @@ describe Spree::Order do
       let(:shipping_method) { create(:shipping_method, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 0)) }
 
       it "updates shipping fees" do
-        # Change the shipping method
         order.shipments = [create(:shipment_with, :shipping_method, shipping_method: shipping_method)]
         order.save
 
-        # Check if fees got updated
-        order.reload
         expect(order.adjustment_total).to eq expected_fees - (item_num * shipping_fee)
         expect(order.shipment.adjustment.included_tax).to eq 0
       end


### PR DESCRIPTION
#### What? Why?

Fixes one of the 3 failing specs in #2685

This ensures we can still use Order#shipment although Spree deprecates
it, while fixing a bug at the same time. The problem that was making the
test fail was on `Order#shipment` that Spree defines.

If the shipments association changes, `#shipment` returns stale data.
That is because the order object we might be using is still alive, and
so its @shipment ivar still holds an old shipment object (it's not nil)
and thus `@shipment ||= shipments.last` doesn't evaluate the right-hand
side of the expression.

Note that we need to `prepend` the evaluation of the concern (which it's
been rename) for our methods to take precedence over Spree ones. With
`include`, Spree's `#shipment` would still be picked up making the test
fail.

#### What should we test?
spec/models/spree/order_spec.rb:711 should pass.