### PR TITLE
Fix wording in email template for orders confirmation

### DIFF
--- a/app/views/spree/order_mailer/_shipping.html.haml
+++ b/app/views/spree/order_mailer/_shipping.html.haml
@@ -50,6 +50,6 @@
   - if @order.order_cycle.andand.pickup_instructions_for(@order.distributor).present?
     %p
       %strong
-        = t :email_shipping_collection_time
+        = t :email_shipping_collection_instructions
       %br
       #{@order.order_cycle.pickup_instructions_for(@order.distributor)}


### PR DESCRIPTION
#### What? Why?

Change one label in email template for confirmation of orders.
Now "Ready for" (collection time) is not repeated in place of "Collection
details" (collection instructions)

Closes #3063 

I got to the same conclusion as @lbwright22 :

> You need to change the code in app/views/spree/order_mailer/_shipping.html.haml which accidentally uses the same translation twice. The second time it should use a different text. It's probably a copy&paste error.

#### What should we test?

In order to test it completely, one must:
1. Prepare from admin page a test order cycle with:
  * pickup shipment available
  * custom messages for pickup details at the "Outgoing" distributors table.
2. Place an order from customers UI with:
  * a valid email to receive the confirmation
  * the prepared pickup option as shipment
3. Check in confirmation page and email whether:
  * pickup details custom message is preceded by "ready for" (wrong) or "collection instructions" (right)

Please, check the email message, I didn't do it because I have a simple dev environment and lack access to a testing instance with a configured SMTP provider.

#### Release notes

Fix wording in email template for orders confirmation

Changelog Category: Changed

#### How is this related to the Spree upgrade?
not related

#### Discourse thread
https://community.openfoodnetwork.org.uk/t/wording-of-order-confirmation-email/376

#### Dependencies
none

#### Documentation updates
none