### PR TITLE
Fix last missing translations covered by specs

### DIFF
--- a/app/controllers/spree/user_sessions_controller_decorator.rb
+++ b/app/controllers/spree/user_sessions_controller_decorator.rb
@@ -7,7 +7,7 @@ Spree::UserSessionsController.class_eval do
     if spree_user_signed_in?
       respond_to do |format|
         format.html {
-          flash[:success] = t(:logged_in_succesfully)
+          flash[:success] = t('devise.success.logged_in_succesfully')
           redirect_back_or_default(after_sign_in_path_for(spree_current_user))
         }
         format.js {

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -48,7 +48,7 @@ class SubscriptionMailer < Spree::BaseMailer
 
   def send_mail(order)
     I18n.with_locale valid_locale(order.user) do
-      confirm_email_subject = t('order_mailer.confirm_email.subject')
+      confirm_email_subject = t('spree.order_mailer.confirm_email.subject')
       subject = "#{Spree::Config[:site_name]} #{confirm_email_subject} ##{order.number}"
       mail(to: order.email,
            from: from_address,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,6 +111,8 @@ en:
         Were you a guest last time?  Perhaps you need to create an account or reset your password.
       unconfirmed: "You have to confirm your account before continuing."
       already_registered: "This email address is already registered. Please log in to continue, or go back and use another email address."
+    success:
+      logged_in_succesfully: "Logged in successfully"
     user_passwords:
       spree_user:
         updated_not_active: "Your password has been reset, but your email has not been confirmed yet."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2321,6 +2321,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   payment_methods: "Payment Methods"
   payment_method_fee: "Transaction fee"
   payment_processing_failed: "Payment could not be processed, please check the details you entered"
+  payment_method_not_supported: "That payment method is unsupported. Please choose another one."
   payment_updated: "Payment Updated"
   inventory_settings: "Inventory Settings"
   tag_rules: "Tag Rules"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,11 @@ en:
       resend_confirmation_email: "Resend confirmation email."
       confirmed: "Thanks for confirming your email! You can now log in."
       not_confirmed: "Your email address could not be confirmed. Perhaps you have already completed this step?"
+    user_confirmations:
+      spree_user:
+        send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
+        confirmation_sent: "Email confirmation sent"
+        confirmation_not_sent: "Error sending confirmation email"
     user_registrations:
       spree_user:
        signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."


### PR DESCRIPTION
#### What? Why?

Closes #3929 
and makes #3006 possible.

#### What should we test?
Green build. We need to verify translations:

- [ ] missing translation: order_mailer.confirm_email.subject - test #3929 

- [ ] missing translation: payment_method_not_supported - this is an exception case in spree code where a payment method does not support a given source, like creditcard... I **cant replicate this** manually...

- [ ] missing translation: logged_in_succesfully - I **cant replicate this** one manually, this message is not showing after login because there's always a redirect to another page making the flash message in the original page disappear....

- [ ] missing translation: spree_user.send_instructions -  same, **I cant replicate this**, seems to be a case in spree_auth_devise that we dont use when resending account confirmation link....

Re these 3 points, I cant replicate manually although the code is called in our tests, the two last ones I believe the flash messages are generated but the user cant see them...
Because it's just a translation key, there's no need to test that everything else is still working correctly. I'd just go ahead as is and keep the translation keys.
What do you think?

#### Release notes
Changelog Category: Added
Added verification of missing translations: developers will know when a missing translation key is used in the code but is not present in the master translations file.