### PR TITLE
Fixed producer profile translation bug

### DIFF
--- a/app/views/admin/enterprises/welcome.html.haml
+++ b/app/views/admin/enterprises/welcome.html.haml
@@ -4,7 +4,8 @@
     %p
       = t('.welcome_text')
       %strong
-        = "#{"producer " if @enterprise.is_primary_producer}profile"
+      - profile_translation_key = @enterprise.is_primary_producer ? '.producer_profile' : '.profile'
+      = t(profile_translation_key)
 
     %section
       %h2= t('.next_step')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -915,6 +915,8 @@ en:
         welcome_text: You have successfully created a
         next_step: Next step
         choose_starting_point: 'Choose your package:'
+        profile: 'Profile'
+        producer_profile: 'Producer Profile'
       invite_manager:
         user_already_exists: "User already exists"
         error: "Something went wrong"


### PR DESCRIPTION
#### What? Why?
 Untranslated "producer profile" in pack selection page (front end) 
Closes #[#3162]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Producer profile was hard coded as a string in English. I put the correct key-value pairs in the english file and then made t function call on them with respect to their status as primary producer. 


#### What should we test?
<!-- List which features should be tested and how. -->
Once transifex does it magic. It will be important to check if the correct key is called by the t function for non-english websites.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
String interpolation cannot be relied upon.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
 Fixed 
