### PR TITLE
3804 Fix editing cart when variant on_demand but its on_hand value is zero or negative 

### DIFF
--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -22,7 +22,7 @@
   %td.text-right.cart-item-price{"data-hook" => "cart_item_price"}
     = line_item.single_display_amount_with_adjustments.to_html
   %td.text-center.cart-item-quantity{"data-hook" => "cart_item_quantity"}
-    = item_form.number_field :quantity, :min => 0, "ofn-on-hand" => variant.on_hand, "ng-model" => "line_item_#{line_item.id}", :class => "line_item_quantity", :size => 5
+    = item_form.number_field :quantity, :min => 0, "ofn-on-hand" => "#{variant.on_demand && 9999 || variant.on_hand}", "ng-model" => "line_item_#{line_item.id}", :class => "line_item_quantity", :size => 5
   %td.cart-item-total.text-right{"data-hook" => "cart_item_total"}
     = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
 


### PR DESCRIPTION
#### What? Why?

Closes #3804

Added test to cover bug and added a quick fix to it.

#### What should we test?
Test the bug in 3804 and other scenarios related to editing the quantity in the cart.

#### Release notes
Changelog Category: Fixed
Fix editing cart bug when variant on_demand but its on_hand value is zero or negative.
