### PR TITLE
Handle soft deleted products in orders and fulfillment report

### DIFF
--- a/lib/open_food_network/order_grouper.rb
+++ b/lib/open_food_network/order_grouper.rb
@@ -24,9 +24,12 @@ module OpenFoodNetwork
       sorted_groups.each do |property, items_by_property|
         branch[property] = build_tree(items_by_property, remaining_rules)
 
-        unless rule[:summary_columns].nil? || is_leaf_node(branch[property])
-          branch[property][:summary_row] = { items: items_by_property, columns: rule[:summary_columns] }
-        end
+        next if rule[:summary_columns].nil? || is_leaf_node(branch[property])
+
+        branch[property][:summary_row] = {
+          items: items_by_property,
+          columns: rule[:summary_columns]
+        }
       end
 
       branch

--- a/lib/open_food_network/order_grouper.rb
+++ b/lib/open_food_network/order_grouper.rb
@@ -18,11 +18,17 @@ module OpenFoodNetwork
     def group_and_sort(rule, remaining_rules, items)
       branch = {}
       groups = items.group_by { |item| rule[:group_by].call(item) }
+
       sorted_groups = groups.sort_by { |key, _value| rule[:sort_by].call(key) }
+
       sorted_groups.each do |property, items_by_property|
         branch[property] = build_tree(items_by_property, remaining_rules)
-        branch[property][:summary_row] = { items: items_by_property, columns: rule[:summary_columns] } unless rule[:summary_columns].nil? || is_leaf_node(branch[property])
+
+        unless rule[:summary_columns].nil? || is_leaf_node(branch[property])
+          branch[property][:summary_row] = { items: items_by_property, columns: rule[:summary_columns] }
+        end
       end
+
       branch
     end
 

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -215,6 +215,8 @@ module OpenFoodNetwork
       end
     end
 
+    # Returns a proc for each column displayed in each report type containing
+    # the logic to compute the value for each cell.
     def columns
       case params[:report_type]
       when "order_cycle_supplier_totals"

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -59,116 +59,168 @@ module OpenFoodNetwork
     def rules
       case params[:report_type]
       when "order_cycle_supplier_totals"
-        [{ group_by: proc { |line_item| line_item.product.supplier },
-           sort_by: proc { |supplier| supplier.name } },
-         { group_by: proc { |line_item| line_item.product },
-           sort_by: proc { |product| product.name } },
-         { group_by: proc { |line_item| line_item.full_name },
-           sort_by: proc { |full_name| full_name } }]
+        [
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
       when "order_cycle_supplier_totals_by_distributor"
-        [{ group_by: proc { |line_item| line_item.product.supplier },
-           sort_by: proc { |supplier| supplier.name } },
-         { group_by: proc { |line_item| line_item.product },
-           sort_by: proc { |product| product.name } },
-         { group_by: proc { |line_item| line_item.full_name },
-           sort_by: proc { |full_name| full_name },
-           summary_columns: [proc { |_line_items| "" },
-                             proc { |_line_items| "" },
-                             proc { |_line_items| "" },
-                             proc { |_line_items| I18n.t('admin.reports.total') },
-                             proc { |_line_items| "" },
-                             proc { |_line_items| "" },
-                             proc { |line_items| line_items.sum(&:amount) },
-                             proc { |_line_items| "" }] },
-         { group_by: proc { |line_item| line_item.order.distributor },
-           sort_by: proc { |distributor| distributor.name } }]
+        [
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            sort_by: proc { |full_name| full_name },
+            summary_columns: [
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| I18n.t('admin.reports.total') },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |line_items| line_items.sum(&:amount) },
+              proc { |_line_items| "" }
+            ]
+          },
+         {
+           group_by: proc { |line_item| line_item.order.distributor },
+           sort_by: proc { |distributor| distributor.name }
+         }
+        ]
       when "order_cycle_distributor_totals_by_supplier"
