### PR TITLE
[Spree Upgrade] Fix xero invoices specs in reports_spec

### DIFF
--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -410,115 +410,119 @@ xfeature %q{
     let(:product1) { create(:taxed_product, zone: zone, price: 12.54, tax_rate_amount: 0, sku: 'sku1') }
     let(:product2) { create(:taxed_product, zone: zone, price: 500.15, tax_rate_amount: 0.2, sku: 'sku2') }
 
-    let!(:line_item1) { create(:line_item, variant: product1.master, price: 12.54, quantity: 1, order: order1) }
-    let!(:line_item2) { create(:line_item, variant: product2.master, price: 500.15, quantity: 3, order: order1) }
-
-    let!(:adj_shipping) { create(:adjustment, adjustable: order1, label: "Shipping", originator: shipping_method, amount: 100.55, included_tax: 10.06) }
-    let!(:adj_fee1) { create(:adjustment, adjustable: order1, originator: enterprise_fee1, label: "Enterprise fee untaxed", amount: 10, included_tax: 0) }
-    let!(:adj_fee2) { create(:adjustment, adjustable: order1, originator: enterprise_fee2, label: "Enterprise fee taxed", amount: 20, included_tax: 2) }
-    let!(:adj_manual1) { create(:adjustment, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 30, included_tax: 0) }
-    let!(:adj_manual2) { create(:adjustment, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 40, included_tax: 3) }
-
-
     before do
-      order1.update_attribute :email, 'customer@email.com'
-      Timecop.travel(Time.zone.local(2015, 4, 25, 14, 0, 0)) { order1.finalize! }
-
-      quick_login_as_admin
-      visit spree.admin_reports_path
-
-      click_link 'Xero Invoices'
+      Spree::Config.shipment_inc_vat = true
+      Spree::Config.shipping_tax_rate = 0.1
     end
 
-    around do |example|
-      Timecop.travel(Time.zone.local(2015, 4, 26, 14, 0, 0)) do
-        example.run
-      end
-    end
+    describe "with adjustments" do
+      let!(:line_item1) { create(:line_item, variant: product1.master, price: 12.54, quantity: 1, order: order1) }
+      let!(:line_item2) { create(:line_item, variant: product2.master, price: 500.15, quantity: 3, order: order1) }
 
-    it "shows Xero invoices report" do
-      click_button "Search"
-      expect(xero_invoice_table).to match_table [
-        xero_invoice_header,
-        xero_invoice_summary_row('Total untaxable produce (no tax)',       12.54, 'GST Free Income'),
-        xero_invoice_summary_row('Total taxable produce (tax inclusive)',  1500.45, 'GST on Income'),
-        xero_invoice_summary_row('Total untaxable fees (no tax)',          10.0, 'GST Free Income'),
-        xero_invoice_summary_row('Total taxable fees (tax inclusive)',     20.0, 'GST on Income'),
-        xero_invoice_summary_row('Delivery Shipping Cost (tax inclusive)', 100.55, 'GST on Income'),
-        xero_invoice_summary_row('Total untaxable admin adjustments (no tax)',      30.0, 'GST Free Income'),
-        xero_invoice_summary_row('Total taxable admin adjustments (tax inclusive)', 40.0, 'GST on Income')
-      ]
-    end
-
-    it "can customise a number of fields" do
-      fill_in 'initial_invoice_number', with: '5'
-      fill_in 'invoice_date', with: '2015-02-12'
-      fill_in 'due_date', with: '2015-03-12'
-      fill_in 'account_code', with: 'abc123'
-      click_button 'Search'
-
-      opts = {invoice_number: '5', invoice_date: '2015-02-12', due_date: '2015-03-12', account_code: 'abc123'}
-
-      expect(xero_invoice_table).to match_table [
-        xero_invoice_header,
-        xero_invoice_summary_row('Total untaxable produce (no tax)',       12.54,   'GST Free Income', opts),
-        xero_invoice_summary_row('Total taxable produce (tax inclusive)',  1500.45, 'GST on Income',   opts),
-        xero_invoice_summary_row('Total untaxable fees (no tax)',          10.0,    'GST Free Income', opts),
-        xero_invoice_summary_row('Total taxable fees (tax inclusive)',     20.0,    'GST on Income',   opts),
-        xero_invoice_summary_row('Delivery Shipping Cost (tax inclusive)', 100.55,  'GST on Income',   opts),
-        xero_invoice_summary_row('Total untaxable admin adjustments (no tax)',      30.0, 'GST Free Income', opts),
-        xero_invoice_summary_row('Total taxable admin adjustments (tax inclusive)', 40.0, 'GST on Income',   opts)
-      ]
-    end
-
-    it "generates a detailed report" do
-      select 'Detailed', from: 'report_type'
-      click_button 'Search'
-
-      opts = {}
-
-      expect(xero_invoice_table).to match_table [
-        xero_invoice_header,
-        xero_invoice_li_row(line_item1),
-        xero_invoice_li_row(line_item2),
-        xero_invoice_adjustment_row(adj_manual1),
-        xero_invoice_adjustment_row(adj_manual2),
-        xero_invoice_summary_row('Total untaxable fees (no tax)',          10.0,    'GST Free Income', opts),
-        xero_invoice_summary_row('Total taxable fees (tax inclusive)',     20.0,    'GST on Income',   opts),
-        xero_invoice_summary_row('Delivery Shipping Cost (tax inclusive)', 100.55,  'GST on Income',   opts)
-      ]
-    end
-
-    describe "account invoices" do
-      let(:accounts_distributor)  { create(:distributor_enterprise) }
-      let(:billable_period) { create(:billable_period, account_invoice: account_invoice) }
-      let(:account_invoice) { create(:account_invoice, order: account_invoice_order) }
-      let!(:account_invoice_order) { create(:order, order_cycle: order_cycle, distributor: accounts_distributor) }
-      let!(:adjustment) { create(:adjustment, adjustable: account_invoice_order, source: billable_period, label: 'Account invoice item', amount: 12.34) } # Tax?
+      let!(:adj_fee1) { create(:adjustment, adjustable: order1, originator: enterprise_fee1, label: "Enterprise fee untaxed", amount: 10, included_tax: 0) }
+      let!(:adj_fee2) { create(:adjustment, adjustable: order1, originator: enterprise_fee2, label: "Enterprise fee taxed", amount: 20, included_tax: 2) }
+      let!(:adj_manual1) { create(:adjustment, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 30, included_tax: 0) }
+      let!(:adj_manual2) { create(:adjustment, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 40, included_tax: 3) }
 
       before do
-        Spree::Config.accounts_distributor_id = accounts_distributor.id
+        order1.update_attribute :email, 'customer@email.com'
+        Timecop.travel(Time.zone.local(2015, 4, 25, 14, 0, 0)) { order1.finalize! }
 
-        account_invoice_order.update_attribute :email, 'customer@email.com'
-        Timecop.travel(Time.zone.local(2015, 4, 25, 14, 0, 0)) { account_invoice_order.finalize! }
+        quick_login_as_admin
+        visit spree.admin_reports_path
 
-        visit current_path
+        click_link 'Xero Invoices'
       end
 
-      it "generates a detailed report for account invoices" do
+      around do |example|
+        Timecop.travel(Time.zone.local(2015, 4, 26, 14, 0, 0)) do
+          example.run
+        end
+      end
+
+      it "shows Xero invoices report" do
+        click_button "Search"
+        expect(xero_invoice_table).to match_table [
+          xero_invoice_header,
+          xero_invoice_summary_row('Total untaxable produce (no tax)',       12.54, 'GST Free Income'),
+          xero_invoice_summary_row('Total taxable produce (tax inclusive)',  1500.45, 'GST on Income'),
+          xero_invoice_summary_row('Total untaxable fees (no tax)',          10.0, 'GST Free Income'),
+          xero_invoice_summary_row('Total taxable fees (tax inclusive)',     20.0, 'GST on Income'),
+          xero_invoice_summary_row('Delivery Shipping Cost (tax inclusive)', 100.55, 'GST on Income'),
+          xero_invoice_summary_row('Total untaxable admin adjustments (no tax)',      30.0, 'GST Free Income'),
+          xero_invoice_summary_row('Total taxable admin adjustments (tax inclusive)', 40.0, 'GST on Income')
+        ]
+      end
+
+      it "can customise a number of fields" do
+        fill_in 'initial_invoice_number', with: '5'
+        fill_in 'invoice_date', with: '2015-02-12'
+        fill_in 'due_date', with: '2015-03-12'
+        fill_in 'account_code', with: 'abc123'
+        click_button 'Search'
+
+        opts = {invoice_number: '5', invoice_date: '2015-02-12', due_date: '2015-03-12', account_code: 'abc123'}
+
+        expect(xero_invoice_table).to match_table [
+          xero_invoice_header,
+          xero_invoice_summary_row('Total untaxable produce (no tax)',       12.54,   'GST Free Income', opts),
+          xero_invoice_summary_row('Total taxable produce (tax inclusive)',  1500.45, 'GST on Income',   opts),
+          xero_invoice_summary_row('Total untaxable fees (no tax)',          10.0,    'GST Free Income', opts),
+          xero_invoice_summary_row('Total taxable fees (tax inclusive)',     20.0,    'GST on Income',   opts),
+          xero_invoice_summary_row('Delivery Shipping Cost (tax inclusive)', 100.55,  'GST on Income',   opts),
+          xero_invoice_summary_row('Total untaxable admin adjustments (no tax)',      30.0, 'GST Free Income', opts),
+          xero_invoice_summary_row('Total taxable admin adjustments (tax inclusive)', 40.0, 'GST on Income',   opts)
+        ]
+      end
+
+      it "generates a detailed report" do
         select 'Detailed', from: 'report_type'
-        select accounts_distributor.name, from: 'q_distributor_id_eq'
         click_button 'Search'
 
         opts = {}
 
         expect(xero_invoice_table).to match_table [
           xero_invoice_header,
-          xero_invoice_account_invoice_row(adjustment)
+          xero_invoice_li_row(line_item1),
+          xero_invoice_li_row(line_item2),
+          xero_invoice_adjustment_row(adj_manual1),
+          xero_invoice_adjustment_row(adj_manual2),
+          xero_invoice_summary_row('Total untaxable fees (no tax)',          10.0,    'GST Free Income', opts),
+          xero_invoice_summary_row('Total taxable fees (tax inclusive)',     20.0,    'GST on Income',   opts),
+          xero_invoice_summary_row('Delivery Shipping Cost (tax inclusive)', 100.55,  'GST on Income',   opts)
         ]
       end
-    end
 
+      describe "account invoices" do
+        let(:accounts_distributor)  { create(:distributor_enterprise) }
+        let(:billable_period) { create(:billable_period, account_invoice: account_invoice) }
+        let(:account_invoice) { create(:account_invoice, order: account_invoice_order) }
+        let!(:account_invoice_order) { create(:order, order_cycle: order_cycle, distributor: accounts_distributor) }
+        let!(:adjustment) { create(:adjustment, adjustable: account_invoice_order, source: billable_period, label: 'Account invoice item', amount: 12.34) } # Tax?
+
+        before do
+          Spree::Config.accounts_distributor_id = accounts_distributor.id
+
+          account_invoice_order.update_attribute :email, 'customer@email.com'
+          Timecop.travel(Time.zone.local(2015, 4, 25, 14, 0, 0)) { account_invoice_order.finalize! }
+
+          visit current_path
+        end
+
+        it "generates a detailed report for account invoices" do
+          select 'Detailed', from: 'report_type'
+          select accounts_distributor.name, from: 'q_distributor_id_eq'
+          click_button 'Search'
+
+          opts = {}
+
+          expect(xero_invoice_table).to match_table [
+            xero_invoice_header,
+            xero_invoice_account_invoice_row(adjustment)
+          ]
+        end
+      end
+    end
 
     private
 


### PR DESCRIPTION
#### What? Why?

Part of  #2792 
This spec was adding the shipping adjustment manually but the adjustment is now already there as the callbacks do the job when the line items are added to the order. The adjustment the callbacks add is exactly the same as the one that was injected manually before, to get that we just need to set the included_tax config option.

#### What should we test?
3 specs fixed in Job 1 - spec/features/admin/reports_spec.rb:434
Only one spec missing in reports_spec.rb but it is related to account invoices.