### PR TITLE
2788 [Subscriptions] Fix address issues when syncing subscriptions and orders

### DIFF
--- a/app/models/order_updater.rb
+++ b/app/models/order_updater.rb
@@ -27,7 +27,7 @@ class OrderUpdater < SimpleDelegator
   def shipping_address_from_distributor
     return if order.shipping_method.blank? || order.shipping_method.require_ship_address
 
-    order.ship_address = order.__send__(:address_from_distributor)
+    order.ship_address = order.address_from_distributor
   end
 
   private

--- a/app/models/order_updater.rb
+++ b/app/models/order_updater.rb
@@ -21,6 +21,15 @@ class OrderUpdater < SimpleDelegator
     shipping_address_from_distributor
   end
 
+  # Sets the distributor's address as shipping address of the order for those
+  # shipments using a shipping method that doesn't require address, such us
+  # a pickup.
+  def shipping_address_from_distributor
+    return if order.shipping_method.blank? || order.shipping_method.require_ship_address
+
+    order.ship_address = order.__send__(:address_from_distributor)
+  end
+
   private
 
   def infer_payment_state
@@ -78,14 +87,5 @@ class OrderUpdater < SimpleDelegator
 
   def failed_payments?
     payments.present? && payments.valid.empty?
-  end
-
-  # Sets the distributor's address as shipping address of the order for those
-  # shipments using a shipping method that doesn't require address, such us
-  # a pickup.
-  def shipping_address_from_distributor
-    return if order.shipping_method.blank? || order.shipping_method.require_ship_address
-
-    order.ship_address = order.__send__(:address_from_distributor)
   end
 end

--- a/app/models/order_updater.rb
+++ b/app/models/order_updater.rb
@@ -84,11 +84,8 @@ class OrderUpdater < SimpleDelegator
   # shipments using a shipping method that doesn't require address, such us
   # a pickup.
   def shipping_address_from_distributor
-    shipments.each do |shipment|
-      shipping_method = shipment.shipping_method
-      next if shipping_method.require_ship_address
+    return if order.shipping_method.blank? || order.shipping_method.require_ship_address
 
-      order.ship_address = order.distributor.address
-    end
+    order.ship_address = order.__send__(:address_from_distributor)
   end
 end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -326,12 +326,6 @@ Spree::Order.class_eval do
     total.to_f > 0.0 && !skip_payment_for_subscription?
   end
 
-  private
-
-  def skip_payment_for_subscription?
-    subscription.present? && order_cycle.orders_close_at.andand > Time.zone.now
-  end
-
   def address_from_distributor
     address = distributor.address.clone
     if bill_address
@@ -340,6 +334,12 @@ Spree::Order.class_eval do
       address.phone = bill_address.phone
     end
     address
+  end
+
+  private
+
+  def skip_payment_for_subscription?
+    subscription.present? && order_cycle.orders_close_at.andand > Time.zone.now
   end
 
   def provided_by_order_cycle?(line_item)

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -38,7 +38,7 @@ class OrderSyncer
     # are ignored or not.
     pickup_to_delivery = force_ship_address_required?(order)
     if !pickup_to_delivery || order.shipment.present?
-      update_ship_address_for(order) if (ship_address.changes.keys & relevant_address_attrs).any?
+      save_ship_address_in_order(order) if (ship_address.changes.keys & relevant_address_attrs).any?
     end
     if !pickup_to_delivery || order.shipment.blank?
       order.updater.__send__(:shipping_address_from_distributor)
@@ -57,11 +57,6 @@ class OrderSyncer
       return order_update_issues.add(order, I18n.t('bill_address'))
     end
     order.bill_address.update_attributes(bill_address.attributes.slice(*relevant_address_attrs))
-  end
-
-  def update_ship_address_for(order)
-    return unless ship_address_updatable?(order)
-    order.ship_address.update_attributes(ship_address.attributes.slice(*relevant_address_attrs))
   end
 
   def update_payment_for(order)
@@ -114,6 +109,11 @@ class OrderSyncer
     relevant_address_attrs.all? do |attr|
       order.ship_address[attr] == distributor_address[attr]
     end
