### PR TITLE
Allow passing s3 region

### DIFF
--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -7,3 +7,5 @@ DB2Fog.config = {
     :directory             => ENV['S3_BACKUPS_BUCKET'],
     :provider              => 'AWS'
 }
+
+DB2Fog.config[:region] = ENV['S3_REGION'] if ENV['S3_REGION']

--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -1,3 +1,5 @@
+require_relative 'spree'
+
 # See: https://github.com/yob/db2fog
 DB2Fog.config = {
     :aws_access_key_id     => Spree::Config[:s3_access_key],


### PR DESCRIPTION
#### What? Why?

This PR does two things:

This ensures that Db2fog always picks up the latest value of the S3_* env vars and not the one that was persisted last time. Now you can do things like S3_BUCKET=xxx bundle exec rake b2fog:backup if you had to.

But also, allows passing a specific AWS region to S3 settings. This solves the error showed below when executed `bundle exec rake db2fog:backup RAILS_ENV=staging` on Katuma staging

    ```
    Excon::Error::BadRequest: Expected(200) <=> Actual(400 Bad Request)
    excon.error.response
      :body          => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>AuthorizationHeaderMalformed</Code><Message>The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-central-1'</Message><Region>eu-central-1</Region><RequestId>3DE2763883FC601D</RequestId><HostId>1E6UapnblBqVZM0SeeLrdPNDd+VaQ0nxCWwrQ9mi8HjRo2xevAUwtSq5V3fxhsj4Cj9ynnDroco=</HostId></Error>"
    ```

#### What should we test?
Backups configured in another region go through without any failures.



#### Release notes

Make Db2fog pick up the latest values of the S3 env vars and not the ones previously persisted.
Changelog Category: Fixed

Allow storing backups in any S3 region
Changelog Category: Added