### PR TITLE
[Proof of Concept] Different bill and ship addresses for subscriptions in specs

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -142,8 +142,8 @@ FactoryBot.define do
     shop { create :enterprise }
     schedule { create(:schedule, order_cycles: [create(:simple_order_cycle, coordinator: shop)]) }
     customer { create(:customer, enterprise: shop) }
-    bill_address { create(:address) }
-    ship_address { create(:address) }
+    bill_address { create(:address, firstname: "Walter", lastname: "Wolf", address1: "White") }
+    ship_address { create(:address, firstname: "Melanie", lastname: "Miller", address1: "Magenta") }
     payment_method { create(:payment_method, distributors: [shop]) }
     shipping_method { create(:shipping_method, distributors: [shop]) }
     begins_at { 1.month.ago }


### PR DESCRIPTION
Different bill and ship addresses for subscriptions in specs

#### What? Why?

Relates to #3605 

This PR is to check if there are other specs aside from those in `OrderSyncer` that would fail if we make bill and ship addresses in sample subscriptions different from each other.

This forces us to write correct assertions when adding specs affected by subscription addresses.

See this related review comment: https://github.com/openfoodfoundation/openfoodnetwork/pull/3605#discussion_r265896370