### PR TITLE
2696,2788 [Spree Upgrade] Fix use of shipping method ID for subscriptions

### DIFF
--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -1,6 +1,21 @@
 Spree::Admin::Orders::CustomerDetailsController.class_eval do
   before_filter :set_guest_checkout_status, only: :update
 
+  def update
+    if @order.update_attributes(params[:order])
+      if params[:guest_checkout] == "false"
+        @order.associate_user!(Spree.user_class.find_by_email(@order.email))
+      end
+      while @order.next; end
+
+      @order.shipments.map &:refresh_rates
+      flash[:success] = Spree.t('customer_details_updated')
+      redirect_to admin_order_customer_path(@order)
+    else
+      render :action => :edit
+    end
+  end
+
   # Inherit CanCan permissions for the current order
   def model_class
     load_order unless @order

--- a/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller_decorator.rb
@@ -6,7 +6,8 @@ Spree::Admin::Orders::CustomerDetailsController.class_eval do
       if params[:guest_checkout] == "false"
         @order.associate_user!(Spree.user_class.find_by_email(@order.email))
       end
-      while @order.next; end
+
+      AdvanceOrderService.new(@order).call
 
       @order.shipments.map &:refresh_rates
       flash[:success] = Spree.t('customer_details_updated')

--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -27,6 +27,18 @@ Spree::Admin::OrdersController.class_eval do
     # within the page then fetches the data it needs from Api::OrdersController
   end
 
+  def edit
+    @order.shipments.map &:refresh_rates
+
+    # Transition as far as we can go
+    while @order.next; end
+
+    # The payment step shows an error of 'No pending payments'
+    # Clearing the errors from the order object will stop this error
+    # appearing on the edit page where we don't want it to.
+    @order.errors.clear
+  end
+
   # Re-implement spree method so that it redirects to edit instead of rendering edit
   #   This allows page reloads while adding variants to the order (/edit), without being redirected to customer details page (/update)
   def update

--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -30,8 +30,7 @@ Spree::Admin::OrdersController.class_eval do
   def edit
     @order.shipments.map &:refresh_rates
 
-    # Transition as far as we can go
-    while @order.next; end
+    AdvanceOrderService.new(@order).call
 
     # The payment step shows an error of 'No pending payments'
     # Clearing the errors from the order object will stop this error

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -19,7 +19,7 @@ Spree::Admin::PaymentsController.class_eval do
 
          redirect_to admin_order_payments_path(@order)
       else
-        AdvanceOrderService.new(@order).call(true)
+        AdvanceOrderService.new(@order).call!
 
         flash[:success] = Spree.t(:new_order_completed)
         redirect_to edit_admin_order_url(@order)

--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -19,10 +19,8 @@ Spree::Admin::PaymentsController.class_eval do
 
          redirect_to admin_order_payments_path(@order)
       else
-        #This is the first payment (admin created order)
-        until @order.completed?
-          @order.next!
-        end
+        AdvanceOrderService.new(@order).call(true)
+
         flash[:success] = Spree.t(:new_order_completed)
         redirect_to edit_admin_order_url(@order)
       end

--- a/app/services/advance_order_service.rb
+++ b/app/services/advance_order_service.rb
@@ -5,15 +5,31 @@ class AdvanceOrderService
     @order = order
   end
 
-  def call
-    shipping_method_id = @order.shipping_method.id if @order.shipping_method.present?
+  def call(raise_on_error = false)
+    shipping_method_id = order.shipping_method.id if order.shipping_method.present?
+    options = { shipping_method_id: shipping_method_id }
+    raise_on_error ? advance_order!(options) : advance_order(options)
+  end
 
-    while @order.state != "complete"
-      break unless @order.next
+  private
 
-      if @order.state == "delivery"
-        @order.select_shipping_method(shipping_method_id) if shipping_method_id.present?
-      end
+  def advance_order(options)
+    until order.state == "complete"
+      break unless order.next
+      after_transition_hook(options)
+    end
+  end
+
+  def advance_order!(options)
+    until order.completed?
+      order.next!
+      after_transition_hook(options)
+    end
+  end
+
+  def after_transition_hook(options)
+    if order.state == "delivery"
+      order.select_shipping_method(options[:shipping_method_id]) if options[:shipping_method_id]
     end
   end
 end

--- a/app/services/advance_order_service.rb
+++ b/app/services/advance_order_service.rb
@@ -5,13 +5,20 @@ class AdvanceOrderService
     @order = order
   end
 
