### PR TITLE
Fix flaky spec by waiting for modal animation

### DIFF
--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -184,6 +184,7 @@ feature 'Customers' do
         it 'updates the existing billing address' do
           expect(page).to have_content 'BILLING ADDRESS'
           first('#bill-address-link').click
+          wait_for_modal_fade_in
 
           expect(page).to have_content 'Edit Billing Address'
           expect(page).to have_select2 'country_id', selected: 'Australia'
@@ -211,6 +212,7 @@ feature 'Customers' do
           expect(page).to have_content 'SHIPPING ADDRESS'
 
           first('#ship-address-link').click
+          wait_for_modal_fade_in
           expect(page).to have_content 'Edit Shipping Address'
 
           fill_in 'firstname', with: "First"
@@ -234,6 +236,15 @@ feature 'Customers' do
           expect(ship_address.address1).to eq 'New Address1'
           expect(ship_address.phone).to eq '12345678'
           expect(ship_address.city).to eq 'Melbourne'
+        end
+
+        # Modal animations are defined in:
+        # app/assets/javascripts/admin/utils/services/dialog_defaults.js.coffee
+        #
+        # Without waiting, `fill_in` can fail randomly:
+        # https://github.com/teamcapybara/capybara/issues/1890
+        def wait_for_modal_fade_in(time = 0.4)
+          sleep time
         end
       end
 


### PR DESCRIPTION

#### What? Why?

Closes #3520

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Bootstrap's fading in of the customer edit modal and the webdriver's sendKeys method returning too early lead to a race condition: https://github.com/teamcapybara/capybara/issues/1890

This pull request introduces waiting for the modal. If we have the same problem in other specs, we should share the waiting method.


#### What should we test?
<!-- List which features should be tested and how. -->

No tests.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Part of Spree upgrade.