### PR TITLE
Soft delete customers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ gem 'wkhtmltopdf-binary'
 
 gem 'foreigner'
 gem 'immigrant'
+gem 'paranoia', '~> 1.3'
 gem 'roo', '~> 2.7.0'
 gem 'roo-xls', '~> 1.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -565,6 +565,8 @@ GEM
       cocaine (~> 0.5.3)
       mime-types
     parallel (1.11.2)
+    paranoia (1.3.4)
+      activerecord (~> 3.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     paypal-sdk-core (0.2.10)
@@ -828,6 +830,7 @@ DEPENDENCIES
   oj
   paper_trail (~> 5.2.3)
   paperclip
+  paranoia (~> 1.3)
   pg
   pry-byebug (>= 3.4.3)
   rabl

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -44,14 +44,17 @@ module Admin
     # copy of Spree::Admin::ResourceController without flash notice
     def destroy
       invoke_callbacks(:destroy, :before)
+
       if @object.destroy
         invoke_callbacks(:destroy, :after)
+
         respond_with(@object) do |format|
           format.html { redirect_to location_after_destroy }
           format.js   { render partial: "spree/admin/shared/destroy" }
         end
       else
         invoke_callbacks(:destroy, :fails)
+
         respond_with(@object) do |format|
           format.html { redirect_to location_after_destroy }
           format.json { render json: { errors: @object.errors.full_messages }, status: :conflict }

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -51,6 +51,7 @@ module Admin
         respond_with(@object) do |format|
           format.html { redirect_to location_after_destroy }
           format.js   { render partial: "spree/admin/shared/destroy" }
+          format.json { render_as_json @object, ams_prefix: params[:ams_prefix] }
         end
       else
         invoke_callbacks(:destroy, :fails)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,10 +1,10 @@
 class Customer < ActiveRecord::Base
   acts_as_taggable
+  acts_as_paranoid
 
   belongs_to :enterprise
   belongs_to :user, class_name: Spree.user_class
   has_many :orders, class_name: Spree::Order
-  before_destroy :check_for_orders
 
   belongs_to :bill_address, foreign_key: :bill_address_id, class_name: Spree::Address
   alias_attribute :billing_address, :bill_address
@@ -42,11 +42,5 @@ class Customer < ActiveRecord::Base
 
   def associate_user
     self.user = user || Spree::User.find_by_email(email)
-  end
-
-  def check_for_orders
-    return true unless orders.any?
-    errors[:base] << I18n.t('admin.customers.destroy.has_associated_orders')
-    false
   end
 end

--- a/db/migrate/20190207172740_add_deleted_at_to_customers.rb
+++ b/db/migrate/20190207172740_add_deleted_at_to_customers.rb
@@ -1,0 +1,8 @@
+class AddDeletedAtToCustomers < ActiveRecord::Migration
+  def change
+    add_column :customers, :deleted_at, :datetime
+    add_index :customers, :deleted_at
+
+    remove_foreign_key :spree_orders, :customers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181128054803) do
+ActiveRecord::Schema.define(:version => 20190207172740) do
 
   create_table "account_invoices", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -83,9 +83,11 @@ ActiveRecord::Schema.define(:version => 20181128054803) do
     t.integer  "ship_address_id"
     t.string   "name"
     t.boolean  "allow_charges",   :default => false, :null => false
+    t.datetime "deleted_at"
   end
 
   add_index "customers", ["bill_address_id"], :name => "index_customers_on_bill_address_id"
+  add_index "customers", ["deleted_at"], :name => "index_customers_on_deleted_at"
   add_index "customers", ["email"], :name => "index_customers_on_email"
   add_index "customers", ["enterprise_id", "code"], :name => "index_customers_on_enterprise_id_and_code", :unique => true
   add_index "customers", ["ship_address_id"], :name => "index_customers_on_ship_address_id"
@@ -1275,7 +1277,6 @@ ActiveRecord::Schema.define(:version => 20181128054803) do
   add_foreign_key "spree_option_values_variants", "spree_option_values", name: "spree_option_values_variants_option_value_id_fk", column: "option_value_id"
   add_foreign_key "spree_option_values_variants", "spree_variants", name: "spree_option_values_variants_variant_id_fk", column: "variant_id"
 
-  add_foreign_key "spree_orders", "customers", name: "spree_orders_customer_id_fk"
   add_foreign_key "spree_orders", "enterprises", name: "spree_orders_distributor_id_fk", column: "distributor_id"
   add_foreign_key "spree_orders", "order_cycles", name: "spree_orders_order_cycle_id_fk"
   add_foreign_key "spree_orders", "spree_addresses", name: "spree_orders_bill_address_id_fk", column: "bill_address_id"

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -181,7 +181,7 @@ describe Admin::CustomersController, type: :controller do
     end
 
     context 'when rendering json' do
