### PR TITLE
Import Catalan translation from Transifex

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,2649 @@
+ca:
+  language_name: "Català"
+  activerecord:
+    attributes:
+      spree/order:
+        payment_state: Estat del Pagament
+        shipment_state: Estat de la Tramesa
+        completed_at: Completat a
+        number: Número
+        state: Estat
+        email: Correu electrònic de la consumidora
+      spree/payment:
+        amount: Import
+      order_cycle:
+        orders_close_at: Data de tancament
+    errors:
+      models:
+        spree/user:
+          attributes:
+            email:
+              taken: "Ja hi ha un compte per a aquest correu electrònic. Si us plau, inicia sessió o restableix la contrasenya."
+        spree/order:
+          no_card: No hi ha targetes de crèdit autoritzades disponibles per carregar
+        order_cycle:
+          attributes:
+            orders_close_at:
+              after_orders_open_at: s'ha de fer amb el termini obert
+        variant_override:
+          count_on_hand:
+            using_producer_stock_settings_but_count_on_hand_set: "ha d'estar en blanc perquè s'utilitza la configuració de l'inventari de la productora"
+            on_demand_but_count_on_hand_set: "ha d'estar en blanc si és sota demanda"
+            limited_stock_but_no_count_on_hand: "cal especificar-se perquè força existències limitades"
+  activemodel:
+    errors:
+      models:
+        subscription_validator:
+          attributes:
+            subscription_line_items:
+              at_least_one_product: "^Afegiu com a mínim un producte"
+              not_available: "^ %{name} no està disponible a l'horari seleccionat"
+            ends_at:
+              after_begins_at: "ha de ser després de"
+            customer:
+              does_not_belong_to_shop: "no pertany a %{shop}"
+            schedule:
+              not_coordinated_by_shop: "no està coordinat per %{shop}"
+            payment_method:
+              not_available_to_shop: "no està disponible per %{shop}"
+              invalid_type: "el mètode ha de ser Efectiu o Stripe"
+              charges_not_allowed: "^ Els càrrecs de la targeta de crèdit no estan permesos per aquest consumidora"
+              no_default_card: "^ No hi ha cap targeta predeterminada disponible per a aquesta consumidora"
+            shipping_method:
+              not_available_to_shop: "no està disponible per %{shop}"
+  devise:
+    confirmations:
+      send_instructions: "Rebreu un correu electrònic amb instruccions sobre com confirmar el vostre compte en pocs minuts."
+      failed_to_send: "S'ha produït un error en enviar el correu electrònic de confirmació."
+      resend_confirmation_email: "Reenvia el correu electrònic de confirmació."
+      confirmed: "Gràcies per confirmar el vostre correu electrònic. Ara podeu iniciar sessió."
+      not_confirmed: "No s'ha pogut confirmar la vostra adreça de correu electrònic. Potser ja heu completat aquest pas?"
+    user_registrations:
+      spree_user:
+        signed_up_but_unconfirmed: "S'ha enviat un missatge amb un enllaç de confirmació a la teva adreça de correu electrònic. Obre l'enllaç per activar el teu compte."
+        unknown_error: "S'ha produït un error en crear el teu compte. Comprova la teva adreça de correu electrònic i torna-ho a provar."
+    failure:
+      invalid: |
+          Correu electrònic o contrasenya no vàlids.
+          Va ser un convitat la última vegada? Potser vostè necessita crear un compte o restablir la contrasenya.
+      unconfirmed: "Heu de confirmar el vostre compte abans de continuar."
+      already_registered: "Aquesta adreça electrònica ja està registrada. Inicieu sessió per continuar o torneu endarrere per utilitzar una altra adreça de correu electrònic."
+    user_passwords:
+      spree_user:
+        updated_not_active: "La vostra contrasenya s'ha restablert, però el vostre correu electrònic encara no s'ha confirmat."
+  models:
+    order_cycle:
+      cloned_order_cycle_name: "CÒPIA DE %{order_cycle}"
+  enterprise_mailer:
+    confirmation_instructions:
+      subject: "Sisplau, confirma l'adreça electrònica d'%{enterprise}"
+    welcome:
+      subject: "%{enterprise} és ara %{sitename}"
+    invite_manager:
+      subject: "%{enterprise} t'ha convidat a ser administrador"
+  order_mailer:
+    cancel_email:
+      dear_customer: "Benvolguda consumidora:"
+      instructions: "S'ha cancel·lat la vostra comanda. Conserveu aquesta informació com a comprovant de la cancel·lació."
+      order_summary_canceled: "Resum de comanda [CANCEL·LAT]"
+      subject: "Cancel·lació de la comanda"
+      subtotal: "Total parcial: %{subtotal}"
+      total: "Total comanda: %{total}"
+  producer_mailer:
+    order_cycle:
+      subject: "Informe del cicle de comanda per %{producer}"
+  shipment_mailer:
+    shipped_email:
+      dear_customer: "Benvolguda consumidora:"
+      instructions: "La vostra comanda s'ha enviat"
+      shipment_summary: "Detalls de l'enviament"
+      subject: "Notificació d'enviament"
+      thanks: "Gràcies per la teva compra."
+      track_information: "Informació del seguiment: %{tracking}"
+      track_link: "Enllaç del seguiment: %{url}"
+  subscription_mailer:
+    placement_summary_email:
+      subject: Un resum de les comandes per subscripció recentment establertes
+      greeting: "Hola %{name},"
+      intro: "A continuació es mostra un resum de les comandes per subscripció que s'acaben de col·locar per %{shop}."
+    confirmation_summary_email:
+      subject: Un resum de les comandes per subscripció confirmades recentment
+      greeting: "Hola %{name},"
+      intro: "A continuació es mostra un resum de les comandes per subscripció que acaben de finalitzar per %{shop}."
+    summary_overview:
+      total: S'ha marcat un total de subscripcions %{count} per al processament automàtic.
+      success_zero: D'aquestes, cap d'elles s'ha processat correctament.
+      success_some: D'aquests, %{count} s'han processat correctament.
+      success_all: Tots s'han processat correctament.
+      issues: A continuació es detallen els problemes trobats.
+    summary_detail:
+      no_message_provided: No s'ha proporcionat cap missatge d'error
+      changes:
+        title: Stock insuficient (%{count} comandes)
+        explainer: Aquestes comandes es van processar, però no hi havia suficients estocs per a alguns articles sol·licitats
+      empty:
+        title: Sense Stock (%{count} comandes)
+        explainer: Aquestes comandes no s'han pogut processar perquè no hi ha disponible cap estoc per a cap dels elements sol·licitats
+      complete:
+        title: Ja està processat (%{count} comandes)
+        explainer: Aquestes comandes ja estaven marcades com a completes i, per tant, no es modificarán
+      processing:
+        title: S'ha trobat un error (%{count} comandes)
+        explainer: El processament automàtic d'aquestes comandes ha fallat a causa d'un error. L'error es mostra sempre que sigui possible.
+      failed_payment:
+        title: Pagament erroni (%{count} comandes)
+        explainer: La tramitació automàtica del pagament d'aquestes comandes va fallar a causa d'un error. L'error es mostra sempre que sigui possible.
+      other:
+        title: Altres errors (%{count} comandes)
+        explainer: El processament automàtic d'aquestes comandes va fallar per un motiu desconegut. Això no hauria de passar, si us plau, contacteu amb nosaltres si esteu veient això.
+  home: "OFN"
+  title: Open Food Network
+  welcome_to: 'Benvingut a'
+  site_meta_description: "Comencem des de baix. Amb agricultors i productors disposats a explicar les seves històries amb orgull i sinceritat. Amb distribuïdors connectant persones i productes de manera justa i honesta. Amb compradors que creuen que millors decisions de compra setmanal poden ..."
+  search_by_name: Cercar per nom o barri ...
+  producers_join: Els productors australians son ara benvinguts a unir-se a la Open Food Network.
+  charges_sales_tax: Càrrecs GST?
+  print_invoice: "Imprimir Factura"
+  print_ticket: "Imprimir Ticket"
+  select_ticket_printer: "Seleccionar la impressora de tickets"
+  send_invoice: "Enviar Factura"
+  resend_confirmation: "Reenviar Confirmació"
+  view_order: "Veure Comanda"
+  edit_order: "Editar Comanda"
+  ship_order: "Enviar Comanda"
+  cancel_order: "Cancel·lar Comanda"
+  confirm_send_invoice: "Una factura per aquesta comanda s'enviarà al client. Està segur de continuar?"
+  confirm_resend_order_confirmation: "Segur que vol reenviar el correu de confirmació de la comanda?"
+  must_have_valid_business_number: "%{enterprise_name} ha de tenir un ABN vàlid abans de les factures es poden enviar."
+  invoice: "Factura"
+  percentage_of_sales: "%{percentage} de vendes"
+  capped_at_cap: "llimitat a %{cap}"
+  per_month: "al mes"
+  free: "gratuït"
+  free_trial: "prova gratuïta"
+  plus_tax: "més GST"
+  min_bill_turnover_desc: "una vegada que el volum de negocis supere %{mbt_amount}"
+  more: "Més"
+  say_no: "No"
+  say_yes: "Si"
+  then: llavors
+  ongoing: En marxa
+  bill_address: Adreça de facturació
+  ship_address: Adreça d'enviament
+  sort_order_cycles_on_shopfront_by: "Ordenar Cicles de Comanda de la Botiga per"
+  required_fields: Els camps obligatoris estan marcats amb un asterisc
+  select_continue: Seleccionar i Continuar
+  remove: Eliminar
+  or: o
+  collapse_all: Col·lapsar tot
+  expand_all: Expandir tot
+  loading: Carregant...
+  show_more: Mostrar més
+  show_all: Mostrar tots
+  show_all_with_more: "Mostrar tot (%{num} més)"
+  cancel: Cancel·lar
+  edit: Editar
+  clone: Clonar
+  distributors: Distribuïdors
+  distribution: Distribució
+  bulk_order_management: Gestió de comandes en bloc
+  enterprises: Organitzacions
+  enterprise_groups: Grups
+  reports: Informes
+  variant_overrides: Inventari
+  spree_products: Productes Spree
+  all: Tots
+  current: Actual
+  available: Disponible
+  dashboard: Panell
+  undefined: indefinit
+  unused: no utilitzat
+  admin_and_handling: Administració i manipulació
+  profile: Perfil
+  supplier_only: Només proveïdor
+  has_shopfront: Té botiga
+  weight: Pes
+  volume: Volum
+  items: Articles
+  summary: Resum
+  detailed: Detallada
+  updated: Actualitzat
+  'yes': "Sí"
+  'no': "No"
+  y: 'S'
+  n: 'N'
+  powered_by: Impulsat per
+  blocked_cookies_alert: "El vostre navegador pot estar bloquejant les galetes necessàries per utilitzar aquesta botiga. Feu clic a continuació per permetre les galetes i tornar a carregar la pàgina."
+  allow_cookies: "Permet les galetes"
+  notes: Notes
+  error: Error
+  processing_payment: S'està processant el pagament ...
+  show_only_unfulfilled_orders: Mostra només comandes no realitzades
+  filter_results: Resultats del filtre
+  quantity: Quantitat
+  pick_up: Recollida
+  copy: Còpia
+  password_confirmation: Confirmació de la contrassenya
+  reset_password_token: Reinicia el token de contrasenya
+  expired: ha caducat, si us plau, sol·liciteu-ne un de nou
+  back_to_payments_list: "Torna a la llista de pagaments"
+  actions:
+    create_and_add_another: "Crea i afegeix-ne una altra"
+  admin:
+    begins_at: Comença a
+    begins_on: Comença
+    customer: Consumidora
+    date: Data
+    email: E-mail
+    ends_at: Acaba a
+    ends_on: Finalitza
+    name: Nom
+    on_hand: Disponibles
+    on_demand: Sota demanda
+    on_demand?: Sota demanda?
+    order_cycle: Cicle de Comanda
+    payment: Pagament
+    payment_method: Mètode de pagament
+    phone: Telèfon
+    price: Preu
+    producer: Productor
+    image: Imatge
+    product: Producte
+    quantity: Quantitat
+    schedule: Horari
+    shipping: Enviament
+    shipping_method: Mètode d'enviament
+    shop: Botiga
+    sku: SKU
+    status_state: Estat
+    tags: Etiquetes
+    variant: Variant
+    weight: Pes
+    volume: Volum
+    items: Articles
+    select_all: Seleccionar tot
+    obsolete_master: Mestre obsolet
+    quick_search: Cerca Ràpida
+    clear_all: Esborrar tot
+    start_date: "Data d'inici"
+    end_date: "Data de finalització"
+    form_invalid: "El formulari conté camps que falten o no son vàlids"
+    clear_filters: Netejar Filtres
+    clear: Netejar
+    save: Desa
+    cancel: Cancel·lar
+    back: Enrere
+    show_more: Mostra més
+    show_n_more: Mostra %{num} més
+    choose: "Tria ..."
+    please_select: Seleccioneu ...
+    columns: Columnes
+    actions: Accions
+    viewing: "Veient: %{current_view_name}"
+    description: Descripció
+    whats_this: Què és això?
+    tag_has_rules: "Regles existents per a aquesta etiqueta: %{num}"
+    has_one_rule: "té una regla"
+    has_n_rules: "té%{num} regles"
+    unsaved_confirm_leave: "Hi ha canvis no desats canviats en aquesta pàgina. Continua sense desar?"
+    unsaved_changes: "Teniu canvis sense desar"
+    accounts_and_billing_settings:
+      method_settings:
+        default_accounts_payment_method: "Mètode de pagament de comptes predeterminats"
+        default_accounts_shipping_method: "Mètode d'enviament de comptes predeterminades"
+      edit:
+        accounts_and_billing: "Comptes i facturació"
+        accounts_administration_distributor: "'administració de comptes de distribuïdora"
+        admin_settings: "Configuració"
+        update_invoice: "Actualitza les factures"
+        auto_update_invoices: "Actualitzeu les factures cada dia a la 1:00 a.m."
+        finalise_invoice: "Finalitzar les factures"
+        auto_finalise_invoices: "Finalitzar automàticament les factures mensualment el dia 2 a la 1:30 a.m."
+        manually_run_task: "Executa la tasca manualment"
+        update_user_invoice_explained: "Utilitzeu aquest botó per actualitzar immediatament les factures del mes actual per a cada usuari d'organització del sistema. Aquesta tasca es pot configurar per executar-se automàticament cada nit."
+        finalise_user_invoices: "Finalitza les factures d'usuari"
+        finalise_user_invoice_explained: "Utilitzeu aquest botó per finalitzar totes les factures del sistema per al mes natural anterior. Aquesta tasca es pot configurar per executar-se automàticament un cop al mes."
+        update_user_invoices: "Actualitzeu factures d'usuari"
+      errors:
+        accounts_distributor: s'ha d'establir si voleu crear factures per a usuàries de la organització.
+        default_payment_method: s'ha d'establir si voleu crear factures per a usuàries de la organització.
+        default_shipping_method: s'ha d'establir si voleu crear factures per a usuàries de la organització.
+    shopfront_settings:
+      embedded_shopfront_settings: "Configuració de botiga incrustada"
+      enable_embedded_shopfronts: "Habilita les botigues incrustades"
+      embedded_shopfronts_whitelist: "Llista blanca de dominis externs"
+    number_localization:
+      number_localization_settings: "Configuració de localització numèrica"
+      enable_localized_number: "Utilitzeu l'estàndard internacional per separar milers/decimals"
+    business_model_configuration:
+      edit:
+        business_model_configuration: "Model de sostenibilitat"
+        business_model_configuration_tip: "Configureu la tarifa què es cobrarà a les botigues cada mes per utilitzar la Xarxa Open Food."
+        bill_calculation_settings: "Configuració del càlcul de ticket"
+        bill_calculation_settings_tip: "Ajusteu la quantitat que es facturarà a les organitzacions cada mes per utilitzar l'OFN."
+        shop_trial_length: "Durada de la prova de la botiga (dies)"
+        shop_trial_length_tip: "El temps (en dies) que les organitzacions que es configuren com a botigues poden funcionar amb període de prova."
+        fixed_monthly_charge: "Càrrec mensual fixat"
+        fixed_monthly_charge_tip: "Un càrrec mensual fix per a totes les organitzacions que es configuren com a botiga i que hagin superat la facturació mínima (si s'estableix)."
+        percentage_of_turnover: "Percentatge de la facturació"
+        percentage_of_turnover_tip: "Quan sigui superior a zero, aquesta taxa (0,0 - 1,0) s'aplicarà a la facturació total de cada botiga i s'afegeix a qualsevol càrrec fixat (a l'esquerra) per calcular la factura mensual."
+        monthly_cap_excl_tax: "Límit mensual (exclòs GST)"
+        monthly_cap_excl_tax_tip: "Quan sigui superior a zero, aquest valor s'utilitzarà com a límit en la quantitat que es cobrarà a les botigues cada mes."
+        tax_rate: "Impost"
+        tax_rate_tip: "Impost que s'aplica a la factura mensual que es cobra a les organitzacions per utilitzar el sistema."
+        minimum_monthly_billable_turnover: "Mínim volum de vendes facturable al mes"
+        minimum_monthly_billable_turnover_tip: "La facturació mensual mínima abans que a una botiga se li cobri per l'ús d'OFN. Les organitzacions que facturin menys d'aquest import en un mes no es cobraran, ja sigui per percentatge o per tipus fix."
+        example_bill_calculator: "Exemple de calculadora de rebut"
+        example_bill_calculator_legend: "Després de l'exemple de volum de ventes per visualitzar l'efecte de la configuració a l'esquerra."
+        example_monthly_turnover: "Exemple de facturació mensual"
+        example_monthly_turnover_tip: "Un exemple de volum de ventes mensual per a una organització que es farà servir per calcular un exemple de factura mensual més a baix."
+        cap_reached?: "S'ha arribat a la capacitat?"
+        cap_reached?_tip: "Si s'ha arribat al límit (especificat a l'esquerra), tenint en compte la configuració i el volum de ventes proporcionat."
+        included_tax: "Impostos incloses"
+        included_tax_tip: "Els impostos totals inclosos a la factura mensual d'exemple, tenint en compte la configuració i la facturació proporcionada."
+        total_monthly_bill_incl_tax: "Factura mensual total (impostos inclosos)"
+        total_monthly_bill_incl_tax_tip: "L'exemple total de la factura mensual amb impostos inclosos, tenint en compte la configuració i la facturació proporcionada."
+    cache_settings:
+      show:
+        title: Emmagatzematge ocult
+        distributor: Distribuïdora
+        order_cycle: Cicle de Comanda
+        status: Estat
+        diff: Diferència
+        error: Error
+    invoice_settings:
+      edit:
+        title: Configuració de la factura
+        invoice_style2?: Utilitzeu el model de factura alternatiu que inclou el desglossament dels càrregs totals per tarifa i la informació sobre la taxa impositiva per article (encara no està disponible per als països sense recàrregs en concpte d'impostos)
+        enable_receipt_printing?: Mostra les opcions per imprimir rebuts amb impressores tèrmiques en el menú desplegable de la comanda?
+    stripe_connect_settings:
+      edit:
+        title: "Stripe Connect"
+        settings: "Configuració"
+        stripe_connect_enabled: Permetre que les botigues acceptin pagaments mitjançant Stripe Connect?
+        no_api_key_msg: No hi ha cap compte de Stripe per a aquesta organització.
+        configuration_explanation_html: Per obtenir instruccions detallades sobre la configuració de la integració de Stripe Connect, <a href='https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance' target='_blank'> consulteu aquesta guia </a>.
+        status: Estat
+        ok: Correcte
+        instance_secret_key: Exemple de clau secreta
+        account_id: Identificador del compte
+        business_name: Nom de l'empresa
+        charges_enabled: Càrrecs habilitats
+        charges_enabled_warning: "Advertència: els càrrecs no estan habilitats per al vostre compte"
+        auth_fail_error: La clau API que heu proporcionat no és vàlida
+        empty_api_key_error_html: No s'ha proporcionat cap clau d'API de Stripe. Per configurar la clau API, seguiu <a href="https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance" target="_blank"> aquestes instruccions < / a>
+    matomo_settings:
+      edit:
+        title: "Configuració de Matomo"
+        matomo_url: "URL de Matomo"
+        matomo_site_id: "Identificador de Matomo"
+        info_html: "Matomo és un analitzador de webs i mòbils. Podeu allotjar Matomo de manera local o utilitzar un servei al núvol. Vegeu <a href='http://matomo.org' target='_blank'> matomo.org </a> per obtenir més informació."
+        config_instructions_html: "Aquí podeu configurar la integració Matomo OFN. L'URL de Matomo que us apareix a continuació ha d'indicar la instància de Matomo en la qual s'enviarà la informació de seguiment de l'usuari; si es deixa buit, el seguiment de l'usuari de Matomo estarà desactivat. El camp d'identificació del lloc no és obligatori, però és útil si fa un seguiment de més d'un lloc web en una sola instància de Matomo; es pot trobar a la consola d'instància de Matomo."
+    customers:
+      index:
+        add_customer: "Afegeix consumidora"
+        new_customer: "Nova consumidora"
+        customer_placeholder: "consumidora@example.org"
+        valid_email_error: siusplau, introduïu una adreça de correu electrònic vàlida
+        add_a_new_customer_for: Afegiu una consumidora nova per %{shop_name}
+        code: Codi
+        duplicate_code: "Aquest codi ja s'ha utilitzat."
+        bill_address: "Adreça de facturació"
+        ship_address: "Adreça d'enviament"
+        update_address_success: 'L''adreça s''ha actualitzat correctament.'
+        update_address_error: 'Ho sentim! Introduïu tots els camps obligatoris.'
+        edit_bill_address: 'Edita l''adreça de facturació'
+        edit_ship_address: 'Edita l''adreça d''enviament'
+        required_fileds: 'Els camps obligatoris es denoten amb un asterisc'
+        select_country: 'Selecciona país'
+        select_state: 'Selecciona província'
+        edit: 'Editar'
+        update_address: 'Actualitza l''adreça'
+        confirm_delete: 'Estàs segur que vols suprimir?'
+        search_by_email: "Cerca per correu electrònic/codi ..."
+        guest_label: 'Fer comanda com a convidat'
+      destroy:
+        has_associated_orders: 'S''ha produït un error en suprimir: la consumidora té comandes associades amb la seva botiga'
+    contents:
+      edit:
+        title: Contingut
+        header: Capçalera
+        home_page: Pàgina d'inici
+        producer_signup_page: Pàgina d'inscripció de productora
+        hub_signup_page: Pàgina d'inscripció de grup
+        group_signup_page: Pàgina d'inscripció de grup
+        main_links: Enllaços del menú principal
+        footer_and_external_links: Peu de pàgina i enllaços externs
+        your_content: El vostre contingut
+        user_guide: Guia de l'usuari
+    enterprise_fees:
+      index:
+        title: Tarifes de l'organització
+        enterprise: Organització
+        fee_type: Tipus de tarifa
+        name: Nom
+        tax_category: Categoria d'impostos
+        calculator: Calculadora
+        calculator_values: Valors de la calculadora
+    enterprise_groups:
+      index:
+        new_button: Grup d'organització nou
+    enterprise_roles:
+      form:
+        manages: gestiona
+      enterprise_role:
+        manages: gestiona
+    products:
+      unit_name_placeholder: 'exemple: grapats'
+      index:
+        unit: Unitat
+        display_as: Mostra com
+        category: Categoria
+        tax_category: Categoria d'impostos
+        inherits_properties?: Hereda propietats?
+        available_on: Disponible el
+        import_date: S'ha importat
+        upload_an_image: Penja una imatge
+      product_search_keywords: Paraules clau de cerca de producte
+      product_search_tip: Escriviu paraules per ajudar-vos a cercar els vostres productes a les botigues. Utilitzeu espai per separar cada paraula clau.
+      SEO_keywords: Paraules clau de SEO
+      seo_tip: Escriviu paraules per ajudar-vos a cercar els vostres productes a la web. Utilitzeu espai per separar cada paraula clau.
+      Search: Cerca
+      properties:
+        property_name: Nom de la propietat
+        inherited_property: Propietat heretada
+      variants:
+        to_order_tip: "Els articles preparats per encàrrec no tenen un nivell fixat d'existències, com ara pa fet sota comanda."
+      product_distributions: "Distribucions de productes"
+      group_buy_options: "Opcions de compra en grup"
+      back_to_products_list: "Torna a la llista de productes"
+    product_import:
+      title: Importació de productes
+      file_not_found: No s'ha trobat el fitxer o no s'ha pogut obrir
+      no_data: No s'ha trobat cap dada al full de càlcul
+      confirm_reset: "Això farà que el nivell d'existències sigui zero en tots els productes d'aquesta\n organització que no estan presents en el fitxer carregat"
+      model:
+        no_file: "error: no s'ha carregat cap fitxer"
+        could_not_process: "no s'ha pogut processar el fitxer: tipus de fitxer no vàlid"
+        incorrect_value: valor incorrecte
+        conditional_blank: no es pot deixar en blanc si el tipus d'unitat està en blanc
+        no_product: no s'ha trobat cap producte a la base de dades
+        not_found: no es troba a la base de dades
+        not_updatable: No es poden actualitzar els productes existents mitjançant la importació de productes
+        blank: no es pot deixar en blanc
+        products_no_permission: no tens el permís per gestionar els productes d'aquesta organització
+        inventory_no_permission: no tens el permís per crear inventari per a aquesta productora
+        none_saved: no s'han desat cap producte amb èxit
+        line_number: "Línia %{number}:"
+      index:
+        select_file: Selecciona un full de càlcul per pujar-lo
+        spreadsheet: Full de càlcul
+        choose_import_type: Selecciona el tipus d'importació
+        import_into: Tipus d'importació
+        product_list: Llista de productes
+        inventories: Inventari
+        import: Importa
+        upload: Carrega
+        csv_templates: Plantilles de CSV
+        product_list_template: Descarrega la plantilla de la llista de productes
+        inventory_template: Descarrega la plantilla d'inventari
+        category_values: Valors de la categoria disponibles
+        product_categories: Tipus de productes
+        tax_categories: Tipus d'impostos
+        shipping_categories: Tipus d'enviament
+      import:
+        review: Revisa
+        import: Importa
+        save: Desa
+        results: Resultats
+        save_imported: Desa els productes importats
+        no_valid_entries: No s'han trobat entrades vàlides
+        none_to_save: No hi ha entrades que es puguin desar
+        some_invalid_entries: El fitxer importat conté entrades no vàlides
+        fix_before_import: Si us plau, corregeix aquests errors i torna a importar el fitxer
+        save_valid?: Vols desar per ara les entrades vàlides i descartar les altres?
+        no_errors: No s'ha detectat cap error!
+        save_all_imported?: Vols desar tots els productes importats?
+        options_and_defaults: Importa opcions i valors predeterminats
+        no_permission: no tens permís per gestionar aquesta organització
+        not_found: No s'ha pogut trobar l'organització a la base de dades
+        no_name: Sense nom
+        blank_enterprise: alguns productes no tenen una organització definida
+        reset_absent?: Restabliu els productes absents
+        reset_absent_tip: Establiu valors a zero per a tots els productes existents que no figurin al fitxer
+        overwrite_all: Sobreescriu-ho tot
+        overwrite_empty: Sobreescriu si està buit
+        default_stock: Estableix el nivell d'existències
+        default_tax_cat: Estableix la categoria d'impostos
+        default_shipping_cat: Estableix la categoria d'enviament
+        default_available_date: Estableix data de disponibilitat
+        validation_overview: Importa la descripció general de la validació
+        entries_found: S'han trobat entrades al fitxer importat
+        entries_with_errors: Els articles contenen errors i no s'importaran
+        products_to_create: Els productes es crearan
+        products_to_update: Els productes s'actualitzaran
+        inventory_to_create: Els articles de l'inventari es crearan
+        inventory_to_update: Els articles de l'inventari s'actualitzaran
+        products_to_reset: Els productes existents reajustaran el nivell d'existències a zero
+        inventory_to_reset: Els articles de l'inventari existents tindran el restabliment d'existències a zero
+        line: Línia
+        item_line: Línia d'article
+      import_review:
+        not_updatable_tip: "Els següents camps no es poden actualitzar mitjançant importació  en bloc per a productes existents:"
+        fields_ignored: Aquests camps s'ignoraran quan es guardin els productes importats.
+      entries_table:
+        not_updatable: Aquest camp no es pot actualitzar mitjançant la importació en bloc per a productes existents
+      save_results:
+        final_results: Importa els resultats finals
+        products_created: Productes creats
+        products_updated: Productes actualitzats
+        inventory_created: S'han creat articles d'inventari
+        inventory_updated: 'S''han actualitzat articles d''inventari '
+        products_reset: S'ha reestablert el nivell d'existències dels productes a zero
+        inventory_reset: S'ha reestablert el nivell d'estoc dels articles de l'inventari a zero
+        all_saved: "Tots els articles s'han desat correctament"
+        some_saved: "els articles s'han desat correctament"
+        save_errors: Desa els errors
+        import_again: Penja un altre fitxer
+        view_products: Anar a la pàgina de Productes
+        view_inventory: Anar a la pàgina d'Inventari
+    variant_overrides:
+      loading_flash:
+        loading_inventory: CARREGANT INVENTARI
+      index:
+        title: Inventari
+        description: Utilitzeu aquesta pàgina per administrar els inventaris de la vostres organitzacions. Tots els detalls del producte aquí establerts substituiran els establerts a la pàgina "Productes"
+        enable_reset?: Habilitar la restauració de valors de stock?
+        inherit?: Heredar?
+        add: Afegeix
+        hide: Amaga
+        import_date: S'ha importat
+        select_a_shop: Seleccioneu una botiga
+        review_now: Reviseu ara
+        new_products_alert_message: Hi ha productes nous %{new_product_count} disponibles per afegir al vostre inventari.
+        currently_empty: El vostre inventari està buit
+        no_matching_products: No es troben productes coincidents al vostre inventari
+        no_hidden_products: No s'ha amagat cap producte d'aquest inventari
+        no_matching_hidden_products: Els productes ocults no coincideixen amb els criteris de cerca
+        no_new_products: No hi ha productes nous disponibles per afegir-los a aquest inventari
+        no_matching_new_products: Cap producte nou coincideix amb els criteris de cerca
+        inventory_powertip: Aquest és el vostre inventari de productes. Per afegir productes al vostre inventari, seleccioneu "Nous productes" al menú desplegable Visualització.
+        hidden_powertip: Aquests productes s'han ocultat al vostre inventari i no estaran disponibles per afegir-los a la vostra botiga. Podeu fer clic a "Afegeix" per afegir un producte a l'inventari.
+        new_powertip: Aquests productes estan disponibles per afegir al vostre inventari. Feu clic a "Afegeix" per afegir un producte al vostre inventari o "Oculta" per ocultar-lo de la vista. Sempre podreu canviar aquestes opcions després.
+      controls:
+        back_to_my_inventory: Torna al meu inventari
+    orders:
+      invoice_email_sent: 'S''ha enviat el correu electrònic de la factura'
+      order_email_resent: 'S''ha reenviat el correu electrònic de la comanda'
+      bulk_management:
+        tip: "Utilitzeu aquesta pàgina per alterar les quantitats de productes en diverses comandes. Els productes també es poden eliminar de les comandes completament, si es requereix."
+        shared: "Recurs compartit?"
+        order_no: "Nº de comanda."
+        order_date: "Completada a"
+        max: "Màx"
+        product_unit: "Producte: Unitat"
+        weight_volume: "Pes/Volum"
+        ask: "Preguntar?"
+        page_title: "Gestió de les comandes en bloc"
+        actions_delete: "Suprimeix seleccionats"
+        loading: "Carregant comandes"
+        no_results: "No s'han trobat comandes."
+        group_buy_unit_size: "Mida d'unitat de grup de compra"
+        total_qtt_ordered: "Quantitat total demanada"
+        max_qtt_ordered: "Quantitat màxima demanada"
+        current_fulfilled_units: "Unitats actuals fetes"
+        max_fulfilled_units: "Unitats màximes fetes"
+        order_error: "S'han de resoldre alguns errors abans de poder actualitzar les comandes.\nQualsevol camp amb vora vermella conté errors."
+        variants_without_unit_value: "Atenció: algunes variants no tenen cap unitat assignada."
+      select_variant: "Selecciona un paràmetre"
+    enterprise:
+      select_outgoing_oc_products_from: Selecciona els productes sortints del Cicle de Comandes
+    enterprises:
+      index:
+        title: Organitzacions
+        new_enterprise: Nova organització
+        producer?: "Productora?"
+        package: Perfil
+        status: Estat
+        manage: Gestiona
+      form:
+        about_us:
+          desc_short: Descripció breu
+          desc_short_placeholder: Explica'ns sobre la teva organització en una o dues frases
+          desc_long: Sobre nosaltres
+          desc_long_placeholder: Explica coses sobre tu als clients. Aquesta informació apareixerà al teu perfil públic.
+        business_details:
+          abn: NIF
+          abn_placeholder: p. ex. F987654321
+          acn: NIF
+          acn_placeholder: p. ex. 123 456 789
+          display_invoice_logo: Mostreu el logotip a les factures
+          invoice_text: Afegeix text personalitzat al final de les factures
+        contact:
+          name: Nom
+          name_placeholder: 'p. ex: Josep Ribes'
+          email_address: Adreça electrònica pública
+          email_address_placeholder: 'p. ex: contacte@hortajosepribes.com'
+          email_address_tip: "Aquesta adreça de correu electrònic es mostrarà al vostre perfil públic"
+          phone: Telèfon
+          phone_placeholder: p. ex. 98 765 43 21
+          website: Lloc web
+          website_placeholder: 'p. ex.: www.hortajosepribes.com'
+        enterprise_fees:
+          name: Nom
+          fee_type: Tipus de tarifa
+          manage_fees: Gestioneu les tarifes de l'organització
+          no_fees_yet: Encara no tens cap tipus de comissió de l'organització
+          create_button: Crea'n una ara
+        images:
+          logo: Logotip
+          promo_image_placeholder: 'Aquesta imatge es mostra a "Sobre Nosaltres"'
+          promo_image_note1: 'ATENCIÓ:'
+          promo_image_note2: Qualsevol imatge promocional que es carregui aquí es tallarà a 1200 x 260.
+          promo_image_note3: 'La imatge promocional es mostra a la part superior de la pàgina de perfil i finestres emergents d''una organització '
+        inventory_settings:
+          text1: 'Pots optar per gestionar els nivells d''existències i els preus a través del teu '
+          inventory: inventari
+          text2: >
+              Si utilitzes l'eina d'inventari, pots seleccionar si els nous productes
+              afegits pels teus proveïdors han de ser afegits al teu inventari primerament,
+              abans de poder emmagatzemar-los a la botiga. Si no estàs utilitzant
+              l'inventari per gestionar els teus productes, has de seleccionar l'opció
+              "recomanada" següent:
+          preferred_product_selection_from_inventory_only_yes: Es poden introduir nous productes directament a la meva botiga (recomanat)
+          preferred_product_selection_from_inventory_only_no: He d'afegir els nous productes a l'inventari abans de poder-los mostrar a la meva botiga.
+        payment_methods:
+          name: Nom
+          applies: Aplicar?
+          manage: Gestiona els mètodes de pagament
+          not_method_yet: Encara no tens cap mètode de pagament.
+          create_button: Crea un nou mètode de pagament
+          create_one_button: Crea'n un ara
+        primary_details:
+          name: Nom
+          name_placeholder: p. ex. Horta Josep Ribes
+          groups: Grups
+          groups_tip: Seleccioneu grups o xarxes de la quals sou membres. Això ajudarà les consumidores a trobar la vostra organització o empresa.
+          groups_placeholder: Comenceu a escriure per cercar xarxes disponibles...
+          primary_producer: Productora principal?
+          primary_producer_tip: Selecciona "Productora" si ets productora principal d'aliments.
+          producer: Productora
+          any: Cap
+          none: No productora
+          own: Propi
+          sells: Ven
+          sells_tip: "Cap: l'organització no ven als clients directament. <br /> Propietari: l'organització ven productes propis als clients. <br /> Qualsevol: l'organització pot vendre productes propis o d'altres empreses. <br />"
+          visible_in_search: Visible a la cerca?
+          visible_in_search_tip: Determina si aquesta organització serà visible per a les consumidores en cercar el lloc.
+          visible: Visible
+          not_visible: No visible
+          permalink: Permalink (sense espais)
+          permalink_tip: "Aquest enllaç permanent s'utilitza per crear l'url a la vostra botiga: %{link}your-shop-name / shop"
+          link_to_front: Enllaç a la botiga
+          link_to_front_tip: Un enllaç directe a la vostra botiga a l'Open Food Netwok.
+        shipping_methods:
+          name: Nom
+          applies: 'Aplicar? '
+          manage: Gestiona els mètodes d'enviament
+          create_button: Crea un nou mètode d'enviament
+          create_one_button: Crea'n un ara
+          no_method_yet: Encara no teniu cap mètode d'enviament.
+        shop_preferences:
+          shopfront_requires_login: "Botiga visible públicament?"
+          shopfront_requires_login_tip: "Trieu si les consumidores han d'iniciar sessió per veure la botiga o si és visible per a tothom."
+          shopfront_requires_login_false: "Públic"
+          shopfront_requires_login_true: "Només visible per a usuaris registrats"
+          recommend_require_login: "Recomanem que es requeireixi inici de sessió quan l'opció de poder modificar les comandes estigui habilitada."
+          allow_guest_orders: "Comandes de convidats"
+          allow_guest_orders_tip: "Permet fer comanda com a convidat o requereix un usuari registrat."
+          allow_guest_orders_false: "Demana un inici de sessió per realitzar la comanda"
+          allow_guest_orders_true: "Permet comandes de convidats"
+          allow_order_changes: "Canviar les comandes"
+          allow_order_changes_tip: "Permetre que les consumidores canviïn o cancel·lin la seva comanda mentre el cicle de comanda estigui obert."
+          allow_order_changes_false: "Les comandes realitzades no es poden canviar / cancel·lar."
+          allow_order_changes_true: "Les consumidores poden canviar o cancel·lar les comandes mentre el cicle de comanda està obert."
+          enable_subscriptions: "Subscripcions"
+          enable_subscriptions_tip: "Habilitar la funcionalitat de subscripcions?"
+          enable_subscriptions_false: "Deshabilitat"
+          enable_subscriptions_true: "Habilitat"
+          shopfront_message: Missatge de la botiga
+          shopfront_message_placeholder: >
+              Una explicació opcional per a les consumidores que detalla com funciona
+              la vostra botiga, que es mostrarà a sobre de la llista de productes.
+          shopfront_closed_message: Missatge de tancament de la botiga
+          shopfront_closed_message_placeholder: >
+              Un missatge que proporciona una explicació més detallada sobre per què
+              la vostra botiga està tancada i / o quan poden esperar les consumidores
+              que es tornarà a obrir. Això només es mostrarà a la vostra botiga quan
+              no hi hagi cicles de comanda actius (és a dir, quan la botiga estigui
+              tancada).
+          shopfront_category_ordering: Ordre de les categories de la botiga
+          open_date: Data d'obertura
+          close_date: Data de tancament
+        social:
+          twitter_placeholder: 'p. ex: @horta_josepribes'
+          instagram_placeholder: 'p. ex: horta_josepribes'
+          facebook_placeholder: 'p .ex: www.facebook.com/NomDeLaPàgina'
+          linkedin_placeholder: 'p. ex: www.linkedin.com/in/ElTeuNom'
+        stripe_connect:
+          connect_with_stripe: "Connectar amb Stripe"
+          stripe_connect_intro: "Per acceptar pagaments amb targeta de crèdit haureu de connectar el vostre compte de Stripe a Open Food Network. Utilitzeu el botó de la dreta per començar. "
+          stripe_account_connected: "Compte de Stripe connectat."
+          disconnect: "Desconnecta el compte"
+          confirm_modal:
+            title: Connectar amb Stripe
+            part1: Stripe és un servei de processament de pagaments que permet que les botigues de l'OFN acceptin els pagaments amb targeta de crèdit de les consumidores.
+            part2: Per utilitzar aquesta funció heu de connectar el vostre compte Stripe a l'OFN. Si feu clic a "Accepto", us redirigirem al lloc web de Stripe on podeu connectar un compte Stripe existent o bé crear-ne un si encara no en teniu cap.
+            part3: Això permetrà que Open Food Network accepti pagaments amb targeta de crèdit de consumidores en nom vostre. Tingueu en compte que haureu de mantenir el vostre propi compte de Stripe, pagar-ne les tarifes i mantenir el servei a les consumidores pel teu compte.
+            i_agree: Accepto
+            cancel: Cancel·lar
+        tag_rules:
+          default_rules:
+            by_default: Per defecte
+            no_rules_yet: Encara no s'aplica cap regla per defecte
+            add_new_button: '+ Afegeix una nova regla per defecte'
+          no_tags_yet: Encara no hi ha cap etiqueta aplicada a aquesta organització
+          no_rules_yet: Encara no hi ha cap regla aplicada a aquesta etiqueta
+          for_customers_tagged: 'Per als clients etiquetats:'
+          add_new_rule: '+ Afegeix una nova regla'
+          add_new_tag: '+ Afegeix una nova etiqueta'
+        users:
+          email_confirmation_notice_html: "La confirmació de correu electrònic està pendent. Hem enviat un correu electrònic de confirmació a %{email}."
+          resend: Reenviar
+          owner: 'Propietària'
+          contact: "Contacte"
+          contact_tip: "El gestor que rebrà els missatges de correu electrònic de l'organització per a comandes i notificacions. Ha de tenir una adreça electrònica confirmada."
+          owner_tip: La usuària principal responsable d'aquesta organització.
+          notifications: Notificacions
+          notifications_tip: Les notificacions sobre les comandes s'enviaran a aquesta adreça de correu electrònic.
+          notifications_placeholder: 'p. ex: contacte@hortajosepribes.com'
+          notifications_note: 'Nota: és possible que hagi de confirmar una nova adreça de correu electrònic abans d''utilitzar-la'
+          managers: Gestors
+          managers_tip: Altres usuàries amb permisos per gestionar aquesta organització
+          invite_manager: "Convida un gestor"
+          invite_manager_tip: "Convida un usuari no registrat a registrar-se i convertir-se en gestor d'aquesta organització."
+          add_unregistered_user: "Afegeix un usuari no registrat"
+          email_confirmed: "S'ha confirmat el correu electrònic"
+          email_not_confirmed: "Correu electrònic no confirmat"
+      actions:
+        edit_profile: Configuració
+        properties: Propietats
+        payment_methods: Mètodes de Pagament
+        payment_methods_tip: Aquesta organització no té mètodes de pagament
+        shipping_methods: Mètodes d'enviament
+        shipping_methods_tip: 'Aquesta organització té mètodes d''enviament '
+        enterprise_fees: Honoraris de l'organització
+        enterprise_fees_tip: Aquesta organització no té comissions
+      admin_index:
+        name: Nom
+        role: Rol
+        sells: Ven
+        visible: Visible?
+        owner: Propietària
+        producer: Productor
+      change_type_form:
+        producer_profile: Perfil de productora
+        connect_ofn: Connecta mitjançant OFN
+        always_free: SEMPRE GRATUÏT
+        producer_description_text: Afegeix els teus productes a Katuma i permet a grups de consum i altres organitzacions emmagatzemar els teus productes a les seves botigues.
+        producer_shop: Botiga d'una productora
+        sell_your_produce: Ven els teus propis productes
+        producer_shop_description_text: Ven els teus productes directament  les consumidores a través de la teva pròpia botiga a Katuma.
+        producer_shop_description_text2: Una productora amb botiga només és per als teus productes; si vols vendre productes produïts / cultivats fora del lloc, selecciona "Grup de productores".
+        producer_hub: Grup de productores
+        producer_hub_text: Ven productes propis i d'altres productores
+        producer_hub_description_text: La vostra organització és la columna vertebral del sistema alimentari local. Podeu vendre els vostres propis productes i o afegir els productes d'altres organitzacions a través de la vostra botiga a la Katuma.
+        profile: Només perfil
+        get_listing: Apareix en els directoris
+        profile_description_text: La gent pot trobar-vos i contactar-vos a Katuma. La vostra organització serà visible al mapa i es podrà cercar als directoris.
+        hub_shop: Botiga
+        hub_shop_text: Veneu productes d'altres
+        hub_shop_description_text: La vostra organització la columna vertebral del vostre sistema alimentari local. Afegeix productes d'altres organitzacions i els podreu vendre a través de la vostra botiga a Katuma.
+        choose_option: Si us plau, trieu una de les opcions anteriors.
+        change_now: Canvia ara
+      enterprise_user_index:
+        loading_enterprises: CARREGANT ORGANITZACIONS
+        no_enterprises_found: No s'han trobat organitzacions.
+        search_placeholder: Cerca pel nom
+        manage: Gestiona
+        manage_link: Configuració
+        producer?: "Productora?"
+        package: "Perfil"
+        status: "Estat"
+      new_form:
+        owner: Propietària
+        owner_tip: La usuària principal responsable d'aquesta organització.
+        i_am_producer: Sóc una productora
+        contact_name: Nom de contacte
+      edit:
+        editing: 'Configuració:'
+        back_link: Tornar a la llista d'organitzacions
+      new:
+        title: Nova organització
+        back_link: 'Tornar a la llista d''organitzacions '
+      remove_logo:
+        remove: "Elimina la imatge"
+        removed_successfully: "Logotip eliminat correctament"
+        immediate_removal_warning: "El logotip s'eliminarà immediatament després de confirmar."
+      remove_promo_image:
+        remove: "Elimina la imatge "
+        removed_successfully: "Imatge promocional eliminada correctament"
+        immediate_removal_warning: "La imatge promocional s'eliminarà immediatament després de confirmar."
+      welcome:
+        welcome_title: Benvingut a la Katuma - Open Food Network!
+        welcome_text: Heu creat correctament un
+        next_step: Següent pas
+        choose_starting_point: 'Escull el teu perfil:'
+      invite_manager:
+        user_already_exists: "L'usuari ja existeix"
+        error: "Alguna cosa ha anat malament"
+    order_cycles:
+      edit:
+        advanced_settings: Configuració avançada
+        update_and_close: Actualitza i tanca
+        choose_products_from: 'Trieu Productes des de:'
+      exchange_form:
+        pickup_time_tip: Quan les comandes d'aquest cicle de comandes estiguin preparades per a les consumidores
+        pickup_instructions_placeholder: "Instruccions de recollida"
+        pickup_instructions_tip: Aquestes instruccions es mostraran a les consumidores després d'haver completat una comanda
+        pickup_time_placeholder: "Preparat per (és a dir, data / hora)"
+        receival_instructions_placeholder: "Instruccions de recepció"
+        add_fee: 'Afegeix una comissió'
+        selected: 'seleccionat'
+      add_exchange_form:
+        add_supplier: 'Afegeix proveïdora'
+        add_distributor: 'Afegeix distribuïdora'
+      advanced_settings:
+        title: Configuració avançada
+        choose_product_tip: Podeu optar per restringir tots els productes disponibles (tant d'entrada com de sortida), per només als que pertanyen a l'inventari de %{inventory}.
+        preferred_product_selection_from_coordinator_inventory_only_here: Només inventari del coordinador
+        preferred_product_selection_from_coordinator_inventory_only_all: Tots els productes disponibles
+        save_reload: Desa i recarrega la pàgina
+      coordinator_fees:
+        add: Afegeix una comissió del coordinador
+      filters:
+        search_by_order_cycle_name: "Cerca pel nom del Cicle de Comanda..."
+        involving: "Implica"
+        any_enterprise: "Qualsevol organització"
+        any_schedule: "Qualsevol horari"
+      form:
+        incoming: Entrant
+        supplier: Proveïdora
+        receival_details: Detalls de recepció
+        fees: Tarifes
+        outgoing: Sortint
+        distributor: Distribuïdora
+        products: Productes
+        tags: Etiquetes
+        add_a_tag: Afegeix una etiqueta
+        delivery_details: Detalls de recollida / lliurament
+        debug_info: Informació de depuració
+      index:
+        schedule: Horari
+        schedules: Horaris
+        adding_a_new_schedule: Afegir una nova programació
+        updating_a_schedule: Actualització una programació
+        new_schedule: Nova programació
+        create_schedule: Crear una programació
+        update_schedule: Actualitza la programació
+        delete_schedule: Suprimeix la programació
+        created_schedule: Programació creada
+        updated_schedule: Programació actualitzada
+        deleted_schedule: Programació eliminada
+        schedule_name_placeholder: Nom de la programació
+        name_required_error: Si us plau introdueix un nom per a aquesta programació
+        no_order_cycles_error: Si us plau selecciona com a mínim un cicle de comanda (arrossega i deixa anar)
+      name_and_timing_form:
+        name: Nom
+        orders_open: Les comandes s'obren a
+        coordinator: Coordinador
+        orders_close: Les comandes tanquen
+      row:
+        suppliers: proveïdores
+        distributors: distribuïdores
+        variants: variants
+      simple_form:
+        ready_for: Preparat per
+        ready_for_placeholder: Data / hora
+        customer_instructions: Instruccions de la consumidora
+        customer_instructions_placeholder: Notes de recollida o de lliurament
+        products: Productes
+        fees: Tarifes
+      destroy_errors:
+        orders_present: Una consumidora ha seleccionat aquest Cicle de Comanda i no es pot esborrar. Per evitar que les consumidores hi accedeixin, tanqueu-lo.
+        schedule_present: Aquest cicle de comanda està vinculat a una programació i no es pot esborrar. Desenllaça o suprimeix primer la programació.
+      bulk_update:
+        no_data: Hm, alguna cosa ha sortit malament. No s'ha trobat cap cicle de comanda.
+      date_warning:
+        msg: Aquest cicle de comanda està enllaçat amb %{n}comandes de subscripció obertes . Si canvieu aquesta data ara això no afectarà comandes que ja s'hagin realitzat però cal evitar-ho si és possible. Esteu segur que voleu continuar?
+        cancel: Cancel·lar
+        proceed: Procedeix
+    producer_properties:
+      index:
+        title: Propietats de la productora
+    proxy_orders:
+      cancel:
+        could_not_cancel_the_order: No s'ha pogut cancel·lar la comanda
+      resume:
+        could_not_resume_the_order: No es pot reprendre la comanda
+    shared:
+      user_guide_link:
+        user_guide: Guia de l'usuari
+    overview:
+      enterprises_header:
+        ofn_with_tip: Les organitzacions són productores i/o grups de consum i són la unitat bàsica d'organització dins d'Open Food Network.
+      enterprises_hubs_tabs:
+        has_no_payment_methods: "%{enterprise} no té mètodes de pagament"
+        has_no_shipping_methods: "%{enterprise} no té mètodes d'enviament"
+        has_no_enterprise_fees: "%{enterprise} no té comissions de l'organització"
+    enterprise_issues:
+      create_new: Crear nou
+      resend_email: Reenvia el correu electrònic
+      has_no_payment_methods: "%{enterprise} actualment no té mètodes de pagament"
+      has_no_shipping_methods: "%{enterprise} actualment no té mètodes d'enviament"
+      email_confirmation: "La confirmació de correu electrònic està pendent. Hem enviat un correu electrònic de confirmació a %{email}."
+      not_visible: "%{enterprise} no és visible i, per tant, no es pot trobar al mapa ni a les cerques"
+    reports:
+      hidden: OCULT
+      unitsize: UNITAT DE MESURA
+      total: TOTAL
+      total_items: ARTICLES TOTALS
+      supplier_totals: Total de de proveïdores del Cicle de Comanda
+      supplier_totals_by_distributor: Total de proveïdores del Cicle de Comanda - per distribuïdora
+      totals_by_supplier: Totals de la distribuïdora del Cicle de Comanda - per proveïdora
+      customer_totals: Totals de consumidores del Cicle de Comanda
+      all_products: Tots els productes
+      inventory: Inventari (disponible)
+      lettuce_share: LettuceShare
+      mailing_list: Llista de correus electrònics
+      addresses: Adreces
+      payment_methods: Informe de Mètodes de pagament
+      delivery: Informe de lliurament
+      tax_types: Tipus d'impostos
+      tax_rates: Tarifes fiscals
+      pack_by_customer: Paquets per consumidora
+      pack_by_supplier: Paquets per proveïdora
+      orders_and_distributors:
+        name: Comandes i distribuïdores
+        description: Comandes amb detalls de la distribuïdora
+      payments:
+        name: Informes de pagament
+        description: Informes per a pagaments
+      orders_and_fulfillment:
+        name: Informes de comandes i compliment
+      customers:
+        name: Consumidores
+      products_and_inventory:
+        name: Productes & Inventari
+      sales_total:
+        name: Total de vendes
+        description: Total de vendes per a totes les comandes
+      users_and_enterprises:
+        name: Usuaris & Organitzacions
+        description: Propietat i estatus de l'organització
+      order_cycle_management:
+        name: Gestió del Cicle de Comanda
+      sales_tax:
+        name: Impostos sobre la venda
+      xero_invoices:
+        name: Factures Xero
+        description: Factures per a la importació a Xero
+      packing:
+        name: Informes d'embalatge
+    subscriptions:
+      subscriptions: Subscripcions
+      new: Nova subscripció
+      create: Crea una subscripció
+      index:
+        please_select_a_shop: Si us plau, seleccioneu una botiga
+        edit_subscription: Edita la subscripció
+        pause_subscription: Pausa la subscripció
+        unpause_subscription: Reprèn la subscripció
+        cancel_subscription: Cancel·la la subscripció
+      setup_explanation:
+        just_a_few_more_steps: 'Només uns quants passos més abans de començar:'
+        enable_subscriptions: "Activa les subscripcions d'almenys una de les teves botigues"
+        enable_subscriptions_step_1_html: 1. Aneu a la pàgina %{enterprises_link}, cerqueu la vostra botiga i feu clic a "Gestionar"
+        enable_subscriptions_step_2: 2. A "Preferències de la botiga", activeu l'opció Subscripcions
+        set_up_shipping_and_payment_methods_html: Configureu els mètodes %{shipping_link} i %{payment_link}
+        set_up_shipping_and_payment_methods_note_html: Tingueu en compte que només es poden utilitzar mètodes de pagament en efectiu i Stripe amb les subscripcions
+        ensure_at_least_one_customer_html: Assegureu-vos que hi hagi almenys un %{customer_link}
+        create_at_least_one_schedule: Crea almenys una programació
+        create_at_least_one_schedule_step_1_html: 1. Aneu a la pàgina %{order_cycles_link}
+        create_at_least_one_schedule_step_2: 2. Creeu un Cicle de Comanda si encara no ho heu fet
+        create_at_least_one_schedule_step_3: 3. Fes clic a '+ Nova programació' i omple el formulari
+        once_you_are_done_you_can_html: Un cop hagueu acabat, podeu %{reload_this_page_link}
+        reload_this_page: tornar a carregar aquesta pàgina
+      steps:
+        details: 1. Detalls bàsics
+        address: 2. Adreça
+        products: 3. Afegeix productes
+        review: 4. Revisa i desa
+      subscription_line_items:
+        this_is_an_estimate: |
+            Els preus que es mostren són només una estimació i es calculen en el moment en què es canvia la subscripció.
+            Si canvieu els preus o les comissions, les comandes s'actualitzaran, però la subscripció continuarà mostrant els valors anteriors.
+      details:
+        details: Detalls
+        invalid_error: Oops! Si us plau ompliu tots els camps obligatoris ...
+        allowed_payment_method_types_tip: Actualment només es poden utilitzar els mètodes de pagament en efectiu i Stripe
+        credit_card: Targeta de crèdit
+        charges_not_allowed: Els càrrecs no estan permesos per aquesta consumidora
+        no_default_card: La consumidora no té targetes disponibles per cobrar
+        card_ok: La consumidora té una targeta disponible per cobrar
+      loading_flash:
+        loading: CARREGANT SUBSCRIPCIONS
+      review:
+        details: Detalls
+        address: Adreça
+        products: 'Productes '
+      product_already_in_order: Aquest producte ja s'ha afegit a la comanda. Editeu-ne la quantitat directament.
+      orders:
+        number: Número
+        confirm_edit: Estàs segur que voleu editar aquesta comanda? Si ho fas és més difícil que es sincronitzin automàticament els canvis a la subscripció en el futur.
+      confirm_cancel_msg: Estàs segur que vols cancel·lar aquesta subscripció? Aquesta acció no es pot desfer.
+      cancel_failure_msg: 'Ho sentim, la cancel·lació ha fallat!'
+      confirm_pause_msg: Estàs segur que vols pausar aquesta subscripció?
+      pause_failure_msg: 'Ho sentim, la pausa ha fallat!'
+      confirm_unpause_msg: Estàs segur que vols reprendre aquesta subscripció?
+      unpause_failure_msg: 'Ho sentim, la represa ha fallat!'
+      confirm_cancel_open_orders_msg: "Actualment hi ha algunes comandes obertes per a aquesta subscripció. Ja s'ha notificat a les consumidores que les comandes serà atesa. Voleu cancel·lar aquestes comandes o conservar-les?"
+      resume_canceled_orders_msg: "Algunes comandes d'aquesta subscripció es poden reprendre ara mateix. Podeu reprendre-les des del menú desplegable de comandes."
+      yes_cancel_them: Cancel·lar-les
+      no_keep_them: Conservar-les
+      yes_i_am_sure: Sí, n'estic segur
+      order_update_issues_msg: Algunes comandes no s'han pogut actualitzar automàticament, probablement perquè s'han editat manualment. Reviseu els problemes que es detallen a continuació i realitzeu els ajustaments a comandes individuals si és necessari.
+      no_results:
+        no_subscriptions: Encara no hi ha cap subscripció...
+        why_dont_you_add_one: Per què no n'afegiu un? :)
+        no_matching_subscriptions: No s'han trobat subscripcions coincidents
+    schedules:
+      destroy:
+        associated_subscriptions_error: Aquesta programació no es pot suprimir perquè té subscripcions associades
+    controllers:
+      enterprises:
+        stripe_connect_cancelled: "S'ha cancel·lat la connexió a Stripe"
+        stripe_connect_success: "S'ha connectat correctament el compte de Stripe"
+        stripe_connect_fail: Ho sentim, s'ha produït un error en la connexió del vostre compte de Stripe
+      stripe_connect_settings:
+        resource: 'Configuració de la connexió amb Stripe '
+  api:
+    enterprise_logo:
+      destroy_attachment_does_not_exist: "El logotip no existeix"
+    enterprise_promo_image:
+      destroy_attachment_does_not_exist: "La imatge promocional no existeix"
+  checkout:
+    already_ordered:
+      cart: "cistella"
+      message_html: "Ja teniu una comanda per a aquest cicle de comanda. Consulteu %{cart} per veure els articles que heu demanat anteriorment. També podeu cancel·lar articles sempre que el cicle de comanda estigui obert."
+  shops:
+    hubs:
+      show_closed_shops: "Mostra les botigues tancades"
+      hide_closed_shops: "Amaga les botigues tancades"
+      show_on_map: "Mostra-ho tot al mapa"
+  shared:
+    menu:
+      cart:
+        checkout: "Validar ara"
+        already_ordered_products: "Ja està demanat en aquest cicle de comanda"
+    register_call:
+      selling_on_ofn: "Estàs interessat en formar part d'Open Food Network?"
+      register: "Registra't aquí"
+    footer:
+      footer_global_headline: "OFN Global"
+      footer_global_home: "Inici"
+      footer_global_news: "Notícies"
+      footer_global_about: "Sobre"
+      footer_global_contact: "Contacte"
+      footer_sites_headline: "Pàgines d'OFN"
+      footer_sites_developer: "Desenvolupador"
+      footer_sites_community: "Comunitat"
+      footer_sites_userguide: "Guia de l'usuari"
+      footer_secure: "Segur i de confiança."
+      footer_secure_text: "Open Food Network utilitza el xifrat SSL (RSA de 2048 bits) a tot arreu per mantenir les vostres dades comercials i de pagament privades. Els nostres servidors no emmagatzemen els detalls de la targeta de crèdit i els pagaments es processen mitjançant serveis compatibles amb PCI."
+      footer_contact_headline: "Mantén el contacte"
+      footer_contact_email: "Envia'ns un correu electrònic"
+      footer_nav_headline: "Navega"
+      footer_join_headline: "Uneix-te a nosaltres"
+      footer_join_body: "Crea un directori de botigues a grups a Open Food Network."
+      footer_join_cta: "Vull saber-ne més!"
+      footer_legal_call: "Llegiu el nostre"
+      footer_legal_tos: "Termes i condicions"
+      footer_legal_visit: "Troba'ns a"
+      footer_legal_text_html: "Open Food Network és una plataforma de programari lliure i de codi obert. El nostre contingut està llicenciat amb %{content_license} i el nostre codi amb %{code_license}."
+      footer_data_text_with_privacy_policy_html: "Tenim cura de les vostres dades. Vegeu les nostres %{privacy_policy} i %{cookies_policy}"
+      footer_data_text_without_privacy_policy_html: "Tenim cura de les vostres dades. Vegeu la nostra %{cookies_policy}"
+      footer_data_privacy_policy: "política de privacitat"
+      footer_data_cookies_policy: "política de cookies"
+      footer_skylight_dashboard_html: Les dades de rendiment estan disponibles a %{dashboard}.
+  shop:
+    messages:
+      login: "Inicia sessió"
+      register: "Registra't"
+      contact: "contacta"
+      require_customer_login: "Aquesta botiga només és per a consumidores registrades."
+      require_login_html: "Si us plau%{login} si ja teniu un compte. En cas contrari, %{register} per convertir-vos en una consumidora."
+      require_customer_html: "Si us plau%{contact} %{enterprise} per convertir-vos en consumidora."
+  card_could_not_be_updated: No s'ha pogut actualitzar la targeta
+  card_could_not_be_saved: no s'ha pogut desar la targeta
+  spree_gateway_error_flash_for_checkout: "Hi ha hagut un problema amb la vostra informació de pagament: %{error}"
+  invoice_billing_address: "Adreça de facturació:"
+  invoice_column_price: "Preu"
+  invoice_column_item: "Article"
+  invoice_column_qty: "Quantitat"
+  invoice_column_unit_price_with_taxes: "Preu unitari (IVA inclòs)"
+  invoice_column_unit_price_without_taxes: "Preu unitari (impost exclòs)"
+  invoice_column_price_with_taxes: "Preu total (IVA inclòs)"
+  invoice_column_price_without_taxes: "Preu total (sense impostos)"
+  invoice_column_tax_rate: "Taxa d'impost"
+  tax_invoice: "FACTURA D'IMPOSTOS"
+  tax_total: "Impost total (%{rate}):"
+  total_excl_tax: "Total (impostos exclòs):"
+  total_incl_tax: "Total (impost inclòs):"
+  invoice_issued_on: "Factura emesa el:"
+  order_number: "Nombre de factura:"
+  date_of_transaction: "Data de la transacció:"
+  ticket_column_qty: "Quantitat"
+  ticket_column_item: "Article"
+  ticket_column_unit_price: "Preu unitari"
+  ticket_column_total_price: "Preu total"
+  menu_1_title: "Botigues"
+  menu_1_url: "/shops"
+  menu_2_title: "Mapa"
+  menu_2_url: "/map"
+  menu_3_title: "Productors"
+  menu_3_url: "/producers"
+  menu_4_title: "Grups"
+  menu_4_url: "/groups"
+  menu_5_title: "Sobre"
+  menu_5_url: " "
+  menu_6_title: "Connecta"
+  menu_6_url: " "
+  menu_7_title: "Aprèn"
+  menu_7_url: " "
+  logo: "Logotip (640x130)"
+  logo_mobile: "Logotip mòbil (75x26)"
+  logo_mobile_svg: "Logotip per mòbil (SVG)"
+  home_hero: " "
+  home_show_stats: "Mostra estadístiques"
+  footer_logo: "Logotip (220x76)"
+  footer_facebook_url: "URL de Facebook"
+  footer_twitter_url: "URL de Twitter"
+  footer_instagram_url: "URL d'Instagram"
+  footer_linkedin_url: "URL de LinkedIn"
+  footer_googleplus_url: "URL de Google Plus"
+  footer_pinterest_url: "URL de Pinterest"
+  footer_email: "Correu electrònic"
+  footer_links_md: "Enllaços"
+  footer_about_url: "Quant a l'URL"
+  user_guide_link: "Enllaç a la guia de l'usuari"
+  name: Nom
+  first_name: Nom
+  last_name: Cognoms
+  email: Correu electrònic
+  phone: Telèfon
+  next: Següent
+  address: Adreça
+  address_placeholder: 'p. ex: Carrer Ample, 123'
+  address2: Adreça (continua)
+  city: Municipi
+  city_placeholder: 'p. ex: Sitges'
+  postcode: Codi postal
+  postcode_placeholder: 'p. ex: 08870'
+  state: Estat
+  country: País
+  unauthorized: No autoritzat
+  terms_of_service: "Termes del servei"
+  on_demand: Sota demanda
+  none: No productora
+  not_allowed: No permès
+  no_shipping: sense mètodes d'enviament
+  no_payment: sense mètodes de pagament
+  no_shipping_or_payment: sense mètodes d'enviament o pagament
+  unconfirmed: no confirmat
+  days: dies
+  label_shop: "Botiga"
+  label_shops: "Botigues"
+  label_map: "Mapa"
+  label_producer: "Productora"
+  label_producers: "Productors"
+  label_groups: "Grups"
+  label_about: "Sobre"
+  label_connect: "Connecta"
+  label_learn: "Aprèn"
+  label_blog: "Blog"
+  label_support: "Suport"
+  label_shopping: "Compres"
+  label_login: "Inicia sessió"
+  label_logout: "Tanca sessió"
+  label_signup: "Registra't"
+  label_administration: "Administració"
+  label_admin: "Administradora"
+  label_account: "Compte"
+  label_more: "Mostrar més"
+  label_less: "Mostra menys"
+  label_notices: "Avisos"
+  cart_items: "articles"
+  cart_headline: "La teva cistella"
+  total: "Total"
+  cart_updating: "Actualitzant la cistella..."
+  cart_empty: "Cistella buida"
+  cart_edit: "Edita la teva cistella"
+  card_number: Número de targeta
+  card_securitycode: "Codi de seguretat"
+  card_expiry_date: Data de caducitat
+  card_masked_digit: "X"
+  new_credit_card: "Nova targeta de crèdit"
+  my_credit_cards: Les meves targetes de crèdit
+  add_new_credit_card: 'Afegeix una nova targeta de crèdit '
+  saved_cards: Targetes desades
+  add_a_card: Afegeix una targeta
+  add_card: Afegeix targeta
+  you_have_no_saved_cards: Encara no heu guardat cap targeta
+  saving_credit_card: Desant la targeta de crèdit...
+  card_has_been_removed: "S'ha eliminat la teva targeta (número: %{number})"
+  card_could_not_be_removed: Ho sentim, no s'ha pogut eliminar la targeta
+  ie_warning_headline: "El vostre navegador no està actualitzat :-("
+  ie_warning_text: "Per obtenir la millor experiència a Open Food Network et recomanem que actualitzis el teu navegador:"
+  ie_warning_chrome: Descarrega Chrome
+  ie_warning_firefox: Descarrega Firefox
+  ie_warning_ie: Actualitza Internet Explorer
+  ie_warning_other: "No pots actualitzar el navegador? Prova Open Food Network al telèfon mòbil :-)"
+  legal:
+    cookies_policy:
+      header: "Com utilitzem les cookies"
+      desc_part_1: "Les cookies són fitxers de text molt petits que s'emmagatzemen a l'ordinador quan visites alguns llocs web."
+      desc_part_2: "A OFN som plenament respectuosos amb la teva privadesa. Utilitzem només les cookies que són necessàries per oferir-te el servei de compra/venda d'aliments en línia. No venem cap de les vostres dades. En el futur, podríem proposar que compartiu algunes de les vostres dades per crear serveis públics nous que poguessin ser útils per a l'ecosistema (com ara serveis de logística per als sistemes d'alimentació curts), però encara no hi estem treballant i no ho farem sense la vostra autorització :-)"
+      desc_part_3: "Utilitzem cookies principalment per recordar qui ets si inicies la sessió al servei o per recordar els elements que heu introduït a la vostra cistella encara que no hàgiu iniciat la sessió. Si continues navegant al lloc web sense fer clic \"Acceptar cookies\", suposem que ens estàs donant el consentiment per emmagatzemar les cookies que són essencials per al funcionament del lloc web. Aquí tens la llista de les cookies que fem servir."
+      essential_cookies: "Cookies essencials"
+      essential_cookies_desc: "Les cookies següents són estrictament necessàries per al funcionament del nostre lloc web."
+      essential_cookies_note: "La majoria de les cookies només contenen un identificador únic, però no hi ha altres dades, de manera que la teva adreça de correu electrònic i contrasenya, per exemple, mai no estan contingudes ni exposades."
+      cookie_domain: "Establert per:"
+      cookie_session_desc: "S'utilitza per permetre que el lloc web recordi usuaris entre visites a la pàgina, per exemple, recordar els articles de la vostra cistella."
+      cookie_consent_desc: "S'utilitza per mantenir l'estat del consentiment de l'usuari per emmagatzemar cookies"
+      cookie_remember_me_desc: "S'utilitza si l'usuari ha demanat que el lloc web el recordi. Aquesta cookie s'elimina automàticament després de 12 dies. Si com a usuari voleu que se suprimeixi aquesta cookie, només heu de tancar la sessió. Si no voleu que aquesta cookie s'instal·li a l'ordinador, no haureu de marcar la casella \"Recorda'm\" quan inicieu la sessió."
+      cookie_openstreemap_desc: "Utilitzat pel nostre proveïdor de confiança d'emmagatzematge de codi obert (OpenStreetMap) per garantir que no rebis massa sol·licituds durant un període de temps determinat, per evitar l'abús dels seus serveis."
+      cookie_stripe_desc: "Dades recollides pel nostre processador de pagaments Stripe per a la detecció de frau https://stripe.com/cookies-policy/legal. No totes les botigues utilitzen Stripe com a mètode de pagament, però és una bona pràctica per evitar que el frau s'apliqui a totes les pàgines. Probablement Stripe construeixi una imatge de quines de les nostres pàgines solen interactuar amb la seva API i, a continuació, marca qualsevol cosa inusual. Així, configurar les cookies d'Stripe té una funció més àmplia que simplement proporcionar un mètode de pagament a un usuari. Eliminant-lo podria afectar la seguretat del propi servei. Pots obtenir més informació sobre Stripe i llegir la seva política de privadesa a https://stripe.com/privacy."
+      statistics_cookies: "Cookies d'estadístiques"
+      statistics_cookies_desc: "Les següents no són estrictament necessàries, però ajuden a proporcionar-vos la millor experiència d'usuari, permetent-nos analitzar el comportament de l'usuari, identificar quines funcions s'utilitzen més o quines no es fan servir, comprendre problemes d'experiència d'usuari, etc."
+      statistics_cookies_analytics_desc_html: "Per recopilar i analitzar les dades d'ús de la plataforma utilitzem Google Analytics ja que era el servei predeterminat connectat amb Spree (el programari de codi obert de comerç en línia que hem construït), però la nostra visió és canviar a <a href = 'https: / / /matomo.org/ 'target =' _ blank '> Matomo </ a> (ex Piwik, eina d'anàlisi de codi obert compatible amb GDPR i protegeix la vostra privadesa) tan aviat com puguem. "
+      statistics_cookies_matomo_desc_html: "Per recopilar i analitzar les dades d'ús de la plataforma, utilitzem <a href='https://matomo.org/' target='_blank'> Matomo </ a> (ex Piwik), una eina d'anàlisi de codi obert que és compatible amb GDPR i protegeix la vostra privadesa."
+      statistics_cookies_matomo_optout: "Vols desactivar l'anàlisi de dades de Matomo? No recopilem cap dada personal i Matomo ens ajuda a millorar el nostre servei però respectem la teva elecció :-)"
+      cookie_analytics_utma_desc: "S'utilitza per distingir usuaris i sessions. La cookie es crea quan s'executa la biblioteca javascript i no existeixen cookies __utma existents. La cookie s'actualitza cada cop que s'envien dades a Google Analytics."
+      cookie_analytics_utmt_desc: "S'utilitza per accelerar la quantitat de sol·licituds."
+      cookie_analytics_utmb_desc: "S'utilitza per determinar noves sessions / visites. La cookie es crea quan s'executa la biblioteca javascript i no existeixen cookies __utmb existents. La cookie s'actualitza cada cop que s'envien dades a Google Analytics."
+      cookie_analytics_utmc_desc: "No s'utilitza a ga.js. Estableix la interoperabilitat amb urchin.js. Històricament, aquesta cookie funcionava juntament amb la cookie __utmb per determinar si l'usuari estava en una nova sessió / visita."
+      cookie_analytics_utmz_desc: "Emmagatzema l'origen del codi o la campanya que explica com l'usuari ha arribat al vostre lloc. La cookie es crea quan s'executa i s'actualitza la biblioteca javascript cada vegada que s'envien dades a Google Analytics."
+      cookie_matomo_basics_desc: "Les primeres cookies de Matomo per recollir estadístiques."
+      cookie_matomo_ignore_desc: "La cookie usada per excloure l'usuari de ser seguit."
+      disabling_cookies_header: "Advertència sobre la desactivació de cookies"
+      disabling_cookies_desc: "Com a usuari sempre podeu permetre, bloquejar o eliminar les cookies Open Food Network o qualsevol altra pàgina web sempre que vulgueu mitjançant el control de configuració del vostre navegador. Cada navegador té una operativa diferent. Aquests són els enllaços:"
+      disabling_cookies_firefox_link: "https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences"
+      disabling_cookies_chrome_link: "https://support.google.com/chrome/answer/95647"
+      disabling_cookies_ie_link: "https://support.microsoft.com/en-us/help/17442/windows-internet-explorer-delete-manage-cookies"
+      disabling_cookies_safari_link: "https://www.apple.com/legal/privacy/en-ww/cookies/"
+      disabling_cookies_note: "Però tingueu en compte que si suprimiu o modifiqueu les cookies essencials que utilitza Open Food Network el lloc web no funcionarà; no podreu afegir res a la vostra cistella ni per validar la compra, per exemple."
+    cookies_banner:
+      cookies_usage: "Aquest lloc utilitza cookies per fer que la teva navegació no sigui problemàtica i sigui segura i ens ajuda a comprendre com navegues per millorar les funcions que oferim."
+      cookies_definition: "Les cookies són fitxers de text molt petits que s'emmagatzemen a l'ordinador quan visites alguns llocs web."
+      cookies_desc: "Utilitzem només les cookies que són necessàries per oferir-te el servei de compra/venda d'aliments en línia. No venem cap de les teves dades. Utilitzem cookies principalment per recordar qui ets si inicies la sessió al servei o per recordar els elements que has introduït a la teva cistella encara que no hagis iniciat la sessió. Si continues navegant al lloc web sense fer clic \"Acceptar cookies\", suposem que ens estàs donant el consentiment per emmagatzemar les cookies que són essencials per al funcionament del lloc web."
+      cookies_policy_link_desc: "Si vols obtenir més informació consulta la nostra"
+      cookies_policy_link: "política de cookies"
+      cookies_accept_button: "Acceptar les cookies"
+  home_shop: Compra ara
+  brandstory_headline: "Aliments de proximitat."
+  brandstory_intro: "De vegades la millor manera de solucionar el sistema és començar una nova ..."
+  brandstory_part1: "Comencem des del principi. Amb agricultores i productores disposades a explicar les seves històries amb orgull i veritat. Amb les distribuïdores disposades a connectar persones amb productes de manera justa i honesta. Amb les consumidores que creuen que millors decisions de compra setmanals poden seriosament canviar el món."
+  brandstory_part2: "A continuació, necessitem una manera de fer-ho real. Una forma d'empoderar a totes les que cultiven, venen i compren aliments. Una manera d'explicar totes les històries, de gestionar tota la logística. Una manera de convertir la transacció en transformació cada dia."
+  brandstory_part3: "Així que construïm un mercat en línia que anivella el camp de joc. És transparent, de manera que crea relacions reals. És de codi obert, de manera que és propietat de tothom. Escala a regions i nacions, de manera que les persones comencin versions a tot el món."
+  brandstory_part4: "Funciona a tot arreu. Ho canvia tot."
+  brandstory_part5_strong: "L'anomenem Open Food Network."
+  brandstory_part6: "A totes ens agrada menjar. Ara també podem estimar el nostre sistema alimentari."
+  learn_body: "Explora models, històries i recursos per ajudar-te a desenvolupar el teu negoci o organització de menjar just. Troba coneixements, esdeveniments i altres oportunitats d'aprendre dels companys."
+  learn_cta: "Inspira't"
+  connect_body: "Busca els nostres directoris complets de productores, organitzacions o xarxes per trobar menjar de proximitat i just a prop teu. Indica i llista la teva empresa o organització a l'OFN perquè les consumidores et trobin. Uneix-te a la comunitat per obtenir consells i resoldre problemes juntes."
+  connect_cta: "Explorar"
+  system_headline: "Compres - aquí t'expliquem com funcionen."
+  system_step1: "1. Cerca"
+  system_step1_text: "Cerca a les nostres botigues diverses i independents per menjar producte local de temporada. Cerca per població i categoria d'aliments, o bé si prefereixes lliurament o recollida."
+  system_step2: "2. Compra"
+  system_step2_text: "Transforma les teves transaccions amb aliments locals assequibles de diverses productores i grups. Coneix les històries del teu menjar i de les persones que el fan!"
+  system_step3: "3. Recollida / lliurament"
+  system_step3_text: "Espereu per al vostre lliurament o visiteu la vostra productora o grup de consum per tenir una connexió més personal amb el vostre menjar. La compra d'aliments és tan diversa com ens proposem."
+  cta_headline: "Compres que fan del món un lloc millor."
+  cta_label: "Estic preparada"
+  stats_headline: "Estem creant un nou sistema alimentari."
+  stats_producers: "productores d'aliments"
+  stats_shops: "botigues d'alimentació"
+  stats_shoppers: "consumidores d'aliments"
+  stats_orders: "comandes de menjar"
+  checkout_title: Realitza la comanda
+  checkout_now: Validar ara
+  checkout_order_ready: Comanda preparada per
+  checkout_hide: Amaga
+  checkout_expand: Expandeix
+  checkout_headline: "Estàs preparada per validar la compra?"
+  checkout_as_guest: "Realitzar comanda com a convidat"
+  checkout_details: "Els teus detalls"
+  checkout_billing: "Informació de facturació"
+  checkout_default_bill_address: "Desa per defecte com a adreça de facturació "
+  checkout_shipping: Informació d'enviament
+  checkout_default_ship_address: "Desa per defecte com a adreça d'enviament "
+  checkout_method_free: Gratuït
+  checkout_address_same: L'adreça d'enviament és igual que l'adreça de facturació?
+  checkout_ready_for: "Preparat per:"
+  checkout_instructions: "Alguns comentaris o instruccions especials?"
+  checkout_payment: Pagament
+  checkout_send: Realitza una comanda ara
+  checkout_your_order: La teva comanda
+  checkout_cart_total: Total de la cistella
+  checkout_shipping_price: Enviament
+  checkout_total_price: Total
+  checkout_back_to_cart: "Tornar a la cistella"
+  cost_currency: "Moneda del cost"
+  order_paid: PAGAT
+  order_not_paid: NO PAGAT
+  order_total: Total de la comanda
+  order_payment: "Pagament a través de:"
+  order_billing_address: Adreça de facturació
+  order_delivery_on: Lliurament a
+  order_delivery_address: Adreça de lliurament
+  order_delivery_time: Hora de lliurament
+  order_special_instructions: "Les teves notes:"
+  order_pickup_time: Llest per a la recollida
+  order_pickup_instructions: Instruccions de recollida
+  order_produce: Productes
+  order_total_price: Total
+  order_includes_tax: (inclou impostos)
+  order_payment_paypal_successful: El teu pagament mitjançant PayPal s'ha processat correctament.
+  order_hub_info: Informació del grup
+  order_back_to_store: Tornar a la botiga
+  order_back_to_cart: Tornar a la cistella
+  bom_tip: "Utilitzeu aquesta pàgina per alterar les quantitats de productes en diverses comandes. Els productes també es poden eliminar de les comandes completament, si es requereix."
+  unsaved_changes_warning: "Hi ha canvis sense desar i es perdran si continueu."
+  unsaved_changes_error: "Els camps amb vora vermella contenen errors."
+  products: "Productes"
+  products_in: "en %{oc}"
+  products_at: "a %{distributor}"
+  products_elsewhere: "Productes trobats en altres llocs"
+  email_welcome: "Benvinguda"
+  email_confirmed: "Gràcies per confirmar la teva adreça de correu electrònic."
+  email_registered: "ara forma part de"
+  email_userguide_html: "La Guia d'usuari amb suport detallat per configurar una productora o grup de consum és aquí: %{link}"
+  email_admin_html: "Pots gestionar el teu compte iniciant sessió a l'%{link} o fent clic a la pestanya a la part superior dreta de la pàgina d'inici i seleccionant Administració."
+  email_community_html: "També tenim un fòrum en línia per debats de la comunitat relacionada amb el programari OFN i els desafiaments únics de triar endavant una organització alimentària. T'animem a unir-t'hi. Estem en constant evolució i les teves contribucions en aquest fòrum donaran forma al que passi a en el futur. %{link}"
+  join_community: "Uneix-te a la comunitat"
+  email_confirmation_activate_account: "Abans de poder activar el compte nou hem de confirmar la teva adreça de correu electrònic."
+  email_confirmation_greeting: "Hola, %{contact}!"
+  email_confirmation_profile_created: "S'ha creat exitosament un perfil per %{name}. Per activar el teu perfil hem de confirmar aquesta adreça de correu electrònic."
+  email_confirmation_click_link: "Si us plau fes clic a l'enllaç següent per confirmar el teu correu electrònic i continuar configurant el teu perfil."
+  email_confirmation_link_label: "Confirma aquesta adreça de correu electrònic »"
+  email_confirmation_help_html: "Després de confirmar el teu correu electrònic podràs accedir al teu compte d'administració per a aquesta organització. Consulta l'%{link} per obtenir més informació sobre les funcions d'%{sitename} i començar a utilitzar el teu perfil o botiga en línia."
+  email_confirmation_notice_unexpected: "Has rebut aquest missatge perquè t'has inscrit a l'%{sitename} o perquè has estat convidada a registrar-te per algú que probablement coneixes. Si no entens per què estàs rebent aquest correu electrònic, escriu a %{contact}."
+  email_social: "Connecta't amb nosaltres:"
+  email_contact: "Envia'ns un correu electrònic:"
+  email_signoff: "Salut,"
+  email_signature: "Equip %{sitename}"
+  email_confirm_customer_greeting: "Hola %{name},"
+  email_confirm_customer_intro_html: "Gràcies per comprar a <strong> %{distributor} </ strong>."
+  email_confirm_customer_number_html: "Confirmació de la comanda <strong> # %{number} </ strong>"
+  email_confirm_customer_details_html: "Aquests són els detalls de la teva comanda de <strong> %{distributor} </ strong>:"
+  email_confirm_customer_signoff: "Salutacions cordials,"
+  email_confirm_shop_greeting: "Hola %{name},"
+  email_confirm_shop_order_html: "Que bé! Tens una nova comanda per <strong> %{distributor} </ strong>."
+  email_confirm_shop_number_html: "Confirmació de la comanda <strong> # %{number} </ strong>"
+  email_order_summary_item: "Article"
+  email_order_summary_quantity: "quant."
+  email_order_summary_price: "Preu"
+  email_order_summary_subtotal: "Subtotal:"
+  email_order_summary_total: "Total:"
+  email_order_summary_includes_tax: "(inclou impostos):"
+  email_payment_paid: PAGAT
+  email_payment_not_paid: 'NO PAGAT '
+  email_payment_summary: Resum del pagament
+  email_payment_method: "Pagament a través de:"
+  email_so_placement_intro_html: "Tens una nova comanda amb <strong> %{distributor} </ strong>"
+  email_so_placement_details_html: "Aquests són els detalls de la comanda de <strong> %{distributor} </ strong>:"
+  email_so_placement_changes: "Malauradament, no tots els productes que has demanat estaven disponibles. Les quantitats originals que has sol·licitat apareixen ratllades a sota."
+  email_so_payment_success_intro_html: "S'ha processat un pagament automàtic per a la vostra comanda des de <strong> %{distributor} </ strong>."
+  email_so_placement_explainer_html: "Aquesta comanda s'ha creat automàticament per tu."
+  email_so_edit_true_html: "Potd <a href='%{order_url}'> fer canvis </ a> fins que les comandes es tanquin el %{orders_close_at}."
+  email_so_edit_false_html: "Pots <a href='%{order_url}'> veure detalls d'aquesta comanda </a> en qualsevol moment."
+  email_so_contact_distributor_html: "Si tens alguna pregunta pots contactar amb <strong> %{distributor} </ strong> a través d'%{email}."
+  email_so_contact_distributor_to_change_order_html: "Aquesta comanda s'ha creat automàticament per a vostè. Podeu fer canvis fins que les comandes es tanquin a %{orders_close_at} contactant a <strong> %{distributor} </ strong> a través d'%{email}."
+  email_so_confirmation_intro_html: "La teva comanda amb <strong> %{distributor} </ strong> ja està confirmada"
+  email_so_confirmation_explainer_html: "Vas realitzar aquesta comanda automàticament i ara s'ha finalitzat."
+  email_so_confirmation_details_html: "A continuació trobareu tot el que necessiteu saber sobre la comanda de <strong> %{distributor} </ strong>:"
+  email_so_empty_intro_html: "Hem intentat fer una nova comanda amb <strong> %{distributor} </ strong>, però hem tingut alguns problemes..."
+  email_so_empty_explainer_html: "Malauradament, cap dels productes que heu demanat estava disponible, de manera que no s'ha realitzat cap comanda. Les quantitats originals que heu sol·licitat apareixen ratllades a sota."
+  email_so_empty_details_html: "Aquests són els detalls de la comanda sense confirmar per <strong> %{distributor} </ strong>:"
+  email_so_failed_payment_intro_html: "Hem intentat processar un pagament però hem tingut alguns problemes..."
+  email_so_failed_payment_explainer_html: "El pagament de la vostra subscripció amb <strong> %{distributor} </ strong> ha fallat a causa d'un problema amb la vostra targeta de crèdit. S'ha notificat a <strong> %{distributor} </ strong> d'aquest pagament fallit."
+  email_so_failed_payment_details_html: "Aquests són els detalls de l'error proporcionats per la passarel·la de pagament:"
+  email_shipping_delivery_details: Detalls de lliurament
+  email_shipping_delivery_time: "Lliurament a:"
+  email_shipping_delivery_address: "Adreça de lliurament:"
+  email_shipping_collection_details: Detalls de la recollida
+  email_shipping_collection_time: "Llest per a la recollida:"
+  email_shipping_collection_instructions: "Instruccions de recollida:"
+  email_special_instructions: "Les teves notes: "
+  email_signup_greeting: Hola!
+  email_signup_welcome: "Benvinguda a %{sitename}!"
+  email_signup_confirmed_email: "Gràcies per confirmar el teu correu electrònic."
+  email_signup_shop_html: "Ara pots iniciar sessió a %{link}."
+  email_signup_text: "Gràcies per unir-te a la xarxa. Si ets una consumidora, esperem presentar-te a moltes agricultores fantàstiques, meravellosos grups de consum i aliments deliciosos. Si ets una productora o organització alimentària, ens complau tenir-te com a part de la xarxa."
+  email_signup_help_html: "Donem la benvinguda a totes les teves preguntes i comentaris; pots utilitzar el botó <em> Enviar comentaris </ em> del lloc web o enviar-nos un correu electrònic a %{email}"
+  invite_email:
+    greeting: "Hola! "
+    invited_to_manage: "Has estat convidada a gestionar %{enterprise} a %{instance}."
+    confirm_your_email: "Hauries d'haver rebut o aviat rebràs un correu electrònic amb un enllaç de confirmació. No podràs accedir al perfil de%{enterprise} fins que no hagis confirmat el teu correu electrònic."
+    set_a_password: "A continuació se us demanarà que configureu una contrasenya abans de poder administrar l'organització."
+    mistakenly_sent: "No esteu segur de perquè heu rebut aquest correu electrònic? Poseu-vos en contacte amb %{owner_email} per obtenir més informació."
+  producer_mail_greeting: "Benvolguda"
+  producer_mail_text_before: "Ara tenim totes les comandes per al proper repartiment."
+  producer_mail_order_text: "Aquí tens un resum de les comandes dels teus productes:"
+  producer_mail_delivery_instructions: "Instruccions de recollida / lliurament d'estoc:"
+  producer_mail_signoff: "Gràcies i els millors desitjos"
+  shopping_oc_closed: Les comandes estan tancades
+  shopping_oc_closed_description: "Si us plau espera fins que s'obri el pròxim cicle (o posa't en contacte amb nosaltres directament per veure si podem acceptar alguna comanda fora de temps)"
+  shopping_oc_last_closed: "L'últim cicle va tancar fa %{distance_of_time} "
+  shopping_oc_next_open: "El següent cicle s'obre en %{distance_of_time}"
+  shopping_tabs_about: "Sobre %{distributor}"
+  shopping_tabs_contact: "Contacte"
+  shopping_contact_address: "Adreça"
+  shopping_contact_web: "Contacte"
+  shopping_contact_social: "Segueix"
+  shopping_groups_part_of: "forma part de:"
+  shopping_producers_of_hub: "Productores de%{hub}:"
+  enterprises_next_closing: "Tancament de la comanda següent"
+  enterprises_ready_for: "Preparat per"
+  enterprises_choose: "Escull quan vols la teva comanda:"
+  maps_open: "Obert"
+  maps_closed: "Tancat"
+  hubs_buy: "Compreu per:"
+  hubs_shopping_here: "Compra aquí"
+  hubs_orders_closed: "Comandes tancades"
+  hubs_profile_only: "Només perfil"
+  hubs_delivery_options: "Opcions de lliurament"
+  hubs_pickup: "Recollida"
+  hubs_delivery: "Lliurament"
+  hubs_producers: "Les nostres productores"
+  hubs_filter_by: "Filtra per"
+  hubs_filter_type: "Tipus"
+  hubs_filter_delivery: "Lliurament "
+  hubs_filter_property: "Propietat"
+  hubs_matches: "Volies dir?"
+  hubs_intro: 'Compreu a la vostra zona '
+  hubs_distance: El més proper a
+  hubs_distance_filter: "Mostra'm botigues properes a%{location}"
+  shop_changeable_orders_alert_html:
+    one: El vostre ordre amb <a href='%{path}' target='_blank'> %{shop} / %{order} </ a> està obert per a la seva revisió. Podeu fer canvis fins %{oc_close}.
+    other: Tens <a href='%{path}' target='_blank'> %{count} comandes amb %{shop} </a> actualment obertes per a la seva revisió. Pots fer canvis fins %{oc_close}.
+  orders_changeable_orders_alert_html: S'ha confirmat aquesta comanda però pots fer-hi canvis fins a <strong> %{oc_close} </ strong>.
+  products_clear_all: Esborra-ho tot
+  products_showing: "S'està mostrant:"
+  products_with: amb
+  products_search: "Cerca per producte o productora"
+  products_loading: "S'estan carregant els productes..."
+  products_updating_cart: "Actualitzant la cistella..."
+  products_cart_empty: "Cistella buida"
+  products_edit_cart: "Edita la teva cistella"
+  products_from: de
+  products_change: "No hi ha canvis per desar."
+  products_update_error: "No s'ha pogut desar pel(s) següent(s) error(s):"
+  products_update_error_msg: "S'ha produït un error en desar."
+  products_update_error_data: "S'ha produït un error en desar a causa de dades no vàlides:"
+  products_changes_saved: "S'han desat els canvis."
+  search_no_results_html: "Ho sentim, no s'ha trobat cap resultat per %{query}. Intentar una altra cerca?"
+  components_profiles_popover: "Els perfils no tenen una botiga a l'OFN però poden tenir la seva pròpia botiga física o en línia en altres llocs"
+  components_profiles_show: "Mostra els perfils"
+  components_filters_nofilters: "Sense filtres"
+  components_filters_clearfilters: "Esborra tots els filtres"
+  groups_title: Grups
+  groups_headline: Xarxes / regions
+  groups_text: "Cada productora és única. Tots els negocis tenen alguna cosa diferent per oferir. Els nostres grups són col·lectius o xarxes de productores, grups de consum o distribuïdores que comparteixen alguna cosa comú com la ubicació, la parada en un mercat de pagès o la filosofia. Això fa que la teva experiència de compra sigui més fàcil. Explora els nostres grups."
+  groups_search: "Cerca nom o paraula clau"
+  groups_no_groups: "No s'ha trobat cap xarxa"
+  groups_about: "Sobre nosaltres"
+  groups_producers: "Les nostres productores"
+  groups_hubs: "Els nostres grups"
+  groups_contact_web: Contacte
+  groups_contact_social: Segueix
+  groups_contact_address: Adreça
+  groups_contact_email: Envieu-nos un correu electrònic
+  groups_contact_website: Visita el nostre lloc web
+  groups_contact_facebook: Segueix-nos a Facebook
+  groups_signup_title: Registra't com a grup
+  groups_signup_headline: Inscripció de xarxes
+  groups_signup_intro: "Som una plataforma sorprenent per a la comercialització col·laborativa, la forma més senzilla perquè els vostres membres i persones interessades arribin a nous mercats. Som sense ànim de lucre, assequibles i senzills."
+  groups_signup_email: Envieu-nos un correu electrònic
+  groups_signup_motivation1: Transformem els sistemes alimentaris de manera justa.
+  groups_signup_motivation2: És per això que sortim del llit cada dia. Som un globals i sense ànim de lucre, basats en codi font obert. Juguem just. Sempre podràs confiar en nosaltres.
+  groups_signup_motivation3: Sabem que tens grans idees i et volem ajudar. Compartirem els nostres coneixements, xarxes i recursos. Sabem que l'aïllament no genera canvis, així que ens associarem amb tu.
+  groups_signup_motivation4: Ens trobem on ets.
+  groups_signup_motivation5: És possible que formis part d'una xarxa de consumidores, grup de consum, productora o distribuïdora, un organisme industrial o un govern local.
+  groups_signup_motivation6: Independentment del teu paper en el moviment d'aliments local, estem preparades per ajudar-te. No obstant això, si vens a preguntar-se com és Open Food Network o que està fent a la teva part del món, comencem la conversa.
+  groups_signup_motivation7: Fem que els moviments dels aliments tinguin més sentit.
+  groups_signup_motivation8: Cal activar i habilitar les xarxes, oferim una plataforma de conversa i d'acció. Necessites un compromís real. Volem ajudar totes les jugadores, totes les parts interessades, tots els sectors.
+  groups_signup_motivation9: Necessites recursos. Et brindarem tota la nostra experiència. Necessites cooperació. Et connectarem millor amb una xarxa global d'iguals.
+  groups_signup_pricing: Compte de grup
+  groups_signup_studies: Casos d'estudi
+  groups_signup_contact: Preparada per debatre?
+  groups_signup_contact_text: "Posa't en contacte per descobrir què pot fer OFN per tu:"
+  groups_signup_detail: "Aquest és el detall."
+  login_invalid: "Correu electrònic o contrasenya no vàlids"
+  modal_hubs: "Grups"
+  modal_hubs_abstract: Els nostres grups són el punt de contacte entre tu i les persones que fan els teus aliments.
+  modal_hubs_content1: Pots cercar un grup convenient per ubicació o nom. Alguns grups tenen diversos punts on pots recollir les vostres comandes i alguns també proporcionen opcions de lliurament. Cada grup és un punt de venda amb operacions comercials i logística independents, per la qual cosa és normal que existeixin variacions d'un grup a un altre.
+  modal_hubs_content2: Només pots comprar en un grup de consum a la vegada.
+  modal_groups: "Xarxes / regions"
+  modal_groups_content1: Aquestes són les organitzacions i les relacions entre els grups que conformen l'OFN
+  modal_groups_content2: Alguns grups estan agrupats per localització o Ajuntament, altres per similituds no geogràfiques.
+  modal_how: "Com funciona"
+  modal_how_shop: Compreu a Open Food Network
+  modal_how_shop_explained: Cerca un grup de consum a prop teu per començar a comprar. Pots expandir cada grup per veure quins tipus de productes estan disponibles i fer clic per començar a comprar. (Només pots comprar en un grup alhora).
+  modal_how_pickup: Costes de recollida, lliurament i enviament
+  modal_how_pickup_explained: Algunes organitzacións o grups lliuren a la vostra porta, mentre que altres requereixen que aneu a buscar les vostres comandes. Podeu veure quines opcions hi ha disponibles a la pàgina d'inici i seleccionar el que vulgueu a les pàgines de confirmació de la compra. L'enviament costarà més, i els preus difereixen de l'organització. Cada grup és un punt de venda amb operacions comercials i logística independents, per la qual cosa es existeixen  variacions entre grups.
+  modal_how_more: Aprèn-ne més
+  modal_how_more_explained: "Si vols saber-ne més sobre l'Open Food Network, com funciona i participar-hi, consulta:"
+  modal_producers: "Productors"
+  modal_producers_explained: "Les nostres productores elaboren tot el menjar deliciós que pots adquirir a l'Open Food Network."
+  producers_about: Sobre nosaltres
+  producers_buy: 'Compreu '
+  producers_contact: Contacte
+  producers_contact_phone: Truca
+  producers_contact_social: Segueix
+  producers_buy_at_html: "Compra productes de %{enterprise} a:"
+  producers_filter: Filtra per
+  producers_filter_type: Tipus
+  producers_filter_property: Propietat
+  producers_title: Productors
+  producers_headline: Troba productores locals
+  producers_signup_title: Registra't com a productora
+  producers_signup_headline: Productores d'aliments, empoderades.
+  producers_signup_motivation: Ven el teu menjar i explica la teva història a diversos nous mercats. Estalvia temps i diners en totes les despeses generals. Done suport la innovació sense el risc. Hem aplanat el terreny de joc.
+  producers_signup_send: Uneix-te ara
+  producers_signup_enterprise: Comptes de l'organització
+  producers_signup_studies: Històries de les nostres productores.
+  producers_signup_cta_headline: Uneix-te ara!
+  producers_signup_cta_action: 'Uneix-te ara '
+  producers_signup_detail: Aquest és el detall.
+  products_item: Article
+  products_description: Descripció
+  products_variant: Variant
+  products_quantity: Quantitat
+  products_available: Disponible?
+  products_producer: "Productor"
+  products_price: "Preu"
+  register_title: Registra't
+  sell_title: "Registra't"
+  sell_headline: "Afegiu-vos a Katuma!"
+  sell_motivation: "Mostra el teu bonic menjar."
+  sell_producers: "Productors"
+  sell_hubs: "Grups"
+  sell_groups: "Grups"
+  sell_producers_detail: "Configura un perfil per a la vostra empresa a Katuma en qüestió de minuts. En qualsevol moment pots convertir el teu perfil en una botiga en línia i vendre els teus productes directament a les consumidores."
+  sell_hubs_detail: "Configura un perfil per a la teva organització alimentària a Katuma. En qualsevol moment, pots modificar i convertir el teu perfil en una botiga de diverses productores."
+  sell_groups_detail: "Configura un directori personalitzat d'empreses (productores i altres empreses alimentàries) per a la teva regió o per a la teva xarxa, organització."
+  sell_user_guide: "Troba més informació a la nostra Guia d'usuari."
+  sell_embed: "També podem incrustar una botiga OFN al vostre web personalitzat o crear un lloc web personalitzat de la xarxa alimentària per a la teva regió."
+  sell_ask_services: "Pregunta'ns sobre els serveis d'OFN."
+  shops_title: Botigues
+  shops_headline: Compres, transformades.
+  shops_text: Els aliments creixen en cicles, les agricultores cullen en cicles, i nosaltres fem les comandes de menjar en cicles. Si trobes un cicle de comandes tancat, torna a consultar properament.
+  shops_signup_title: Inscriu-te com a grup
+  shops_signup_headline: Grups, il·limitats.
+  shops_signup_motivation: Sigui quin sigui el teu model, et donem suport. Tot i que canvieu, estarem amb tu. Som sense ànim de lucre, independents i obertes. Som les sòcies de programari que has somiat.
+  shops_signup_action: Uneix-te ara
+  shops_signup_pricing: Comptes de l'organització
+  shops_signup_stories: Històries dels nostres grups.
+  shops_signup_help: Estem preparadess per ajudar.
+  shops_signup_help_text: Necessites un millor retorn. Necessites noves compradores i sòcies logístiques. Necessites la teva història explicada a través de majoristes, minoristes i de la taula de la cuina.
+  shops_signup_detail: Aquest és el detall.
+  orders: Comandes
+  orders_fees: Comissions...
+  orders_edit_title: Cistella de la compra
+  orders_edit_headline: El teu cistell de la compra
+  orders_edit_time: Comanda preparada per
+  orders_edit_continue: Continuar comprant
+  orders_edit_checkout: Realitza la compra
+  orders_form_empty_cart: "Cistella buida"
+  orders_form_admin: Administració i manipulació
+  orders_form_total: Total
+  orders_oc_expired_headline: S'han tancat les comandes per a aquest cicle de comanda
+  orders_oc_expired_text: "Ho sentim, les comandes d'aquest cicle de comanda es van tancar fa %{time} ! Posa't en contacte amb el teu grup directament per veure si poden acceptar comandes fora de temps."
+  orders_oc_expired_text_others_html: "Ho sentim, les comandes d'aquest cicle de comanda es van tancar fa %{time} ! Posa't en contacte amb el teu grup directament per veure si poden acceptar comandes fora de temps<strong> %{link} </ strong>."
+  orders_oc_expired_text_link: "o consulta els altres cicles de comanda disponibles en aquest grup"
+  orders_oc_expired_email: "Correu electrònic:"
+  orders_oc_expired_phone: "Telèfon:"
+  orders_show_title: Confirmació de la comanda
+  orders_show_time: Comanda preparada
+  orders_show_order_number: "Comanda # %{number}"
+  orders_show_cancelled: Cancel·lada
+  orders_show_confirmed: Confirmada
+  orders_your_order_has_been_cancelled: "S'ha cancel·lat la teva comanda"
+  orders_could_not_cancel: "Disculpa, no s'ha pogut cancel·lar la teva comanda "
+  orders_cannot_remove_the_final_item: "No es pot eliminar l'article final d'una comanda, si us plau, en comptes d'això cancel·leu la comanda."
+  orders_bought_items_notice:
+    one: "Ja s'ha confirmat un element addicional per al cicle d'aquest ordre"
+    other: "%{count}articles addicionals confirmats per a aquest cicle de comandes"
+  orders_bought_edit_button: Edita articles confirmats
+  orders_bought_already_confirmed: "* ja confirmat"
+  orders_confirm_cancel: Estàs segur que vols cancel·lar aquesta comanda?
+  products_cart_distributor_choice: "Distribuïdora de la teva comanda:"
+  products_cart_distributor_change: "La teva distribuïdora d'aquesta comanda canviarà a %{name} si afegeixes aquest producte a la teva cistella."
+  products_cart_distributor_is: "La distribuïdora d'aquesta comanda és %{name}."
+  products_distributor_error: "Si us plau, completa la comanda a: %{link} abans de comprar amb una altra distribuïdora."
+  products_oc: "Cicle de comanda per a la teva comanda:"
+  products_oc_change: "El cicle de comandes d'aquesta comanda canviarà a %{name} si afegeixes aquest producte a la cistella."
+  products_oc_is: "El cicle de comandes per a aquesta comanda és %{name}."
+  products_oc_error: "Si us plau valideu la comanda de%{link} abans de comprar en un cicle de comanda diferent."
+  products_oc_current: "el vostre cicle de comanda actual"
+  products_max_quantity: Quantitat màxima
+  products_distributor: Distribuïdora
+  products_distributor_info: Quan seleccionis una distribuïdora per a la teva comanda, aquí es mostraran la seva d'adreça i hores de recollida.
+  products_distribution_adjustment_label: "Distribució del producte per part de %{distributor} per a %{product}"
+  shop_trial_expires_in: "El període de prova de la vostra botiga caduca en"
+  shop_trial_expired_notice: "Bones notícies! Hem decidit ampliar els període de prova de la botiga fins a un altre avís."
+  password: Contrasenya
+  remember_me: Recorda'm
+  are_you_sure: "Estàs segur?"
+  orders_open: Comandes obertes
+  closing: "Tancant"
+  going_back_to_home_page: "Tornant a la pàgina d'inici"
+  creating: Creant
+  updating: Actualitzant
+  failed_to_create_enterprise: "No s'ha pogut crear la vostra organització."
+  failed_to_create_enterprise_unknown: "No s'ha pogut crear la teva organització.\nAssegura't que tots els camps estan completament emplenats."
+  failed_to_update_enterprise_unknown: "No s'ha pogut actualitzar la teva organització.\nAssegura't que tots els camps estan completament emplenats."
+  enterprise_confirm_delete_message: "Això també eliminarà el %{product} que subministra aquesta organització. Estàs segura que vols continuar?"
+  order_not_saved_yet: "Encara no s'ha desat la teva comanda. Dona'ns uns segons per acabar!"
+  filter_by: "Filtra per"
+  hide_filters: "Amaga els filtres"
+  one_filter_applied: "S'ha aplicat 1 filtre"
+  x_filters_applied: " filtres aplicats"
+  submitting_order: "Enviant la teva comanda: espereu si us plau"
+  confirm_hub_change: "Estàs segura? Això canviarà el grup que has seleccionat i eliminarà els articles de la cistella de la compra."
+  confirm_oc_change: "N'estàs segur? Això canviarà el cicle de comanda seleccionat i eliminarà els articles de la cistella de la compra."
+  location_placeholder: "Escriu una ubicació..."
+  error_required: "no es pot deixar en blanc"
+  error_number: "ha de ser un nombre"
+  error_email: "ha de ser una adreça de correu electrònic"
+  error_not_found_in_database: "%{name} no s'ha trobat a la base de dades"
+  error_not_primary_producer: "%{name} no està habilitat com a productora"
+  error_no_permission_for_enterprise: "\"%{name}\": no tens permís per gestionar els productes d'aquesta organització"
+  january: "Gener"
+  february: "Febrer"
+  march: "Març"
+  april: "Abril"
+  may: "Maig"
+  june: "Juny"
+  july: "Juliol"
+  august: "Agost"
+  september: "Setembre"
+  october: "Octubre"
+  november: "Novembre"
+  december: "Desembre"
+  email_not_found: "No s'ha trobat l'adreça de correu electrònic "
+  email_unconfirmed: "Has de confirmar la teva adreça de correu electrònic abans de poder restablir la contrasenya."
+  email_required: "Has de proporcionar una adreça de correu electrònic"
+  logging_in: "Espereu-vos un moment, estem iniciant-vos la sessió"
+  signup_email: "El teu correu electrònic"
+  choose_password: "Escull una contrasenya"
+  confirm_password: "Confirma la contrassenya"
+  action_signup: "Registra't ara"
+  welcome_to_ofn: "Benvingut a la xarxa Open Food Network!"
+  have_an_account: "Ja tens un compte?"
+  action_login: "Inicia la sessió ara."
+  forgot_password: "Has oblidat la contrasenya?"
+  password_reset_sent: "S'ha enviat un correu electrònic amb instruccions per restablir la teva contrasenya."
+  reset_password: "Restablir la contrasenya"
+  who_is_managing_enterprise: "Qui és responsable de gestionar %{enterprise}?"
+  update_and_recalculate_fees: "Actualitza i recalcula les comissions"
+  registration:
+    steps:
+      images:
+        continue: "Continua"
+        back: "Enrere"
+        headline: "Gràcies!"
+        description: "Som-hi, pugem unes imatges perquè el teu perfil es vegi bonic. :)"
+      type:
+        headline: "El darrer pas per afegir %{enterprise}!"
+        question: "Ets productora?"
+        yes_producer: "Sí, sóc productora"
+        no_producer: "No, no sóc productora"
+        producer_field_error: "Si us plau, escull una de les opcions. Ets productora?"
+        yes_producer_help: "Les productores fan coses delicioses per menjar i/o beure. Ets productora si cultives, cries, elabores, cous, fermentes..."
+        no_producer_help: "Si no ets productora, probablement ets algú que ven i distribueix aliments. Pot ser un grup de consum, cooperativa, minorista, majorista o altres."
+        create_profile: "Crea un perfil"
+  enterprise:
+    registration:
+      modal:
+        steps:
+          details:
+            title: 'Detalls'
+            headline: "Comencem!"
+            enterprise: "Ep! Primer necessitem saber una mica sobre la vostra organització:"
+            producer: "Ep! Primer necessitem saber una mica sobre la teva granja:"
+            enterprise_name_field: "Nom de l'organització:"
+            producer_name_field: "Nom de la granja:"
+            producer_name_field_placeholder: "p. ex: Horta Josep Ribes"
+            producer_name_field_error: "Si us plau, selecciona un únic nom per a la teva organització"
+            address1_field: "Adreça línia 1:"
+            address1_field_placeholder: "p. ex: Carrer Ample, 123"
+            address1_field_error: "Si us plau, introdueix una adreça"
+            address2_field: "Adreça (línia 2):"
+            suburb_field: "Barri:"
+            suburb_field_placeholder: "p. ex: Les Corts"
+            suburb_field_error: "Si us plau, introdueix un barri"
+            postcode_field: "Codi postal:"
+            postcode_field_placeholder: "p. ex: 08870"
+            postcode_field_error: "El codi postal és obligatori"
+            state_field: "Estat:"
+            state_field_error: "Estat obligatori"
+            country_field: "País:"
+            country_field_error: "Si us plau, selecciona un país"
+          contact:
+            title: 'Contacte'
+            contact_field: 'Contacte principal'
+            contact_field_placeholder: 'Nom de contacte'
+            contact_field_required: "Has d'introduir un contacte principal."
+            email_field: 'Correu electrònic'
+            email_field_placeholder: 'ex: josep@hortajosepribes.com'
+            phone_field: 'Número de telèfon'
+            phone_field_placeholder: 'p. ex. 012 345 678'
+          type:
+            title: 'Tipus'
+          about:
+            title: 'Sobre'
+          images:
+            title: 'Imatges'
+          social:
+            title: 'Social'
+  enterprise_contact: "Contacte principal"
+  enterprise_contact_placeholder: "Nom de contacte"
+  enterprise_contact_required: "Has d'introduir un contacte principal."
+  enterprise_email_address: "Correu electrònic"
+  enterprise_email_placeholder: "ex: josep@hortajosepribes.com"
+  enterprise_phone: "Número de telèfon "
+  enterprise_phone_placeholder: "p. ex. 012 345 678 "
+  back: "Enrere"
+  continue: "Continua"
+  limit_reached_headline: "Oh, no!"
+  limit_reached_message: "Has arribat al límit!"
+  limit_reached_text: "Has arribat al límit de la quantitat de les organitzacions de les quals pots ser propietari a"
+  limit_reached_action: "Torna a la pàgina d'inici"
+  select_promo_image: "Pas 3. Selecciona una imatge promocional"
+  promo_image_tip: "Consell: es mostra com a banner, la mida recomanada és de 1200 × 260 píxels"
+  promo_image_label: "Escull una imatge promocional"
+  action_or: "O"
+  promo_image_drag: "Arrossegueu i deixeu anar la vostra imatge promocional aquí"
+  review_promo_image: "Pas 4. Reviseu el vostre banner promocional"
+  review_promo_image_tip: "Consell: per obtenir millors resultats, la teva imatge de promoció hauria d'omplir l'espai disponible"
+  promo_image_placeholder: "El teu logotip apareixerà aquí per a la seva revisió una vegada que s'hagi carregat"
+  uploading: "Carregant..."
+  select_logo: "Pas 1. Selecciona imatge del logotip"
+  logo_tip: "Consell: les imatges quadrades funcionaran millor, preferiblement com a mínim 300×300 px"
+  logo_label: "Escull una imatge de logotip"
+  logo_drag: "Arrossega i deixa anar el teu logotip aquí"
+  review_logo: "Pas 2. Revisa el teu logotip"
+  review_logo_tip: "Consell: per obtenir millors resultats, el teu logotip ha d'omplir l'espai disponible"
+  logo_placeholder: "El teu logotip apareixerà aquí per a la seva revisió una vegada que s'hagi carregat "
+  enterprise_about_headline: "Bona!"
+  enterprise_about_message: "Ara expliqueu-ne els detalls"
+  enterprise_success: "Enhorabona! %{enterprise} s'ha afegit a Open Food Network"
+  enterprise_registration_exit_message: "Si surts de l'assistent en qualsevol moment, podràs continuar creant el teu perfil anant a la interfície d'administració."
+  enterprise_description: "Descripció breu"
+  enterprise_description_placeholder: "Una frase breu que descrigui la teva organització"
+  enterprise_long_desc: "Descripció llarga"
+  enterprise_long_desc_placeholder: "Aquesta és la teva oportunitat per explicar la història de la vostra organització: què et fa diferent i meravellós? Et suggerim que la descripció sigui inferior a 600 caràcters o 150 paraules."
+  enterprise_long_desc_length: "%{num} caràcters / fins a 600 recomanats"
+  enterprise_abn: "NIF"
+  enterprise_abn_placeholder: "ex. 99 123 456 789"
+  enterprise_acn: "IVA"
+  enterprise_acn_placeholder: "p. ex. 123 456 789"
+  enterprise_tax_required: "Has de fer una selecció."
+  enterprise_final_step: "Pas final!"
+  enterprise_social_text: "Com poden la gent trobar %{enterprise}en línia?"
+  website: "Lloc web"
+  facebook: "Facebook"
+  facebook_placeholder: "p .ex: www.facebook.com/NomDeLaPàgina"
+  linkedin: "LinkedIn"
+  linkedin_placeholder: "p. ex: www.linkedin.com/YourNameHere"
+  twitter: "Twitter"
+  twitter_placeholder: "p. ex: @twitter_hortajosepribes"
+  instagram: "Instagram"
+  instagram_placeholder: "p. ex: @instagram_hortajosepribes"
+  registration_greeting: "Hola!"
+  registration_intro: "Ara pots crear un perfil per productora o grup de consum"
+  registration_action: "Comencem!"
+  registration_checklist: "Necessitaràs"
+  registration_time: "5-10 minuts"
+  registration_enterprise_address: "Adreça de l'organització"
+  registration_contact_details: "Dades de contacte principals"
+  registration_logo: "Imatge del logotip"
+  registration_promo_image: "Imatge promocional per al vostre perfil"
+  registration_about_us: "Text \"Sobre nosaltres\""
+  registration_outcome_headline: "Què aconsegueixo?"
+  registration_outcome1_html: "El vostre perfil ajuda els usuaris <strong> a trobar </ strong> i <strong> contactar </ strong> a l'Open Food Network."
+  registration_outcome2: "Utilitza aquest espai per explicar la història de la teva organització, per ajudar a connectar-te amb la vostra presència social i a les xarxes."
+  registration_outcome3: "També és el primer pas cap al comenrç a través d'Open Food Network o per obrir una botiga en línia."
+  registration_finished_headline: "Acabat!"
+  registration_finished_thanks: "Gràcies per omplir els detalls de%{enterprise}."
+  registration_finished_login: "Pots canviar o actualitzar la teva organització en qualsevol moment accedint a Katuma i anant a Admin."
+  registration_contact_name: 'Nom de contacte'
+  registration_type_headline: "El darrer pas per afegir %{enterprise}!"
+  registration_type_question: "Ets productora?"
+  registration_type_producer: "Sí, sóc productora"
+  registration_type_no_producer: "No, no sóc productora"
+  registration_type_error: "Si us plau, escull una de les opcions. Ets productora?"
+  registration_type_producer_help: "Les productores fan coses delicioses per menjar i/o beure. Ets productora si cultives, cries, elabores, cous, fermentes..."
+  registration_type_no_producer_help: "Si no ets productora, probablement ets algú que ven i distribueix aliments. Pot ser un grup de consum, cooperativa, minorista, majorista o altres."
+  registration_detail_headline: "Comencem!"
+  registration_detail_enterprise: "Ep! Primer necessitem saber una mica sobre la vostra organització:"
+  registration_detail_producer: "Ep! Primer necessitem saber una mica sobre la teva granja:"
+  registration_detail_name_enterprise: "Nom de l'organització:"
+  registration_detail_name_producer: "Nom de la granja:"
+  registration_detail_name_placeholder: "p. ex: Horta Josep Ribes  "
+  registration_detail_name_error: "Si us plau, selecciona un únic nom per a la teva organització"
+  registration_detail_address1: "Adreça línia 1: "
+  registration_detail_address1_placeholder: "p. ex: Carrer Ample, 123 "
+  registration_detail_address1_error: "Si us plau, introdueix una adreça"
+  registration_detail_address2: "Adreça (línia 2):"
+  registration_detail_suburb: "Barri: "
+  registration_detail_suburb_placeholder: "p. ex: Les Corts "
+  registration_detail_suburb_error: "Si us plau, introdueix un barri "
+  registration_detail_postcode: "Codi postal:"
+  registration_detail_postcode_placeholder: "p. ex: 08870"
+  registration_detail_postcode_error: "El codi postal és obligatori"
+  registration_detail_state: "Estat:"
+  registration_detail_state_error: "Estat obligatori"
+  registration_detail_country: "País:"
+  registration_detail_country_error: "Si us plau, selecciona un país"
+  shipping_method_destroy_error: "Aquest mètode d'enviament no es pot esborrar perquè s'hi fa referència en una comanda: %{number}."
+  accounts_and_billing_task_already_running_error: "Ja s'està executant una tasca, espera fins que hagi acabat"
+  accounts_and_billing_start_task_notice: "Tasca en cua"
+  fees: "Tarifes"
+  item_cost: "Cost de l'article"
+  shop_variant_quantity_min: "min"
+  shop_variant_quantity_max: "màx"
+  follow: "Segueix"
+  shop_for_products_html: "Compra productes de <span class = \"turquesa\"> %{enterprise} </ span> a:"
+  shop_at: "Compra ara a:"
+  admin_fee: "Comissió d'administració"
+  sales_fee: "Comissió de venda"
+  packing_fee: "Comissió d'embalatge"
+  transport_fee: "Comissió de transport"
+  fundraising_fee: "Comissió d'autogestió"
+  price_graph: "Gràfic de preus"
+  included_tax: "Impostos incloses"
+  transaction: "Transacció"
+  transaction_date: "Data"
+  payment_state: "Estat del pagament"
+  shipping_state: "Estat d'enviament"
+  value: "Valor"
+  credit: "Crèdit"
+  Paid: "Pagat"
+  Ready: "Llest"
+  ok: D'acord
+  not_visible: no visible
+  you_have_no_orders_yet: "Encara no tens comandes"
+  admin_enterprise_relationships: "Permisos de l'organització"
+  admin_enterprise_relationships_everything: "Marcar tots"
+  admin_enterprise_relationships_permits: "Permet"
+  admin_enterprise_relationships_seach_placeholder: "Cerca"
+  admin_enterprise_relationships_button_create: "Crear"
+  admin_enterprise_groups: "Grups d'organització"
+  admin_enterprise_groups_name: "Nom"
+  admin_enterprise_groups_owner: "Propietària"
+  admin_enterprise_groups_enterprise: "Organitzacions"
+  admin_enterprise_groups_data_powertip: "La usuària principal responsable d'aquest grup."
+  admin_enterprise_groups_data_powertip_logo: "Això és el logotip del grup"
+  admin_enterprise_groups_data_powertip_promo_image: "Aquesta imatge es mostra a la part superior del perfil del grup"
+  admin_enterprise_groups_contact: "Contacte"
+  admin_enterprise_groups_contact_phone_placeholder: "p. ex.: 98 7654 3210"
+  admin_enterprise_groups_contact_address1_placeholder: "p. ex: Carrer Ample, 23"
+  admin_enterprise_groups_contact_city: "Barri"
+  admin_enterprise_groups_contact_city_placeholder: "p. ex: Sitges"
+  admin_enterprise_groups_contact_zipcode: "Codi postal"
+  admin_enterprise_groups_contact_zipcode_placeholder: "p. ex: 08870"
+  admin_enterprise_groups_contact_state_id: "Estat"
+  admin_enterprise_groups_contact_country_id: "País"
+  admin_enterprise_groups_web: "Recursos web"
+  admin_enterprise_groups_web_twitter: "p. ex: @horta_josepribes"
+  admin_enterprise_groups_web_website_placeholder: "p. ex.: www.hortajosepribes.coop"
+  admin_order_cycles: "Cicles de comanda de l'Admin"
+  open: "Obert"
+  close: "Tanca"
+  create: "Crear"
+  search: "Cerca"
+  supplier: "Proveïdora"
+  product_name: "Nom del producte"
+  product_description: "Descripció del producte"
+  coordinator: "Coordinador"
+  distributor: "Distribuïdora"
+  enterprise_fees: "Honoraris de l'organització"
+  process_my_order: "Processa la meva comanda"
+  delivery_instructions: Instruccions de lliurament
+  delivery_method: Mètode de lliurament
+  fee_type: "Tipus de tarifa"
+  tax_category: "Categoria d'impostos"
+  calculator: "Calculadora"
+  calculator_values: "Valors de la calculadora"
+  flat_percent_per_item: "Percentatge fixe (per article)"
+  flat_rate_per_item: "Tarifa fixa (per article)"
+  flat_rate_per_order: "Tarifa fixa (per comanda)"
+  flexible_rate: "Tarifa Flexible"
+  new_order_cycles: "Nou cicle de comanda"
+  new_order_cycle: "Nou cicle de comanda"
+  select_a_coordinator_for_your_order_cycle: "Selecciona una coordinadora per al vostre cicle de comanda"
+  notify_producers: 'Notifica les productores'
+  edit_order_cycle: "Edita el cicle de comanda"
+  roles: "Rols"
+  update: "Actualitzar"
+  delete: Suprimir
+  add_producer_property: "Afegeix propietats de la productora"
+  in_progress: "En progrés"
+  started_at: "Va començar a"
+  queued: "En cua"
+  scheduled_for: "Programat per a"
+  customers: "Consumidores"
+  please_select_hub: "Si us plau selecciona un grup"
+  loading_customers: "Carregant consumidores"
+  no_customers_found: "No s'han trobat consumidores"
+  go: "Anar"
+  hub: "Grup"
+  producer: "Productor"
+  product: "Producte"
+  price: "Preu"
+  on_hand: "Disponible"
+  save_changes: "Desa els canvis"
+  order_saved: "Comanda desada"
+  no_products: Sense productes
+  spree_admin_overview_enterprises_header: "Les meves organitzacions"
+  spree_admin_overview_enterprises_footer: "GESTIONAR LES MEVES ORGANITZACIONS"
+  spree_admin_enterprises_hubs_name: "Nom"
+  spree_admin_enterprises_create_new: "CREA'N UNA DE NOVA"
+  spree_admin_enterprises_shipping_methods: "Mètodes d'enviament"
+  spree_admin_enterprises_fees: "Honoraris de l'organització"
+  spree_admin_enterprises_none_create_a_new_enterprise: "CREA UNA NOVA ORGANITZACIÓ"
+  spree_admin_enterprises_none_text: "Encara no tens cap organització"
+  spree_admin_enterprises_tabs_hubs: "GRUPS"
+  spree_admin_enterprises_producers_manage_products: "GESTIONA ELS PRODUCTES"
+  spree_admin_enterprises_any_active_products_text: "No tens cap producte actiu."
+  spree_admin_enterprises_create_new_product: "CREA UN NOU PRODUCTE"
+  spree_admin_single_enterprise_alert_mail_confirmation: "Si us plau confirma l'adreça de correu electrònic de"
+  spree_admin_single_enterprise_alert_mail_sent: "Hem enviat un correu electrònic a"
+  spree_admin_overview_action_required: "Acció requerida"
+  spree_admin_overview_check_your_inbox: "Si us plat comproveu la vostra safata d'entrada per obtenir més instruccions. Gràcies!"
+  spree_admin_unit_value: Valor de la unitat
+  spree_admin_unit_description: Descripció de la unitat
+  spree_admin_supplier: Proveïdora
+  spree_admin_product_category: Categoria del producte
+  change_package: "Canvia el perfil"
+  spree_admin_single_enterprise_hint: "Suggeriment: per permetre que la gent us trobi, activeu la vostra visibilitat"
+  spree_admin_eg_pickup_from_school: "p. ex: 'Recollida al local del grup de consum'"
+  spree_admin_eg_collect_your_order: "p. ex: \"Recolliu la vostra comanda al c/Ample, n. 123'"
+  spree_order_availability_error: "La distribuïdora o el cicle de comanda no pot subministrar els productes de la vostra cistella"
+  spree_order_populator_error: "Aquesta distribuïdora o cicle de comanda no pot subministrar tots els productes de la vostra cistella. Si us plau trieu-ne d'altres."
+  spree_order_populator_availability_error: "Aquest producte no està disponible des de la distribuïdora o cicle de comanda seleccionat."
+  spree_distributors_error: "Cal seleccionar almenys un grup"
+  spree_user_enterprise_limit_error: "^ %{email} no està autoritzat a tenir més organitzacions (el límit és %{enterprise_limit})."
+  spree_variant_product_error: ha de tenir com a mínim una variant
+  on_ofn_map: "al mapa d'Open Food Network"
+  manage: "Gestiona"
+  resend: "Reenviar"
+  add_and_manage_products: "Afegeix & gestiona productes"
+  add_and_manage_order_cycles: "Afegeix & gestiona cicles de comanda"
+  manage_order_cycles: "Gestiona els cicles de comanda"
+  manage_products: "Gestiona els productes"
+  edit_profile_details: "Edita els detalls del perfil"
+  edit_profile_details_etc: "Canvia la descripció del perfil, les imatges, etc."
+  order_cycle: "Cicle de Comanda"
+  order_cycles: "Cicles de comanda"
+  remove_tax: "Suprimeix comissions"
+  enterprise_tos_message: "Volem treballar amb persones que comparteixen els nostres objectius i valors. Com a tal, demanem a les noves organitzacions que acceptin la nostra"
+  enterprise_tos_link_text: "Termes del servei."
+  enterprise_tos_agree: "Accepto els Termes i condicions anteriors"
+  admin_shared_address_1: "Adreça"
+  admin_shared_address_2: "Adreça (cont.)"
+  admin_share_city: "Municipi"
+  admin_share_zipcode: "Codi postal"
+  admin_share_country: "País"
+  admin_share_state: "Estat"
+  hub_sidebar_hubs: "Grups"
+  hub_sidebar_none_available: "Cap disponible"
+  hub_sidebar_manage: "Gestiona"
+  hub_sidebar_at_least: "Cal seleccionar almenys un grup "
+  hub_sidebar_blue: "blau"
+  hub_sidebar_red: "vermell"
+  shop_trial_in_progress: "El període de prova de la vostra botiga caduca en %{days}."
+  report_customers_distributor: "Distribuïdora"
+  report_customers_supplier: "Proveïdora"
+  report_customers_cycle: "Cicle de Comanda"
+  report_customers_type: "Tipus d'informe"
+  report_customers_csv: "Descarrega com a csv"
+  report_producers: "Productores:"
+  report_type: "Tipus d'informe:"
+  report_hubs: "Grups:"
+  report_payment: "Mètodes de pagament:"
+  report_distributor: "Distribuïdora:"
+  report_payment_by: 'Pagaments per tipus'
+  report_itemised_payment: 'Totals de pagament especificats'
+  report_payment_totals: 'Totals de pagament'
+  report_all: 'tot'
+  report_order_cycle: "Cicle de comanda:"
+  report_enterprises: "Organitzacions:"
+  report_users: "Usuàries:"
+  report_tax_rates: Taxes d'impostos
+  report_tax_types: Tipus d'impostos
+  report_header_order_cycle: Cicle de comanda
+  report_header_user: Usuàries
+  report_header_email: Correu electrònic
+  report_header_status: Estat
+  report_header_comments: Comentaris
+  report_header_first_name: Nom
+  report_header_last_name: Cognoms
+  report_header_phone: Telèfon
+  report_header_suburb: Barri
+  report_header_address: Adreça
+  report_header_billing_address: Adreça de facturació
+  report_header_relationship: Relació
+  report_header_hub: Grup
+  report_header_hub_address: Adreça del grup
+  report_header_to_hub: Per al grup
+  report_header_hub_code: Codi del grup
+  report_header_code: Codi
+  report_header_paid: Pagat?
+  report_header_delivery: Lliurament?
+  report_header_shipping: Enviament
+  report_header_shipping_method: Mètode d'enviament
+  report_header_shipping_instructions: Instruccions d'enviament
+  report_header_ship_street: Carrer d'enviament
+  report_header_ship_street_2: Carrer d'enviament 2
+  report_header_ship_city: Ciutat d'enviament
+  report_header_ship_postcode: Codi postal d'enviament
+  report_header_ship_state: Estat d'enviament
+  report_header_billing_street: Carrer de facturació
+  report_header_billing_street_2: Carrer de facturació 2
+  report_header_billing_street_3: Carrer de facturació 3
+  report_header_billing_street_4: Carrer de facturació 4
+  report_header_billing_city: Ciutat de facturació
+  report_header_billing_postcode: Codi postal de facturació
+  report_header_billing_state: Estat de facturació
+  report_header_incoming_transport: Transport entrant
+  report_header_special_instructions: Instruccions especials
+  report_header_order_number: Número de comanda
+  report_header_date: Data
+  report_header_tags: Etiquetes
+  report_header_items: Articles
+  report_header_items_total: "Total d'articles %{currency_symbol}"
+  report_header_delivery_charge: "Càrrec de lliurament (%{currency_symbol})"
+  report_header_tax_on_delivery: "Impost sobre el lliurament (%{currency_symbol})"
+  report_header_enterprise: Organització
+  report_header_customer: Consumidora
+  report_header_customer_code: Codi de la consumidora
+  report_header_product: Producte
+  report_header_product_properties: Propietats del producte
+  report_header_quantity: Quantitat
+  report_header_max_quantity: Quantitat màxima
+  report_header_variant: Variant
+  report_header_variant_value: Valor de la variant
+  report_header_variant_unit: Unitat de la variant
+  report_header_total_available: Total disponible
+  report_header_unallocated: Sense assignar
+  report_header_supplier: Proveïdora
+  report_header_producer: Productora
+  report_header_unit: Unitat
+  report_header_cost: Cost
+  report_header_shipping_cost: Despeses d'enviament
+  report_header_total_shipping_cost: Cost total d'enviament
+  report_header_payment_method: Mètode de pagament
+  report_header_sells: Ven
+  report_header_visible: Visible
+  report_header_price: Preu
+  report_header_distributor: Distribuïdora
+  report_header_distributor_address: Adreça de la distribuïdora
+  report_header_distributor_city: Ciutat de la distribuïdora
+  report_header_distributor_postcode: Codi postal de la distribuïdora
+  report_header_delivery_address: Adreça de lliurament
+  report_header_delivery_postcode: Codi postal de lliurament
+  report_header_weight: Pes
+  report_header_amount_owing: Import adeutat
+  report_header_amount_paid: Import pagat
+  report_header_units_required: Unitats necessàries
+  report_header_remainder: Restant
+  report_header_order_date: Data de comanda
+  report_header_order_id: Identificació de comanda
+  report_header_item_name: Nom de l'article
+  report_header_temp_controlled_items: Articles amb control de temperatura?
+  report_header_customer_name: Nom de la consumidora
+  report_header_customer_email: Correu electrònic de la consumidora
+  report_header_customer_phone: Telèfon de la consumidora
+  report_header_customer_city: Ciutat de la consumidora
+  report_header_payment_state: Estat del pagament
+  report_header_payment_type: Tipus de pagament
+  report_header_item_price: "Article (%{currency})"
+  report_header_total_price: "Total (%{currency})"
+  report_header_product_total_price: "Total del producte (%{currency})"
+  report_header_shipping_total_price: "Enviament total (%{currency})"
+  report_header_paypal_price: "PayPal (%{currency})"
+  report_header_sku: Número de referència (SKU)
+  report_header_amount: Import
+  report_header_total_excl_vat: "Total excl. impostos (%{currency_symbol})"
+  report_header_total_incl_vat: "Total incl. impostos (%{currency_symbol})"
+  report_header_temp_controlled: Control de temperatura?
+  report_header_is_producer: Productor?
+  initial_invoice_number: "Número de la comanda inicial:"
+  invoice_date: "Data del comprovant de compra:"
+  contains: "conté"
+  discount: "Descompte"
+  delete_product_variant: "L'última variant no es pot esborrar!"
+  progress: "progressió"
+  saving: "Desant..."
+  success: "èxit"
+  failure: "error"
+  unsaved_changes_confirmation: "Es perdran els canvis sense desar. Vols continuar de totes maneres?"
+  one_product_unsaved: "Els canvis d'un producte romanen sense desar."
+  products_unsaved: "Els canvis a %{n} productes romanen sense desar."
+  is_already_manager: "ja és gestor!"
+  no_change_to_save: " No hi ha cap canvi per desar"
+  user_invited: "%{email} ha estat convidada a gestionar aquesta organització"
+  add_manager: "Afegeix una usuària existent"
+  users: "Usuàries"
+  about: "Sobre"
+  images: "Imatges"
+  web: "Web"
+  primary_details: "Detalls principals"
+  adrdress: "Adreça"
+  contact: "Contacte"
+  social: "Social"
+  business_details: "Dades comercials"
+  properties: "Propietats"
+  shipping: "Enviament"
+  shipping_methods: "Mètodes d'enviament"
+  payment_methods: "Mètodes de Pagament"
+  payment_method_fee: "Tarifa de transacció"
+  inventory_settings: "Configuració de l'inventari"
+  tag_rules: "Regles d'etiqueta"
+  shop_preferences: "Preferències de la botiga"
+  enterprise_fee_whole_order: Comanda sencera
+  validation_msg_relationship_already_established: "^ Aquesta relació ja està establerta."
+  validation_msg_at_least_one_hub: "^ Cal seleccionar com a mínim un grup"
+  validation_msg_product_category_cant_be_blank: "^ La categoria de producte no pot estar en blanc"
+  validation_msg_is_associated_with_an_exising_customer: "Està associada amb una consumidora existent"
+  enterprise_name_error: "ja ha estat agafat. Si aquesta és la vostra organització i voleu reclamar-ne la propietat o si voleu comerciar amb aquesta organització, poseu-vos en contacte amb l'administradora actual d'aquest perfil %{email}."
+  enterprise_owner_error: "^ %{email} no està autoritzat a tenir més organitzacions (el límit és %{enterprise_limit})."
+  inventory_item_visibility_error: ha de ser veritable o falsa
+  product_importer_file_error: "error: no s'ha carregat cap fitxer"
+  product_importer_spreadsheet_error: "no s'ha pogut processar el fitxer: tipus de fitxer no vàlid"
+  product_importer_products_save_error: no s'han desat cap producte amb èxit
+  product_import_file_not_found_notice: 'No s''ha trobat el fitxer o no s''ha pogut obrir'
+  product_import_no_data_in_spreadsheet_notice: 'No s''ha trobat cap dada al full de càlcul'
+  order_choosing_hub_notice: El teu grup ha estat seleccionat.
+  order_cycle_selecting_notice: S'ha seleccionat el teu cicle de comanda.
+  enterprise_fees_update_notice: S'han actualitzat les comissions de l'organització.
+  enterprise_register_package_error: "Si us plau, selecciona un perfil"
+  enterprise_register_error: "No es pot completar el registre de %{enterprise}"
+  enterprise_register_success_notice: "Enhorabona! El registre de %{enterprise} s'ha completat!"
+  enterprise_bulk_update_success_notice: "Les organitzacions s'han actualitzat correctament"
+  enterprise_bulk_update_error: 'No s''ha pogut actualitzar'
+  order_cycles_create_notice: 'S''ha creat el cicle de comanda.'
+  order_cycles_update_notice: 'S''ha actualitzat el cicle de comanda.'
+  order_cycles_bulk_update_notice: 'S''han actualitzat els cicles de comanda.'
+  order_cycles_clone_notice: "S'ha clonat el teu cicle de comanda %{name}."
+  order_cycles_email_to_producers_notice: 'Els correus electrònics per enviar a les productores estan en cua.'
+  order_cycles_no_permission_to_coordinate_error: "Cap de les vostres organitzacions té permís per coordinar un cicle de comanda"
+  order_cycles_no_permission_to_create_error: "No teniu permís per crear un cicle de comandes coordinat per aquesta organització"
+  back_to_orders_list: "Torna a la llista de comandes"
+  no_orders_found: "No s'han trobat comandes"
+  order_information: "Informació de la comanda"
+  date_completed: "Data finalitzada"
+  amount: "Import"
+  state_names:
+    ready: Llest
+    pending: Pendents
+    shipped: Enviat
+  js:
+    saving: 'Desant...'
+    changes_saved: 'S''han desat els canvis.'
+    save_changes_first: Desa els canvis en primer lloc.
+    all_changes_saved: S'han desat tots els canvis
+    unsaved_changes: Teniu canvis sense desar
+    all_changes_saved_successfully: Tots els canvis s'han desat correctament
+    oh_no: "Ah no! No he pogut desar els canvis."
+    unauthorized: "No tens autorització per accedir a aquesta pàgina."
+    error: Error
+    unavailable: No disponible
+    profile: Perfil
+    hub: Grup
+    shop: Botiga
+    choose: Escull
+    resolve_errors: Si us plau, resol els errors següents
+    more_items: "+ %{count} Més"
+    admin:
+      enterprise_limit_reached: "Has assolit el límit estàndard d'organitzacions per compte. Escriu a %{contact_email} si necessites augmentar-lo."
+      modals:
+        got_it: Ho tinc
+        close: "Tanca"
+        invite: "Convida"
+        invite_title: "Convida un usuari no registrat"
+        tag_rule_help:
+          title: Regles d'etiqueta
+          overview: Visió general
+          overview_text: >
+              Les regles d'etiquetes proporcionen una manera de descriure quins elements
+              són visibles o pel contrari s'amaguen a segons quins clients. Els elements
+              poden ser mètodes d'enviament, mètodes de pagament, productes i cicles
+              de comanda.
+          by_default_rules: "Regles 'per defecte...'"
+          by_default_rules_text: >
+              Les regles predeterminades o per defecte permeten ocultar elements perquè
+              no siguin visibles de manera predeterminada. Aquest comportament es
+              pot reemplaçar per regles no predeterminades per a clients amb etiquetes
+              particulars.
+          customer_tagged_rules: "Regles de 'clients etiquetats...'"
+          customer_tagged_rules_text: >
+              En crear regles relacionades amb una etiqueta de client específica,
+              podeu anul·lar el comportament predeterminat (ja sigui per mostrar o
+              ocultar elements) per als clients amb l'etiqueta especificada.
+      panels:
+        save: DESA
+        saved: DESAT
+        saving: DESANT
+        enterprise_package:
+          hub_profile: Perfil de grup
+          hub_profile_cost: "COST: SEMPRE GRATUÏT"
+          hub_profile_text1: >
+              La gent podrà trobar-vos i posar-se en contacte amb vosaltres a Open
+              Food Network. La vostra organització serà visible al mapa i es podrà
+              cercar a les llistes.
+          hub_profile_text2: >
+              Tenir un perfil i fer contactes amb vostre moviment alimentari local
+              a través d'Open Food Network sempre serà gratuït.
+          hub_shop: Botiga
+          hub_shop_text1: >
+              La teva organització és la columna vertebral del vostre sistema alimentari
+              local. Afegeix productes d'altres organitzacions productores i ven-los
+              a través de la vostra botiga a la Katuma.
+          hub_shop_text2: >
+              Els grups poden prendre moltes formes, ja siguin una cooperativa d'aliments,
+              un grup de compra, o una botiga de queviures local, un supermercat cooperatiu.
+          hub_shop_text3: >
+              Si també vols vendre els teus propis productes, hauràs de canviar d'organització
+              per ser productora.
+          choose_package: Si us plau tria un perfil
+          choose_package_text1: >
+              La teva organització no s'activarà completament fins que es seleccioni
+              un perfil d'entre les opcions de l'esquerra.
+          choose_package_text2: >
+              Fes clic a una opció per veure informació més detallada sobre cada perfil
+              i prem el botó vermell "DESA" quan hagis acabat.
+          profile_only: Només perfil
+          profile_only_cost: "COST: SEMPRE GRATUÏT"
+          profile_only_text1: >
+              Un perfil et fa visible i contactablede cara als altres i és una forma
+              de compartir la teva història.
+          profile_only_text2: >
+              Si prefereixes concentrar-te en produir menjar i vols deixar la feina
+              de vendre'l a una altra persona, no necessitaràs una botiga Katuma.
+          profile_only_text3: >
+              Afegeix els teus productes a Katuma, permetent que els grups de consum
+              o altres puguin emmagatzemar-los a les seves botigues.
+          producer_shop: Productora amb botiga
+          producer_shop_text1: >
+              Ven els teus productes directament a les consumidores a través de la
+              teva pròpia botiga a Katuma.
+          producer_shop_text2: >
+              Una botiga de productores només és per als teus productes, si vols vendre
+              productes produïts / cultivats per un altre, selecciona "Grup de productores"
+          producer_hub: Grup de productores
+          producer_hub_text1: >
+              La teva organització és la columna vertebral del vostre sistema alimentari
+              local. Pots vendre els vostres propis productes i productes agregats
+              d'altres organitzacions a través de la vostra botiga a Katuma.
+          producer_hub_text2: >
+              Un grup pot prendre moltes formes, ja siguin una cooperativa de consum,
+              un programa de cistelles o un hort comunitari que produeix per als seus
+              socis.
+          producer_hub_text3: >
+              L'Open Food Network té com a objectiu donar suport a tots els models
+              de grups possibles, de manera que, independentment de la teva situació,
+              volem proporcionar les eines que necessites per executar la teva organització
+              o empresa alimentària local.
+          get_listing: Obtenir una llista
+          always_free: SEMPRE GRATUÏT
+          sell_produce_others: Ven productes d'altres
+          sell_own_produce: Ven els teus propis productes
+          sell_both: Ven productes d'un mateix i d'altres
+        enterprise_producer:
+          producer: Productor
+          producer_text1: >
+              Les productores fan coses delicioses per menjar o beure. Ets productora
+              si cultives, cries, fermentes, cous pa, vens llet, fas formatges...
+          producer_text2: >
+              Les productores també poden realitzar altres funcions, com ara agregar
+              productes d'altres productores i vendre-la a través d'una botiga a Katuma.
+          non_producer: No productora
+          non_producer_text1: >
+              Les no-productores no produeixen cap aliment, per la qual cosa no poden
+              crear productes propis per vendre a través de Katuma.
+          non_producer_text2: >
+              En canvi, les no-productores s'especialitzen en vincular les productores
+              amb el consumidor final, ja sigui classificant, envasant, venent o lliurant
+              aliments.
+          producer_desc: Productores d'aliments
+          producer_example: 'p. ex: AGRICULTORES, FORNERES, CERVESERES, TRANSFORMADORES D''ALIMENTS...'
+          non_producer_desc: Totes les altres organitzacions alimentàries
+          non_producer_example: 'p. ex: botigues de queviures, cooperatives d''aliments, grups de compra...'
+        enterprise_status:
+          description: Descripció
+          resolve: Resoldre
+      new_tag_rule_dialog:
+        select_rule_type: "Selecciona un tipus de regla:"
+      orders:
+        index:
+          per_page: "%{results} per pàgina"
+      resend_user_email_confirmation:
+        resend: "Reenviar"
+        sending: "Reenviar..."
+        done: "Reenviament fet ✓"
+        failed: "Reenviament fallit ✗"
+    out_of_stock:
+      reduced_stock_available: Estoc reduït disponible
+      out_of_stock_text: >
+          Mentre heu estat comprant, s'han reduït els nivells d'existències d'un o
+          més dels productes de la cistella. Aquí podeu veure el que ha canviat:
+      now_out_of_stock: ara està fora d'estoc.
+      only_n_remainging: "ara només n'hi ha %{num}restants."
+    variants:
+      on_demand:
+        'yes': "Sota demanda"
+    variant_overrides:
+      on_demand:
+        use_producer_settings: "Utilitzeu la configuració d'inventari de la productora"
+        'yes': "Sí"
+        'no': "No"
+      inventory_products: "Productes de l'inventari"
+      hidden_products: "Productes ocults"
+      new_products: "Nous productes"
+      reset_stock_levels: Restablir els nivells d'existències a valors predeterminats
+      remain_unsaved: romanen sense desar.
+      no_changes_to_save: No hi ha canvis per desar.
+      no_authorisation: "No he pogut obtenir l'autorització per guardar aquests canvis, de manera que romanen sense desar."
+      some_trouble: "He tingut problemes per desar: %{errors}"
+      changing_on_hand_stock: Canviant els nivells de disponibilitat d'existències...
+      stock_reset: Existències restablertes als valors predeterminats.
+    tag_rules:
+      show_hide_variants: 'Mostra o amaga variants a la meva botiga'
+      show_hide_shipping: 'Mostra o amaga mètodes d''enviament en la validació de la comanda'
+      show_hide_payment: 'Mostra o amaga mètodes de pagament en la validació de la comanda'
+      show_hide_order_cycles: 'Mostra o amaga els cicles de comanda a la meva botiga'
+      visible: VISIBLE
+      not_visible: NO VISIBLE
+    services:
+      unsaved_changes_message: Actualment hi ha canvis sense desar, vols desar-los o ignorar-los?
+      save: DESA
+      ignore: IGNORA
+      add_to_order_cycle: "afegeix al cicle de comanda"
+      manage_products: "gestiona els productes"
+      edit_profile: "edita el perfil"
+      add_products_to_inventory: "afegeix productes a l'inventari"
+    resources:
+      could_not_delete_customer: 'No s''ha pogut eliminar la consumidora'
+    order_cycles:
+      create_failure: "No s'ha pogut crear el cicle de comanda"
+      update_success: 'S''ha actualitzat el cicle de comanda.'
+      update_failure: "No s'ha pogut actualitzar el cicle de comanda"
+      no_distributors: 'No hi ha distribuïdores en aquest cicle de comanda. Aquest cicle de comanda no serà visible per a les consumidores fins que no n''afegiu un. Voleu continuar desant aquest cicle de comanda? '
+    enterprises:
+      producer: "Productora"
+      non_producer: "No-productora"
+    customers:
+      select_shop: 'Si us plau seleccioneu primer una botiga'
+      could_not_create: Ho sentim! No s'ha pogut crear
+    subscriptions:
+      closes: tanca
+      closed: tancat
+      close_date_not_set: La data de tancament no està establerta
+  producers:
+    signup:
+      start_free_profile: "Comença amb un perfil gratuït i amplia'l quan estiguis preparada."
+  spree:
+    email: Correu electrònic
+    account_updated: "Compte actualitzat!"
+    my_account: "El meu compte"
+    date: "Data"
+    time: "Hora"
+    layouts:
+      admin:
+        header:
+          store: Botiga
+    admin:
+      orders:
+        index:
+          new_order: "Nova comanda"
+          capture: "Captura"
+          ship: "Enviament"
+          edit: "Editar"
+          note: "Nota"
+          first: "Primer"
+          last: "Últim"
+          next: "Següent"
+          loading: "S'està carregant"
+          no_orders_found: "No s'ha trobat cap comanda"
+          results_found: "%{number} Resultats trobats."
+          viewing: "Veient %{start} a %{end}."
+        invoice:
+          issued_on: Publicat a
+          tax_invoice: FACTURA D'IMPOSTOS
+          code: Codi
+          from: De
+          to: Per a
+        form:
+          distribution_fields:
+            title: Distribució
+            distributor: "Distribuïdora:"
+            order_cycle: "Cicle de comanda:"
+      overview:
+        order_cycles:
+          order_cycles: "Cicles de comanda"
+          order_cycles_tip: "Els cicles de comanda determinen quan i on els teus productes estan disponibles per a les consumidores."
+          you_have_active:
+            zero: "No tens cicles de comanda actius."
+            one: "Tens un cicle de comanda actiu."
+            other: "Tens %{count}cicles de comanda actius"
+          manage_order_cycles: "GESTIONA ELS CICLES DE COMANDA"
+      payment_methods:
+        new:
+          new_payment_method: "Nou mètode de pagament"
+          back_to_payment_methods_list: "Tornar a la llista de mètodes de pagament"
+        edit:
+          editing_payment_method: "Edició del mètode de pagament"
+          back_to_payment_methods_list: "Tornar a la llista de mètodes de pagament"
+        stripe_connect:
+          enterprise_select_placeholder: Tria ...
+          loading_account_information_msg: S'està carregant la informació del compte de Stripe, si us plau espera...
+          stripe_disabled_msg: Els pagaments de Stripe han estat inhabilitat per l'administrador del sistema.
+          request_failed_msg: Ho sentim. S'ha produït un error en provar de verificar els detalls del compte amb Stripe...
+          account_missing_msg: No hi ha cap compte de Stripe per a aquesta organització.
+          access_revoked_msg: S'ha revocat l'accés a aquest compte de Stripe, si us plau torna a connectar el teu compte.
+          status: Estat
+          connected: Connectat
+          account_id: Identificador del compte
+          business_name: Nom de l'empresa
+          charges_enabled: Càrrecs habilitats
+      payments:
+        source_forms:
+          stripe:
+            error_saving_payment: Error en desar el pagament
+            submitting_payment: S'està lliurant el pagament...
+      products:
+        new:
+          title: 'Nou producte'
+        index:
+          header:
+            title: Edició de productes en bloc
+          indicators:
+            title: CARREGANT PRODUCTES
+            no_products: "Encara no hi ha productes. Per què no afegeixes alguna cosa?"
+            no_results: "Ho sentim, no hi ha coincidència de resultats"
+          products_head:
+            name: Nom
+            unit: Unitat
+            display_as: Mostra com
+            category: Categoria
+            tax_category: Categoria d'impostos
+            inherits_properties?: Hereda propietats?
+            available_on: Disponible el
+          products_variant:
+            new_variant: "Nova variant"
+          product_name: Nom del producte
+        primary_taxon_form:
+          product_category: Categoria del producte
+        group_buy_form:
+          group_buy: "Compra en grup?"
+        display_as:
+          display_as: Mostra com
+      users:
+        index:
+          listing_users: "Llistat d'usuàries"
+          new_user: "Nova usuària"
+          user: "Usuàries"
+          enterprise_limit: "Límit d'organitzacions"
+          search: "Cerca"
+          email: "E-mail"
+        edit:
+          editing_user: "S'està editant una usuària"
+          back_to_users_list: "Torna a la llista d'usuàries"
+          general_settings: "Configuració general"
+        form:
+          email: "E-mail"
+          roles: "Rols"
+          enterprise_limit: "Límit d'organitzacions"
+          confirm_password: "Confirma la contrassenya"
+          password: "Contrasenya"
+        email_confirmation:
+          confirmation_pending: "La confirmació de correu electrònic està pendent. Hem enviat un correu electrònic de confirmació a %{address}."
+      variants:
+        autocomplete:
+          producer_name: Productor
+      general_settings:
+        edit:
+          cookies_consent_banner_toggle: "Mostra banner de consentiment de cookies"
+          privacy_policy_url: "URL de la política de privacitat "
+          cookies_policy_matomo_section: "Mostra la secció de Matomo a la pàgina de política de cookies"
+          cookies_policy_ga_section: "Mostra la secció de Google Analytics a la pàgina de política de cookies"
+    checkout:
+      payment:
+        stripe:
+          choose_one: Escull-ne un
+          enter_new_card: Introdueix els detalls d'una targeta nova
+          used_saved_card: "Utilitza una targeta desada:"
+          or_enter_new_card: "O bé introdueix els detalls d'una nova targeta:"
+          remember_this_card: Recordar aquesta targeta?
+    inventory: Inventari
+    orders:
+      edit:
+        login_to_view_order: "Si us plau inicia sessió per veure la teva comanda."
+      bought:
+        item: "Ja està demanat en aquest cicle de comandes"
+    order_mailer:
+      invoice_email:
+        hi: "Hola %{name}"
+        invoice_attached_text: Trobareu adjunta un comprovant de la compra per a la vostra comanda recent
+    order_state:
+      address: adreça
+      adjustments: ajustaments
+      awaiting_return: esperant el retorn
+      canceled: cancel·lat
+      cart: cistella
+      complete: completa
+      confirm: confirma
+      delivery: lliurament
+      paused: en pausa
+      payment: pagament
+      pending: pendents
+      resumed: reprès
+      returned: retornat
+      skrill: habilitat
+    subscription_state:
+      active: actiu
+      pending: pendents
+      ended: acabat
+      paused: en pausa
+      canceled: cancel·lat
+    payment_states:
+      completed: completat
+      credit_owed: crèdit a deure
+      failed: error
+      paid: pagat
+      pending: pendents
+      processing: processant
+      void: buit
+      invalid: invàlid
+    shipment_states:
+      backorder: per tornar
+      partial: parcial
+      pending: pendents
+      ready: llest
+      shipped: enviat
+    user_mailer:
+      reset_password_instructions:
+        request_sent_text: |
+            S'ha fet una sol·licitud per restablir la teva contrasenya.
+            Si no has fet aquesta sol·licitud, simplement ignora aquest correu electrònic.
+        link_text: >
+            Si has fet aquesta sol·licitud, fes clic a l'enllaç següent:
+        issue_text: |
+            Si l'URL anterior no funciona, prova de copiar-lo i enganxar-lo al navegador.
+            Si continues tenint problemes, no dubtis en contactar-nos.
+      confirmation_instructions:
+        subject: Si us plau confirma el teu compte d'OFN
+    weight: Pes (per kg)
+    zipcode: Codi postal
+    users:
+      form:
+        account_settings: Configuració del compte
+      show:
+        tabs:
+          orders: Comandes
+          cards: Targetes de crèdit
+          transactions: Transaccions
+          settings: Configuració del compte
+        unconfirmed_email: "Confirmació pendent de correu electrònic per a: %{unconfirmed_email}. La vostra adreça de correu electrònic s'actualitzarà un cop confirmat el nou correu electrònic."
+      orders:
+        open_orders: Comandes obertes
+        past_orders: Comandes anteriors
+      transactions:
+        transaction_history: Historial de transaccions
+      open_orders:
+        order: Comanda
+        shop: Botiga
+        changes_allowed_until: Canvis permesos fins a
+        items: Articles
+        total: Total
+        edit: Editar
+        cancel: Cancel·lar
+        closed: Tancat
+        until: Fins a
+      past_orders:
+        order: Comanda
+        shop: Botiga
+        completed_at: Completat a
+        items: Articles
+        total: Total
+        paid?: Pagat?
+        view: Veure
+      saved_cards:
+        default?: Per defecte?
+        delete?: Suprimeix?
+      cards:
+        authorised_shops: Botigues autoritzades
+        authorised_shops_popover: Aquesta és la llista de botigues que tenen permís per carregar la teva targeta de crèdit predeterminada per a qualsevol subscripció (és a dir, comandes de repetició) que puguis tenir. Les dades de la targeta es mantindran segures i no es compartiran amb els propietaris de botigues. Sempre se us notificarà quan se us faci un càrrec.
+        saved_cards_popover: Aquesta és la llista de targetes que heu optat per guardar per a un ús posterior. El vostre "valor predeterminat" es seleccionarà automàticament quan valideu una comanda i es pot carregar per qualsevol botiga a la que li hagueu permès fer-ho (vegeu a la dreta).
+      authorised_shops:
+        shop_name: "Nom de la botiga"
+        allow_charges?: "Permetre càrrecs?"
+    localized_number:
+      invalid_format: té un format no vàlid. Si us plau introdueix un número.


### PR DESCRIPTION
#### What? Why?

Although we've started translating to Catalan very long ago and focused on it recently, we never imported the file in the app. The language menu showed "English" for the "ca" locale and clicking on it switched to English as well instead of Catalan.

As we already had the Spanish translation, we moved along with it (too many things) delaying the end of the Catalan one forever. Truth is that all Katuma users' mother tongue is Catalan so they will be more than happy.

#### What should we test?
It should be possible to switch to Catalan when testing this from staging.katuma.org. Catalan 101: the menu should look like

![screenshot from 2019-02-08 15-31-22](https://user-images.githubusercontent.com/762088/52484438-9d067880-2bb6-11e9-8175-f5ea674e126c.png)

#### Release notes

Added Catalan translation which will work on Katuma.

Changelog Category: Added