+  end
+
+  def save_ship_address_in_order(order)
+    return unless ship_address_updatable?(order)
+    order.ship_address.update_attributes(ship_address.attributes.slice(*relevant_address_attrs))
   end
 
   def pending_shipment_with?(order, shipping_method_id)

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -37,10 +37,10 @@ class OrderSyncer
     # switching from pick-up to delivery affects whether simultaneous changes to shipping address
     # are ignored or not.
     pickup_to_delivery = force_ship_address_required?(order)
-    if (ship_address.changes.keys & relevant_address_attrs).any?
-      update_ship_address_for(order) unless pickup_to_delivery && order.shipment.blank?
+    if !pickup_to_delivery || order.shipment.present?
+      update_ship_address_for(order) if (ship_address.changes.keys & relevant_address_attrs).any?
     end
-    unless pickup_to_delivery && order.shipment.present?
+    if !pickup_to_delivery || order.shipment.blank?
       order.updater.__send__(:shipping_address_from_distributor)
     end
 

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -107,7 +107,7 @@ class OrderSyncer
   # address on the order matches the shop's address
   def force_ship_address_required?(order)
     return false unless shipping_method.require_ship_address?
-    distributor_address = order.__send__(:address_from_distributor)
+    distributor_address = order.address_from_distributor
     relevant_address_attrs.all? do |attr|
       order.ship_address[attr] == distributor_address[attr]
     end

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -32,18 +32,7 @@ class OrderSyncer
   def update_associations_for(order)
     update_bill_address_for(order) if (bill_address.changes.keys & relevant_address_attrs).any?
     update_shipment_for(order) if shipping_method_id_changed?
-
-    # The conditions here are to achieve the same behaviour in earlier versions of Spree, where
-    # switching from pick-up to delivery affects whether simultaneous changes to shipping address
-    # are ignored or not.
-    pickup_to_delivery = force_ship_address_required?(order)
-    if !pickup_to_delivery || order.shipment.present?
-      save_ship_address_in_order(order) if (ship_address.changes.keys & relevant_address_attrs).any?
-    end
-    if !pickup_to_delivery || order.shipment.blank?
-      order.updater.__send__(:shipping_address_from_distributor)
-    end
-
+    update_ship_address_for(order)
     update_payment_for(order) if payment_method_id_changed?
   end
 
@@ -78,6 +67,19 @@ class OrderSyncer
       order.select_shipping_method(shipping_method_id)
     else
       order_update_issues.add(order, I18n.t('admin.shipping_method'))
+    end
+  end
+
+  def update_ship_address_for(order)
+    # The conditions here are to achieve the same behaviour in earlier versions of Spree, where
+    # switching from pick-up to delivery affects whether simultaneous changes to shipping address
+    # are ignored or not.
+    pickup_to_delivery = force_ship_address_required?(order)
+    if !pickup_to_delivery || order.shipment.present?
+      save_ship_address_in_order(order) if (ship_address.changes.keys & relevant_address_attrs).any?
+    end
+    if !pickup_to_delivery || order.shipment.blank?
+      order.updater.__send__(:shipping_address_from_distributor)
     end
   end
 

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -79,7 +79,7 @@ class OrderSyncer
       save_ship_address_in_order(order) if (ship_address.changes.keys & relevant_address_attrs).any?
     end
     if !pickup_to_delivery || order.shipment.blank?
-      order.updater.__send__(:shipping_address_from_distributor)
+      order.updater.shipping_address_from_distributor
     end
   end
 

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -82,7 +82,7 @@ describe SubscriptionPlacementJob do
           variant3.update_attribute(:on_hand, 0)
         end
 
-        xit "caps quantity at the stock level for stock-limited items, and reports the change" do
+        it "caps quantity at the stock level for stock-limited items, and reports the change" do
           changes = job.send(:cap_quantity_and_store_changes, order.reload)
           expect(line_item1.reload.quantity).to be 3 # not capped
           expect(line_item2.reload.quantity).to be 2 # capped
@@ -104,7 +104,7 @@ describe SubscriptionPlacementJob do
           variant3.update_attribute(:on_hand, 0)
         end
 
-        xit "sets quantity to 0 for unavailable items, and reports the change" do
+        it "sets quantity to 0 for unavailable items, and reports the change" do
           changes = job.send(:cap_quantity_and_store_changes, order.reload)
           expect(line_item1.reload.quantity).to be 0 # unavailable
           expect(line_item2.reload.quantity).to be 2 # capped
