### PR TITLE
3782 Fix missing translation in subscription update modal

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/controllers/order_update_issues_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/order_update_issues_controller.js.coffee
@@ -6,5 +6,6 @@ angular.module("admin.subscriptions").controller "OrderUpdateIssuesController", 
 
   $scope.orderCycleCloses = (id) ->
     closes_at = moment(OrderCycles.byID[id].orders_close_at)
-    text = if closes_at > moment() then t('js.closes') else t('js.closed')
+    key = if closes_at > moment() then "closes" else "closed"
+    text = t("js.subscriptions." + key)
     "#{text} #{closes_at.fromNow()}"


### PR DESCRIPTION
Fix missing translation in subscription update modal.

:warning: This includes changes in #3589 and needs to be rebased after that PR is merged. Only the last commit here is really for this PR.

#### What? Why?

Closes #3782 

See issue for details.

#### What should we test?

1. Create a subscription with no end date for an open OC. Set pickup as the shipping method.
2. Edit the subscription order.
3. Change the billing name for the order.
4. Edit the subscription.
5. Change the billing name for the subscription.
6. In the modal that opens, there should be no missing translation.

#### Release notes

This is for 2-0-stable.

#### Dependencies

This includes changes in #3589.