### PR TITLE
1829 missing translation product category

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -25,7 +25,7 @@ Spree::Product.class_eval do
 
   # validates_presence_of :variants, unless: :new_record?, message: "Product must have at least one variant"
   validates_presence_of :supplier
-  validates :primary_taxon, presence: { message: I18n.t("validation_msg_product_category_cant_be_blank") }
+  validates :primary_taxon, presence: true
   validates :tax_category_id, presence: { message: I18n.t("validation_msg_tax") }, if: "Spree::Config.products_require_tax_category"
 
   validates_presence_of :variant_unit

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -23,10 +23,9 @@ Spree::Product.class_eval do
   attr_accessible :variant_unit, :variant_unit_scale, :variant_unit_name, :unit_value
   attr_accessible :inherits_properties, :sku
 
-  # validates_presence_of :variants, unless: :new_record?, message: "Product must have at least one variant"
   validates_presence_of :supplier
   validates :primary_taxon, presence: true
-  validates :tax_category_id, presence: { message: I18n.t("validation_msg_tax") }, if: "Spree::Config.products_require_tax_category"
+  validates :tax_category_id, presence: true, if: "Spree::Config.products_require_tax_category"
 
   validates_presence_of :variant_unit
   validates_presence_of :variant_unit_scale,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2394,7 +2394,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   enterprise_fee_by: "%{type} fee by %{role} %{enterprise_name}"
   validation_msg_relationship_already_established: "^That relationship is already established."
   validation_msg_at_least_one_hub: "^At least one hub must be selected"
-  validation_msg_tax: "^Tax Category is required"
   validation_msg_tax_category_cant_be_blank: "^Tax Category can't be blank"
   validation_msg_is_associated_with_an_exising_customer: "is associated with an existing customer"
   content_configuration_pricing_table: "(TODO: Pricing table)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
         email: Customer E-Mail
       spree/payment:
         amount: Amount
+      spree/product:
+        primary_taxon: Product Category
       order_cycle:
         orders_close_at: Close date
     errors:
@@ -2392,7 +2394,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   enterprise_fee_by: "%{type} fee by %{role} %{enterprise_name}"
   validation_msg_relationship_already_established: "^That relationship is already established."
   validation_msg_at_least_one_hub: "^At least one hub must be selected"
-  validation_msg_product_category_cant_be_blank: "^Product Category cant be blank"
   validation_msg_tax: "^Tax Category is required"
   validation_msg_tax_category_cant_be_blank: "^Tax Category can't be blank"
   validation_msg_is_associated_with_an_exising_customer: "is associated with an existing customer"


### PR DESCRIPTION
#### What? Why?

Closes #1829

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Some product validation messages were not translated because they were loaded before the translations. I have no idea how to load our translations before decorators are loaded. But using ActiveRecord's default way of customising error messages and translations works well.

I looked for any other uses of `I18n.t` within decorators and couldn't find any loaded during class eval. Usages within methods are okay because they are executed later when translations are available.

#### What should we test?
<!-- List which features should be tested and how. -->

- Log in as admin.
- Go to Products and Create new.
- Don't enter anything and hit Create so that a lot of validation messages come up.
- All messages should make sense.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed the display of validation errors when creating a product as admin.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

