### PR TITLE
Remove matching of shipping method zone to user address on checkout

### DIFF
--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -53,6 +53,14 @@ Spree::ShippingMethod.class_eval do
     spree_calculators.send model_name_without_spree_namespace
   end
 
+  # This is bypassing the validation of shipping method zones on checkout
+  # It allows checkout using shipping methods without zones (see issue #3928 for details)
+  #   and it allows checkout with addresses outside of the zones of the selected shipping method
+  def include?(address)
+    return false unless address
+    true
+  end
+
   def has_distributor?(distributor)
     distributors.include?(distributor)
   end

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -57,8 +57,7 @@ Spree::ShippingMethod.class_eval do
   # It allows checkout using shipping methods without zones (see issue #3928 for details)
   #   and it allows checkout with addresses outside of the zones of the selected shipping method
   def include?(address)
-    return false unless address
-    true
+    address.present?
   end
 
   def has_distributor?(distributor)

--- a/app/models/stock/package.rb
+++ b/app/models/stock/package.rb
@@ -10,7 +10,7 @@
 #
 module Stock
   class Package < Spree::Stock::Package
-    # Returns all exsiting shipping categories.
+    # Returns all existing shipping categories.
     #   It does not filter by the shipping categories of the products in the order.
     #   It allows checkout of products with categories that are not the shipping methods categories
     #   It disables the matching of product shipping category with shipping method's category

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -41,5 +41,6 @@ FactoryBot.modify do
   factory :shipping_method, parent: :base_shipping_method do
     distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
     display_on ''
+    zones { |a| [] }
   end
 end

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -92,5 +92,22 @@ module Spree
         it { expect(shipping_method.delivery?).to be false }
       end
     end
+
+    describe "#include?" do
+      let(:shipping_method) { create(:shipping_method) }
+
+      it "does not include a nil address" do
+        expect(shipping_method.include?(nil)).to be false
+      end
+
+      it "includes an address that is not included in the zones of the shipping method" do
+        address = create(:address)
+        zone_mock = instance_double(Spree::Zone)
+        allow(zone_mock).to receive(:include?).with(address).and_return(false)
+        allow(shipping_method).to receive(:zones) { [zone_mock] }
+
+        expect(shipping_method.include?(address)).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3928
We go for option C in see comment in 3928 [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/3928#issuecomment-502394688).

#### What should we test?
Verify issue is fixed and that other checkout cases related to shipping methods are also working, for example, verifying that #3879 is still working.

#### Release notes
Changelog Category: Changed
To make everyone's life easier, no shipping method zone validation is now done on checkout. Users can now checkout using shipping methods without zone and also using an address outside the zones of the selected shipping method.
