### PR TITLE
3487,2786 [Spree Upgrade] Address spec failures for SubscriptionConfirmJob

### DIFF
--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -11,7 +11,10 @@ describe SubscriptionConfirmJob do
     let(:order_cycle2) { create(:simple_order_cycle, coordinator: shop, orders_close_at: 61.minutes.ago, updated_at: 1.day.ago) }
     let(:schedule) { create(:schedule, order_cycles: [order_cycle1, order_cycle2]) }
     let(:subscription) { create(:subscription, with_items: true, shop: shop, schedule: schedule) }
-    let!(:proxy_order) { create(:proxy_order, subscription: subscription, order_cycle: order_cycle1, placed_at: 5.minutes.ago) }
+    let!(:proxy_order) do
+      create(:proxy_order, subscription: subscription, order_cycle: order_cycle1,
+                           placed_at: 5.minutes.ago)
+    end
     let!(:order) { proxy_order.initialise_order! }
     let(:proxy_orders) { job.send(:proxy_orders) }
 

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -170,13 +170,16 @@ describe SubscriptionConfirmJob do
         end
 
         context "when payments are processed without error" do
+          around do |example|
+            performing_deliveries { example.run }
+          end
+
           before do
             expect(payment).to receive(:process!) { true }
             expect(payment).to receive(:completed?) { true }
           end
 
           it "sends only a subscription confirm email, no regular confirmation emails" do
-            ActionMailer::Base.perform_deliveries = true
             ActionMailer::Base.deliveries.clear
             expect{ job.send(:process!) }.to_not enqueue_job ConfirmOrderJob
             expect(job).to have_received(:send_confirm_email).once


### PR DESCRIPTION
#### What? Why?

Closes #3487
Relates to #2786 

This fixes order status advancement in the setup code for the specs.

#### What should we test?

This doesn't update app code. A green build is sufficient.