### PR TITLE
Remove usage of ProductDistribution which is dead

### DIFF
--- a/lib/tasks/sample_data/product_factory.rb
+++ b/lib/tasks/sample_data/product_factory.rb
@@ -76,18 +76,6 @@ class ProductFactory
       unit_value: 1,
       on_demand: true
     )
-    create_product_with_distribution(params, hash[:supplier])
-  end
-
-  def create_product_with_distribution(params, supplier)
-    product = Spree::Product.create_with(params).find_or_create_by_name!(params[:name])
-
-    distribution_params = {
-      distributor_id: params[:distributor].id,
-      enterprise_fee_id: supplier.enterprise_fees.first.id
-    }
-    ProductDistribution.create_with(distribution_params).find_or_create_by_product_id!(product.id)
-
-    product
+    Spree::Product.create_with(params).find_or_create_by_name!(params[:name])
   end
 end


### PR DESCRIPTION

#### What? Why?

Sample data was failing since:
https://github.com/openfoodfoundation/openfoodnetwork/pull/3570

I need sample data for local testing and the fix was really simple: :fire: 

#### What should we test?
<!-- List which features should be tested and how. -->

I tested running the sample data rake task. Nothing should be affected. We could test the sample data again but it looks good at a first glance and I don't think we need to do that.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

I wouldn't mention this separately. https://github.com/openfoodfoundation/openfoodnetwork/pull/3570 has release notes for this already.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

