### PR TITLE
Use OFN logo in admin area

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -24,6 +24,7 @@ require "#{Rails.root}/app/models/spree/gateway_decorator"
 Spree.config do |config|
   config.shipping_instructions = true
   config.address_requires_state = true
+  config.admin_interface_logo = 'ofn-logo.png'
 
   # -- spree_paypal_express
   # Auto-capture payments. Without this option, payments must be manually captured in the paypal interface.


### PR DESCRIPTION
#### What? Why?

Closes #3733

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Uses OFN logo in admin area instead of Spree logo.

![admin-logo](https://user-images.githubusercontent.com/9029026/58389946-79145900-8026-11e9-8efa-6aa634f8d591.png)


#### What should we test?
<!-- List which features should be tested and how. -->

Admin area logo has changed.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed the logo in admin area.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
