### PR TITLE
Delete empty controller class eval and spec

### DIFF
--- a/app/controllers/spree/api/orders_controller_decorator.rb
+++ b/app/controllers/spree/api/orders_controller_decorator.rb
@@ -1,7 +1,0 @@
-Spree::Api::OrdersController.class_eval do
-
-  # We need to add expections for collection actions other than :index here
-  # because Spree's API controller causes authorize_read! to be called, which
-  # results in an ActiveRecord::NotFound Exception as the order object is not
-  # defined for collection actions
-end

--- a/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/spec/controllers/spree/api/orders_controller_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-require 'spree/api/testing_support/helpers'
-
-module Spree
-  describe Spree::Api::OrdersController, type: :controller do
-
-  end
-end


### PR DESCRIPTION
#### What? Why?
These are useless left overs from 0ad2978926f17e663b96bafffe4f8365e660af50
Correct? Is there ever a reason to have an empty class eval?

#### What should we test?
I dont think this controller is being used as the commit above says the BOM is using the admin ctrl not this api controller. The auto tests are validating that it's not a problem. We can make a simple sanity check on the BOM.

#### Release notes
Changelog Category: Removed
Removed old useless code.
