### PR TITLE
[Spree Upgrade] 3428 Fix in_stock? and shopping/variant_overrides_spec

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -125,11 +125,6 @@ module VariantStock
     on_demand || total_on_hand >= quantity
   end
 
-  # We override Spree::Variant.in_stock? to avoid depending on the non-overidable method Spree::Stock::Quantifier.can_supply?
-  def in_stock?(quantity = 1)
-    can_supply?(quantity)
-  end
-
   # Moving Spree::StockLocation.fill_status to the variant enables us to override this behaviour for variant overrides
   # We can have this responsibility here in the variant because there is only one stock item per variant
   #

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -87,6 +87,12 @@ Spree::Variant.class_eval do
     ]
   end
 
+  # We override in_stock? to avoid depending on the non-overridable method Spree::Stock::Quantifier.can_supply?
+  #   VariantStock implements can_supply? itself which depends on overridable methods
+  def in_stock?(quantity = 1)
+    can_supply?(quantity)
+  end
+
   def price_with_fees(distributor, order_cycle)
     price + fees_for(distributor, order_cycle)
   end

--- a/spec/features/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/features/consumer/shopping/variant_overrides_spec.rb
@@ -39,12 +39,10 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
   end
 
   describe "viewing products" do
-    it "shows the overridden price" do
-      page.should_not have_price with_currency(12.22) # product1_variant1.price ($11.11) + 10% fee
+    it "shows price and stock from the override" do
       page.should have_price with_currency(61.11) # product1_variant1_override.price ($55.55) + 10% fee
-    end
+      page.should_not have_price with_currency(12.22) # product1_variant1.price ($11.11) + 10% fee
 
-    it "looks up stock from the override" do
       # Product should appear but one of the variants is out of stock
       page.should_not have_content product1_variant2.options_text
 
@@ -150,7 +148,7 @@ feature "shopping with variant overrides defined", js: true, retry: 3 do
     end
 
     it "does not show out of stock flags on order confirmation page" do
-      product1_variant3.update_attribute :count_on_hand, 0
+      product1_variant3.count_on_hand = 0
       fill_in "variants[#{product1_variant3.id}]", with: "2"
       click_checkout
 

--- a/spec/models/concerns/variant_stock_spec.rb
+++ b/spec/models/concerns/variant_stock_spec.rb
@@ -159,4 +159,44 @@ describe VariantStock do
       end
     end
   end
+
+  describe '#can_supply?' do
+    context 'when variant on_demand' do
+      let(:variant) { create(:variant, on_demand: true) }
+
+      it "returns true for zero" do
+        expect(variant.can_supply?(0)).to eq(true)
+      end
+      it "returns true for large quantity" do
+        expect(variant.can_supply?(100000)).to eq(true)
+      end
+    end
+
+    context 'when variant not on_demand' do
+      context 'when variant in stock' do
+        it "returns true for zero" do
+          expect(variant.can_supply?(0)).to eq(true)
+        end
+        it "returns true for number equal to stock level" do
+          expect(variant.can_supply?(variant.total_on_hand)).to eq(true)
+        end
+
+        it "returns false for number above stock level" do
+          expect(variant.can_supply?(variant.total_on_hand + 1)).to eq(false)
+        end        
+      end
+
+      context 'when variant out of stock' do
+        before { variant.count_on_hand = 0 }
+
+        it "returns true for zero" do
+          expect(variant.can_supply?(0)).to eq(true)
+        end
+
+        it "returns false for one" do
+          expect(variant.can_supply?(1)).to eq(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3428

This is a bug in #3232 should have added unit tests... some of them would be broken. See new tests in scope_variant_to_hub_spec (2 of them were broken before this fix).

We cannot override Variant.in_stock? inside the concern VariantStock, we need to do it directly in the variant_decorator. The VariantStock.in_stock? was just not seen from the outside and was the source of #3428.
I think the VO shopping spec was a false positive before headless chrome and became a true error after it. This PR fixes the spec and the in_stock issue, this time, thanks to spring, with some unit testing covering the different cases.

#### What should we test?
the 2 specs in #3428 should be green.
