### PR TITLE
Test empty variants_attrs in bulk_update

### DIFF
--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -71,6 +71,57 @@ describe Spree::Admin::ProductsController, type: :controller do
         )
       end
     end
+
+    context 'when passing empty variants_attributes' do
+      let(:producer) { create(:enterprise) }
+      let!(:product) do
+        create(
+          :simple_product,
+          supplier: producer,
+          variant_unit: 'items',
+          variant_unit_scale: nil,
+          variant_unit_name: 'bunches',
+          unit_value: nil,
+          unit_description: 'bunches'
+        )
+      end
+      let!(:another_product) do
+        create(
+          :simple_product,
+          supplier: producer,
+          variant_unit: 'weight',
+          variant_unit_scale: 1000,
+          variant_unit_name: nil
+        )
+      end
+
+      before { login_as_enterprise_user([producer]) }
+
+      it 'does not fail' do
+        spree_post :bulk_update, {
+          "products" => [
+            {
+              "id" => another_product.id,
+              "variants_attributes" => [{}]
+            },
+            {
+              "id" => product.id,
+              "variants_attributes" => [
+                {
+                  "on_hand" => 2,
+                  "price" => "5.0",
+                  "unit_value" => 4,
+                  "unit_description" => "",
+                  "display_name" => "name"
+                }
+              ]
+            }
+          ]
+        }
+
+        expect(response).to have_http_status(:found)
+      end
+    end
   end
 
   context "creating a new product" do


### PR DESCRIPTION
#### What? Why?

This covers the scenario we saw in https://app.bugsnag.com/katuma/katuma/errors/5cd0595bece0b7001984f64c?event_id=5cd0595b0038be3b070d0000&i=sk&m=nw which raised our concerns.
There is some other context we might be missing that makes it not possible to reproduce.

I guess then, that this is an isolated case that does not prevent us from deploying v2.0.0. 


#### What should we test?

This is just a test so nothing to test.

#### Release notes
Check that sending empty `variant_attributes` through bulk update does not make the update fail.

Changelog Category: Added
