### PR TITLE
Avoid `undefined method 'order'` errors when removing lineitems from basket

### DIFF
--- a/app/models/spree/calculator_decorator.rb
+++ b/app/models/spree/calculator_decorator.rb
@@ -9,7 +9,7 @@ module Spree
         [object]
       elsif object.respond_to? :line_items
         object.line_items
-      elsif object.order.present?
+      elsif object.respond_to? :order
         object.order.line_items
       else
         [object]

--- a/app/models/spree/calculator_decorator.rb
+++ b/app/models/spree/calculator_decorator.rb
@@ -9,7 +9,7 @@ module Spree
         [object]
       elsif object.respond_to? :line_items
         object.line_items
-      elsif object.respond_to? :order
+      elsif object.respond_to?(:order) && object.order.present?
         object.order.line_items
       else
         [object]

--- a/spec/models/spree/calculator_spec.rb
+++ b/spec/models/spree/calculator_spec.rb
@@ -5,12 +5,14 @@ module Spree
     let(:calculator) { Spree::Calculator.new }
     let!(:enterprise) { create(:enterprise) }
     let!(:order) { create(:order) }
+    let!(:shipment) { create(:shipment) }
     let!(:line_item) { create(:line_item, order: order) }
     let!(:line_item2) { create(:line_item, order: order) }
 
     before do
       order.line_items << line_item
       order.line_items << line_item2
+      order.shipments = [shipment]
     end
 
     describe "#line_items_for" do
@@ -20,8 +22,14 @@ module Spree
         expect(result).to eq [line_item]
       end
 
-      it "returns line items if given an order" do
+      it "returns line items if given an object with line items" do
         result = calculator.__send__(:line_items_for, order)
+
+        expect(result).to eq [line_item, line_item2]
+      end
+
+      it "returns line items if given an object with an order" do
+        result = calculator.__send__(:line_items_for, shipment)
 
         expect(result).to eq [line_item, line_item2]
       end

--- a/spec/models/spree/calculator_spec.rb
+++ b/spec/models/spree/calculator_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+module Spree
+  describe Calculator do
+    let(:calculator) { Spree::Calculator.new }
+    let!(:enterprise) { create(:enterprise) }
+    let!(:order) { create(:order) }
+    let!(:line_item) { create(:line_item, order: order) }
+    let!(:line_item2) { create(:line_item, order: order) }
+
+    before do
+      order.line_items << line_item
+      order.line_items << line_item2
+    end
+
+    describe "#line_items_for" do
+      it "returns the line item if given a line item" do
+        result = calculator.__send__(:line_items_for, line_item)
+
+        expect(result).to eq [line_item]
+      end
+
+      it "returns line items if given an order" do
+        result = calculator.__send__(:line_items_for, order)
+
+        expect(result).to eq [line_item, line_item2]
+      end
+
+      it "returns the original object if given anything else" do
+        result = calculator.__send__(:line_items_for, enterprise)
+
+        expect(result).to eq [enterprise]
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #3969 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

A recent change in `app/models/spree/calculator_decorator.rb:12` is now generating fatal (undefined method) errors when the object does not respond to `#order`. This should fix it.

#### What should we test?
<!-- List which features should be tested and how. -->

Items can be removed from basket without generating a snail page.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed error when removing items from basket.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
