### PR TITLE
[Spree Upgrade] Add on_hand and on_demand to the variants create and edit pages

### DIFF
--- a/app/controllers/spree/admin/variants_controller_decorator.rb
+++ b/app/controllers/spree/admin/variants_controller_decorator.rb
@@ -6,9 +6,13 @@ Spree::Admin::VariantsController.class_eval do
   def create
     on_demand = params[:variant].delete(:on_demand)
     on_hand = params[:variant].delete(:on_hand)
+
     super
-    @object.on_demand = on_demand if @object.present?
-    @object.on_hand = on_hand.to_i if @object.present?
+
+    if @object.present? && @object.valid?
+      @object.on_demand = on_demand if on_demand.present?
+      @object.on_hand = on_hand.to_i if on_hand.present?
+    end
   end
 
   def search

--- a/app/controllers/spree/admin/variants_controller_decorator.rb
+++ b/app/controllers/spree/admin/variants_controller_decorator.rb
@@ -3,6 +3,14 @@ require 'open_food_network/scope_variants_for_search'
 Spree::Admin::VariantsController.class_eval do
   helper 'spree/products'
 
+  def create
+    on_demand = params[:variant].delete(:on_demand)
+    on_hand = params[:variant].delete(:on_hand)
+    super
+    @object.on_demand = on_demand if @object.present?
+    @object.on_hand = on_hand.to_i if @object.present?
+  end
+
   def search
     scoper = OpenFoodNetwork::ScopeVariantsForSearch.new(params)
     @variants = scoper.search

--- a/app/overrides/spree/admin/shared/_product_tabs/add_distributions.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_distributions.html.haml.deface
@@ -1,5 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_tabs']"
-
-- klass = current == 'Product Distributions' ? 'active' : ''
-%li{:class => klass}
-  = link_to_with_icon 'icon-tasks', t('admin.products.product_distributions'), product_distributions_admin_product_url(@product)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_group_buy.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_group_buy.html.haml.deface
@@ -1,5 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_tabs']"
-
-- klass = current == 'Group Buy Options' ? 'active' : ''
-%li{:class => klass}
-  = link_to_with_icon 'icon-tasks', t('admin.products.group_buy_options'), group_buy_options_admin_product_url(@product)

--- a/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_seo.html.haml.deface
@@ -1,5 +1,0 @@
-/ insert_bottom "[data-hook='admin_product_tabs']"
-
-- klass = current == t(:Search) ? 'active' : ''
-%li{:class => klass}
-  = link_to_with_icon 'icon-tasks', t(:Search), seo_admin_product_url(@product)

--- a/app/overrides/spree/admin/variants/_form/add_stock_management.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_stock_management.html.haml.deface
@@ -1,11 +1,11 @@
 / insert_bottom "[data-hook='admin_variant_form_fields']"
 
 - if Spree::Config[:track_inventory_levels]
-  .field.checkbox{ "data-hook" => "on_hand" }
+  .field.checkbox
     %label
       = f.check_box :on_demand
       = t(:on_demand)
-  .field{ "data-hook" => "on_hand" }
+  .field
     = f.label :on_hand, t(:on_hand)
     .fullwidth
       = f.text_field :on_hand

--- a/app/overrides/spree/admin/variants/_form/add_stock_management.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_stock_management.html.haml.deface
@@ -1,0 +1,11 @@
+/ insert_bottom "[data-hook='admin_variant_form_fields']"
+
+- if Spree::Config[:track_inventory_levels]
+  .field.checkbox{ "data-hook" => "on_hand" }
+    %label
+      = f.check_box :on_demand
+      = t(:on_demand)
+  .field{ "data-hook" => "on_hand" }
+    = f.label :on_hand, t(:on_hand)
+    .fullwidth
+      = f.text_field :on_hand

--- a/app/overrides/spree/admin/variants/_form/on_demand_script.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/on_demand_script.html.haml.deface
@@ -6,23 +6,28 @@
         var on_demand = $('input#variant_on_demand');
         var on_hand = $('input#variant_on_hand');
 
