### PR TITLE
Make weight calculator use line_item.final_weight_volume rather than variant.weight

### DIFF
--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -18,11 +18,16 @@ module Calculator
 
     def total_weight(line_items)
       line_items.sum do |line_item|
-        if line_item.final_weight_volume.present?
-          line_item.final_weight_volume / 1000
-        else
-          (line_item.variant.andand.weight || 0) * line_item.quantity
-        end
+        line_item_weight(line_item)
+      end
+    end
+
+    def line_item_weight(line_item)
+      if line_item.final_weight_volume.present?
+        # Divided by 1000 because grams is the base weight unit and the calculator price is per_kg
+        line_item.final_weight_volume / 1000
+      else
+        (line_item.variant.andand.weight || 0) * line_item.quantity
       end
     end
   end

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -13,7 +13,7 @@ module Calculator
 
     def compute(object)
       line_items = line_items_for object
-      total_weight(line_items) * preferred_per_kg
+      (total_weight(line_items) * preferred_per_kg).round(2)
     end
 
     private

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -13,7 +13,13 @@ module Calculator
 
     def compute(object)
       line_items = line_items_for object
-      total_weight = line_items.sum { |li| ((li.variant.andand.weight || 0) * li.quantity) }
+      total_weight = line_items.sum do |line_item|
+        if line_item.final_weight_volume.present?
+          line_item.final_weight_volume / 1000
+        else
+          ((line_item.variant.andand.weight || 0) * line_item.quantity)
+        end
+      end
       total_weight * preferred_per_kg
     end
   end

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -16,6 +16,8 @@ module Calculator
       total_weight(line_items) * preferred_per_kg
     end
 
+    private
+
     def total_weight(line_items)
       line_items.sum do |line_item|
         line_item_weight(line_item)
@@ -23,6 +25,7 @@ module Calculator
     end
 
     def line_item_weight(line_item)
+      return 0 if line_item.variant.product.andand.variant_unit != 'weight'
       if line_item.final_weight_volume.present?
         # Divided by 1000 because grams is the base weight unit and the calculator price is per_kg
         line_item.final_weight_volume / 1000

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -13,14 +13,17 @@ module Calculator
 
     def compute(object)
       line_items = line_items_for object
-      total_weight = line_items.sum do |line_item|
+      total_weight(line_items) * preferred_per_kg
+    end
+
+    def total_weight(line_items)
+      line_items.sum do |line_item|
         if line_item.final_weight_volume.present?
           line_item.final_weight_volume / 1000
         else
-          ((line_item.variant.andand.weight || 0) * line_item.quantity)
+          (line_item.variant.andand.weight || 0) * line_item.quantity
         end
       end
-      total_weight * preferred_per_kg
     end
   end
 end

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -45,6 +45,9 @@ module Calculator
       end
     end
 
+    #  Example: 2 (line_item.quantity) wine glasses of 125mL (line_item.variant.unit_value)
+    #    Customer ends up getting 350mL (line_item.final_weight_volume) of wine
+    #      that represent 2.8 (quantity_implied_in_final_weight_volume) glasses of wine
     def quantity_implied_in_final_weight_volume(line_item)
       (1.0 * line_item.final_weight_volume / line_item.variant.unit_value).round(3)
     end

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -26,13 +26,7 @@ module Calculator
 
     def line_item_weight(line_item)
       if line_item.final_weight_volume.present?
-        if line_item.variant.product.andand.variant_unit == 'weight'
-          # Divided by 1000 because grams is the base weight unit and the calculator price is per_kg
-          line_item.final_weight_volume / 1000.0
-        else
-          final_units = (1.0 * line_item.final_weight_volume / line_item.variant.unit_value).round(3)
-          weight_per_variant(line_item) * final_units
-        end
+        weight_per_final_weight_volume(line_item)
       else
         weight_per_variant(line_item) * line_item.quantity
       end
@@ -40,6 +34,19 @@ module Calculator
 
     def weight_per_variant(line_item)
       line_item.variant.andand.weight || 0
+    end
+
+    def weight_per_final_weight_volume(line_item)
+      if line_item.variant.product.andand.variant_unit == 'weight'
+        # Divided by 1000 because grams is the base weight unit and the calculator price is per_kg
+        line_item.final_weight_volume / 1000.0
+      else
+        weight_per_variant(line_item) * quantity_implied_in_final_weight_volume(line_item)
+      end
+    end
+
+    def quantity_implied_in_final_weight_volume(line_item)
+      (1.0 * line_item.final_weight_volume / line_item.variant.unit_value).round(3)
     end
   end
 end

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -25,13 +25,21 @@ module Calculator
     end
 
     def line_item_weight(line_item)
