### PR TITLE
3466,3478 [Enterprise Fee Summary] Scope report to eligible: true and non-zero adjustments

### DIFF
--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
@@ -46,7 +46,7 @@ module OrderManagement
 
         def find_adjustments
           chain_to_scope do
-            Spree::Adjustment
+            Spree::Adjustment.eligible
           end
         end
 

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
@@ -17,7 +17,7 @@ module OrderManagement
         end
 
         def result
-          group_data.select_attributes
+          group_data.exclude_groups_with_zero_total.select_attributes
           @scope.all
         end
 
@@ -334,6 +334,10 @@ module OrderManagement
             if params.shipping_method_ids.present?
           filter_scope(spree_payment_methods: { id: params.payment_method_ids }) \
             if params.payment_method_ids.present?
+        end
+
+        def exclude_groups_with_zero_total
+          filter_scope("spree_adjustments.amount != 0")
         end
 
         def group_data

--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
@@ -151,6 +151,36 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
     end
   end
 
+  describe "data exclusions" do
+    describe "invalid adjustments (through 'eligible') like failed payments" do
+      let!(:customer_order) { prepare_order(customer: customer) }
+
+      before do
+        # Make the payment fail. See Spree::Payment#revoke_adjustment_eligibility.
+        payment = customer_order.payments.first
+        payment.state = "failed"
+        payment.save!
+      end
+
+      it "is included" do
+        totals = service.list
+
+        expect(totals.length).to eq(2)
+
+        expected_result = [
+          ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
+           nil, nil, nil, "2.00"],
+          ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
+           nil, nil, "Platform Rate", "1.00"]
+        ]
+
+        expected_result.each_with_index do |expected_attributes, row_index|
+          expect_total_attributes(totals[row_index], expected_attributes)
+        end
+      end
+    end
+  end
+
   describe "handling of more complex cases" do
     context "with non-sender fee for incoming exchange and non-receiver fee for outgoing" do
       let!(:variant) do

--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
@@ -214,6 +214,31 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
         end
       end
     end
+
+    describe "$0 mandatory adjustments" do
+      let!(:payment_method) do
+        create(:payment_method, :per_item, amount: 0, name: "Sample Payment Method")
+      end
+
+      let!(:customer_order) { prepare_order(customer: customer) }
+
+      it "is included" do
+        totals = service.list
+
+        expect(totals.length).to eq(2)
+
+        expected_result = [
+          ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
+           nil, nil, nil, "0.00"],
+          ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
+           nil, nil, "Platform Rate", "1.00"]
+        ]
+
+        expected_result.each_with_index do |expected_attributes, row_index|
+          expect_total_attributes(totals[row_index], expected_attributes)
+        end
+      end
+    end
   end
 
   describe "handling of more complex cases" do

--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
@@ -225,11 +225,9 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
       it "is included" do
         totals = service.list
 
-        expect(totals.length).to eq(2)
+        expect(totals.length).to eq(1)
 
         expected_result = [
-          ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
-           nil, nil, nil, "0.00"],
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
            nil, nil, "Platform Rate", "1.00"]
         ]

--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb
@@ -165,11 +165,9 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
       it "is included" do
         totals = service.list
 
-        expect(totals.length).to eq(2)
+        expect(totals.length).to eq(1)
 
         expected_result = [
-          ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
-           nil, nil, nil, "2.00"],
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",
            nil, nil, "Platform Rate", "1.00"]
         ]
@@ -202,11 +200,9 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::ReportService do
       it "is included" do
         totals = service.list
 
-        expect(totals.length).to eq(3)
+        expect(totals.length).to eq(2)
 
         expected_result = [
-          ["Admin", "Sample Distributor", "Sample Enterprise Fee", "Sample Customer",
-           "Outgoing", "Sample Distributor", nil, "0.00"],
           ["Payment Transaction", "Sample Distributor", "Sample Payment Method", "Sample Customer",
            nil, nil, nil, "2.00"],
           ["Shipment", "Sample Distributor", "Sample Shipping Method", "Sample Customer",


### PR DESCRIPTION
Report should not include `eligible: false` and $0 adjustments.

#### What? Why?

Closes #3466 
Closes #3478 

At the moment, `eligible: false` adjustments (such as payment transactions for failed payments), and $0 adjustments (such as for pick-up orders) are still included in the report.

These should not appear.

#### What should we test?

**Preparations for Testing**

For each of these tests, it would be convenient to create a new user with a unique name, to more easily see results in the report.

As superadmin:

1. Configure the hub to allow pick-up shipping method, with no shipping fee.
2. Create a payment method with "Bogus" as provider. Set a non-zero fee for this.
3. Configure the hub to allow both cheque payment and payment through Bogus in Step 

A sample card number that works with this test provider is `4111111111111111`. A sample invalid card number is `1111111111111111`.

**Test $0 adjustment is not included**

1. Check out with pick-up for shipping and cheque for payment.
2. There should be no shipping adjustment for the customer in the report.

**Check failed/invalid adjustment is not included**

1. Attempt an invalid checkout using Bogus payment method.
2. There would be no payment adjustment for the customer in the report yet.
3. Complete the checkout with a valid card number for Bogus again.
4. There would be an entry for the payment transaction under the customer. The amount should be correct, not double.

#### Release notes

- Exclude failed and invalid adjustments from Enterprise Fee Summary
- Exclude $0 adjustments from Enterprise Fee Summary

Changelog Category: Fixed