### PR TITLE
[Spree Upgrade] Fix bug in Variant Overrides controller

### DIFF
--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -77,6 +77,7 @@ module Admin
 
     def collection
       @variant_overrides = VariantOverride.for_hubs(params[:hub_id] || @hubs)
+      @variant_overrides.select { |vo| vo.variant.present? }
     end
 
     def collection_actions

--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -76,7 +76,7 @@ module Admin
     end
 
     def collection
-      @variant_overrides = VariantOverride.for_hubs(params[:hub_id] || @hubs)
+      @variant_overrides = VariantOverride.includes(:variant).for_hubs(params[:hub_id] || @hubs)
       @variant_overrides.select { |vo| vo.variant.present? }
     end
 

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -68,6 +68,21 @@ describe Admin::VariantOverridesController, type: :controller do
               expect(VariantOverride.find_by_id(variant_override.id)).to be_nil
             end
           end
+
+          context "and there is a variant override for a deleted variant" do
+            let(:deleted_variant) { create(:variant) }
+            let!(:variant_override_of_deleted_variant) { create(:variant_override, hub: hub, variant: deleted_variant) }
+
+            it "allows to update other variant overrides" do
+              deleted_variant.update_attribute :deleted_at, Time.zone.now
+
+              spree_put :bulk_update, format: format, variant_overrides: variant_override_params
+
+              expect(response).to_not redirect_to spree.unauthorized_path
+              variant_override.reload
+              expect(variant_override.price).to eq 123.45
+            end
+          end
         end
       end
     end

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -73,9 +73,9 @@ describe Admin::VariantOverridesController, type: :controller do
             let(:deleted_variant) { create(:variant) }
             let!(:variant_override_of_deleted_variant) { create(:variant_override, hub: hub, variant: deleted_variant) }
 
-            it "allows to update other variant overrides" do
-              deleted_variant.update_attribute :deleted_at, Time.zone.now
+            before { deleted_variant.update_attribute :deleted_at, Time.zone.now }
 
+            it "allows to update other variant overrides" do
               spree_put :bulk_update, format: format, variant_overrides: variant_override_params
 
               expect(response).to_not redirect_to spree.unauthorized_path


### PR DESCRIPTION
the controller was validating authorization for variant overrides of deleted variants. These overrides are never shown on the UI.

#### What? Why?

Closes #3715

#### What should we test?
This can be easily replicated but only as enterprise manager, not as super admin:
- create a product in a producer with 2 variants
- create overrides on a hub for those two variants with overridden price for example
- delete one of the variants from the producer catalog
- go to hub's inventory and try to update the other variants price
- you should not see the authorization error reported in the issue

#### Release notes
It's an issue introduced in v2 only.

#### Thoughts
This was the fix I managed to find before leaving on holidays but it's probably better to put it in the for_hubs scope of the VariantOverride model. Maybe reviewers can suggest or put a new commit to move the fix to the scope ;-)