-        [{ group_by: proc { |line_item| line_item.order.distributor },
-           sort_by: proc { |distributor| distributor.name },
-           summary_columns: [proc { |_line_items| "" },
-                             proc { |_line_items| I18n.t('admin.reports.total') },
-                             proc { |_line_items| "" },
-                             proc { |_line_items| "" },
-                             proc { |_line_items| "" },
-                             proc { |_line_items| "" },
-                             proc { |line_items| line_items.sum(&:amount) },
-                             proc { |line_items| line_items.map(&:order).uniq.sum(&:ship_total) },
-                             proc { |_line_items| "" }] },
-         { group_by: proc { |line_item| line_item.product.supplier },
-           sort_by: proc { |supplier| supplier.name } },
-         { group_by: proc { |line_item| line_item.product },
-           sort_by: proc { |product| product.name } },
-         { group_by: proc { |line_item| line_item.full_name },
-           sort_by: proc { |full_name| full_name } }]
+        [
+          {
+            group_by: proc { |line_item| line_item.order.distributor },
+            sort_by: proc { |distributor| distributor.name },
+            summary_columns: [
+              proc { |_line_items| "" },
+              proc { |_line_items| I18n.t('admin.reports.total') },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |line_items| line_items.sum(&:amount) },
+              proc { |line_items| line_items.map(&:order).uniq.sum(&:ship_total) },
+              proc { |_line_items| "" }
+            ]
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
       when "order_cycle_customer_totals"
-        [{ group_by: proc { |line_item| line_item.order.distributor },
-           sort_by: proc { |distributor| distributor.name } },
-         { group_by: proc { |line_item| line_item.order },
-           sort_by: proc { |order| order.bill_address.full_name_reverse },
-           summary_columns: [
-             proc { |line_items| line_items.first.order.distributor.name },
-             proc { |line_items| line_items.first.order.bill_address.full_name },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| I18n.t('admin.reports.total') },
-             proc { |_line_items| "" },
+        [
+          {
+            group_by: proc { |line_item| line_item.order.distributor },
+            sort_by: proc { |distributor| distributor.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.order },
+            sort_by: proc { |order| order.bill_address.full_name_reverse },
+            summary_columns: [
+              proc { |line_items| line_items.first.order.distributor.name },
+              proc { |line_items| line_items.first.order.bill_address.full_name },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| I18n.t('admin.reports.total') },
+              proc { |_line_items| "" },
 
-             proc { |_line_items| "" },
-             proc { |line_items| line_items.sum(&:amount) },
-             proc { |line_items| line_items.sum(&:amount_with_adjustments) },
-             proc { |line_items| line_items.first.order.admin_and_handling_total },
-             proc { |line_items| line_items.first.order.ship_total },
-             proc { |line_items| line_items.first.order.payment_fee },
-             proc { |line_items| line_items.first.order.total },
-             proc { |line_items| line_items.first.order.paid? ? I18n.t(:yes) : I18n.t(:no) },
+              proc { |_line_items| "" },
+              proc { |line_items| line_items.sum(&:amount) },
+              proc { |line_items| line_items.sum(&:amount_with_adjustments) },
+              proc { |line_items| line_items.first.order.admin_and_handling_total },
+              proc { |line_items| line_items.first.order.ship_total },
+              proc { |line_items| line_items.first.order.payment_fee },
+              proc { |line_items| line_items.first.order.total },
+              proc { |line_items| line_items.first.order.paid? ? I18n.t(:yes) : I18n.t(:no) },
 
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
 
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
 
-             proc { |line_items| line_items.first.order.special_instructions },
-             proc { |_line_items| "" },
+              proc { |line_items| line_items.first.order.special_instructions },
+              proc { |_line_items| "" },
 
-             proc { |line_items| line_items.first.order.order_cycle.andand.name },
-             proc { |line_items|
-               line_items.first.order.payments.first.andand.payment_method.andand.name
-             },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" },
-             proc { |_line_items| "" }
-           ] },
-         { group_by: proc { |line_item| line_item.product },
-           sort_by: proc { |product| product.name } },
-         { group_by: proc { |line_item| line_item.variant },
-           sort_by: proc { |variant| variant.full_name } },
-         { group_by: proc { |line_item| line_item.full_name },
-           sort_by: proc { |full_name| full_name } }]
+              proc { |line_items| line_items.first.order.order_cycle.andand.name },
+              proc { |line_items|
+                line_items.first.order.payments.first.andand.payment_method.andand.name
+              },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" }
+            ]
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id) },
+            sort_by: proc { |variant| variant.full_name }
+          },
+          {
+            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
       else
-        [{ group_by: proc { |line_item| line_item.product.supplier },
-           sort_by: proc { |supplier| supplier.name } },
-         { group_by: proc { |line_item| line_item.product },
-           sort_by: proc { |product| product.name } },
-         { group_by: proc { |line_item| line_item.full_name },
-           sort_by: proc { |full_name| full_name } }]
+        [
+          {
+            group_by: proc { |line_item| line_item.product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.full_name },
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
       end
     end
 
     def columns
       case params[:report_type]
       when "order_cycle_supplier_totals"
-        [proc { |line_items| line_items.first.product.supplier.name },
-         proc { |line_items| line_items.first.product.name },
-         proc { |line_items| line_items.first.full_name },
+        [proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
+         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
+         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
          proc { |line_items| line_items.sum(&:quantity) },
          proc { |line_items| total_units(line_items) },
          proc { |line_items| line_items.first.price },
@@ -176,9 +228,9 @@ module OpenFoodNetwork
          proc { |_line_items| "" },
          proc { |_line_items| I18n.t(:report_header_incoming_transport) }]
       when "order_cycle_supplier_totals_by_distributor"
-        [proc { |line_items| line_items.first.product.supplier.name },
-         proc { |line_items| line_items.first.product.name },
-         proc { |line_items| line_items.first.full_name },
+        [proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
+         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
+         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
          proc { |line_items| line_items.first.order.distributor.name },
          proc { |line_items| line_items.sum(&:quantity) },
          proc { |line_items| line_items.first.price },
@@ -186,9 +238,9 @@ module OpenFoodNetwork
          proc { |_line_items| I18n.t(:report_header_shipping_method) }]
       when "order_cycle_distributor_totals_by_supplier"
         [proc { |line_items| line_items.first.order.distributor.name },
-         proc { |line_items| line_items.first.product.supplier.name },
-         proc { |line_items| line_items.first.product.name },
-         proc { |line_items| line_items.first.full_name },
+         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
+         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
+         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
          proc { |line_items| line_items.sum(&:quantity) },
          proc { |line_items| line_items.first.price },
          proc { |line_items| line_items.sum(&:amount) },
@@ -201,9 +253,9 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.order.bill_address.firstname + " " + line_items.first.order.bill_address.lastname },
           proc { |line_items| line_items.first.order.email },
           proc { |line_items| line_items.first.order.bill_address.phone },
-          proc { |line_items| line_items.first.product.supplier.name },
-          proc { |line_items| line_items.first.product.name },
-          proc { |line_items| line_items.first.full_name },
+          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
+          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
+          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
 
           proc { |line_items| line_items.sum(&:quantity) },
           proc { |line_items| line_items.sum(&:amount) },
@@ -224,7 +276,7 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.order.ship_address.andand.state if rsa.call(line_items) },
 
           proc { |_line_items| "" },
-          proc { |line_items| line_items.first.variant.sku },
+          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).sku },
 
           proc { |line_items| line_items.first.order.order_cycle.andand.name },
           proc { |line_items| line_items.first.order.payments.first.andand.payment_method.andand.name },
@@ -258,8 +310,10 @@ module OpenFoodNetwork
 
     def total_units(line_items)
       return " " if line_items.map{ |li| li.unit_value.nil? }.any?
+
       total_units = line_items.sum do |li|
-        scale_factor = ( li.product.variant_unit == 'weight' ? 1000 : 1 )
+        product = Spree::Variant.unscoped.find(li.variant_id).product
+        scale_factor = ( product.variant_unit == 'weight' ? 1000 : 1 )
         li.quantity * li.unit_value / scale_factor
       end
       total_units.round(3)

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -1,5 +1,5 @@
 require "open_food_network/reports/line_items"
-require 'open_food_network/orders_and_fulfillments_report/other_type'
+require 'open_food_network/orders_and_fulfillments_report/default_report'
 
 include Spree::ReportsHelper
 
@@ -42,7 +42,7 @@ module OpenFoodNetwork
          I18n.t(:report_header_order_cycle), I18n.t(:report_header_payment_method), I18n.t(:report_header_customer_code), I18n.t(:report_header_tags),
          I18n.t(:report_header_billing_street), I18n.t(:report_header_billing_street_2), I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode), I18n.t(:report_header_billing_state),]
       else
