### PR TITLE
Close adjustments so that updates are effective

### DIFF
--- a/app/controllers/spree/admin/adjustments_controller_decorator.rb
+++ b/app/controllers/spree/admin/adjustments_controller_decorator.rb
@@ -3,7 +3,7 @@ module Spree
     AdjustmentsController.class_eval do
       prepend_before_filter :set_included_tax, only: [:create, :update]
       before_filter :set_default_tax_rate, only: :edit
-
+      before_filter :enable_updates, only: :update
 
       private
 
@@ -37,6 +37,17 @@ module Spree
         else
           params[:adjustment][:included_tax] = 0
         end
+      end
+
+      # Spree 2.0 keeps shipping fee adjustments open unless they are manually
+      # closed. But open adjustments cannot be edited.
+      # To preserve updates, like changing the amount of the shipping fee,
+      # we close the adjustment first.
+      #
+      # The Spree admin interface allows to open and close adjustments manually
+      # but we removed that functionality as it had no purpose for us.
+      def enable_updates
+        @adjustment.close
       end
     end
   end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -350,6 +350,16 @@ feature %q{
           end
         end
       end
+
+      scenario "editing shipping fees" do
+        click_link "Adjustments"
+        page.find('td.actions a.icon-edit').click
+
+        fill_in "Amount", with: "5"
+        click_button "Continue"
+
+        expect(page.find("td.amount")).to have_content "$5.00"
+      end
     end
 
     scenario "creating an order with distributor and order cycle" do


### PR DESCRIPTION
#### What? Why?

Closes #1830

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Spree 2.0 keeps shipping fee adjustments open unless they are manually    closed. But open adjustments cannot be edited.    To preserve updates, like changing the amount of the shipping fee    we close the adjustment first.


#### What should we test?
<!-- List which features should be tested and how. -->

1. Place an order.
2. Log in as admin and go to the order.
3. Observe the shipping fee and total amount.
4. Click on Adjustments.
5. Click on the edit icon of the shipping fee.
6. Enter a different amount and click Continue.
7. Check the amount was updated.
8. Click on Order Details and check the shipping fee and totals have updated.


#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

Part of the Spree Upgrade.

#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

**Deleting shipping fees**

If you delete a shipping fee and look at the order details again, the shipping fee will re-appear. You can use this behaviour if you want to re-calculate the shipping fee. If you don't want to charge a shipping fee you can set the amount of the shipping fee to `0`.