### PR TITLE
Make a few more things translatable in the Enterprise Fees management page

### DIFF
--- a/app/helpers/enterprise_fees_helper.rb
+++ b/app/helpers/enterprise_fees_helper.rb
@@ -8,6 +8,6 @@ module EnterpriseFeesHelper
   end
 
   def enterprise_fee_type_options
-    EnterpriseFee::FEE_TYPES.map { |f| [f.capitalize, f] }
+    EnterpriseFee::FEE_TYPES.map { |fee_type| [t("#{fee_type}_fee"), fee_type] }
   end
 end

--- a/app/views/admin/enterprise_fees/index.html.haml
+++ b/app/views/admin/enterprise_fees/index.html.haml
@@ -32,7 +32,7 @@
             %ofn-select{ :id => angular_id(:enterprise_id), data: 'enterprises', include_blank: true, ng: { model: 'enterprise_fee.enterprise_id' } }
             %input{ type: "hidden", name: angular_name(:enterprise_id), ng: { value: "enterprise_fee.enterprise_id" } }
           %td= f.ng_select :fee_type, enterprise_fee_type_options, 'enterprise_fee.fee_type'
-          %td= f.ng_text_field :name, { placeholder: 'e.g. packing fee' }
+          %td= f.ng_text_field :name, { placeholder: t('.name_placeholder') }
           %td
             %ofn-select{ :id => angular_id(:tax_category_id), data: 'tax_categories', include_blank: true, ng: { model: 'enterprise_fee.tax_category_id' } }
             %input{ type: "hidden", name: angular_name(:tax_category_id), 'watch-tax-category' => true }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -421,14 +421,15 @@ en:
 
     enterprise_fees:
       index:
-        title: Enterprise Fees
-        enterprise: Enterprise
-        fee_type: Fee Type
-        name: Name
-        tax_category: Tax Category
-        calculator: Calculator
-        calculator_values: Calculator Values
+        title: "Enterprise Fees"
+        enterprise: "Enterprise"
+        fee_type: "Fee Type"
+        name: "Name"
+        tax_category: "Tax Category"
+        calculator: "Calculator"
+        calculator_values: "Calculator Values"
         search: "Search"
+        name_placeholder: "e.g. packing fee"
 
     enterprise_groups:
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2862,6 +2862,17 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     create: "Create"
     loading: "Loading"
 
+    flat_percent: "Flat Percent"
+    per_kg: "Per Kg"
+    amount: "Amount"
+    currency: "Currency"
+    first_item: "First Item Cost"
+    additional_item: "Additional Item Cost"
+    max_items: "Max Items"
+    minimal_amount: "Minimal Amount"
+    normal_amount: "Normal Amount"
+    discount_amount: "Discount Amount"
+
     # TODO: remove `email` key once we get to Spree 2.0
     email: Email
     # TODO: remove 'account_updated' key once we get to Spree 2.0

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -18,7 +18,7 @@ feature '
     click_link 'Enterprise Fees'
 
     expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"
-    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Packing'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Packing fee'
     expect(page).to have_selector "input[value='$0.50 / kg']"
     expect(page).to have_select "enterprise_fee_set_collection_attributes_0_tax_category_id", selected: 'GST'
     expect(page).to have_select "enterprise_fee_set_collection_attributes_0_calculator_type", selected: 'Flat Rate (per item)'
@@ -72,7 +72,7 @@ feature '
 
     # Then I should see the updated fields for my fee
     expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id", selected: 'Foo'
-    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Admin'
+    expect(page).to have_select "enterprise_fee_set_collection_attributes_0_fee_type", selected: 'Admin fee'
     expect(page).to have_selector "input[value='Greetings!']"
     expect(page).to have_select 'enterprise_fee_set_collection_attributes_0_tax_category_id', selected: 'Inherit From Product'
     expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'


### PR DESCRIPTION
#### What? Why?

Closes #3781

We are fixing 3 problems in this PR:
1 - make enterprise fees name placeholder translatable (was static "'e.g. packing fee'")
2 - make the fields in the column "calculator values" translatable for all fields of all current calculators, there are quite a few, for example, flat percent or per kg:
![Screenshot 2019-05-29 at 21 57 11](https://user-images.githubusercontent.com/1640378/58591690-c3801a80-825e-11e9-9097-8959f111dfe7.png)
![Screenshot 2019-05-29 at 21 57 24](https://user-images.githubusercontent.com/1640378/58591692-c418b100-825e-11e9-9aa6-6ed563800de1.png)

3 - make fee type options translatable #3781 
![Screenshot 2019-05-29 at 22 05 42](https://user-images.githubusercontent.com/1640378/58591694-c418b100-825e-11e9-84b4-0a0a02951be3.png)


#### What should we test?
This is only testable after translations are done...
regarding point 2 above, note that each calculator has a specific list of fields, for example, "max items" or "minimal amount".

#### Release notes
Changelog Category: Fixed
Enterprise Fees management page is now fully translatable.
