### PR TITLE
[Spree Upgrade] Finish up deleting account invoices

### DIFF
--- a/app/assets/javascripts/admin/enterprises/directives/monthly_pricing_description.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/directives/monthly_pricing_description.js.coffee
@@ -1,8 +1,0 @@
-angular.module("admin.enterprises").directive "monthlyPricingDescription", (monthlyBillDescription) ->
-  restrict: 'E'
-  scope:
-    joiner: "@"
-  template: "<span ng-bind-html='billDescription'></span>"
-  link: (scope, element, attrs) ->
-    joiners = { comma: ", ", newline: "<br>" }
-    scope.billDescription = monthlyBillDescription.replace("{joiner}", joiners[scope.joiner])

--- a/app/assets/javascripts/templates/admin/panels/enterprise_package.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/enterprise_package.html.haml
@@ -20,10 +20,6 @@
           {{ 'js.admin.panels.enterprise_package.hub_shop' | t }}
 
         %p
-          %strong
-            %monthly-pricing-description{ joiner: "comma" }
-
-        %p
           {{ 'js.admin.panels.enterprise_package.hub_shop_text1' | t }}
 
         %p
@@ -67,10 +63,6 @@
           {{ 'js.admin.panels.enterprise_package.producer_shop' | t }}
 
         %p
-          %strong
-            %monthly-pricing-description{ joiner: "comma" }
-
-        %p
           {{ 'js.admin.panels.enterprise_package.producer_shop_text1' | t }}
 
         %p
@@ -79,10 +71,6 @@
       .info{ ng: { switch: { when: "any" } } }
         %h3
           {{ 'js.admin.panels.enterprise_package.producer_hub' | t }}
-
-        %p
-          %strong
-            %monthly-pricing-description{ joiner: "comma" }
 
         %p
           {{ 'js.admin.panels.enterprise_package.producer_hub_text1' | t }}
@@ -121,8 +109,6 @@
             {{ 'js.admin.panels.enterprise_package.hub_shop' | t }}
           %p
             {{ 'js.admin.panels.enterprise_package.sell_produce_others' | t }}
-        .bottom
-          %monthly-pricing-description{ joiner: "newline" }
 
     %div{ ng: { switch: { when: "true" } } }
       %a.button.selector.producer-profile{ ng: { click: "enterprise.owned && (enterprise.sells='none')", class: "{selected: enterprise.sells=='none', disabled: !enterprise.owned}" } }
@@ -139,8 +125,6 @@
             {{ 'js.admin.panels.enterprise_package.producer_shop' | t }}
           %p
             {{ 'js.admin.panels.enterprise_package.sell_own_produce' | t }}
-        .bottom
-          %monthly-pricing-description{ joiner: "newline" }
 
       %a.button.selector.producer-hub{ ng: { click: "enterprise.owned && (enterprise.sells='any')", class: "{selected: enterprise.sells=='any', disabled: !enterprise.owned}" } }
         .top
@@ -148,8 +132,6 @@
             {{ 'js.admin.panels.enterprise_package.producer_hub' | t }}
           %p
             {{ 'js.admin.panels.enterprise_package.sell_both' | t }}
-        .bottom
-          %monthly-pricing-description{ joiner: "newline" }
 
     %a.button.update.fullwidth{ ng: { show: "enterprise.owned", class: "{disabled: saved() && !saving, saving: saving}", click: "save()" } }
       %span{ ng: {hide: "saved() || saving" } }

--- a/app/views/admin/enterprises/_change_type_form.html.haml
+++ b/app/views/admin/enterprises/_change_type_form.html.haml
@@ -22,9 +22,6 @@
             .top
               %h3= t('.producer_shop')
               %p= t('.sell_your_produce')
-            .bottom
-              %monthly-pricing-description{ joiner: "newline" }
-
           %p.description
             = t('.producer_shop_description_text')
             %br
@@ -36,9 +33,6 @@
             .top
               %h3= t('.producer_hub')
               %p= t('.producer_hub_text')
-            .bottom
-              %monthly-pricing-description{ joiner: "newline" }
-
           %p.description
             = t('.producer_hub_description_text')
 
@@ -59,8 +53,6 @@
             .top
               %h3= t('.hub_shop')
               %p= t('.hub_shop_text')
-            .bottom
-              %monthly-pricing-description{ joiner: "newline" }
           %p.description
             = t('.hub_shop_description_text')
         .two.columns.omega

