### PR TITLE
[ISSUE-3348] LC: Fix moment.js deprecation warning

### DIFF
--- a/app/assets/javascripts/darkswarm/filters/dates.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/dates.js.coffee
@@ -4,7 +4,7 @@ Darkswarm.filter "date_in_words", ->
 
 Darkswarm.filter "sensible_timeframe", (date_in_wordsFilter)->
   (date) ->
-    if moment().add('days', 2) < moment(date)
+    if moment().add(2, 'days') < moment(date)
       t 'orders_open'
     else
       t('closing') + date_in_wordsFilter(date)


### PR DESCRIPTION
#### What? Why?

Closes #3348

Calling `moment().add(period, number)` is deprecated so changed it to `moment().add(number, period) `

#### What should we test?

- Check the shops page for displaying shops that have open order cycles.
- Test if the deprecation warning has gone. (dev task)

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Deprecated

I hope it's all good.
Tks
Leandro.