### PR TITLE
Fix hash merge for recording already created products by name

### DIFF
--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -175,7 +175,7 @@ module ProductImport
         assign_errors product.errors.full_messages, entry.line_number
       end
 
-      @already_created[entry.enterprise_id] = { entry.name => product.id }
+      @already_created.deep_merge! entry.enterprise_id => { entry.name => product.id }
     end
 
     def save_variant(entry)

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -247,6 +247,7 @@ describe ProductImport::ProductImporter do
       csv_data = CSV.generate do |csv|
         csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag"]
+        csv << ["Chives", "User Enterprise", "Vegetables", "6", "4.50", "500", "g", "Small Bag"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag"]
       end
       File.write('/tmp/test-m.csv', csv_data)
@@ -260,17 +261,17 @@ describe ProductImport::ProductImporter do
       @importer.validate_entries
       entries = JSON.parse(@importer.entries_json)
 
-      expect(filter('valid', entries)).to eq 2
+      expect(filter('valid', entries)).to eq 3
       expect(filter('invalid', entries)).to eq 0
-      expect(filter('create_product', entries)).to eq 2
+      expect(filter('create_product', entries)).to eq 3
     end
 
     it "saves and updates" do
       @importer.save_entries
 
-      expect(@importer.products_created_count).to eq 2
+      expect(@importer.products_created_count).to eq 3
       expect(@importer.updated_ids).to be_a(Array)
-      expect(@importer.updated_ids.count).to eq 2
+      expect(@importer.updated_ids.count).to eq 3
 
       small_bag = Spree::Variant.find_by_display_name('Small Bag')
       expect(small_bag.product.name).to eq 'Potatoes'


### PR DESCRIPTION
#### What? Why?

This fixes an issue found by @mkllnk here: https://github.com/openfoodfoundation/openfoodnetwork/commit/e7a909e828dbf8234cdebcbacd8591801caf7518#r32142681

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

A hash that recorded products that had already been created was not being added to correctly, which meant if multiple variants of the same product were added in a CSV the subsequent entries could create new products instead of variants of the first product.

#### What should we test?
<!-- List which features should be tested and how. -->

With a CSV like this, we should get these results: 

```
Apples 1kg -> new product
Apples 2kg -> new variant of new product above
Pears         -> new product
Apples 3kg -> new variant of new product above (not a new product!)
```

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a potential bug when importing multiple variants at once with product import.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