-  def call(raise_on_error = false)
-    shipping_method_id = order.shipping_method.id if order.shipping_method.present?
-    options = { shipping_method_id: shipping_method_id }
-    raise_on_error ? advance_order!(options) : advance_order(options)
+  def call
+    advance_order(advance_order_options)
+  end
+
+  def call!
+    advance_order!(advance_order_options)
   end
 
   private
+
+  def advance_order_options
+    shipping_method_id = order.shipping_method.id if order.shipping_method.present?
+    { shipping_method_id: shipping_method_id }
+  end
 
   def advance_order(options)
     until order.state == "complete"

--- a/app/services/advance_order_service.rb
+++ b/app/services/advance_order_service.rb
@@ -1,0 +1,11 @@
+class AdvanceOrderService
+  attr_reader :order
+
+  def initialize(order)
+    @order = order
+  end
+
+  def call
+    while order.next; end
+  end
+end

--- a/app/services/advance_order_service.rb
+++ b/app/services/advance_order_service.rb
@@ -6,6 +6,14 @@ class AdvanceOrderService
   end
 
   def call
-    while order.next; end
+    shipping_method_id = @order.shipping_method.id if @order.shipping_method.present?
+
+    while @order.state != "complete"
+      break unless @order.next
+
+      if @order.state == "delivery"
+        @order.select_shipping_method(shipping_method_id) if shipping_method_id.present?
+      end
+    end
   end
 end

--- a/app/services/order_factory.rb
+++ b/app/services/order_factory.rb
@@ -15,8 +15,10 @@ class OrderFactory
     set_user
     build_line_items
     set_addresses
+    create_shipment
     set_shipping_method
     create_payment
+
     @order
   end
 
@@ -64,6 +66,10 @@ class OrderFactory
 
   def set_addresses
     @order.update_attributes(attrs.slice(:bill_address_attributes, :ship_address_attributes))
+  end
+
+  def create_shipment
+    @order.create_proposed_shipments
   end
 
   def set_shipping_method

--- a/app/services/order_factory.rb
+++ b/app/services/order_factory.rb
@@ -15,6 +15,7 @@ class OrderFactory
     set_user
     build_line_items
     set_addresses
+    set_shipping_method
     create_payment
     @order
   end
@@ -63,6 +64,10 @@ class OrderFactory
 
   def set_addresses
     @order.update_attributes(attrs.slice(:bill_address_attributes, :ship_address_attributes))
+  end
+
+  def set_shipping_method
+    @order.select_shipping_method(attrs[:shipping_method_id])
   end
 
   def create_payment

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -67,13 +67,12 @@ class OrderSyncer
 
   def update_shipment_for(order)
     shipment = order.shipment
+    return track_shipping_method_issue(order) if shipment.blank?
 
-    if shipment.andand.state == "pending" && shipment.shipping_method.id == shipping_method_id_was
+    if shipment.state == "pending" && shipment.shipping_method.id == shipping_method_id_was
       order.select_shipping_method(shipping_method_id)
-    else
-      unless shipment.andand.state == "pending" && shipment.shipping_method.id == shipping_method_id
-        order_update_issues.add(order, I18n.t('admin.shipping_method'))
-      end
+    elsif !(shipment.state == "pending" && shipment.shipping_method.id == shipping_method_id)
+      track_shipping_method_issue(order)
     end
   end
 
@@ -105,5 +104,9 @@ class OrderSyncer
     relevant_address_attrs.all? do |attr|
       order.ship_address[attr] == distributor_address[attr]
     end
+  end
+
+  def track_shipping_method_issue(order)
+    order_update_issues.add(order, I18n.t('admin.shipping_method'))
   end
 end

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -69,8 +69,7 @@ class OrderSyncer
     shipment = order.shipment
 
     if shipment.andand.state == "pending" && shipment.shipping_method.id == shipping_method_id_was
-      shipment.update_attributes(shipping_method_id: shipping_method_id)
-      order.update_attribute(:shipping_method_id, shipping_method_id)
+      order.select_shipping_method(shipping_method_id)
     else
       unless shipment.andand.state == "pending" && shipment.shipping_method.id == shipping_method_id
         order_update_issues.add(order, I18n.t('admin.shipping_method'))

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -66,12 +66,13 @@ class OrderSyncer
   end
 
   def update_shipment_for(order)
-    shipment = order.shipments.with_state('pending').where(shipping_method_id: shipping_method_id_was).last
-    if shipment
+    shipment = order.shipment
+
+    if shipment.andand.state == "pending" && shipment.shipping_method.id == shipping_method_id_was
       shipment.update_attributes(shipping_method_id: shipping_method_id)
       order.update_attribute(:shipping_method_id, shipping_method_id)
     else
