### PR TITLE
Improve message in private shopfront when user is not logged in or not a customer

### DIFF
--- a/app/views/shop/_messages.html.haml
+++ b/app/views/shop/_messages.html.haml
@@ -7,7 +7,9 @@
         - if spree_current_user.nil?
           = t '.require_login_html',
             {login: ('<a auth="login">' + t('.login') + '</a>').html_safe,
-             register: ('<a auth="signup">' + t('.register') + '</a>').html_safe}
+             signup: ('<a auth="signup">' + t('.signup') + '</a>').html_safe,
+             contact: link_to(t('.contact'), '#contact'),
+             enterprise: current_distributor.name}
         - else
           = t '.require_customer_html',
             {contact: link_to(t('.contact'), '#contact'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1165,12 +1165,11 @@ en:
   shop:
     messages:
       login: "login"
-      register: "register"
+      signup: "signup"
       contact: "contact"
-      require_customer_login: "This shop is for customers only."
-      require_login_html: "Please %{login} if you have an account already. Otherwise, %{register} to become a customer."
-      require_customer_html: "Please %{contact} %{enterprise} to become a customer."
-
+      require_customer_login: "Only approved customers can access this shop."
+      require_login_html: "If you're already an approved customer, %{login} or %{signup} to proceed. Want to start shopping here? Please %{contact} %{enterprise} and ask about joining."
+      require_customer_html: "If you'd like to start shopping here, please %{contact} %{enterprise} to ask about joining."
 
   # Front-end controller translations
   card_could_not_be_updated: Card could not be updated

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -462,8 +462,8 @@ feature "As a consumer I want to shop with a distributor", js: true do
       context "when not logged in" do
         it "tells us to login" do
           visit shop_path
-          expect(page).to have_content "This shop is for customers only."
-          expect(page).to have_content "Please login"
+          expect(page).to have_content "Only approved customers can access this shop."
+          expect(page).to have_content "login or signup"
           expect(page).to have_no_content product.name
         end
       end
@@ -479,8 +479,8 @@ feature "As a consumer I want to shop with a distributor", js: true do
         context "as non-customer" do
           it "tells us to contact enterprise" do
             visit shop_path
-            expect(page).to have_content "This shop is for customers only."
-            expect(page).to have_content "Please contact #{distributor.name}"
+            expect(page).to have_content "Only approved customers can access this shop."
+            expect(page).to have_content "please contact #{distributor.name}"
             expect(page).to have_no_content product.name
           end
         end


### PR DESCRIPTION
#### What? Why?

Closes #1613

New messages:

![Screenshot 2019-06-13 at 19 54 52](https://user-images.githubusercontent.com/1640378/59459637-2fdd4b00-8e15-11e9-8407-ab99ec14c292.png)
![Screenshot 2019-06-13 at 19 55 06](https://user-images.githubusercontent.com/1640378/59459639-2fdd4b00-8e15-11e9-8e52-69bef027e246.png)

I kept the first sentence shared between cases, they differ in the issue (the second one starts with "Sorry,"). I think it's ok as is. Let me know if you disagree, I can add it.

#### What should we test?
See steps in issue details.

#### Release notes
Changelog Category: Changed
Improved message to user in private shopfronts when user is not logged in or user is not a customer yet.
