### PR TITLE
[Spree Upgrade] Fix two issues in admin orders edit page

### DIFF
--- a/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -34,23 +34,20 @@
     <legend align="center"><%= Spree.t(:select_stock) %></legend>
       <table class="stock-levels" data-hook="stock-levels">
         <colgroup>
+          <col style="width: 60%;" />
           <col style="width: 30%;" />
-          <col style="width: 40%;" />
-          <col style="width: 20%;" />
           <col style="width: 10%;" />
         </colgroup>
         <thead>
-          <th><%= Spree.t(:location) %></th>
           <th><%= Spree.t(:on_hand) %></th>
           <th><%= Spree.t(:quantity) %></th>
           <th class="actions"></th>
         </thead>
         <tbody>
           <tr>
-            <td>{{variant.stock_location_name}}</td>
             {{#if variant.[in_stock?]}}
               {{#if variant.on_demand}}
-                <td>Spree.t(:on_demand)</td>
+                <td><%= Spree.t(:on_demand) %></td>
               {{else}}
                 <td>
                   {{variant.on_hand}}


### PR DESCRIPTION
#### What? Why?

Closes #3684 and #3685 
Removes stock location from stock levels table and fix Spree.t entry bug.

This is the lazy man quick fix, this autocomplete.erb file needs to be converted to haml and the js code moved to angular. Next time... 🙏 

#### What should we test?
Order edit page works as usual, stock location column is not there and if variant is on demand, it shows the translation, not the Spree.t command.
