### PR TITLE
3845 Validate uniqueness of optional variant SKU

### DIFF
--- a/app/models/concerns/variant_unique_sku_validation.rb
+++ b/app/models/concerns/variant_unique_sku_validation.rb
@@ -1,0 +1,29 @@
+# This adds validation to require SKU to be unique among the non-master and not deleted variants of
+# the same product. Additionally, there can be at most one variant with blank SKU for a products
+# variants with the same unit_value, unit_description, display_name, and display_as.
+#
+# Master and deleted variants are ignored.
+
+module VariantUniqueSkuValidation
+  extend ActiveSupport::Concern
+
+  included do
+    # Including is_master and deleted_at in the uniqueness scope is a workaround to ignore master
+    # and deleted variants.
+    #
+    # Handle validation for blank SKU separately.
+    validates :sku, uniqueness: { scope: [:product_id, :is_master, :deleted_at], allow_blank: true,
+                                  if: :validate_sku_uniqueness? }
+
+    # When SKU is blank, make sure that there is no other variant that looks similar which also has
+    # blank SKU.
+    validate :validate_no_lookalikes_with_blank_sku, if: :validate_sku_uniqueness?
+  end
+
+  def variant_unique_sku_validator
+    @variant_unique_sku_validator ||= VariantUniqueSkuValidator.new(self)
+  end
+
+  delegate :validate_sku_uniqueness?, to: :variant_unique_sku_validator
+  delegate :validate_no_lookalikes_with_blank_sku, to: :variant_unique_sku_validator
+end

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -240,7 +240,7 @@ module ProductImport
     end
 
     def entry_matches_variant_sku?(entry, variant)
-      entry.sku.nil? || entry.sku == variant.sku
+      variant.sku.blank? || entry.sku.nil? || entry.sku == variant.sku
     end
 
     def category_validation(entry)

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -234,7 +234,13 @@ module ProductImport
     end
 
     def entry_matches_existing_variant?(entry, existing_variant)
-      existing_variant.display_name == entry.display_name && existing_variant.unit_value == entry.unit_value.to_f
+      existing_variant.display_name == entry.display_name \
+        && existing_variant.unit_value == entry.unit_value.to_f \
+        && entry_matches_variant_sku?(entry, existing_variant)
+    end
+
+    def entry_matches_variant_sku?(entry, variant)
+      entry.sku.nil? || entry.sku == variant.sku
     end
 
     def category_validation(entry)

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -10,6 +10,7 @@ Spree::Variant.class_eval do
   # removing the Spree method to prevent error.
   remove_method :options_text if instance_methods(false).include? :options_text
   include OpenFoodNetwork::VariantAndLineItemNaming
+  include VariantUniqueSkuValidation
   include VariantStock
 
   has_many :exchange_variants

--- a/app/services/variant_unique_sku_validator.rb
+++ b/app/services/variant_unique_sku_validator.rb
@@ -1,0 +1,46 @@
+class VariantUniqueSkuValidator
+  attr_reader :variant
+
+  def initialize(variant)
+    @variant = variant
+  end
+
+  def validate_sku_uniqueness?
+    !variant.is_master && !variant.deleted?
+  end
+
+  def validate_no_lookalikes_with_blank_sku
+    return if variant.sku.present? || variant.product_id.blank?
+
+    variants_with_blank_sku = lookalike_variants.where(sku: ["", nil])
+    return if (variants_with_blank_sku - [variant]).blank?
+
+    variant.errors.add(:sku, error_message_if_has_lookalike_with_same_sku_error)
+  end
+
+  private
+
+  def error_message_if_has_lookalike_with_same_sku_error
+    I18n.t("activerecord.errors.models.spree/variant.attributes.sku.has_lookalike_with_same_sku")
+  end
+
+  # Find variants that look like the current variant. This does not distinguish between "" and nil
+  # in string attributes.
+  def lookalike_variants
+    variant.product.variants.where(lookalike_variants_conditions)
+  end
+
+  # Conditions for finding lookalike variants.
+  def lookalike_variants_conditions
+    { unit_value: variant.unit_value,
+      unit_description: similar_string_attribute_value(variant.unit_description),
+      display_name: similar_string_attribute_value(variant.display_name),
+      display_as: similar_string_attribute_value(variant.display_as) }
+  end
+
+  # Use this to find similar values for a string attribute in the database. This is merely a helper
+  # method for not distinguishing between "" and nil.
+  def similar_string_attribute_value(value)
+    value.presence || ["", nil]
+  end
+end

