### PR TITLE
Disable harmful rake tasks in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'rails', '~> 3.2.22'
 gem 'rails-i18n', '~> 3.0.0'
+gem 'rails_safe_tasks', '~> 1.0'
 gem 'i18n', '~> 0.6.11'
 gem 'i18n-js', '~> 3.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,6 +617,7 @@ GEM
     rails-i18n (3.0.1)
       i18n (~> 0.5)
       rails (>= 3.0.0, < 4.0.0)
+    rails_safe_tasks (1.0.0)
     railties (3.2.22.5)
       actionpack (= 3.2.22.5)
       activesupport (= 3.2.22.5)
@@ -853,6 +854,7 @@ DEPENDENCIES
   rack-ssl
   rails (~> 3.2.22)
   rails-i18n (~> 3.0.0)
+  rails_safe_tasks (~> 1.0)
   redcarpet
   roadie-rails (~> 1.1.1)
   roo (~> 2.7.0)


### PR DESCRIPTION
#### What? Why?

No need to check whether you are running that `bundle exec rake db:reset` command on staging or production anymore :scream:.

As described in https://github.com/adamcooke/rails-safe-tasks

> This gem provides an extra layer of safety between you and deleting all your
> production data by accident.

> It restricts the use of various rake tasks (including db:drop, db:reset etc...)
> when you are running your application in a production environment.

#### What should we test?

This rake tasks should keep working in staging.

#### Release notes

Disable dangerous rake tasks that could lead to data loss in production such as `db:reset`.

Changelog Category: Added
