### PR TITLE
Add delayed job web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'jwt', '~> 2.1'
 
 gem 'delayed_job_active_record'
 gem 'daemons'
+gem 'delayed_job_web'
 
 # Fix bug in simple_form preventing collection_check_boxes usage within form_for block
 # When merged, revert to upstream gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,11 @@ GEM
     delayed_job_active_record (4.1.3)
       activerecord (>= 3.0, < 5.3)
       delayed_job (>= 3.0, < 5)
+    delayed_job_web (1.4.3)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      rack-protection (>= 1.5.5)
+      sinatra (>= 1.4.4)
     devise (2.2.8)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
@@ -599,6 +604,8 @@ GEM
       rack (>= 0.4)
     rack-mini-profiler (0.10.7)
       rack (>= 1.2.0)
+    rack-protection (1.5.5)
+      rack
     rack-rewrite (1.5.1)
     rack-ssl (1.3.4)
       rack
@@ -710,6 +717,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     skylight (1.7.2)
       activesupport (>= 3.0.0)
     spinjs-rails (1.4)
@@ -802,6 +813,7 @@ DEPENDENCIES
   debugger-linecache
   deface!
   delayed_job_active_record
+  delayed_job_web
   diffy
   eventmachine (>= 1.2.3)
   factory_bot_rails

--- a/app/models/feature_flags.rb
+++ b/app/models/feature_flags.rb
@@ -11,25 +11,17 @@ class FeatureFlags
   #
   # @return [Boolean]
   def product_import_enabled?
-    superadmin?
+    user.superadmin?
   end
 
   # Checks whether the "Enterprise Fee Summary" is enabled for the specified user
   #
   # @return [Boolean]
   def enterprise_fee_summary_enabled?
-    superadmin?
+    user.superadmin?
   end
 
   private
 
   attr_reader :user
-
-  # Checks whether the specified user is a superadmin, with full control of the
-  # instance
-  #
-  # @return [Boolean]
-  def superadmin?
-    user.has_spree_role?('admin')
-  end
 end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -74,6 +74,14 @@ Spree.user_class.class_eval do
     credit_cards.where(is_default: true).first
   end
 
+  # Checks whether the specified user is a superadmin, with full control of the
+  # instance
+  #
+  # @return [Boolean]
+  def superadmin?
+    has_spree_role?('admin')
+  end
+
   private
 
   def limit_owned_enterprises

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -1,7 +1,7 @@
 Openfoodnetwork::Application.routes.draw do
   namespace :admin do
 
-    authenticated :spree_user, -> user { user.has_spree_role?('admin') } do
+    authenticated :spree_user, -> user { user.superadmin? } do
       mount DelayedJobWeb, at: '/delayed_job'
     end
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -1,5 +1,10 @@
 Openfoodnetwork::Application.routes.draw do
   namespace :admin do
+
+    authenticated :spree_user, -> user { user.has_spree_role?('admin') } do
+      mount DelayedJobWeb, at: '/delayed_job'
+    end
+
     resources :bulk_line_items
 
     resources :order_cycles do

--- a/spec/models/feature_flags_spec.rb
+++ b/spec/models/feature_flags_spec.rb
@@ -7,7 +7,7 @@ describe FeatureFlags do
   describe '#product_import_enabled?' do
     context 'when the user is superadmin' do
       before do
-        allow(user).to receive(:has_spree_role?).with('admin') { true }
+        allow(user).to receive(:superadmin?) { true }
       end
 
       it 'returns true' do
@@ -17,7 +17,7 @@ describe FeatureFlags do
 
     context 'when the user is not superadmin' do
       before do
-        allow(user).to receive(:has_spree_role?).with('admin') { false }
+        allow(user).to receive(:superadmin?) { false }
       end
 
       it 'returns false' do

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -162,4 +162,22 @@ describe Spree.user_class do
       end
     end
   end
+
+  describe '#superadmin?' do
+    let(:user) { create(:user) }
+
+    context 'when the user has an admin spree role' do
+      before { user.spree_roles << Spree::Role.create(name: 'admin') }
+
+      it 'returns true' do
+        expect(user.superadmin?).to eq(true)
+      end
+    end
+
+    context 'when the user does not have an admin spree role' do
+      it 'returns false' do
+        expect(user.superadmin?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3622 

This adds https://github.com/ejschmitt/delayed_job_web to enable async job management such as retries, removal of failed jobs, etc.

Only superadmins can access this web UI though. Therefore any sysadmin that needs to use it should have access to the appropriate instance superadmin credentials in Bitwarden.

**For the UI to be accessible you need to log in as superadmin first**

![Screenshot from 2019-04-04 16-03-17](https://user-images.githubusercontent.com/762088/55561871-32c00f00-56f3-11e9-9f2c-2ca0a246efba.png)



#### What should we test?
As superadmin you should be able to access `/admin/delayed_job`. For the UI to be accessible you need to log in first.

#### Release notes

Add Delayed Job Web to enable delayed job management to superadmins through a web UI.

Changelog Category: Added

#### Discourse thread

https://community.openfoodnetwork.org/t/making-operations-a-first-class-citizen/1601