-        OtherType.new(self).header
+        DefaultReport.new(self).header
       end
     end
 
@@ -197,20 +197,7 @@ module OpenFoodNetwork
           }
         ]
       else
-        [
-          {
-            group_by: proc { |line_item| find_variant(line_item.variant_id).product.supplier },
-            sort_by: proc { |supplier| supplier.name }
-          },
-          {
-            group_by: proc { |line_item| find_variant(line_item.variant_id).product },
-            sort_by: proc { |product| product.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.full_name },
-            sort_by: proc { |full_name| full_name }
-          }
-        ]
+        DefaultReport.new(self).rules
       end
     end
 
@@ -295,14 +282,7 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.order.bill_address.andand.state }
         ]
       else
-        [proc { |line_items| line_items.first.product.supplier.name },
-         proc { |line_items| line_items.first.product.name },
-         proc { |line_items| line_items.first.full_name },
-         proc { |line_items| line_items.sum(&:quantity) },
-         proc { |line_items| line_items.first.price },
-         proc { |line_items| line_items.sum { |li| li.quantity * li.price } },
-         proc { |_line_items| "" },
-         proc { |_line_items| I18n.t(:report_header_incoming_transport) }]
+        DefaultReport.new(self).columns
       end
     end
 

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -97,10 +97,10 @@ module OpenFoodNetwork
               proc { |_line_items| "" }
             ]
           },
