### PR TITLE
[Spree Upgrade] Fix split button reappearing when editing line item quantity

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/order_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/order_controller.js.coffee
@@ -24,3 +24,8 @@ angular.module("admin.orders").controller "orderCtrl", ($scope, shops, orderCycl
 
   for shop in $scope.shops
     shop.disabled = !$scope.distributorHasOrderCycles(shop)
+
+  # Removes the split button introduced by spree in the order form
+  #   We only have one stock location in OFN so it's meaningless to split the order between stock locations
+  #   We delete it instead of hiding or changing CSS so that, when spree code toggles the element, nothing hapens
+  $('.split-item').remove()

--- a/app/assets/stylesheets/admin/pages/order_edit_form.css.scss
+++ b/app/assets/stylesheets/admin/pages/order_edit_form.css.scss
@@ -1,5 +1,0 @@
-// Hides the split button introduced by spree in the order form
-//   We only have one stock location in OFN so it's meaningless to split the order between stock locations
-table td.actions [class*='icon-'].split-item {
-  display: none;
-}


### PR DESCRIPTION
#### What? Why?

Closes #3683 

#3683 is a bug in PR #3548 in [this commit](https://github.com/openfoodfoundation/openfoodnetwork/pull/3548/commits/37685c8107ac1cc59ef9e3f866e70cbbe813c111).
We need to remove the split button from the dom so that when spree does a toggle on it [here](https://github.com/openfoodfoundation/spree/blob/060d0a5d8b31f68990fa792e0e88910c742d9a96/backend/app/assets/javascripts/admin/variant_autocomplete.js.erb#L112), the button doesnt re-appear.

#### What should we test?
Make sure 3683 is fixed.
