### PR TITLE
Fix "What's this?" on admin dashboard

### DIFF
--- a/app/views/spree/admin/overview/_enterprises_header.html.haml
+++ b/app/views/spree/admin/overview/_enterprises_header.html.haml
@@ -7,4 +7,4 @@
         = t "spree_admin_enterprises_create_new"
   - else
     %a{ "ofn-with-tip" => t('.ofn_with_tip') }
-      = t "admin_enterprise_groups_what_s_this"
+      = t "admin.whats_this"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1013,9 +1013,6 @@ en:
     shared:
       user_guide_link:
         user_guide: User Guide
-    overview:
-      enterprises_header:
-        ofn_with_tip: Enterprises are Producers and/or Hubs and are the basic unit of organisation within the Open Food Network.
       enterprises_hubs_tabs:
         has_no_payment_methods: "%{enterprise} has no payment methods"
         has_no_shipping_methods: "%{enterprise} has no shipping methods"
@@ -3001,6 +2998,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             distributor: "Distributor:"
             order_cycle: "Order cycle:"
       overview:
+        enterprises_header:
+          ofn_with_tip: Enterprises are Producers and/or Hubs and are the basic unit of organisation within the Open Food Network.
         products:
           active_products:
             zero: "You don't have any active products."


### PR DESCRIPTION

#### What? Why?

When a user has no enterprises, the admin dashboard displays a "What's
this?" hint in the right corner of the enterprises tab. The link text
and the tooltip were both broken (missing translation).


#### What should we test?
<!-- List which features should be tested and how. -->

I don't think the actual translation is worth testing. The only way to see this page is to delete all enterprises.

1. Delete all enterprises or reset the database. Don't load sample data.
2. Log in as super admin and verify there are no missing translations in the dashboard.

Instead I would suggest to test that the dashboard still displays correctly:

1. Log in as super admin and visit the dashboard.
2. Log in as enterprise user and visit the dashboard.

In both cases the "+ Create new" button is in the corner of the enterprises tab. Only when there are no enterprises, the fixed tooltip displays there.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: Corrected a tooltip in the admin dash board.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