-         {
-           group_by: proc { |line_item| line_item.order.distributor },
-           sort_by: proc { |distributor| distributor.name }
-         }
+          {
+            group_by: proc { |line_item| line_item.order.distributor },
+            sort_by: proc { |distributor| distributor.name }
+          }
         ]
       when "order_cycle_distributor_totals_by_supplier"
         [
@@ -311,15 +311,22 @@ module OpenFoodNetwork
     end
 
     def total_units(line_items)
-      return " " if line_items.map{ |li| li.unit_value.nil? }.any?
+      return " " if not_all_have_unit?(line_items)
 
       total_units = line_items.sum do |li|
         product = find_variant(li.variant_id).product
-
-        scale_factor = ( product.variant_unit == 'weight' ? 1000 : 1 )
-        li.quantity * li.unit_value / scale_factor
+        li.quantity * li.unit_value / scale_factor(product)
       end
+
       total_units.round(3)
+    end
+
+    def not_all_have_unit?(line_items)
+      line_items.map { |li| li.unit_value.nil? }.any?
+    end
+
+    def scale_factor(product)
+      product.variant_unit == 'weight' ? 1000 : 1
     end
 
     # Returns the variant with the given id, including soft-deleted ones

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -61,30 +61,30 @@ module OpenFoodNetwork
       when "order_cycle_supplier_totals"
         [
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product.supplier },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product.supplier },
             sort_by: proc { |supplier| supplier.name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product },
             sort_by: proc { |product| product.name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).full_name },
             sort_by: proc { |full_name| full_name }
           }
         ]
       when "order_cycle_supplier_totals_by_distributor"
         [
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product.supplier },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product.supplier },
             sort_by: proc { |supplier| supplier.name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product },
             sort_by: proc { |product| product.name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).full_name },
             sort_by: proc { |full_name| full_name },
             summary_columns: [
               proc { |_line_items| "" },
@@ -120,15 +120,15 @@ module OpenFoodNetwork
             ]
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product.supplier },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product.supplier },
             sort_by: proc { |supplier| supplier.name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product },
             sort_by: proc { |product| product.name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).full_name },
             sort_by: proc { |full_name| full_name }
           }
         ]
@@ -185,15 +185,15 @@ module OpenFoodNetwork
             ]
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).product },
+            group_by: proc { |line_item| find_variant(line_item).product },
             sort_by: proc { |product| product.name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id) },
+            group_by: proc { |line_item| find_variant(line_item.variant_id) },
             sort_by: proc { |variant| variant.full_name }
           },
           {
-            group_by: proc { |line_item| Spree::Variant.unscoped.find(line_item.variant_id).full_name },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).full_name },
             sort_by: proc { |full_name| full_name }
           }
         ]
@@ -220,9 +220,9 @@ module OpenFoodNetwork
     def columns
       case params[:report_type]
       when "order_cycle_supplier_totals"
