### PR TITLE
Use localized currency symbols in Subs pages

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/subscriptions.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/subscriptions.js.coffee
@@ -1,1 +1,1 @@
-angular.module("admin.subscriptions", ['ngResource','admin.indexUtils','admin.dropdown'])
+angular.module("admin.subscriptions", ['ngResource','admin.indexUtils','admin.dropdown', 'admin.utils'])

--- a/app/assets/javascripts/admin/utils/filters/localize_currency.js.coffee
+++ b/app/assets/javascripts/admin/utils/filters/localize_currency.js.coffee
@@ -1,0 +1,14 @@
+angular.module("admin.utils").filter "localizeCurrency", (currencyConfig)->
+  # Convert number to string currency using injected currency configuration.
+  (amount) ->
+    # Set country code (eg. "US").
+    currency_code = if currencyConfig.display_currency then " " + currencyConfig.currency else ""
+    # Set decimal points, 2 or 0 if hide_cents.
+    decimals = if currencyConfig.hide_cents == "true" then 0 else 2
+    # Set format if the currency symbol should come after the number, otherwise (default) use the locale setting.
+    format = if currencyConfig.symbol_position == "after" then "%n %u" else undefined
+    # We need to use parseFloat as the amount should come in as a string.
+    amount = parseFloat(amount)
+
+    # Build the final price string.
+    I18n.toCurrency(amount, {precision: decimals, unit: currencyConfig.symbol, format: format}) + currency_code

--- a/app/helpers/admin/injection_helper.rb
+++ b/app/helpers/admin/injection_helper.rb
@@ -65,6 +65,10 @@ module Admin
       admin_inject_json_ams_array opts[:module], "columns", column_preferences, Api::Admin::ColumnPreferenceSerializer
     end
 
