### PR TITLE
3408 Remove feature flag for Enterprise Fee Summary

### DIFF
--- a/app/models/feature_flags.rb
+++ b/app/models/feature_flags.rb
@@ -14,13 +14,6 @@ class FeatureFlags
     user.superadmin?
   end
 
-  # Checks whether the "Enterprise Fee Summary" is enabled for the specified user
-  #
-  # @return [Boolean]
-  def enterprise_fee_summary_enabled?
-    user.superadmin?
-  end
-
   private
 
   attr_reader :user

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -188,7 +188,7 @@ class AbilityDecorator
     can [:admin, :index, :customers, :orders_and_distributors, :group_buys, :bulk_coop, :payments,
          :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :packing],
         Spree::Admin::ReportsController
-    add_enterprise_fee_summary_abilities(user)
+    add_enterprise_fee_summary_abilities
   end
 
   def add_order_cycle_management_abilities(user)
@@ -264,7 +264,7 @@ class AbilityDecorator
     can [:admin, :index, :customers, :group_buys, :bulk_coop, :sales_tax, :payments,
          :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory,
          :order_cycle_management, :xero_invoices], Spree::Admin::ReportsController
-    add_enterprise_fee_summary_abilities(user)
+    add_enterprise_fee_summary_abilities
 
     can [:create], Customer
     can [:admin, :index, :update, :destroy, :show], Customer, enterprise_id: Enterprise.managed_by(user).pluck(:id)
@@ -288,7 +288,7 @@ class AbilityDecorator
     end
   end
 
-  def add_enterprise_fee_summary_abilities(user)
+  def add_enterprise_fee_summary_abilities
     # Reveal the report link in spree/admin/reports#index
     can [:enterprise_fee_summary], Spree::Admin::ReportsController
     # Allow direct access to the report resource

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -289,9 +289,6 @@ class AbilityDecorator
   end
 
   def add_enterprise_fee_summary_abilities(user)
-    feature_enabled = FeatureFlags.new(user).enterprise_fee_summary_enabled?
-    return unless feature_enabled
-
     # Reveal the report link in spree/admin/reports#index
     can [:enterprise_fee_summary], Spree::Admin::ReportsController
     # Allow direct access to the report resource

--- a/spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb
@@ -8,9 +8,6 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
   let(:current_user) { distributor.owner }
 
   before do
-    feature_flags = instance_double(FeatureFlags, enterprise_fee_summary_enabled?: true)
-    allow(FeatureFlags).to receive(:new).with(current_user) { feature_flags }
-
     allow(controller).to receive(:spree_current_user) { current_user }
   end
 
@@ -20,15 +17,6 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
 
       expect(response).to be_success
       expect(response).to render_template(new_template_path)
-    end
-
-    context "when feature flag is in effect" do
-      before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
-
-      it "is unauthorized" do
-        get :new
-        expect(response).to redirect_to spree.unauthorized_path
-      end
     end
   end
 
@@ -40,15 +28,6 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
         expect(response).to be_success
         expect(response.body).not_to be_blank
         expect(response.header["Content-Type"]).to eq("text/csv")
-      end
-
-      context "when feature flag is in effect" do
-        before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
-
-        it "is unauthorized" do
-          post :create, report: { start_at: "2018-10-09 07:30:00" }, report_format: "csv"
-          expect(response).to redirect_to spree.unauthorized_path
-        end
       end
     end
 

--- a/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/features/admin/reports/enterprise_fee_summaries_spec.rb
@@ -11,9 +11,6 @@ feature "enterprise fee summaries", js: true do
   let!(:other_order_cycle) { create(:simple_order_cycle, coordinator: other_distributor) }
 
   before do
-    feature_flags = instance_double(FeatureFlags, enterprise_fee_summary_enabled?: true)
-    allow(FeatureFlags).to receive(:new).with(current_user) { feature_flags }
-
     login_as current_user
   end
 
@@ -36,17 +33,6 @@ feature "enterprise fee summaries", js: true do
         click_on I18n.t("admin.reports.enterprise_fee_summary.name")
         expect(page).to have_button(I18n.t("filters.generate_report", scope: i18n_scope))
       end
-
-      context "when feature flag is in effect" do
-        before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
-
-        it "does not show link now allow direct access to the report" do
-          visit spree.admin_reports_path
-          expect(page).to have_no_link I18n.t("admin.reports.enterprise_fee_summary.name")
-          visit spree.new_admin_reports_enterprise_fee_summary_path
-          expect(page).to have_no_button(I18n.t("filters.generate_report", scope: i18n_scope))
-        end
-      end
     end
 
     context "when accessing the report as an enterprise user without sufficient permissions" do
@@ -57,17 +43,6 @@ feature "enterprise fee summaries", js: true do
         expect(page).to have_no_link(I18n.t("admin.reports.enterprise_fee_summary.name"))
         visit spree.new_admin_reports_enterprise_fee_summary_path
         expect(page).to have_content(I18n.t("unauthorized"))
