### PR TITLE
Update Rake task namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 
 script:
   - 'if [ "$KARMA" = "true" ]; then bundle exec rake karma:run; else echo "Skipping karma run"; fi'
-  - 'if [ "$RSPEC_ENGINES" = "true" ]; then bundle exec rake openfoodnetwork:specs:engines:rspec; else echo "Skipping RSpec run in engines"; fi'
+  - 'if [ "$RSPEC_ENGINES" = "true" ]; then bundle exec rake ofn:specs:engines:rspec; else echo "Skipping RSpec run in engines"; fi'
   - "bundle exec rake 'knapsack:rspec[--format progress --tag ~performance]'"
 
 after_success:

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -75,7 +75,7 @@ Then the main application tests can be run with:
 
 The tests of all custom engines can be run with:
 
-    bundle exec rake openfoodnetwork:specs:engines:rspec
+    bundle exec rake ofn:specs:engines:rspec
 
 Note: If your OS is not explicitly supported in the setup guides then not all tests may pass. However, you may still be able to develop. Get in touch with the [#dev][slack-dev] channel on Slack to troubleshoot issues and determine if they will preclude you from contributing to OFN.
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,7 +13,7 @@ job_type :enqueue_job,  "cd :path; :environment_variable=:environment bundle exe
 
 
 every 1.hour do
-  rake 'openfoodnetwork:cache:check_products_integrity'
+  rake 'ofn:cache:check_products_integrity'
 end
 
 every 1.day, at: '12:05am' do
@@ -35,10 +35,10 @@ every 5.minutes do
 end
 
 every 1.day, at: '1:00am' do
-  rake 'openfoodnetwork:billing:update_account_invoices'
+  rake 'ofn:billing:update_account_invoices'
 end
 
 # On the 2nd of every month at 1:30am
 every '30 1 2 * *' do
-  rake 'openfoodnetwork:billing:finalize_account_invoices'
+  rake 'ofn:billing:finalize_account_invoices'
 end

--- a/lib/tasks/billing.rake
+++ b/lib/tasks/billing.rake
@@ -1,4 +1,4 @@
-namespace :openfoodnetwork do
+namespace :ofn do
   namespace :billing do
     desc 'Update enterprise user invoices'
     task update_account_invoices: :environment do

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,6 +1,6 @@
 require 'open_food_network/products_cache_integrity_checker'
 
-namespace :openfoodnetwork do
+namespace :ofn do
   namespace :cache do
     desc 'check the integrity of the products cache'
     task :check_products_integrity => :environment do

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,4 +1,4 @@
-namespace :openfoodnetwork do
+namespace :ofn do
   namespace :data do
     desc "Adding relationships based on recent order cycles"
     task :create_order_cycle_relationships => :environment do

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,4 +1,4 @@
-namespace :openfoodnetwork do
+namespace :ofn do
   namespace :dev do
     desc 'load sample data'
     task load_sample_data: :environment do

--- a/lib/tasks/enterprises.rake
+++ b/lib/tasks/enterprises.rake
@@ -1,6 +1,6 @@
 require 'csv'
 
-namespace :openfoodnetwork do
+namespace :ofn do
   namespace :dev do
     desc 'export enterprises to CSV'
     task :export_enterprises => :environment do

--- a/lib/tasks/specs.rake
+++ b/lib/tasks/specs.rake
@@ -1,4 +1,4 @@
-namespace :openfoodnetwork do
+namespace :ofn do
   namespace :specs do
     namespace :engines do
       def detect_engine_paths

--- a/script/setup
+++ b/script/setup
@@ -52,7 +52,7 @@ printf '\n\n' | bundle exec rake db:setup db:test:prepare
 printf '\n'
 
 # Load some default data for your environment
-bundle exec rake openfoodnetwork:dev:load_sample_data
+bundle exec rake ofn:dev:load_sample_data
 printf '\n'
 
 printf "${YELLOW}WELCOME TO OPEN FOOD NETWORK!\n"


### PR DESCRIPTION
This PR changes the rake tasks namespace from the verbose `openfoodnetwork` to `ofn`.

Closes #3248 

#### What should we test?
1. Checking the output of `rake -T`
2. Attempt to use one of the now renamed tasks. It should be invoked.
  - Rake found the tasks for me when I tested against `rake ofn:specs:engines:rspec` and `rake ofn:dev:load_sample_data`

**Note**: I did not add specs for the rake tasks because it involved some `Spree` stubbing; `ofn:billing`, `ofn:data`, `ofn:dev` tasks. However, I can add them because the specs will explode anyway after the Spree update and doesn't changed any business logic. Please let me know and I will be happy to add the coverage.

#### Release notes
Renamed rake tasks from `openfoodnetwork` -> `ofn` to be less verbose.

Changelog Category: Changed

#### How is this related to the Spree upgrade?
This does not affect Spree, **unless** the above note does result in adding missing specs for the rake tasks. Then there could possibly, depending on test setup, be some `Spree` stubbing that will need updated.

#### Discourse thread
[Discussion thread](https://community.openfoodnetwork.org/t/rake-task-naming/1531)

#### Documentation updates
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Set-and-Deploy-on-Heroku
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Locale-and-sample-data

##### And this page is actually missing the namespace in an example
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Troubleshooting-your-instance


