### PR TITLE
Add missing translation keys to the create product page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,11 @@ en:
       spree/payment:
         amount: Amount
       spree/product:
-        primary_taxon: Product Category
+        primary_taxon: "Product Category"
+        supplier: "Supplier"
+        shipping_category_id: "Shipping Category"
+        variant_unit: "Variant Unit"
+        variant_unit_name: "Variant Unit Name"
       order_cycle:
         orders_close_at: Close date
     errors:
@@ -2061,6 +2065,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_admin_supplier: Supplier
   spree_admin_product_category: Product Category
   spree_admin_variant_unit_name: Variant unit name
+  unit_name: "Unit name"
   change_package: "Change Package"
   spree_admin_single_enterprise_hint: "Hint: To allow people to find you, turn on your visibility under"
   spree_admin_eg_pickup_from_school: "eg. 'Pick-up from Primary School'"


### PR DESCRIPTION
Fixing the fields names displayed in error messages.

#### What? Why?

Closes #1467

Adds missing translations keys, not just the one in the issue but all the mandatory fields in the page.

#### What should we test?
Go to the new product page and click "create" without fillin in any fields. You should see the error message for all fields.

Additionally, there's an extra field called "unit name" that shows up when "unit size" is "items": go to new product page, select only unit size items and see the new field name translated. After that click "create" without filling in any other field, the error message should show "variant unit name" which is now a translatable string.

#### Release notes
Changelog Category: Fixed
Errors in the create product page are now translatable.
