### PR TITLE
WIP Translate date pickers (not datetime pickers)

### DIFF
--- a/app/assets/javascripts/admin/directives/date_picker.js.coffee
+++ b/app/assets/javascripts/admin/directives/date_picker.js.coffee
@@ -1,6 +1,7 @@
 angular.module("ofn.admin").directive "datepicker", ->
   require: "ngModel"
   link: (scope, element, attrs, ngModel) ->
+    element.datepicker.regional[""]
     element.datepicker
       dateFormat: "yy-mm-dd"
       onSelect: (dateText, inst) ->

--- a/app/assets/javascripts/admin/utils/directives/date_picker.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/date_picker.js.coffee
@@ -1,6 +1,7 @@
 angular.module("admin.utils").directive "datepicker", ->
   require: "ngModel"
   link: (scope, element, attrs, ngModel) ->
+    element.datepicker.regional[""]
     element.datepicker
       dateFormat: "yy-mm-dd"
       onSelect: (dateText, inst) ->


### PR DESCRIPTION
Make datepickers use selected locale by settging the regional property to empty. This makes the datepicker use the selected locale.

#### What? Why?

Relates to #1803

I have created #3894 to remove code duplication.

#### What should we test?
All datepickers in the backoffice should be translated now. I tested orders list and a couple of reports with pt and fr.
This will not work for all languages, I tested with fr_BE and it doesnt work, I am not sure why. Maybe we can create an issue for these languages.

#### Release notes
Changelog Category: Fixed
Date pickers are now translated (not datetime pickers yet).
