### PR TITLE
Admin order cycles performance

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -142,7 +142,15 @@ module Admin
         @order_cycle = OrderCycle.find_by_id(params[:order_cycle_id]) if params[:order_cycle_id]
         coordinator = Enterprise.find_by_id(params[:coordinator_id]) if params[:coordinator_id]
         @order_cycle = OrderCycle.new(coordinator: coordinator) if @order_cycle.nil? && coordinator.present?
-        OpenFoodNetwork::OrderCyclePermissions.new(spree_current_user, @order_cycle).visible_enterprises
+
+        enterprises = OpenFoodNetwork::OrderCyclePermissions.new(spree_current_user, @order_cycle)
+          .visible_enterprises
+
+        unless enterprises.empty?
+          enterprises.includes(
+            supplied_products: [:supplier, :variants, master: [:images]]
+          )
+        end
       when :index
         if spree_current_user.admin?
           OpenFoodNetwork::Permissions.new(spree_current_user).

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -154,7 +154,8 @@ module Admin
           Enterprise.where("1=0")
         end
       when :visible
-        OpenFoodNetwork::Permissions.new(spree_current_user).visible_enterprises.ransack(params[:q]).result
+        OpenFoodNetwork::Permissions.new(spree_current_user).visible_enterprises
+          .includes(:shipping_methods, :payment_methods).ransack(params[:q]).result
       else
         # TODO was ordered with is_distributor DESC as well, not sure why or how we want to sort this now
         OpenFoodNetwork::Permissions.new(spree_current_user).

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -37,7 +37,7 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
   end
 
   def products
-    @products ||= products_scope.includes(:variants, :supplier, master: [:images])
+    @products ||= products_scope
   end
 
   def order_cycle

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -37,7 +37,7 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
   end
 
   def products
-    @products ||= products_scope.includes(:supplier, master: [:images])
+    @products ||= products_scope.includes(:variants, :supplier, master: [:images])
   end
 
   def order_cycle


### PR DESCRIPTION
#### What? Why?

Related to #3858 

I did some investigation and managed to find a couple of places where there were quick wins. I managed to improve a couple of endpoints related to Order Cycles index and edit pages.

Endpoint before: 548 queries, 2.9 seconds.
![Screenshot from 2019-05-28 23-58-21](https://user-images.githubusercontent.com/9029026/58521396-85c6b780-81b4-11e9-8f1b-82a856daa5b3.png)

Endpoint after: 42 queries, 0.4 seconds.
![Screenshot from 2019-05-29 00-00-56](https://user-images.githubusercontent.com/9029026/58521397-865f4e00-81b4-11e9-90fa-8bfb2190778e.png)

Endpoint before: 2048 queries, 12.2 seconds.
![Screenshot from 2019-05-29 00-53-29](https://user-images.githubusercontent.com/9029026/58521304-21a3f380-81b4-11e9-97a0-af8a69cae809.png)

Endpoint before: 952 queries, 7.3 seconds.
![enpoint_after](https://user-images.githubusercontent.com/9029026/58551220-72910780-8207-11e9-91cd-ae112fedf1e3.png)


The remaining 952 queries on this page are mostly this, repeating:

```ruby
lib/open_food_network/variant_and_line_item_naming.rb:13:in `options_text'
lib/open_food_network/variant_and_line_item_naming.rb:42:in `unit_to_display'
lib/open_food_network/variant_and_line_item_naming.rb:30:in `full_name'
app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb:22:in `block in variants'
app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb:22:in `variants'
app/controllers/admin/enterprises_controller.rb:100:in `block (2 levels) in for_order_cycle'
app/controllers/admin/enterprises_controller.rb:98:in `for_order_cycle'

SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" 
ON "spree_option_types"."id" = "spree_option_values"."option_type_id" 
INNER JOIN "spree_option_values_variants" 
ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" 
WHERE "spree_option_values_variants"."variant_id" = 203347 
ORDER BY spree_option_types.position asc;
```
There's obviously more N+1 problems here, but I didn't manage to crack this bit. :point_up: If anyone else fancies a go, be my guest. 

I think if we want more improvements on order cycles we'll need some big changes. I think we currently preload basically everything into Angular objects. We can move to doing quick API calls for some of the UI parts, like adding a product to the OC or selecting an enterprise.

#### What should we test?
<!-- List which features should be tested and how. -->

Admin order cycle index and edit pages should work as before, and load faster.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance on admin Order Cycle pages

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
