### PR TITLE
3327 [Flaky Spec] Fix shop accidentally becoming order coordinator

### DIFF
--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -11,7 +11,9 @@ module Api
       let!(:distributor2) { create(:distributor_enterprise) }
       let!(:supplier) { create(:supplier_enterprise) }
       let!(:coordinator) { create(:distributor_enterprise) }
+      let!(:coordinator2) { create(:distributor_enterprise) }
       let!(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
+      let!(:order_cycle2) { create(:simple_order_cycle, coordinator: coordinator2) }
       let!(:order1) do
         create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now,
                        distributor: distributor, billing_address: create(:address) )
@@ -24,7 +26,9 @@ module Api
         create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now,
                        distributor: distributor, billing_address: create(:address) )
       end
-      let!(:order4) { create(:completed_order_with_fees) }
+      let!(:order4) do
+        create(:completed_order_with_fees, order_cycle: order_cycle2, distributor: distributor2)
+      end
       let!(:order5) { create(:order, state: 'cart', completed_at: nil) }
       let!(:line_item1) do
         create(:line_item, order: order1,
@@ -148,7 +152,7 @@ module Api
           get :index, per_page: 15, page: 1
 
           pagination_data = {
-            'results' => 3,
+            'results' => 2,
             'pages' => 1,
             'page' => 1,
             'per_page' => 15


### PR DESCRIPTION
Fix shop accidentally becoming order coordinator in spec.

#### What? Why?

Closes #3327

The original setup of the order calls:

```ruby
create(:simple_order_cycle)
```

Which picks an arbitrary distributor as coordinator:

```ruby
coordinator { Enterprise.is_distributor.first || ... }
```

There is a chance that any of the existing distributor enterprises is selected as order coordinator. When this is `distributor`, the test fails.

This commit makes the relationship between the reference enterprises and the order consistent.

#### What should we test?

Semaphore build should be green.

In the long term, these specs should also not fail.

#### Release notes

* Address intermittently failing feature tests

Changelog Category: Fixed