### PR TITLE
Closes translation bug for enterprise fee settings

### DIFF
--- a/app/assets/javascripts/admin/enterprise_fees/controllers/enterprise_fees_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprise_fees/controllers/enterprise_fees_controller.js.coffee
@@ -1,6 +1,6 @@
 angular.module('admin.enterpriseFees').controller 'enterpriseFeesCtrl', ($scope, $http, $window, enterprises, tax_categories, calculators) ->
   $scope.enterprises = enterprises
-  $scope.tax_categories =  [{id: -1, name: "Inherit From Product"}].concat tax_categories
+  $scope.tax_categories =  [{id: -1, name: t('js.admin.enterprise_fees.inherit_from_product') }].concat tax_categories
   $scope.calculators = calculators
 
   $scope.enterpriseFeesUrl = ->

--- a/app/views/admin/enterprise_fees/index.html.haml
+++ b/app/views/admin/enterprise_fees/index.html.haml
@@ -6,7 +6,7 @@
   = render "admin/enterprise_fees/data"
   = render :partial => 'spree/shared/error_messages', :locals => { :target => @enterprise_fee_set }
 
-  %input.search{'ng-model' => 'query', 'placeholder' => 'Search'}
+  %input.search{'ng-model' => 'query', 'placeholder' => t('.search')}
 
   %table.index#listing_enterprise_fees
     %thead

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,6 +501,7 @@ en:
         tax_category: Tax Category
         calculator: Calculator
         calculator_values: Calculator Values
+        search: "Search"
 
     enterprise_groups:
       index:
@@ -2572,6 +2573,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           resolve: Resolve
       new_tag_rule_dialog:
         select_rule_type: "Select a rule type:"
+      enterprise_fees:
+        inherit_from_product: "Inherit From Product"
       orders:
         index:
           per_page: "%{results} per page"


### PR DESCRIPTION
#### What? Why?
The enterprise fee management menu has two missing keys. Namely, the search text in search bar and the inherit from product option in tax category. Closed previous PR because of squashing issues. Created new PR instead. 

Closes #3722
I have generated keys for both and put them in the en.yml file. After reviewing, both cases work.

What should we test?

Check if the correct keys are accessed.
Release notes

Transifex will do its magic once everything is merged

FIxed