### PR TITLE
Adapt scope_variant_to_hub to new VO rules where on_demand=nil means use_producer_settings

### DIFF
--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -62,6 +62,10 @@ class VariantOverride < ActiveRecord::Base
     count_on_hand.present?
   end
 
+  def use_producer_settings?
+    on_demand.nil?
+  end
+
   def decrement_stock!(quantity)
     if stock_overridden?
       decrement! :count_on_hand, quantity

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -57,7 +57,7 @@ class VariantOverride < ActiveRecord::Base
   end
 
   def stock_overridden?
-    count_on_hand.present?
+    on_demand == false && count_on_hand.present?
   end
 
   def decrement_stock!(quantity)

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -62,7 +62,7 @@ class VariantOverride < ActiveRecord::Base
     count_on_hand.present?
   end
 
-  def use_producer_settings?
+  def use_producer_stock_settings?
     on_demand.nil?
   end
 

--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -57,7 +57,9 @@ class VariantOverride < ActiveRecord::Base
   end
 
   def stock_overridden?
-    on_demand == false && count_on_hand.present?
+    # If count_on_hand is present, it means on_demand is false
+    #   See StockSettingsOverrideValidation for details
+    count_on_hand.present?
   end
 
   def decrement_stock!(quantity)

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -29,15 +29,19 @@ module OpenFoodNetwork
       end
 
       def count_on_hand
-        return super unless @variant_override.andand.stock_overridden?
-
-        @variant_override.count_on_hand
+        if @variant_override.present? && @variant_override.stock_overridden?
+          @variant_override.count_on_hand
+        else
+          super
+        end
       end
 
       def on_demand
-        return super if @variant_override.andand.on_demand.nil?
-
-        @variant_override.andand.on_demand
+        if @variant_override.present? && !@variant_override.use_producer_settings?
+          @variant_override.on_demand
+        else
+          super
+        end
       end
 
       def decrement!(attribute, by = 1)

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -29,21 +29,15 @@ module OpenFoodNetwork
       end
 
       def count_on_hand
-        @variant_override.andand.count_on_hand || super
+        return super unless @variant_override.andand.stock_overridden?
+
+        @variant_override.count_on_hand
       end
 
       def on_demand
-        if @variant_override.andand.on_demand.nil?
-          if @variant_override.andand.count_on_hand.present?
-            # If we're overriding the stock level of an on_demand variant, show it as not
-            # on_demand, so our stock control can take effect.
-            false
-          else
-            super
-          end
-        else
-          @variant_override.andand.on_demand
-        end
+        return super if @variant_override.andand.on_demand.nil?
+
+        @variant_override.andand.on_demand
       end
 
       def decrement!(attribute, by = 1)

--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -37,7 +37,7 @@ module OpenFoodNetwork
       end
 
       def on_demand
-        if @variant_override.present? && !@variant_override.use_producer_settings?
+        if @variant_override.present? && !@variant_override.use_producer_stock_settings?
           @variant_override.on_demand
         else
           super

--- a/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
+++ b/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
@@ -82,19 +82,19 @@ module OpenFoodNetwork
           context "without an on_demand set" do
             before { vo.update_column(:on_demand, nil) }
 
-            context "when count_on_hand is set" do
-              it "returns variant's on_demand" do
-                scoper.scope v
-                expect(v.on_demand).to be true
-              end
-            end
-
             context "when count_on_hand is not set" do
               before { vo.update_column(:count_on_hand, nil) }
 
               it "returns the variant's on_demand" do
                 scoper.scope v
                 expect(v.on_demand).to be true
+              end
+            end
+
+            context "when count_on_hand is set" do
+              it "should return validation error on save" do
+                scoper.scope v
+                expect{ vo.save! }.to raise_error ActiveRecord::RecordInvalid
               end
             end
           end

--- a/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
+++ b/spec/lib/open_food_network/scope_variant_to_hub_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'open_food_network/scope_variant_to_hub'
 
 module OpenFoodNetwork
@@ -82,9 +83,9 @@ module OpenFoodNetwork
             before { vo.update_column(:on_demand, nil) }
 
             context "when count_on_hand is set" do
-              it "returns false" do
+              it "returns variant's on_demand" do
                 scoper.scope v
-                expect(v.on_demand).to be false
+                expect(v.on_demand).to be true
               end
             end
 


### PR DESCRIPTION
#### What? Why?

This is the continuation of #3198 where on_demand nil became explicitly use_producer_settings.
I specially like the new variant_override.stock_overridden? method where this rule becomes explicit.

#### What should we test?
We need to test inventory and possible scenarios where count_on_hand in the inventory is used when the use_producer_settings is set.

#### Release notes
Changelog Category: Changed
Inventory rules are now more strict about using producer settings in inventory where stock levels are always ignored.

#### How is this related to the Spree upgrade?
This was detected as part of the spree upgrade when verifying inventory logic in v2. It is related to upcoming PR #3504 