+    def admin_inject_currency_config
+      admin_inject_json_ams 'admin.utils', "currencyConfig", {}, Api::CurrencyConfigSerializer
+    end
+
     def admin_inject_enterprise_permissions
       permissions =
         {can_manage_shipping_methods: can?(:manage_shipping_methods, @enterprise),

--- a/app/overrides/spree/layouts/admin/add_currency_config.html.haml.deface
+++ b/app/overrides/spree/layouts/admin/add_currency_config.html.haml.deface
@@ -1,0 +1,3 @@
+/ insert_before "div#wrapper"
+
+= admin_inject_currency_config

--- a/app/views/admin/subscriptions/_orders_panel.html.haml
+++ b/app/views/admin/subscriptions/_orders_panel.html.haml
@@ -19,7 +19,7 @@
                 %div{ ng: { bind: "::orderCycleCloses(proxyOrder.order_cycle_id)" } }
               %td.text-center
                 %span.state{ ng: { class: "proxyOrder.state", bind: 'stateText(proxyOrder.state)' } }
-              %td.text-center{ ng: { bind: '(proxyOrder.total || subscription.estimatedTotal()) | currency' } }
+              %td.text-center{ ng: { bind: '(proxyOrder.total || subscription.estimatedTotal()) | localizeCurrency' } }
               %td.actions
                 %a.edit-order.icon-edit.no-text{ href: '{{::proxyOrder.edit_path}}', target: '_blank', 'ofn-with-tip' => t(:edit_order), confirm_order_edit: true }
                 %a.cancel-order.icon-remove.no-text{ href: 'javascript:void(0)', ng: { hide: "proxyOrder.state == 'canceled'", click: "cancelOrder(proxyOrder)" }, 'ofn-with-tip' => t(:cancel_order) }

--- a/app/views/admin/subscriptions/_review.html.haml
+++ b/app/views/admin/subscriptions/_review.html.haml
@@ -75,9 +75,9 @@
                   .description {{ item.description }}
                   .not-in-open-and-upcoming-order-cycles-warning{ ng: { if: '!item.in_open_and_upcoming_order_cycles' } }
                     = t(".no_open_or_upcoming_order_cycle")
-                %td.price.align-center {{ item.price_estimate | currency }}
+                %td.price.align-center {{ item.price_estimate | localizeCurrency }}
                 %td.quantity {{ item.quantity }}
-                %td.total.align-center {{ (item.price_estimate * item.quantity) | currency }}
+                %td.total.align-center {{ (item.price_estimate * item.quantity) | localizeCurrency }}
             %tbody#subtotal.no-border-top{"data-hook" => "admin_order_form_subtotal"}
               %tr#subtotal-row
                 %td{:colspan => "3"}
@@ -85,7 +85,7 @@
                     = t(:subtotal)
                     \:
                 %td.total.align-center
-                  %span {{ subscription.estimatedSubtotal() | currency }}
+                  %span {{ subscription.estimatedSubtotal() | localizeCurrency }}
             %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
               %tr
                 %td{:colspan => "3"}
@@ -93,6 +93,6 @@
                     = t(:order_total_price)
                     \:
                 %td.total.align-center
-                  %span#order_form_total {{ subscription.estimatedTotal() | currency }}
+                  %span#order_form_total {{ subscription.estimatedTotal() | localizeCurrency }}
           %p.notice
             = t "this_is_an_estimate", scope: 'admin.subscriptions.subscription_line_items'

--- a/app/views/admin/subscriptions/_subscription_line_items.html.haml
+++ b/app/views/admin/subscriptions/_subscription_line_items.html.haml
@@ -19,10 +19,10 @@
         .description {{ item.description }}
         .not-in-open-and-upcoming-order-cycles-warning{ ng: { if: '!item.in_open_and_upcoming_order_cycles' } }
           = t(".not_in_open_and_upcoming_order_cycles_warning")
-      %td.price.align-center {{ item.price_estimate | currency }}
+      %td.price.align-center {{ item.price_estimate | localizeCurrency }}
       %td.quantity
         %input{ name: 'quantity', type: 'number', min: 0, ng: { model: 'item.quantity' } }
-      %td.total.align-center {{ (item.price_estimate * item.quantity) | currency }}
+      %td.total.align-center {{ (item.price_estimate * item.quantity) | localizeCurrency }}
       %td.actions
         %a.delete-item.icon-trash.no-text{ ng: { click: 'removeSubscriptionLineItem(item)'}, :href => "javascript:void(0)" }
   %tbody#subtotal.no-border-top{"data-hook" => "admin_order_form_subtotal"}
@@ -32,7 +32,7 @@
           = t(:subtotal)
           \:
       %td.total.align-center
-        %span#order_subtotal {{ subscription.estimatedSubtotal() | currency }}
+        %span#order_subtotal {{ subscription.estimatedSubtotal() | localizeCurrency }}
       %td.actions
   %tbody#fees.no-border-top{ ng: { show: "subscription.estimatedFees() > 0" } }
     %tr#fees-row
@@ -41,7 +41,7 @@
           = t(:fees)
           \:
       %td.total.align-center
-        %span#order_fees {{ subscription.estimatedFees() | currency }}
+        %span#order_fees {{ subscription.estimatedFees() | localizeCurrency }}
       %td.actions
   %tbody#order-total.grand-total.no-border-top{"data-hook" => "admin_order_form_total"}
     %tr
@@ -50,7 +50,7 @@
           = t(:order_total_price)
           \:
       %td.total.align-center
-        %span#order_form_total {{ subscription.estimatedTotal() | currency }}
+        %span#order_form_total {{ subscription.estimatedTotal() | localizeCurrency }}
       %td.actions
 %p.notice
   = t ".this_is_an_estimate"


### PR DESCRIPTION
#### What? Why?

Closes #2875

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Shows localized currency symbols in the subscriptions UI.

#### What should we test?
<!-- List which features should be tested and how. -->

Localized currency symbols should be shown in subscriptions.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed currency symbol localization in subscriptions.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
