### PR TITLE
3415 [Enterprise Fee Summary] Address Rubocop layout violation in Spree::Ability decorator

### DIFF
--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -186,7 +186,7 @@ class AbilityDecorator
     # Reports page
     can [:admin, :index, :customers, :orders_and_distributors, :group_buys, :bulk_coop, :payments,
          :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :packing],
-         :report
+        :report
     add_enterprise_fee_summary_abilities(user)
   end
 


### PR DESCRIPTION
Address Rubocop layout violation in `Spree::Ability` decorator.

## Description

* Relates to #2616 

There is a Rubocop layout violation in `Spree::Ability` decorator`:

![20190201123045-rubocop-violation](https://user-images.githubusercontent.com/2243/52102778-51cff100-261d-11e9-9311-29848aee69cc.png)

I haven't checked which PR introduced this violation.

## Expected Behavior

There should be no Rubocop violations.

## Actual Behavior

There should be no Rubocop violations.

## Steps to Reproduce

Check Rubocop results for PR #3415.