### PR TITLE
Add missing translation key for order shipment state canceled

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2599,6 +2599,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           pending: "pending"
           ready: "ready"
           shipped: "shipped"
+          canceled: "cancelled"
         payment_states:
           balance_due: "balance due"
           completed: "completed"


### PR DESCRIPTION
#### What? Why?

Closes #3625

Add missing translation key. 

#### What should we test?
Adding it to master so it can be translated but it will only be testable when merged to v2.
See issue for details of the test.

#### Release notes
Changelog Category: Added
Add missing translation key.
