### PR TITLE
3417,2962,3358 [Flaky Spec] Address some race conditions for bulk order management specs

### DIFF
--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -157,7 +157,7 @@
               = t("admin.orders.bulk_management.ask")
               %input{ :type => 'checkbox', 'ng-model' => "confirmDelete" }
 
-        %tr.line_item{ 'ng-repeat' => "line_item in filteredLineItems = ( lineItems | filter:quickSearch | selectFilter:supplierFilter:distributorFilter:orderCycleFilter | variantFilter:selectedUnitsProduct:selectedUnitsVariant:sharedResource | orderBy:sorting.predicate:sorting.reverse )", 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'", :id => "li_{{line_item.id}}" }
+        %tr.line_item{ 'ng-repeat' => "line_item in filteredLineItems = ( lineItems | filter:quickSearch | selectFilter:supplierFilter:distributorFilter:orderCycleFilter | variantFilter:selectedUnitsProduct:selectedUnitsVariant:sharedResource | orderBy:sorting.predicate:sorting.reverse )", 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'", ng: { attr: { id: "li_{{line_item.id}}" } } }
           %td.bulk
             %input{ :type => "checkbox", :name => 'bulk', 'ng-model' => 'line_item.checked', 'ignore-dirty' => true }
           %td.order_no{ 'ng-show' => 'columns.order_no.visible' } {{ line_item.order.number }}

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -112,7 +112,7 @@
 
   .margin-bottom-50{ 'ng-hide' => 'RequestMonitor.loading || filteredLineItems.length == 0' }
     %form{ name: 'bulk_order_form' }
-      %table.index#listing_orders.bulk{ :class => "sixteen columns alpha" }
+      %table.index#listing_orders.bulk{ :class => "sixteen columns alpha", ng: { show: "initialized" } }
         %thead
           %tr{ ng: { controller: "ColumnsCtrl" } }
             %th.bulk

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -181,6 +181,6 @@
             %input.show-dirty{ :type => 'text', :name => 'price', :id => 'price', :ng => { value: 'line_item.price * line_item.quantity | currency:""', readonly: "true", class: '{"update-error": line_item.errors.price}' } }
             %span.error{ ng: { bind: 'line_item.errors.price' } }
           %td.actions
-            %a{ href: "/admin/orders/{{line_item.order.number}}/edit", :class => "edit-order icon-edit no-text", 'confirm-link-click' => 'confirmRefresh()' }
+            %a{ ng: { href: "/admin/orders/{{line_item.order.number}}/edit" }, :class => "edit-order icon-edit no-text", 'confirm-link-click' => 'confirmRefresh()' }
           %td.actions
             %a{ 'ng-click' => "deleteLineItem(line_item)", :class => "delete-line-item icon-trash no-text" }

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -567,6 +567,7 @@ feature %q{
       context "when a filter has been applied" do
         it "only toggles checkboxes which are in filteredLineItems" do
           fill_in "quick_search", with: o1.number
+          expect(page).to have_no_selector "tr#li_#{li2.id}"
           check "toggle_bulk"
           fill_in "quick_search", with: ''
           expect(find("tr#li_#{li1.id} input[type='checkbox'][name='bulk']").checked?).to be true
@@ -577,11 +578,13 @@ feature %q{
         it "only applies the delete action to filteredLineItems" do
           check "toggle_bulk"
           fill_in "quick_search", with: o1.number
+          expect(page).to have_no_selector "tr#li_#{li2.id}"
           find("div#bulk-actions-dropdown").click
           find("div#bulk-actions-dropdown div.menu_item", :text => "Delete Selected" ).click
-          fill_in "quick_search", with: ''
           expect(page).to have_no_selector "tr#li_#{li1.id}"
+          fill_in "quick_search", with: ''
           expect(page).to have_selector "tr#li_#{li2.id}"
+          expect(page).to have_no_selector "tr#li_#{li1.id}"
         end
       end
     end

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -439,7 +439,7 @@ feature %q{
         expect(page).to have_selector "tr#li_#{li3.id}"
         fill_in "quick_search", :with => o1.email
         expect(page).to have_selector "tr#li_#{li1.id}"
-        expect(page).to have_no_selector "tr#li_#{li2.id}",  true
+        expect(page).to have_no_selector "tr#li_#{li2.id}"
         expect(page).to have_no_selector "tr#li_#{li3.id}"
       end
     end

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -743,13 +743,11 @@ feature %q{
   end
 
   def select_date(date)
-    current_month = Time.zone.today.strftime("%B")
-    target_month = date.strftime("%B")
-
     # Wait for datepicker to open and be associated to the datepicker trigger.
     expect(page).to have_selector("#ui-datepicker-div")
 
-    find('#ui-datepicker-div .ui-datepicker-header .ui-datepicker-prev').click if current_month != target_month
+    navigate_datepicker_to_month date
+
     find('#ui-datepicker-div .ui-datepicker-calendar .ui-state-default', text: date.strftime("%e").to_s.strip, exact_text: true).click
   end
 end

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -743,6 +743,9 @@ feature %q{
     current_month = Time.zone.today.strftime("%B")
     target_month = date.strftime("%B")
 
+    # Wait for datepicker to open and be associated to the datepicker trigger.
+    expect(page).to have_selector("#ui-datepicker-div")
+
     find('#ui-datepicker-div .ui-datepicker-header .ui-datepicker-prev').click if current_month != target_month
     find('#ui-datepicker-div .ui-datepicker-calendar .ui-state-default', text: date.strftime("%e").to_s.strip, exact_text: true).click
   end

--- a/spec/support/features/datepicker_helper.rb
+++ b/spec/support/features/datepicker_helper.rb
@@ -5,5 +5,29 @@ module Features
         find(".ui-datepicker-today").click
       end
     end
+
+    def navigate_datepicker_to_month(date, reference_date = Time.zone.today)
+      month_and_year = date.strftime("%B %Y")
+
+      until datepicker_month_and_year == month_and_year.upcase
+        if date < reference_date
+          navigate_datepicker_to_previous_month
+        elsif date > reference_date
+          navigate_datepicker_to_next_month
+        end
+      end
+    end
+
+    def navigate_datepicker_to_previous_month
+      find('#ui-datepicker-div .ui-datepicker-header .ui-datepicker-prev').click
+    end
+
+    def navigate_datepicker_to_next_month
+      find('#ui-datepicker-div .ui-datepicker-header .ui-datepicker-next').click
+    end
+
+    def datepicker_month_and_year
+      find("#ui-datepicker-div .ui-datepicker-title").text
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

* Closes #3417 
* Closes #2962 
* Closes #3358 (two separate issues)

Specs in affected examples are intermittently failing.

#### What should we test?

Please do a general test that the bulk order management page is still functioning.

Semaphore build should be green.

In the long term, these specs should also not fail.

#### Release notes

* Address intermittently failing feature tests

Changelog Category: Fixed