### PR TITLE
[Spree Upgrade] Bang version of create in DB migration for shipping rates

### DIFF
--- a/db/migrate/20180426145653_add_shipping_rates_to_shipments.spree.rb
+++ b/db/migrate/20180426145653_add_shipping_rates_to_shipments.spree.rb
@@ -2,9 +2,9 @@
 class AddShippingRatesToShipments < ActiveRecord::Migration
   def up
     Spree::Shipment.all.each do |shipment|
-      shipment.shipping_rates.create(:shipping_method_id => shipment.shipping_method_id,
-                                     :cost => shipment.cost,
-                                     :selected => true)
+      shipment.shipping_rates.create!(:shipping_method_id => shipment.shipping_method_id,
+                                      :cost => shipment.cost,
+                                      :selected => true)
     end
 
     remove_column :spree_shipments, :shipping_method_id


### PR DESCRIPTION
#### What? Why?

Relates to #3285 

Using the bang version of the method will enable us to find out if creation of the shipping rate fails for whatever reason.

#### What should we test?

Nothing to test in staging.

I've already done the following locally:

1. Set up a v1 DB locally with `script/setup`.
2. Added sample data with `bundle exec rake ofn:sample_data`.
3. Created an order with shipment through the UI.
4. Switched to v2 with this PR's branch.
5. Ran migrations with `bundle exec rake db:migrate`.

The `Spree::ShippingRate` record was successfully created.