### PR TITLE
3877,3843 Improve handling of units and unit type in product import

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -4,7 +4,8 @@
 
 module ProductImport
   class EntryValidator
-    def initialize(current_user, import_time, spreadsheet_data, editable_enterprises, inventory_permissions, reset_counts, import_settings)
+    def initialize(current_user, import_time, spreadsheet_data, editable_enterprises,
+                   inventory_permissions, reset_counts, import_settings, all_entries)
       @current_user = current_user
       @import_time = import_time
       @spreadsheet_data = spreadsheet_data
@@ -12,6 +13,7 @@ module ProductImport
       @inventory_permissions = inventory_permissions
       @reset_counts = reset_counts
       @import_settings = import_settings
+      @all_entries = all_entries
     end
 
     def self.non_updatable_fields
@@ -30,6 +32,7 @@ module ProductImport
         assign_enterprise_field(entry)
         enterprise_validation(entry)
         unit_fields_validation(entry)
+        variant_of_product_validation(entry)
 
         next if entry.enterprise_id.blank?
 
@@ -156,6 +159,17 @@ module ProductImport
 
       # variant_unit_name must be present if unit_type not present
       mark_as_invalid(entry, attribute: 'variant_unit_name', error: I18n.t('admin.product_import.model.conditional_blank')) unless entry.variant_unit_name && entry.variant_unit_name.present?
+    end
+
+    def variant_of_product_validation(entry)
+      return if entry.producer.blank? || entry.name.blank?
+
+      reference_entry = all_entries_for_product(entry).first
+      if entry.unit_type.present? && entry.unit_type.to_s != reference_entry.unit_type.to_s
+        mark_as_not_updatable(entry, "unit_type")
+      elsif entry.variant_unit_name.present? && entry.variant_unit_name.to_s != reference_entry.variant_unit_name.to_s
+        mark_as_not_updatable(entry, "variant_unit_name")
+      end
     end
 
     def producer_validation(entry)
@@ -332,6 +346,11 @@ module ProductImport
       entry.product_validations = options[:product_validations] if options[:product_validations]
     end
 
+    def mark_as_not_updatable(entry, attribute)
+      mark_as_invalid(entry, attribute: attribute,
+                             error: I18n.t("admin.product_import.model.not_updatable"))
+    end
+
     def import_into_inventory?
       @import_settings[:settings].andand['import_into'] == 'inventories'
     end
@@ -385,6 +404,20 @@ module ProductImport
       object.count_on_hand = entry.on_hand.presence
       object.on_demand = object.count_on_hand.blank? if entry.on_demand.blank?
       entry.on_hand_nil = object.count_on_hand.blank?
+    end
+
+    def all_entries_for_product(entry)
+      all_entries_by_product[entries_by_product_key(entry)]
+    end
+
+    def all_entries_by_product
+      @all_entries_by_product ||= @all_entries.group_by do |entry|
+        entries_by_product_key(entry)
+      end
+    end
+
+    def entries_by_product_key(entry)
+      [entry.producer.to_s, entry.name.to_s]
     end
   end
 end

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -164,12 +164,22 @@ module ProductImport
     def variant_of_product_validation(entry)
       return if entry.producer.blank? || entry.name.blank?
 
+      validate_unit_type_unchanged(entry)
+      validate_variant_unit_name_unchanged(entry)
+    end
+
+    def validate_unit_type_unchanged(entry)
+      return if entry.unit_type.blank?
       reference_entry = all_entries_for_product(entry).first
