### PR TITLE
[Spree Upgrade] Improve order factories

### DIFF
--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -224,16 +224,9 @@ describe Spree::OrdersController, type: :controller do
           } }
         }
 
-        # Before issuing the update, the second adjustment, which is associated
-        # to the shipment, is already open thus restoring its state leaves it
-        # also open.
-        #
-        # The third adjustment is originated from an EnterpriseFee and it gets
-        # created by #update_distribution_charge! in
-        # app/models/spree/order_decorator.rb:220, which is in turn triggered
-        # by the `contents_changed` notification event defined in
-        # app/models/spree/order_decorator.rb:7
-        expect(order.adjustments.map(&:state)).to eq(['closed', 'open', 'closed'])
+        # The second adjustment (shipping adjustment) is open before the update
+        #   so, restoring its state leaves it open.
+        expect(order.adjustments.map(&:state)).to eq(['closed', 'open'])
       end
     end
 


### PR DESCRIPTION
#### What? Why?
There was something wrong with #3456... I had to come back to it. line_item_with_shipment is using line_item.target_shipment and that was introducing noise in the test order. I removed it and it looks good!

This PR:
- Makes order_with_totals_and_distribution shorter by inheriting from order_with_distributor
- Makes completed_order_with_fees more correct by inheriting only from order_with_distributor: this removes the line_item_with_shipment of order_with_totals_and_distribution that was causing an extra shipping adjustment to be kept in the order. This adjustment was being tested in the order controller spec (fixed the explanation comment in the spec which was wrong, there was no enterprise fee in this order)

#### What should we test?
green build!
