### PR TITLE
Add specs for the cache refresh on variant removal

### DIFF
--- a/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/spec/controllers/spree/api/variants_controller_spec.rb
@@ -55,15 +55,24 @@ module Spree
         lambda { variant.reload }.should_not raise_error
         variant.deleted_at.should be_nil
       end
+
+      context 'when the variant is not the master' do
+        before { variant.update_attribute(:is_master, false) }
+
+        it 'refreshes the cache' do
+          expect(OpenFoodNetwork::ProductsCache).to receive(:variant_destroyed).with(variant)
+          spree_delete :soft_delete, variant_id: variant.id, product_id: variant.product.permalink, format: :json
+        end
+      end
     end
 
     context "as an administrator" do
       sign_in_as_admin!
 
-      it "soft deletes a variant" do
-        product = create(:product)
-        variant = product.master
+      let(:product) { create(:product) }
+      let(:variant) { product.master }
 
+      it "soft deletes a variant" do
         spree_delete :soft_delete, {variant_id: variant.to_param, product_id: product.to_param, format: :json}
         response.status.should == 204
         lambda { variant.reload }.should_not raise_error
@@ -78,6 +87,15 @@ module Spree
 
         expect(variant.reload).to_not be_deleted
         expect(assigns(:variant).errors[:product]).to include "must have at least one variant"
+      end
+
+      context 'when the variant is not the master' do
+        before { variant.update_attribute(:is_master, false) }
+
+        it 'refreshes the cache' do
+          expect(OpenFoodNetwork::ProductsCache).to receive(:variant_destroyed).with(variant)
+          spree_delete :soft_delete, variant_id: variant.id, product_id: variant.product.permalink, format: :json
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

It was reported in https://github.com/openfoodfoundation/openfoodnetwork/issues/3691#issuecomment-480996225 that was working but a bit slow.

I investigated and the issue is that from the Bulk Products page we send a different HTTP request compared to the variants section of product details page. While in the latter we send `DELETE /admin/products/tomatoes/variants/17`, in the former we send a `DELETE /api/products/tomatoes/variants/17/soft_delete`.

This is failing in `master` but thanks to the `VariantDeleter` it does work in v2. This specs prove it.

#### What should we test?

The same as #3639 from the Bulk Products page. We should have an OC with a product containing more than one variant. Then, deleting one of them from the Bulk Products page should refresh the cache and therefore neither the shopfront nor the OC should display it anymore.

#### Release notes

Added specs to cover the products cache refresh when removing a variant from the Bulk Products page

Changelog Category: Added
