### PR TITLE
Add translation keys to actions in the order payments list page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2745,6 +2745,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     continue: "Continue"
     fill_in_customer_info: "Please fill in customer info"
     new_payment: "New Payment"
+    capture: "Capture"
+    void: "Void"
 
     configurations: "Configurations"
     general_settings: "General Settings"


### PR DESCRIPTION
#### What? Why?

Related to #3642
Investigating 3642 I found the actions in the order payments list page were not translated. This PR fixes that.

#### What should we test?
Order payments list page, actions capture and void should be translatable now.

#### Release notes
Changelog Category: Fixed
Actions in the order payments list page are now translatable.
