### PR TITLE
[Spree Upgrade] Phase 2 - Fix product_importer spec

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -183,7 +183,7 @@ module VariantStock
   # Calling stock_item.adjust_count_on_hand will bypass filling backorders and creating stock movements
   # If that was required we could call self.move
   def overwrite_stock_levels(new_level)
-    stock_item.adjust_count_on_hand(new_level - stock_item.count_on_hand)
+    stock_item.adjust_count_on_hand(new_level.to_i - stock_item.count_on_hand)
   end
 
   # There shouldn't be any other stock items, because we should

--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -163,7 +163,7 @@ module ProductImport
       end
 
       product = Spree::Product.new
-      product.assign_attributes(entry.attributes.except('id'))
+      product.assign_attributes(entry.attributes.except('id', 'on_hand', 'on_demand'))
       product.supplier_id = entry.producer_id
       assign_defaults(product, entry)
 
@@ -249,6 +249,7 @@ module ProductImport
       variant = product.variants.first
       variant.display_name = entry.display_name if entry.display_name
       variant.on_demand = entry.on_demand if entry.on_demand
+      variant.on_hand = entry.on_hand if entry.on_hand
       variant.import_date = @import_time
       variant.save
     end

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -293,9 +293,10 @@ module ProductImport
     end
 
     def convert_to_trusted_type(untrusted_attribute, trusted_attribute)
-      if trusted_attribute.is_a? Integer
+      case trusted_attribute
+      when Integer
         untrusted_attribute.to_i
-      elsif trusted_attribute.is_a? Float
+      when Float
         untrusted_attribute.to_f
       else
         untrusted_attribute.to_s

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -54,7 +54,11 @@ module ProductImport
     end
 
     def mark_as_new_variant(entry, product_id)
-      new_variant = Spree::Variant.new(entry.attributes.except('id', 'product_id'))
+      new_variant = Spree::Variant.new(entry.attributes.except('id', 'product_id', 'on_hand', 'on_demand'))
+      new_variant.save
+      new_variant.on_demand = entry.attributes['on_demand'] if entry.attributes['on_demand'].present?
+      new_variant.on_hand = entry.attributes['on_hand'] if entry.attributes['on_hand'].present?
+
       new_variant.product_id = product_id
       check_on_hand_nil(entry, new_variant)
 
@@ -283,7 +287,11 @@ module ProductImport
     end
 
     def attributes_match?(attribute, existing_product, entry)
-      existing_product.public_send(attribute) == entry.public_send(attribute)
+      if existing_product.public_send(attribute).is_a?(Numeric) || entry.public_send(attribute).is_a?(Numeric)
+        return existing_product.public_send(attribute).to_i == entry.public_send(attribute).to_i
+      else
+        return existing_product.public_send(attribute).to_s == entry.public_send(attribute).to_s
+      end
     end
 
     def attributes_blank?(attribute, existing_product, entry)

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -287,10 +287,18 @@ module ProductImport
     end
 
     def attributes_match?(attribute, existing_product, entry)
-      if existing_product.public_send(attribute).is_a?(Numeric) || entry.public_send(attribute).is_a?(Numeric)
-        return existing_product.public_send(attribute).to_i == entry.public_send(attribute).to_i
+      existing_product_value = existing_product.public_send(attribute)
+      entry_value = entry.public_send(attribute)
+      existing_product_value == convert_to_trusted_type(entry_value, existing_product_value)
+    end
+
+    def convert_to_trusted_type(untrusted_attribute, trusted_attribute)
+      if trusted_attribute.is_a? Integer
+        untrusted_attribute.to_i
+      elsif trusted_attribute.is_a? Float
+        untrusted_attribute.to_f
       else
-        return existing_product.public_send(attribute).to_s == entry.public_send(attribute).to_s
+        untrusted_attribute.to_s
       end
     end
 

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -28,15 +28,17 @@ feature "Product Import", js: true do
   let!(:variant_override) { create(:variant_override, variant_id: product4.variants.first.id, hub: enterprise2, count_on_hand: 42) }
   let!(:variant_override2) { create(:variant_override, variant_id: product5.variants.first.id, hub: enterprise, count_on_hand: 96) }
 
+  let(:shipping_category_id_str) { Spree::ShippingCategory.all.first.id.to_s }
+
   describe "when importing products from uploaded file" do
     before { quick_login_as_admin }
     after { File.delete('/tmp/test.csv') }
 
     xit "validates entries and saves them if they are all valid and allows viewing new items in Bulk Products" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", shipping_category_id_str]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", shipping_category_id_str]
       end
       File.write('/tmp/test.csv', csv_data)
 
@@ -130,9 +132,9 @@ feature "Product Import", js: true do
 
     xit "records a timestamp on import that can be viewed and filtered under Bulk Edit Products" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", shipping_category_id_str]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", shipping_category_id_str]
       end
       File.write('/tmp/test.csv', csv_data)
 
