### PR TITLE
Wait for angular to load in BOM spec

### DIFF
--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -45,7 +45,7 @@ feature %q{
 
       before :each do
         visit '/admin/orders/bulk_management'
-        wait_for_angular_requests
+        wait_until { request_monitor_finished 'LineItemsCtrl' }
       end
 
       it "displays a column for user's full name" do
@@ -93,6 +93,7 @@ feature %q{
 
       before do
         visit spree.admin_bulk_order_management_path
+        wait_until { request_monitor_finished 'LineItemsCtrl' }
       end
 
       it "sorts by customer name when the customer name header is clicked" do
@@ -261,6 +262,7 @@ feature %q{
 
         before :each do
           visit '/admin/orders/bulk_management'
+          wait_until { request_monitor_finished 'LineItemsCtrl' }
         end
 
         it "displays a select box for producers, which filters line items by the selected supplier" do
@@ -299,6 +301,7 @@ feature %q{
 
         before :each do
           visit '/admin/orders/bulk_management'
+          wait_until { request_monitor_finished 'LineItemsCtrl' }
         end
 
         it "displays a select box for distributors, which filters line items by the selected distributor" do
@@ -338,6 +341,7 @@ feature %q{
 
         before do
           visit '/admin/orders/bulk_management'
+          wait_until { request_monitor_finished 'LineItemsCtrl' }
         end
 
         it "displays a select box for order cycles, which filters line items by the selected order cycle" do
@@ -378,6 +382,7 @@ feature %q{
 
         before :each do
           visit '/admin/orders/bulk_management'
+          wait_until { request_monitor_finished 'LineItemsCtrl' }
         end
 
         it "allows filters to be used in combination" do
@@ -428,6 +433,7 @@ feature %q{
 
       before :each do
         visit '/admin/orders/bulk_management'
+        wait_until { request_monitor_finished 'LineItemsCtrl' }
       end
 
       it "displays a quick search input" do
@@ -457,7 +463,7 @@ feature %q{
 
       before :each do
         visit '/admin/orders/bulk_management'
-        wait_for_angular_requests
+        wait_until { request_monitor_finished 'LineItemsCtrl' }
       end
 
       it "displays date fields for filtering orders, with default values set" do
@@ -530,6 +536,7 @@ feature %q{
 
       before :each do
         visit '/admin/orders/bulk_management'
+        wait_until { request_monitor_finished 'LineItemsCtrl' }
       end
 
       it "displays a checkbox for each line item in the list" do
@@ -572,6 +579,7 @@ feature %q{
           expect(page).to have_no_selector "tr#li_#{li2.id}"
           check "toggle_bulk"
           fill_in "quick_search", with: ''
+          wait_until { request_monitor_finished 'LineItemsCtrl' }
           expect(find("tr#li_#{li1.id} input[type='checkbox'][name='bulk']").checked?).to be true
           expect(find("tr#li_#{li2.id} input[type='checkbox'][name='bulk']").checked?).to be false
           expect(find("input[type='checkbox'][name='toggle_bulk']").checked?).to be false
@@ -585,6 +593,7 @@ feature %q{
           find("div#bulk-actions-dropdown div.menu_item", :text => "Delete Selected" ).click
           expect(page).to have_no_selector "tr#li_#{li1.id}"
           fill_in "quick_search", with: ''
+          wait_until { request_monitor_finished 'LineItemsCtrl' }
           expect(page).to have_selector "tr#li_#{li2.id}"
           expect(page).to have_no_selector "tr#li_#{li1.id}"
         end

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -45,6 +45,7 @@ feature %q{
 
       before :each do
         visit '/admin/orders/bulk_management'
+        wait_for_angular_requests
       end
 
       it "displays a column for user's full name" do
@@ -456,6 +457,7 @@ feature %q{
 
       before :each do
         visit '/admin/orders/bulk_management'
+        wait_for_angular_requests
       end
 
       it "displays date fields for filtering orders, with default values set" do

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -152,15 +152,17 @@ module WebHelper
     page.driver.browser.switch_to.alert.accept
   end
 
-  def wait_for_angular_requests
-    wait_until { angular_requests_finished }
+  def angular_http_requests_finished(angular_controller=nil)
+    scope_element = angular_controller ? "[ng-controller=#{angular_controller}]" : '.ng-scope'
+    page.evaluate_script("angular.element(document.querySelector('#{scope_element}')).injector().get('$http').pendingRequests.length == 0")
+  end
+
+  def request_monitor_finished(angular_controller=nil)
+    scope_element = angular_controller ? "[ng-controller=#{angular_controller}]" : '.ng-scope'
+    page.evaluate_script("angular.element(document.querySelector('#{scope_element}')).scope().RequestMonitor.loading == false")
   end
 
   private
-
-  def angular_requests_finished
-    page.evaluate_script('angular.element(".ng-scope").injector().get("$http").pendingRequests.length === 0')
-  end
 
   def wait_for_ajax
     wait_until { page.evaluate_script("$.active") == 0 }

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -152,17 +152,22 @@ module WebHelper
     page.driver.browser.switch_to.alert.accept
   end
 
-  def angular_http_requests_finished(angular_controller=nil)
-    scope_element = angular_controller ? "[ng-controller=#{angular_controller}]" : '.ng-scope'
-    page.evaluate_script("angular.element(document.querySelector('#{scope_element}')).injector().get('$http').pendingRequests.length == 0")
+  def angular_http_requests_finished(controller=nil)
+    page.evaluate_script("#{angular_scope(controller)}.injector().get('$http').pendingRequests.length == 0")
   end
 
-  def request_monitor_finished(angular_controller=nil)
-    scope_element = angular_controller ? "[ng-controller=#{angular_controller}]" : '.ng-scope'
-    page.evaluate_script("angular.element(document.querySelector('#{scope_element}')).scope().RequestMonitor.loading == false")
+  def request_monitor_finished(controller=nil)
+    page.evaluate_script("#{angular_scope(controller)}.scope().RequestMonitor.loading == false")
   end
 
   private
+
+  # Takes an optional angular controller name eg: "LineItemsCtrl",
+  # otherwise finds the first object in the DOM with an angular scope
+  def angular_scope(controller=nil)
+    element = controller ? "[ng-controller=#{controller}]" : '.ng-scope'
+    "angular.element(document.querySelector('#{element}'))"
+  end
 
   def wait_for_ajax
     wait_until { page.evaluate_script("$.active") == 0 }

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -152,7 +152,15 @@ module WebHelper
     page.driver.browser.switch_to.alert.accept
   end
 
+  def wait_for_angular_requests
+    wait_until { angular_requests_finished }
+  end
+
   private
+
+  def angular_requests_finished
+    page.evaluate_script('angular.element(".ng-scope").injector().get("$http").pendingRequests.length === 0')
+  end
 
   def wait_for_ajax
     wait_until { page.evaluate_script("$.active") == 0 }


### PR DESCRIPTION
#### What? Why?

Closes #3383

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Hopefully this will finally fix this flaky spec!

#### The issue:

There are a number of tests that fail occasionally in this file. Angular is making some asynchronous requests on the page, then updating the DOM when it's finished. The issue seems to be that Capybara is not waiting long enough, or is not waiting until Angular has finished loading. It's consistently green in people's dev environments, but fails sometimes on Semaphore, so I think the problem is partly due to the CI environment being slower?

#### My solution:

I've added a couple of helper methods for feature specs that enable us to interrogate angular directly from within a test, and find out if the `$http` module is still processing requests, or if the `RequestMonitor` class is still loading data. They should be re-usable in the future if we have similar issues.

#### What should we test?
<!-- List which features should be tested and how. -->

Tests in `/spec/features/admin/bulk_order_management_spec.rb` should not be flaky.



