### PR TITLE
3792 Optimize saving Order Cycle changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rails', '~> 3.2.22'
 gem 'rails-i18n', '~> 3.0.0'
 gem 'rails_safe_tasks', '~> 1.0'
 
+gem "activerecord-import"
 # Patched version. See http://rubysec.com/advisories/CVE-2015-5312/.
 gem 'nokogiri', '>= 1.6.7.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
       activesupport (= 3.2.22.5)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
+    activerecord-import (1.0.1)
+      activerecord (>= 3.2)
     activeresource (3.2.22.5)
       activemodel (= 3.2.22.5)
       activesupport (= 3.2.22.5)
@@ -785,6 +787,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (= 0.8.4)
   activemerchant (~> 1.78)
+  activerecord-import
   acts-as-taggable-on (~> 3.4)
   andand
   angular-rails-templates (~> 0.3.0)

--- a/app/services/exchange_variant_bulk_updater.rb
+++ b/app/services/exchange_variant_bulk_updater.rb
@@ -1,0 +1,36 @@
+class ExchangeVariantBulkUpdater
+  def initialize(exchange)
+    @exchange = exchange
+  end
+
+  def update!(variant_ids)
+    sanitized_variant_ids = variant_ids.map(&:to_i).uniq
+    existing_variant_ids = @exchange.variant_ids
+
+    disassociate_variants!(existing_variant_ids - sanitized_variant_ids)
+    associate_variants!(sanitized_variant_ids - existing_variant_ids)
+
+    uncache_variant_associations
+  end
+
+  private
+
+  def disassociate_variants!(variant_ids)
+    return if variant_ids.blank?
+    @exchange.exchange_variants.where(variant_id: variant_ids).delete_all
+  end
+
+  def associate_variants!(variant_ids)
+    return if variant_ids.blank?
+
+    new_exchange_variants = variant_ids.map do |variant_id|
+      ExchangeVariant.new(exchange_id: @exchange.id, variant_id: variant_id)
+    end
+    ExchangeVariant.import!(new_exchange_variants)
+  end
+
+  def uncache_variant_associations
+    @exchange.exchange_variants.reset
+    @exchange.variants.proxy_association.reset
+  end
+end

--- a/lib/open_food_network/order_cycle_form_applicator.rb
+++ b/lib/open_food_network/order_cycle_form_applicator.rb
@@ -79,13 +79,7 @@ module OpenFoodNetwork
 
     def update_exchange(sender_id, receiver_id, incoming, attrs = {})
       exchange = @order_cycle.exchanges.where(sender_id: sender_id, receiver_id: receiver_id, incoming: incoming).first
-
-      unless manages_coordinator? || manager_for(exchange)
-        attrs.delete :enterprise_fee_ids
-        attrs.delete :pickup_time
-        attrs.delete :pickup_instructions
-        attrs.delete :tag_list
-      end
+      remove_unauthorized_exchange_attributes(exchange, attrs)
 
       if permission_for exchange
         variant_ids = attrs.delete :variant_ids
@@ -95,6 +89,15 @@ module OpenFoodNetwork
         ExchangeVariantBulkUpdater.new(exchange).update!(variant_ids) unless variant_ids.nil?
 
         @touched_exchanges << exchange
+      end
+    end
+
+    def remove_unauthorized_exchange_attributes(exchange, exchange_attrs)
+      unless manages_coordinator? || manager_for(exchange)
+        exchange_attrs.delete :enterprise_fee_ids
+        exchange_attrs.delete :pickup_time
+        exchange_attrs.delete :pickup_instructions
+        exchange_attrs.delete :tag_list
       end
     end
 

--- a/lib/open_food_network/order_cycle_form_applicator.rb
+++ b/lib/open_food_network/order_cycle_form_applicator.rb
@@ -66,10 +66,13 @@ module OpenFoodNetwork
 
     def add_exchange(sender_id, receiver_id, incoming, attrs = {})
       attrs = attrs.reverse_merge(sender_id: sender_id, receiver_id: receiver_id, incoming: incoming)
