### PR TITLE
Sanitize non-parsable BOM characters inserted by Excel

### DIFF
--- a/app/controllers/admin/product_import_controller.rb
+++ b/app/controllers/admin/product_import_controller.rb
@@ -84,7 +84,8 @@ module Admin
       directory = 'tmp/product_import'
       Dir.mkdir(directory) unless File.exist?(directory)
       File.open(Rails.root.join(directory, filename + extension), 'wb') do |f|
-        f.write(upload.read)
+        data = UploadSanitizer.new(upload.read).call
+        f.write(data)
         f.path
       end
     end

--- a/app/services/upload_sanitizer.rb
+++ b/app/services/upload_sanitizer.rb
@@ -1,0 +1,18 @@
+# Formats uploaded files to UTF-8 encoding and strips unexpected BOM characters.
+# Takes an open File object as input
+class UploadSanitizer
+  def initialize(upload)
+    @data = upload
+  end
+
+  def call
+    @data.force_encoding('UTF-8')
+    strip_bom_character
+  end
+
+  private
+
+  def strip_bom_character
+    @data.gsub("\xEF\xBB\xBF".force_encoding("UTF-8"), '')
+  end
+end

--- a/spec/services/upload_sanitizer_spec.rb
+++ b/spec/services/upload_sanitizer_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe UploadSanitizer do
+  describe "#call" do
+    let(:upload) do
+      File.open("/tmp/unsanitized.csv", 'wb:ascii-8bit') do |f|
+        f << "\xEF\xBB\xBF"
+        f << "Test"
+      end
+    end
+    let(:service) { UploadSanitizer.new(File.open(upload).read) }
+
+    it "sanitizes the uploaded file" do
+      sanitized_upload = service.call
+
+      expect(sanitized_upload.encoding.name).to eq "UTF-8"
+      expect(sanitized_upload.to_s).to eq "Test"
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #3448
Closes #3414

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Microsoft Excel was sometimes adding a BOM character at the start of CSV files, which was causing the entire first column to not be parsed and disappear. 

![](https://user-images.githubusercontent.com/2243/52367347-d2ac4400-2a86-11e9-9e05-9225523398a7.png)

#### What should we test?
<!-- List which features should be tested and how. -->

The CSV file originally tested with here should now work: https://github.com/openfoodfoundation/openfoodnetwork/pull/3233#issuecomment-461056579

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed another encoding issue with CSV files made in Excel.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
