### PR TITLE
Db2fog patch

### DIFF
--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -2,6 +2,6 @@
 DB2Fog.config = {
     :aws_access_key_id     => Spree::Config[:s3_access_key],
     :aws_secret_access_key => Spree::Config[:s3_secret],
-    :directory             => Spree::Config[:s3_bucket],
+    :directory             => ENV['S3_BACKUPS_BUCKET'],
     :provider              => 'AWS'
 }

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -26,6 +26,7 @@ Spree.config do |config|
   config.s3_access_key = ENV['S3_ACCESS_KEY'] if ENV['S3_ACCESS_KEY']
   config.s3_secret = ENV['S3_SECRET'] if ENV['S3_SECRET']
   config.use_s3 = true if ENV['S3_ACCESS_KEY'] && ENV['S3_SECRET']
+  config.s3_protocol = ENV.fetch('S3_PROTOCOL', 'https')
 end
 
 # Don't log users out when setting a new password

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -20,6 +20,12 @@ Spree.config do |config|
   # Auto-capture payments. Without this option, payments must be manually captured in the paypal interface.
   config.auto_capture = true
   #config.override_actionmailer_config = false
+
+  # S3 settings
+  config.s3_bucket = ENV['S3_BUCKET'] if ENV['S3_BUCKET']
+  config.s3_access_key = ENV['S3_ACCESS_KEY'] if ENV['S3_ACCESS_KEY']
+  config.s3_secret = ENV['S3_SECRET'] if ENV['S3_SECRET']
+  config.use_s3 = true if ENV['S3_ACCESS_KEY'] && ENV['S3_SECRET']
 end
 
 # Don't log users out when setting a new password

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,11 +21,11 @@ every 1.day, at: '12:05am' do
 end
 
 every 1.day, at: '2:45am' do
-  rake 'db2fog:clean'
+  rake 'db2fog:clean' if ENV['S3_BACKUPS_BUCKET']
 end
 
 every 4.hours do
-  rake 'db2fog:backup'
+  rake 'db2fog:backup' if ENV['S3_BACKUPS_BUCKET']
 end
 
 every 5.minutes do


### PR DESCRIPTION
#### What? Why?

This is a pre-release patch for the recent changes in #3694

- Switches to the use of ENV vars for db2fog bucket name so it can be provisioned separately. This is to avoid conflicts with the `Spree::Config[:s3_bucket]` preference which was previously accessible through the superadmin config page, but could not be provisioned.
- Makes the `db2fog` tasks in `schedule.rb` conditional.
- Sets the `s3_protocol` to 'https' by default unless another option is specified.

Whilst testing this more thoroughly I also discovered the variables we were provisioning in `application.yml` were not being picked up by `Spree::Config` (for the last 2 years! :see_no_evil: ), so I've fixed that.

See related change in ofn-install: https://github.com/openfoodfoundation/ofn-install/pull/386