### PR TITLE
DRY and make database.yml more flexible

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,8 +3,8 @@ defaults: &defaults
   encoding: unicode
   pool: 5
   host: localhost
-  username: <%= ENV.fetch('DB_USERNAME', 'ofn') %>
-  password: <%= ENV.fetch('DB_PASSWORD', 'f00d') %>
+  username: <%= ENV.fetch('OFN_DB_USERNAME', 'ofn') %>
+  password: <%= ENV.fetch('OFN_DB_PASSWORD', 'f00d') %>
 
 development:
   <<: *defaults

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ defaults: &defaults
   adapter: postgresql
   encoding: unicode
   pool: 5
-  host: localhost
+  host: <%= ENV.fetch('OFN_DB_HOST', 'localhost') %>
   username: <%= ENV.fetch('OFN_DB_USERNAME', 'ofn') %>
   password: <%= ENV.fetch('OFN_DB_PASSWORD', 'f00d') %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,19 +1,23 @@
-default: &default
+defaults: &defaults
   adapter: postgresql
-  encoding: utf8
+  encoding: unicode
   pool: 5
-  timeout: 5000
-  host: db
-  port: 5432
+  host: localhost
+  username: <%= ENV.fetch('DB_USERNAME', 'ofn') %>
+  password: <%= ENV.fetch('DB_PASSWORD', 'f00d') %>
 
 development:
-  <<: *default
+  <<: *defaults
   database: open_food_network_dev
-  username: ofn
-  password: f00d
 
 test:
-  <<: *default
+  <<: *defaults
   database: open_food_network_test
-  username: ofn
-  password: f00d
+
+production:
+  <<: *defaults
+  database: open_food_network_prod
+
+staging:
+  <<: *defaults
+  database: open_food_network_prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       ADMIN_EMAIL: ofn@example.com
       ADMIN_PASSWORD: ofn123
+      OFN_DB_HOST: db
     command: >
       bash -c "(bundle check || bundle install) &&
                wait-for-it -t 30 db:5432 &&


### PR DESCRIPTION
Closes #3981

#### What? Why?

This enables us to work on https://github.com/openfoodfoundation/ofn-install/issues/387 and brings the
needed flexibility so things like https://github.com/openfoodfoundation/openfoodnetwork/pull/3887 or any CI don't require a custom version. That's what ENV vars are for!

For instance, I no longer need to mess with my LXC setup to connect to the DB. I just need to have 2 env vars.

This won't change how we deal with DB connections in production, which is still done through [roles/app/templates/postgresql.yml.j2](https://github.com/openfoodfoundation/ofn-install/blob/master/roles/app/templates/postgresql.yml.j2)

#### What should we test?

the app should be able to connect to the DB without any problem. It's enough with the deployment process as it already connects to the DB.

#### Release notes

DRY and make database.yml more flexible with ENV vars 

Changelog Category: Changed
