### PR TITLE
references to payment_enterprise_id removed, new migration created

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -4,7 +4,6 @@ class Exchange < ActiveRecord::Base
   belongs_to :order_cycle
   belongs_to :sender, class_name: 'Enterprise'
   belongs_to :receiver, class_name: 'Enterprise', touch: true
-  belongs_to :payment_enterprise, class_name: 'Enterprise'
 
   has_many :exchange_variants, dependent: :destroy
   has_many :variants, through: :exchange_variants

--- a/db/migrate/20190504151144_remove_field_name_from_exchange.rb
+++ b/db/migrate/20190504151144_remove_field_name_from_exchange.rb
@@ -1,0 +1,9 @@
+class RemoveFieldNameFromExchange < ActiveRecord::Migration
+  def up
+    remove_column :exchanges, :payment_enterprise_id
+  end
+
+  def down
+    add_column :exchanges, :payment_enterprise_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190501143327) do
+ActiveRecord::Schema.define(:version => 20190504151144) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -247,7 +247,6 @@ ActiveRecord::Schema.define(:version => 20190501143327) do
     t.integer  "order_cycle_id"
     t.integer  "sender_id"
     t.integer  "receiver_id"
-    t.integer  "payment_enterprise_id"
     t.string   "pickup_time"
     t.string   "pickup_instructions"
     t.datetime "created_at",                               :null => false
@@ -257,7 +256,6 @@ ActiveRecord::Schema.define(:version => 20190501143327) do
   end
 
   add_index "exchanges", ["order_cycle_id"], :name => "index_exchanges_on_order_cycle_id"
-  add_index "exchanges", ["payment_enterprise_id"], :name => "index_exchanges_on_payment_enterprise_id"
   add_index "exchanges", ["receiver_id"], :name => "index_exchanges_on_receiver_id"
   add_index "exchanges", ["sender_id"], :name => "index_exchanges_on_sender_id"
 
@@ -1265,7 +1263,6 @@ ActiveRecord::Schema.define(:version => 20190501143327) do
   add_foreign_key "exchange_variants", "exchanges", name: "exchange_variants_exchange_id_fk"
   add_foreign_key "exchange_variants", "spree_variants", name: "exchange_variants_variant_id_fk", column: "variant_id"
 
-  add_foreign_key "exchanges", "enterprises", name: "exchanges_payment_enterprise_id_fk", column: "payment_enterprise_id"
   add_foreign_key "exchanges", "enterprises", name: "exchanges_receiver_id_fk", column: "receiver_id"
   add_foreign_key "exchanges", "enterprises", name: "exchanges_sender_id_fk", column: "sender_id"
   add_foreign_key "exchanges", "order_cycles", name: "exchanges_order_cycle_id_fk"

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -293,7 +293,6 @@ describe Exchange do
     let(:oc) { create(:order_cycle) }
     let(:exchange) do
       exchange = oc.exchanges.last
-      exchange.payment_enterprise = Enterprise.last
       exchange.save!
       exchange.stub(:variant_ids) { [1835, 1834] } # Test id ordering
       exchange.stub(:enterprise_fee_ids) { [1493, 1492] } # Test id ordering
@@ -305,7 +304,7 @@ describe Exchange do
         {'id' => exchange.id, 'order_cycle_id' => oc.id,
         'sender_id' => exchange.sender_id, 'receiver_id' => exchange.receiver_id,
         'incoming' => exchange.incoming,
-        'payment_enterprise_id' => exchange.payment_enterprise_id, 'variant_ids' => exchange.variant_ids.sort,
+        'variant_ids' => exchange.variant_ids.sort,
         'enterprise_fee_ids' => exchange.enterprise_fee_ids.sort,
         'pickup_time' => exchange.pickup_time, 'pickup_instructions' => exchange.pickup_instructions,
         'receival_instructions' => exchange.receival_instructions,
@@ -316,7 +315,7 @@ describe Exchange do
       exchange.to_h(true).should ==
         {'sender_id' => exchange.sender_id, 'receiver_id' => exchange.receiver_id,
          'incoming' => exchange.incoming,
-         'payment_enterprise_id' => exchange.payment_enterprise_id, 'variant_ids' => exchange.variant_ids.sort,
+         'variant_ids' => exchange.variant_ids.sort,
          'enterprise_fee_ids' => exchange.enterprise_fee_ids.sort,
          'pickup_time' => exchange.pickup_time, 'pickup_instructions' => exchange.pickup_instructions,
          'receival_instructions' => exchange.receival_instructions}


### PR DESCRIPTION
1. we ran `git grep payment_enterprise` and removed all the references (Exchange model, Spec files)
2. we created a new migration, removing payment_enterprise_id 
3. we ran the migration