### PR TITLE
3381 Load enterprise users tab before inspecting table

### DIFF
--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -99,6 +99,7 @@ feature %q{
         click_link 'Enterprises'
         click_link 'Test Enterprise'
         within('.side_menu') { click_link 'Users' }
+        expect(page).to have_selector "table.managers"
       end
 
       it "lists managers and shows icons for owner, contact, and email confirmation" do


### PR DESCRIPTION
#### What? Why?

Closes #3381 

Specs in affected example group are intermittently failing.

#### What should we test?

Semaphore build should be green.

In the long term, these specs should also not fail.

#### Release notes

- Address intermittently failing feature tests

Changelog Category: Fixed