### PR TITLE
Make subs radio button visible to all managers

### DIFF
--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -77,16 +77,15 @@
       = f.radio_button :allow_order_changes, true, "ng-model" => "Enterprise.allow_order_changes", "ng-value" => "true"
       = f.label :allow_order_changes, t('.allow_order_changes_true'), value: :true
 
-- if spree_current_user.admin?
-  .row
-    .alpha.eleven.columns
-      .three.columns.alpha
-        %label= t '.enable_subscriptions'
-        %div{'ofn-with-tip' => t('.enable_subscriptions_tip')}
-          %a= t 'admin.whats_this'
-      .three.columns
-        = f.radio_button :enable_subscriptions, true
-        = f.label :enable_subscriptions, t('.enable_subscriptions_true'), value: :true
-      .five.columns.omega
-        = f.radio_button :enable_subscriptions, false
-        = f.label :enable_subscriptions, t('.enable_subscriptions_false'), value: :false
+.row
+  .alpha.eleven.columns
+    .three.columns.alpha
+      %label= t '.enable_subscriptions'
+      %div{'ofn-with-tip' => t('.enable_subscriptions_tip')}
+        %a= t 'admin.whats_this'
+    .three.columns
+      = f.radio_button :enable_subscriptions, true
+      = f.label :enable_subscriptions, t('.enable_subscriptions_true'), value: :true
+    .five.columns.omega
+      = f.radio_button :enable_subscriptions, false
+      = f.label :enable_subscriptions, t('.enable_subscriptions_false'), value: :false


### PR DESCRIPTION
#### What? Why?

Closes #2915

Makes the "enable subs" radio button available to all enterprise managers.

#### What should we test?
Go to shop preferences, enable and disable subscriptions as a hub manager and make sure subs are correctly enabled for that enterprise.

#### Release notes
Changelog Category: Added
Enterprise managers can now activate subscriptions.