### PR TITLE
[Spree Upgrade] Remove allow backorders from subscriptions specs

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1718,6 +1718,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   products_available: Available?
   products_producer: "Producer"
   products_price: "Price"
+  name_or_sku: "NAME OR SKU"
 
   register_title: Register
 

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -71,8 +71,6 @@ describe SubscriptionPlacementJob do
     let!(:line_item2) { create(:line_item, order: order, variant: variant2, quantity: 3) }
     let!(:line_item3) { create(:line_item, order: order, variant: variant3, quantity: 3) }
 
-    before { Spree::Config.set(:allow_backorders, false) }
-
     context "when all items are available from the order cycle" do
       before { [variant1, variant2, variant3].each { |v| ex.variants << v } }
 

--- a/spec/services/subscription_form_spec.rb
+++ b/spec/services/subscription_form_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 xdescribe SubscriptionForm do
   describe "creating a new subscription" do
     let!(:shop) { create(:distributor_enterprise) }
@@ -44,7 +46,6 @@ xdescribe SubscriptionForm do
     let(:form) { SubscriptionForm.new(subscription, params) }
 
     it "creates orders for each order cycle in the schedule" do
-      Spree::Config.set allow_backorders: false
       expect(form.save).to be true
 
       expect(subscription.proxy_orders.count).to be 2
@@ -61,11 +62,11 @@ xdescribe SubscriptionForm do
       proxy_order2 = subscription.proxy_orders.find_by_order_cycle_id(order_cycle2.id)
       expect(proxy_order2).to be_a ProxyOrder
       order2 = proxy_order2.initialise_order!
-      expect(order2.line_items.count).to be 3
+      expect(order2.line_items.count).to eq 3
       expect(order2.line_items.find_by_variant_id(variant3.id).quantity).to be 3
-      expect(order2.shipments.count).to be 1
+      expect(order2.shipments.count).to eq 1
       expect(order2.shipments.first.shipping_method).to eq shipping_method
-      expect(order2.payments.count).to be 1
+      expect(order2.payments.count).to eq 1
       expect(order2.payments.first.payment_method).to eq payment_method
       expect(order2.payments.first.state).to eq 'checkout'
       expect(order2.total).to eq 42
@@ -77,11 +78,11 @@ xdescribe SubscriptionForm do
       expect(proxy_order3).to be_a ProxyOrder
       order3 = proxy_order3.initialise_order!
       expect(order3).to be_a Spree::Order
-      expect(order3.line_items.count).to be 3
+      expect(order3.line_items.count).to eq 3
       expect(order2.line_items.find_by_variant_id(variant3.id).quantity).to be 3
-      expect(order3.shipments.count).to be 1
+      expect(order3.shipments.count).to eq 1
       expect(order3.shipments.first.shipping_method).to eq shipping_method
-      expect(order3.payments.count).to be 1
+      expect(order3.payments.count).to eq 1
       expect(order3.payments.first.payment_method).to eq payment_method
       expect(order3.payments.first.state).to eq 'checkout'
       expect(order3.total).to eq 31.50


### PR DESCRIPTION
#### What? Why?

Part of #2954

Removed allow backorders global setting from subscriptions specs and added a missing translation detected in features/admin/subscriptions_spec.

This PR fixes 2 specs in subscription_placement_job_spec.

Additionally, this PR improves:
- subscription_form_spec where the error becomes related to shipping methods and is now represented in #2696
- #3370 fixes 1 spec in subscriptions_spec and, with 3370 and the translation in this PR, 2 other specs improve to become UI test errors, probably due to broken data, I create new issue to fix this #3396

#### What should we test?
- 2 specs in subscription_placement_job_spec are green
- subscription_form_spec error is now related to shipments
- subscriptions_spec are UI validation errors (missing expected data)