### PR TITLE
Add missing translation for order form in v2

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3003,6 +3003,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             title: "Distribution"
             distributor: "Distributor:"
             order_cycle: "Order cycle:"
+          line_item_adjustments: "Line Item Adjustments"
+          order_adjustments: "Order Adjustments"
+          order_total: "Order Total"
       overview:
         products:
           active_products:


### PR DESCRIPTION

#### What? Why?

Related to #3477 and a partial backport of #3667.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

I saw the following error on the 2-0-stable branch:

  translation missing: en.spree.line_item_adjustments

In a pending PR I change all three translations in the view file to use
lazy lookup. This commit backports the addition to the locale so that it
can be translated via Transifex before we release v2.


#### What should we test?
<!-- List which features should be tested and how. -->

No test.

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

This PR only makes sense if #3667 is reviewed successfully.
