### PR TITLE
[Spree Upgrade] Fix order_cycle_management_report shipping methods filter

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -107,7 +107,7 @@ module OpenFoodNetwork
 
     def filter_to_shipping_method(orders)
       if params[:shipping_method_in].present?
-        orders.joins(shipments: :shipping_methods).where(shipping_method_id: params[:shipping_method_in])
+        orders.joins(shipments: :shipping_rates).where(spree_shipping_rates: { shipping_method_id: params[:shipping_method_in] })
       else
         orders
       end


### PR DESCRIPTION
The original fix to adapt to v2 was wrong and still using deprecated order.shipping_method_id, this new version is now filtering the correct shipping_method_id in shipping_rates

#### What? Why?

Closes #3020

#### What should we test?
spec/lib/open_food_network/order_cycle_management_report_spec should be green.
