### PR TITLE
Add rake task to report lost payments

### DIFF
--- a/lib/tasks/missing_payments.rake
+++ b/lib/tasks/missing_payments.rake
@@ -1,0 +1,56 @@
+# Find gaps in the sequence of payment ids.
+# If there are gaps then see if there is a log entry with a payment result for
+# the now lost payment. If there are some then you probably want to follow up
+# with the affected enterprise and see if customers need to be refunded.
+#
+# ## Usage
+
+# Report of the last 35 days:
+#   rake ofn:missing_payments[35]
+namespace :ofn do
+  desc 'Find payments that got lost'
+  task :missing_payments, [:days] => :environment do |_task_, args|
+    days = args[:days].andand.to_i || 7
+    payments_sequence = Spree::Payment.where("created_at > ?", days.days.ago).order(:id).pluck(:id)
+    payments_range = (payments_sequence.first..payments_sequence.last).to_a
+    missing_payment_ids = payments_range - payments_sequence
+    puts "Gaps in the payments sequence: #{missing_payment_ids.count}"
+    log_entries = Spree::LogEntry.where(
+      source_type: "Spree::Payment",
+      source_id: missing_payment_ids
+    )
+    return if log_entries.empty?
+
+    CSV do |out|
+      out << headers
+      log_entries.each do |entry|
+        begin
+          details = Psych.load(entry.details)
+        rescue StandardError
+          Logger.new(STDERR).warn(entry)
+          next
+        end
+        out << row(details, details.params)
+      end
+    end
+  end
+
+  def headers
+    [
+      "Created", "Order", "Success", "Message", "Payment ID", "Action",
+      "Amount", "Currencty", "Receipt"
+    ]
+  end
+
+  def row(details, params)
+    [
+      Time.zone.at(params["created"] || 0).to_datetime,
+      params["description"],
+      details.success?,
+      details.message,
+      params["id"],
+      params["object"],
+      params["amount"], params["currency"], params["receipt_url"]
+    ]
+  end
+end


### PR DESCRIPTION

#### What? Why?

Related to #3924 and #3925.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

In rare cases, payment records can get lost through database rollbacks. This new rake task tries to find log entries for lost transactions and reports them as CSV. It can help us until the underlying bug is fixed. It will also help us monitor if we really fixed the bug or if this happens again.

I'm not sure if we should make this more sophisticaed (run through schedule.rb) or keep it as temporary tool we want to get rid of as soon as possible.

#### What should we test?
<!-- List which features should be tested and how. -->

No testing required.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added script for sys admins to find lost payments.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

