### PR TITLE
[Spree Upgrade] Add checkbox to disable products cache

### DIFF
--- a/app/controllers/admin/cache_settings_controller.rb
+++ b/app/controllers/admin/cache_settings_controller.rb
@@ -1,8 +1,7 @@
 require 'open_food_network/products_cache_integrity_checker'
 
 class Admin::CacheSettingsController < Spree::Admin::BaseController
-
-  def show
+  def edit
     @results = Exchange.cachable.map do |exchange|
       checker = OpenFoodNetwork::ProductsCacheIntegrityChecker.new(exchange.receiver, exchange.order_cycle)
 
@@ -10,4 +9,10 @@ class Admin::CacheSettingsController < Spree::Admin::BaseController
     end
   end
 
+  def update
+    Spree::Config.set(params[:preferences])
+    respond_to do |format|
+      format.html { redirect_to main_app.edit_admin_cache_settings_path }
+    end
+  end
 end

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -52,4 +52,7 @@ Spree::AppConfiguration.class_eval do
 
   # Number localization
   preference :enable_localized_number?, :boolean, default: false
+
+  # Enable cache
+  preference :enable_products_cache?, :boolean, default: true
 end

--- a/app/overrides/spree/admin/shared/_configuration_menu/add_caching.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_configuration_menu/add_caching.html.haml.deface
@@ -1,4 +1,4 @@
 / insert_bottom "[data-hook='admin_configurations_sidebar_menu']"
 
 %li
-  = link_to t('admin.cache_settings.show.title'), main_app.admin_cache_settings_path
+  = link_to t('admin.cache_settings.edit.title'), main_app.edit_admin_cache_settings_path

--- a/app/views/admin/cache_settings/edit.html.haml
+++ b/app/views/admin/cache_settings/edit.html.haml
@@ -1,6 +1,19 @@
 - content_for :page_title do
   = t(:cache_settings)
 
+= form_tag main_app.admin_cache_settings_path, :method => :put do
+  .field
+    = hidden_field_tag 'preferences[enable_products_cache?]', '0'
+    = check_box_tag 'preferences[enable_products_cache?]', '1',  Spree::Config[:enable_products_cache?]
+    = label_tag nil, t('.enable_products_cache')
+  .form-buttons
+    = button t(:update), 'icon-refresh'
+
+%br
+%br
+
+%h4= t(:cache_state)
+%br
 %table.index
   %thead
     %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -389,13 +389,14 @@ en:
         total_monthly_bill_incl_tax_tip: "The example total monthly bill with tax included, given the settings and the turnover provided."
 
     cache_settings:
-      show:
-        title: Caching
-        distributor: Distributor
-        order_cycle: Order Cycle
-        status: Status
-        diff: Diff
-        error: Error
+      edit:
+        title: "Caching"
+        distributor: "Distributor"
+        order_cycle: "Order Cycle"
+        status: "Status"
+        diff: "Diff"
+        error: "Error"
+        enable_products_cache: "Enable Products Cache?"
 
     invoice_settings:
       edit:

--- a/lib/open_food_network/cached_products_renderer.rb
+++ b/lib/open_food_network/cached_products_renderer.rb
@@ -27,19 +27,19 @@ module OpenFoodNetwork
     private
 
     def cached_products_json
-      return uncached_products_json unless Spree::Config[:enable_products_cache?]
+      return uncached_products_json unless use_cached_products?
 
-      if Rails.env.production? || Rails.env.staging?
-        Rails.cache.fetch("products-json-#{@distributor.id}-#{@order_cycle.id}") do
-          begin
-            uncached_products_json
-          rescue ProductsRenderer::NoProducts
-            nil
-          end
+      Rails.cache.fetch("products-json-#{@distributor.id}-#{@order_cycle.id}") do
+        begin
+          uncached_products_json
+        rescue ProductsRenderer::NoProducts
+          nil
         end
-      else
-        uncached_products_json
       end
+    end
+
+    def use_cached_products?
+      Spree::Config[:enable_products_cache?] && (Rails.env.production? || Rails.env.staging?)
     end
 
     def uncached_products_json

--- a/lib/open_food_network/cached_products_renderer.rb
+++ b/lib/open_food_network/cached_products_renderer.rb
@@ -27,6 +27,8 @@ module OpenFoodNetwork
     private
 
     def cached_products_json
+      return uncached_products_json unless Spree::Config[:enable_products_cache?]
+
       if Rails.env.production? || Rails.env.staging?
         Rails.cache.fetch("products-json-#{@distributor.id}-#{@order_cycle.id}") do
           begin

