### PR TITLE
Make inserting delayed jobs from cron quiet

### DIFF
--- a/script/enqueue
+++ b/script/enqueue
@@ -26,6 +26,7 @@ def psql
   raise "Missing config for #{env} environment" unless config
 
   "psql".tap do |s|
+    s << " --quiet"
     s << " --host #{config['host']}"     if config['host']
     s << " --user #{config['username']}" if config['username']
     s << " --port #{config['port']}"     if config['port']


### PR DESCRIPTION
#### What? Why?

`config/schedule.rb` defines entries for cron jobs. Every five minutes
it insert several delayed jobs via `script/enqueue`. A recent upgrade of
Postgresql (a year or two ago) made that script noisy. Every time we
insert a delayed job with that script it outputs:

    INSERT 0 1

Standard output like this is seen as error message by cron an forwarded
to the unix user's local mailbox in `/var/mail/openfoodnetwork`. This
file grows over time and accumulates tens of thousands of error
messages, hiding any important failures.

This patch makes inserting delayed jobs quiet. A failure is still
reported.




#### What should we test?
<!-- List which features should be tested and how. -->

- Stage the pull request.
- Wait half an hour.
- DelayedJob should still be reported running. You can check that, e.g.: https://staging.openfoodnetwork.org.au/api/status/job_queue


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed error reporting of scheduled background tasks.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

