### PR TITLE
[Spree Upgrade] Add spec to order_cycle model covering variant scoping

### DIFF
--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -523,20 +523,31 @@ describe OrderCycle do
     let(:shop) { create(:enterprise) }
     let(:user) { create(:user) }
     let(:oc) { create(:order_cycle) }
-    let!(:order1) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: oc)  }
-    let!(:order2) { create(:completed_order_with_totals, distributor: create(:enterprise), user: user, order_cycle: oc)  }
-    let!(:order3) { create(:completed_order_with_totals, distributor: shop, user: create(:user), order_cycle: oc)  }
-    let!(:order4) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: create(:order_cycle))  }
-    let!(:order5) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: oc)  }
+    let!(:order) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: oc)  }
+    let!(:order_from_other_hub) { create(:completed_order_with_totals, distributor: create(:enterprise), user: user, order_cycle: oc)  }
+    let!(:order_from_other_user) { create(:completed_order_with_totals, distributor: shop, user: create(:user), order_cycle: oc)  }
+    let!(:order_from_other_oc) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: create(:order_cycle))  }
+    let!(:order_cancelled) { create(:completed_order_with_totals, distributor: shop, user: user, order_cycle: oc)  }
 
     before do
       setup_email
     end
-    before { order5.cancel }
+    before { order_cancelled.cancel }
 
     it "only returns items from non-cancelled orders in the OC, placed by the user at the shop" do
       items = oc.items_bought_by_user(user, shop)
-      expect(items).to match_array order1.reload.line_items
+      expect(items).to match_array order.reload.line_items
+    end
+
+    it "returns items with scoped variants" do
+      overridden_variant = order.line_items.first.variant
+      create(:variant_override, hub: shop, variant: overridden_variant, count_on_hand: 1000)
+
+      items = oc.items_bought_by_user(user, shop)
+
+      expect(items).to match_array order.reload.line_items
+      item_with_overridden_variant = items.find { |item| item.variant_id == overridden_variant.id }
+      expect(item_with_overridden_variant.variant.on_hand).to eq(1000)
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3172 
This PR adds a missing spec to cover variant scoping in the order_cycle model.
All other cases were reviewed in 3172, please also review [this comment](https://github.com/openfoodfoundation/openfoodnetwork/issues/3172#issuecomment-465125458) (this PR refers to point 2).

#### What should we test?
Build should be green, including the new spec.