-      unless order.shipments.with_state('pending').where(shipping_method_id: shipping_method_id).any?
+      unless shipment.andand.state == "pending" && shipment.shipping_method.id == shipping_method_id
         order_update_issues.add(order, I18n.t('admin.shipping_method'))
       end
     end

--- a/spec/controllers/admin/proxy_orders_controller_spec.rb
+++ b/spec/controllers/admin/proxy_orders_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-xdescribe Admin::ProxyOrdersController, type: :controller do
+describe Admin::ProxyOrdersController, type: :controller do
   include AuthenticationWorkflow
 
   describe 'cancel' do
@@ -107,7 +107,7 @@ xdescribe Admin::ProxyOrdersController, type: :controller do
           before { shop.update_attributes(owner: user) }
 
           context "when resuming succeeds" do
-            it 'renders the resumed proxy_order as json' do
+            xit 'renders the resumed proxy_order as json' do
               spree_get :resume, params
               json_response = JSON.parse(response.body)
               expect(json_response['state']).to eq "resumed"

--- a/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -39,6 +39,14 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
         login_as_enterprise_user [order.distributor]
       end
 
+      it "advances the order state" do
+        expect {
+          spree_post :update, order: { email: user.email, bill_address_attributes: address_params,
+                                       ship_address_attributes: address_params },
+                              order_id: order.number
+        }.to change { order.reload.state }.from("cart").to("complete")
+      end
+
       context "when adding details of a registered user" do
         it "redirects to shipments on success" do
           spree_post :update, order: { email: user.email, bill_address_attributes: address_params, ship_address_attributes: address_params }, order_id: order.number

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -4,6 +4,18 @@ describe Spree::Admin::OrdersController, type: :controller do
   include AuthenticationWorkflow
   include OpenFoodNetwork::EmailHelper
 
