### PR TITLE
Handle soft deleted variants in order edit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'pg'
 # for details.
 gem 'spree_api', github: 'openfoodfoundation/spree', branch: '2-0-4-stable'
 gem 'spree_backend', github: 'openfoodfoundation/spree', branch: '2-0-4-stable'
-gem 'spree_core', github: 'openfoodfoundation/spree', branch: '2-0-4-stable'
+gem 'spree_core', github: 'coopdevs/spree', branch: 'handle-soft-deleted-variants-in-order-edit'
 
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-0-stable'
 gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,40 @@ GIT
       activemodel (~> 3.0)
 
 GIT
+  remote: https://github.com/coopdevs/spree.git
+  revision: b5a37e95a0d54e37aab42b32a29f23906116700e
+  branch: handle-soft-deleted-variants-in-order-edit
+  specs:
+    spree_core (2.0.4)
+      activemerchant (~> 1.34)
+      acts_as_list (= 0.2.0)
+      awesome_nested_set (= 2.1.5)
+      aws-sdk (~> 1.11.1)
+      cancan (~> 1.6.10)
+      deface (>= 0.9.1)
+      ffaker (~> 1.16)
+      highline (= 1.6.18)
+      httparty (~> 0.11)
+      json (>= 1.7.7)
+      kaminari (~> 0.14.1)
+      money (= 5.1.1)
+      paperclip (~> 3.4.1)
+      paranoia (~> 1.3)
+      rails (~> 3.2.14)
+      ransack (= 0.7.2)
+      state_machine (= 1.2.0)
+      stringex (~> 1.5.1)
+      truncate_html (= 0.9.2)
+    spree_frontend (2.0.4)
+      canonical-rails
+      deface (>= 0.9.0)
+      jquery-rails (~> 3.0.0)
+      rails (~> 3.2.13)
+      spree_api (= 2.0.4)
+      spree_core (= 2.0.4)
+      stringex (~> 1.5.1)
+
+GIT
   remote: https://github.com/jeremydurham/custom-err-msg.git
   revision: 3a8ec9dddc7a5b0aab7c69a6060596de300c68f4
   specs:
@@ -46,34 +80,6 @@ GIT
       select2-rails (~> 3.4.7)
       spree_api (= 2.0.4)
       spree_core (= 2.0.4)
-    spree_core (2.0.4)
-      activemerchant (~> 1.34)
-      acts_as_list (= 0.2.0)
-      awesome_nested_set (= 2.1.5)
-      aws-sdk (~> 1.11.1)
-      cancan (~> 1.6.10)
-      deface (>= 0.9.1)
-      ffaker (~> 1.16)
-      highline (= 1.6.18)
-      httparty (~> 0.11)
-      json (>= 1.7.7)
-      kaminari (~> 0.14.1)
-      money (= 5.1.1)
-      paperclip (~> 3.0)
-      paranoia (~> 1.3)
-      rails (~> 3.2.14)
-      ransack (= 0.7.2)
-      state_machine (= 1.2.0)
-      stringex (~> 1.5.1)
-      truncate_html (= 0.9.2)
-    spree_frontend (2.0.4)
-      canonical-rails
-      deface (>= 0.9.0)
-      jquery-rails (~> 3.0.0)
-      rails (~> 3.2.13)
-      spree_api (= 2.0.4)
-      spree_core (= 2.0.4)
-      stringex (~> 1.5.1)
 
 GIT
   remote: https://github.com/spree/spree_auth_devise.git
@@ -286,7 +292,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffaker (1.22.1)
+    ffaker (1.32.1)
     ffi (1.10.0)
     figaro (1.1.1)
       thor (~> 0.14)


### PR DESCRIPTION
#### What? Why?

Closes #3903 

This allows us to test https://github.com/openfoodfoundation/spree/pull/41. If it passes testing I will then revert it back to the `2-0-4-stable` branch but updating the target commit in the Gemfile.lock.

#### What should we test?

1. Delete a product that it's been purchased in an existing order
2. Go edit said order from /admin

You should see the page, including the deleted product, without any problem.


#### Release notes

Orders listing products that got deleted after the purchase can still be edited from the admin section

Changelog Category: Fixed