### PR TITLE
Relax stripe version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'spree_auth_devise', github: 'openfoodfoundation/spree_auth_devise', branch:
 # - Change type of password from string to password to hide it in the form
 gem 'spree_paypal_express', github: "openfoodfoundation/better_spree_paypal_express", branch: "spree-upgrade-intermediate"
 #gem 'spree_paypal_express', github: "spree-contrib/better_spree_paypal_express", branch: "1-3-stable"
-gem 'stripe', '~> 4.11.0'
+gem 'stripe'
 # We need at least this version to have Digicert's root certificate
 # which is needed for Pin Payments (and possibly others).
 gem 'activemerchant', '~> 1.78'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -865,7 +865,7 @@ DEPENDENCIES
   spree_paypal_express!
   spring (= 1.7.2)
   spring-commands-rspec
-  stripe (~> 4.11.0)
+  stripe
   therubyracer (= 0.12.0)
   timecop
   truncate_html


### PR DESCRIPTION

#### What? Why?

Follow up from #3656.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We are using the latest version of the `stripe` gem. We don't depend on
any particular version. I'm proposing to drop our dependency declaration
on a particular version and just track the current used version in
Gemfile.lock. That means fewer code changes when updating, which happens
quite frequently with this gem and dependabot.


#### What should we test?
<!-- List which features should be tested and how. -->

No test required. The actual version of the gem is not changed here.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Our dependency specification (`Gemfile`) became more accurate.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

