### PR TITLE
Perform delivery when checking deliveries in specs

### DIFF
--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -68,9 +68,11 @@ describe UserConfirmationsController, type: :controller do
     end
 
     it "sends the confirmation email" do
-      expect do
-        spree_post :create, { spree_user: { email: unconfirmed_user.email } }
-      end.to send_confirmation_instructions
+      performing_deliveries do
+        expect do
+          spree_post :create, { spree_user: { email: unconfirmed_user.email } }
+        end.to send_confirmation_instructions
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3486

Otherwise checking `ActionMailer::Base.deliveries.count` won't see any email. In test, they won't be sent but put into `deliveries`.

#### What should we test?

spec/controllers/user_confirmations_controller_spec.rb:70 should pass
