### PR TITLE
Allow unauthenticated access to OFN API endpoints

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -9,6 +9,7 @@ module Api
     include ActionController::UrlFor
     include Rails.application.routes.url_helpers
     use_renderers :json
+    check_authorization
 
     def respond_with_conflict(json_hash)
       render json: json_hash, status: :conflict
@@ -20,6 +21,14 @@ module Api
     def authenticate_user
       @current_api_user = try_spree_current_user
       super
+    end
+
+    # Allows API access without authentication, but only for OFN controllers which inherit
+    # from Api::BaseController. @current_api_user will now initialize an empty Spree::User
+    # unless one is present. We now also apply devise's `check_authorization`. See here for
+    # details: https://github.com/CanCanCommunity/cancancan/wiki/Ensure-Authorization
+    def requires_authentication?
+      false
     end
   end
 end

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class CustomersController < BaseController
+    skip_authorization_check only: :index
+
     def index
       @customers = current_api_user.customers
       render json: @customers, each_serializer: CustomerSerializer

--- a/app/controllers/api/enterprises_controller.rb
+++ b/app/controllers/api/enterprises_controller.rb
@@ -1,11 +1,11 @@
 module Api
   class EnterprisesController < BaseController
-
     before_filter :override_owner, only: [:create, :update]
     before_filter :check_type, only: :update
     before_filter :override_sells, only: [:create, :update]
     before_filter :override_visible, only: [:create, :update]
     respond_to :json
+    skip_authorization_check only: [:shopfront, :managed]
 
     def managed
       @enterprises = Enterprise.ransack(params[:q]).result.managed_by(current_api_user)
@@ -76,13 +76,6 @@ module Api
 
     def override_visible
       params[:enterprise][:visible] = false
-    end
-
-    # Allows API access without a logged in user for actions in this controller.
-    # Actions that require authentication should all use #authorize!
-    # @current_api_user will now initialize an empty Spree::User unless one is present.
-    def requires_authentication?
-      false
     end
   end
 end

--- a/app/controllers/api/enterprises_controller.rb
+++ b/app/controllers/api/enterprises_controller.rb
@@ -77,5 +77,12 @@ module Api
     def override_visible
       params[:enterprise][:visible] = false
     end
+
+    # Allows API access without a logged in user for actions in this controller.
+    # Actions that require authentication should all use #authorize!
+    # @current_api_user will now initialize an empty Spree::User unless one is present.
+    def requires_authentication?
+      false
+    end
   end
 end

--- a/spec/controllers/api/enterprises_controller_spec.rb
+++ b/spec/controllers/api/enterprises_controller_spec.rb
@@ -82,7 +82,7 @@ module Api
       end
     end
 
-    describe "fetching shopfronts data" do
+    context "as a non-authenticated user" do
       let!(:hub) {
         create(:distributor_enterprise, with_payment_and_shipping: true, name: 'Shopfront Test Hub')
       }
@@ -92,15 +92,17 @@ module Api
       let!(:relationship) { create(:enterprise_relationship, parent: hub, child: producer) }
 
       before do
-        allow(controller).to receive(:spree_current_user) { Spree::User.anonymous! }
+        allow(controller).to receive(:spree_current_user) { nil }
       end
 
-      it "returns data for an enterprise" do
-        spree_get :shopfront, id: producer.id, format: :json
+      describe "fetching shopfronts data" do
+        it "returns data for an enterprise" do
+          spree_get :shopfront, id: producer.id, format: :json
 
-        expect(json_response['name']).to eq 'Shopfront Test Producer'
-        expect(json_response['hubs'][0]['name']).to eq 'Shopfront Test Hub'
-        expect(json_response['supplied_taxons'][0]['name']).to eq 'Fruit'
+          expect(json_response['name']).to eq 'Shopfront Test Producer'
+          expect(json_response['hubs'][0]['name']).to eq 'Shopfront Test Hub'
+          expect(json_response['supplied_taxons'][0]['name']).to eq 'Fruit'
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

I just retested the maps changes, and found the authentication on the new endpoint is really inconsistent. Most of the time it allows access when the user is logged out, but sometimes it denies the request with the error: "You must specify an API key". 

![api_error](https://user-images.githubusercontent.com/9029026/57551050-f4f07f00-735f-11e9-9564-87fae41f10bd.png)

Logging in and logging out again seems to sometimes change the allow/deny behaviour from one state to the other, but I can't discern a pattern to it.

I've made a small change to the authentication:
- Allows API access without authentication, but only for OFN controllers which inherit from `BaseController`.
- Spree will now initialize `@current_api_user` with an empty `Spree::User` object (basically a "guest") if the current user is not logged in.
- This does not affect the authentication for existing Spree::Api endpoints.
- We should always use `authorize!` when required on API actions.

#### What should we test?
<!-- List which features should be tested and how. -->

The new map page always load the modal when the user is logged out. Logging in and out doesn't change the outcome.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed API authentication for custom endpoints

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

