### PR TITLE
Start upgrade to Rails 4

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -82,7 +82,6 @@ Metrics/LineLength:
   - app/models/enterprise_group.rb
   - app/models/enterprise_role.rb
   - app/models/inventory_item.rb
-  - app/models/order_cycle.rb
   - app/models/product_import/entry_processor.rb
   - app/models/product_import/entry_validator.rb
   - app/models/product_import/product_importer.rb

--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -81,7 +81,6 @@ Metrics/LineLength:
   - app/models/enterprise_fee.rb
   - app/models/enterprise_group.rb
   - app/models/enterprise_role.rb
-  - app/models/exchange.rb
   - app/models/inventory_item.rb
   - app/models/order_cycle.rb
   - app/models/product_import/entry_processor.rb

--- a/app/controllers/spree/admin/base_controller_decorator.rb
+++ b/app/controllers/spree/admin/base_controller_decorator.rb
@@ -52,7 +52,7 @@ Spree::Admin::BaseController.class_eval do
   def active_distributors_not_ready_for_checkout
     ocs = OrderCycle.managed_by(spree_current_user).active
     distributors = ocs.map(&:distributors).flatten.uniq
-    Enterprise.where('id IN (?)', distributors).not_ready_for_checkout
+    Enterprise.where('enterprises.id IN (?)', distributors).not_ready_for_checkout
   end
 
   def active_distributors_not_ready_for_checkout_message(distributors)

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -111,12 +111,12 @@ class Enterprise < ActiveRecord::Base
     joins(:shipping_methods).
       joins(:payment_methods).
       merge(Spree::PaymentMethod.available).
-      select('enterprises.id')
+      select('DISTINCT enterprises.*')
   }
   scope :not_ready_for_checkout, lambda {
     # When ready_for_checkout is empty, return all rows when there are no enterprises ready for
     # checkout.
-    ready_enterprises = Enterprise.ready_for_checkout
+    ready_enterprises = Enterprise.ready_for_checkout.select('enterprises.id')
     if ready_enterprises.present?
       where("enterprises.id NOT IN (?)", ready_enterprises)
     else

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -111,14 +111,14 @@ class Enterprise < ActiveRecord::Base
     joins(:shipping_methods).
       joins(:payment_methods).
       merge(Spree::PaymentMethod.available).
-      select('DISTINCT enterprises.id')
+      select('enterprises.id')
   }
   scope :not_ready_for_checkout, lambda {
     # When ready_for_checkout is empty, return all rows when there are no enterprises ready for
     # checkout.
     ready_enterprises = Enterprise.ready_for_checkout
     if ready_enterprises.present?
-      where("id NOT IN (?)", ready_enterprises)
+      where("enterprises.id NOT IN (?)", ready_enterprises)
     else
       where("TRUE")
     end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -26,11 +26,25 @@ class Exchange < ActiveRecord::Base
   scope :to_enterprise, lambda { |enterprise| where(receiver_id: enterprise) }
   scope :from_enterprises, lambda { |enterprises| where('exchanges.sender_id IN (?)', enterprises) }
   scope :to_enterprises, lambda { |enterprises| where('exchanges.receiver_id IN (?)', enterprises) }
-  scope :involving, lambda { |enterprises| where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises, enterprises).select('DISTINCT exchanges.*') }
-  scope :supplying_to, lambda { |distributor| where('exchanges.incoming OR exchanges.receiver_id = ?', distributor) }
-  scope :with_variant, lambda { |variant| joins(:exchange_variants).where('exchange_variants.variant_id = ?', variant) }
-  scope :with_any_variant, lambda { |variant_ids| joins(:exchange_variants).where('exchange_variants.variant_id IN (?)', variant_ids).select('DISTINCT exchanges.*') }
-  scope :with_product, lambda { |product| joins(:exchange_variants).where('exchange_variants.variant_id IN (?)', product.variants_including_master) }
+  scope :involving, lambda { |enterprises|
+    where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises, enterprises).
+      select('DISTINCT exchanges.*')
+  }
+  scope :supplying_to, lambda { |distributor|
+    where('exchanges.incoming OR exchanges.receiver_id = ?', distributor)
+  }
+  scope :with_variant, lambda { |variant|
+    joins(:exchange_variants).where('exchange_variants.variant_id = ?', variant)
+  }
+  scope :with_any_variant, lambda { |variant_ids|
+    joins(:exchange_variants).
+      where('exchange_variants.variant_id IN (?)', variant_ids).
+      select('DISTINCT exchanges.*')
+  }
+  scope :with_product, lambda { |product|
+    joins(:exchange_variants).
+      where('exchange_variants.variant_id IN (?)', product.variants_including_master)
+  }
   scope :by_enterprise_name, -> {
     joins('INNER JOIN enterprises AS sender   ON (sender.id   = exchanges.sender_id)').
       joins('INNER JOIN enterprises AS receiver ON (receiver.id = exchanges.receiver_id)').
@@ -49,11 +63,12 @@ class Exchange < ActiveRecord::Base
     if user.has_spree_role?('admin')
       scoped
     else
-      joins('LEFT JOIN enterprises senders ON senders.id = exchanges.sender_id').
-        joins('LEFT JOIN enterprises receivers ON receivers.id = exchanges.receiver_id').
-        joins('LEFT JOIN enterprise_roles sender_roles ON sender_roles.enterprise_id = senders.id').
-        joins('LEFT JOIN enterprise_roles receiver_roles ON receiver_roles.enterprise_id = receivers.id').
-        where('sender_roles.user_id = ? AND receiver_roles.user_id = ?', user.id, user.id)
+      joins("LEFT JOIN enterprises senders ON senders.id = exchanges.sender_id").
+        joins("LEFT JOIN enterprises receivers ON receivers.id = exchanges.receiver_id").
+        joins("LEFT JOIN enterprise_roles sender_roles ON sender_roles.enterprise_id = senders.id").
+        joins("LEFT JOIN enterprise_roles receiver_roles
+            ON receiver_roles.enterprise_id = receivers.id").
+        where("sender_roles.user_id = ? AND receiver_roles.user_id = ?", user.id, user.id)
     end
   }
 
@@ -76,7 +91,8 @@ class Exchange < ActiveRecord::Base
   end
 
   def to_h(core_only = false)
-    h = attributes.merge('variant_ids' => variant_ids.sort, 'enterprise_fee_ids' => enterprise_fee_ids.sort)
+    h = attributes.merge('variant_ids' => variant_ids.sort,
+                         'enterprise_fee_ids' => enterprise_fee_ids.sort)
     h.reject! { |k| %w(id order_cycle_id created_at updated_at).include? k } if core_only
     h
   end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -29,7 +29,7 @@ class Exchange < ActiveRecord::Base
   scope :involving, lambda { |enterprises| where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises, enterprises).select('DISTINCT exchanges.*') }
   scope :supplying_to, lambda { |distributor| where('exchanges.incoming OR exchanges.receiver_id = ?', distributor) }
   scope :with_variant, lambda { |variant| joins(:exchange_variants).where('exchange_variants.variant_id = ?', variant) }
