### PR TITLE
3455 [Flaky Spec] Do not expect modal still open when checking that the spinner is gone

### DIFF
--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -762,9 +762,9 @@ feature %q{
 
         # Shows spinner whilst loading
         expect(page).to have_css "img.spinner", visible: true
-        expect(page).to have_no_css "img.spinner", visible: true
       end
 
+      expect(page).to have_no_css "img.spinner", visible: true
       expect(page).to have_no_selector "div.reveal-modal"
 
       within "table#listing_products tr#p_#{product.id}" do


### PR DESCRIPTION
Do not expect that the modal is still open when checking that the spinner is already hidden.

#### What? Why?

Closes #3455 

The element referenced in the following might no longer be visible:

    within "div.reveal-modal"

#### What should we test?

Semaphore build should be green.

In the long term, this test should also not fail.

#### Release notes

* Address intermittently failing feature tests

Changelog Category: Fixed