### PR TITLE
Remove matching of product shipping category with shipping method's category on checkout

### DIFF
--- a/app/models/stock/package.rb
+++ b/app/models/stock/package.rb
@@ -10,6 +10,16 @@
 #
 module Stock
   class Package < Spree::Stock::Package
+    # Returns all exsiting shipping categories.
+    #   It does not filter by the shipping categories of the products in the order.
+    #   It allows checkout of products with categories that are not the shipping methods categories
+    #   It disables the matching of product shipping category with shipping method's category
+    #
+    # @return [Array<Spree::ShippingCategory>]
+    def shipping_categories
+      Spree::ShippingCategory.all
+    end
+
     # Skips the methods that are not used by the order's distributor
     #
     # @return [Array<Spree::ShippingMethod>]

--- a/spec/models/stock/package_spec.rb
+++ b/spec/models/stock/package_spec.rb
@@ -2,49 +2,56 @@ require 'spec_helper'
 
 module Stock
   describe Package do
+    let(:stock_location) { double(:stock_location) }
+
+    subject(:package) { Package.new(stock_location, order, contents) }
+
+    let(:enterprise) { build(:enterprise) }
+    let(:other_enterprise) { build(:enterprise) }
+
+    let(:order) { build(:order, distributor: enterprise) }
+
+    let(:variant1) do
+      instance_double(
+        Spree::Variant,
+        shipping_category: shipping_method1.shipping_categories.first
+      )
+    end
+    let(:variant2) do
+      instance_double(
+        Spree::Variant,
+        shipping_category: shipping_method2.shipping_categories.first
+      )
+    end
+    let(:variant3) do
+      instance_double(Spree::Variant, shipping_category: nil)
+    end
+
+    let(:contents) do
+      [
+        Package::ContentItem.new(variant1, 1),
+        Package::ContentItem.new(variant1, 1),
+        Package::ContentItem.new(variant2, 1),
+        Package::ContentItem.new(variant3, 1)
+      ]
+    end
+
+    let(:shipping_method1) { create(:shipping_method, distributors: [enterprise]) }
+    let(:shipping_method2) { create(:shipping_method, distributors: [other_enterprise]) }
+
     describe '#shipping_methods' do
-      let(:stock_location) { double(:stock_location) }
-      let(:order) { build(:order) }
+      it 'does not return shipping methods not used by the package\'s order distributor' do
+        expect(package.shipping_methods).to eq [shipping_method1]
+      end
+    end
 
-      subject(:package) { Package.new(stock_location, order, contents) }
+    describe '#shipping_categories' do
+      it "returns shipping categories that are not shipping categories of the order's products" do
+        package
+        other_shipping_category = create(:shipping_category)
 
-      describe '#shipping_methods' do
-        let(:enterprise) { build(:enterprise) }
-        let(:other_enterprise) { build(:enterprise) }
-
-        let(:order) { build(:order, distributor: enterprise) }
-
-        let(:variant1) do
-          instance_double(
-            Spree::Variant,
-            shipping_category: shipping_method1.shipping_categories.first
-          )
-        end
-        let(:variant2) do
-          instance_double(
-            Spree::Variant,
-            shipping_category: shipping_method2.shipping_categories.first
-          )
-        end
-        let(:variant3) do
-          instance_double(Spree::Variant, shipping_category: nil)
-        end
-
-        let(:contents) do
-          [
-            Package::ContentItem.new(variant1, 1),
-            Package::ContentItem.new(variant1, 1),
-            Package::ContentItem.new(variant2, 1),
-            Package::ContentItem.new(variant3, 1)
-          ]
-        end
-
-        let(:shipping_method1) { create(:shipping_method, distributors: [enterprise]) }
-        let(:shipping_method2) { create(:shipping_method, distributors: [other_enterprise]) }
-
-        it 'does not return shipping methods not used by the package\'s order distributor' do
-          expect(package.shipping_methods).to eq [shipping_method1]
-        end
+        expect(package.shipping_categories).to eq [shipping_method1.shipping_categories.first,
+                                                   other_shipping_category]
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #3879
Users can now checkout products with shipping categories not supported by the shipping methods. 
To make this verification work properly it would require some work in the backoffice, this is a quick solution to the problem where checkout would not work and hub managers would have no way to know why.

#### What should we test?
Verify issue is fixed.

#### Release notes
Changelog Category: Changed
Users can now checkout products with shipping categories not supported by the shipping methods. The shipping categories are not verified at checkout time.

#### How is this related to the Spree upgrade?
This problem was introduced by the upgrade.
