### PR TITLE
3420 [Flaky Spec] Fix date format in spec when single-digit day of month

### DIFF
--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -164,7 +164,7 @@ feature "Product Import", js: true do
       end
 
       expect(page).to have_selector 'div#s2id_import_date_filter'
-      import_time = carrots.import_date.to_date.to_formatted_s(:long).gsub('  ', ' ')
+      import_time = carrots.import_date.to_date.to_formatted_s(:long)
       select2_select import_time, from: "import_date_filter"
 
       expect(page).to have_field "product_name", with: carrots.name


### PR DESCRIPTION
Fix date format in spec when single-digit day of month.

#### What? Why?

Closes #3420

Affected spec was failing if the current day of month has only one digit. The test could not find the date in the import date filter.

Before this commit, the resulting string in the test replaced "&nbsp;&nbsp;" (2 spaces) with " " (1 space), so "February&nbsp;&nbsp;2" was being changed to "February 2". The import date filter however uses 2 spaces in this case, even if the browser shows only 1 (HTML inline text renders multiple consecutive spaces as just one).

Selection of the date in the filter is done in `select_select2_result` (defined in Spree) with `:contains()` in selector used by jQuery.

#### What should we test?

Semaphore build should be green.

In the long term, these specs should also not fail.

#### Release notes

* Address intermittently failing feature tests

Changelog Category: Fixed