### PR TITLE
Use Dir::Tmpname.make_tmpname for threadsafe file naming

### DIFF
--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -79,11 +79,9 @@ module Admin
     end
 
     def save_uploaded_file(upload)
-      filename = 'import' + Time.zone.now.strftime('%d-%m-%Y-%H-%M-%S')
-      extension = '.' + upload.original_filename.split('.').last
-      directory = 'tmp/product_import'
-      Dir.mkdir(directory) unless File.exist?(directory)
-      File.open(Rails.root.join(directory, filename + extension), 'wb') do |f|
+      extension = File.extname(upload.original_filename)
+      directory = Dir.mktmpdir 'product_import'
+      File.open(File.join(directory, "import#{extension}"), 'wb') do |f|
         data = UploadSanitizer.new(upload.read).call
         f.write(data)
         f.path


### PR DESCRIPTION
#### What? Why?

Closes #3423

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Uploaded CSV files were using a time-based filename that was not adequately unique, so if two files were uploaded in the same second by different users it could cause an issue.

I've used `Dir::Tmpname.make_tmpname` as suggested by @mkllnk (thanks for the lesson!)

It's output looks like this in the Rails console, if anyone's interested:
```
irb(main):001:0> Dir::Tmpname.make_tmpname 'import', nil
=> "import20190203-28965-1j8l7ha"
```

#### What should we test?
<!-- List which features should be tested and how. -->

No testing required. If the specs are green it should be fine.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed naming method for temporary uploaded CSV files.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

