### PR TITLE
Bring back ‘Shop for X products at:’ title

### DIFF
--- a/app/assets/javascripts/templates/partials/producer_details.html.haml
+++ b/app/assets/javascripts/templates/partials/producer_details.html.haml
@@ -2,14 +2,14 @@
 -# Do not show this for producer shops selling only their own produce,
 -# Since a shopping link will already have been displayed in hub_details.html.haml
 .row.active_table_row.pad-top{ "ng-if" => "enterprise.is_primary_producer && enterprise.hubs.length > 0 && !(enterprise.hubs.length == 1 && enterprise.hubs[0] == enterprise)"}
-  .columns.small-12
+  .columns.small-12.cta-container
     .row
       .columns.small-12.fat
         %div{"ng-if" => "::enterprise.name"}
-          %label{"ng-html" => "::'shop_for_products_html' | t:{enterprise: enterprise.name}"}
+          %label{"ng-bind-html" => "::'shop_for_products_html' | t:{enterprise: enterprise.name}"}
         %div.show-for-medium-up{"ng-if" => "::!enterprise.name"}
           &nbsp;
-    .row.cta-container
+    .row
       .columns.small-12
         %a.cta-hub{"ng-repeat" => "hub in enterprise.hubs | filter:{id: '!'+enterprise.id} | orderBy:'-active'",
         "ng-href" => "{{::hub.path}}", "ofn-empties-cart" => "hub",

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -186,6 +186,7 @@ feature 'Shops', js: true do
       within ".reveal-modal" do
         expect(page).to have_content 'Fruit'   # Taxon
         expect(page).to have_content 'Organic' # Producer property
+        expect(page).to have_content "Shop for #{producer.name} products at:".upcase
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Fixes #2112

It looks like this bug was accidentally introduced during a refactor in
e5ca494db83e067f6f6863619561d5e7e8206bbd. The `bo-html` attribute was
replaced with `ng-html`, but it appears that it should actually have
used `ng-bind-html`
(https://docs.angularjs.org/api/ng/directive/ngBindHtml) because the
former is not a valid AngularJS directive.

It was also necessary to bubble up the `.cta-container` class in order to
get the appropriate styling on the title.

#### Before
![image](https://user-images.githubusercontent.com/1979/59580877-2eae6580-9116-11e9-9cd3-469b902c56a2.png)

#### After

![image](https://user-images.githubusercontent.com/1979/59580858-1cccc280-9116-11e9-8dc5-9988ec8540be.png)


#### What should we test?

The producer modal

#### Release notes

Bring back the 'Shop for X products at:' title on the producer modal. This was
accidentally lost some time ago.

Changelog Category: Fixed