### PR TITLE
Fix missing translations in tag rules management page

### DIFF
--- a/app/assets/javascripts/admin/tag_rules/directives/tag_rules/tag_rule.js.coffee
+++ b/app/assets/javascripts/admin/tag_rules/directives/tag_rules/tag_rule.js.coffee
@@ -4,8 +4,8 @@ angular.module("admin.tagRules").directive "tagRule", ->
   link: (scope, element, attrs) ->
     scope.opt =
       "TagRule::FilterShippingMethods":
-         textTop: "Shipping methods tagged"
-         textBottom: "are:"
+         textTop: t('js.admin.tag_rules.shipping_method_tagged_top')
+         textBottom: t('js.admin.tag_rules.shipping_method_tagged_bottom')
          taggable: "shipping_method"
          tagsAttr: "shipping_method_tags"
          tagListAttr: "preferred_shipping_method_tags"
@@ -13,8 +13,8 @@ angular.module("admin.tagRules").directive "tagRule", ->
          tagListFor: (rule) ->
           rule.preferred_shipping_method_tags
       "TagRule::FilterPaymentMethods":
-         textTop: "Payment methods tagged"
-         textBottom: "are:"
+         textTop: t('js.admin.tag_rules.payment_method_tagged_top')
+         textBottom: t('js.admin.tag_rules.payment_method_tagged_bottom')
          taggable: "payment_method"
          tagsAttr: "payment_method_tags"
          tagListAttr: "preferred_payment_method_tags"
@@ -22,8 +22,8 @@ angular.module("admin.tagRules").directive "tagRule", ->
          tagListFor: (rule) ->
           rule.preferred_payment_method_tags
       "TagRule::FilterOrderCycles":
-         textTop: "Order Cycles tagged"
-         textBottom: "are:"
+         textTop: t('js.admin.tag_rules.order_cycle_tagged_top')
+         textBottom: t('js.admin.tag_rules.order_cycle_tagged_bottom')
          taggable: "exchange"
          tagsAttr: "exchange_tags"
          tagListAttr: "preferred_exchange_tags"
@@ -31,8 +31,8 @@ angular.module("admin.tagRules").directive "tagRule", ->
          tagListFor: (rule) ->
            rule.preferred_exchange_tags
       "TagRule::FilterProducts":
-         textTop: "Inventory variants tagged"
-         textBottom: "are:"
+         textTop: t('js.admin.tag_rules.inventory_tagged_top')
+         textBottom: t('js.admin.tag_rules.inventory_tagged_bottom')
          taggable: "variant"
          tagsAttr: "variant_tags"
          tagListAttr: "preferred_variant_tags"

--- a/app/assets/javascripts/templates/admin/new_tag_rule_dialog.html.haml
+++ b/app/assets/javascripts/templates/admin/new_tag_rule_dialog.html.haml
@@ -7,4 +7,4 @@
     %input.ofn-select2.fullwidth{ :id => 'rule_type_selector', ng: { model: "ruleType" }, data: "ruleTypes", 'min-search' => "5" }
 
   .text-center
-    %input.button.red.icon-plus{ type: 'button', value: "Add Rule", ng: { click: 'addRule(tagGroup, ruleType)' } }
+    %input.button.red.icon-plus{ type: 'button', value: "{{ 'js.admin.new_tag_rule_dialog.add_rule' | t }}", ng: { click: 'addRule(tagGroup, ruleType)' } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2484,6 +2484,15 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           severity: Severity
           description: Description
           resolve: Resolve
+      tag_rules:
+        shipping_method_tagged_top: "Shipping methods tagged"
+        shipping_method_tagged_bottom: "are:"
+        payment_method_tagged_top: "Payment methods tagged"
+        payment_method_tagged_bottom: "are:"
+        order_cycle_tagged_top: "Order Cycles tagged"
+        order_cycle_tagged_bottom: "are:"
+        inventory_tagged_top: "Inventory variants tagged"
+        inventory_tagged_bottom: "are:"
       new_tag_rule_dialog:
         select_rule_type: "Select a rule type:"
         add_rule: "Add Rule"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2486,6 +2486,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           resolve: Resolve
       new_tag_rule_dialog:
         select_rule_type: "Select a rule type:"
+        add_rule: "Add Rule"
       enterprise_fees:
         inherit_from_product: "Inherit From Product"
       orders:


### PR DESCRIPTION
#### What? Why?

Closes #3761

Fixes translations not only for OC but all the 4 types of tag rules.

#### What should we test?
Verify all 4 types are translatable now.
Also, the submit button when adding new rule is also translatable.

#### Release notes
Changelog Category: Fixed
Tag rules config page is now fully translatable.