### PR TITLE
3059 [Flaky Spec] Fix race condition in enterprise image feature specs

### DIFF
--- a/spec/features/admin/enterprises/images_spec.rb
+++ b/spec/features/admin/enterprises/images_spec.rb
@@ -58,7 +58,7 @@ feature "Managing enterprise images" do
         expect(page).to have_content("Logo removed successfully")
 
         within ".page-admin-enterprises-form__logo-field-group" do
-          expect(page).to have_no_selector(".image-field-group__preview-image")
+          expect_no_preview_image
         end
       end
 
@@ -94,7 +94,7 @@ feature "Managing enterprise images" do
         expect(page).to have_content("Promo image removed successfully")
 
         within ".page-admin-enterprises-form__promo-image-field-group" do
-          expect(page).to have_no_selector(".image-field-group__preview-image")
+          expect_no_preview_image
         end
       end
     end
@@ -102,5 +102,9 @@ feature "Managing enterprise images" do
 
   def expect_preview_image(file_name)
     expect(page).to have_selector(".image-field-group__preview-image[src*='#{file_name}']")
+  end
+
+  def expect_no_preview_image
+    expect(page).to have_no_selector(".image-field-group__preview-image")
   end
 end

--- a/spec/features/admin/enterprises/images_spec.rb
+++ b/spec/features/admin/enterprises/images_spec.rb
@@ -35,7 +35,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__logo-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-white.png']")
+          expect_preview_image "logo-white.png"
         end
 
         # Replacing image
@@ -46,7 +46,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__logo-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-black.png']")
+          expect_preview_image "logo-black.png"
         end
 
         # Removing image
@@ -71,7 +71,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__promo-image-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-white.jpg']")
+          expect_preview_image "logo-white.jpg"
         end
 
         # Replacing image
@@ -82,7 +82,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__promo-image-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-black.jpg']")
+          expect_preview_image "logo-black.jpg"
         end
 
         # Removing image
@@ -98,5 +98,9 @@ feature "Managing enterprise images" do
         end
       end
     end
+  end
+
+  def expect_preview_image(file_name)
+    expect(page).to have_selector(".image-field-group__preview-image[src*='#{file_name}']")
   end
 end

--- a/spec/features/admin/enterprises/images_spec.rb
+++ b/spec/features/admin/enterprises/images_spec.rb
@@ -35,8 +35,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__logo-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image")
-          expect(html).to include("logo-white.png")
+          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-white.png']")
         end
 
         # Replacing image
@@ -47,8 +46,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__logo-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image")
-          expect(html).to include("logo-black.png")
+          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-black.png']")
         end
 
         # Removing image
@@ -73,8 +71,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__promo-image-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image")
-          expect(html).to include("logo-white.jpg")
+          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-white.jpg']")
         end
 
         # Replacing image
@@ -85,8 +82,7 @@ feature "Managing enterprise images" do
 
         go_to_images
         within ".page-admin-enterprises-form__promo-image-field-group" do
-          expect(page).to have_selector(".image-field-group__preview-image")
-          expect(html).to include("logo-black.jpg")
+          expect(page).to have_selector(".image-field-group__preview-image[src*='logo-black.jpg']")
         end
 
         # Removing image


### PR DESCRIPTION
Fix race condition in enterprise image feature specs.

#### What? Why?

Closes #3059 

Specs in affected example group are intermittently failing.

#### What should we test?

Semaphore build should be green.

In the long term, these specs should also not fail.

#### Release notes

* Address intermittently failing feature tests

Changelog Category: Fixed