### PR TITLE
Install and set up newrelic_rpm gem for development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ NERD_tree*
 coverage
 libpeerconnection.log
 /config/application.yml
+/config/newrelic.yml
 node_modules
 vendor/bundle/
 coverage

--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,7 @@ end
 
 group :development do
   gem 'byebug', '~> 9.0.0' # 9.1 requires ruby 2.2
+  gem "newrelic_rpm", "~> 3.0"
   gem 'pry-byebug', '>= 3.4.3'
   gem 'debugger-linecache'
   gem 'guard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,6 +542,7 @@ GEM
     nenv (0.3.0)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
+    newrelic_rpm (3.18.1.330)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
@@ -824,6 +825,7 @@ DEPENDENCIES
   letter_opener (>= 1.4.1)
   listen (= 3.0.8)
   momentjs-rails
+  newrelic_rpm (~> 3.0)
   nokogiri (>= 1.6.7.1)
   oauth2 (~> 1.4.1)
   ofn-qz!

--- a/config/newrelic.yml.example
+++ b/config/newrelic.yml.example
@@ -1,0 +1,4 @@
+development:
+  app_name: Open Food Network (Development)
+  developer_mode: true
+  monitor_mode: false

--- a/script/setup
+++ b/script/setup
@@ -46,6 +46,12 @@ if [ ! -f config/application.yml ]; then
   printf "${YELLOW}Copied config/application.yml Make sure to fill it with the appropriate configuration values.\n\n${NO_COLOR}"
 fi
 
+# Set up newrelic.yml for development environment, used by the newrelic_rpm gem
+if [ ! -f config/newrelic.yml ]; then
+  cp config/newrelic.yml.example config/newrelic.yml
+  printf "${YELLOW}Copied config/newrelic.yml which configures the development environment for the newrelic_rpm gem.\n\n${NO_COLOR}"
+fi
+
 # Set up the database for both development and test
 # Confirming the default user and password Spree prompts
 printf '\n\n' | bundle exec rake db:setup db:test:prepare


### PR DESCRIPTION
#### What? Why?

The 3.x version of `newrelic_rpm` gem offers a local dashboard (does not require registration on their website) for tracking and analyzing SQL queries that were done for a Rails instance.

Over `rack-mini-profiler`, it provides the following:

* Tracking for multiple requests - Can analyze requests not just for the current page
* Centralized page for reviewing
* :point_up: Which allows us to easily analyze data for AJAX requests
* Ability to drill down to exact line of code (with stacktrace) where the SQL queries were executed
* Nice summaries

The next major version of the gem removes this local dashboard, so this doesn't seem like a good idea to introduce now. There is actually version 6.x already. But the 3.x version works for the OFN `2-0-stable` branch, and might still be worth keeping until we have improved performance issues.

This PR only adds this gem for the `development` environment.

To go to that quite helpful dashboard in `development` environment, go to `/newrelic`, e.g. http://localhost:3000/newrelic

#### What should we test?

Just test that any page loads. The admin dashboard might be a nice sample page for this.

#### Release notes

- Install and set up `newrelic_rpm` gem for the development environment.

Changelog Category: Added