### PR TITLE
Add extra (Instagram) social media links to emails sent to customers and users [Looking for feedback/direction on completing solution]

### DIFF
--- a/app/views/shared/mailers/_social_and_contact.html.haml
+++ b/app/views/shared/mailers/_social_and_contact.html.haml
@@ -17,6 +17,9 @@
               - if ContentConfig.footer_linkedin_url.present?
                 %a.soc-btn.li{href: ContentConfig.footer_linkedin_url}
                   LinkedIn
+              -if ContentConfig.footer_instagram_url.present?
+                %a.soc-btn.tw{href: ContentConfig.footer_instagram_url}
+                  Instagram
       %table.column{:align => "left"}
         %tr
           %td

--- a/app/views/spree/order_mailer/_signoff.html.haml
+++ b/app/views/spree/order_mailer/_signoff.html.haml
@@ -13,3 +13,6 @@
     = @order.distributor.contact.email
   %br
   = @order.distributor.website || ""
+  %br
+  = @order.distributor.instagram || ""
+


### PR DESCRIPTION
#### What? Why?
There are only two social media links are in the footer of emails sent to OFN users: these are Facebook and Twitter. I am adding an instagram link as well.
.
Starts #3509

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Provides effective social media communication and marketing. I added the links.


#### What should we test?
<!-- List which features should be tested and how. -->
Generate emails for respective features to test them.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
I am uncertain if this is the complete solution so I would appreciate directions on completing it.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added 

