### PR TITLE
Add spec for registration link on Spree pages

### DIFF
--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -20,17 +20,6 @@ feature "full-page cart", js: true do
       set_order order
     end
 
-    it "shows the right registration link" do
-      # We have an issue with the registration link within Spree controllers.
-      # The `registration_path` helper resolves to `/signup` due to
-      # spree_auth_device > config > routes.rb. This spec verifies that we have
-      # a solution to that problem.
-      add_product_to_cart order, product_with_fee
-      visit spree.cart_path
-      register_page = window_opened_by { click_link "Register here" }
-      within_window(register_page) { expect(page).to have_content "Welcome" }
-    end
-
     describe "product description" do
       it "does not link to the product page" do
         add_product_to_cart order, product_with_fee, quantity: 2

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -20,6 +20,17 @@ feature "full-page cart", js: true do
       set_order order
     end
 
+    it "shows the right registration link" do
+      # We have an issue with the registration link within Spree controllers.
+      # The `registration_path` helper resolves to `/signup` due to
+      # spree_auth_device > config > routes.rb. This spec verifies that we have
+      # a solution to that problem.
+      add_product_to_cart order, product_with_fee
+      visit spree.cart_path
+      register_page = window_opened_by { click_link "Register here" }
+      within_window(register_page) { expect(page).to have_content "Welcome" }
+    end
+
     describe "product description" do
       it "does not link to the product page" do
         add_product_to_cart order, product_with_fee, quantity: 2


### PR DESCRIPTION
#### What? Why?

Closes #2873

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The `registration_path` helper resolves to `/signup` in Spree
controllers due to spree_auth_device > config > routes.rb.
We worked around that in:
https://github.com/openfoodfoundation/openfoodnetwork/pull/3174

Here we add a spec for this so that we can test more easily if we can
remove that workaround or detect it's accidental removal.



#### What should we test?
<!-- List which features should be tested and how. -->

No test, spec changes only.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added: Added a new integration test to ensure that the registration link works on all pages.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

