### PR TITLE
[Spree Upgrade] Fix create default stock migration 

### DIFF
--- a/db/migrate/20180426145632_create_default_stock.spree.rb
+++ b/db/migrate/20180426145632_create_default_stock.spree.rb
@@ -1,3 +1,10 @@
+Spree::Stock::Quantifier.class_eval do
+  def initialize(variant)
+    @variant = variant
+    @stock_items = Spree::StockItem.joins(:stock_location).where(:variant_id => @variant)
+  end
+end
+
 # This migration comes from spree (originally 20130213191427)
 class CreateDefaultStock < ActiveRecord::Migration
   def up

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -533,9 +533,9 @@ ActiveRecord::Schema.define(:version => 20181128054803) do
     t.datetime "updated_at",                                         :null => false
     t.integer  "max_quantity"
     t.string   "currency"
-    t.decimal  "distribution_fee",     :precision => 10, :scale => 2
-    t.decimal  "final_weight_volume",  :precision => 10, :scale => 2
-    t.decimal  "cost_price",           :precision => 8,  :scale => 2
+    t.decimal  "distribution_fee",    :precision => 10, :scale => 2
+    t.decimal  "final_weight_volume", :precision => 10, :scale => 2
+    t.decimal  "cost_price",          :precision => 8,  :scale => 2
     t.integer  "tax_category_id"
   end
 


### PR DESCRIPTION
#### What? Why?

This is an alternative to #3489 
Closes #3301 

Here we change Stock::Quantifier not to use the inexistent column stock_location.active. That fixes the migration.

#### What should we test?
db:migrate with sample data should work. see 3301 issue for details.