### PR TITLE
Handle deleted order cycle when refreshing cache

### DIFF
--- a/app/jobs/refresh_products_cache_job.rb
+++ b/app/jobs/refresh_products_cache_job.rb
@@ -3,6 +3,8 @@ require 'open_food_network/products_renderer'
 RefreshProductsCacheJob = Struct.new(:distributor_id, :order_cycle_id) do
   def perform
     Rails.cache.write(key, products_json)
+  rescue ActiveRecord::RecordNotFound
+    true
   end
 
   private

--- a/spec/jobs/refresh_products_cache_job_spec.rb
+++ b/spec/jobs/refresh_products_cache_job_spec.rb
@@ -38,12 +38,16 @@ describe RefreshProductsCacheJob do
   end
 
   describe "fetching products JSON" do
-    let(:job) { RefreshProductsCacheJob.new distributor.id, order_cycle.id }
-    let(:pr) { double(:products_renderer, products_json: nil) }
+    let(:job) { RefreshProductsCacheJob.new(distributor.id, order_cycle.id) }
+    let(:products_renderer) { instance_double(OpenFoodNetwork::ProductsRenderer, products_json: nil) }
+
+    before do
+      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new).with(distributor, order_cycle) { products_renderer }
+    end
 
     it "fetches products JSON" do
-      expect(OpenFoodNetwork::ProductsRenderer).to receive(:new).with(distributor, order_cycle) { pr }
-      job.send(:products_json)
+      job.perform
+      expect(OpenFoodNetwork::ProductsRenderer).to have_received(:new).with(distributor, order_cycle) { products_renderer }
     end
   end
 end

--- a/spec/jobs/refresh_products_cache_job_spec.rb
+++ b/spec/jobs/refresh_products_cache_job_spec.rb
@@ -6,11 +6,13 @@ describe RefreshProductsCacheJob do
   let(:order_cycle) { create(:simple_order_cycle) }
 
   context 'when the enterprise and the order cycle exist' do
-    it "renders products and writes them to cache" do
-      RefreshProductsCacheJob.any_instance.stub(:products_json) { 'products' }
+    before do
+      refresh_products_cache_job = instance_double(OpenFoodNetwork::ProductsRenderer, products_json: 'products')
+      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new).with(distributor, order_cycle) { refresh_products_cache_job }
+    end
 
+    it 'renders products and writes them to cache' do
       run_job RefreshProductsCacheJob.new distributor.id, order_cycle.id
-
       expect(Rails.cache.read("products-json-#{distributor.id}-#{order_cycle.id}")).to eq 'products'
     end
   end

--- a/spec/jobs/refresh_products_cache_job_spec.rb
+++ b/spec/jobs/refresh_products_cache_job_spec.rb
@@ -5,12 +5,34 @@ describe RefreshProductsCacheJob do
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle) }
 
-  it "renders products and writes them to cache" do
-    RefreshProductsCacheJob.any_instance.stub(:products_json) { 'products' }
+  context 'when the enterprise and the order cycle exist' do
+    it "renders products and writes them to cache" do
+      RefreshProductsCacheJob.any_instance.stub(:products_json) { 'products' }
 
-    run_job RefreshProductsCacheJob.new distributor.id, order_cycle.id
+      run_job RefreshProductsCacheJob.new distributor.id, order_cycle.id
 
-    expect(Rails.cache.read("products-json-#{distributor.id}-#{order_cycle.id}")).to eq 'products'
+      expect(Rails.cache.read("products-json-#{distributor.id}-#{order_cycle.id}")).to eq 'products'
+    end
+  end
+
+  context 'when the order cycle does not exist' do
+    before do
+      allow(OrderCycle)
+        .to receive(:find)
+        .with(order_cycle.id)
+        .and_raise(ActiveRecord::RecordNotFound)
+    end
+
+    it 'does not raise' do
+      expect {
+        run_job RefreshProductsCacheJob.new(distributor.id, order_cycle.id)
+      }.not_to raise_error(/ActiveRecord::RecordNotFound/)
+    end
+
+    it 'returns true' do
+      refresh_products_cache_job = RefreshProductsCacheJob.new(distributor.id, order_cycle.id)
+      expect(refresh_products_cache_job.perform).to eq(true)
+    end
   end
 
   describe "fetching products JSON" do


### PR DESCRIPTION
#### What? Why?

Closes #3571 

When refreshing the cache of an order cycle that got deleted there is not need to retry the job. Essentially, it does not constitute a failure scenario so returning true does the job.

#### What should we test?

It's worth testing this in a staging environment. Check that after changing an order cycle products and then deleting it does not retry cache refreshes. I'll help to do so.


#### Release notes

Cache refreshes of a deleted order cycle no longer get retried.

Changelog Category: Fixed