### PR TITLE
Don't process proxy_order if the order has been cancelled

### DIFF
--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -25,7 +25,7 @@ class SubscriptionConfirmJob
   def proxy_orders
     ProxyOrder.not_canceled.where('confirmed_at IS NULL AND placed_at IS NOT NULL')
       .joins(:order_cycle).merge(recently_closed_order_cycles)
-      .joins(:order).merge(Spree::Order.complete)
+      .joins(:order).merge(Spree::Order.complete.not_state('canceled'))
   end
 
   def recently_closed_order_cycles

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -58,6 +58,12 @@ describe SubscriptionConfirmJob do
       proxy_order.update_attributes!(confirmed_at: 1.second.ago)
       expect(proxy_orders).to_not include proxy_order
     end
+
+    it "ignores orders that have been cancelled" do
+      setup_email
+      proxy_order.order.cancel!
+      expect(proxy_orders).to_not include proxy_order
+    end
   end
 
   describe "performing the job" do


### PR DESCRIPTION
#### What? Why?

Closes #3388 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Subscriptions create proxy orders which generate orders, which are processed when an order cycle closes. If the user or an admin cancels the order from the orders page before the OC closes, the proxy order still gets processed at the end of the OC (and confirmation emails are sent).

I've updated the `SubscriptionConfirmJob` to exclude proxy orders where the related order has been cancelled.

#### What should we test?
<!-- List which features should be tested and how. -->

Follow the steps detailed in #3388. An order confirmation should not be sent at the end of the order cycle.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Subscriptions: orders created by a subscription that have been manually cancelled before an OC closes will not be incorrectly processed.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

