### PR TITLE
[Spree Upgrade] Improve order state translations in v2

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/orders_panel_controller.js.coffee
@@ -19,4 +19,4 @@ angular.module("admin.subscriptions").controller "OrdersPanelController", ($scop
     text = if closes_at > moment() then t('js.subscriptions.closes') else t('js.subscriptions.closed')
     "#{text} #{closes_at.fromNow()}"
 
-  $scope.stateText = (state) -> t("spree.order_state.#{state}")
+  $scope.stateText = (state) -> t("js.admin.orders.order_state.#{state}")

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -11,7 +11,7 @@
       .field
         = label_tag nil, t(:status)
         = select_tag("q[state_eq]",
-            options_for_select(Spree::Order.state_machines[:state].states.collect {|s| [t("order_state.#{s.name}"), s.value]}),
+            options_for_select(Spree::Order.state_machines[:state].states.collect {|s| [t("spree.order_state.#{s.name}"), s.value]}),
             {include_blank: true, class: 'select2', 'ng-model' => 'q.state_eq'})
     .four.columns
       .field

--- a/app/views/spree/admin/orders/_sortable_header.html.haml
+++ b/app/views/spree/admin/orders/_sortable_header.html.haml
@@ -1,4 +1,4 @@
 %a{'ng-click' => "sortOptions.toggle('#{column_name}')"}
-  = t(column_name.to_s, scope: 'activerecord.attributes.spree/order')
+  = t(".#{column_name.to_s}")
   %span{'ng-show' => "sorting == '#{column_name} asc'"}= "&#x25B2;".html_safe
   %span{'ng-show' => "sorting == '#{column_name} desc'"}= "&#x25BC;".html_safe

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -59,14 +59,14 @@
             = t('.note')
       %td.align-center
         %span.state{'ng-class' => 'order.state'}
-          {{'order_state.' + order.state | t}}
+          {{'js.admin.orders.order_state.' + order.state | t}}
       %td.align-center
         %span.state{'ng-class' => 'order.payment_state', 'ng-if' => 'order.payment_state'}
           %a{'ng-href' => '{{order.payments_path}}' }
-            {{'payment_states.' + order.payment_state | t}}
+            {{'js.admin.orders.payment_states.' + order.payment_state | t}}
       %td.align-center
         %span.state{'ng-class' => 'order.shipment_state', 'ng-if' => 'order.shipment_state'}
-          {{'shipment_states.' + order.shipment_state | t}}
+          {{'js.admin.orders.shipment_states.' + order.shipment_state | t}}
       %td
         = mail_to "{{order.email}}"
       %td.align-center

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -19,7 +19,7 @@
       %dd
         - order_state_classes = "state #{@order.state}"
         %span{ class: order_state_classes }
-          = t(@order.state, scope: :order_state)
+          = t(@order.state, scope: "spree.order_state")
       %dt
         = t(:total)
         \:


### PR DESCRIPTION
#### What? Why?

Closes #3542

Here we are improving the way we manage order state translations by using en.spree.order_state on haml code and js.admin.orders.order_state in angular (remember the objective with js translations set in #2721). See what translations were changed in "what to test" below.

#### What should we test?
We need to validate the places where we are changing translations.

In the orders list:
- the order states in the filters
- the name of the columns: Payment State, Shipment State, Completed At, Number, State, Customer E-Mail
- each value of the order state column
- each value of the shipment state column
- each value of the payments state column

In order edit page, the state of the order on the right side panel

In the subscriptions order panel, the orders state (this one can’t be tested yet in v2).

#### Dependencies
To be tested, this PR needs translations coming from master in #3535
