### PR TITLE
1218 Remove OC "Debug Information" which appears in non-production environments

### DIFF
--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -154,19 +154,6 @@ form.order_cycle {
   .actions {
     margin-top: 3em;
   }
-
-  /* This styling makes it easier to read the debug info at the same time as working with the
-   * interface, but it breaks the tests. Enable when you need it.
-  #order-cycles-debug {
-    position: fixed;
-    top: 0px;
-    left: 0px;
-    height: 100%;
-    width: 316px;
-    overflow-y: scroll;
-    background-color: #fff;
-  }
-  */
 }
 
 table#listing_order_cycles {

--- a/app/views/admin/order_cycles/_form.html.haml
+++ b/app/views/admin/order_cycles/_form.html.haml
@@ -47,17 +47,3 @@
 
 .actions
   %span{'ng-hide' => 'loaded()'}= t(:loading)
-
-- unless Rails.env.production?
-  #order-cycles-debug
-    %h2= t('.debug_info')
-
-    %pre loaded =  {{ loaded() | json }}
-    %hr/
-    %pre order_cycle = {{ order_cycle | json }}
-    %hr/
-    %pre enterprises = {{ enterprises | json }}
-    %hr/
-    %pre enterprise_fees = {{ enterprise_fees | json }}
-    %hr/
-    %pre supplied_products = {{ supplied_products | json }}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -896,7 +896,6 @@ en:
         tags: Tags
         add_a_tag: Add a tag
         delivery_details: Pickup / Delivery details
-        debug_info: Debug information
       index:
         schedule: Schedule
         schedules: Schedules


### PR DESCRIPTION
#### What? Why?

- Closes #1218 

The section adds so much content to the page, which makes the page loading and interactions slower. It also makes scrolling difficult when editing an OC.

#### What should we test?

Check that loading and editing an OC where the coordinator is a producer-hub still works. Test with an OC that has exchanges for another supplier and the producer-hub.

#### Release notes

- Remove "Debug Information" at the bottom of the Edit Order Cycle page, which only appeared in non-production environments.

Changelog Category: Removed