### PR TITLE
Fix nil values in on_hand column

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -254,6 +254,7 @@ module ProductImport
       new_product = Spree::Product.new
       new_product.assign_attributes(entry.attributes.except('id'))
       new_product.supplier_id = entry.producer_id
+      entry.on_hand = 0 if entry.on_hand.nil?
 
       if new_product.valid?
         entry.validates_as = 'new_product' unless entry.errors?

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -50,7 +50,7 @@ describe ProductImport::ProductImporter do
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "2", "kg", "", ""]
         csv << ["Pea Soup", "User Enterprise", "Vegetables", "8", "5.50", "750", "ml", "", "0"]
         csv << ["Salad", "User Enterprise", "Vegetables", "7", "4.50", "1", "", "bags", ""]
-        csv << ["Hot Cross Buns", "User Enterprise", "Cake", "7", "3.50", "1", "", "buns", "1"]
+        csv << ["Hot Cross Buns", "User Enterprise", "Cake", nil, "3.50", "1", "", "buns", "1"]
       end
       File.write('/tmp/test-m.csv', csv_data)
       file = File.new('/tmp/test-m.csv')
@@ -122,7 +122,8 @@ describe ProductImport::ProductImporter do
 
       buns = Spree::Product.find_by_name('Hot Cross Buns')
       expect(buns.supplier).to eq enterprise
-      # buns.on_hand).to eq Infinity
+      expect(buns.on_hand).to eq Float::INFINITY
+      expect(buns.count_on_hand).to eq 0
       expect(buns.price).to eq 3.50
       expect(buns.unit_value).to eq 1
       expect(buns.variant_unit).to eq 'items'


### PR DESCRIPTION
#### What? Why?

Closes #3523

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

`on_hand` value should be set to zero for new products when the column is left blank.

#### What should we test?
<!-- List which features should be tested and how. -->

Product Import: `on_hand` should be set to zero on new products when the column is left blank.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
