### PR TITLE
[Spree Upgrade] Fix Enterprise fee report specs

### DIFF
--- a/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
@@ -120,8 +120,9 @@ xfeature "enterprise fee summaries", js: true do
         it "generates file with data for all enterprises" do
           check I18n.t("filters.report_format_csv", scope: i18n_scope)
           click_on I18n.t("filters.generate_report", scope: i18n_scope)
-          expect(page.response_headers['Content-Type']).to eq "text/csv"
-          expect(page.body).to have_content(distributor.name)
+
+          expect(downloaded_filename).to include ".csv"
+          expect(downloaded_content).to have_content(distributor.name)
         end
       end
 
@@ -139,9 +140,11 @@ xfeature "enterprise fee summaries", js: true do
         it "generates file with data for the enterprise" do
           check I18n.t("filters.report_format_csv", scope: i18n_scope)
           click_on I18n.t("filters.generate_report", scope: i18n_scope)
-          expect(page.response_headers['Content-Type']).to eq "text/csv"
-          expect(page.body).to have_content(distributor.name)
-          expect(page.body).not_to have_content(other_distributor.name)
+
+          expect(downloaded_filename).to include ".csv"
+          csv_content = downloaded_content
+          expect(csv_content).to have_content(distributor.name)
+          expect(csv_content).not_to have_content(other_distributor.name)
         end
       end
     end
@@ -169,9 +172,11 @@ xfeature "enterprise fee summaries", js: true do
         select order_cycle.name, from: "report_order_cycle_ids"
         check I18n.t("filters.report_format_csv", scope: i18n_scope)
         click_on I18n.t("filters.generate_report", scope: i18n_scope)
-        expect(page.response_headers['Content-Type']).to eq "text/csv"
-        expect(page.body).to have_content(distributor.name)
-        expect(page.body).not_to have_content(second_distributor.name)
+
+        expect(downloaded_filename).to include ".csv"
+        csv_content = downloaded_content
+        expect(csv_content).to have_content(distributor.name)
+        expect(csv_content).not_to have_content(second_distributor.name)
       end
     end
   end

--- a/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
@@ -100,9 +100,7 @@ feature "enterprise fee summaries", js: true do
 
   describe "csv downloads" do
     around do |example|
-      clear_downloads
-      example.run
-      clear_downloads
+      with_empty_downloads_folder { example.run }
     end
 
     describe "smoke test for generation of report based on permissions" do

--- a/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-xfeature "enterprise fee summaries", js: true do
+feature "enterprise fee summaries", js: true do
   include AuthenticationWorkflow
   include WebHelper
 

--- a/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
@@ -98,73 +98,81 @@ xfeature "enterprise fee summaries", js: true do
     end
   end
 
-  describe "smoke test for generation of report based on permissions" do
-    before do
-      visit spree.new_admin_reports_enterprise_fee_summary_path
+  describe "csv downloads" do
+    around do |example|
+      clear_downloads
+      example.run
+      clear_downloads
     end
 
-    context "when logged in as admin" do
+    describe "smoke test for generation of report based on permissions" do
+      before do
+        visit spree.new_admin_reports_enterprise_fee_summary_path
+      end
+
+      context "when logged in as admin" do
+        let!(:order) do
+          create(:completed_order_with_fees, order_cycle: order_cycle,
+                                             distributor: distributor)
+        end
+        let(:current_user) { create(:admin_user) }
+
+        it "generates file with data for all enterprises" do
+          check I18n.t("filters.report_format_csv", scope: i18n_scope)
+          click_on I18n.t("filters.generate_report", scope: i18n_scope)
+          expect(page.response_headers['Content-Type']).to eq "text/csv"
+          expect(page.body).to have_content(distributor.name)
+        end
+      end
+
+      context "when logged in as enterprise user" do
+        let!(:order) do
+          create(:completed_order_with_fees, order_cycle: order_cycle,
+                                             distributor: distributor)
+        end
+        let!(:other_order) do
+          create(:completed_order_with_fees, order_cycle: other_order_cycle,
+                                             distributor: other_distributor)
+        end
+        let(:current_user) { distributor.owner }
+
+        it "generates file with data for the enterprise" do
+          check I18n.t("filters.report_format_csv", scope: i18n_scope)
+          click_on I18n.t("filters.generate_report", scope: i18n_scope)
+          expect(page.response_headers['Content-Type']).to eq "text/csv"
+          expect(page.body).to have_content(distributor.name)
+          expect(page.body).not_to have_content(other_distributor.name)
+        end
+      end
+    end
+
+    describe "smoke test for filtering report based on filters" do
+      let!(:second_distributor) { create(:distributor_enterprise) }
+      let!(:second_order_cycle) { create(:simple_order_cycle, coordinator: second_distributor) }
+
       let!(:order) do
         create(:completed_order_with_fees, order_cycle: order_cycle,
                                            distributor: distributor)
       end