--- a/app/services/variant_unique_sku_validator.rb
+++ b/app/services/variant_unique_sku_validator.rb
@@ -11,9 +11,7 @@ class VariantUniqueSkuValidator
 
   def validate_no_lookalikes_with_blank_sku
     return if variant.sku.present? || variant.product_id.blank?
-
-    variants_with_blank_sku = lookalike_variants.where(sku: ["", nil])
-    return if (variants_with_blank_sku - [variant]).blank?
+    return if (lookalike_variants_with_blank_sku - [variant]).blank?
 
     variant.errors.add(:sku, error_message_if_has_lookalike_with_same_sku_error)
   end
@@ -22,6 +20,10 @@ class VariantUniqueSkuValidator
 
   def error_message_if_has_lookalike_with_same_sku_error
     I18n.t("activerecord.errors.models.spree/variant.attributes.sku.has_lookalike_with_same_sku")
+  end
+
+  def lookalike_variants_with_blank_sku
+    lookalike_variants.where(sku: ["", nil])
   end
 
   # Find variants that look like the current variant. This does not distinguish between "" and nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,10 @@ en:
               taken: "There's already an account for this email. Please login or reset your password."
         spree/order:
           no_card: There are no authorised credit cards available to charge
+        spree/variant:
+          attributes:
+            sku:
+              has_lookalike_with_same_sku: "allows only one variant to have blank SKU for each similar variant"
         order_cycle:
           attributes:
             orders_close_at:

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -879,7 +879,7 @@ def import_data(csv_data, args = {})
   settings = args[:settings] || { 'import_into' => import_into, 'reset_all_absent' => reset_all_absent }
 
   File.write('/tmp/test-m.csv', csv_data)
