### PR TITLE
Limit cache settings to 5 results

### DIFF
--- a/app/controllers/admin/cache_settings_controller.rb
+++ b/app/controllers/admin/cache_settings_controller.rb
@@ -3,7 +3,7 @@ require 'open_food_network/products_cache_integrity_checker'
 module Admin
   class CacheSettingsController < Spree::Admin::BaseController
     def edit
-      @results = Exchange.cachable.map do |exchange|
+      @results = Exchange.cachable.limit(5).map do |exchange|
         checker = OpenFoodNetwork::ProductsCacheIntegrityChecker
           .new(exchange.receiver, exchange.order_cycle)
 


### PR DESCRIPTION
#### What? Why?

Related to  #3830

Helps identify the actual difference between the products cache and the latest shopfront state using `/admin/cache_settings/edit`. From the issue:

> Additionally, as explained in https://github.com/openfoodfoundation/openfoodnetwork/wiki/Products-cache#development, there is a settings page to debug cache's staleness but it currently crashes in Katuma for unknown reasons. 

Without this is very hard to know what model we might not be refreshing. See #3830 for details.

#### What should we test?

The `/admin/cache_settings/edit` should only list 3 cacheable exchanges.


#### Release notes

Limit the cache_settings page results to only 3 exchanges for performance reasons. It can crash a server.