-      end
-
-      context "when feature flag is in effect" do
-        before { allow(FeatureFlags).to receive(:new).with(current_user).and_call_original }
-
-        it "does not show link now allow direct access to the report" do
-          visit spree.admin_reports_path
-          expect(page).to have_no_link I18n.t("admin.reports.enterprise_fee_summary.name")
-          visit spree.new_admin_reports_enterprise_fee_summary_path
-          expect(page).to have_no_button(I18n.t("filters.generate_report", scope: i18n_scope))
-        end
       end
     end
   end

--- a/spec/models/feature_flags_spec.rb
+++ b/spec/models/feature_flags_spec.rb
@@ -25,22 +25,4 @@ describe FeatureFlags do
       end
     end
   end
-
-  describe "#enterprise_fee_summary_enabled?" do
-    context "when the user is superadmin" do
-      let!(:user) { create(:admin_user) }
-
-      it "returns true" do
-        expect(feature_flags).to be_enterprise_fee_summary_enabled
-      end
-    end
-
-    context "when the user is not superadmin" do
-      let!(:user) { create(:user) }
-
-      it "returns false" do
-        expect(feature_flags).not_to be_enterprise_fee_summary_enabled
-      end
-    end
-  end
 end

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -216,7 +216,7 @@ module Spree
           is_expected.to have_ability([:admin, :index, :customers, :bulk_coop, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management], for: Spree::Admin::ReportsController)
         end
 
-        include_examples "allows access to Enterprise Fee Summary only if feature flag enabled"
+        include_examples "allows access to Enterprise Fee Summary"
 
         it "should not be able to read other reports" do
           is_expected.not_to have_ability([:sales_total, :group_buys, :payments, :orders_and_distributors, :users_and_enterprises, :xero_invoices], for: Spree::Admin::ReportsController)
@@ -409,7 +409,7 @@ module Spree
           is_expected.to have_ability([:admin, :index, :customers, :sales_tax, :group_buys, :bulk_coop, :payments, :orders_and_distributors, :orders_and_fulfillment, :products_and_inventory, :order_cycle_management, :xero_invoices], for: Spree::Admin::ReportsController)
         end
 
-        include_examples "allows access to Enterprise Fee Summary only if feature flag enabled"
+        include_examples "allows access to Enterprise Fee Summary"
 
         it "should not be able to read other reports" do
           is_expected.not_to have_ability([:sales_total, :users_and_enterprises], for: Spree::Admin::ReportsController)

--- a/spec/support/ability_helper.rb
+++ b/spec/support/ability_helper.rb
@@ -1,20 +1,8 @@
 module AbilityHelper
-  shared_examples "allows access to Enterprise Fee Summary only if feature flag enabled" do
-    it "should not be able to read Enterprise Fee Summary" do
-      is_expected.not_to have_link_to_enterprise_fee_summary
-      is_expected.not_to have_direct_access_to_enterprise_fee_summary
-    end
-
-    context "when feature flag for Enterprise Fee Summary is enabled absolutely" do
-      before do
-        feature_flags = instance_double(FeatureFlags, enterprise_fee_summary_enabled?: true)
-        allow(FeatureFlags).to receive(:new).with(user) { feature_flags }
-      end
-
-      it "should be able to see link and read report" do
-        is_expected.to have_link_to_enterprise_fee_summary
-        is_expected.to have_direct_access_to_enterprise_fee_summary
-      end
+  shared_examples "allows access to Enterprise Fee Summary" do
+    it "should be able to see link and read report" do
+      is_expected.to have_link_to_enterprise_fee_summary
+      is_expected.to have_direct_access_to_enterprise_fee_summary
     end
 
     def have_link_to_enterprise_fee_summary


### PR DESCRIPTION
#### What? Why?

- Closes #3408

This mostly reverses/updates the changes done in #3334.

#### What should we test?

This is best to be tested with existing OCs (if already available) that would already have data for this report. Before testing, it would be helpful to identify hubs, producers, and coordinators that would have data needed for Step 2 below.

Each of the following roles would be checked for Steps 2 and 3.

1. Admin
2. Hub
3. Producer
4. Coordinator

To test:

1. Check that HTML and CSV report generation work. These are using the same data objects, so except occasionally, for Steps 2 and 3 there is no need to check results for both formats - just checking one should be sufficient.
2. Check that the "Enterprise Fee Summary" link is available in the Reports page, as described in #2656.
3. For each user role listed above, check that these data are properly summarized:
a. Coordinator fee for order cycle
b. Coordinator fee for incoming exchange
c. Coordinator fee for outgoing exchange
d. Producer fee for incoming exchange
e. Distributor fee for outgoing exchange
f. Shipping fee
g. Payment method fee
4. Do a smoke test that the correct filter options are available to each user role.
5. Check that orders for orders cycles to which their enterprise is not participant are not available to the user.
6. Test that using each filter field works. (No need to do this for each user role.)

#### Release notes

- Enable Enterprise Fee Summary report for non-superadmin enterprise users.

Changelog Category: Changed