### PR TITLE
[Spree Upgrade] Add order distributor to shipping method in reports_spec

### DIFF
--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -182,7 +182,7 @@ feature %q{
     let(:distributor2) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
     let(:user1) { create_enterprise_user enterprises: [distributor1] }
     let(:user2) { create_enterprise_user enterprises: [distributor2] }
-    let!(:shipping_method) { create(:shipping_method_with, :expensive_name) }
+    let!(:shipping_method) { create(:shipping_method_with, :expensive_name, distributors: [distributor1]) }
     let(:enterprise_fee) { create(:enterprise_fee, enterprise: user1.enterprises.first, tax_category: product2.tax_category, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 120.0)) }
     let(:order_cycle) { create(:simple_order_cycle, coordinator: distributor1, coordinator_fees: [enterprise_fee], distributors: [distributor1], variants: [product1.master]) }
 
@@ -194,8 +194,6 @@ feature %q{
 
     let!(:line_item1) { create(:line_item, variant: product1.master, price: 12.54, quantity: 1, order: order1) }
     let!(:line_item2) { create(:line_item, variant: product2.master, price: 500.15, quantity: 3, order: order1) }
-
-    let!(:adj_shipping) { create(:adjustment, adjustable: order1, label: "Shipping", amount: 100.55) }
 
     before do
       allow(Spree::Config).to receive(:shipment_inc_vat) { true }


### PR DESCRIPTION
#### What? Why?

This PR makes the 2-0-stable build green again.
After #3604 shipping methods need to have the same distributor as the order distributor otherwise it wont be used in the test.
This was breaking reports_spec.

Additionally, the manual adjustment is redundant. The pit of callback hell will recalculate the adjustments correctly :-D

#### What should we test?
only a spec changed. a green build is enough.
