### PR TITLE
[Spree Upgrade] Remove allow_backorders from product stock verification

### DIFF
--- a/app/helpers/add_to_cart_helper.rb
+++ b/app/helpers/add_to_cart_helper.rb
@@ -1,8 +1,4 @@
 module AddToCartHelper
-  def product_out_of_stock
-    !@product.has_stock? && !Spree::Config[:allow_backorders]
-  end
-
   def distributor_available_for?(order, product)
     DistributionChangeValidator.new(order).distributor_available_for?(product)
   end

--- a/app/views/spree/products/_add_to_cart.html.haml
+++ b/app/views/spree/products/_add_to_cart.html.haml
@@ -1,7 +1,7 @@
 .add-to-cart
   - order = current_order(false)
 
-  - if product_out_of_stock
+  - if !@product.has_stock?
     = content_tag('strong', t(:out_of_stock))
 
   - elsif !distributor_available_for?(order, @product)


### PR DESCRIPTION
#### What? Why?

Closes #2886 

This can be done because product.has_stock? already uses product.on_demand and in v2 allow_backorders becomes on_demand.

#### What should we test?
The build looks good, but it's not green yet.