+      let!(:second_order) do
+        create(:completed_order_with_fees, order_cycle: second_order_cycle,
+                                           distributor: second_distributor)
+      end
+
       let(:current_user) { create(:admin_user) }
 
-      it "generates file with data for all enterprises" do
+      before do
+        visit spree.new_admin_reports_enterprise_fee_summary_path
+      end
+
+      it "generates file with data for selected order cycle" do
+        select order_cycle.name, from: "report_order_cycle_ids"
         check I18n.t("filters.report_format_csv", scope: i18n_scope)
         click_on I18n.t("filters.generate_report", scope: i18n_scope)
         expect(page.response_headers['Content-Type']).to eq "text/csv"
         expect(page.body).to have_content(distributor.name)
+        expect(page.body).not_to have_content(second_distributor.name)
       end
-    end
-
-    context "when logged in as enterprise user" do
-      let!(:order) do
-        create(:completed_order_with_fees, order_cycle: order_cycle,
-                                           distributor: distributor)
-      end
-      let!(:other_order) do
-        create(:completed_order_with_fees, order_cycle: other_order_cycle,
-                                           distributor: other_distributor)
-      end
-      let(:current_user) { distributor.owner }
-
-      it "generates file with data for the enterprise" do
-        check I18n.t("filters.report_format_csv", scope: i18n_scope)
-        click_on I18n.t("filters.generate_report", scope: i18n_scope)
-        expect(page.response_headers['Content-Type']).to eq "text/csv"
-        expect(page.body).to have_content(distributor.name)
-        expect(page.body).not_to have_content(other_distributor.name)
-      end
-    end
-  end
-
-  describe "smoke test for filtering report based on filters" do
-    let!(:second_distributor) { create(:distributor_enterprise) }
-    let!(:second_order_cycle) { create(:simple_order_cycle, coordinator: second_distributor) }
-
-    let!(:order) do
-      create(:completed_order_with_fees, order_cycle: order_cycle,
-                                         distributor: distributor)
-    end
-    let!(:second_order) do
-      create(:completed_order_with_fees, order_cycle: second_order_cycle,
-                                         distributor: second_distributor)
-    end
-
-    let(:current_user) { create(:admin_user) }
-
-    before do
-      visit spree.new_admin_reports_enterprise_fee_summary_path
-    end
-
-    it "generates file with data for selected order cycle" do
-      select order_cycle.name, from: "report_order_cycle_ids"
-      check I18n.t("filters.report_format_csv", scope: i18n_scope)
-      click_on I18n.t("filters.generate_report", scope: i18n_scope)
-      expect(page.response_headers['Content-Type']).to eq "text/csv"
-      expect(page.body).to have_content(distributor.name)
-      expect(page.body).not_to have_content(second_distributor.name)
     end
   end
 

--- a/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
@@ -86,8 +86,10 @@ xfeature "enterprise fee summaries", js: true do
     end
 
     context "when logged in as enterprise user" do
-      let!(:order) { create(:completed_order_with_fees, order_cycle: order_cycle, distributor: distributor) }
-
+      let!(:order) do
+        create(:completed_order_with_fees, order_cycle: order_cycle,
+                                           distributor: distributor)
+      end
       let(:current_user) { distributor.owner }
 
       it "shows available options for the enterprise" do
@@ -102,8 +104,10 @@ xfeature "enterprise fee summaries", js: true do
     end
 
     context "when logged in as admin" do
-      let!(:order) { create(:completed_order_with_fees, order_cycle: order_cycle, distributor: distributor) }
-
+      let!(:order) do
+        create(:completed_order_with_fees, order_cycle: order_cycle,
+                                           distributor: distributor)
+      end
       let(:current_user) { create(:admin_user) }
 
       it "generates file with data for all enterprises" do
@@ -115,9 +119,14 @@ xfeature "enterprise fee summaries", js: true do
     end
 
     context "when logged in as enterprise user" do
