### PR TITLE
Clear product.variants.unit_description if product.variant_unit is items

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -39,6 +39,8 @@ Spree::Admin::ProductsController.class_eval do
     delete_stock_params_and_set_after do
       super
     end
+
+    clear_variants_unit_description if @object.variant_unit == 'items'
   end
 
   def bulk_update
@@ -153,5 +155,11 @@ Spree::Admin::ProductsController.class_eval do
 
   def set_product_master_variant_price_to_zero
     @product.price = 0 if @product.price.nil?
+  end
+
+  def clear_variants_unit_description
+    @object.variants.each do |variant|
+      variant.update_attribute :unit_description, ''
+    end
   end
 end

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -150,16 +150,30 @@ describe Spree::Admin::ProductsController, type: :controller do
   end
 
   describe "updating" do
+    let(:producer) { create(:enterprise) }
+    let!(:product) { create(:simple_product, supplier: producer) }
+
+    before do
+      @request.env['HTTP_REFERER'] = 'http://test.com/'
+      login_as_enterprise_user [producer]
+    end
+
+    describe "product variant unit is items" do
+      it "clears unit description of all variants of the product" do
+        product.variants.first.update_attribute :unit_description, "grams"
+        spree_put :update,
+                  id: product,
+                  product: {
+                    variant_unit: "items",
+                    variant_unit_name: "bag"
+                  }
+        expect(product.reload.variants.first.unit_description).to be_empty
+      end
+    end
+
     describe "product properties" do
       context "as an enterprise user" do
-        let(:producer) { create(:enterprise) }
-        let!(:product) { create(:simple_product, supplier: producer) }
         let!(:property) { create(:property, name: "A nice name") }
-
-        before do
-          @request.env['HTTP_REFERER'] = 'http://test.com/'
-          login_as_enterprise_user [producer]
-        end
 
         context "when a submitted property does not already exist" do
           it "does not create a new property, or product property" do

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -154,7 +154,6 @@ describe Spree::Admin::ProductsController, type: :controller do
     let!(:product) { create(:simple_product, supplier: producer) }
 
     before do
-      @request.env['HTTP_REFERER'] = 'http://test.com/'
       login_as_enterprise_user [producer]
     end
 


### PR DESCRIPTION
When product.variant_unit is items, the product.variant_unit_name is used instead of the variant.unit_description (this field is not available in the variants edit page if product.variant_unit is items). So, we need to clear it.

#### What? Why?

Closes #1582

#### What should we test?
The product edit page needs to be tested as well as verifying the issue if fixed.

#### Release notes
Changelog Category: Fixed
Unit description (only used for weight or volume products) is cleared when switching a product unit from weight or volume to items.
