### PR TITLE
First stored credit card becomes default again

### DIFF
--- a/app/models/spree/credit_card_decorator.rb
+++ b/app/models/spree/credit_card_decorator.rb
@@ -15,7 +15,7 @@ Spree::CreditCard.class_eval do
   belongs_to :user
 
   after_create :ensure_single_default_card
-  after_save :ensure_single_default_card, if: :is_default_changed?
+  after_save :ensure_single_default_card, if: :default_card_needs_updating?
 
   # Allows us to use a gateway_payment_profile_id to store Stripe Tokens
   # Should be able to remove once we reach Spree v2.2.0
@@ -37,6 +37,10 @@ Spree::CreditCard.class_eval do
 
   def default_missing?
     !user.credit_cards.exists?(is_default: true)
+  end
+
+  def default_card_needs_updating?
+    is_default_changed? || gateway_customer_profile_id_changed?
   end
 
   def ensure_single_default_card

--- a/spec/models/spree/credit_card_spec.rb
+++ b/spec/models/spree/credit_card_spec.rb
@@ -83,11 +83,26 @@ module Spree
           end
         end
 
-        context "and the checkout creates a one-time-use card" do
+        context "and the checkout creates a card" do
           let!(:card1) { create(:credit_card, onetime_card_attrs) }
+          let(:store_card_profile_attrs) {
+            {
+              cc_type: "visa",
+              gateway_customer_profile_id: "cus_FH9HflKAJw6Kxy",
+              gateway_payment_profile_id: "card_1EmayNBZvgSKc1B2wctIzzoh"
+            }
+          }
 
-          it "sets it as the default anyway" do
+          it "doesn't set a one-time card as the default" do
             expect(card1.reload.is_default).to be false
+          end
+
+          it "sets a re-usable card as the default" do
+            # The checkout first creates a one-time card and then converts it
+            # to a re-usable card.
+            # This imitates Stripe::ProfileStorer.
+            card1.update_attributes!(store_card_profile_attrs)
+            expect(card1.reload.is_default).to be true
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

Closes #3727 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

A user can store their credit card when checking out. Due to a bug in https://github.com/openfoodfoundation/openfoodnetwork/pull/3840 it
didn't become the default card any more. This behaviour is now restored.
If there is no default card yet, a new card added during checkout
becomes the default card.


#### What should we test?
<!-- List which features should be tested and how. -->

Not storing:

- Set up Stripe for a shop.
- Delete all credit cards of the current user.
- Check out using Stripe, not storing the credit card.
- The new card should not appear in the stored cards (account profile).

Storing:

- Check out using Stripe, storing the entered credit card.
- Check the stored cards. The new card should be there and should be the default.
- Repeat another checkout storing a new card.
- The new card should be stored but not become the default (the default stays the same).

Storing a card in the profile:

- Create a card in the profile.
- The previous default card should stay the same.
- Then delete the default card.
- Now there is no default card.
- Create a new card.
- The new card should be the default.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: The first stored credit card is automatically the default card again.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

