### PR TITLE
Update cancan permissions for second iteration of bulk invoices

### DIFF
--- a/app/controllers/spree/admin/invoices_controller.rb
+++ b/app/controllers/spree/admin/invoices_controller.rb
@@ -2,6 +2,7 @@ module Spree
   module Admin
     class InvoicesController < Spree::Admin::BaseController
       respond_to :json
+      authorize_resource class: false
 
       def create
         invoice_service = BulkInvoiceService.new

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -210,9 +210,10 @@ class AbilityDecorator
       # during the order creation process from the admin backend
       order.distributor.nil? || user.enterprises.include?(order.distributor) || order.order_cycle.andand.coordinated_by?(user)
     end
-    can [:admin, :bulk_management, :managed, :bulk_invoice], Spree::Order do
+    can [:admin, :bulk_management, :managed], Spree::Order do
       user.admin? || user.enterprises.any?(&:is_distributor)
     end
+    can [:admin, :create, :show, :poll], :invoice
     can [:admin, :visible], Enterprise
     can [:admin, :index, :create, :update, :destroy], :line_item
     can [:admin, :index, :create], Spree::LineItem

--- a/spec/controllers/spree/admin/invoices_controller_spec.rb
+++ b/spec/controllers/spree/admin/invoices_controller_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 
 describe Spree::Admin::InvoicesController, type: :controller do
   let(:order) { create(:order_with_totals_and_distribution) }
-  let(:user) { create(:admin_user) }
+  let(:enterprise_user) { create(:user) }
+  let!(:enterprise) { create(:enterprise, owner: enterprise_user) }
 
   before do
-    allow(controller).to receive(:spree_current_user) { user }
+    allow(controller).to receive(:spree_current_user) { enterprise_user }
   end
 
   describe "#create" do


### PR DESCRIPTION
#### What? Why?

Closes #3409

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Updates the CanCan permissions to reflect the changes made in the second iteration of bulk invoice printing, using polling and the updated Admin::InvoicesController. The old permissions were still in place, so the routes in the new controller were returning unauthorized for non-superadmin users.

#### What should we test?
<!-- List which features should be tested and how. -->

Bulk Invoice printing works with non-superadmin users.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed permissions on bulk invoices for producers. 

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