-      if entry.unit_type.present? && entry.unit_type.to_s != reference_entry.unit_type.to_s
-        mark_as_not_updatable(entry, "unit_type")
-      elsif entry.variant_unit_name.present? && entry.variant_unit_name.to_s != reference_entry.variant_unit_name.to_s
-        mark_as_not_updatable(entry, "variant_unit_name")
-      end
+      return if entry.unit_type.to_s == reference_entry.unit_type.to_s
+      mark_as_not_updatable(entry, "unit_type")
+    end
+
+    def validate_variant_unit_name_unchanged(entry)
+      return if entry.variant_unit_name.blank?
+      reference_entry = all_entries_for_product(entry).first
+      return if entry.variant_unit_name.to_s == reference_entry.variant_unit_name.to_s
+      mark_as_not_updatable(entry, "variant_unit_name")
     end
 
     def producer_validation(entry)

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -4,6 +4,7 @@
 
 module ProductImport
   class EntryValidator
+    # rubocop:disable Metrics/ParameterLists
     def initialize(current_user, import_time, spreadsheet_data, editable_enterprises,
                    inventory_permissions, reset_counts, import_settings, all_entries)
       @current_user = current_user
@@ -15,6 +16,7 @@ module ProductImport
       @import_settings = import_settings
       @all_entries = all_entries
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def self.non_updatable_fields
       {

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -238,18 +238,14 @@ module ProductImport
     end
 
     def build_entries_in_range
-      start_line = @import_settings[:start]
-      end_line = @import_settings[:end]
+      # In the JS, start and end are calculated like this:
+      # start = (batchIndex * $scope.batchSize) + 1
+      # end = (batchIndex + 1) * $scope.batchSize
+      start_data_index = @import_settings[:start] - 1
+      end_data_index = @import_settings[:end] - 1
 
-      (start_line..end_line).each do |i|
-        line_number = i + 1
-        row = @sheet.row(line_number)
-        row_data = Hash[[headers, row].transpose]
-        entry = SpreadsheetEntry.new(row_data)
-        entry.line_number = line_number
-        @entries.push entry
-        break if @sheet.last_row == line_number
-      end
+      data_rows = rows[start_data_index..end_data_index]
+      @entries = build_entries_from_rows(data_rows, start_data_index)
     end
 
     def build_entries
@@ -267,11 +263,11 @@ module ProductImport
       File.delete(@file)
     end
 
-    def build_entries_from_rows(rows)
+    def build_entries_from_rows(rows, offset = 0)
       rows.each_with_index.inject([]) do |entries, (row, i)|
         row_data = Hash[[headers, row].transpose]
         entry = SpreadsheetEntry.new(row_data)
-        entry.line_number = i + 2
+        entry.line_number = offset + i + 2
         entries.push entry
       end
     end

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -253,13 +253,7 @@ module ProductImport
     end
 
     def build_entries
-      rows.each_with_index do |row, i|
-        row_data = Hash[[headers, row].transpose]
-        entry = SpreadsheetEntry.new(row_data)
-        entry.line_number = i + 2
-        @entries.push entry
-      end
-      @entries
+      @entries = build_entries_from_rows(rows)
     end
 
     def save_all_valid
@@ -271,6 +265,15 @@ module ProductImport
     def delete_uploaded_file
       return unless @file.path == Rails.root.join('tmp', 'product_import').to_s
       File.delete(@file)
+    end
+
+    def build_entries_from_rows(rows)
+      rows.each_with_index.inject([]) do |entries, (row, i)|
+        row_data = Hash[[headers, row].transpose]
+        entry = SpreadsheetEntry.new(row_data)
+        entry.line_number = i + 2
+        entries.push entry
+      end
     end
   end
 end

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -182,7 +182,7 @@ module ProductImport
       @spreadsheet_data = SpreadsheetData.new(@entries, @import_settings)
       @validator = EntryValidator.new(@current_user, @import_time, @spreadsheet_data,
                                       @editable_enterprises, @inventory_permissions, @reset_counts,
-                                      @import_settings)
+                                      @import_settings, build_all_entries)
       @processor = EntryProcessor.new(self, @validator, @import_settings, @spreadsheet_data,
                                       @editable_enterprises, @import_time, @updated_ids)
 
@@ -249,6 +249,10 @@ module ProductImport
 
     def build_entries
       @entries = build_entries_from_rows(rows)
