### PR TITLE
User friendly error when creating a product with an image in an unsupported format

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -33,6 +33,10 @@ Spree::Admin::ProductsController.class_eval do
     delete_stock_params_and_set_after do
       super
     end
+  rescue Paperclip::Errors::NotIdentifiedByImageMagickError
+    invoke_callbacks(:create, :fails)
+    @object.errors.add(:base, t('spree.admin.products.image_upload_error'))
+    respond_with(@object)
   end
 
   def update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3011,6 +3011,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             error_saving_payment: Error saving payment
             submitting_payment: Submitting payment...
       products:
+        image_upload_error: "The product image was not recognised. Please upload an image in PNG or JPG format."
+
         new:
           title: 'New Product'
         unit_name_placeholder: 'eg. bunches'

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -147,6 +147,25 @@ describe Spree::Admin::ProductsController, type: :controller do
       spree_post :create, product: product_attrs, button: 'add_another'
       expect(response).to redirect_to spree.new_admin_product_path
     end
+
+    describe "when user uploads an image in an unsupported format" do
+      it "does not throw an exception" do
+        product_image = ActionDispatch::Http::UploadedFile.new({
+          :filename => 'unsupported_image_format.exr',
+          :content_type => 'application/octet-stream',
+          :tempfile => Tempfile.new('unsupported_image_format.exr')
+        })
+        product_attrs_with_image = product_attrs.merge(
+          images_attributes: {
+            '0' => { attachment: product_image }
+          })
+
+        expect do
+          spree_put :create, product: product_attrs_with_image
+        end.not_to raise_error Paperclip::Errors::NotIdentifiedByImageMagickError
+        expect(response.status).to eq 200
+      end
+    end
   end
 
   describe "updating" do


### PR DESCRIPTION
#### What? Why?

Closes #764

Instead of a [stack trace](https://github.com/openfoodfoundation/openfoodnetwork/issues/764#issuecomment-501280800) the user now sees a nice error message:
![Screenshot 2019-06-12 at 23 02 58](https://user-images.githubusercontent.com/1640378/59389518-6019e080-8d66-11e9-89fe-6a2f60922cb7.png)

We do this by catching the exception in the controller.

#### What should we test?
Product creation still works correctly.
Uploading a good image still works.
Uploading an image in a weird format (I tested with exr) shows a friendly error.

#### Release notes
Changelog Category: Fixed
Creating a product with an unsupported image format now shows a user friendly error.