-        on_hand.attr('disabled', on_demand.attr('checked'));
+        disableOnHandIfOnDemand = function() {
+            on_demand_checked = on_demand.attr('checked')
+            if ( on_demand_checked == undefined )
+                on_demand_checked = false;
+
+            on_hand.attr('disabled', on_demand_checked);
+            if(on_demand_checked) {
+              on_hand.attr('data-stock', on_hand.val());
+              on_hand.val("Infinity");
+            }
+        }
+
+        disableOnHandIfOnDemand();
 
         on_demand.change(function(){
-
-            on_hand.attr('disabled', this.checked);
-
-            if(this.checked) {
-                on_hand.attr('data-stock', on_hand.val());
-                on_hand.val("Infinity");
-            } else {
+            disableOnHandIfOnDemand();
+            if(!this.checked) {
                 if(on_hand.attr('data-stock') !== undefined) {
                     on_hand.val(on_hand.attr('data-stock'));
                 } else {
                     on_hand.val("0");
                 }
             }
-
         });
-
     });

--- a/app/views/spree/admin/shared/_product_tabs.html.haml
+++ b/app/views/spree/admin/shared/_product_tabs.html.haml
@@ -1,0 +1,36 @@
+= content_for :page_title do
+  = Spree.t(:editing_product)
+  = "\"#{@product.name}\""
+
+= content_for :sidebar_title do
+  %span.sku
+    = @product.sku
+
+= content_for :sidebar do
+  %nav.menu
+    %ul
+      - if can?(:admin, Spree::Product)
+        - klass = current == 'Product Details' ? 'active' : ''
+        %li{:class => klass}
+          = link_to_with_icon 'icon-edit', Spree.t(:product_details), edit_admin_product_url(@product)
+      - if can?(:admin, Spree::Image)
+        - klass = current == 'Images' ? 'active' : ''
+        %li{:class => klass}
+          = link_to_with_icon 'icon-picture', Spree.t(:images), admin_product_images_url(@product)
+      - if can?(:admin, Spree::Variant)
+        - klass = current == 'Variants' ? 'active' : ''
+        %li{:class => klass}
+          = link_to_with_icon 'icon-th-large', Spree.t(:variants),  admin_product_variants_url(@product)
+      - if can?(:admin, Spree::ProductProperty)
+        - klass = current == 'Product Properties' ? 'active' : ''
+        %li{:class => klass}
+          = link_to_with_icon 'icon-tasks', Spree.t(:product_properties), admin_product_product_properties_url(@product)
+      - klass = current == 'Product Distributions' ? 'active' : ''
+      %li{:class => klass}
+        = link_to_with_icon 'icon-tasks', t('admin.products.product_distributions'), product_distributions_admin_product_url(@product)
+      - klass = current == 'Group Buy Options' ? 'active' : ''
+      %li{:class => klass}
+        = link_to_with_icon 'icon-tasks', t('admin.products.group_buy_options'), group_buy_options_admin_product_url(@product)
+      - klass = current == t(:Search) ? 'active' : ''
+      %li{:class => klass}
+        = link_to_with_icon 'icon-tasks', t(:Search), seo_admin_product_url(@product)


### PR DESCRIPTION
#### What? Why?

Closes #3573 

##### shared/_product_tabs
Here I de-deface shared/_product_tabs and remove the new Stock Management option from it.

##### Variants create/edit Page
In spree v2, on_hand and on_demand were removed from the variants edit page (on_hand [here](https://github.com/openfoodfoundation/spree/commit/64d5843b83b5f4f94d78fe2327f44aa1c7679f13#diff-4cc0ba3139a87f563a1faedee946fe6c) and on_demand [here](https://github.com/openfoodfoundation/spree/commit/40665ab244277138801ee278f663fd2f6da7da22#diff-4cc0ba3139a87f563a1faedee946fe6c)).

These fields were moved to a new submenu/page "Stock Management" but because this new page includes the complexity of stock management, it looks at lot easier (for both the dev and the user!) to just re-add these two fields in the variants edit page. Maybe when/if we make OFN work with multiple stock locations we can move OFN to use the stock management page.

This variants edit page is obviously needing a de-deface. But with the de-deface it will also need more specs and a new angular controller to do what's currently being done in  on_demand_script.html.haml.deface for example. It will take some effort so I created a new tech debt issue for it #3615

Meanwhile, in this PR, I added a new deface override to add the two fields back to the page and adapted on_demand_script.html.haml.deface so that it works.
In terms of improvement, I didn't want to waste time improving the overrides so I decided to write feature specs on top of the page that will be valid after #3615 I added the specs in master #3617 these specs pass in master and pass in v2 with this PR (I tested locally and we can validate this when #3617 is merged into 2-0-stable).

#### What should we test?
The variants edit page should work as normal and the user should be able to manage on_hand and on_demand. These 2 fields should play well with changing the same values on the bulk edit page.
I have tested this locally and it's working correctly.