### PR TITLE
Support international decimals in weight calculator

### DIFF
--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -1,7 +1,11 @@
+require 'spree/localized_number'
+
 module Calculator
   class Weight < Spree::Calculator
+    extend Spree::LocalizedNumber
     preference :per_kg, :decimal, default: 0.0
     attr_accessible :preferred_per_kg
+    localize_number :preferred_per_kg
 
     def self.description
       I18n.t('spree.weight')

--- a/spec/lib/spree/localized_number_spec.rb
+++ b/spec/lib/spree/localized_number_spec.rb
@@ -1,7 +1,19 @@
 require 'spec_helper'
 
 describe Spree::LocalizedNumber do
-  context ".parse" do
+  describe ".parse" do
+    context "with point separator" do
+      it "captures the proper amount for a formatted string" do
+        expect(described_class.parse('5.67')).to eql 5.67
+      end
+    end
+
+    context "with comma separator" do
+      it "captures the proper amount for a formatted string" do
+        expect(described_class.parse('5,67')).to eql 5.67
+      end
+    end
+
     context "with decimal point" do
       it "captures the proper amount for a formatted string" do
         expect(described_class.parse('1,599.99')).to eql 1599.99
@@ -19,9 +31,15 @@ describe Spree::LocalizedNumber do
         expect(described_class.parse(1599.99)).to eql 1599.99
       end
     end
+
+    context "with a string having 2 digits between separators" do
+      it "ignores the left separator" do
+        expect(described_class.parse('1,59.99')).to eql 159.99
+      end
+    end
   end
 
-  context ".valid_localizable_number?" do
+  describe ".valid_localizable_number?" do
     context "with a properly formatted string" do
       it "returns true" do
         expect(described_class.valid_localizable_number?('1.599,99')).to eql true

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Calculator::Weight do
+  it_behaves_like "a model using the LocalizedNumber module", [:preferred_per_kg]
+
   it "computes shipping cost for an order by total weight" do
     variant1 = build(:variant, weight: 10)
     variant2 = build(:variant, weight: 20)

--- a/spec/support/localized_number_helper.rb
+++ b/spec/support/localized_number_helper.rb
@@ -1,10 +1,6 @@
 shared_examples "a model using the LocalizedNumber module" do |attributes|
   before do
-    Spree::Config[:enable_localized_number?] = true
-  end
-
-  after do
-    Spree::Config[:enable_localized_number?] = false
+    allow(Spree::Config).to receive(:enable_localized_number?).and_return true
   end
 
   attributes.each do |attribute|


### PR DESCRIPTION

#### What? Why?

Closes #3335.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

A previous pull request added support for flexible decimal characters
when editing money amounts.
https://github.com/openfoodfoundation/openfoodnetwork/pull/1831

This pull request applies the same principle to the weight calculator
which was missed in the previous pull request.


#### What should we test?
<!-- List which features should be tested and how. -->

1. Go to admin settings and make sure that "Use the international thousand/decimal separator logic" is enabled.
1. Go to the enterprise fees of an enterprise.
2. Create a fee with "Weight (per kg)" calculator.
3. Update the fee with `,` as decimal separator, for example `1,23`.
4. Save and make sure that the price is correct, for example `1.23`. It should not be `0` or `1.00`.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: The international decimal separator logic can now be used for the weight calculator as well.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

