### PR TITLE
[Spree upgrade] Workaround Rails inheritance bug in Spree::Gateway

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -8,6 +8,16 @@
 
 require 'spree/product_filters'
 
+# Due to a bug in ActiveRecord we need to load the tagging code in Gateway which
+# should have inherited it from its parent PaymentMethod.
+# We have to call it before loading the PaymentMethod decorator because the
+# tagging code won't load twice within the inheritance chain.
+# https://github.com/openfoodfoundation/openfoodnetwork/issues/3121
+Spree::Gateway.class_eval do
+  acts_as_taggable
+  attr_accessible :tag_list
+end
+
 require "#{Rails.root}/app/models/spree/payment_method_decorator"
 require "#{Rails.root}/app/models/spree/gateway_decorator"
 

--- a/spec/models/spree/gateway_tagging_spec.rb
+++ b/spec/models/spree/gateway_tagging_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+# An inheritance bug made these specs fail.
+# See config/initializers/spree.rb
+shared_examples "taggable" do |parameter|
+  it "uses the given parameter" do
+    expect(subject.tag_list).to eq []
+  end
+end
+
+module Spree
+  describe PaymentMethod do
+    it_behaves_like "taggable"
+  end
+
+  describe Gateway do
+    it_behaves_like "taggable"
+  end
+
+  describe Gateway::PayPalExpress do
+    it_behaves_like "taggable"
+  end
+
+  describe Gateway::StripeConnect do
+    it_behaves_like "taggable"
+  end
+end

--- a/spec/models/spree/gateway_tagging_spec.rb
+++ b/spec/models/spree/gateway_tagging_spec.rb
@@ -1,27 +1,56 @@
 require "spec_helper"
 
-# An inheritance bug made these specs fail.
-# See config/initializers/spree.rb
-shared_examples "taggable" do |parameter|
-  it "uses the given parameter" do
+# We extended Spree::PaymentMethod to be taggable. Unfortunately, an inheritance
+# bug prevented the taggable code to be passed on to the descendants of
+# PaymentMethod. We fixed that in config/initializers/spree.rb.
+#
+# This spec tests several descendants for their taggability. The tests are in
+# a separate file, because they cover one aspect of several classes.
+shared_examples "taggable" do |expected_taggable_type|
+  it "provides a tag list" do
     expect(subject.tag_list).to eq []
+  end
+
+  it "stores tags for the root taggable type" do
+    subject.tag_list.add("one")
+    subject.save!
+
+    expect(subject.taggings.last.taggable_type).to eq expected_taggable_type
   end
 end
 
 module Spree
-  describe PaymentMethod do
-    it_behaves_like "taggable"
-  end
+  describe "PaymentMethod and descendants" do
 
-  describe Gateway do
-    it_behaves_like "taggable"
-  end
+    let(:shop) { create(:enterprise) }
+    let(:valid_subject) do
+      # Supply required parameters so that it can be saved to attach taggings.
+      described_class.new(
+        name: "Some payment method",
+        distributor_ids: [shop.id]
+      )
+    end
+    subject { valid_subject }
 
-  describe Gateway::PayPalExpress do
-    it_behaves_like "taggable"
-  end
+    describe PaymentMethod do
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
 
-  describe Gateway::StripeConnect do
-    it_behaves_like "taggable"
+    describe Gateway do
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
+
+    describe Gateway::PayPalExpress do
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
+
+    describe Gateway::StripeConnect do
+      subject do
+        # StripeConnect needs an owner to be valid.
+        valid_subject.tap { |m| m.preferred_enterprise_id = shop.id }
+      end
+
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
   end
 end


### PR DESCRIPTION

#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/3121

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Due to a bug in ActiveRecord we need to load the tagging code in Gateway which should have inherited it from its parent PaymentMethod. We have to call it before loading the PaymentMethod decorator because the tagging code won't load twice within the inheritance chain.

I tested what happens when you assign tags to a PayPalExpress gateway and they are correctly stored with `:taggable_type => "Spree::PaymentMethod"`.

I also considered a tagging implementation that doesn't require decorating, but we would be working against the used gem which assumes to be called on the tagged ActiveRecord model. It may still be an option, but needs deeper study of the acts_as_taggable_on code.


#### What should we test?
<!-- List which features should be tested and how. -->

If we test this: Create a PayPal payment method from the admin interface.

Please note: the affected `spec/features/admin/payment_method_spec.rb:72` executes further, but does not pass. The following failure means that this pull request is successful:
```
     Failure/Error: expect(page).to have_field 'Password', with: ''
       expected to find visible field "Password" that is not disabled with value "" but there were no matches. Also found "", which matched the selector but not all filters.
     # ./spec/features/admin/payment_method_spec.rb:108:in `block (2 levels) in <top (required)>'
```

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

This is part of the Spree upgrade.

