### PR TITLE
[Spree Upgrade] Override default spree splitters config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -83,6 +83,17 @@ module Openfoodnetwork
       ]
     end
 
+    # Every splitter (except Base splitter) will split the order in multiple packages
+    #   Each package will generate a separate shipment in the order
+    #   Base splitter does not split the packages
+    #   So, because in OFN we have locked orders to have only one shipment,
+    #     we must use this splitter and no other
+    initializer "spree.register.stock_splitters" do |app|
+      app.config.spree.stock_splitters = [
+        Spree::Stock::Splitter::Base
+      ]
+    end
+
     # Register Spree payment methods
     initializer "spree.gateway.payment_methods", :after => "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << Spree::Gateway::Migs

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Openfoodnetwork::Application, 'configuration' do
+  let(:config) { described_class.config }
+
+  it "sets Spree::Stock::Splitter::Base as the only stock splitter" do
+    expect(config.spree.stock_splitters).to eq [Spree::Stock::Splitter::Base]
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -443,6 +443,7 @@ FactoryBot.define do
       shipment = order.reload.shipments.first
       if shipment.nil?
         shipping_method = create(:shipping_method_with, :shipping_fee, shipping_fee: shipping_fee)
+        shipping_method.distributors << order.distributor if order.distributor
         shipment = create(:shipment_with, :shipping_method, shipping_method: shipping_method, order: order)
       end
       shipment

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -427,7 +427,7 @@ FactoryBot.define do
       payment_method = create(:payment_method, calculator: payment_calculator)
       create(:payment, order: order, amount: order.total, payment_method: payment_method, state: 'checkout')
 
-      create(:shipping_method_with, :shipping_fee, shipping_fee: evaluator.shipping_fee)
+      create(:shipping_method_with, :shipping_fee, shipping_fee: evaluator.shipping_fee, distributors: [order.distributor])
 
       order.reload
       while !order.completed? do break unless order.next! end

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -78,7 +78,9 @@ describe ProxyOrder, type: :model do
   describe "resume" do
     let!(:payment_method) { create(:payment_method) }
     let!(:shipment) { create(:shipment) }
-    let(:order) { create(:order_with_totals, ship_address: create(:address), shipments: [shipment]) }
+    let(:order) { create(:order_with_totals, ship_address: create(:address),
+                                             shipments: [shipment],
+                                             distributor: shipment.shipping_method.distributors.first) }
     let(:proxy_order) { create(:proxy_order, order: order, canceled_at: Time.zone.now) }
     let(:order_cycle) { proxy_order.order_cycle }
 

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -36,9 +36,7 @@ describe Spree::Order do
       order.order_cycle = create(:simple_order_cycle,
                                  distributors: [order.distributor],
                                  variants: [order.line_items.first.variant, other_variant])
-      order.line_items = [order.line_items.first, create(:line_item,
-                                                         order: order,
-                                                         variant: other_variant)]
+      order.line_items << create(:line_item, order: order, variant: other_variant)
     end
 
     it "can progress to delivery" do

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe Spree::Order do
   describe 'event :restart_checkout' do
-    context 'when the order is not complete' do
-      let(:order) { create(:order) }
+    let(:order) { create(:order) }
 
+    context 'when the order is not complete' do
       before { allow(order).to receive(:completed?) { false } }
 
       it 'does transition to cart state' do
@@ -13,8 +13,6 @@ describe Spree::Order do
     end
 
     context 'when the order is complete' do
-      let(:order) { create(:order) }
-
       before { allow(order).to receive(:completed?) { true } }
 
       it 'raises' do
@@ -24,6 +22,34 @@ describe Spree::Order do
             /Cannot transition state via :restart_checkout/
           )
       end
+    end
+  end
+
+  describe "order with products with different shipping categories" do
+    let(:order) { create(:order_with_totals_and_distribution, ship_address: create(:address) ) }
+    let(:shipping_method) { create(:shipping_method, distributors: [order.distributor]) }
+    let(:other_shipping_category) { create(:shipping_category) }
+    let(:other_product) { create(:product, shipping_category: other_shipping_category ) }
+    let(:other_variant) { other_product.variants.first }
+
+    before do
+      order.order_cycle = create(:simple_order_cycle,
+                                 distributors: [order.distributor],
+                                 variants: [order.line_items.first.variant, other_variant])
+      order.line_items = [order.line_items.first, create(:line_item,
+                                                         order: order,
+                                                         variant: other_variant)]
+    end
+
+    it "can progress to delivery" do
+      shipping_method.shipping_categories << other_shipping_category
+
+      # If the shipping category package splitter is enabled,
+      #   an order with products with two shipping categories will be split into two shipments
+      #   and the spec will fail with a unique constraint error on index_spree_shipments_on_order_id
+      order.next
+      order.next
+      expect(order.state).to eq "delivery"
     end
   end
 end

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -8,7 +8,7 @@ describe OrderFactory do
   let(:shop) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle) }
   let!(:other_shipping_method_a) { create(:shipping_method) }
-  let!(:shipping_method) { create(:shipping_method) }
+  let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
   let!(:other_shipping_method_b) { create(:shipping_method) }
   let(:payment_method) { create(:payment_method) }
   let(:ship_address) { create(:address) }


### PR DESCRIPTION
#### What? Why?
After #3594, I found that if you try to checkout with two products with different shipping categories, the order would be split into multiple shipments and checkout would break with an error on the DB constraint index_spree_shipments_on_order_id, unique: true.

The solution is to override default spree config and set one single splitter called Base that never splits the orders.

In spree, orders are always split by stock location and optionally by shipping categories and/or on_hand/backordered items.

#### Context
We have one single stock location and one shipment per order to significantly simplify the solution to manage stock at variant overrides level: we dont have stock items for variant overrides, just a single count_on_hand in the variant_overrides table.

#### What should we test?
Create an order with products with different shipping categories, you should be able to checkout.

#### How is this related to the Spree upgrade?
Part of testing v2 with live data.

#### Spree bug and PR to fix
In the investigation that led to this PR I found a bug in the Spree adaptation of package_factory that was breaking all splitters except the Base splitter. But because this PR changes OFN to use only the Base splitter, we don't need to fix that bug right now.
Anyway, there's a new Spree PR that fixes this splitters problem (which is not necessary) but also fixes a problem in shipment.to_package that is required for OFN (#3607).
The Spree PR: https://github.com/openfoodfoundation/spree/pull/39
