### PR TITLE
Add missing 'active products' translation on dashboard

### DIFF
--- a/app/views/spree/admin/overview/_products.html.haml
+++ b/app/views/spree/admin/overview/_products.html.haml
@@ -21,7 +21,7 @@
     - else
       %div.seven.columns.alpha.list-item.red
         %span.six.columns.alpha
-          = t "spree_admin_enterprises_any_active_products_text"
+          = t(".active_products", count: @product_count )
         %span.one.column.omega
           %span.icon-remove-sign
       %a.seven.columns.alpha.button.bottom.red{ href: "#{new_admin_product_path}" }

--- a/app/views/spree/admin/overview/_products.html.haml
+++ b/app/views/spree/admin/overview/_products.html.haml
@@ -12,7 +12,10 @@
     - if @product_count > 0
       %div.seven.columns.alpha.list-item
         %span.six.columns.alpha
-          = t(".you_have") + " #{@product_count} #{@product_count > 1 ? t(".active_products") : t(".active_product")}."
+          - if @product_count == 1
+            = t(".active_products_count_single", product_count: @product_count )
+          - else
+            = t(".active_products_count_multiple", product_count: @product_count )
         %span.one.column.omega
           %span.icon-ok-sign
       %a.seven.columns.alpha.button.bottom.blue{ href: "#{admin_products_path}" }

--- a/app/views/spree/admin/overview/_products.html.haml
+++ b/app/views/spree/admin/overview/_products.html.haml
@@ -12,10 +12,7 @@
     - if @product_count > 0
       %div.seven.columns.alpha.list-item
         %span.six.columns.alpha
-          - if @product_count == 1
-            = t(".active_products_count_single", product_count: @product_count )
-          - else
-            = t(".active_products_count_multiple", product_count: @product_count )
+          = t(".active_products", count: @product_count )
         %span.one.column.omega
           %span.icon-ok-sign
       %a.seven.columns.alpha.button.bottom.blue{ href: "#{admin_products_path}" }

--- a/app/views/spree/admin/overview/_products.html.haml
+++ b/app/views/spree/admin/overview/_products.html.haml
@@ -12,7 +12,7 @@
     - if @product_count > 0
       %div.seven.columns.alpha.list-item
         %span.six.columns.alpha
-          = "You have #{@product_count} active product#{@product_count > 1 ? "s" : ""}."
+          = t(".you_have") + " #{@product_count} #{@product_count > 1 ? t(".active_products") : t(".active_product")}."
         %span.one.column.omega
           %span.icon-ok-sign
       %a.seven.columns.alpha.button.bottom.blue{ href: "#{admin_products_path}" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2717,8 +2717,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             order_cycle: "Order cycle:"
       overview:
         products:
-          active_products_count_single: "You have %{product_count} active product"
-          active_products_count_multiple: "You have %{product_count} active products"
+          active_products:
+            one: "You have one active product"
+            other: "You have %{count} active products"
         order_cycles:
           order_cycles: "Order Cycles"
           order_cycles_tip: "Order cycles determine when and where your products are available to customers."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2717,9 +2717,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             order_cycle: "Order cycle:"
       overview:
         products:
-          you_have: "You have"
-          active_products: "active products"
-          active_product: "active product"
+          active_products_count_single: "You have %{product_count} active product"
+          active_products_count_multiple: "You have %{product_count} active products"
         order_cycles:
           order_cycles: "Order Cycles"
           order_cycles_tip: "Order cycles determine when and where your products are available to customers."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2149,7 +2149,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_admin_enterprises_none_text: "You don't have any enterprises yet"
   spree_admin_enterprises_tabs_hubs: "HUBS"
   spree_admin_enterprises_producers_manage_products: "MANAGE PRODUCTS"
-  spree_admin_enterprises_any_active_products_text: "You don't have any active products."
   spree_admin_enterprises_create_new_product: "CREATE A NEW PRODUCT"
   spree_admin_single_enterprise_alert_mail_confirmation: "Please confirm the email address for"
   spree_admin_single_enterprise_alert_mail_sent: "We've sent an email to"
@@ -2718,6 +2717,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       overview:
         products:
           active_products:
+            zero: "You don't have any active products."
             one: "You have one active product"
             other: "You have %{count} active products"
         order_cycles:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2716,6 +2716,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             distributor: "Distributor:"
             order_cycle: "Order cycle:"
       overview:
+        products:
+          you_have: "You have"
+          active_products: "active products"
+          active_product: "active product"
         order_cycles:
           order_cycles: "Order Cycles"
           order_cycles_tip: "Order cycles determine when and where your products are available to customers."


### PR DESCRIPTION
#### What? Why?

Closes [#3290]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The admin dashboard is missing a translation for "You have XX active products".

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added missing translation for "You have XX active products" in admin dashboard.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed