### PR TITLE
 Add shipping method name to orders detail report

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,6 @@ Layout/AlignArray:
   Exclude:
     - 'lib/open_food_network/bulk_coop_report.rb'
     - 'lib/open_food_network/customers_report.rb'
-    - 'lib/open_food_network/order_and_distributor_report.rb'
     - 'lib/open_food_network/orders_and_fulfillments_report.rb'
     - 'lib/open_food_network/packing_report.rb'
     - 'spec/lib/open_food_network/order_grouper_spec.rb'

--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -10,7 +10,8 @@ module OpenFoodNetwork
     end
 
     def header
-      [I18n.t(:report_header_order_date),
+      [
+        I18n.t(:report_header_order_date),
         I18n.t(:report_header_order_id),
         I18n.t(:report_header_customer_name),
         I18n.t(:report_header_customer_email),
@@ -28,7 +29,9 @@ module OpenFoodNetwork
         I18n.t(:report_header_distributor_address),
         I18n.t(:report_header_distributor_city),
         I18n.t(:report_header_distributor_postcode),
-        I18n.t(:report_header_shipping_instructions)]
+        I18n.t(:report_header_shipping_method),
+        I18n.t(:report_header_shipping_instructions)
+      ]
     end
 
     def search
@@ -95,6 +98,7 @@ module OpenFoodNetwork
         order.distributor.address.address1,
         order.distributor.address.city,
         order.distributor.address.zipcode,
+        order.shipping_method.name,
         order.special_instructions
       ]
     end

--- a/spec/lib/open_food_network/order_and_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/order_and_distributor_report_spec.rb
@@ -11,15 +11,16 @@ module OpenFoodNetwork
                               'Customer Name', 'Customer Email', 'Customer Phone', 'Customer City',
                               'SKU', 'Item name', 'Variant', 'Quantity', 'Max Quantity', 'Cost', 'Shipping Cost',
                               'Payment Method',
-                              'Distributor', 'Distributor address', 'Distributor city', 'Distributor postcode', 'Shipping instructions'])
+                              'Distributor', 'Distributor address', 'Distributor city', 'Distributor postcode', 'Shipping Method', 'Shipping instructions'])
       end
 
       context 'with completed order' do
         let(:bill_address) { create(:address) }
         let(:distributor) { create(:distributor_enterprise) }
         let(:product) { create(:product) }
+        let(:shipping_method) { create(:shipping_method) }
         let(:shipping_instructions) { 'pick up on thursday please!' }
-        let(:order) { create(:order, state: 'complete', completed_at: Time.zone.now, distributor: distributor, bill_address: bill_address, special_instructions: shipping_instructions) }
+        let(:order) { create(:order, state: 'complete', completed_at: Time.zone.now, distributor: distributor, bill_address: bill_address, shipping_method: shipping_method, special_instructions: shipping_instructions) }
         let(:payment_method) { create(:payment_method, distributors: [distributor]) }
         let(:payment) { create(:payment, payment_method: payment_method, order: order) }
         let(:line_item) { create(:line_item, product: product, order: order) }
@@ -53,6 +54,7 @@ module OpenFoodNetwork
             distributor.address.address1,
             distributor.address.city,
             distributor.address.zipcode,
+            shipping_method.name,
             shipping_instructions
           ])
         end


### PR DESCRIPTION
#### What? Why?

Adds a Shipping Method column to the Orders And Distributors report. This allows the users to see the the shipping detail of each order.

Closes #3446 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Before:

![Screenshot from 2019-03-27 19-39-00](https://user-images.githubusercontent.com/22715037/55124259-405e0f00-50cb-11e9-9855-2c0e4950befd.png)

After:

![Screenshot from 2019-03-27 19-04-20](https://user-images.githubusercontent.com/22715037/55124268-4a800d80-50cb-11e9-8820-3687640e5107.png)

#### What should we test?
<!-- List which features should be tested and how. -->

Generating a Orders and Distributors report will show the result of this PR.

