### PR TITLE
[Subscriptions] (v1) Fix assertions in specs for OrderSyncer

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -142,8 +142,8 @@ FactoryBot.define do
     shop { create :enterprise }
     schedule { create(:schedule, order_cycles: [create(:simple_order_cycle, coordinator: shop)]) }
     customer { create(:customer, enterprise: shop) }
-    bill_address { create(:address, firstname: "Walter", lastname: "Wolf", address1: "White") }
-    ship_address { create(:address, firstname: "Melanie", lastname: "Miller", address1: "Magenta") }
+    bill_address { create(:address, :randomized) }
+    ship_address { create(:address, :randomized) }
     payment_method { create(:payment_method, distributors: [shop]) }
     shipping_method { create(:shipping_method, distributors: [shop]) }
     begins_at { 1.month.ago }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -142,8 +142,8 @@ FactoryBot.define do
     shop { create :enterprise }
     schedule { create(:schedule, order_cycles: [create(:simple_order_cycle, coordinator: shop)]) }
     customer { create(:customer, enterprise: shop) }
-    bill_address { create(:address) }
-    ship_address { create(:address) }
+    bill_address { create(:address, firstname: "Walter", lastname: "Wolf", address1: "White") }
+    ship_address { create(:address, firstname: "Melanie", lastname: "Miller", address1: "Magenta") }
     payment_method { create(:payment_method, distributors: [shop]) }
     shipping_method { create(:shipping_method, distributors: [shop]) }
     begins_at { 1.month.ago }

--- a/spec/factories/address_factory.rb
+++ b/spec/factories/address_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.modify do
+  factory :address do
+    trait :randomized do
+      firstname { Faker::Name.first_name }
+      lastname { Faker::Name.last_name }
+      address1 { Faker::Address.street_address }
+      address2 nil
+      phone { Faker::PhoneNumber.phone_number }
+    end
+  end
+end

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -1,3 +1,5 @@
+require "spec_helper"
+
 describe OrderSyncer do
   describe "updating the shipping method" do
     let(:subscription) { create(:subscription, with_items: true, with_proxy_orders: true) }

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -126,9 +126,8 @@ describe OrderSyncer do
   end
 
   describe "changing the billing address" do
-    let!(:distributor_address) { create(:address, address1: "Distributor Address") }
+    let!(:distributor_address) { create(:address, :randomized) }
     let!(:distributor) { create(:distributor_enterprise, address: distributor_address) }
-    let!(:shipping_method) { create(:shipping_method, distributors: [distributor]) }
     let(:subscription) do
       create(:subscription, shop: distributor, shipping_method: shipping_method, with_items: true,
                             with_proxy_orders: true)
@@ -225,21 +224,16 @@ describe OrderSyncer do
   end
 
   describe "changing the ship address" do
-    let!(:distributor_address) { create(:address, address1: "Distributor Address") }
+    let!(:distributor_address) { create(:address, :randomized) }
     let!(:distributor) { create(:distributor_enterprise, address: distributor_address) }
-    let!(:shipping_method) do
-      create(:shipping_method, distributors: [distributor], require_ship_address: true)
-    end
-
-    let(:subscription) do
+    let!(:subscription) do
       create(:subscription, shop: distributor, shipping_method: shipping_method, with_items: true,
                             with_proxy_orders: true)
     end
-
-    let(:shipping_method) { subscription.shipping_method }
     let!(:order) { subscription.proxy_orders.first.initialise_order! }
     let!(:bill_address_attrs) { subscription.bill_address.attributes }
     let!(:ship_address_attrs) { subscription.ship_address.attributes }
+
     let(:params) { { ship_address_attributes: { id: ship_address_attrs["id"], firstname: "Ship", address1: "123 abc st", phone: "1123581321" } } }
     let(:syncer) { OrderSyncer.new(subscription) }
 


### PR DESCRIPTION
#### What? Why?

Relates to #2696 

There are some wrong assertions in specs for `OrderSyncer`, caused by addresses (subscription shipping, subscription billing, distributor) having the same attributes.

This shows how it can be dangerous to use static data in factories.

#### What should we test?

This only affects specs. No manual tests are needed.

#### Release notes

- Fix setup data and assertions for `OrderSyncer` specs.

Changelog Category: Fixed

#### How is this related to the Spree upgrade?

This is in preparation for some fixes for subscriptions in v2. This is best to merge in v1 so we can be sure that the behaviour that we wish to achieve in v2 is indeed the behaviour in v1.