### PR TITLE
First 2 view specs in OFN

### DIFF
--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe "spree/admin/orders/edit.html.haml" do
+  include AuthenticationWorkflow
+  helper Spree::BaseHelper # required to make pretty_time work
+
+  around do |example|
+    original_config = Spree::Config[:enable_invoices?]
+    example.run
+    Spree::Config[:enable_invoices?] = original_config
+  end
+
+  before do
+    controller.singleton_class.class_eval do
+      def current_ability
+        Spree::Ability.new(Spree.user_class.new)
+      end
+    end
+
+    allow(view).to receive_messages spree_current_user: create_enterprise_user
+
+    order = create(:completed_order_with_fees)
+    order.distributor = create(:distributor_enterprise)
+    assign(:order, order)
+    assign(:shops, [order.distributor])
+    assign(:order_cycles, [])
+  end
+
+  describe "order values" do
+    it "displays order shipping costs, transaction fee and order total" do
+      render
+
+      expect(rendered).to have_content("Shipping: UPS Ground $6.00")
+      expect(rendered).to have_content("Transaction fee: $10.00")
+      expect(rendered).to have_content("Order Total $36.00")
+    end
+  end
+end

--- a/spec/views/spree/admin/orders/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/index.html.haml_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe "spree/admin/orders/index.html.haml" do
+  include AuthenticationWorkflow
+
+  around do |example|
+    original_config = Spree::Config[:enable_invoices?]
+    example.run
+    Spree::Config[:enable_invoices?] = original_config
+  end
+
+  before do
+    allow(view).to receive_messages spree_current_user: create_enterprise_user
+  end
+
+  describe "print invoices button" do
+    it "displays button when invoices are enabled" do
+      Spree::Config[:enable_invoices?] = true
+
+      render
+
+      expect(rendered).to have_content("Print Invoices")
+    end
+
+    it "does not display button when invoices are disabled" do
+      Spree::Config[:enable_invoices?] = false
+
+      render
+
+      expect(rendered).to_not have_content("Print Invoices")
+    end
+  end
+end

--- a/spec/views/spree/admin/orders/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/index.html.haml_spec.rb
@@ -10,6 +10,12 @@ describe "spree/admin/orders/index.html.haml" do
   end
 
   before do
+    controller.singleton_class.class_eval do
+      def current_ability
+        Spree::Ability.new(Spree.user_class.new)
+      end
+    end
+
     allow(view).to receive_messages spree_current_user: create_enterprise_user
   end
 


### PR DESCRIPTION
#### What? Why?

This PR adds the first 2 view specs. This is testing code added in #3963 (I include code from 3963 here so that we can run the spec before 3963 is merged).

This was blocked by an error in CanCan code in the NavigationHelper decorator, thanks @mkllnk for the help!!!
It's now working and ready for review. Only the 2 last commits:
https://github.com/openfoodfoundation/openfoodnetwork/pull/3962/commits

#### What should we test?
Green build. No tests.

#### Release notes
Changelog Category: Added
Added a new type of automated test (view spec) that will ease writing tests for template views.

#### Dependencies
Can only be merged after  #3963