### PR TITLE
[Spree Upgrade] Update spree revision to include last package_factory fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: f55722b38db7e706a8521c9091a0e00119bb4d20
+  revision: 060d0a5d8b31f68990fa792e0e88910c742d9a96
   branch: 2-0-4-stable
   specs:
     spree (2.0.4)

--- a/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -25,7 +25,9 @@ describe Spree::Api::ShipmentsController, type: :controller do
     let(:error_message) { "broken shipments creation" }
 
     before do
-      order.update_attribute(:ship_address_id, order_ship_address.id)
+      order.update_attribute :ship_address_id, order_ship_address.id
+      order.update_attribute :distributor, variant.product.supplier
+      shipment.shipping_method.distributors << variant.product.supplier
     end
 
     sign_in_as_admin!
@@ -56,6 +58,7 @@ describe Spree::Api::ShipmentsController, type: :controller do
       it 'updates existing shipment with variant override if an VO is sent' do
         hub = create(:distributor_enterprise)
         order.update_attribute(:distributor, hub)
+        shipment.shipping_method.distributors << hub
         variant_override = create(:variant_override, hub: hub, variant: variant)
 
         spree_post :create, params


### PR DESCRIPTION
#### What? Why?

Closes #3607

ok, I figured this one out. With the new spree revision, the package shipping methods get filtered by distributor, so to get a green green build, we need to adapt the factories and specs to always set the order distributor on the shipping methods used in the test. This was already partially done in #3604 

#### What should we test?
For a green build, this PR requires #3604 and also #3667 (due to duplicate order-charges html id).

We need to verify issue #3607 is fixed.

#### Dependencies
This PR can only be tested and merged after 3604 and 3667 but can be reviewed now.