### PR TITLE
3760 Optimizations related to OCs

### DIFF
--- a/app/controllers/spree/admin/base_controller_decorator.rb
+++ b/app/controllers/spree/admin/base_controller_decorator.rb
@@ -6,7 +6,7 @@ Spree::Admin::BaseController.class_eval do
   layout 'spree/layouts/admin'
 
   before_filter :set_locale
-  before_filter :warn_invalid_order_cycles
+  before_filter :warn_invalid_order_cycles, if: :html_request?
 
   # Warn the user when they have an active order cycle with hubs that are not ready
   # for checkout (ie. does not have valid shipping and payment methods).

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -96,12 +96,10 @@ class Enterprise < ActiveRecord::Base
   scope :not_ready_for_checkout, lambda {
     # When ready_for_checkout is empty, ActiveRecord generates the SQL:
     # id NOT IN (NULL)
-    # I would have expected this to return all rows, but instead it returns none. To
-    # work around this, we use the "OR ?=0" clause to return all rows when there are
-    # no enterprises ready for checkout.
-    where('id NOT IN (?) OR ?=0',
-          Enterprise.ready_for_checkout,
-          Enterprise.ready_for_checkout.count)
+    # I would have expected this to return all rows, but instead it returns none. But we want to
+    # return all rows when there are no enterprises ready for checkout.
+    ready_enterprises = Enterprise.ready_for_checkout
+    ready_enterprises.present? ? where("id NOT IN (?)", ready_enterprises) : where("TRUE")
   }
   scope :is_primary_producer, where(:is_primary_producer => true)
   scope :is_distributor, where('sells != ?', 'none')

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -97,7 +97,11 @@ class Enterprise < ActiveRecord::Base
     # When ready_for_checkout is empty, return all rows when there are no enterprises ready for
     # checkout.
     ready_enterprises = Enterprise.ready_for_checkout
-    ready_enterprises.present? ? where("id NOT IN (?)", ready_enterprises) : where("TRUE")
+    if ready_enterprises.present?
+      where("id NOT IN (?)", ready_enterprises)
+    else
+      where("TRUE")
+    end
   }
   scope :is_primary_producer, where(:is_primary_producer => true)
   scope :is_distributor, where('sells != ?', 'none')

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -94,10 +94,8 @@ class Enterprise < ActiveRecord::Base
       select('DISTINCT enterprises.*')
   }
   scope :not_ready_for_checkout, lambda {
-    # When ready_for_checkout is empty, ActiveRecord generates the SQL:
-    # id NOT IN (NULL)
-    # I would have expected this to return all rows, but instead it returns none. But we want to
-    # return all rows when there are no enterprises ready for checkout.
+    # When ready_for_checkout is empty, return all rows when there are no enterprises ready for
+    # checkout.
     ready_enterprises = Enterprise.ready_for_checkout
     ready_enterprises.present? ? where("id NOT IN (?)", ready_enterprises) : where("TRUE")
   }

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -9,7 +9,7 @@ class OrderCycle < ActiveRecord::Base
   has_many :exchanges, :dependent => :destroy
 
   # These scope names are prepended with "cached_" because there are existing accessor methods
-  # :incoming_exchanges and :outgoing_exchanges. Future work can be done to name these properly.
+  # :incoming_exchanges and :outgoing_exchanges.
   has_many :cached_incoming_exchanges, conditions: { incoming: true }, class_name: "Exchange"
   has_many :cached_outgoing_exchanges, conditions: { incoming: false }, class_name: "Exchange"
 
@@ -18,9 +18,6 @@ class OrderCycle < ActiveRecord::Base
 
   has_and_belongs_to_many :schedules, join_table: 'order_cycle_schedules'
 
-  # TODO: DRY the incoming/outgoing clause used in several cases below
-  # See Spree::Product definition, scopes variants and variants_including_master
-  # This will require these accessors to be renamed
   attr_accessor :incoming_exchanges, :outgoing_exchanges
 
   validates_presence_of :name, :coordinator_id

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -28,13 +28,18 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
 
   private
 
-  def products
-    return @products unless @products.nil?
-    @products = if order_cycle.prefers_product_selection_from_coordinator_inventory_only?
+  def products_scope
+    if order_cycle.prefers_product_selection_from_coordinator_inventory_only?
       object.supplied_products.visible_for(order_cycle.coordinator)
     else
       object.supplied_products
     end
+  end
+
+  def products
+    return @products unless @products.nil?
+
+    @products = products_scope.includes(:supplier, master: [:images])
   end
 
   def order_cycle

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -37,9 +37,7 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
   end
 
   def products
-    return @products unless @products.nil?
-
-    @products = products_scope.includes(:supplier, master: [:images])
+    @products ||= products_scope.includes(:supplier, master: [:images])
   end
 
   def order_cycle


### PR DESCRIPTION
#### What? Why?

- Relates to #3792 
- Relates to #3760

This set of optimizations should affect not just the OC pages, but there should also be minor improvements in admin pages in general, and possible minor improvements for code that involve OCs.

#### What should we test?

**Edit OC page**

Smoke test of the edit OC page should pass. Test with an OC where the coordinator is not the only producer.

**Warning if there is an invalid OC setup**

Also, as admin, remove all shipping methods for a producer-hub with an active OC. You can easily undo this change if you simply edit the shipping methods and untick the producer-hub. The warning that there is an invalid OC setup should still appear at the top of the page.

#### Release notes

- Improve performance, especially in the edit order cycle page.

Changelog Category: Fixed

#### How is this related to the Spree upgrade?

Needs discussion on whether this should be code reviewed and tested in the pre-v2.0 branch.