-      return 0 if line_item.variant.product.andand.variant_unit != 'weight'
       if line_item.final_weight_volume.present?
-        # Divided by 1000 because grams is the base weight unit and the calculator price is per_kg
-        line_item.final_weight_volume / 1000
+        if line_item.variant.product.andand.variant_unit == 'weight'
+          # Divided by 1000 because grams is the base weight unit and the calculator price is per_kg
+          line_item.final_weight_volume / 1000.0
+        else
+          final_units = (1.0 * line_item.final_weight_volume / line_item.variant.unit_value).round(3)
+          weight_per_variant(line_item) * final_units
+        end
       else
-        (line_item.variant.andand.weight || 0) * line_item.quantity
+        weight_per_variant(line_item) * line_item.quantity
       end
+    end
+
+    def weight_per_variant(line_item)
+      line_item.variant.andand.weight || 0
     end
   end
 end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -29,9 +29,15 @@ describe Calculator::Weight do
     end
 
     describe "and with final_weight_volume defined" do
+      before { line_item.update_attribute :final_weight_volume, '18000' }
+
       it "computes fee using final_weight_volume, not the variant weight" do
-        line_item.final_weight_volume = "18000"
         expect(subject.compute(line_item)).to eq(10 * 18)
+      end
+
+      it "returns zero for variant where unit type is not weight" do
+        line_item.variant.product.update_attribute :variant_unit, 'items'
+        expect(subject.compute(line_item)).to eq(0)
       end
     end
   end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -18,13 +18,22 @@ describe Calculator::Weight do
     expect(subject.compute(order)).to eq((10 * 1 + 20 * 3) * 10)
   end
 
-  it "computes shipping cost for a line item" do
-    variant = build(:variant, weight: 10)
+  describe "line item with variant weight" do
+    let(:variant) { build(:variant, weight: 10) }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
 
-    line_item = build(:line_item, variant: variant, quantity: 2)
+    before { subject.set_preference(:per_kg, 10) }
 
-    subject.set_preference(:per_kg, 10)
-    expect(subject.compute(line_item)).to eq(10 * 2 * 10)
+    it "computes shipping cost for a line item" do
+      expect(subject.compute(line_item)).to eq(10 * 2 * 10)
+    end
+
+    describe "and with final_weight_volume defined" do
+      it "computes fee using final_weight_volume, not the variant weight" do
+        line_item.final_weight_volume = "18000"
+        expect(subject.compute(line_item)).to eq(10 * 18)
+      end
+    end
   end
 
   it "computes shipping cost for an object with an order" do

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -55,4 +55,97 @@ describe Calculator::Weight do
     subject.set_preference(:per_kg, 10)
     expect(subject.compute(object_with_order)).to eq((10 * 1 + 5 * 2) * 10)
   end
