### PR TITLE
Stub default value for other calls to File.exist?

### DIFF
--- a/spec/controllers/spree/admin/invoices_controller_spec.rb
+++ b/spec/controllers/spree/admin/invoices_controller_spec.rb
@@ -23,7 +23,9 @@ describe Spree::Admin::InvoicesController, type: :controller do
 
     context "when the file is available" do
       it "returns true" do
-        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:exist?)
+        allow(File).to receive(:exist?).with("tmp/invoices/#{invoice_id}.pdf").and_return(true)
+
         spree_get :poll, invoice_id: invoice_id
 
         expect(response.body).to eq({ created: true }.to_json)


### PR DESCRIPTION
#### What? Why?

Closes #3427

This fixes the following error

```
 1) Spree::Admin::InvoicesController#poll when the file is available returns true
     Failure/Error: spree_get :poll, invoice_id: invoice_id

       #<File (class)> received :exist? with unexpected arguments
         expected: ("tmp/invoices/479186263.pdf")
              got: ("/home/pau/dev/openfoodnetwork/tmp/cache/paralleltests/3B7/CD1/spree%2Fapp_configuration%2Fredirect_https_to_http")
        Please stub a default value first if message might be received with other args as well.
     # ./spec/controllers/spree/admin/invoices_controller_spec.rb:28:in `block (4 levels) in <top (required)>'
     # -e:1:in `<main>'
```

`paralleltests` also relies on `File.exist?` and so stubbing it breaks
it unless we purposefully allow other calls.

#### What should we test?

`spree/admin/invoices_controller_spec.rb` should pass.