@@ -175,8 +177,8 @@ feature "Product Import", js: true do
 
     xit "can reset product stock to zero for products not present in the CSV" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["Carrots", "User Enterprise", "Vegetables", "500", "3.20", "500", "g"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "500", "3.20", "500", "g", shipping_category_id_str]
       end
       File.write('/tmp/test.csv', csv_data)
 
@@ -202,10 +204,10 @@ feature "Product Import", js: true do
 
     xit "can save a new product and variant of that product at the same time, add variant to existing product" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag"]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag"]
-        csv << ["Beans", "User Enterprise", "Vegetables", "7", "2.50", "250", "g", nil]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name", "shipping_category_id"]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag", shipping_category_id_str]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag", shipping_category_id_str]
+        csv << ["Beans", "User Enterprise", "Vegetables", "7", "2.50", "250", "g", nil, shipping_category_id_str]
       end
       File.write('/tmp/test.csv', csv_data)
 
@@ -337,9 +339,9 @@ feature "Product Import", js: true do
 
     xit "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
-        csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", shipping_category_id_str]
+        csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg", shipping_category_id_str]
       end
       File.write('/tmp/test.csv', csv_data)
 

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'open_food_network/permissions'
 
-xdescribe ProductImport::ProductImporter do
+describe ProductImport::ProductImporter do
   include AuthenticationWorkflow
 
   let!(:admin) { create(:admin_user) }
@@ -42,15 +42,17 @@ xdescribe ProductImport::ProductImporter do
 
   let(:permissions) { OpenFoodNetwork::Permissions.new(user) }
 
+  let(:shipping_category_id_str) { Spree::ShippingCategory.all.first.id.to_s }
+
   describe "importing products from a spreadsheet" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "variant_unit_name", "on_demand"]
-        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", "", ""]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "2", "kg", "", ""]
-        csv << ["Pea Soup", "User Enterprise", "Vegetables", "8", "5.50", "750", "ml", "", "0"]
-        csv << ["Salad", "User Enterprise", "Vegetables", "7", "4.50", "1", "", "bags", ""]
-        csv << ["Hot Cross Buns", "User Enterprise", "Cake", "7", "3.50", "1", "", "buns", "1"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "variant_unit_name", "on_demand", "shipping_category_id"]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", "", "", shipping_category_id_str]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "2", "kg", "", "", shipping_category_id_str]
+        csv << ["Pea Soup", "User Enterprise", "Vegetables", "8", "5.50", "750", "ml", "", "0", shipping_category_id_str]
+        csv << ["Salad", "User Enterprise", "Vegetables", "7", "4.50", "1", "", "bags", "", shipping_category_id_str]
+        csv << ["Hot Cross Buns", "User Enterprise", "Cake", "7", "3.50", "1", "", "buns", "1", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -135,9 +137,9 @@ xdescribe ProductImport::ProductImporter do
   describe "when uploading a spreadsheet with some invalid entries" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["Good Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
-        csv << ["Bad Potatoes", "", "Vegetables", "6", "6.50", "1", ""]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["Good Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", shipping_category_id_str]
+        csv << ["Bad Potatoes", "", "Vegetables", "6", "6.50", "1", "", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -199,9 +201,9 @@ xdescribe ProductImport::ProductImporter do
   describe "adding new variants to existing products and updating exiting products" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
-        csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "5", "5.50", "500", "g", "Preexisting Banana"]
-        csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "6", "3.50", "500", "g", "Emergent Coffee"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name", "shipping_category_id"]
+        csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "5", "5.50", "500", "g", "Preexisting Banana", shipping_category_id_str]
+        csv << ["Hypothetical Cake", "Another Enterprise", "Cake", "6", "3.50", "500", "g", "Emergent Coffee", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -245,9 +247,9 @@ xdescribe ProductImport::ProductImporter do
   describe "adding new product and sub-variant at the same time" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag"]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name", "shipping_category_id"]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag", shipping_category_id_str]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -289,9 +291,9 @@ xdescribe ProductImport::ProductImporter do
   describe "updating various fields" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "on_demand", "sku"]
-        csv << ["Beetroot", "And Another Enterprise", "Vegetables", "5", "3.50", "500", "g", "0", nil]
-        csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "g", "1", "TOMS"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "on_demand", "sku", "shipping_category_id"]
+        csv << ["Beetroot", "And Another Enterprise", "Vegetables", "5", "3.50", "500", "g", "0", nil, shipping_category_id_str]
+        csv << ["Tomato", "And Another Enterprise", "Vegetables", "6", "5.50", "500", "g", "1", "TOMS", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -358,12 +360,12 @@ xdescribe ProductImport::ProductImporter do
   describe "when more than one product of the same name already exists with multiple variants each" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "description", "on_hand", "price", "units", "unit_type", "display_name"]
