### PR TITLE
Toggle features via env instead of initializer

### DIFF
--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -1,13 +1,21 @@
 module OpenFoodNetwork
   class FeatureToggle
-    def self.enabled?(feature)
-      !!features.with_indifferent_access[feature]
+    def self.enabled?(feature_name)
+      true?(env_variable_value(feature_name))
     end
 
     private
 
-    def self.features
-      { connect_learn_homepage: false }
+    def self.env_variable_value(feature_name)
+      ENV.fetch(env_variable_name(feature_name), nil)
+    end
+
+    def self.env_variable_name(feature_name)
+      "OFN_FEATURE_#{feature_name.to_s.upcase}"
+    end
+
+    def self.true?(value)
+      value.to_s.casecmp("true").zero?
     end
   end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -3,18 +3,26 @@ require 'open_food_network/feature_toggle'
 module OpenFoodNetwork
   describe FeatureToggle do
     it "returns true when feature is on" do
-      allow(FeatureToggle).to receive(:features).and_return(foo: true)
+      stub_foo("true")
       expect(FeatureToggle.enabled?(:foo)).to be true
     end
 
     it "returns false when feature is off" do
-      allow(FeatureToggle).to receive(:features).and_return(foo: false)
+      stub_foo("false")
+      expect(FeatureToggle.enabled?(:foo)).to be false
+    end
+
+    it "returns false when feature is unspecified" do
+      stub_foo("maybe")
       expect(FeatureToggle.enabled?(:foo)).to be false
     end
 
     it "returns false when feature is undefined" do
-      allow(FeatureToggle).to receive(:features).and_return({})
       expect(FeatureToggle.enabled?(:foo)).to be false
+    end
+
+    def stub_foo(value)
+      allow(ENV).to receive(:fetch).with("OFN_FEATURE_FOO", nil).and_return(value)
     end
   end
 end


### PR DESCRIPTION

#### What? Why?

First part of https://github.com/openfoodfoundation/ofn-install/issues/444.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
A FeatureToggle could be switched via a class_eval in an initializer.
The initializer was installed via ofn-install. We want to get rid of
custom, untracked initializers. Here I'm changing the FeatureToggle
class to use environment variables instead.

This change needs to be followed up with a change in ofn-install to use
the new environment variable. It affects only Australian production.



#### What should we test?
<!-- List which features should be tested and how. -->

Staging servers should not show the Connect and Learn sections on the home page.

![Screenshot from 2019-06-25 17-35-08](https://user-images.githubusercontent.com/3524483/60078621-a3654d80-976f-11e9-9ac6-2a28f41d0bb0.png)


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed the technical way of switching experimental features on or off.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