+  describe "#edit" do
+    let!(:order) { create(:order_with_totals_and_distribution, ship_address: create(:address)) }
+
+    before { login_as_admin }
+
+    it "advances the order state" do
+      expect {
+        spree_get :edit, id: order
+      }.to change { order.reload.state }.from("cart").to("complete")
+    end
+  end
+
   context "#update" do
     let(:params) do
       { id: order,

--- a/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -6,9 +6,27 @@ describe Spree::Admin::PaymentsController, type: :controller do
   let!(:order) { create(:order, distributor: shop, state: 'complete') }
   let!(:line_item) { create(:line_item, order: order, price: 5.0) }
 
+  before do
+    allow(controller).to receive(:spree_current_user) { user }
+  end
+
+  context "#create" do
+    let!(:payment_method) { create(:payment_method, distributors: [ shop ]) }
+    let!(:order) do
+      create(:order_with_totals_and_distribution, distributor: shop, state: "payment")
+    end
+
+    let(:params) { { amount: order.total, payment_method_id: payment_method.id } }
+
+    it "advances the order state" do
+      expect {
+        spree_post :create, payment: params, order_id: order.number
+      }.to change { order.reload.state }.from("payment").to("complete")
+    end
+  end
+
   context "as an enterprise user" do
     before do
-      allow(controller).to receive(:spree_current_user) { user }
       order.reload.update_totals
     end
 

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-xfeature 'Subscriptions' do
+feature 'Subscriptions' do
   include AdminHelper
   include AuthenticationWorkflow
   include WebHelper

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -40,7 +40,8 @@ describe SubscriptionPlacementJob do
 
   describe "performing the job" do
     context "when unplaced proxy_orders exist" do
-      let!(:proxy_order) { create(:proxy_order) }
+      let!(:subscription) { create(:subscription, with_items: true) }
+      let!(:proxy_order) { create(:proxy_order, subscription: subscription) }
 
       before do
         allow(job).to receive(:proxy_orders) { ProxyOrder.where(id: proxy_order.id) }

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -78,7 +78,7 @@ xdescribe ProxyOrder, type: :model do
   describe "resume" do
     let!(:payment_method) { create(:payment_method) }
     let!(:shipment) { create(:shipment) }
-    let(:order) { create(:order_with_totals, shipments: [shipment]) }
+    let(:order) { create(:order_with_totals, ship_address: create(:address), shipments: [shipment]) }
     let(:proxy_order) { create(:proxy_order, order: order, canceled_at: Time.zone.now) }
     let(:order_cycle) { proxy_order.order_cycle }
 

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-xdescribe ProxyOrder, type: :model do
+describe ProxyOrder, type: :model do
   describe "cancel" do
     let(:order_cycle) { create(:simple_order_cycle) }
     let(:subscription) { create(:subscription) }

--- a/spec/services/advance_order_service_spec.rb
+++ b/spec/services/advance_order_service_spec.rb
@@ -34,4 +34,22 @@ describe AdvanceOrderService do
       expect(order.shipping_method).to eq(shipping_method_b)
     end
   end
+
+  context "when raising on error" do
+    it "transitions the order multiple steps" do
+      service.call!
+      order.reload
+      expect(order.state).to eq("complete")
+    end
+
+    context "when order cannot advance to the next state" do
+      let!(:order) do
+        create(:order, distributor: distributor)
+      end
+
+      it "raises error" do
+        expect { service.call! }.to raise_error(StateMachine::InvalidTransition)
+      end
+    end
+  end
 end

--- a/spec/services/advance_order_service_spec.rb
+++ b/spec/services/advance_order_service_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe AdvanceOrderService do
+  let!(:order) do
+    create(:order_with_totals_and_distribution, bill_address: create(:address),
+                                                ship_address: create(:address))
+  end
+
+  let(:service) { described_class.new(order) }
+
+  it "transitions the order multiple steps" do
+    expect(order.state).to eq("cart")
+    service.call
+    order.reload
+    expect(order.state).to eq("complete")
+  end
+end

--- a/spec/services/advance_order_service_spec.rb
+++ b/spec/services/advance_order_service_spec.rb
@@ -1,8 +1,10 @@
 require "spec_helper"
 
 describe AdvanceOrderService do
+  let!(:distributor) { create(:distributor_enterprise) }
   let!(:order) do
-    create(:order_with_totals_and_distribution, bill_address: create(:address),
+    create(:order_with_totals_and_distribution, distributor: distributor,
+                                                bill_address: create(:address),
                                                 ship_address: create(:address))
   end
 
@@ -13,5 +15,23 @@ describe AdvanceOrderService do
     service.call
     order.reload
     expect(order.state).to eq("complete")
+  end
+
+  describe "transition from delivery" do
+    let!(:shipping_method_a) { create(:shipping_method, distributors: [ distributor ]) }
+    let!(:shipping_method_b) { create(:shipping_method, distributors: [ distributor ]) }
+    let!(:shipping_method_c) { create(:shipping_method, distributors: [ distributor ]) }
+
+    before do
+      # Create shipping rates for available shipping methods.
+      order.shipments.each(&:refresh_rates)
+    end
+
+    it "retains delivery method of the order" do
+      order.select_shipping_method(shipping_method_b.id)
+      service.call
+      order.reload
+      expect(order.shipping_method).to eq(shipping_method_b)
+    end
   end
 end

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -42,6 +42,19 @@ describe OrderFactory do
       expect(order.complete?).to be false
     end
 
+    it "retains address, delivery, and payment attributes until completion of the order" do
+      while !order.completed? do break unless order.next! end
+
+      order.reload
+
+      expect(order.customer).to eq customer
+      expect(order.shipping_method).to eq shipping_method
+      expect(order.payments.first.payment_method).to eq payment_method
+      expect(order.bill_address).to eq bill_address
+      expect(order.ship_address).to eq ship_address
+      expect(order.total).to eq 38.0
+    end
+
     context "when the customer does not have a user associated with it" do
       before { customer.update_attribute(:user_id, nil) }
 

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -7,6 +7,9 @@ describe OrderFactory do
   let(:customer) { create(:customer, user: user) }
   let(:shop) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle) }
+  let!(:other_shipping_method_a) { create(:shipping_method) }
+  let!(:shipping_method) { create(:shipping_method) }
+  let!(:other_shipping_method_b) { create(:shipping_method) }
   let(:payment_method) { create(:payment_method) }
   let(:ship_address) { create(:address) }
   let(:bill_address) { create(:address) }
@@ -43,7 +46,7 @@ describe OrderFactory do
     end
 
     it "retains address, delivery, and payment attributes until completion of the order" do
-      while !order.completed? do break unless order.next! end
+      AdvanceOrderService.new(order).call
 
       order.reload
 

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -24,6 +24,7 @@ describe OrderFactory do
       attrs[:customer_id] = customer.id
       attrs[:distributor_id] = shop.id
       attrs[:order_cycle_id] = order_cycle.id
+      attrs[:shipping_method_id] = shipping_method.id
       attrs[:payment_method_id] = payment_method.id
       attrs[:bill_address_attributes] = bill_address.attributes.except("id")
       attrs[:ship_address_attributes] = ship_address.attributes.except("id")
