### PR TITLE
Report cache diff in new tab

### DIFF
--- a/app/jobs/products_cache_integrity_checker_job.rb
+++ b/app/jobs/products_cache_integrity_checker_job.rb
@@ -3,7 +3,14 @@ require 'open_food_network/products_cache_integrity_checker'
 ProductsCacheIntegrityCheckerJob = Struct.new(:distributor_id, :order_cycle_id) do
   def perform
     unless checker.ok?
-      Bugsnag.notify RuntimeError.new("Products JSON differs from cached version for distributor: #{distributor_id}, order cycle: #{order_cycle_id}"), diff: checker.diff.to_s(:text)
+      exception = RuntimeError.new(
+        "Products JSON differs from cached version for distributor: #{distributor_id}, " \
+        "order cycle: #{order_cycle_id}"
+      )
+
+      Bugsnag.notify(exception) do |report|
+        report.add_tab(:products_cache, diff: checker.diff.to_s(:text))
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Related to #3830

This will allow us to see the difference between the cache entry and the actual shopfront. Otherwise, there is no way to see what wasn't refreshed in the cache. 

![Captura de pantalla 2019-05-10 a les 0 09 59](https://user-images.githubusercontent.com/762088/57489974-0716e280-72b8-11e9-8bd4-2f8c9f78e3df.png)

We'll see a new tab next to "job" ☝️ 


#### What should we test?

We should see a new tab in these Bugsnag notifications. Since I don't know how to reproduce it yet I'll just trigger the notification from the rails console.


#### Release notes
Add a new tab with the cache diff for products_cache_integrity_checker_job.rb errors in Bugsnag.

Changelog Category: Added

