### PR TITLE
3468 [Flaky Spec] Check for presence of flash div before trying to get its text

### DIFF
--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -29,7 +29,9 @@ feature 'shipping methods' do
       fill_in 'shipping_method_name', with: 'Carrier Pidgeon'
       check "shipping_method_distributor_ids_#{d1.id}"
       check "shipping_method_distributor_ids_#{d2.id}"
-      click_button 'Create'
+      click_button I18n.t("actions.create")
+
+      expect(page).to have_no_button I18n.t("actions.create")
 
       # Then the shipping method should have its distributor set
       message = "Shipping method \"Carrier Pidgeon\" has been successfully created!"
@@ -99,8 +101,9 @@ feature 'shipping methods' do
         expect(page).to have_css '.tag-item'
       end
 
-      click_button 'Create'
+      click_button I18n.t("actions.create")
 
+      expect(page).to have_no_button I18n.t("actions.create")
       message = "Shipping method \"Teleport\" has been successfully created!"
       expect(page).to have_flash_message message
 

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -32,7 +32,8 @@ feature 'shipping methods' do
       click_button 'Create'
 
       # Then the shipping method should have its distributor set
-      flash_message.should == 'Shipping method "Carrier Pidgeon" has been successfully created!'
+      message = "Shipping method \"Carrier Pidgeon\" has been successfully created!"
+      expect(page).to have_flash_message message
 
       sm = Spree::ShippingMethod.last
       sm.name.should == 'Carrier Pidgeon'
@@ -100,7 +101,9 @@ feature 'shipping methods' do
 
       click_button 'Create'
 
-      flash_message.should == 'Shipping method "Teleport" has been successfully created!'
+      message = "Shipping method \"Teleport\" has been successfully created!"
+      expect(page).to have_flash_message message
+
       expect(first('tags-input .tag-list ti-tag-item')).to have_content "local"
 
       shipping_method = Spree::ShippingMethod.find_by_name('Teleport')

--- a/spec/support/matchers/flash_message_matchers.rb
+++ b/spec/support/matchers/flash_message_matchers.rb
@@ -1,0 +1,31 @@
+RSpec::Matchers.define :have_flash_message do |message|
+  match do |node|
+    @message, @node = message, node
+
+    # Ignore leading and trailing whitespace. Later versions of Capybara have :exact_text option.
+    # The :exact option is not supported in has_selector?.
+    message_substring_regex = substring_match_regex(message)
+    node.has_selector?(".flash", text: message_substring_regex, visible: false)
+  end
+
+  failure_message do |actual|
+    "expected to find flash message ##{@message}"
+  end
+
+  match_when_negated do |node|
+    @message, @node = message, node
+
+    # Ignore leading and trailing whitespace. Later versions of Capybara have :exact_text option.
+    # The :exact option is not supported in has_selector?.
+    message_substring_regex = substring_match_regex(message)
+    node.has_no_selector?(".flash", text: message_substring_regex, visible: false)
+  end
+
+  failure_message_when_negated do |actual|
+    "expected not to find flash message ##{@message}"
+  end
+
+  def substring_match_regex(text)
+    /\A\s*#{Regexp.escape(text)}\s*\Z/
+  end
+end


### PR DESCRIPTION
Check for presence of flash `div` before trying to get its text.

#### What? Why?

Closes #3468 

Not checking for the flash `div` first could result in timing issues when using AJAX in the previous action.

This also adds a matcher `have_flash_message`. I did not update tests in other spec files to try to avoid merge conflicts especially with the Spree upgrade branch.

#### What should we test?

Semaphore build should be green.

In the long term, this test should also not fail.

#### Release notes

* Address intermittently failing feature tests

Changelog Category: Fixed