### PR TITLE
[Spree Upgrade] WIP Remove update_shipping_fees! and update_payment_fees! from order_decorator

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -39,8 +39,6 @@ class LineItemsController < BaseController
     order = item.order
     order.with_lock do
       item.destroy
-      order.update_shipping_fees!
-      order.update_payment_fees!
       order.update_distribution_charge!
       order.create_tax_charge!
     end

--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -23,6 +23,10 @@ module Spree
 
     localize_number :amount
 
+    def immutable?
+      finalized?
+    end
+
     def set_included_tax!(rate)
       tax = amount - (amount / (1 + rate))
       set_absolute_included_tax! tax

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -33,9 +33,6 @@ Spree::Order.class_eval do
   before_validation :associate_customer, unless: :customer_id?
   before_validation :ensure_customer, unless: :customer_is_valid?
 
-  before_save :update_shipping_fees!, if: :complete?
-  before_save :update_payment_fees!, if: :complete?
-
   # Orders are confirmed with their payment, we don't use the confirm step.
   # Here we remove that step from Spree's checkout state machine.
   # See: https://guides.spreecommerce.org/developer/checkout.html#modifying-the-checkout-flow
@@ -159,28 +156,6 @@ Spree::Order.class_eval do
 
     reload
     current_item
-  end
-
-  # After changing line items of a completed order
-  # TODO: perhaps this should be triggered from a controller
-  # rather than an after_save callback?
-  def update_shipping_fees!
-    shipments.each do |shipment|
-      next if shipment.shipped?
-      update_adjustment! shipment.adjustment if shipment.adjustment
-      shipment.save # updates included tax
-    end
-  end
-
-  # After changing line items of a completed order
-  # TODO: perhaps this should be triggered from a controller
-  # rather than an after_save callback?
-  def update_payment_fees!
-    payments.each do |payment|
-      next if payment.completed?
-      update_adjustment! payment.adjustment if payment.adjustment
-      payment.save
-    end
   end
 
   def cap_quantity_at_stock!

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -58,6 +58,18 @@ Spree::ShippingMethod.class_eval do
     self.distributors.include?(distributor)
   end
 
+  def update_adjustment(adjustment, calculable)
+    amount = compute_amount(calculable)
+    adjustment.update_attribute_without_callbacks(:amount, amount)
+    #adjustment.source.update_adjustment_included_tax # cant do this because it will trigger callsbacks
+    if Spree::Config.shipment_inc_vat && (adjustment.adjustable.distributor.nil? || adjustment.adjustable.distributor.charges_sales_tax)
+      tax = amount - (amount / (1 + Spree::Config.shipping_tax_rate))
+    else
+      tax = 0
+    end
+    adjustment.update_attribute_without_callbacks(:included_tax, tax.round(2))
+  end
+
   def adjustment_label
     I18n.t('shipping')
   end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -224,16 +224,9 @@ describe Spree::OrdersController, type: :controller do
           } }
         }
 
-        # Before issuing the update, the second adjustment, which is associated
-        # to the shipment, is already open thus restoring its state leaves it
-        # also open.
-        #
-        # The third adjustment is originated from an EnterpriseFee and it gets
-        # created by #update_distribution_charge! in
-        # app/models/spree/order_decorator.rb:220, which is in turn triggered
-        # by the `contents_changed` notification event defined in
-        # app/models/spree/order_decorator.rb:7
-        expect(order.adjustments.map(&:state)).to eq(['closed', 'open', 'closed'])
+        # The second adjustment (shipping adjustment) is open before the update
+        #   so, restoring its state leaves it open.
+        expect(order.adjustments.map(&:state)).to eq(['closed', 'open'])
       end
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -705,8 +705,8 @@ describe Spree::Order do
     context "removing line_items" do
       it "updates shipping and transaction fees" do
         order.line_items.first.update_attribute(:quantity, 0)
-        order.save
 
+        order.reload
         expect(order.adjustment_total).to eq expected_fees - shipping_fee - payment_fee
         expect(order.shipment.adjustment.included_tax).to eq 0.6
       end


### PR DESCRIPTION

#### What? Why?

Related to #1830
Exploring the removal of order_decorator.update_shipping_fees and order_decorator.update_payment_fees.

This logic _obivously_ has to be moved to order_updater where all this is already happening in spree...

#### What should we test?
Build is green and order_decorator is not handling any kind of updates, all order updates are handled by order_updater.
