### PR TITLE
Invalid pickup instrc

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -14,6 +14,7 @@ class Exchange < ActiveRecord::Base
 
   validates_presence_of :order_cycle, :sender, :receiver
   validates_uniqueness_of :sender_id, scope: [:order_cycle_id, :receiver_id, :incoming]
+  validates_length_of :pickup_instructions, :maximum => 255
 
   after_save :refresh_products_cache
   after_destroy :refresh_products_cache_from_destroy

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -17,7 +17,7 @@
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
       %span.icon-question-sign{'ofn-with-tip' => t('.pickup_time_tip')}
       %br/
-      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => t('.pickup_instructions_placeholder'), 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'
+      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => t('.pickup_instructions_placeholder'), 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 255
       %span.icon-question-sign{'ofn-with-tip' => t('.pickup_instructions_tip')}
   %td.fees
     %ol{ ng: { show: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }


### PR DESCRIPTION
#### What? Why?

Closes #3192 

Added validation of length on pickup_instructions in exchanges model, as well as added text limit on input field for pickup_instructions to only, allow a user to enter 255 characters.



#### What should we test?
Creating and updating a new order cycle with exchanges that have pickup instructions with vaid and invalid lengths.



#### Release notes

Changelog Category: Fixed