### PR TITLE
Add spec to cover editing on_hand and on_demand values in the variants edit page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2900,7 +2900,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     shipping_methods: "Shipping Methods"
 
     shipping_categories: "Shipping Categories"
-    new_shipping_category: "NEWEW Shipping Categories"
+    new_shipping_category: "New Shipping Category"
     back_to_shipping_categories: "Back To Shipping Categories"
 
     analytics_trackers: "Analytics Trackers"


### PR DESCRIPTION
#### What? Why?

This PR adds a spec to cover editing on_hand and on_demand in the variants edit page (from what I have seen so far, this was the most significant feature the build was not covering and so we only detected now that it was broken in v2 #3573).

Additionally and unrelated, I am fixing a typo in the en.yml file (new_shipping_category).

#### What should we test?
The build should be green which means the new test is passing. It's testing an existing feature.

This spec is also passing in the v2 PR that fixes this feature in v2: #3613

#### Release notes
Changelog Category: Added
Improved test coverage in the edit variants page.

#### How is this related to the Spree upgrade?
This was detected as part of the spree upgrade and will be fixed in v2 as part of #3613