### PR TITLE
[Spree Upgrade] Fix translation missing in order confirmation email subject and bring cancel email to ofn

### DIFF
--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -9,7 +9,7 @@ Spree::OrderMailer.class_eval do
     I18n.with_locale valid_locale(@order.user) do
       mail(to: @order.email,
            from: from_address,
-           subject: mail_subject(t('order_mailer.cancel_email.subject'), resend))
+           subject: mail_subject(t('spree.order_mailer.cancel_email.subject'), resend))
     end
   end
 

--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -16,7 +16,7 @@ Spree::OrderMailer.class_eval do
   def confirm_email_for_customer(order_or_order_id, resend = false)
     @order = find_order(order_or_order_id)
     I18n.with_locale valid_locale(@order.user) do
-      subject = mail_subject(t('order_mailer.confirm_email.subject'), resend)
+      subject = mail_subject(t('spree.order_mailer.confirm_email.subject'), resend)
       mail(:to => @order.email,
            :from => from_address,
            :subject => subject,
@@ -27,7 +27,7 @@ Spree::OrderMailer.class_eval do
   def confirm_email_for_shop(order_or_order_id, resend = false)
     @order = find_order(order_or_order_id)
     I18n.with_locale valid_locale(@order.user) do
-      subject = mail_subject(t('order_mailer.confirm_email.subject'), resend)
+      subject = mail_subject(t('spree.order_mailer.confirm_email.subject'), resend)
       mail(:to => @order.distributor.contact.email,
            :from => from_address,
            :subject => subject)

--- a/app/views/spree/order_mailer/cancel_email.html.haml
+++ b/app/views/spree/order_mailer/cancel_email.html.haml
@@ -1,0 +1,11 @@
+%h3
+  = t(".customer_greeting", name: @order.bill_address.firstname)
+%h4
+  = t(".instructions")
+%span.clear
+
+%p &nbsp;
+
+= t(".order_summary_canceled")
+= render 'order_summary'
+= render 'signoff'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,14 +127,6 @@ en:
       subject: "%{enterprise} is now on %{sitename}"
     invite_manager:
       subject: "%{enterprise} has invited you to be a manager"
-  order_mailer:
-    cancel_email:
-      dear_customer: "Dear Customer,"
-      instructions: "Your order has been CANCELED.  Please retain this cancellation information for your records."
-      order_summary_canceled: "Order Summary [CANCELED]"
-      subject: "Cancellation of Order"
-      subtotal: "Subtotal: %{subtotal}"
-      total: "Order Total: %{total}"
   producer_mailer:
     order_cycle:
       subject: "Order cycle report for %{producer}"
@@ -3091,6 +3083,11 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       void: void
       invalid: invalid
     order_mailer:
+      cancel_email:
+        customer_greeting: "Hi %{name}!"
+        instructions: "Your order has been CANCELED. Please retain this cancellation information for your records."
+        order_summary_canceled: "Order Summary [CANCELED]"
+        subject: "Cancellation of Order"
       invoice_email:
         hi: "Hi %{name}"
         invoice_attached_text: Please find attached an invoice for your recent order from

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3088,6 +3088,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         instructions: "Your order has been CANCELED. Please retain this cancellation information for your records."
         order_summary_canceled: "Order Summary [CANCELED]"
         subject: "Cancellation of Order"
+      confirm_email:
+        subject: "Order Confirmation"
       invoice_email:
         hi: "Hi %{name}"
         invoice_attached_text: Please find attached an invoice for your recent order from

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -417,7 +417,7 @@ describe Spree::OrdersController, type: :controller do
       end
 
       context "when the order is complete" do
-        let(:order) { create(:completed_order_with_totals, user: user) }
+        let(:order) { create(:completed_order_with_totals, user: user, distributor: create(:distributor_enterprise)) }
 
         before do
           setup_email

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -489,7 +489,7 @@ describe Spree::Order do
       end
 
       it "finds only orders not in specified state" do
-        o = FactoryBot.create(:completed_order_with_totals)
+        o = FactoryBot.create(:completed_order_with_totals, distributor: create(:distributor_enterprise))
         o.cancel!
         Spree::Order.not_state(:canceled).should_not include o
       end


### PR DESCRIPTION
#### What? Why?

Closes #3696 and brings cancel email from spree to ofn!
Cancelation email has the normal ofn style now, see below!

There's more todo... for example, use lazy lookup translation keys in order confirmation emails. For next time.

#### What should we test?
Re order confirmation email:
Before:
![Screenshot 2019-04-04 at 12 29 26](https://user-images.githubusercontent.com/1640378/55553425-08148d00-56d8-11e9-8513-19e3a9cc50fa.png)

After:
![Screenshot 2019-04-04 at 12 34 55](https://user-images.githubusercontent.com/1640378/55553431-0c40aa80-56d8-11e9-8443-e0fe08ba20f6.png)

Re cancel email:
Before:
![Screenshot 2019-04-04 at 12 29 04](https://user-images.githubusercontent.com/1640378/55553436-11055e80-56d8-11e9-82d4-9457cbb02b41.png)

After:
![Screenshot 2019-04-04 at 12 29 09](https://user-images.githubusercontent.com/1640378/55553446-1793d600-56d8-11e9-8bd0-004bbe321a56.png)

#### Release notes
Using 2-0-stable as default dev branch now! And this one deserves release notes.

Changelog Category: Fixed
The order cancelation email is not styled like all other emails.
