### PR TITLE
changed string into translation key & add 'infinity' key

### DIFF
--- a/app/overrides/spree/admin/variants/_form/on_demand_script.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/on_demand_script.html.haml.deface
@@ -14,7 +14,7 @@
             on_hand.attr('disabled', on_demand_checked);
             if(on_demand_checked) {
               on_hand.attr('data-stock', on_hand.val());
-              on_hand.val("Infinity");
+              on_hand.val(t('admin.products.variants.infinity'));
             }
         }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -467,6 +467,7 @@ en:
         property_name: Property Name
         inherited_property: Inherited Property
       variants:
+        infinity: "Infinity"
         to_order_tip: "Items made to order do not have a set stock level, such as loaves of bread made fresh to order."
       group_buy_options: "Group Buy Options"
       back_to_products_list: "Back to products list"


### PR DESCRIPTION

#### What? Why?

Closes #3687

Changed string "Infinity" into translation key and add 'infinity' key to get a translated string.


#### What should we test?

1. Log in as a producer or super admin or hub
2. Go on "products"
3. Click on the edit icon of one product
4. Click on the variant submenu
5. Click on the edit icon of the product
6. Check the string "infinity" translated (in "es" local page)


#### Release notes

Fixed translation on variants page

Changelog Category: Fixed