-      let!(:order) { create(:completed_order_with_fees, order_cycle: order_cycle, distributor: distributor) }
-      let!(:other_order) { create(:completed_order_with_fees, order_cycle: other_order_cycle, distributor: other_distributor) }
-
+      let!(:order) do
+        create(:completed_order_with_fees, order_cycle: order_cycle,
+                                           distributor: distributor)
+      end
+      let!(:other_order) do
+        create(:completed_order_with_fees, order_cycle: other_order_cycle,
+                                           distributor: other_distributor)
+      end
       let(:current_user) { distributor.owner }
 
       it "generates file with data for the enterprise" do
@@ -134,8 +143,14 @@ xfeature "enterprise fee summaries", js: true do
     let!(:second_distributor) { create(:distributor_enterprise) }
     let!(:second_order_cycle) { create(:simple_order_cycle, coordinator: second_distributor) }
 
-    let!(:order) { create(:completed_order_with_fees, order_cycle: order_cycle, distributor: distributor) }
-    let!(:second_order) { create(:completed_order_with_fees, order_cycle: second_order_cycle, distributor: second_distributor) }
+    let!(:order) do
+      create(:completed_order_with_fees, order_cycle: order_cycle,
+                                         distributor: distributor)
+    end
+    let!(:second_order) do
+      create(:completed_order_with_fees, order_cycle: second_order_cycle,
+                                         distributor: second_distributor)
+    end
 
     let(:current_user) { create(:admin_user) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,7 +155,7 @@ RSpec.configure do |config|
   config.include ActionView::Helpers::DateHelper
   config.include OpenFoodNetwork::DelayedJobHelper
   config.include OpenFoodNetwork::PerformanceHelper
-  config.include DownloadsHelper
+  config.include DownloadsHelper, type: :feature
 
   # FactoryBot
   require 'factory_bot_rails'

--- a/spec/support/downloads_helper.rb
+++ b/spec/support/downloads_helper.rb
@@ -1,0 +1,38 @@
+module DownloadsHelper
+  TIMEOUT = 10
+  PATH    = Rails.root.join("tmp", "downloads")
+
+  def downloaded_filename
+    wait_for_download
+    downloaded_filenames.first
+  end
+
+  def downloaded_content
+    wait_for_download
+    File.read(downloaded_filename)
+  end
+
+  def clear_downloads
+    FileUtils.rm_f(downloaded_filenames)
+  end
+
+  private
+
+  def downloaded_filenames
+    Dir[PATH.join("*")]
+  end
+
+  def wait_for_download
+    Timeout.timeout(TIMEOUT) do
+      sleep 0.1 until downloaded?
+    end
+  end
+
+  def downloaded?
+    !downloading? && downloaded_filenames.any?
+  end
+
+  def downloading?
+    downloaded_filenames.grep(/\.crdownload$/).any?
+  end
+end

--- a/spec/support/downloads_helper.rb
+++ b/spec/support/downloads_helper.rb
@@ -15,8 +15,10 @@ module DownloadsHelper
     File.read(downloaded_filename)
   end
 
-  def clear_downloads
-    FileUtils.rm_f(downloaded_filenames)
+  def with_empty_downloads_folder
+    remove_downloaded_files
+    yield
+    remove_downloaded_files
   end
 
   private
@@ -37,5 +39,9 @@ module DownloadsHelper
 
   def downloading?
     downloaded_filenames.grep(/\.crdownload$/).any?
+  end
+
+  def remove_downloaded_files
+    FileUtils.rm_f(downloaded_filenames)
   end
 end

--- a/spec/support/downloads_helper.rb
+++ b/spec/support/downloads_helper.rb
@@ -1,6 +1,9 @@
 module DownloadsHelper
   TIMEOUT = 10
-  PATH    = Rails.root.join("tmp", "downloads")
+
+  def self.path
+    Rails.root.join("tmp", "downloads")
+  end
 
   def downloaded_filename
     wait_for_download
@@ -19,7 +22,7 @@ module DownloadsHelper
   private
 
   def downloaded_filenames
-    Dir[PATH.join("*")]
+    Dir[DownloadsHelper.path.join("*")]
   end
 
   def wait_for_download


### PR DESCRIPTION
#### What? Why?

Closes #3483

Chrome driver doesnt support file downloads with standard config so we need specific configuration to make it download files and have specs get the file contents.

#### What should we test?
Spec should be green.
We should test the enterprise fees summary report and make sure it's working correctly.

This build is green if I include the commits from #3316 (they fix the authorization problem, they are present in build number 2 in this PR). I have removed those commits now to make the review of this PR easier. So, this should be merged only after #3316.