### PR TITLE
WIP Make list of products in admin products page sort results alphabetically

### DIFF
--- a/app/controllers/spree/api/products_controller_decorator.rb
+++ b/app/controllers/spree/api/products_controller_decorator.rb
@@ -13,7 +13,7 @@ Spree::Api::ProductsController.class_eval do
   def bulk_products
     @products = OpenFoodNetwork::Permissions.new(current_api_user).editable_products.
       merge(product_scope).
-      order('created_at DESC').
+      order('lower(name) ASC').
       ransack(params[:q]).result.
       page(params[:page]).per(params[:per_page])
 


### PR DESCRIPTION
Products were being sorted by creation date, most recently create at the top.
The sorting is case insensitive so that products starting with a and A stay together.

#### What? Why?

Closes #3909

#### What should we test?
Make sure this does not create problems with the pagination.

#### Release notes
Changelog Category: Changed
Products are listed alphabetically in the products list page.

