### PR TITLE
[Spree Upgrade] WIP _Trying_ to fix unreliable customers_spec

### DIFF
--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -197,11 +197,11 @@ feature 'Customers' do
           fill_in 'address1', with: "New Address1"
           click_button 'Update Address'
 
-          expect(page).to have_selector "th.bill_address"
           expect(page).to have_content 'Address updated successfully.'
-          expect(page).to have_link 'New Address1'
           expect(customer4.reload.bill_address.address1).to eq 'New Address1'
+          expect(page).to have_selector 'th.bill_address'
 
+          expect(page).to have_link 'New Address1'
           first('#bill-address-link').click
           
           expect(page).to have_content 'Edit Billing Address'

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -197,6 +197,7 @@ feature 'Customers' do
           fill_in 'address1', with: "New Address1"
           click_button 'Update Address'
 
+          expect(page).to have_selector "th.bill_address"
           expect(page).to have_content 'Address updated successfully.'
           expect(page).to have_link 'New Address1'
           expect(customer4.reload.bill_address.address1).to eq 'New Address1'


### PR DESCRIPTION
#### What? Why?

Closes #3520
The spec opens the edit address dialog, puts a new value "New Address1" and save the data. The save action should close the dialog and spec goes on to expect the unerlying list to be updated with the new address. This is done through angular data bindings.

The specs fails ocasionally probably because the angular bindings do not have time to update the data and capybara is not waiting. I don't know how to find out when angular has finished its event processing...

#### What should we test?
customers_spec not broken after 10 runs :-)