-  scope :with_any_variant, lambda { |variants| joins(:exchange_variants).where('exchange_variants.variant_id IN (?)', variants).select('DISTINCT exchanges.*') }
+  scope :with_any_variant, lambda { |variant_ids| joins(:exchange_variants).where('exchange_variants.variant_id IN (?)', variant_ids).select('DISTINCT exchanges.*') }
   scope :with_product, lambda { |product| joins(:exchange_variants).where('exchange_variants.variant_id IN (?)', product.variants_including_master) }
   scope :by_enterprise_name, -> {
     joins('INNER JOIN enterprises AS sender   ON (sender.id   = exchanges.sender_id)').

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -52,7 +52,7 @@ class OrderCycle < ActiveRecord::Base
     if user.has_spree_role?('admin')
       scoped
     else
-      where('coordinator_id IN (?)', user.enterprises)
+      where('coordinator_id IN (?)', user.enterprises.map(&:id))
     end
   }
 
@@ -217,7 +217,7 @@ class OrderCycle < ActiveRecord::Base
   end
 
   def exchanges_supplying(order)
-    exchanges.supplying_to(order.distributor).with_any_variant(order.variants)
+    exchanges.supplying_to(order.distributor).with_any_variant(order.variants.map(&:id))
   end
 
   def coordinated_by?(user)

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -62,7 +62,7 @@ class OrderCycle < ActiveRecord::Base
       scoped
     else
       with_exchanging_enterprises_outer.
-        where('order_cycles.coordinator_id IN (?) OR enterprises.id IN (?)', user.enterprises, user.enterprises).
+        where('order_cycles.coordinator_id IN (?) OR enterprises.id IN (?)', user.enterprises.map(&:id), user.enterprises.map(&:id)).
         select('DISTINCT order_cycles.*')
     end
   }
