### PR TITLE
Bring in Bugsnag initializer from ofn-install

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,0 +1,5 @@
+Bugsnag.configure do |config|
+  config.api_key = ENV['BUGSNAG_API_KEY']
+  config.notify_release_stages = %w(production staging)
+  config.use_ssl = true
+end


### PR DESCRIPTION
#### What? Why?

Closes #1929

This copies ofn-install's `roles/app/templates/bugsnag.rb.j2` to `config/initializers/bugsnag.rb`. All tasks and templates regarding Bugsnag can then be :fire: from ofn-install.

As a result, it'll fix the issue that both Katuma and OFF are facing where the `config/initializer/bugsnag.rb` symlink to `shared/config/bugsnag.rb` does not exist thus, nothing gets notified to Bugsnag since December 3rd (according to customer support).

#### What should we test?

After the deploy any errors should appear in Bugsnag's dashboard. You can try running the following from a `bundle exec rails console` in staging

```ruby
Bugsnag.notify('foo')
```

#### Release notes

Changelog Category: Added

Bring into the app the Bugsnag initializer used in ofn-install. It won't be symlinked at deploy time anymore.

#### Dependencies

https://github.com/openfoodfoundation/ofn-install/pull/329
