### PR TITLE
Add translation to order cycle spinner

### DIFF
--- a/app/views/admin/order_cycles/_loading_flash.html.haml
+++ b/app/views/admin/order_cycles/_loading_flash.html.haml
@@ -1,4 +1,6 @@
 %div.sixteen.columns.alpha.omega#loading{ ng: { cloak: true, if: 'RequestMonitor.loading' } }
   %img.spinner{ src: "/assets/spinning-circles.svg" }
-  %h1{ ng: { hide: 'orderCycles.length > 0' } } LOADING ORDER CYCLES
-  %h1{ ng: { show: 'orderCycles.length > 0' } } LOADING...
+  %h1{ ng: { hide: 'orderCycles.length > 0' } }
+    =t('.loading_order_cycles')
+  %h1{ ng: { show: 'orderCycles.length > 0' } }
+    =t('.loading')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -856,6 +856,9 @@ en:
         user_already_exists: "User already exists"
         error: "Something went wrong"
     order_cycles:
+      loading_flash:
+        loading_order_cycles: LOADING ORDER CYCLES
+        loading: LOADING...
       edit:
         advanced_settings: Advanced Settings
         update_and_close: Update and Close


### PR DESCRIPTION
#### What? Why?

Closes #3731 

#### What should we test?
<!-- List which features should be tested and how. -->
1. Log in as a producer or a hub or a super admin
2. Go to /admin/order_cycles
3. You will see a loader before the order cycles appear
4. It is translated


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Add translation text to the Order Cycle spinner


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category:  Fixed 

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
none


#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->
none


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
none


#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
none
