### PR TITLE
Apply import defaults to variants of new products in Spree 2

### DIFF
--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -212,12 +212,20 @@ module ProductImport
         case setting['mode']
         when 'overwrite_all'
           object.assign_attributes(attribute => setting['value'])
+          # In case of new products, some attributes are saved on the variant.
+          # We write them to the entry here to be copied to the variant later.
+          if entry.respond_to? "#{attribute}="
+            entry.public_send("#{attribute}=", setting['value'])
+          end
         when 'overwrite_empty'
           if object.public_send(attribute).blank? ||
              ((attribute == 'on_hand' || attribute == 'count_on_hand') &&
              entry.on_hand_nil)
 
             object.assign_attributes(attribute => setting['value'])
+            if entry.respond_to? "#{attribute}="
+              entry.public_send("#{attribute}=", setting['value'])
+            end
           end
         end
       end


### PR DESCRIPTION

#### What? Why?

Closes #2783

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Spree 2 doesn't have `Product#on_hand=` any more. We actually can't save
stock levels without saving the product first which creates a stock
item.

This hacky solution overwrites the attribute in the entry so that it
gets copied to the variant later on. I think a better solution needs
some refactoring as proposed in:
https://github.com/openfoodfoundation/openfoodnetwork/issues/2783#issuecomment-459601530


#### What should we test?
<!-- List which features should be tested and how. -->

Product import with some default settings to overwrite stock levels and other properties.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Updated the product import code for future Spree updates.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

This fixes overriding stock levels in Spree 2.