--- a/db/migrate/20190315224423_drop_account_invoices_and_billable_periods.rb
+++ b/db/migrate/20190315224423_drop_account_invoices_and_billable_periods.rb
@@ -1,0 +1,6 @@
+class DropAccountInvoicesAndBillablePeriods < ActiveRecord::Migration
+  def up
+    drop_table :billable_periods
+    drop_table :account_invoices
+  end
+end

--- a/db/migrate/20190320111312_delete_obsolete_pending_jobs.rb
+++ b/db/migrate/20190320111312_delete_obsolete_pending_jobs.rb
@@ -1,0 +1,9 @@
+class DeleteObsoletePendingJobs < ActiveRecord::Migration
+  def up
+    Delayed::Job.all.each do |job|
+      job.delete if job.name == "FinalizeAccountInvoices" ||
+                    job.name == "UpdateAccountInvoices" ||
+                    job.name == "UpdateBillablePeriods"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190313142540) do
-
-  create_table "account_invoices", :force => true do |t|
-    t.integer  "user_id",    :null => false
-    t.integer  "order_id"
-    t.integer  "year",       :null => false
-    t.integer  "month",      :null => false
-    t.datetime "issued_at"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  add_index "account_invoices", ["order_id"], :name => "index_account_invoices_on_order_id"
-  add_index "account_invoices", ["user_id"], :name => "index_account_invoices_on_user_id"
+ActiveRecord::Schema.define(:version => 20190315224423) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -36,22 +23,6 @@ ActiveRecord::Schema.define(:version => 20190313142540) do
 
   add_index "adjustment_metadata", ["adjustment_id"], :name => "index_adjustment_metadata_on_adjustment_id"
   add_index "adjustment_metadata", ["enterprise_id"], :name => "index_adjustment_metadata_on_enterprise_id"
-
-  create_table "billable_periods", :force => true do |t|
-    t.integer  "enterprise_id"
-    t.integer  "owner_id"
-    t.datetime "begins_at"
-    t.datetime "ends_at"
-    t.string   "sells"
-    t.boolean  "trial",              :default => false
-    t.decimal  "turnover",           :default => 0.0
-    t.datetime "deleted_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "account_invoice_id",                    :null => false
-  end
-
-  add_index "billable_periods", ["account_invoice_id"], :name => "index_billable_periods_on_account_invoice_id"
 
   create_table "column_preferences", :force => true do |t|
     t.integer  "user_id",     :null => false
@@ -1263,15 +1234,8 @@ ActiveRecord::Schema.define(:version => 20190313142540) do
 
   add_index "versions", ["item_type", "item_id"], :name => "index_versions_on_item_type_and_item_id"
 
-  add_foreign_key "account_invoices", "spree_orders", name: "account_invoices_order_id_fk", column: "order_id"
-  add_foreign_key "account_invoices", "spree_users", name: "account_invoices_user_id_fk", column: "user_id"
-
   add_foreign_key "adjustment_metadata", "enterprises", name: "adjustment_metadata_enterprise_id_fk"
   add_foreign_key "adjustment_metadata", "spree_adjustments", name: "adjustment_metadata_adjustment_id_fk", column: "adjustment_id", dependent: :delete
-
-  add_foreign_key "billable_periods", "account_invoices", name: "billable_periods_account_invoice_id_fk"
-  add_foreign_key "billable_periods", "enterprises", name: "bill_items_enterprise_id_fk"
-  add_foreign_key "billable_periods", "spree_users", name: "bill_items_owner_id_fk", column: "owner_id"
 
   add_foreign_key "coordinator_fees", "enterprise_fees", name: "coordinator_fees_enterprise_fee_id_fk"
   add_foreign_key "coordinator_fees", "order_cycles", name: "coordinator_fees_order_cycle_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190315224423) do
+ActiveRecord::Schema.define(:version => 20190320111312) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"


### PR DESCRIPTION
#### What? Why?
Closes #3533

Additionally this PR:
- cleans up monthly bill description that was left from #3321
- drops account invoices and billable periods tables, for some reason not dropped in #3321

#### What should we test?
Tests are required for the "monthly bill description" removal.
We need to test all the pages where the package selection appears:
- the welcome page that enterprises see after registration
- the drop down menu "change package" in the single enterprise dashboard
- the non-admin list of enterprises
