### PR TITLE
Instrument products cache

### DIFF
--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -54,5 +54,5 @@ Spree::AppConfiguration.class_eval do
   preference :enable_localized_number?, :boolean, default: false
 
   # Enable cache
-  preference :enable_products_cache?, :boolean, default: true
+  preference :enable_products_cache?, :boolean, default: !Rails.env.development?
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,9 +9,6 @@ Openfoodnetwork::Application.configure do
   # :file_store is used by default when no cache store is specifically configured.
   # config.cache_store = :file_store
 
-  # Enable cache instrumentation, which is disabled by default
-  ActiveSupport::Cache::Store.instrument = true
-
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 
@@ -45,4 +42,6 @@ Openfoodnetwork::Application.configure do
   # Show emails using Letter Opener
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_url_options = { host: "0.0.0.0:3000" }
+
+  config.log_level = :debug
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,6 +7,9 @@ Openfoodnetwork::Application.configure do
   config.cache_classes = false
   config.cache_store = :memory_store
 
+  # Enable cache instrumentation, which is disabled by default
+  ActiveSupport::Cache::Store.instrument = true
+
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,9 @@ Openfoodnetwork::Application.configure do
   # every request.  This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-  config.cache_store = :memory_store
+
+  # :file_store is used by default when no cache store is specifically configured.
+  # config.cache_store = :file_store
 
   # Enable cache instrumentation, which is disabled by default
   ActiveSupport::Cache::Store.instrument = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -42,6 +42,9 @@ Openfoodnetwork::Application.configure do
   # Use a different cache store in production
   config.cache_store = :dalli_store
 
+  # Enable cache instrumentation, which is disabled by default
+  ActiveSupport::Cache::Store.instrument = true
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -42,9 +42,6 @@ Openfoodnetwork::Application.configure do
   # Use a different cache store in production
   config.cache_store = :dalli_store
 
-  # Enable cache instrumentation, which is disabled by default
-  ActiveSupport::Cache::Store.instrument = true
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,0 +1,7 @@
+unless Rails.env.production?
+  # Enable cache instrumentation, which is disabled by default
+  ActiveSupport::Cache::Store.instrument = true
+
+  # Log message in the same default logger
+  ActiveSupport::Cache::Store.logger = Rails.logger
+end

--- a/lib/open_food_network/cached_products_renderer.rb
+++ b/lib/open_food_network/cached_products_renderer.rb
@@ -39,7 +39,7 @@ module OpenFoodNetwork
     end
 
     def use_cached_products?
-      Spree::Config[:enable_products_cache?] && (Rails.env.production? || Rails.env.staging?)
+      Spree::Config[:enable_products_cache?]
     end
 
     def uncached_products_json


### PR DESCRIPTION
#### What? Why?

Related to #3391

This PR makes it possible to both use and debug products cache in development.

Firstly, the configured cache store didn't work with our background-job based cache writes. Check b5a2670 commit message for details.

Secondly, the development's default log level didn't output any log messages related to the cache store, so it was impossible to know the particular cache operations being executed. Now, to watch its accesses you can either look at the sever's output or to make it easier run:

```
tail -f log/development.log | grep Cache
```
You will see lines like the following

```
Cache read: spree/app_configuration/enable_products_cache?
Cache read: products-json-2-1                               
Cache fetch_hit: products-json-2-1        
Cache read: spree/app_configuration/layout     
```

I've been more conservative in staging to avoid tons of lines we might not care about. If you want to debug the cache there, you'll need to change the log level to debug.

#### What should we test?

Changes in an order cycles products should still be reflected in the shopfront.

#### Release notes

Make it possible to both use and debug products cache in development.

Changelog Category: Added

#### How is this related to the Spree upgrade?

This will allow debugging cache issues before they hit production

#### Dependencies

https://github.com/openfoodfoundation/openfoodnetwork/pull/3581

#### Documentation updates

I created https://github.com/openfoodfoundation/openfoodnetwork/wiki/Products-cache with all the acquired know-how from here and #3581 