### PR TITLE
Move shipping methods translations to lazy lookups

### DIFF
--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -18,7 +18,7 @@
       .alpha.three.columns
         = f.label :display_on, t(:display)
       .omega.eight.columns
-        = select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
+        = select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [t(".#{display}"), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
         = error_message_on :shipping_method, :display_on
 
   .row
@@ -49,7 +49,7 @@
 .alpha.six.columns
   .alpha.six.columns
     %fieldset.categories.no-border-bottom
-      %legend{align: "center"}= Spree.t(:categories)
+      %legend{align: "center"}= t('.categories')
       = f.field_container :categories do
         - Spree::ShippingCategory.all.each do |category|
           = label_tag do
@@ -60,7 +60,7 @@
 
   .alpha.six.columns
     %fieldset.no-border-bottom
-      %legend{align: "center"}= Spree.t(:zones)
+      %legend{align: "center"}= t('.zones')
       = f.field_container :zones do
         - shipping_method_zones = @shipping_method.zones.to_a
         - Spree::Zone.all.each do |zone|

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -2,9 +2,9 @@
   = t('.editing_shipping_method')
 - content_for :page_actions do
   %li
-    = button_link_to t(:new), spree.new_admin_shipping_method_path, icon: 'icon-plus'
+    = button_link_to t('.new'), spree.new_admin_shipping_method_path, icon: 'icon-plus'
   %li
-    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, icon: 'icon-arrow-left'
+    = button_link_to t('.back_to_shipping_methods_list'), spree.admin_shipping_methods_path, icon: 'icon-arrow-left'
 %div
   = render partial: 'spree/shared/error_messages', locals: { target: @shipping_method }
 %div

--- a/app/views/spree/admin/shipping_methods/index.html.haml
+++ b/app/views/spree/admin/shipping_methods/index.html.haml
@@ -1,8 +1,8 @@
 - content_for :page_title do
-  = Spree.t(:shipping_methods)
+  = t('.shipping_methods')
 - content_for :page_actions do
   %li
-    = button_link_to Spree.t(:new_shipping_method), new_object_url,  icon: 'icon-plus', id: 'admin_new_shipping_method_link'
+    = button_link_to t('.new_shipping_method'), new_object_url,  icon: 'icon-plus', id: 'admin_new_shipping_method_link'
 - if @shipping_methods.any?
   %table#listing_shipping_methods.index
     %colgroup
@@ -13,11 +13,11 @@
       %col{style: "width: 15%"}/
     %thead
       %tr
-        %th= Spree.t(:name)
-        %th= t(:products_distributor)
-        %th= Spree.t(:zone)
-        %th= Spree.t(:calculator)
-        %th= Spree.t(:display)
+        %th= t('.name')
+        %th= t('.products_distributor')
+        %th= t('.zone')
+        %th= t('.calculator')
+        %th= t('.display')
         %th.actions
     %tbody
       - @shipping_methods.each do |shipping_method|
@@ -29,9 +29,9 @@
               %br/
           %td= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones
           %td= shipping_method.calculator.description
-          %td.align-center= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on)
+          %td.align-center= shipping_method.display_on.blank? ? t('.both') : t(".#{shipping_method.display_on}")
           %td.actions
             = link_to_edit shipping_method, no_text: true
             = link_to_delete shipping_method, no_text: true
 - else
-  .alpha.twelve.columns.no-objects-found= Spree.t(:no_shipping_methods_found)
+  .alpha.twelve.columns.no-objects-found= t('.no_shipping_methods_found')

--- a/app/views/spree/admin/shipping_methods/new.html.haml
+++ b/app/views/spree/admin/shipping_methods/new.html.haml
@@ -1,8 +1,8 @@
 - content_for :page_title do
-  = Spree.t(:new_shipping_method)
+  = t('.new_shipping_method')
 - content_for :page_actions do
   %li
-    = button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, icon: 'icon-arrow-left'
+    = button_link_to t('.back_to_shipping_methods_list'), spree.admin_shipping_methods_path, icon: 'icon-arrow-left'
 %div
   = render partial: 'spree/shared/error_messages', locals: { target: @shipping_method }
 %div

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2961,8 +2961,31 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             other: "You have %{count} active order cycles."
           manage_order_cycles: "MANAGE ORDER CYCLES"
       shipping_methods:
+        index:
+          shipping_methods: "Shipping Methods"
+          new_shipping_method: "New Shipping Method"
+          name: "Name"
+          products_distributor: "Distributor"
+          zone: "Zone"
+          calculator: "Calculator"
+          display: "Display"
+          both: "Both"
+          front_end: "Front End"
+          back_end: "Back End"
+          no_shipping_methods_found: "No shipping methods found"
+        new:
+          new_shipping_method: "New Shipping Method"
+          back_to_shipping_methods_list: "Back To Shipping Methods List"
         edit:
           editing_shipping_method: "Editing Shipping Method"
+          new: "New"
+          back_to_shipping_methods_list: "Back To Shipping Methods List"
+        form:
+          categories: "Categories"
+          zones: "Zones"
+          both: "Both"
+          front_end: "Front End"
+          back_end: "Back End"
       payment_methods:
         new:
           new_payment_method: "New Payment Method"


### PR DESCRIPTION
#### What? Why?

Make all translations in the shipping methods admin view use lazy lookup translations instead of the spree root namespace.

#### What should we test?
I tested each key locally.
The admin shipping methods page both list, edit and create should be correctly translated.

#### Release notes
Changelog Category: Changed
Better organize code and translations related to the shipping methods page.

#### How is this related to the Spree upgrade?
This view was copied from spree during the upgrade but the translation calls to Spree.t were left.

