### PR TITLE
Remove retries from previously flaky specs

### DIFF
--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -84,7 +84,7 @@ feature '
     expect(o.order_cycle).to eq(@order_cycle)
   end
 
-  scenario "can add a product to an existing order", retry: 3 do
+  scenario "can add a product to an existing order" do
     quick_login_as_admin
     visit '/admin/orders'
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -426,7 +426,7 @@ feature "
           select2_select hub.name, from: 'hub_id'
         end
 
-        it "alerts the user to the presence of new products, and allows them to be added or hidden", retry: 3 do
+        it "alerts the user to the presence of new products, and allows them to be added or hidden" do
           expect(page).to have_no_selector "table#variant-overrides tr#v_#{variant1.id}"
           expect(page).to have_no_selector "table#variant-overrides tr#v_#{variant2.id}"
 

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "As a consumer I want to check out my cart", js: true, retry: 3 do
+feature "As a consumer I want to check out my cart", js: true do
   include AuthenticationWorkflow
   include ShopWorkflow
   include CheckoutWorkflow

--- a/spec/features/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/features/consumer/shopping/variant_overrides_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "shopping with variant overrides defined", js: true, retry: 3 do
+feature "shopping with variant overrides defined", js: true do
   include AuthenticationWorkflow
   include WebHelper
   include ShopWorkflow


### PR DESCRIPTION
#### What? Why?


It's not acceptable to have flaky specs that only pass once in three
tries. Our specs might be more stable now that we use Chrome as test
browser. Otherwise we have to find out why these specs are not stable.
It might be an important bug that happens only sometimes.

The retries also cost a lot of time in TDD.

#### What should we test?
<!-- List which features should be tested and how. -->

No manual testing required.

I ran the four affected specs 200+ times each on Semaphore. They all passed.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Our automated tests became more reliable in detecting race condition bugs.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