@@ -151,7 +151,7 @@ describe SubscriptionPlacementJob do
           allow(job).to receive(:unavailable_stock_lines_for) { order.line_items }
         end
 
-        xit "does not place the order, clears, all adjustments, and sends an empty_order email" do
+        it "does not place the order, clears, all adjustments, and sends an empty_order email" do
           expect{ job.send(:process, order) }.to_not change{ order.reload.completed_at }.from(nil)
           expect(order.adjustments).to be_empty
           expect(order.total).to eq 0
@@ -162,7 +162,7 @@ describe SubscriptionPlacementJob do
       end
 
       context "when at least one stock item is available after capping stock" do
-        xit "processes the order to completion, but does not process the payment" do
+        it "processes the order to completion, but does not process the payment" do
           # If this spec starts complaining about no shipping methods being available
           # on CI, there is probably another spec resetting the currency though Rails.cache.clear
           expect{ job.send(:process, order) }.to change{ order.reload.completed_at }.from(nil)
@@ -170,7 +170,7 @@ describe SubscriptionPlacementJob do
           expect(order.payments.first.state).to eq "checkout"
         end
 
-        xit "does not enqueue confirmation emails" do
+        it "does not enqueue confirmation emails" do
           expect{ job.send(:process, order) }.to_not enqueue_job ConfirmOrderJob
           expect(job).to have_received(:send_placement_email).with(order, anything).once
         end
@@ -178,7 +178,7 @@ describe SubscriptionPlacementJob do
         context "when progression of the order fails" do
           before { allow(order).to receive(:next) { false } }
 
-          xit "records an error and does not attempt to send an email" do
+          it "records an error and does not attempt to send an email" do
             expect(job).to_not receive(:send_placement_email)
             expect(job).to receive(:record_and_log_error).once
             job.send(:process, order)

--- a/spec/models/order_updater_spec.rb
+++ b/spec/models/order_updater_spec.rb
@@ -131,7 +131,7 @@ describe OrderUpdater do
 
       it "populates the shipping address from distributor" do
         order_updater.before_save_hook
-        expect(order.ship_address.firstname).to eq(distributor.address.firstname)
+        expect(order.ship_address.address1).to eq(distributor.address.address1)
       end
     end
 

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-xdescribe OrderSyncer do
+describe OrderSyncer do
   describe "updating the shipping method" do
     let!(:subscription) { create(:subscription, with_items: true, with_proxy_orders: true) }
     let!(:order) { subscription.proxy_orders.first.initialise_order! }

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -156,7 +156,7 @@ xdescribe OrderSyncer do
       end
 
       context "when the bill_address on the order matches that on the subscription" do
-        xit "updates all bill_address attrs and ship_address names + phone" do
+        it "updates all bill_address attrs and ship_address names + phone" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true
           expect(syncer.order_update_issues.keys).to_not include order.id
@@ -173,8 +173,12 @@ xdescribe OrderSyncer do
       end
 
       context "when the bill_address on the order doesn't match that on the subscription" do
-        before { order.bill_address.update_attributes(firstname: "Jane") }
-        xit "does not update bill_address or ship_address on the order" do
+        before do
+          order.bill_address.update_attributes!(firstname: "Jane")
+          order.update!
+        end
+
+        it "does not update bill_address or ship_address on the order" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true
           expect(syncer.order_update_issues.keys).to include order.id
@@ -214,7 +218,10 @@ xdescribe OrderSyncer do
       end
 
       context "when the bill_address on the order doesn't match that on the subscription" do
-        before { order.bill_address.update_attributes(firstname: "Jane") }
+        before do
+          order.bill_address.update_attributes!(firstname: "Jane")
+          order.update!
+        end
 
         it "does not update bill_address or ship_address on the order" do
           subscription.assign_attributes(params)
@@ -265,7 +272,7 @@ xdescribe OrderSyncer do
       end
 
       context "but the shipping method is being changed to one that requires a ship_address" do