@@ -78,7 +78,7 @@ class OrderCycle < ActiveRecord::Base
     # Order cycles where I managed an enterprise at either end of an outgoing exchange
     # ie. coordinator or distributor
     joins(:exchanges).merge(Exchange.outgoing).
-      where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises, enterprises).
+      where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises.pluck(:id), enterprises.pluck(:id)).
       select('DISTINCT order_cycles.*')
   }
 
@@ -88,7 +88,7 @@ class OrderCycle < ActiveRecord::Base
     # Order cycles where I managed an enterprise at either end of an incoming exchange
     # ie. coordinator or producer
     joins(:exchanges).merge(Exchange.incoming).
-      where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises, enterprises).
+      where('exchanges.receiver_id IN (?) OR exchanges.sender_id IN (?)', enterprises.pluck(:id), enterprises.pluck(:id)).
       select('DISTINCT order_cycles.*')
   }
 

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -112,7 +112,7 @@ Spree::Product.class_eval do
     if user.has_spree_role?('admin')
       scoped
     else
-      where('supplier_id IN (?)', user.enterprises)
+      where('supplier_id IN (?)', user.enterprises.select("enterprises.id"))
     end
   }
 

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -189,7 +189,9 @@ Spree::Product.class_eval do
       OpenFoodNetwork::ProductsCache.product_deleted(self) do
         touch_distributors
 
-        ExchangeVariant.where('exchange_variants.variant_id IN (?)', variants_including_master.with_deleted.select(:id)).destroy_all
+        ExchangeVariant.
+          where('exchange_variants.variant_id IN (?)', variants_including_master.with_deleted.
+          select(:id)).destroy_all
 
         destroy_without_delete_from_order_cycles
       end
@@ -216,7 +218,7 @@ Spree::Product.class_eval do
   end
 
   def touch_distributors
-    Enterprise.distributing_products(self.id).each(&:touch)
+    Enterprise.distributing_products(id).each(&:touch)
   end
 
   def add_primary_taxon_to_taxons

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -216,7 +216,7 @@ Spree::Product.class_eval do
   end
 
   def touch_distributors
-    Enterprise.distributing_products(self).each(&:touch)
+    Enterprise.distributing_products(self.id).each(&:touch)
   end
 
   def add_primary_taxon_to_taxons

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -189,7 +189,7 @@ Spree::Product.class_eval do
       OpenFoodNetwork::ProductsCache.product_deleted(self) do
         touch_distributors
 
-        ExchangeVariant.where('exchange_variants.variant_id IN (?)', variants_including_master.with_deleted).destroy_all
+        ExchangeVariant.where('exchange_variants.variant_id IN (?)', variants_including_master.with_deleted.select(:id)).destroy_all
 
         destroy_without_delete_from_order_cycles
       end

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -55,7 +55,7 @@ module OpenFoodNetwork
           # TODO: Remove this when all P-OC are sorted out
           # Any hubs that currently have outgoing exchanges distributing variants of producers I manage
           variants = Spree::Variant.joins(:product).where('spree_products.supplier_id IN (?)', managed_enterprises.is_primary_producer)
-          active_exchanges = @order_cycle.exchanges.outgoing.with_any_variant(variants)
+          active_exchanges = @order_cycle.exchanges.outgoing.with_any_variant(variants.select("spree_variants.id"))
           hubs_active = active_exchanges.map(&:receiver_id)
 
           # TODO: Remove this when all P-OC are sorted out
@@ -249,7 +249,7 @@ module OpenFoodNetwork
       # outgoing exchange to those where the producer had granted P-OC to the distributor
       # For any of my managed producers, any outgoing exchanges with their variants
       variants = Spree::Variant.joins(:product).where('spree_products.supplier_id IN (?)', producers)
-      active_exchanges = @order_cycle.exchanges.outgoing.with_any_variant(variants).pluck :id
+      active_exchanges = @order_cycle.exchanges.outgoing.with_any_variant(variants.select("spree_variants.id")).pluck :id
 
       permitted_exchanges | active_exchanges
     end

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -55,7 +55,8 @@ module OpenFoodNetwork
           # TODO: Remove this when all P-OC are sorted out
           # Any hubs that currently have outgoing exchanges distributing variants of producers I manage
           variants = Spree::Variant.joins(:product).where('spree_products.supplier_id IN (?)', managed_enterprises.is_primary_producer)
