### PR TITLE
[Spree Upgrade] Change app config to keep using ofn customized spree v1 shipping method calculators, not the new spree v2 ones

### DIFF
--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -42,6 +42,14 @@ Spree::ShippingMethod.class_eval do
     ]
   end
 
+  # This method is overriden so that we can remove the restriction added in Spree
+  #   Spree restricts shipping method calculators to the ones that inherit from Spree::Shipping::ShippingCalculator
+  #   Spree::Shipping::ShippingCalculator makes sure that calculators are able to handle packages and not orders as input
+  #   This is not necessary in OFN because calculators in OFN are already customized to work with different types of input
+  def self.calculators
+    spree_calculators.send model_name_without_spree_namespace
+  end
+
   def has_distributor?(distributor)
     self.distributors.include?(distributor)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,7 +55,15 @@ module Openfoodnetwork
 
     # Register Spree calculators
     initializer 'spree.register.calculators' do |app|
-      app.config.spree.calculators.shipping_methods << Calculator::Weight
+      app.config.spree.calculators.shipping_methods = [
+        Spree::Calculator::FlatPercentItemTotal,
+        Spree::Calculator::FlatRate,
+        Spree::Calculator::FlexiRate,
+        Spree::Calculator::PerItem,
+        Spree::Calculator::PriceSack,
+        Calculator::Weight
+      ]
+
       app.config.spree.calculators.add_class('enterprise_fees')
       config.spree.calculators.enterprise_fees = [
         Calculator::FlatPercentPerItem,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,4 +51,4 @@ end
 spree_user = Spree::User.first
 spree_user && spree_user.confirm!
 
-DefaultStockLocation.create!
+DefaultStockLocation.find_or_create

--- a/spec/serializers/api/shipping_method_serializer_spec.rb
+++ b/spec/serializers/api/shipping_method_serializer_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Api::ShippingMethodSerializer do
+  let(:shipping_method) { create(:shipping_method) }
+
+  it "serializes a test shipping_method" do
+    serializer = Api::ShippingMethodSerializer.new shipping_method
+
+    expect(serializer.to_json).to match(shipping_method.name)
+  end
+
+  it "can serialize all configured shipping method calculators" do
+    Rails.application.config.spree.calculators.shipping_methods.each do |calculator|
+      shipping_method.calculator = calculator.new
+      serializer = Api::ShippingMethodSerializer.new shipping_method
+      allow(serializer).to receive(:options).and_return(current_order: create(:order))
+
+      expect(serializer.price).to eq(0.0)
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #3393

Spree v2 introduces a new class Spree::Calculator::Shipping and copy pastes (yes!) *all* calculators from /calculator to /calculator/shipping and changed each of them to handle packages.
https://github.com/openfoodfoundation/spree/commit/18e5b98f5cc31a973b63cf89eabb513e7230e3ca#diff-b0846898827183f530c113ad7b83b8ea

This requires a few comments:
- This is a very poor solution... the work done in spree v2 around shipments/packages/coordinators/estimators is quite nice, but the same contributor ended up doing this very ugly change in calculators.... also, I just confirmed that this is still there in spree v3 with not many changes.
- I didn't see this until now: all OFN tests are injecting the shipping methods explicitly with its calculators (the calculators in /calculator). That led me to miss the change.
- the calculators under /calculator are already decorated in OFN with the magic line_items_for exactly to do that: handle objects that are not orders. In our v2 ofn branch, I just extended the line_items_for method to work with packages as well. This was done in [this spec in #2932](https://github.com/openfoodfoundation/openfoodnetwork/pull/2932/files#diff-3fdb6616ce830efde9ec47815f1d8eb5R28) (which introduced a bug that had to be fixed and covered with auto tests in #3072 )

The solution presented here instead of moving to the new calculators in v2, only changes the app config to use the existing calculators in OFN. I believe this is better and much easier than using the new calculators in spree v2 because the calculators from spree v2 would have to be decorated as well with OFN's stuff.

Some of the new calculators use package.contents to make the calculations while the existing OFN calculators use the line_items. I verified that each of these calculators did not introduce any important changes to the way these calculators are working.

Finally, it's incredible but the problem introduced with the copy paste and the bad abstraction in the Spree calculators make our calculator decorator with its line_items_for look good! So, we end up with a solution that is definitely not worse than the Spree one...

#### What should we test?
We need to create new shipping methods and test that checkout works with these new shipping methods.
I could replicate #3393. I have now deployed this branch to staging FR and the problem looks resolved.
I have verified this build and the broken tests here are the same ones in the 2-0-stable branch build.