-        [proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
-         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
-         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
+        [proc { |line_items| find_variant(line_items.first.variant_id).product.supplier.name },
+         proc { |line_items| find_variant(line_items.first.variant_id).product.name },
+         proc { |line_items| find_variant(line_items.first.variant_id).full_name },
          proc { |line_items| line_items.sum(&:quantity) },
          proc { |line_items| total_units(line_items) },
          proc { |line_items| line_items.first.price },
@@ -230,9 +230,9 @@ module OpenFoodNetwork
          proc { |_line_items| "" },
          proc { |_line_items| I18n.t(:report_header_incoming_transport) }]
       when "order_cycle_supplier_totals_by_distributor"
-        [proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
-         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
-         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
+        [proc { |line_items| find_variant(line_items.first.variant_id).product.supplier.name },
+         proc { |line_items| find_variant(line_items.first.variant_id).product.name },
+         proc { |line_items| find_variant(line_items.first.variant_id).full_name },
          proc { |line_items| line_items.first.order.distributor.name },
          proc { |line_items| line_items.sum(&:quantity) },
          proc { |line_items| line_items.first.price },
@@ -240,9 +240,9 @@ module OpenFoodNetwork
          proc { |_line_items| I18n.t(:report_header_shipping_method) }]
       when "order_cycle_distributor_totals_by_supplier"
         [proc { |line_items| line_items.first.order.distributor.name },
-         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
-         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
-         proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
+         proc { |line_items| find_variant(line_items.first.variant_id).product.supplier.name },
+         proc { |line_items| find_variant(line_items.first.variant_id).product.name },
+         proc { |line_items| find_variant(line_items.first.variant_id).full_name },
          proc { |line_items| line_items.sum(&:quantity) },
          proc { |line_items| line_items.first.price },
          proc { |line_items| line_items.sum(&:amount) },
@@ -255,9 +255,9 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.order.bill_address.firstname + " " + line_items.first.order.bill_address.lastname },
           proc { |line_items| line_items.first.order.email },
           proc { |line_items| line_items.first.order.bill_address.phone },
-          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.supplier.name },
-          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).product.name },
-          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).full_name },
+          proc { |line_items| find_variant(line_items.first.variant_id).product.supplier.name },
+          proc { |line_items| find_variant(line_items.first.variant_id).product.name },
+          proc { |line_items| find_variant(line_items.first.variant_id).full_name },
 
           proc { |line_items| line_items.sum(&:quantity) },
           proc { |line_items| line_items.sum(&:amount) },
@@ -278,7 +278,7 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.order.ship_address.andand.state if rsa.call(line_items) },
 
           proc { |_line_items| "" },
-          proc { |line_items| Spree::Variant.unscoped.find(line_items.first.variant_id).sku },
+          proc { |line_items| find_variant(line_items.first.variant_id).sku },
 
           proc { |line_items| line_items.first.order.order_cycle.andand.name },
           proc { |line_items| line_items.first.order.payments.first.andand.payment_method.andand.name },
@@ -314,11 +314,17 @@ module OpenFoodNetwork
       return " " if line_items.map{ |li| li.unit_value.nil? }.any?
 
       total_units = line_items.sum do |li|
-        product = Spree::Variant.unscoped.find(li.variant_id).product
+        product = find_variant(li.variant_id).product
+
         scale_factor = ( product.variant_unit == 'weight' ? 1000 : 1 )
         li.quantity * li.unit_value / scale_factor
       end
       total_units.round(3)
+    end
+
+    # Returns the variant with the given id, including soft-deleted ones
+    def find_variant(id)
+      Spree::Variant.unscoped.find(id)
     end
   end
 end

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -185,7 +185,7 @@ module OpenFoodNetwork
             ]
           },
           {
-            group_by: proc { |line_item| find_variant(line_item).product },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product },
             sort_by: proc { |product| product.name }
           },
           {
@@ -200,11 +200,11 @@ module OpenFoodNetwork
       else
         [
           {
-            group_by: proc { |line_item| line_item.product.supplier },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product.supplier },
             sort_by: proc { |supplier| supplier.name }
           },
           {
-            group_by: proc { |line_item| line_item.product },
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product },
             sort_by: proc { |product| product.name }
           },
           {

--- a/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
@@ -1,7 +1,8 @@
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     class DefaultReport
-      delegate :line_item_name, :find_variant, :supplier_name, :product_name, :line_items_name, to: :context
+      delegate :line_item_name, :find_variant, :supplier_name, :product_name,
+               :line_items_name, to: :context
 
       def initialize(context)
         @context = context
@@ -20,6 +21,7 @@ module OpenFoodNetwork
         ]
       end
 
+      # rubocop:disable Metrics/MethodLength
       def rules
         [
           {
@@ -36,7 +38,9 @@ module OpenFoodNetwork
           }
         ]
       end
+      # rubocop:enable Metrics/MethodLength
 
+      # rubocop:disable Metrics/AbcSize
       def columns
         [
           supplier_name,
@@ -49,6 +53,7 @@ module OpenFoodNetwork
           proc { |_line_items| I18n.t(:report_header_incoming_transport) }
         ]
       end
