### PR TITLE
Add display_name and display_as to admin edit variant page

### DIFF
--- a/app/overrides/spree/admin/variants/_form/add_display_name.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_display_name.html.haml.deface
@@ -1,8 +1,0 @@
-/ insert_top "[data-hook='variants']"
-
-.field
-  = f.label :display_name, t(:display_name)
-  = f.text_field :display_name, class: "fullwidth"
-.field
-  = f.label :display_as, t(:display_as)
-  = f.text_field :display_as, class: "fullwidth"

--- a/app/overrides/spree/admin/variants/_form/add_display_name.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_display_name.html.haml.deface
@@ -1,0 +1,8 @@
+/ insert_top "[data-hook='variants']"
+
+.field
+  = f.label :display_name, t(:display_name)
+  = f.text_field :display_name, class: "fullwidth"
+.field
+  = f.label :display_as, t(:display_as)
+  = f.text_field :display_as, class: "fullwidth"

--- a/app/overrides/spree/admin/variants/_form/add_display_name_unit_value_and_description.html.haml.deface
+++ b/app/overrides/spree/admin/variants/_form/add_display_name_unit_value_and_description.html.haml.deface
@@ -1,5 +1,12 @@
 / insert_top "[data-hook='admin_variant_form_fields']"
 
+.field
+  = f.label :display_name, t(:display_name)
+  = f.text_field :display_name, class: "fullwidth"
+.field
+  = f.label :display_as, t(:display_as)
+  = f.text_field :display_as, class: "fullwidth"
+
 - if product_has_variant_unit_option_type?(@product)
   - if @product.variant_unit != 'items'
     .field{"data-hook" => "unit_value", 'ng-controller' => 'variantUnitsCtrl'}

--- a/spec/features/admin/variants_spec.rb
+++ b/spec/features/admin/variants_spec.rb
@@ -118,4 +118,29 @@ feature %q{
     v.reload
     v.deleted_at.should_not be_nil
   end
+
+  scenario "editing display name for a variant", js:true do
+    p = create(:simple_product)
+    v = p.variants.first
+
+    # When I view the variant
+    login_to_admin_section
+    visit spree.admin_product_variants_path p
+    page.find('table.index .icon-edit').click
+
+    # It should allow the display name to be changed
+    page.should have_field "variant_display_name"
+    page.should have_field "variant_display_as"
+
+    # When I update the fields and save the variant
+    fill_in "variant_display_name", with: "Display Name"
+    fill_in "variant_display_as", with: "Display As This"
+    click_button 'Update'
+    page.should have_content %Q(Variant "#{p.name}" has been successfully updated!)
+
+    # Then the displayed values should have been saved
+    v.reload
+    v.display_name.should == "Display Name"
+    v.display_as.should == "Display As This"
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3249

Adds "Display name" and "Display As" fields to Variant edit form.



#### What should we test?
Test that fields display and update the correct variant attributes



#### Release notes
Display name can now be set while creating/editing an individual variant

Changelog Category: Fixed 


#### Discourse thread

https://community.openfoodnetwork.org/t/product-option-types-vs-product-variant-unit-fields/1535/3