-        csv << ["Oats", "User Enterprise", "Cereal", "", "50", "3.50", "500", "g", "Rolled Oats"]   # Update
-        csv << ["Oats", "User Enterprise", "Cereal", "", "80", "3.75", "500", "g", "Flaked Oats"]   # Update
-        csv << ["Oats", "User Enterprise", "Cereal", "", "60", "5.50", "500", "g", "Magic Oats"]    # Add
-        csv << ["Oats", "User Enterprise", "Cereal", "", "70", "8.50", "500", "g", "French Oats"]   # Add
-        csv << ["Oats", "User Enterprise", "Cereal", "", "70", "8.50", "500", "g", "Scottish Oats"] # Add
+        csv << ["name", "producer", "category", "description", "on_hand", "price", "units", "unit_type", "display_name", "shipping_category_id"]
+        csv << ["Oats", "User Enterprise", "Cereal", "", "50", "3.50", "500", "g", "Rolled Oats", shipping_category_id_str]   # Update
+        csv << ["Oats", "User Enterprise", "Cereal", "", "80", "3.75", "500", "g", "Flaked Oats", shipping_category_id_str]   # Update
+        csv << ["Oats", "User Enterprise", "Cereal", "", "60", "5.50", "500", "g", "Magic Oats", shipping_category_id_str]    # Add
+        csv << ["Oats", "User Enterprise", "Cereal", "", "70", "8.50", "500", "g", "French Oats", shipping_category_id_str]   # Add
+        csv << ["Oats", "User Enterprise", "Cereal", "", "70", "8.50", "500", "g", "Scottish Oats", shipping_category_id_str] # Add
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -398,12 +400,12 @@ xdescribe ProductImport::ProductImporter do
   describe "when importer processes create and update across multiple stages" do
     before do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
-        csv << ["Bag of Oats", "User Enterprise", "Cereal", "60", "5.50", "500", "g", "Magic Oats"]     # Add
-        csv << ["Bag of Oats", "User Enterprise", "Cereal", "70", "8.50", "500", "g", "French Oats"]    # Add
-        csv << ["Bag of Oats", "User Enterprise", "Cereal", "80", "9.50", "500", "g", "Organic Oats"]   # Add
-        csv << ["Bag of Oats", "User Enterprise", "Cereal", "90", "7.50", "500", "g", "Scottish Oats"]  # Add
-        csv << ["Bag of Oats", "User Enterprise", "Cereal", "30", "6.50", "500", "g", "Breakfast Oats"] # Add
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name", "shipping_category_id"]
+        csv << ["Bag of Oats", "User Enterprise", "Cereal", "60", "5.50", "500", "g", "Magic Oats", shipping_category_id_str]     # Add
+        csv << ["Bag of Oats", "User Enterprise", "Cereal", "70", "8.50", "500", "g", "French Oats", shipping_category_id_str]    # Add
+        csv << ["Bag of Oats", "User Enterprise", "Cereal", "80", "9.50", "500", "g", "Organic Oats", shipping_category_id_str]   # Add
+        csv << ["Bag of Oats", "User Enterprise", "Cereal", "90", "7.50", "500", "g", "Scottish Oats", shipping_category_id_str]  # Add
+        csv << ["Bag of Oats", "User Enterprise", "Cereal", "30", "6.50", "500", "g", "Breakfast Oats", shipping_category_id_str] # Add
       end
       File.write('/tmp/test-m.csv', csv_data)
       @file = File.new('/tmp/test-m.csv')
@@ -517,9 +519,9 @@ xdescribe ProductImport::ProductImporter do
 
     it "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
-        csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["My Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", shipping_category_id_str]
+        csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -601,9 +603,9 @@ xdescribe ProductImport::ProductImporter do
 
     it "can reset all products for an enterprise that are not present in the uploaded file to zero stock" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g"]
-        csv << ["Beans", "User Enterprise", "Vegetables", "6", "6.50", "500", "g"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", shipping_category_id_str]
+        csv << ["Beans", "User Enterprise", "Vegetables", "6", "6.50", "500", "g", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -681,9 +683,9 @@ xdescribe ProductImport::ProductImporter do
 
     it "can overwrite fields with selected defaults when importing to product list" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "tax_category_id", "available_on"]
-        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.id, ""]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", "", ""]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "tax_category_id", "available_on", "shipping_category_id"]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", tax_category.id, "", shipping_category_id_str]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg", "", "", shipping_category_id_str]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')


### PR DESCRIPTION
Added now mandatory shipping_category_id to CSVs in PI tests
Adapted VariantStock to handle on_hand string values
Adapted EntryValidator and EntryProcessor to new VariantStock logic where on_hand is set at variant level, not at product level

#### What? Why?

Part of #2791

#### What should we test?
with this PR and #3328 and #3347:
models/product_importer_spec and features/admin/product_import_spec should both be green (29 specs fixed!)

Only spec/models/product_importer_spec.rb:684 is still broken, see #2783 