+    end
+
+    def build_all_entries
+      build_entries_from_rows(rows)
     end
 
     def save_all_valid

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -13,7 +13,7 @@ module ProductImport
     include ActiveModel::Conversion
     include ActiveModel::Validations
 
-    attr_reader :updated_ids, :import_settings
+    attr_reader :entries, :updated_ids, :import_settings
 
     def initialize(file, current_user, import_settings = {})
       unless file.is_a?(File)
@@ -88,10 +88,6 @@ module ProductImport
 
     def total_enterprise_products
       @processor.total_enterprise_products
-    end
-
-    def all_entries
-      @entries
     end
 
     def entries_json

--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -180,8 +180,11 @@ module ProductImport
       end
 
       @spreadsheet_data = SpreadsheetData.new(@entries, @import_settings)
-      @validator = EntryValidator.new(@current_user, @import_time, @spreadsheet_data, @editable_enterprises, @inventory_permissions, @reset_counts, @import_settings)
-      @processor = EntryProcessor.new(self, @validator, @import_settings, @spreadsheet_data, @editable_enterprises, @import_time, @updated_ids)
+      @validator = EntryValidator.new(@current_user, @import_time, @spreadsheet_data,
+                                      @editable_enterprises, @inventory_permissions, @reset_counts,
+                                      @import_settings)
+      @processor = EntryProcessor.new(self, @validator, @import_settings, @spreadsheet_data,
+                                      @editable_enterprises, @import_time, @updated_ids)
 
       @processor.count_existing_items unless staged_import?
     end

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -79,8 +79,10 @@ feature "Product Import", js: true do
 
     it "displays info about invalid entries but no save button if all items are invalid" do
       csv_data = CSV.generate do |csv|
-        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type"]
-        csv << ["Bad Carrots", "Unkown Enterprise", "Mouldy vegetables", "666", "3.20", "", "g"]
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g", shipping_category_id_str]
+        csv << ["Carrots", "User Enterprise", "Vegetables", "5", "5.50", "1", "kg", shipping_category_id_str]
+        csv << ["Bad Carrots", "Unkown Enterprise", "Mouldy vegetables", "666", "3.20", "", "g", shipping_category_id_str]
         csv << ["Bad Potatoes", "", "Vegetables", "6", "6", "6", ""]
       end
       File.write('/tmp/test.csv', csv_data)
@@ -93,9 +95,9 @@ feature "Product Import", js: true do
 
       proceed_to_validation
 
-      expect(page).to have_selector '.item-count', text: "2"
-      expect(page).to have_selector '.invalid-count', text: "2"
-      expect(page).to have_no_selector '.create-count'
+      expect(page).to have_selector '.item-count', text: "4"
+      expect(page).to have_selector '.invalid-count', text: "3"
+      expect(page).to have_selector ".create-count", text: "1"
       expect(page).to have_no_selector '.update-count'
 
       expect(page).to have_no_selector 'input[type=submit][value="Save"]'
@@ -206,7 +208,7 @@ feature "Product Import", js: true do
       csv_data = CSV.generate do |csv|
         csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "display_name", "shipping_category_id"]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag", shipping_category_id_str]
-        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag", shipping_category_id_str]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2000", "g", "Big Bag", shipping_category_id_str]
         csv << ["Beans", "User Enterprise", "Vegetables", "7", "2.50", "250", "g", nil, shipping_category_id_str]
       end
       File.write('/tmp/test.csv', csv_data)

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -254,6 +254,8 @@ describe ProductImport::ProductImporter do
         csv << ["Potatoes", "User Enterprise", "Vegetables", "5", "3.50", "500", "g", "Small Bag", shipping_category.name]
         csv << ["Chives", "User Enterprise", "Vegetables", "6", "4.50", "500", "g", "Small Bag", shipping_category.name]
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "5.50", "2", "kg", "Big Bag", shipping_category.name]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "22.00", "10000", "g", "Small Sack", shipping_category.name]
+        csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "60.00", "30000", "", "Big Sack", shipping_category.name]
       end
       @importer = import_data csv_data
     end
