### PR TITLE
[Spree Upgrade] Migrate spree_variants.on_demand to spree_stock_items.backorderable

### DIFF
--- a/db/migrate/20180426145635_remove_on_demand_from_product_and_variant.spree.rb
+++ b/db/migrate/20180426145635_remove_on_demand_from_product_and_variant.spree.rb
@@ -2,6 +2,6 @@
 class RemoveOnDemandFromProductAndVariant < ActiveRecord::Migration
   def change
     remove_column :spree_products, :on_demand
-    remove_column :spree_variants, :on_demand
+    # we are removing spree_variants.on_demand in a later migration
   end
 end

--- a/db/migrate/20190501143327_migrate_variants_on_demand_to_stock_items_backorderable.rb
+++ b/db/migrate/20190501143327_migrate_variants_on_demand_to_stock_items_backorderable.rb
@@ -1,0 +1,16 @@
+class MigrateVariantsOnDemandToStockItemsBackorderable < ActiveRecord::Migration
+  def up
+    # We use SQL directly here to avoid going through VariantStock.on_demand and VariantStock.on_demand=
+    sql = "update spree_stock_items set backorderable = (select on_demand from spree_variants where spree_variants.id = spree_stock_items.variant_id)"
+    ActiveRecord::Base.connection.execute(sql)
+
+    remove_column :spree_variants, :on_demand
+  end
+
+  def down
+    add_column :spree_variants, :on_demand, :boolean, :default => false
+
+    sql = "update spree_variants set on_demand = (select backorderable from spree_stock_items where spree_variants.id = spree_stock_items.variant_id)"
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190320111312) do
+ActiveRecord::Schema.define(:version => 20190501143327) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"


### PR DESCRIPTION
#### What? Why?

Closes #3767
Copies data from spree_variants.on_demand to spree_stock_items.backorderable and then drops spree_variants.on_demand.

#### What should we test?
See issue #3767