### PR TITLE
[Spree Upgrade] Fix "back to list" button overlap and remove configurations menu from payments methods list

### DIFF
--- a/app/assets/stylesheets/admin/components/page_actions.css.scss
+++ b/app/assets/stylesheets/admin/components/page_actions.css.scss
@@ -1,0 +1,10 @@
+.page-actions {
+  li {
+    margin-top: 1px;
+    margin-bottom: 1px;
+  }
+
+  a {
+    display: inline-block;
+  }
+}

--- a/app/overrides/spree/admin/payment_methods/index/remove_configuration_sidebar.deface
+++ b/app/overrides/spree/admin/payment_methods/index/remove_configuration_sidebar.deface
@@ -1,1 +1,1 @@
-remove "code[erb-loud]:contains(\"render :partial => 'spree/admin/shared/configuration_menu'\")"
+remove "erb[loud]:contains(\"render :partial => 'spree/admin/shared/configuration_menu'\")"


### PR DESCRIPTION
#### What? Why?

Closes #3543

In this PR we fix the button layout  issue 3543 and we remove the configurations menu from the payments methods list.
@RachL I think you said it was good to have the configurations menu back but we can't because this page is also seen by non-admins coming from the enterprise management page (they would see the menu and all the links would take the user to the "no authorization" page). You can create an issue to detect if user is admin or not and show the menu if user is admin, OR show the menu if user is coming from the configurations and not from enterprise management.

#### What should we test?
- "back to list" buttons do not overlap.
- payment methods list doesnt show the configurations list.