### PR TITLE
[Spree Upgrade] Fix admin new order page flow (from order details to customer details)

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -27,6 +27,23 @@ Spree::Admin::OrdersController.class_eval do
     # within the page then fetches the data it needs from Api::OrdersController
   end
 
+  # Re-implement spree method so that it redirects to edit instead of rendering edit
+  #   This allows page reloads while adding variants to the order (/edit), without being redirected to customer details page (/update)
+  def update
+    unless @order.update_attributes(params[:order]) && @order.line_items.present?
+      @order.errors.add(:line_items, Spree.t('errors.messages.blank')) if @order.line_items.empty?
+      return redirect_to edit_admin_order_path(@order), :flash => { :error => @order.errors.full_messages.join(', ') }
+    end
+
+    @order.update!
+    if @order.complete?
+      redirect_to edit_admin_order_path(@order)
+    else
+      # Jump to next step if order is not complete
+      redirect_to admin_order_customer_path(@order)
+    end
+  end
+
   # Overwrite to use confirm_email_for_customer instead of confirm_email.
   # This uses a new template. See mailers/spree/order_mailer_decorator.rb.
   def resend


### PR DESCRIPTION
#### What? Why?

Closes #3103

The new spree admin orders controller together with the variant search JS, after adding the variant, run a window.reload on order#update which redirects to customer details after the first variant is added to the order...

I dont think this behaviour of jumping to customer details after the first variant is added is acceptable. So, we need to find a way to keep the user in the order details page when variants are added and keep the behaviour of jumping to customer details if user clicks "update and recalculate" and the order is not complete.

This PR changes the spree admin orders controller to adapt to our needs by redirecting from update to edit when there are errors (and sends the errors in flash errors) so that when a variant is added and the page is reloaded, the current action is edit and the page doesn't jump to the customer details (the jump is configured on the update action).

#### What should we test?
The 3 specs in #3103 should be green but only together with #3194 (I have verified this in a [previous build](https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/branches/pull-request-3436/builds/2))