+      variant_ids = attrs.delete :variant_ids
       exchange = @order_cycle.exchanges.build attrs
 
       if manages_coordinator?
         exchange.save!
+        ExchangeVariantBulkUpdater.new(exchange).update!(variant_ids) unless variant_ids.nil?
+
         @touched_exchanges << exchange
       end
     end
@@ -85,7 +88,12 @@ module OpenFoodNetwork
       end
 
       if permission_for exchange
+        variant_ids = attrs.delete :variant_ids
+
         exchange.update_attributes!(attrs)
+
+        ExchangeVariantBulkUpdater.new(exchange).update!(variant_ids) unless variant_ids.nil?
+
         @touched_exchanges << exchange
       end
     end

--- a/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
@@ -1,3 +1,5 @@
+require "spec_helper"
+
 require 'open_food_network/order_cycle_form_applicator'
 
 module OpenFoodNetwork

--- a/spec/services/exchange_variant_bulk_updater_spec.rb
+++ b/spec/services/exchange_variant_bulk_updater_spec.rb
@@ -1,11 +1,11 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe ExchangeVariantBulkUpdater do
   let!(:first_variant) { create(:variant) }
   let!(:second_variant) { create(:variant) }
   let!(:third_variant) { create(:variant) }
 
-  it "associates new variants to the exchange" do
+  it 'associates new variants to the exchange' do
     exchange = create(:exchange)
 
     described_class.new(exchange).update!([first_variant.id, second_variant.id])
@@ -19,7 +19,7 @@ describe ExchangeVariantBulkUpdater do
     expect(exchange.variants).to include(second_variant)
   end
 
-  it "disassociates variants from the exchange" do
+  it 'disassociates variants from the exchange' do
     exchange = create(:exchange, variant_ids: [first_variant.id, second_variant.id])
 
     described_class.new(exchange).update!([first_variant.id, third_variant.id])

--- a/spec/services/exchange_variant_bulk_updater_spec.rb
+++ b/spec/services/exchange_variant_bulk_updater_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe ExchangeVariantBulkUpdater do
+  let!(:first_variant) { create(:variant) }
+  let!(:second_variant) { create(:variant) }
+  let!(:third_variant) { create(:variant) }
+
+  it "associates new variants to the exchange" do
+    exchange = create(:exchange)
+
+    described_class.new(exchange).update!([first_variant.id, second_variant.id])
+
+    # Check association cache.
+    expect(exchange.variants).to include(first_variant)
+    expect(exchange.variants).to include(second_variant)
+    # Check if changes are actually persisted.
+    exchange.reload
+    expect(exchange.variants).to include(first_variant)
+    expect(exchange.variants).to include(second_variant)
+  end
+
+  it "disassociates variants from the exchange" do
+    exchange = create(:exchange, variant_ids: [first_variant.id, second_variant.id])
+
+    described_class.new(exchange).update!([first_variant.id, third_variant.id])
+
+    # Check association cache.
+    expect(exchange.variants).to include(first_variant)
+    expect(exchange.variants).to include(third_variant)
+    # Check if changes are actually persisted.
+    exchange.reload
+    expect(exchange.variants).to include(first_variant)
+    expect(exchange.variants).to include(third_variant)
+
+    described_class.new(exchange).update!([])
+
+    # Check association cache.
+    expect(exchange.variants).to be_blank
+    # Check if changes are actually persisted.
+    exchange.reload
+    expect(exchange.variants).to be_blank
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Relates to #3792

This PR makes the edit OC page add and remove exchange variants in bulk, instead of doing one SQL call for each affected record.

This is an experiment in using the `activerecord-import` gem, which does bulk SQL inserts. (It's my first time to use this gem.) A similar approach can be used when addressing #3760 whenever applicable.

#### What should we test?

Test removing, adding, and saving as is variants in the edit OC page.

#### Release notes

- Optimize saving exchange variants through the edit order cycle page. 

Changelog Category: Fixed