### PR TITLE
3477 Render only eligible adjustments on the order page

### DIFF
--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -4,16 +4,9 @@ module Admin
     #
     # We exclude shipping method adjustments because they are displayed in a
     # separate table together with the order line items.
-    #
-    # We also exclude tax rate adjustment with zero value.
     def order_adjustments_for_display(order)
       order.adjustments.eligible.select do |adjustment|
-        type = adjustment.originator_type
-
-        is_shipping_method_adjustment = (type == 'Spree::ShippingMethod')
-        is_zero_tax_rate_adjustment = (type == 'Spree::TaxRate' && adjustment.amount.zero?)
-
-        !is_shipping_method_adjustment && !is_zero_tax_rate_adjustment
+        adjustment.originator_type != "Spree::ShippingMethod"
       end
     end
   end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -1,7 +1,14 @@
 module Admin
   module OrdersHelper
     def order_adjustments(order)
-      order.adjustments.eligible
+      order.adjustments.eligible.select do |adjustment|
+        type = adjustment.originator_type
+
+        is_shipping_method_fee = (type == 'Spree::ShippingMethod')
+        is_zero_tax_rate = (type == 'Spree::TaxRate' && adjustment.amount.zero?)
+
+        !is_shipping_method_fee && !is_zero_tax_rate
+      end
     end
   end
 end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -1,0 +1,7 @@
+module Admin
+  module OrdersHelper
+    def order_adjustments(order)
+      order.adjustments.eligible
+    end
+  end
+end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -1,13 +1,19 @@
 module Admin
   module OrdersHelper
-    def order_adjustments(order)
+    # Adjustments to display under "Order adjustments".
+    #
+    # We exclude shipping method adjustments because they are displayed in a
+    # separate table together with the order line items.
+    #
+    # We also exclude tax rate adjustment with zero value.
+    def order_adjustments_for_display(order)
       order.adjustments.eligible.select do |adjustment|
         type = adjustment.originator_type
 
-        is_shipping_method_fee = (type == 'Spree::ShippingMethod')
-        is_zero_tax_rate = (type == 'Spree::TaxRate' && adjustment.amount.zero?)
+        is_shipping_method_adjustment = (type == 'Spree::ShippingMethod')
+        is_zero_tax_rate_adjustment = (type == 'Spree::TaxRate' && adjustment.amount.zero?)
 
-        !is_shipping_method_fee && !is_zero_tax_rate
+        !is_shipping_method_adjustment && !is_zero_tax_rate_adjustment
       end
     end
   end

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -5,7 +5,7 @@
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
 
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :title => t(".line_item_adjustments")}
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments(@order), :title => t(".order_adjustments")}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments_for_display(@order), :title => t(".order_adjustments")}
 
   - if order.line_items.exists?
     %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -4,12 +4,12 @@
 
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
 
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :title => Spree.t(:line_item_adjustments)}
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments(@order), :title => Spree.t(:order_adjustments)}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :title => t(".line_item_adjustments")}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments(@order), :title => t(".order_adjustments")}
 
   - if order.line_items.exists?
     %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}
-      %legend= Spree.t(:order_total)
+      %legend= t(".order_total")
       %span.order-total= order.display_total
 
   = form_for @order, url: admin_order_url(@order), method: :put do |f|

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -4,8 +4,8 @@
 
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
 
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :order => order, :title => Spree.t(:line_item_adjustments)}
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.adjustments.eligible, :order => order, :title => Spree.t(:order_adjustments)}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :title => Spree.t(:line_item_adjustments)}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.adjustments.eligible, :title => Spree.t(:order_adjustments)}
 
   - if order.line_items.exists?
     %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -5,7 +5,7 @@
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
 
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :title => Spree.t(:line_item_adjustments)}
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.adjustments.eligible, :title => Spree.t(:order_adjustments)}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments(@order), :title => Spree.t(:order_adjustments)}
 
   - if order.line_items.exists?
     %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -5,7 +5,7 @@
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
 
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :order => order, :title => Spree.t(:line_item_adjustments)}
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.adjustments, :order => order, :title => Spree.t(:order_adjustments)}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.adjustments.eligible, :order => order, :title => Spree.t(:order_adjustments)}
 
   - if order.line_items.exists?
     %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}

--- a/app/views/spree/admin/orders/_form/_adjustments.html.haml
+++ b/app/views/spree/admin/orders/_form/_adjustments.html.haml
@@ -8,8 +8,7 @@
           %th= Spree.t('amount')
       %tbody.with-border
         - adjustments.each do |adjustment|
-          - if (adjustment.originator_type != 'Spree::ShippingMethod') && !(adjustment.originator_type == 'Spree::TaxRate' && adjustment.amount == 0)
-            %tr.total
-              %td.strong= adjustment.label + ":"
-              %td.total.align-center
-                %span= Spree::Money.new(adjustment.amount)
+          %tr.total
+            %td.strong= adjustment.label + ":"
+            %td.total.align-center
+              %span= Spree::Money.new(adjustment.amount)

--- a/app/views/spree/admin/orders/_form/_adjustments.html.haml
+++ b/app/views/spree/admin/orders/_form/_adjustments.html.haml
@@ -6,7 +6,7 @@
         %tr
           %th= Spree.t('name')
           %th= Spree.t('amount')
-      %tbody#order-charges.with-border
+      %tbody.with-border
         - adjustments.each do |adjustment|
           - if (adjustment.originator_type != 'Spree::ShippingMethod') && !(adjustment.originator_type == 'Spree::TaxRate' && adjustment.amount == 0)
             %tr.total