+
+  context "when line item final_weight_volume is set" do
+    let!(:product) { create(:product, product_attributes) }
+    let!(:variant) { create(:variant, variant_attributes.merge(product: product)) }
+
+    let(:calculator) { described_class.new(preferred_per_kg: 6) }
+    let(:line_item) do
+      build(:line_item, variant: variant, quantity: 2).tap do |object|
+        object.send(:calculate_final_weight_volume)
+      end
+    end
+
+    context "when the product uses weight unit" do
+      context "when the product is in g (3g)" do
+        let!(:product_attributes) { { variant_unit: "weight", variant_unit_scale: 1.0 } }
+        let!(:variant_attributes) { { unit_value: 300.0, weight: 0.30 } }
+
+        it "is correct" do
+          expect(line_item.final_weight_volume).to eq(600) # 600g
+          line_item.final_weight_volume = 700 # 700g
+          expect(calculator.compute(line_item)).to eq(4.2)
+        end
+      end
+
+      context "when the product is in kg (3kg)" do
+        let!(:product_attributes) { { variant_unit: "weight", variant_unit_scale: 1_000.0 } }
+        let!(:variant_attributes) { { unit_value: 3_000.0, weight: 3.0 } }
+
+        it "is correct" do
+          expect(line_item.final_weight_volume).to eq(6_000) # 6kg
+          line_item.final_weight_volume = 7_000 # 7kg
+          expect(calculator.compute(line_item)).to eq(42)
+        end
+      end
+
+      context "when the product is in T (3T)" do
+        let!(:product_attributes) { { variant_unit: "weight", variant_unit_scale: 1_000_000.0 } }
+        let!(:variant_attributes) { { unit_value: 3_000_000.0, weight: 3_000.0 } }
+
+        it "is correct" do
+          expect(line_item.final_weight_volume).to eq(6_000_000) # 6T
+          line_item.final_weight_volume = 7_000_000 # 7T
+          expect(calculator.compute(line_item)).to eq(42_000)
+        end
+      end
+    end
+
+    context "when the product uses volume unit" do
+      context "when the product is in mL (300mL)" do
+        let!(:product_attributes) { { variant_unit: "volume", variant_unit_scale: 0.001 } }
+        let!(:variant_attributes) { { unit_value: 0.3, weight: 0.25 } }
+
+        it "is correct" do
+          expect(line_item.final_weight_volume).to eq(0.6) # 600mL
+          line_item.final_weight_volume = 0.7 # 700mL
+          expect(calculator.compute(line_item)).to eq(3.50)
+        end
+      end
+
+      context "when the product is in L (3L)" do
+        let!(:product_attributes) { { variant_unit: "volume", variant_unit_scale: 1 } }
+        let!(:variant_attributes) { { unit_value: 3.0, weight: 2.5 } }
+
+        it "is correct" do
+          expect(line_item.final_weight_volume).to eq(6) # 6L
+          line_item.final_weight_volume = 7 # 7L
+          expect(calculator.compute(line_item)).to eq(35.00)
+        end
+      end
+
+      context "when the product is in kL (3kL)" do
+        let!(:product_attributes) { { variant_unit: "volume", variant_unit_scale: 1_000 } }
+        let!(:variant_attributes) { { unit_value: 3_000.0, weight: 2_500.0 } }
+
+        it "is correct" do
+          expect(line_item.final_weight_volume).to eq(6_000) # 6kL
+          line_item.final_weight_volume = 7_000 # 7kL
+          expect(calculator.compute(line_item)).to eq(34_995)
+        end
+      end
+    end
+
+    context "when the product uses item unit" do
+      let!(:product_attributes) { { variant_unit: "items", variant_unit_scale: nil, variant_unit: "pc", display_as: "pc" } }
+      let!(:variant_attributes) { { unit_value: 3.0, weight: 2.5, display_as: "pc" } }
+
+      it "is correct" do
+        expect(line_item.final_weight_volume).to eq(6) # 6 pcs
+        line_item.final_weight_volume = 7 # 7 pcs
+        expect(calculator.compute(line_item)).to eq(35.0)
+      end
+    end
+  end
 end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -35,9 +35,11 @@ describe Calculator::Weight do
         expect(subject.compute(line_item)).to eq(10 * 18)
       end
 
-      it "returns zero for variant where unit type is not weight" do
-        line_item.variant.product.update_attribute :variant_unit, 'items'
-        expect(subject.compute(line_item)).to eq(0)
+      context "where variant unit is not weight" do
+        it "uses both final_weight_volume and weight to calculate fee" do
+          line_item.variant.product.update_attribute :variant_unit, 'items'
+          expect(subject.compute(line_item)).to eq(180)
+        end
       end
     end
   end


### PR DESCRIPTION
This is for cases where the final weight is set manually in the BOM

#### What? Why?

Closes #3661 

Re 3661, the fees are being recalculated, the problem is that the manual weight was not being picked up.
The weight calculator for fees was always using the variant weight, the fixed value. When the final weight is set by the seller on the BOM, that value is stored in the line_item.final_weight_volume field, the weight calculator is now using that value if it is present.

#### What should we test?
We need to verify all cases where the weight calculator is used.

Make sure the issue is fixed and shipping fees are updated when final weight volume is updated in the BOM.
This should be tested for the simple case where variant unit is weight but also for variants where unit is items or volume: in these cases, the fees should be calculated based on the variant weight field that can be found when editing a variant even when unit is volume for example. The test is: update the weight of a volume based variant, add the variant to the order and make sure the weight based shipping fee is correctly calculated based on that weight, then, go to BOM and change the final weight volume and check the shipping fee is also correctly calculated. (I tested this and it worked in staging UK).

#### Release notes
Changelog Category: Fixed
Manual weight values introduced by the seller in the backoffice are now picked up when calculating fees by weight based calculators.
