### PR TITLE
[WIP] Use system version of chromedriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,6 @@ group :test, :development do
   gem 'letter_opener', '>= 1.4.1'
   gem 'timecop'
   gem 'selenium-webdriver'
-  gem 'chromedriver-helper'
   gem 'rspec-retry'
   gem 'json_spec', '~> 1.1.4'
   gem 'unicorn-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,8 +188,6 @@ GEM
       tilt
     angularjs-file-upload-rails (2.4.1)
     angularjs-rails (1.5.5)
-    archive-zip (0.7.0)
-      io-like (~> 0.3.0)
     arel (3.0.3)
     ast (2.4.0)
     atomic (1.1.101)
@@ -217,9 +215,6 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.1.0)
-      archive-zip (~> 0.7.0)
-      nokogiri (~> 1.6)
     chronic (0.10.2)
     chunky_png (1.3.10)
     climate_control (0.2.0)
@@ -497,7 +492,6 @@ GEM
       i18n (>= 0.6.6, < 2)
     immigrant (0.3.6)
       activerecord (>= 3.0)
-    io-like (0.3.0)
     ipaddress (0.8.3)
     jaro_winkler (1.5.1)
     journey (1.0.4)
@@ -783,7 +777,6 @@ DEPENDENCIES
   bugsnag
   byebug (~> 9.0.0)
   capybara (>= 2.15.4)
-  chromedriver-helper
   coffee-rails (~> 3.2.1)
   combine_pdf
   compass-rails


### PR DESCRIPTION
#### What? Why?

Our build is broken at the moment, because our chromedriver-helper is downloading the latest chromedriver which is not compatible with Semaphore's Chrome.

Here I remove the helper. We can add it with more time when we discussed the best solution to this problem.

#### What should we test?
<!-- List which features should be tested and how. -->

Only automated tests.