-  @file ||= File.new('/tmp/test-m.csv')
+  @file = File.new('/tmp/test-m.csv')
   ProductImport::ProductImporter.new(@file,
                                      import_user,
                                      start: start_row,

--- a/spec/services/variant_unique_sku_validator_spec.rb
+++ b/spec/services/variant_unique_sku_validator_spec.rb
@@ -1,0 +1,113 @@
+require "spec_helper"
+
+# variants with the same unit_value, unit_description, display_name, and display_as.
+describe VariantUniqueSkuValidator do
+  let!(:product) do
+    create(:product, sku: "PRODUCT_SKU", unit_value: 1.0, unit_description: "",
+                     variant_unit: "weight", variant_unit_scale: 1.0)
+  end
+
+  let(:validator) { described_class.new(variant) }
+  let(:master) { product.master }
+
+  context "when SKU is non-blank" do
+    let!(:existing_variant) { create(:variant, product: product, sku: "V0001") }
+
+    it "allows SKU that is unique among product's variants" do
+      variant = build(:variant, product: product, sku: "V0002")
+      expect(variant.save).to be_truthy
+    end
+
+    it "does not allow SKU that is not unique among product's variants" do
+      variant = build(:variant, product: product, sku: existing_variant.sku)
+      expect(variant.save).to be_falsey
+      expect(variant.errors[:sku]).to eq(["has already been taken"])
+    end
+
+    it "ignores deleted variant with same SKU" do
+      existing_variant.destroy
+
+      variant = build(:variant, product: product, sku: existing_variant.sku)
+      expect(variant.save).to be_truthy
+    end
+
+    it "ignores master variant with same SKU" do
+      # Make the SKU of the first variant different from that of the master variant.
+      first_variant = product.variants.order(:id).first
+      first_variant.update_attributes!(sku: "FIRST_VARIANT_SKU")
+
+      variant = build(:variant, product: product, sku: master.sku)
+      expect(variant.save).to be_truthy
+    end
+  end
+
+  context "when SKU is blank" do
+    let!(:existing_variant) { create(:variant, product: product, sku: "", unit_value: 1) }
+
+    it "allows SKU if there is no lookalike variant of product that has blank SKU" do
+      variant = build(:variant, product: product, sku: "", unit_value: 2)
+      expect(variant.save).to be_truthy
+    end
+
+    it "does not allow SKU if there is a lookalike variant of product that has blank SKU" do
+      variant = build(:variant, product: product, sku: "", unit_value: 1)
+      expect(variant.save).to be_falsey
+      expect(variant.errors[:sku]).to eq([error_message_if_has_lookalike_with_same_sku_error])
+    end
+
+    it "treats empty string and nil SKU as identical" do
+      variant = build(:variant, product: product, sku: nil, unit_value: 1)
+      expect(variant.save).to be_falsey
+      expect(variant.errors[:sku]).to eq([error_message_if_has_lookalike_with_same_sku_error])
+
+      variant.sku = ""
+      expect(variant.save).to be_falsey
+      expect(variant.errors[:sku]).to eq([error_message_if_has_lookalike_with_same_sku_error])
+    end
+
+    it "ignores deleted variant that has blank SKU" do
+      existing_variant.destroy
+
+      variant = build(:variant, product: product, sku: "", unit_value: 1)
+      expect(variant.save).to be_truthy
+    end
+
+    it "ignores master variant that has blank SKU" do
+      # Make the SKU of the first variant different from that of the master variant.
+      first_variant = product.variants.order(:id).first
+      first_variant.update_attributes!(sku: "FIRST_VARIANT_SKU")
+
+      master.update_attributes!(sku: "", unit_value: 2)
+
+      existing_variant.unit_value = master.unit_value
+      existing_variant.unit_description = master.unit_description
+      existing_variant.display_name = master.display_name
+      existing_variant.display_as = master.display_as
+      expect(existing_variant.save).to be_truthy
+    end
+  end
+
+  context "when the variant is master variant" do
+    it "does not require non-blank SKU to be unique among product's variants" do
+      variant = create(:variant, product: product, sku: "V0001", unit_value: master.unit_value,
+                                 unit_description: master.unit_description,
+                                 display_name: master.display_name, display_as: master.display_as)
+
+      master.sku = variant.sku
+      expect(master.save).to be_truthy
+    end
+
+    it "allows blank SKU even if non-master variant of product already has blank SKU" do
+      create(:variant, product: product, sku: "", unit_value: master.unit_value,
+                       unit_description: master.unit_description, display_name: master.display_name,
+                       display_as: master.display_as)
+
+      master.sku = ""
+      expect(master.save).to be_truthy
+    end
+  end
+
+  def error_message_if_has_lookalike_with_same_sku_error
+    I18n.t("activerecord.errors.models.spree/variant.attributes.sku.has_lookalike_with_same_sku")
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Closes #3845

The following validation rules for variant SKU are now enforced:

1. SKU of master variants are not checked for uniqueness.
2. SKU of deleted variants are not checked for uniqueness.
3. For non-blank SKU, the SKU needs to be unique among the non-master, non-deleted variants of the product.
4. For blank SKU, there needs to be no other variant with blank SKU among the non-master, non-deleted variants of the product that look similar. Looking similar means that the variants have the same product ID, `unit_value`, `unit_description`, `display_name`, and `display_as`.

For the product import:

1. If you have an existing variant with blank SKU, importing a row with filled SKU would match the variant.
2. If you have an existing variant with filled SKU, the SKU in the spreadsheets needs to be the same.

#### What should we test?

1. Test importing the spreadsheet in #3845.
2. Do a smoke test of product import.

#### Release notes

- Require SKU of variants for the same product to be unique among those with the same `unit_value`, `unit_description`, `display_name`, and `display_as`.
- In product and inventory import, if set, require the SKU to match the SKU of an existing variant. If the existing variant has blank SKU, allow the SKU to be updated.

Changelog Category: Changed