--- a/app/views/spree/admin/orders/_form/_adjustments.html.haml
+++ b/app/views/spree/admin/orders/_form/_adjustments.html.haml
@@ -3,8 +3,9 @@
     %legend= title
     %table>
       %thead
-        %th= Spree.t('name')
-        %th= Spree.t('amount')
+        %tr
+          %th= Spree.t('name')
+          %th= Spree.t('amount')
       %tbody#order-charges.with-border
         - adjustments.each do |adjustment|
           - if (adjustment.originator_type != 'Spree::ShippingMethod') && !(adjustment.originator_type == 'Spree::TaxRate' && adjustment.amount == 0)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2932,6 +2932,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             title: "Distribution"
             distributor: "Distributor:"
             order_cycle: "Order cycle:"
+          line_item_adjustments: "Line Item Adjustments"
+          order_adjustments: "Order Adjustments"
+          order_total: "Order Total"
       overview:
         products:
           active_products:

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -14,6 +14,23 @@ describe Spree::Admin::OrdersController, type: :controller do
         spree_get :edit, id: order
       }.to change { order.reload.state }.from("cart").to("complete")
     end
+
+    describe "view" do
+      render_views
+
+      it "shows only eligible adjustments" do
+        adjustment = create(
+          :adjustment,
+          adjustable: order,
+          label: "invalid adjustment",
+          amount: 0
+        )
+
+        spree_get :edit, id: order
+
+        expect(response.body).to_not match adjustment.label
+      end
+    end
   end
 
   context "#update" do

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -267,7 +267,7 @@ feature %q{
       end
 
       scenario "shows the order tax adjustments" do
-        within('tbody#order-charges') do
+        within('fieldset', text: 'LINE ITEM ADJUSTMENTS') do
           expect(page).to have_selector "td", match: :first, text: "Tax 1"
           expect(page).to have_selector "td.total", text: Spree::Money.new(10)
         end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -267,7 +267,7 @@ feature %q{
       end
 
       scenario "shows the order tax adjustments" do
-        within('fieldset', text: 'LINE ITEM ADJUSTMENTS') do
+        within('fieldset', text: I18n.t('spree.admin.orders.form.line_item_adjustments').upcase) do
           expect(page).to have_selector "td", match: :first, text: "Tax 1"
           expect(page).to have_selector "td.total", text: Spree::Money.new(10)
         end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -255,7 +255,6 @@ feature %q{
       scenario "shows the order non-tax adjustments" do
         within('table.index tbody') do
           @order.adjustments.eligible.each do |adjustment|
-            next if (adjustment.originator_type == 'Spree::TaxRate') && (adjustment.amount == 0)
             expect(page).to have_selector "td", match: :first, text: adjustment.label
             expect(page).to have_selector "td.total", text: adjustment.display_amount
           end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -282,19 +282,6 @@ feature %q{
         end
       end
 
-      scenario "shows only eligible adjustments" do
-        adjustment = create(
-          :adjustment,
-          adjustable: @order,
-          label: "invalid adjustment",
-          amount: 0
-        )
-
-        visit spree.edit_admin_order_path(@order)
-
-        expect(page).to have_no_content adjustment.label
-      end
-
       scenario "cannot split the order in different stock locations" do
         # There's only 1 stock location in OFN, so the split functionality that comes with spree should be hidden
         expect(page).to_not have_selector '.split-item'

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -283,6 +283,19 @@ feature %q{
         end
       end
 
+      scenario "shows only eligible adjustments" do
+        adjustment = create(
+          :adjustment,
+          adjustable: @order,
+          label: "invalid adjustment",
+          amount: 0
+        )
+
+        visit spree.edit_admin_order_path(@order)
+
+        expect(page).to have_no_content adjustment.label
+      end
+
       scenario "cannot split the order in different stock locations" do
         # There's only 1 stock location in OFN, so the split functionality that comes with spree should be hidden
         expect(page).to_not have_selector '.split-item'

--- a/spec/helpers/admin/orders_helper_spec.rb
+++ b/spec/helpers/admin/orders_helper_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe Admin::OrdersHelper, type: :helper do
+  describe "#order_adjustments_for_display" do
+    let(:order) { create(:order) }
+
+    it "selects eligible adjustments" do
+      adjustment = create(:adjustment, adjustable: order, amount: 1)
+
+      expect(helper.order_adjustments_for_display(order)).to eq [adjustment]
+    end
+
+    it "filters shipping method adjustments" do
+      create(:adjustment, adjustable: order, amount: 1, originator_type: "Spree::ShippingMethod")
+
+      expect(helper.order_adjustments_for_display(order)).to eq []
+    end
+
+    it "filters zero tax rate adjustments" do
+      create(:adjustment, adjustable: order, amount: 0, originator_type: "Spree::TaxRate")
+
+      expect(helper.order_adjustments_for_display(order)).to eq []
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #3477 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The admin orders edit form was displaying adjustments even if they were    "not eligible". For example, an additional fee with amount `0` is not    eligible. They were already hidden in the adjustments view and we are    hiding them in reports.

#### What should we test?
<!-- List which features should be tested and how. -->

1. Place an order.
2. Log in as admin and go to the order.
3. Go to adjustments and create an adjustment with zero amount.
4. After Saving you will see a success message but you won't see the adjustment. That's confusing but correct, I think.
5. Go back to the order details. You shouldn't see the adjustment there either.

Bad:
![Screenshot from 2019-03-29 18-45-48](https://user-images.githubusercontent.com/3524483/55217168-f2741300-5252-11e9-823e-0f39f5012ecb.png)

Good:
![Screenshot from 2019-03-29 18-47-06](https://user-images.githubusercontent.com/3524483/55217242-1e8f9400-5253-11e9-8ba3-5f292a89e31c.png)


