### PR TITLE
fix coordinator on order cycles page

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycles_controller.js.coffee
@@ -1,4 +1,4 @@
-angular.module("admin.orderCycles").controller "OrderCyclesCtrl", ($scope, $q, Columns, StatusMessage, RequestMonitor, OrderCycles, Enterprises, Schedules, Dereferencer) ->
+angular.module("admin.orderCycles").controller "OrderCyclesCtrl", ($scope, $q, $sce, Columns, StatusMessage, RequestMonitor, OrderCycles, Enterprises, Schedules, Dereferencer) ->
   $scope.RequestMonitor = RequestMonitor
   $scope.columns = Columns.columns
   $scope.saveAll = -> OrderCycles.saveChanges($scope.order_cycles_form)
@@ -15,7 +15,9 @@ angular.module("admin.orderCycles").controller "OrderCyclesCtrl", ($scope, $q, C
       Dereferencer.dereference(schedule.order_cycles, OrderCycles.byID)
     for orderCycle in $scope.orderCycles
       coordinator = Enterprises.byID[orderCycle.coordinator.id]
-      orderCycle.coordinator = coordinator if coordinator?
+      if coordinator?
+        orderCycle.coordinator = coordinator
+        orderCycle.coordinator.name = $sce.trustAsHtml(coordinator.name)
       Dereferencer.dereference(orderCycle.producers, Enterprises.byID)
       Dereferencer.dereference(orderCycle.shops, Enterprises.byID)
       Dereferencer.dereference(orderCycle.schedules, Schedules.byID)

--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -19,8 +19,7 @@
         {{ orderCycle.producers.length }}
         = t('.suppliers')
       %span{ ng: { hide: 'orderCycle.producers.length > 3', bind: 'orderCycle.producerNames' } }
-    %td.coordinator{ ng: { show: 'columns.coordinator.visible' } }
-      {{ orderCycle.coordinator.name }}
+    %td.coordinator{ ng: { show: 'columns.coordinator.visible', bind_html: 'orderCycle.coordinator.name' } }
     %td.shops{ ng: { show: 'columns.shops.visible' } }
       %span{'ofn-with-tip' => '{{ orderCycle.shopNames }}', ng: { show: 'orderCycle.shops.length > 3' } }
         {{ orderCycle.shops.length }}

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -57,6 +57,7 @@ feature %q{
       expect(page).to have_content oc1.coordinator.name
 
       # And I should see the suppliers and distributors
+      # binding.pry
       oc1.suppliers.each    { |s| page.should have_content s.name }
       oc1.distributors.each { |d| page.should have_content d.name }
 

--- a/spec/javascripts/unit/admin/order_cycles/controllers/order_cycles_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/controllers/order_cycles_controller_spec.js.coffee
@@ -26,7 +26,7 @@ describe "OrderCyclesCtrl", ->
     producer = { id: 1, name: "Producer" }
     shop = { id: 5, name: "Shop" }
     schedule = { id: 7, name: 'Weekly', order_cycles: [{id: 4}]}
-    orderCycle = { id: 4, schedules: [{id: 7}], name: "OC1", coordinator: {id: 3}, shops: [{id: 3},{id: 5}], producers: [{id: 1}] }
+    orderCycle = { id: 4, schedules: [{id: 7}], name: "OC1", coordinator: coordinator, shops: [{id: 3},{id: 5}], producers: [{id: 1}] }
 
     httpBackend.expectGET("/admin/enterprises/visible.json?ams_prefix=basic").respond [coordinator, producer, shop]
     httpBackend.expectGET("/admin/schedules.json").respond [schedule]


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/3193

In a first approach, I was trying to fix it on the controller, using sanitize https://github.com/openfoodfoundation/openfoodnetwork/issues/3193#issuecomment-458117480

However, with further research, I've arrived at the current solution, which is using both $sce.trustAsHtml at the controller, and bind_html at the row partial.

#### What should we test?

Order Cycles table at admin/order_cycles
I think it would be necessary to test on enterprises with more order cycles, to make sure loading several order cycles isn't going to be affected.

![image](https://user-images.githubusercontent.com/7442967/52146419-c9684500-264a-11e9-8c85-bd7e7cdc3600.png)
