### PR TITLE
Use patch to hide Paypal gateway password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-0-stable'
 # Our branch contains two changes
 # - Pass customer email and phone number to PayPal (merged to upstream master)
 # - Change type of password from string to password to hide it in the form
-gem 'spree_paypal_express', github: "spree-contrib/better_spree_paypal_express", branch: "2-0-stable"
+gem 'spree_paypal_express', github: "openfoodfoundation/better_spree_paypal_express", branch: "2-0-stable"
 gem 'stripe', '~> 3.3.2'
 # We need at least this version to have Digicert's root certificate
 # which is needed for Pin Payments (and possibly others).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,15 @@ GIT
     custom_error_message (1.1.1)
 
 GIT
+  remote: https://github.com/openfoodfoundation/better_spree_paypal_express.git
+  revision: 27ad7165ea4c6e8c5f120b42b676cb9c2c272100
+  branch: 2-0-stable
+  specs:
+    spree_paypal_express (2.0.3)
+      paypal-sdk-merchant (= 1.106.1)
+      spree_core (~> 2.0.3)
+
+GIT
   remote: https://github.com/openfoodfoundation/ofn-qz.git
   revision: 60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c
   ref: 60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c
@@ -76,15 +85,6 @@ GIT
       stringex (~> 1.5.1)
     spree_sample (2.0.4)
       spree_core (= 2.0.4)
-
-GIT
-  remote: https://github.com/spree-contrib/better_spree_paypal_express.git
-  revision: 1206925d1c85bdc4b68b728d6676150ab0785486
-  branch: 2-0-stable
-  specs:
-    spree_paypal_express (2.0.3)
-      paypal-sdk-merchant (= 1.106.1)
-      spree_core (~> 2.0.3)
 
 GIT
   remote: https://github.com/spree/spree_auth_devise.git


### PR DESCRIPTION
#### What? Why?

Closes #3379

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

When we updated our Gemfile for the Spree upgrade, we chose Spree's original 2-0-stable branch of better_spree_paypal_express. We would like to keep our two patches though. One of the two patches changes the password field to the type `password` and therefore hiding the password on the screen. 

#### What should we test?
<!-- List which features should be tested and how. -->

`./spec/features/admin/payment_method_spec.rb:72` should pass. No user testing required.

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

This depends on #3370 to make the spec pass.