--- a/spec/lib/open_food_network/cached_products_renderer_spec.rb
+++ b/spec/lib/open_food_network/cached_products_renderer_spec.rb
@@ -5,7 +5,7 @@ module OpenFoodNetwork
   describe CachedProductsRenderer do
     let(:distributor) { double(:distributor, id: 123) }
     let(:order_cycle) { double(:order_cycle, id: 456) }
-    let(:cpr) { CachedProductsRenderer.new(distributor, order_cycle) }
+    let(:cached_products_renderer) { CachedProductsRenderer.new(distributor, order_cycle) }
 
     # keeps global state unchanged
     around do |example|
@@ -37,7 +37,7 @@ module OpenFoodNetwork
           end
 
           it "returns uncached products JSON" do
-            expect(cpr.products_json).to eq 'uncached products'
+            expect(cached_products_renderer.products_json).to eq 'uncached products'
           end
         end
 
@@ -47,7 +47,7 @@ module OpenFoodNetwork
           end
 
           it "returns the cached JSON" do
-              expect(cpr.products_json).to eq 'products'
+              expect(cached_products_renderer.products_json).to eq 'products'
           end
         end
       end
@@ -58,7 +58,7 @@ module OpenFoodNetwork
         end
 
         it "returns uncached products JSON" do
-          expect(cpr.products_json).to eq 'uncached products'
+          expect(cached_products_renderer.products_json).to eq 'uncached products'
         end
       end
 
@@ -68,10 +68,10 @@ module OpenFoodNetwork
         end
 
         describe "when the distribution is not set" do
-          let(:cpr) { CachedProductsRenderer.new(nil, nil) }
+          let(:cached_products_renderer) { CachedProductsRenderer.new(nil, nil) }
 
           it "raises an exception and returns no products" do
-            expect { cpr.products_json }.to raise_error CachedProductsRenderer::NoProducts
+            expect { cached_products_renderer.products_json }.to raise_error CachedProductsRenderer::NoProducts
           end
         end
 
@@ -81,12 +81,12 @@ module OpenFoodNetwork
           end
 
           it "returns the cached JSON" do
-            expect(cpr.products_json).to eq 'products'
+            expect(cached_products_renderer.products_json).to eq 'products'
           end
 
           it "raises an exception when there are no products" do
             Rails.cache.write "products-json-#{distributor.id}-#{order_cycle.id}", nil
-            expect { cpr.products_json }.to raise_error CachedProductsRenderer::NoProducts
+            expect { cached_products_renderer.products_json }.to raise_error CachedProductsRenderer::NoProducts
           end
         end
 
@@ -108,11 +108,11 @@ module OpenFoodNetwork
 
           describe "when there are products" do
             it "returns products as JSON" do
-              expect(cpr.products_json).to eq 'fresh products'
+              expect(cached_products_renderer.products_json).to eq 'fresh products'
             end
 
             it "caches the JSON" do
-              cpr.products_json
+              cached_products_renderer.products_json
               expect(cached_json).to eq 'fresh products'
             end
           end
@@ -129,11 +129,11 @@ module OpenFoodNetwork
             end
 
             it "raises an error" do
-              expect { cpr.products_json }.to raise_error CachedProductsRenderer::NoProducts
+              expect { cached_products_renderer.products_json }.to raise_error CachedProductsRenderer::NoProducts
             end
 
             it "caches the products as nil" do
-              expect { cpr.products_json }.to raise_error CachedProductsRenderer::NoProducts
+              expect { cached_products_renderer.products_json }.to raise_error CachedProductsRenderer::NoProducts
               expect(cache_present).to be
               expect(cached_json).to be_nil
             end


### PR DESCRIPTION
#### What? Why?
I couldnt replicate #3392 locally and I was having serious trouble debugging it in FR staging so, after 6 hours of unsuccessful investigations around what is wrong with the products cache, I decided to implement this feature:
In configuration - cache settings there's a new checkbox that admins can use to disable the products cache all together, this will be very useful to detect cache problems in staging and live without having to go through the unreadable diffs currently available...

#### What should we test?
There are auto tests to validate this is working. If the system is working correctly, disabling the cache should not change anything apart from making the PLP slower.
I have tested this in staging FR and it is working as it is successfully detecting a problem in the cache:
- go to shopfront "Winery District Food Hub" - OC#2
- see Apples
- go to the backoffice and check the new checkbox to activate cache
- go back to the shofront and see Apples disappear from the shopfront 

This feature helps detect an existing problem in caching this product Apples.

#### Release notes
Changelog Category: Added
Easier cache debugging with a new checkbox for admins to disable products cache.

#### How is this related to the Spree upgrade?
This will be very useful to debug the cache in v2.