-        let(:new_shipping_method) { create(:shipping_method, require_ship_address: true) }
+        let(:new_shipping_method) { create(:shipping_method, distributors: [distributor], require_ship_address: true) }
 
         before { params.merge!(shipping_method_id: new_shipping_method.id) }
 
@@ -284,22 +291,27 @@ xdescribe OrderSyncer do
                                   with_proxy_orders: true)
           end
 
-          before do
-            subscription.assign_attributes(params)
-          end
+          context "when there is no pending shipment using the former shipping method" do
+            before do
+              order.shipment.destroy
+              subscription.assign_attributes(params)
+            end
 
-          it "updates ship_address attrs" do
-            expect(syncer.sync!).to be true
-            expect(syncer.order_update_issues.keys).to include order.id
-            order.reload
-            expect(order.ship_address.firstname).to eq ship_address_attrs["firstname"]
-            expect(order.ship_address.lastname).to eq ship_address_attrs["lastname"]
-            expect(order.ship_address.address1).to eq ship_address_attrs["address1"]
-            expect(order.ship_address.phone).to eq ship_address_attrs["phone"]
+            it "updates ship_address attrs" do
+              expect(syncer.sync!).to be true
+              expect(syncer.order_update_issues.keys).to include order.id
+              order.reload
+              expect(order.ship_address.firstname).to eq ship_address_attrs["firstname"]
+              expect(order.ship_address.lastname).to eq ship_address_attrs["lastname"]
+              expect(order.ship_address.address1).to eq ship_address_attrs["address1"]
+              expect(order.ship_address.phone).to eq ship_address_attrs["phone"]
+            end
           end
 
           context "when the order has a pending shipment using the former shipping method" do
-            let!(:shipment) { create(:shipment, order: order, shipping_method: shipping_method) }
+            before do
+              subscription.assign_attributes(params)
+            end
 
             it "updates ship_address attrs" do
               expect(syncer.sync!).to be true
@@ -334,7 +346,11 @@ xdescribe OrderSyncer do
       end
 
       context "when the ship address on the order doesn't match that on the subscription" do
-        before { order.ship_address.update_attributes(firstname: "Jane") }
+        before do
+          order.ship_address.update_attributes(firstname: "Jane")
+          order.update!
+        end
+
         it "does not update ship_address on the order" do
           subscription.assign_attributes(params)
           expect(syncer.sync!).to be true


### PR DESCRIPTION
Fix shipping and billing address issues when syncing subscriptions and orders.

#### What? Why?

This fixes remaining issues in #2788, related to how changes to subscriptions' bill address, ship address, and shipping method are carried over to the orders.

This PR includes changes in PR #3560, and cherry-picks commits for v1 in #3605, so should not be merged until those have been approved and merged to their respective base branches.

It turned out that many spec assertions were passing only by accident in v1. See more info here: #3605 The specs had to be fixed in v1 so we could make sure to preserve the behaviour in v2. The fix specific to v2 is only in these commits:

- https://github.com/openfoodfoundation/openfoodnetwork/pull/3589/commits/d1c3bbf3edc2ac222c22a8883c04f79db747b036
- https://github.com/openfoodfoundation/openfoodnetwork/pull/3589/commits/e98de7e6821e2452807075d39c7369b3ae109f91
- https://github.com/openfoodfoundation/openfoodnetwork/pull/3589/commits/8c7e176fa9dad9baac1cbae9133ca7ec028be67b
- https://github.com/openfoodfoundation/openfoodnetwork/pull/3589/commits/eb1961c5f3a2627d119dea7685e95f1d0002c7d6

#### What should we test?

1. Create a subscription with no end date for an open OC. Set pickup as the shipping method, but set billing details that is different from the shipping details.
2. "Edit" the subscription order generated. This will create the order. The order ship address should be: bill address name and phone number, and shop address.
4. Edit the subscription bill address. This should affect the bill and ship address of the order.
5. Change the order bill address.
6. Edit the subscription bill address again. This should not affect the order bill and ship address.
7. Change back order bill address to be the same as subscription bill address.
7. Switch subscription to delivery.
8. Edit the subscription bill address again. Check that the order bill address is updated.
9. Change the order bill address.
10. Edit the subscription bill address again. The order bill addresses should not be updated.

#### Dependencies

- #3560 
- #3605 
- #3640