### PR TITLE
Update rubocop style

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -493,6 +493,72 @@ Metrics/AbcSize:
   - spec/models/product_importer_spec.rb
   - spec/support/performance_helper.rb
 
+Metrics/BlockLength:
+  Max: 25
+  ExcludedMethods: ["class_eval", "collection", "context", "describe", "it", "member", "namespace", "resource", "resources"]
+  Exclude:
+  - lib/tasks/data.rake
+  - lib/tasks/dev.rake
+  - spec/controllers/spree/admin/invoices_controller_spec.rb
+  - spec/factories/variant_factory.rb
+  - spec/features/admin/adjustments_spec.rb
+  - spec/features/admin/bulk_order_management_spec.rb
+  - spec/features/admin/bulk_product_update_spec.rb
+  - spec/features/admin/caching_spec.rb
+  - spec/features/admin/content_spec.rb
+  - spec/features/admin/customers_spec.rb
+  - spec/features/admin/enterprise_fees_spec.rb
+  - spec/features/admin/enterprise_groups_spec.rb
+  - spec/features/admin/enterprise_relationships_spec.rb
+  - spec/features/admin/enterprise_roles_spec.rb
+  - spec/features/admin/enterprises/images_spec.rb
+  - spec/features/admin/enterprises/index_spec.rb
+  - spec/features/admin/enterprises_spec.rb
+  - spec/features/admin/enterprise_user_spec.rb
+  - spec/features/admin/multilingual_spec.rb
+  - spec/features/admin/order_cycles_spec.rb
+  - spec/features/admin/orders_spec.rb
+  - spec/features/admin/overview_spec.rb
+  - spec/features/admin/payment_method_spec.rb
+  - spec/features/admin/product_import_spec.rb
+  - spec/features/admin/products_spec.rb
+  - spec/features/admin/reports/enterprise_fee_summaries_spec.rb
+  - spec/features/admin/reports_spec.rb
+  - spec/features/admin/schedules_spec.rb
+  - spec/features/admin/shipping_methods_spec.rb
+  - spec/features/admin/subscriptions_spec.rb
+  - spec/features/admin/tag_rules_spec.rb
+  - spec/features/admin/tax_settings_spec.rb
+  - spec/features/admin/users_spec.rb
+  - spec/features/admin/variant_overrides_spec.rb
+  - spec/features/admin/variants_spec.rb
+  - spec/features/consumer/account/cards_spec.rb
+  - spec/features/consumer/account/settings_spec.rb
+  - spec/features/consumer/account_spec.rb
+  - spec/features/consumer/authentication_spec.rb
+  - spec/features/consumer/cookies_spec.rb
+  - spec/features/consumer/external_services_spec.rb
+  - spec/features/consumer/groups_spec.rb
+  - spec/features/consumer/multilingual_spec.rb
+  - spec/features/consumer/producers_spec.rb
+  - spec/features/consumer/registration_spec.rb
+  - spec/features/consumer/shopping/cart_spec.rb
+  - spec/features/consumer/shopping/checkout_auth_spec.rb
+  - spec/features/consumer/shopping/checkout_spec.rb
+  - spec/features/consumer/shopping/embedded_groups_spec.rb
+  - spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+  - spec/features/consumer/shopping/orders_spec.rb
+  - spec/features/consumer/shopping/products_spec.rb
+  - spec/features/consumer/shopping/shopping_spec.rb
+  - spec/features/consumer/shopping/variant_overrides_spec.rb
+  - spec/features/consumer/shops_spec.rb
+  - spec/lib/open_food_network/group_buy_report_spec.rb
+  - spec/models/tag_rule/discount_order_spec.rb
+  - spec/spec_helper.rb
+  - spec/support/delayed_job_helper.rb
+  - spec/support/matchers/select2_matchers.rb
+  - spec/support/matchers/table_matchers.rb
+
 Metrics/CyclomaticComplexity:
   Max: 6
   Exclude:

--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -187,6 +187,7 @@ Metrics/AbcSize:
   Max: 15
 
 Metrics/BlockLength:
+  Max: 25
   ExcludedMethods: ["class_eval", "collection", "context", "describe", "it", "member", "namespace", "resource", "resources"]
 
 Metrics/BlockNesting:

--- a/spec/features/admin/caching_spec.rb
+++ b/spec/features/admin/caching_spec.rb
@@ -14,7 +14,9 @@ feature 'Caching' do
     it "displays results when things are good" do
       # Given matching data
       Rails.cache.write "products-json-#{distributor.id}-#{order_cycle.id}", "[1, 2, 3]\n"
-      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new) { double(:pr, products_json: "[1, 2, 3]\n") }
+      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new) {
+        double(:pr, products_json: "[1, 2, 3]\n")
+      }
 
       # When I visit the cache status page
       visit spree.admin_path
@@ -28,7 +30,9 @@ feature 'Caching' do
     it "displays results when there are errors" do
       # Given matching data
       Rails.cache.write "products-json-#{distributor.id}-#{order_cycle.id}", "[1, 2, 3]\n"
-      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new) { double(:pr, products_json: "[1, 3]\n") }
+      allow(OpenFoodNetwork::ProductsRenderer).to receive(:new) {
+        double(:pr, products_json: "[1, 3]\n")
+      }
 
       # When I visit the cache status page
       visit spree.admin_path

--- a/spec/features/admin/enterprise_relationships_spec.rb
+++ b/spec/features/admin/enterprise_relationships_spec.rb
@@ -27,7 +27,7 @@ feature '
         expect(page).to have_relationship e1, e2, ['to add to order cycle']
         expect(page).to have_relationship e2, e3, ['to manage products']
         expect(page).to have_relationship e3, e4,
-          ['to add to order cycle', 'to manage products']
+                                          ['to add to order cycle', 'to manage products']
       end
     end
 

--- a/spec/models/spree/credit_card_spec.rb
+++ b/spec/models/spree/credit_card_spec.rb
@@ -5,7 +5,7 @@ module Spree
     describe "setting default credit card for a user" do
       let(:user) { create(:user) }
       let(:onetime_card_attrs) do
-        {user: user, gateway_payment_profile_id: "tok_1EY..."}
+        { user: user, gateway_payment_profile_id: "tok_1EY..." }
       end
       let(:stored_card_attrs) do
         {


### PR DESCRIPTION
#### What? Why?

Working on #3926 rubocop didn't complain about the block length in my rake task. I only found out about the style violation through Code Climate. This happened because of the automatically generated `.rubocop_todo.yml` file which set the allowed block length to 774. Here I adjust the config so that the default block length of 25 is enforced on all files except some files already violating the style which are now listed in `.rubocop_manual_todo.yml`.

I also quickly cleaned up pre-existing violations that must have slipped through our processes in the last weeks.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

No testing.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed the enforcement of code style guidelines.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