@@ -263,7 +265,7 @@ describe ProductImport::ProductImporter do
       entries = JSON.parse(@importer.entries_json)
 
       expect(filter('valid', entries)).to eq 3
-      expect(filter('invalid', entries)).to eq 0
+      expect(filter('invalid', entries)).to eq 2
       expect(filter('create_product', entries)).to eq 3
     end
 
@@ -279,12 +281,17 @@ describe ProductImport::ProductImporter do
       expect(small_bag.price).to eq 3.50
       expect(small_bag.on_hand).to eq 5
 
-      big_bag = Spree::Variant.find_by_display_name('Big Bag')
-      expect(big_bag.product.name).to eq 'Potatoes'
-      expect(big_bag.price).to eq 5.50
-      expect(big_bag.on_hand).to eq 6
+      big_bag = Spree::Variant.find_by_display_name("Big Bag")
+      expect(big_bag).to be_blank
 
-      expect(big_bag.product.id).to eq small_bag.product.id
+      small_sack = Spree::Variant.find_by_display_name("Small Sack")
+      expect(small_sack.product.name).to eq "Potatoes"
+      expect(small_sack.price).to eq 22.00
+      expect(small_sack.on_hand).to eq 6
+      expect(small_sack.product.id).to eq small_bag.product.id
+
+      big_sack = Spree::Variant.find_by_display_name("Big Sack")
+      expect(big_sack).to be_blank
     end
   end
 

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -343,7 +343,7 @@ describe ProductImport::ProductImporter do
       expect(filter('valid', entries)).to eq 0
       expect(filter('invalid', entries)).to eq 2
 
-      @importer.all_entries.each do |entry|
+      @importer.entries.each do |entry|
         expect(entry.errors.messages.values).to include [I18n.t('admin.product_import.model.not_updatable')]
       end
     end


### PR DESCRIPTION
#### What? Why?

- Closes #3877 
Edit - #3843 not solved by this. See comments below.

Let's say a shop already has a certain pre-existing product. We already show a validation error when importing a variant for this product with a _unit type_ or _variant unit name_ that does not match that of the product.

However, there are issues when the product does not yet exist before importing the file:

1. #3877 - When "Variant 1" in the import sheet uses "kg", and "Variant 2" uses "g". "Variant 2" is imported successfully but it uses the wrong unit type "kg".
2. #3843 - Remember that product import is processed in batches of 50, for performance reasons. When "Variant 1" in batch no. 1 uses "kg" and "Variant 2" in batch no. 2 uses "g", the import proceeds but "Variant 2" isn't saved without providing warning. The row for "Variant 2" passes validation because it is valid on its own, but not after "Variant 1" has been imported.

This PR adds validation for each row in the import spreadsheet. The _unit type_ or _variant unit name_ for a product-producer now needs to match that of the first row for that product-producer in the spreadsheet.

#### What should we test?

There is a chance of noticeable increase in processing time, although I doubt it because we're not doing anything that involves the DB. If this is noticeable while testing with the sample CSV files in the issues, kindly note.

* Test #3877 and #3843 using the spreadsheets provided in the respective issues.
* Test importing variant for an existing product:
    - With wrong and then correct unit type / variant unit name
* Test importing new product and a second variant for this product:
    - With second variant using wrong and then correct unit type / variant unit name
* Test importing new product and a second variant for this product which is in another batch (e.g. first variant in Row 4, second variant in Row 52):
    - With second variant using wrong and then correct unit type / variant unit name

#### Release notes

- Fix product import of a new product and subsequent variants, when the subsequent variants use the wrong unit type or variant unit name. More data validation is done now, which can result in slightly higher memory and CPU usage.

Changelog Category: Fixed