+      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
@@ -1,0 +1,58 @@
+module OpenFoodNetwork
+  class OrdersAndFulfillmentsReport
+    class DefaultReport
+      delegate :line_item_name, :find_variant, :supplier_name, :product_name, :line_items_name, to: :context
+
+      def initialize(context)
+        @context = context
+      end
+
+      def header
+        [
+          I18n.t(:report_header_producer),
+          I18n.t(:report_header_product),
+          I18n.t(:report_header_variant),
+          I18n.t(:report_header_amount),
+          I18n.t(:report_header_curr_cost_per_unit),
+          I18n.t(:report_header_total_cost),
+          I18n.t(:report_header_status),
+          I18n.t(:report_header_incoming_transport)
+        ]
+      end
+
+      def rules
+        [
+          {
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| find_variant(line_item.variant_id).product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: line_item_name,
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
+      end
+
+      def columns
+        [
+          supplier_name,
+          product_name,
+          line_items_name,
+          proc { |line_items| line_items.sum(&:quantity) },
+          proc { |line_items| line_items.first.price },
+          proc { |line_items| line_items.sum { |li| li.quantity * li.price } },
+          proc { |_line_items| "" },
+          proc { |_line_items| I18n.t(:report_header_incoming_transport) }
+        ]
+      end
+
+      private
+
+      attr_reader :context
+    end
+  end
+end

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -202,6 +202,15 @@ describe Spree::Admin::ReportsController, type: :controller do
           expect(resulting_orders_prelim).to     include(orderA1)
           expect(resulting_orders_prelim).not_to include(orderB1)
         end
+
+        context 'when a purchased product is deleted' do
+          before { orderA1.line_items.first.product.destroy }
+
+          it "only shows product line items that I am supplying" do
+            spree_post :orders_and_fulfillment, q: {}
+            expect(resulting_products).to     include product1
+          end
+        end
       end
 
       context "where I have not granted P-OC to the distributor" do

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -208,7 +208,11 @@ describe Spree::Admin::ReportsController, type: :controller do
 
           it "only shows product line items that I am supplying" do
             spree_post :orders_and_fulfillment, q: {}
-            expect(resulting_products).to     include product1
+
+            table_items = assigns(:report).table_items
+            variant = Spree::Variant.unscoped.find(table_items.first.variant_id)
+
+            expect(variant.product).to eq(product1)
           end
         end
       end


### PR DESCRIPTION
### What? Why?

Closes #3956

Because of the `default_scope` paranoia adds to models, soft-deleted rows are excluded from the result set. Therefore, when the report class tries to compute values from them finds `nil` everywhere.

#### Solution

The solution I came up with is disgusting. 

First of all, I did spend a few hours digging through the mess of this implementation trying to see if it was possible to solve this using `ActiveRecord::Relation`'s `#includes` to eager load the products and their variant but skipping the `default_scope`. Which should have look similar to:

```ruby
line_items = permissions.visible_line_items.merge(
  Spree::LineItem
    .where(order_id: orders)
    .joins(product: :variants)
    .includes(product: :variants)
)
```

if anyone wants to give a try, that's what https://github.com/openfoodfoundation/openfoodnetwork/blob/ab1ed53507bc4726ec779491849dbe0733d419a6/lib/open_food_network/reports/line_items.rb#L12 would become.

We were lucky because indeed we pass an `ActiveRecord::Relation` around but I didn't manage to stop AR from adding `deleted_at IS NULL` in that query above.

The only quick way to solve it that I found was querying the variant wherever it's needed, which does not cause any new N+1 other than the ones we have, I think. So there should be no change in performance.

I haven't investigated any further (it's very tough to read this code) but apparently, deleted products, although they `acts_as_paranoid` now, are included in the result set. Thus, they are not returned as `nil`.

#### The future of this report

We must stop this madness. What should have a rather straightforward change has become a deep dive into the way our fancy algorithm works. Also, I had a few "Stop this s***" moments not even being able to follow all those procs of the report class and trying to see how the AR Relation is passed around. (I even though it was a lack of respect to every one of us to have such code LOL).

So I'm fully committed to refactoring it as soon as we get to the performance epic. It won't be possible to increase its performance by performing the right SQL queries (and possibly adding one or more database views) unless we refactor it almost completely. Meanwhile, I say we don't invest any minute on it. And I'm eager to do so now that understand how the current implementation works.

#### What should we test?

We should test each of the subtypes of report combining both deleted and non-deleted products. All of them should show up in the report's aggregates.

The steps I took while developing are:

1. Place an order with one product
2. Place another one with another product
3. Delete the first one
4. Check all the subtypes of orders and fulfillments report and see if they show both products and their variants

#### Release notes

Deleted products and variants are successfully displayed in the orders and fulfillments report. 

Changelog Category: Fixed