### PR TITLE
Rescue checkout on shipping id conflict

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -166,21 +166,23 @@ Spree::Order.class_eval do
     shipments.each do |shipment|
       next if shipment.shipped?
       update_adjustment! shipment.adjustment if shipment.adjustment
-      begin
-        shipment.save # updates included tax
-      rescue ActiveRecord::RecordNotUnique => error
-        # This error was seen in production on `shipment.save` above.
-        # It caused lost payments and duplicate payments due to database rollbacks.
-        # While we don't understand the cause of this error yet, we rescue here
-        # because an outdated shipping fee is not as bad as a lost payment.
-        # And the shipping fee is already up-to-date when this error occurs.
-        # https://github.com/openfoodfoundation/openfoodnetwork/issues/3924
-        Bugsnag.notify(error) do |report|
-          report.add_tab(:order, attributes)
-          report.add_tab(:shipment, shipment.attributes)
-          report.add_tab(:shipment_in_db, Spree::Shipment.find_by_id(shipment.id).attributes)
-        end
-      end
+      save_or_rescue_shipment(shipment)
+    end
+  end
+
+  def save_or_rescue_shipment(shipment)
+    shipment.save # updates included tax
+  rescue ActiveRecord::RecordNotUnique => error
+    # This error was seen in production on `shipment.save` above.
+    # It caused lost payments and duplicate payments due to database rollbacks.
+    # While we don't understand the cause of this error yet, we rescue here
+    # because an outdated shipping fee is not as bad as a lost payment.
+    # And the shipping fee is already up-to-date when this error occurs.
+    # https://github.com/openfoodfoundation/openfoodnetwork/issues/3924
+    Bugsnag.notify(error) do |report|
+      report.add_tab(:order, attributes)
+      report.add_tab(:shipment, shipment.attributes)
+      report.add_tab(:shipment_in_db, Spree::Shipment.find_by_id(shipment.id).attributes)
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Helps to investigate https://github.com/openfoodfoundation/openfoodnetwork/issues/3924

A better solution would be to move the update of shipments out of the
after_save callback and deal with it in controllers. Unfortunately,
that's a big and tricky task.

Since this exception is causing a lot of pain for some Australian
farmers, I introduced more logging here to understand the problem
better. The issue was observed in OFN v1 and may disappear with v2. But
we don't know that and should monitor it.

#### What should we test?
<!-- List which features should be tested and how. -->

- Checkout
- Creating an order in the admin interface
- Modifying an order in the admin interface and recalculate fees

*Note: this patch is used already in Australian production.*

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added logging for a rare checkout issue.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

