### PR TITLE
Make stock locations backorderable_default false

### DIFF
--- a/db/migrate/20190506194625_update_stock_locations_backorderable_default.rb
+++ b/db/migrate/20190506194625_update_stock_locations_backorderable_default.rb
@@ -1,0 +1,5 @@
+class UpdateStockLocationsBackorderableDefault < ActiveRecord::Migration
+  def change
+    Spree::StockLocation.update_all(backorderable_default: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190501143327) do
+ActiveRecord::Schema.define(:version => 20190506194625) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"


### PR DESCRIPTION
This is required because when the default stock location is created, the backorderable_default column doesnt exist and when this column is created, the initial default is true. This is why we need to force it to false here. This column is the default value for on_demand which must be false.

#### What? Why?

Closes #3803

Although the default value for column backorderable_default is changed from true to false, the value of the existing records stay true. This is why we need to force it to false with this new migration.


#### What should we test?
#3803 should be fixed.