-          active_exchanges = @order_cycle.exchanges.outgoing.with_any_variant(variants.select("spree_variants.id"))
+          active_exchanges = @order_cycle.
+            exchanges.outgoing.with_any_variant(variants.select("spree_variants.id"))
           hubs_active = active_exchanges.map(&:receiver_id)
 
           # TODO: Remove this when all P-OC are sorted out
@@ -248,8 +249,10 @@ module OpenFoodNetwork
       # active_exchanges is for backward compatability, before we restricted variants in each
       # outgoing exchange to those where the producer had granted P-OC to the distributor
       # For any of my managed producers, any outgoing exchanges with their variants
-      variants = Spree::Variant.joins(:product).where('spree_products.supplier_id IN (?)', producers)
-      active_exchanges = @order_cycle.exchanges.outgoing.with_any_variant(variants.select("spree_variants.id")).pluck :id
+      variants = Spree::Variant.
+        joins(:product).where('spree_products.supplier_id IN (?)', producers)
+      active_exchanges = @order_cycle.
+        exchanges.outgoing.with_any_variant(variants.select("spree_variants.id")).pluck :id
 
       permitted_exchanges | active_exchanges
     end

--- a/lib/open_food_network/products_cache.rb
+++ b/lib/open_food_network/products_cache.rb
@@ -94,7 +94,8 @@ module OpenFoodNetwork
     end
 
     def self.inventory_item_changed(inventory_item)
-      exchanges_featuring_variants(inventory_item.variant.id, distributor: inventory_item.enterprise).each do |exchange|
+      exchanges_featuring_variants(inventory_item.variant.id,
+                                   distributor: inventory_item.enterprise).each do |exchange|
         refresh_cache exchange.receiver, exchange.order_cycle
       end
     end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -360,13 +360,13 @@ describe Enterprise do
 
       it "returns enterprises distributing via an order cycle" do
         order_cycle = create(:simple_order_cycle, distributors: [distributor], variants: [product.master])
-        expect(Enterprise.distributing_products(product)).to eq([distributor])
+        expect(Enterprise.distributing_products(product.id)).to eq([distributor])
       end
 
       it "does not return duplicate enterprises" do
         another_product = create(:product)
         order_cycle = create(:simple_order_cycle, distributors: [distributor], variants: [product.master, another_product.master])
-        expect(Enterprise.distributing_products([product, another_product])).to eq([distributor])
+        expect(Enterprise.distributing_products([product.id, another_product.id])).to eq([distributor])
       end
     end
 

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -240,7 +240,7 @@ describe Exchange do
       ex.variants << v1
       ex.variants << v2
 
-      expect(Exchange.with_any_variant([v1, v2, v3])).to eq([ex])
+      expect(Exchange.with_any_variant([v1.id, v2.id, v3.id])).to eq([ex])
     end
 
     it "finds exchanges with a particular product's master variant" do


### PR DESCRIPTION
#### What? Why?

Starts #3708
This makes some of our code in models compatible with rails 4 by making scopes select the appropriate field when using the IN operator.

This PR does not close the issue, there are quite a few more places where we have to do this, this PR serves as a sample of what we need to do so we can validate the approach and do the same for the rest of the codebase.

#### map, select or pluck
The trick here is to know when to use map, select or pluck. With this PR I have learned a few things including [how CollectionProxy works](https://technology.customink.com/blog/2014/10/07/rails-association-proxies/)!
Relations have the methods select and pluck. Arrays have the map method.
A scope returns a relation but an association returns a CollectionProxy that has both methods from a relation select and pluck plus all the array methods including map. So we can use map on an association but not on a scope.
The challenge is that select returns a relation while pluck returns an array. So, when we use pluck we can't really chain relations and we create an extra query just for that pluck statement.
SO, when we are handling relations that will be chained or used in other queries, we need to use select.

#### What should we test?
This 2-0 build should be green.
This code can also be seen in the 2-1-stable where it fixes a few specs.

I think we will be ok with a sanity check. Maybe we can test adding variants to an order cycle and removing them and make sure the shopfront reacts correctly. Making sure the products cache is active.

#### Release notes
Changelog Category: Changed
Started adapting our codebase to Rails 4.

#### How is this related to the Spree upgrade?
Upgrading our code to rails 4 is part of the upgrade to spree 2-1.

