### PR TITLE
3292 link popup text translation

### DIFF
--- a/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
@@ -18,8 +18,8 @@ angular.module("admin.enterprises", [
       '$delegate'
       (taTranslations) ->
         taTranslations.insertLink = {
-          tooltip: 'Insert / edit link',
-          dialogPrompt: "Please enter a URL to insert"
+          tooltip: "{{'admin.enterprises.form.shop_preferences.shopfront_message_link_tooltip' | t}}",
+          dialogPrompt: "{{'admin.enterprises.form.shop_preferences.shopfront_message_link_prompt' | t}}"
         }
         taTranslations
     ]

--- a/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
@@ -18,8 +18,8 @@ angular.module("admin.enterprises", [
       '$delegate'
       (taTranslations) ->
         taTranslations.insertLink = {
-          tooltip: "{{'admin.enterprises.form.shop_preferences.shopfront_message_link_tooltip' | t}}",
-          dialogPrompt: "{{'admin.enterprises.form.shop_preferences.shopfront_message_link_prompt' | t}}"
+          tooltip: t('admin.enterprises.form.shop_preferences.shopfront_message_link_tooltip'),
+          dialogPrompt: t('admin.enterprises.form.shop_preferences.shopfront_message_link_prompt')
         }
         taTranslations
     ]

--- a/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
@@ -11,6 +11,7 @@ angular.module("admin.enterprises", [
   'admin.dropdown',
   'ngSanitize']
 )
+# For more options: https://github.com/textAngular/textAngular/blob/master/src/textAngularSetup.js
 .config [
   '$provide', ($provide) ->
     $provide.decorator 'taTranslations', [

--- a/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/enterprises.js.coffee
@@ -1,1 +1,25 @@
-angular.module("admin.enterprises", [  "admin.paymentMethods",  "admin.utils",  "admin.shippingMethods",  "admin.users",  "textAngular",  "admin.side_menu",  "admin.taxons",  'admin.indexUtils',  'admin.tagRules',  'admin.dropdown',  'ngSanitize'])
+angular.module("admin.enterprises", [
+  "admin.paymentMethods",
+  "admin.utils",
+  "admin.shippingMethods",
+  "admin.users",
+  "textAngular",
+  "admin.side_menu",
+  "admin.taxons",
+  'admin.indexUtils',
+  'admin.tagRules',
+  'admin.dropdown',
+  'ngSanitize']
+)
+.config [
+  '$provide', ($provide) ->
+    $provide.decorator 'taTranslations', [
+      '$delegate'
+      (taTranslations) ->
+        taTranslations.insertLink = {
+          tooltip: 'Insert / edit link',
+          dialogPrompt: "Please enter a URL to insert"
+        }
+        taTranslations
+    ]
+]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -793,6 +793,8 @@ en:
           shopfront_message_placeholder: >
             An optional explanation for customers detailing how your shopfront works,
             to be displayed above the product list on your shop page.
+          shopfront_message_link_tooltip: Insert / edit link
+          shopfront_message_link_prompt: Please enter a URL to insert
           shopfront_closed_message: Shopfront Closed Message
           shopfront_closed_message_placeholder: >
             A message which provides a more detailed explanation about why your shop is

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -789,25 +789,25 @@ en:
           enable_subscriptions_tip: "Enable subscriptions functionality?"
           enable_subscriptions_false: "Disabled"
           enable_subscriptions_true: "Enabled"
-          shopfront_message: Shopfront Message
+          shopfront_message: "Shopfront Message"
           shopfront_message_placeholder: >
             An optional explanation for customers detailing how your shopfront works,
             to be displayed above the product list on your shop page.
-          shopfront_message_link_tooltip: Insert / edit link
-          shopfront_message_link_prompt: Please enter a URL to insert
-          shopfront_closed_message: Shopfront Closed Message
+          shopfront_message_link_tooltip: "Insert / edit link"
+          shopfront_message_link_prompt: "Please enter a URL to insert"
+          shopfront_closed_message: "Shopfront Closed Message"
           shopfront_closed_message_placeholder: >
             A message which provides a more detailed explanation about why your shop is
             closed and/or when customers can expect it to open again. This is displayed
             on your shop only when you have no active order cycles (ie. shop is closed).
-          shopfront_category_ordering: Shopfront Category Ordering
-          open_date: Open Date
-          close_date: Close Date
+          shopfront_category_ordering: "Shopfront Category Ordering"
+          open_date: "Open Date"
+          close_date: "Close Date"
         social:
-          twitter_placeholder: eg. @the_prof
-          instagram_placeholder: eg. the_prof
-          facebook_placeholder: eg. www.facebook.com/PageNameHere
-          linkedin_placeholder: eg. www.linkedin.com/in/YourNameHere
+          twitter_placeholder: "eg. @the_prof"
+          instagram_placeholder: "eg. the_prof"
+          facebook_placeholder: "eg. www.facebook.com/PageNameHere"
+          linkedin_placeholder: "eg. www.linkedin.com/in/YourNameHere"
         stripe_connect:
           connect_with_stripe: "Connect with Stripe"
           stripe_connect_intro: "To accept payments using credit card, you will need to connect your stripe account to the Open Food Network. Use the button to the right to get started."

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -209,6 +209,12 @@ feature %q{
     page.should have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
     expect(page).to have_checked_field "enterprise_require_login_true"
     expect(page).to have_checked_field "enterprise_enable_subscriptions_true"
+
+    # Test that the right input alert text is displayed
+    accept_alert('Please enter a URL to insert') do
+      first('.ta-text').click
+      first('button[name="insertLink"]').click
+    end
   end
 
   describe "producer properties" do


### PR DESCRIPTION
Closes #3292 

Getting close to translating pop-up alert from textAngular, can't figure out how to make the dynamic parsing of the translation work. Looks like this is an existing issue: https://github.com/textAngular/textAngular/issues/821

Filling out the rest of the info below in case this is seen through to completion.

UPDATE (Luis): removed double quotes and used t function, it's working now. I think this is ready for review and test.

#### Release notes
Ability to translate text on pop-up input field when adding a link to shopfront messages in admin configs.

Changelog Category: Changed

#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

