### PR TITLE
Simplify specs with stripe factory

### DIFF
--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -695,7 +695,7 @@ describe Admin::SubscriptionsController, type: :controller do
     end
 
     context "when other payment methods exist" do
-      let!(:stripe) { create(:stripe_payment_method, distributors: [shop], preferred_enterprise_id: shop.id) }
+      let!(:stripe) { create(:stripe_payment_method, distributors: [shop]) }
       let!(:paypal) { Spree::Gateway::PayPalExpress.create!(name: "PayPalExpress", distributor_ids: [shop.id]) }
       let!(:bogus) { create(:bogus_payment_method, distributors: [shop]) }
 

--- a/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -19,7 +19,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
       before { @request.env['HTTP_REFERER'] = spree.admin_order_payments_url(payment) }
 
       context "that was processed by stripe" do
-        let!(:payment_method) { create(:stripe_payment_method, distributors: [shop], preferred_enterprise_id: shop.id) }
+        let!(:payment_method) { create(:stripe_payment_method, distributors: [shop]) }
         # let!(:credit_card) { create(:credit_card, gateway_customer_profile_id: "cus_1", gateway_payment_profile_id: 'card_2') }
         let!(:payment) { create(:payment, order: order, state: 'completed', payment_method: payment_method, response_code: 'ch_1a2b3c', amount: order.total) }
 
@@ -76,7 +76,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
       before { @request.env['HTTP_REFERER'] = spree.admin_order_payments_url(payment) }
 
       context "that was processed by stripe" do
-        let!(:payment_method) { create(:stripe_payment_method, distributors: [shop], preferred_enterprise_id: shop.id) }
+        let!(:payment_method) { create(:stripe_payment_method, distributors: [shop]) }
         let!(:payment) { create(:payment, order: order, state: 'completed', payment_method: payment_method, response_code: 'ch_1a2b3c', amount: order.total + 5) }
 
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -450,6 +450,8 @@ FactoryBot.define do
   factory :stripe_payment_method, :class => Spree::Gateway::StripeConnect do
     name 'Stripe'
     environment 'test'
+    distributors { [FactoryBot.create(:enterprise)] }
+    preferred_enterprise_id { distributors.first.id }
   end
 
   factory :stripe_account do

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -153,7 +153,7 @@ feature 'Subscriptions' do
       let!(:order_cycle) { create(:simple_order_cycle, coordinator: shop, orders_open_at: 2.days.from_now, orders_close_at: 7.days.from_now) }
       let!(:outgoing_exchange) { order_cycle.exchanges.create(sender: shop, receiver: shop, variants: [test_variant, shop_variant], enterprise_fees: [enterprise_fee]) }
       let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
-      let!(:payment_method) { create(:stripe_payment_method, name: 'Credit Card', distributors: [shop], preferred_enterprise_id: shop.id) }
+      let!(:payment_method) { create(:stripe_payment_method, name: 'Credit Card', distributors: [shop]) }
       let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
 
       before do
@@ -300,7 +300,7 @@ feature 'Subscriptions' do
       let!(:variant3_oc) { create(:simple_order_cycle, coordinator: shop, orders_open_at: 2.days.from_now, orders_close_at: 7.days.from_now) }
       let!(:variant3_ex) { variant3_oc.exchanges.create(sender: shop, receiver: shop, variants: [variant3]) }
       let!(:payment_method) { create(:payment_method, distributors: [shop]) }
-      let!(:stripe_payment_method) { create(:stripe_payment_method, name: 'Credit Card', distributors: [shop], preferred_enterprise_id: shop.id) }
+      let!(:stripe_payment_method) { create(:stripe_payment_method, name: 'Credit Card', distributors: [shop]) }
       let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
       let!(:subscription) {
         create(:subscription,
@@ -438,7 +438,7 @@ feature 'Subscriptions' do
       let!(:enterprise_fee) { create(:enterprise_fee, amount: 1.75) }
       let!(:order_cycle) { create(:simple_order_cycle, coordinator: shop) }
       let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
-      let!(:payment_method) { create(:stripe_payment_method, distributors: [shop], preferred_enterprise_id: shop.id) }
+      let!(:payment_method) { create(:stripe_payment_method, distributors: [shop]) }
       let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
 
       before do

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -160,8 +160,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
         let!(:stripe_pm) do
           create(:stripe_payment_method,
             distributors: [distributor],
-            name: "Stripe",
-            preferred_enterprise_id: distributor.id)
+            name: "Stripe")
         end
 
         let!(:saved_card) do

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -158,9 +158,7 @@ feature "As a consumer I want to check out my cart", js: true, retry: 3 do
 
       context "with Stripe" do
         let!(:stripe_pm) do
-          create(:stripe_payment_method,
-            distributors: [distributor],
-            name: "Stripe")
+          create(:stripe_payment_method, distributors: [distributor])
         end
 
         let!(:saved_card) do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -810,7 +810,7 @@ describe Spree::Order do
   describe "determining checkout steps for an order" do
     let!(:enterprise) { create(:enterprise) }
     let!(:order) { create(:order, distributor: enterprise) }
-    let!(:payment_method) { create(:stripe_payment_method, distributor_ids: [enterprise.id], preferred_enterprise_id: enterprise.id) }
+    let!(:payment_method) { create(:stripe_payment_method, distributor_ids: [enterprise.id]) }
     let!(:payment) { create(:payment, order: order, payment_method: payment_method) }
 
     it "does not include the :confirm step" do

--- a/spec/requests/checkout/stripe_connect_spec.rb
+++ b/spec/requests/checkout/stripe_connect_spec.rb
@@ -8,7 +8,7 @@ describe "checking out an order with a Stripe Connect payment method", type: :re
   let!(:enterprise) { create(:distributor_enterprise) }
   let!(:exchange) { create(:exchange, order_cycle: order_cycle, sender: order_cycle.coordinator, receiver: enterprise, incoming: false, pickup_time: "Monday") }
   let!(:shipping_method) { create(:shipping_method, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 0), distributors: [enterprise]) }
-  let!(:payment_method) { create(:stripe_payment_method, distributors: [enterprise], preferred_enterprise_id: enterprise.id) }
+  let!(:payment_method) { create(:stripe_payment_method, distributors: [enterprise]) }
   let!(:stripe_account) { create(:stripe_account, enterprise: enterprise) }
   let!(:line_item) { create(:line_item, price: 12.34) }
   let!(:order) { line_item.order }


### PR DESCRIPTION
#### What? Why?

While working on fixing payment methods for Spree 2 I noticed that the `stripe_payment_method` factory doesn't work without additional parameters. A lot of specs share some duplicate code to set these parameters. This PR removes the duplication.

#### What should we test?
<!-- List which features should be tested and how. -->

Automated tests only.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Improved our automated tests.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

