### PR TITLE
Add Australian English locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,16 +1,14 @@
 # English language file
 # ---------------------
 #
-# This is the source language file maintained by the global OFN team and used
-# by the Australian OFN instance.
-#
+# This is the source language file maintained by the global OFN team.
 # Visit Transifex to translate this file into other languages:
 #
 #   https://www.transifex.com/open-food-foundation/open-food-network/
 #
 # Read more about it at:
 #
-#   https://github.com/openfoodfoundation/openfoodnetwork/wiki/i18n
+#   https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29
 #
 # Changing this file
 # ==================
@@ -18,7 +16,7 @@
 # You are welcome to fix typos, add missing translations and remove unused ones.
 # But read our guidelines first:
 #
-#   https://github.com/openfoodfoundation/openfoodnetwork/wiki/i18n#development
+#   https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29#development
 #
 en:
   # Overridden here due to a bug in spree i18n (Issue #870, and issue #1800)


### PR DESCRIPTION

#### What? Why?

Closes https://github.com/openfoodfoundation/ofn-install/issues/438.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The Australian instance is using the source locale so far. This commit
just copies the source locale. Adding en_AU to Transifex is pending.


#### What should we test?
<!-- List which features should be tested and how. -->

This should be tested on the Australian staging server after the locale has been changed. The homepage should look normal.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added support to for Australian language customisations.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

 The ofn-install config for Australia needs updating.

#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

The wiki page https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29 is up to date.