@@ -38,6 +39,7 @@ describe OrderFactory do
       expect(order.user).to eq user
       expect(order.distributor).to eq shop
       expect(order.order_cycle).to eq order_cycle
+      expect(order.shipments.first.shipping_method).to eq shipping_method
       expect(order.payments.first.payment_method).to eq payment_method
       expect(order.bill_address).to eq bill_address
       expect(order.ship_address).to eq ship_address

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -11,7 +11,7 @@ describe OrderSyncer do
     context "when the shipping method on an order is the same as the subscription" do
       let(:params) { { shipping_method_id: new_shipping_method.id } }
 
-      xit "updates the shipping_method on the order and on shipments" do
+      it "updates the shipping_method on the order and on shipments" do
         expect(order.shipments.first.shipping_method_id_was).to eq shipping_method.id
         subscription.assign_attributes(params)
         expect(syncer.sync!).to be true
@@ -34,7 +34,7 @@ describe OrderSyncer do
           expect(syncer.sync!).to be true
         end
 
-        xit "does not update the shipping_method on the subscription or on the pre-altered shipment" do
+        it "does not update the shipping_method on the subscription or on the pre-altered shipment" do
           expect(order.reload.shipping_method).to eq new_shipping_method
           expect(order.reload.shipments.first.shipping_method).to eq new_shipping_method
           expect(syncer.order_update_issues[order.id]).to be nil
@@ -54,7 +54,7 @@ describe OrderSyncer do
           expect(syncer.sync!).to be true
         end
 
-        xit "does not update the shipping_method on the subscription or on the pre-altered shipment" do
+        it "does not update the shipping_method on the subscription or on the pre-altered shipment" do
           expect(order.reload.shipping_method).to eq changed_shipping_method
           expect(order.reload.shipments.first.shipping_method).to eq changed_shipping_method
           expect(syncer.order_update_issues[order.id]).to include "Shipping Method"
@@ -226,7 +226,7 @@ describe OrderSyncer do
     context "when a ship address is not required" do
       before { shipping_method.update_attributes(require_ship_address: false) }
 
-      xit "does not change the ship address" do
+      it "does not change the ship address" do
         subscription.assign_attributes(params)
         expect(syncer.sync!).to be true
         expect(syncer.order_update_issues.keys).to_not include order.id
@@ -241,7 +241,7 @@ describe OrderSyncer do
         let(:new_shipping_method) { create(:shipping_method, require_ship_address: true) }
         before { params.merge!(shipping_method_id: new_shipping_method.id) }
 
-        xit "updates ship_address attrs" do
+        it "updates ship_address attrs" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true
           expect(syncer.order_update_issues.keys).to_not include order.id
@@ -272,7 +272,7 @@ describe OrderSyncer do
 
       context "when the ship address on the order doesn't match that on the subscription" do
         before { order.ship_address.update_attributes(firstname: "Jane") }
-        xit "does not update ship_address on the order" do
+        it "does not update ship_address on the order" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true
           expect(syncer.order_update_issues.keys).to include order.id
@@ -312,7 +312,7 @@ describe OrderSyncer do
       let(:params) { { subscription_line_items_attributes: [{ id: sli.id, quantity: 3}] } }
       let(:syncer) { OrderSyncer.new(subscription) }
 
-      xit "updates the line_item quantities and totals on all orders" do
+      it "updates the line_item quantities and totals on all orders" do
         expect(order.reload.total.to_f).to eq 59.97
         subscription.assign_attributes(params)
         expect(syncer.sync!).to be true

--- a/spec/services/subscription_form_spec.rb
+++ b/spec/services/subscription_form_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-xdescribe SubscriptionForm do
+describe SubscriptionForm do
   describe "creating a new subscription" do
     let!(:shop) { create(:distributor_enterprise) }
     let!(:customer) { create(:customer, enterprise: shop) }


### PR DESCRIPTION
Fix use of shipping method ID for subscriptions.

#### What? Why?

- Closes #2696
- Relates to #2788 (does not close issue)

The shipping method in Spree 2.0 is not associated directly to orders, but through shipment shipping rates.

Before Spree 2, `OrderFactory` keeps subscription orders in cart state but already sets associations and creates associated records (like payments). But in Spree 2, transitioning an order to "delivery" state removes and regenerates shipments. Considering above, this means that the selected shipping method could be forgotten.

To work around this, the code that regenerates shipping rates for a shipment has been updated to remember the previously selected shipping method first and select it again after creating the new shipping rates.

#### What should we test?

Not worth testing as there are still some broken functionalities. But some unit and feature tests have been uncommented and now pass.