### PR TITLE
Don't use s3 for images unless images bucket has been provisioned.

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -25,7 +25,7 @@ Spree.config do |config|
   config.s3_bucket = ENV['S3_BUCKET'] if ENV['S3_BUCKET']
   config.s3_access_key = ENV['S3_ACCESS_KEY'] if ENV['S3_ACCESS_KEY']
   config.s3_secret = ENV['S3_SECRET'] if ENV['S3_SECRET']
-  config.use_s3 = true if ENV['S3_ACCESS_KEY'] && ENV['S3_SECRET']
+  config.use_s3 = true if ENV['S3_BUCKET']
   config.s3_protocol = ENV.fetch('S3_PROTOCOL', 'https')
 end
 


### PR DESCRIPTION
#### What? Why?

Closes #3766 

Sets the `use_s3` (for images) option based on presence of `s3_images_bucket` from ofn-install instead of presence of s3 keys, for instances that use s3 for backups but not for images.

#### What should we test?
<!-- List which features should be tested and how. -->

Provisioning Katuma shouldn't activate the use of s3 for images.

@sauloperez 