-      context 'and the customer has no orders' do
+      context 'and the destroy succeeds' do
         it 'invokes before destroy callbacks' do
           allow(controller).to receive(:invoke_callbacks).with(:destroy, :after)
 
@@ -191,7 +191,7 @@ describe Admin::CustomersController, type: :controller do
 
         it 'returns a no_content status code' do
           spree_delete :destroy, id: customer, format: :json
-          expect(response).to have_http_status(:no_content)
+          expect(JSON.parse(response.body)['id']).to eq customer.id
         end
 
         it 'invokes after destroy callbacks' do
@@ -202,8 +202,11 @@ describe Admin::CustomersController, type: :controller do
         end
       end
 
-      context 'and the customer has orders' do
-        before { customer.orders << build(:order) }
+      context 'and the destroy fails' do
+        before do
+          allow(Customer).to receive(:find).with(customer.id.to_s).and_return(customer)
+          allow(customer).to receive(:destroy).and_return(false)
+        end
 
         it 'invokes before destroy callbacks' do
           allow(controller).to receive(:invoke_callbacks).with(:destroy, :fails)
@@ -214,7 +217,7 @@ describe Admin::CustomersController, type: :controller do
 
         it 'renders the errors' do
           spree_delete :destroy, id: customer, format: :json
-          expect(response.body).to match(I18n.t('admin.customers.destroy.has_associated_orders'))
+          expect(response.body).to match('errors')
         end
 
         it 'returns conflict HTTP status code' do
@@ -232,7 +235,7 @@ describe Admin::CustomersController, type: :controller do
     end
 
     context 'when rendering html' do
-      context 'and the customer has no orders' do
+      context 'and the destroy succeeds' do
         it 'invokes before destroy callbacks' do
           allow(controller).to receive(:location_after_destroy) { '/fix_location_after_destroy' }
           allow(controller).to receive(:invoke_callbacks).with(:destroy, :after)
@@ -256,8 +259,11 @@ describe Admin::CustomersController, type: :controller do
         end
       end
 
-      context 'and the customer has orders' do
-        before { customer.orders << build(:order) }
+      context 'and the destroy fails' do
+        before do
+          allow(Customer).to receive(:find).with(customer.id.to_s).and_return(customer)
+          allow(customer).to receive(:destroy).and_return(false)
+        end
 
         it 'invokes before destroy callbacks' do
           allow(controller).to receive(:location_after_destroy) { '/fix_location_after_destroy' }
@@ -284,7 +290,7 @@ describe Admin::CustomersController, type: :controller do
     end
 
     context 'when rendering js' do
-      context 'and the customer has no orders' do
+      context 'and the destroy succeeds' do
         it 'invokes before destroy callbacks' do
           allow(controller).to receive(:invoke_callbacks).with(:destroy, :after)
 
@@ -305,8 +311,11 @@ describe Admin::CustomersController, type: :controller do
         end
       end
 
-      context 'and the customer has orders' do
-        before { customer.orders << build(:order) }
+      context 'and the destroy fails' do
+        before do
+          allow(Customer).to receive(:find).with(customer.id.to_s).and_return(customer)
+          allow(customer).to receive(:destroy).and_return(false)
+        end
 
         it 'raises due to missing template' do
           expect {

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -73,24 +73,19 @@ feature 'Customers' do
 
         # Deleting
         create(:order, customer: customer1)
-        expect{
-          within "tr#c_#{customer1.id}" do
-            accept_alert do
-              find("a.delete-customer").click
-            end
+        within "tr#c_#{customer1.id}" do
+          accept_alert do
+            find("a.delete-customer").click
           end
-          expect(page).to have_selector "#info-dialog .text", text: I18n.t('admin.customers.destroy.has_associated_orders')
-          click_button "OK"
-        }.to_not change{Customer.count}
+        end
+        expect(page).to have_no_selector "tr#c_#{customer1.id}"
 
-        expect{
-          within "tr#c_#{customer2.id}" do
-            accept_alert do
-              find("a.delete-customer").click
-            end
+        within "tr#c_#{customer2.id}" do
+          accept_alert do
+            find("a.delete-customer").click
           end
-          expect(page).to have_no_selector "tr#c_#{customer2.id}"
-        }.to change{Customer.count}.by(-1)
+        end
+        expect(page).to have_no_selector "tr#c_#{customer2.id}"
       end
 
       it "allows updating of attributes" do


### PR DESCRIPTION
#### What? Why?

Closes #1494

This enables soft-deleting customers by means of `paranoia`. The same gem v2 uses. Therefore, I specified the same version Spree defines.

This allows disabling access to private shops while still showing any customer's orders and her details in reports.



#### What should we test?
* A customer can be removed from the customers' list regardless of the orders she might have placed (test with and without order)
* The removed customer can't access the private shop
* Reports still show the deleted customer's orders and her details


#### Release notes

Access to a private shop can be revoked by removing the customer from the list while still showing her orders from reports.

Changelog Category: Added
