### PR TITLE
Remove non-functional Price field from Edit Product screen

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -151,4 +151,8 @@ Spree::Admin::ProductsController.class_eval do
     variant.on_demand = on_demand if on_demand.present?
     variant.on_hand = on_hand.to_i if on_hand.present?
   end
+
+  def set_product_master_variant_price_to_zero
+    @product.price = 0 if @product.price.nil?
+  end
 end

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -46,11 +46,6 @@
       = f.collection_select(:supplier_id, @producers, :id, :name, {:include_blank => true}, {:class => "select2"})
       = f.error_message_on :supplier
 
-    = f.field_container :price do
-      = f.label :price, raw(t(:price) + content_tag(:span, ' *', :class => 'required'))
-      = f.text_field :price, :value => number_to_currency(@product.price, :unit => '')
-      = f.error_message_on :price
-
     .clear
 
     - unless @product.has_variants?


### PR DESCRIPTION
#### What? Why?

Closes #2979 

The Price field is non functional and catches many users out when they 'update' a price but do not see the changes flow through to the live product in their shopfront.

Instead users must update variant prices.

#### What should we test?
<!-- List which features should be tested and how. -->
Update:
We need to test:
Creating a new product and variant with and without price
Updating a product and variant price
Updating a product and variant but not updating the price.

![Screenshot from 2019-05-05 14-41-13](https://user-images.githubusercontent.com/8669848/57195096-7900cc00-6f46-11e9-8a90-1af7c5e74e11.png)

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Enterprise managers can no longer access the non-functional product price field.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed 

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
none


#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->
none


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
none


#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
none. Checked the user guide but found no reference.
