### PR TITLE
3819 [WIP] Index "deleted_at" and "is_master" columns in "spree_variants" table

### DIFF
--- a/db/migrate/20190507090132_index_spree_variants_deleted_at.rb
+++ b/db/migrate/20190507090132_index_spree_variants_deleted_at.rb
@@ -1,0 +1,5 @@
+class IndexSpreeVariantsDeletedAt < ActiveRecord::Migration
+  def change
+    add_index :spree_variants, :deleted_at
+  end
+end

--- a/db/migrate/20190507090858_index_spree_variants_is_master.rb
+++ b/db/migrate/20190507090858_index_spree_variants_is_master.rb
@@ -1,0 +1,5 @@
+class IndexSpreeVariantsIsMaster < ActiveRecord::Migration
+  def change
+    add_index :spree_variants, :is_master
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190504151144) do
+ActiveRecord::Schema.define(:version => 20190507090132) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -1089,6 +1089,7 @@ ActiveRecord::Schema.define(:version => 20190504151144) do
     t.datetime "import_date"
   end
 
+  add_index "spree_variants", ["deleted_at"], :name => "index_spree_variants_on_deleted_at"
   add_index "spree_variants", ["product_id"], :name => "index_variants_on_product_id"
   add_index "spree_variants", ["sku"], :name => "index_spree_variants_on_sku"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190507090132) do
+ActiveRecord::Schema.define(:version => 20190507090858) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -1090,6 +1090,7 @@ ActiveRecord::Schema.define(:version => 20190507090132) do
   end
 
   add_index "spree_variants", ["deleted_at"], :name => "index_spree_variants_on_deleted_at"
+  add_index "spree_variants", ["is_master"], :name => "index_spree_variants_on_is_master"
   add_index "spree_variants", ["product_id"], :name => "index_variants_on_product_id"
   add_index "spree_variants", ["sku"], :name => "index_spree_variants_on_sku"
 


### PR DESCRIPTION
#### What? Why?

Practically every query that involves the `spree_variants` table checks `deleted_at`, and this is not indexed. :crossed_fingers: Very hopeful that this brings a considerable improvement in performance.

There are a lot of DB queries that filter by `is_master` too.

#### What should we test?

Test that deployment to staging works, to check that running the DB migration with general sample data works.

#### Release notes

- Index `deleted_at` and `is_master` columns in `spree_variants` table.

Changelog Category: Changed