### PR TITLE
[Product Import] Process only one batch of rows at a time

### DIFF
--- a/app/assets/javascripts/admin/product_import/controllers/import_form_controller.js.coffee
+++ b/app/assets/javascripts/admin/product_import/controllers/import_form_controller.js.coffee
@@ -10,6 +10,7 @@ angular.module("admin.productImport").controller "ImportFormCtrl", ($scope, $htt
   $scope.updated_ids = []
   $scope.update_errors = []
 
+  $scope.batchSize = 50
   $scope.step = 'settings'
   $scope.chunks = 0
   $scope.completed = 0
@@ -51,14 +52,13 @@ angular.module("admin.productImport").controller "ImportFormCtrl", ($scope, $htt
   $scope.start = () ->
     $scope.started = true
     total = ams_data.item_count
-    size = 50
-    $scope.chunks = Math.ceil(total / size)
+    $scope.chunks = Math.ceil(total / $scope.batchSize)
 
     i = 0
 
     while i < $scope.chunks
-      start = (i*size)+1
-      end = (i+1)*size
+      start = (i * $scope.batchSize) + 1
+      end = (i + 1) * $scope.batchSize
       if $scope.step == 'import'
         $scope.processImport(start, end)
       if $scope.step == 'save'

--- a/app/assets/javascripts/admin/product_import/controllers/import_form_controller.js.coffee
+++ b/app/assets/javascripts/admin/product_import/controllers/import_form_controller.js.coffee
@@ -54,16 +54,24 @@ angular.module("admin.productImport").controller "ImportFormCtrl", ($scope, $htt
     total = ams_data.item_count
     $scope.chunks = Math.ceil(total / $scope.batchSize)
 
-    i = 0
+    # Process only the first batch.
+    $scope.processBatch($scope.step, 0, $scope.chunks)
 
-    while i < $scope.chunks
-      start = (i * $scope.batchSize) + 1
-      end = (i + 1) * $scope.batchSize
-      if $scope.step == 'import'
-        $scope.processImport(start, end)
-      if $scope.step == 'save'
-        $scope.processSave(start, end)
-      i++
+  $scope.processBatch = (step, batchIndex, batchCount) ->
+    start = (batchIndex * $scope.batchSize) + 1
+    end = (batchIndex + 1) * $scope.batchSize
+    withNextBatch = batchIndex + 1 < batchCount
+
+    promise = if step == 'import'
+      $scope.processImport(start, end)
+    else if step == 'save'
+      $scope.processSave(start, end)
+
+    processNextBatch = ->
+      $scope.processBatch(step, batchIndex + 1, batchCount)
+
+    # Process next batch whether or not processing of the current batch succeeds.
+    promise.then(processNextBatch, processNextBatch) if withNextBatch
 
   $scope.processImport = (start, end) ->
     $http(


### PR DESCRIPTION
#### What? Why?

Addresses #3384 

There doesn't seem to be JS or feature tests for the batch processing in particular. I'll work on adding these tests in a separate PR.

#### What should we test?

Do this for product import and inventory import:

1. Prepare a CSV file with more than 120 lines.
2. (For Chrome) Open the Network panel of Developer Tools. Filter results to `_data`: We want to see requests for `validate_data` and `save_data`.
3. Upload the file.
4. When the file is being validated, there should be 3 HTTP requests for `validate_data` that are not simultaneous but happen one at a time.
5. When the file is being saved, there should be 3 HTTP requests for `save_data` that happen also one at a time.
6. Test a random row from each batch of 50. The row should have been processed successfully.
7. Introduce an invalid row to each batch, and upload the file.
8. The validation errors for each of these invalid rows should show.

#### Release notes

- Change processing by batch of rows in product import and inventory import CSV files to happen one batch after another, not simultaneous.

Changelog Category: Fixed