### PR TITLE
Store S3 keys in Config before calling db2fog

### DIFF
--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -1,3 +1,5 @@
+require './config/initializers/spree'
+
 # See: https://github.com/yob/db2fog
 DB2Fog.config = {
     :aws_access_key_id     => Spree::Config[:s3_access_key],


### PR DESCRIPTION
#### What? Why?

This ensures that Db2fog always picks up the latest value of the S3_* env vars and not the one that was persisted last time. Now you can do things like `S3_BUCKET=xxx bundle exec rake b2fog:backup` if you had to.

#### What should we test?
Nothing

#### Release notes

Make Db2fog pick up the latest values of the S3 env vars and not the ones previously persisted.

Changelog Category: Fixed