### PR TITLE
3437 supplier name on invoice

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -37,9 +37,7 @@ Spree::Admin::OrdersController.class_eval do
   end
 
   def invoice
-    pdf = render_to_string pdf: "invoice-#{@order.number}.pdf",
-                           template: invoice_template,
-                           formats: [:html], encoding: "UTF-8"
+    pdf = InvoiceRenderer.new.render(@order)
 
     Spree::OrderMailer.invoice_email(@order.id, pdf).deliver
     flash[:success] = t('admin.orders.invoice_email_sent')
@@ -48,7 +46,7 @@ Spree::Admin::OrdersController.class_eval do
   end
 
   def print
-    render pdf: "invoice-#{@order.number}", template: invoice_template, encoding: "UTF-8"
+    render InvoiceRenderer.new.args(@order)
   end
 
   def print_ticket
@@ -60,10 +58,6 @@ Spree::Admin::OrdersController.class_eval do
   end
 
   private
-
-  def invoice_template
-    Spree::Config.invoice_style2? ? "spree/admin/orders/invoice2" : "spree/admin/orders/invoice"
-  end
 
   def require_distributor_abn
     unless @order.distributor.abn.present?

--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -37,7 +37,7 @@ Spree::Admin::OrdersController.class_eval do
   end
 
   def invoice
-    pdf = InvoiceRenderer.new.render(@order)
+    pdf = InvoiceRenderer.new.render_to_string(@order)
 
     Spree::OrderMailer.invoice_email(@order.id, pdf).deliver
     flash[:success] = t('admin.orders.invoice_email_sent')

--- a/app/services/bulk_invoice_service.rb
+++ b/app/services/bulk_invoice_service.rb
@@ -10,7 +10,7 @@ class BulkInvoiceService
     orders = Spree::Order.where(id: order_ids)
 
     orders.each do |order|
-      invoice = InvoiceRenderer.new.render_to_string(order)
+      invoice = renderer.render_to_string(order)
 
       pdf << CombinePDF.parse(invoice)
     end
@@ -35,6 +35,10 @@ class BulkInvoiceService
 
   def directory
     'tmp/invoices'
+  end
+
+  def renderer
+    @renderer ||= InvoiceRenderer.new
   end
 
   def file_directory

--- a/app/services/bulk_invoice_service.rb
+++ b/app/services/bulk_invoice_service.rb
@@ -1,5 +1,4 @@
 class BulkInvoiceService
-  include WickedPdf::PdfHelper
   attr_reader :id
 
   def initialize
@@ -11,10 +10,7 @@ class BulkInvoiceService
     orders = Spree::Order.where(id: order_ids)
 
     orders.each do |order|
-      invoice = renderer.render_to_string pdf: "invoice-#{order.number}.pdf",
-                                          template: invoice_template,
-                                          formats: [:html], encoding: "UTF-8",
-                                          locals: { :@order => order }
+      invoice = InvoiceRenderer.new.render_to_string(order)
 
       pdf << CombinePDF.parse(invoice)
     end
@@ -39,14 +35,6 @@ class BulkInvoiceService
 
   def directory
     'tmp/invoices'
-  end
-
-  def renderer
-    ApplicationController.new
-  end
-
-  def invoice_template
-    Spree::Config.invoice_style2? ? "spree/admin/orders/invoice2" : "spree/admin/orders/invoice"
   end
 
   def file_directory

--- a/app/services/invoice_renderer.rb
+++ b/app/services/invoice_renderer.rb
@@ -1,0 +1,29 @@
+class InvoiceRenderer
+  def render_to_string(order)
+    renderer.render_to_string(args(order))
+  end
+
+  def args(order)
+    {
+      pdf: "invoice-#{order.number}.pdf",
+      template: invoice_template,
+      formats: [:html],
+      encoding: "UTF-8",
+      locals: { :@order => order }
+    }
+  end
+
+  private
+
+  def renderer
+    ApplicationController.new
+  end
+
+  def invoice_template
+    if Spree::Config.invoice_style2?
+      "spree/admin/orders/invoice2"
+    else
+      "spree/admin/orders/invoice"
+    end
+  end
+end

--- a/app/views/spree/admin/orders/_invoice_table.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table.html.haml
@@ -14,6 +14,9 @@
       %tr
         %td
           = render 'spree/shared/line_item_name', line_item: item
+          %br
+          %small
+            %em= raw(item.variant.product.supplier.name)
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/app/views/spree/admin/orders/_invoice_table2.html.haml
+++ b/app/views/spree/admin/orders/_invoice_table2.html.haml
@@ -17,6 +17,9 @@
       %tr
         %td
           = render 'spree/shared/line_item_name', line_item: item
+          %br
+          %small
+            %em= raw(item.variant.product.supplier.name)
         %td{:align => "right"}
           = item.quantity
         %td{:align => "right"}

--- a/spec/services/bulk_invoice_service_spec.rb
+++ b/spec/services/bulk_invoice_service_spec.rb
@@ -17,8 +17,7 @@ describe BulkInvoiceService do
       order.bill_address = order.ship_address
       order.save!
 
-      service.start_pdf_job([order.id])
-      Delayed::Job.last.invoke_job
+      service.start_pdf_job_without_delay([order.id])
 
       expect(service.invoice_created?(service.id)).to be_truthy
     end

--- a/spec/services/bulk_invoice_service_spec.rb
+++ b/spec/services/bulk_invoice_service_spec.rb
@@ -11,6 +11,17 @@ describe BulkInvoiceService do
 
       expect(Delayed::Job.last.payload_object.method_name).to eq :start_pdf_job_without_delay
     end
+
+    it "creates a PDF invoice" do
+      order = create(:completed_order_with_fees)
+      order.bill_address = order.ship_address
+      order.save!
+
+      service.start_pdf_job([order.id])
+      Delayed::Job.last.invoke_job
+
+      expect(service.invoice_created?(service.id)).to be_truthy
+    end
   end
 
   describe "#invoice_created?" do

--- a/spec/services/invoice_renderer_spec.rb
+++ b/spec/services/invoice_renderer_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe InvoiceRenderer do
+  let(:service) { described_class.new }
+
+  it "creates a PDF invoice" do
+    order = create(:completed_order_with_fees)
+    order.bill_address = order.ship_address
+    order.save!
+
+    result = service.render_to_string(order)
+
+    expect(result).to match /^%PDF/
+  end
+end

--- a/spec/services/invoice_renderer_spec.rb
+++ b/spec/services/invoice_renderer_spec.rb
@@ -3,13 +3,18 @@ require 'spec_helper'
 describe InvoiceRenderer do
   let(:service) { described_class.new }
 
-  it "creates a PDF invoice" do
+  it "creates a PDF invoice with two different templates" do
     order = create(:completed_order_with_fees)
     order.bill_address = order.ship_address
     order.save!
 
     result = service.render_to_string(order)
-
     expect(result).to match /^%PDF/
+
+    allow(Spree::Config).to receive(:invoice_style2?).and_return true
+
+    alternative = service.render_to_string(order)
+    expect(alternative).to match /^%PDF/
+    expect(alternative).to_not eq result
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3437.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Simply adding the supplier name to each line item on the invoice allows a food hub to use the invoice as packing sheet.

#### What should we test?
<!-- List which features should be tested and how. -->

- Create an order and look at the emailed template.
- Change the invoice template as super-admin in Settings/ Invoice Settings.
- View an order as admin and look at the invoice through the action "Print Invoice"

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Invoices now contain the supplier name for each item.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

