### PR TITLE
[Spree Upgrade] Update to spree revision that depends on aws-sdk 1.11.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 060d0a5d8b31f68990fa792e0e88910c742d9a96
+  revision: 46d6f8f5fd434105b0c69958276d1727a3066a97
   branch: 2-0-4-stable
   specs:
     spree (2.0.4)


### PR DESCRIPTION
#### What? Why?
This makes ofn gemfile.lock compatible with ofn/spree 2-0-4 gemspec. This problem was originally discussed [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/3641#discussion_r272578245).

In this PR we update the spree revision to the revision generated in https://github.com/openfoodfoundation/spree/pull/40

#### What should we test?
This build is green but only with #3641 and #3667 

Manual Test: Product images are correctly uploaded to AWS.

#### Dependencies
This PR can only be merged after #3641.
