### PR TITLE
Fixes menu problem with long shop names

### DIFF
--- a/app/assets/stylesheets/darkswarm/menu.css.scss
+++ b/app/assets/stylesheets/darkswarm/menu.css.scss
@@ -14,17 +14,17 @@ nav.top-bar {
 }
 
 @media #{$large-only} {
-  .top-bar__menu-item-with-icon span {
+  .top-bar--menu-item-with-icon span {
     display: none;
   }
 
-  .top-bar__current-hub-prefix,
-  .top-bar__current-hub-name {
+  .top-bar--current-hub-prefix,
+  .top-bar--current-hub-name {
     display: inline-block;
     vertical-align: middle;
   }
 
-  .top-bar__current-hub-name {
+  .top-bar--current-hub-name {
     max-width: 10em;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -32,12 +32,12 @@ nav.top-bar {
   }
 }
 
-.top-bar-section ul li > a.top-bar__menu-item-with-icon {
+.top-bar-section ul li > a.top-bar--menu-item-with-icon {
   display: inline;
 }
 
-.top-bar__menu-item-with-icon i,
-.top-bar__menu-item-with-icon img {
+.top-bar--menu-item-with-icon i,
+.top-bar--menu-item-with-icon img {
   line-height: $topbar-height;
 }
 

--- a/app/assets/stylesheets/darkswarm/menu.css.scss
+++ b/app/assets/stylesheets/darkswarm/menu.css.scss
@@ -13,6 +13,21 @@ nav.top-bar {
   height: $topbar-height;
 }
 
+@media #{$large-only} {
+  .top-bar__menu-item-with-icon span {
+    display: none;
+  }
+}
+
+.top-bar-section ul li > a.top-bar__menu-item-with-icon {
+  display: inline;
+}
+
+.top-bar__menu-item-with-icon i,
+.top-bar__menu-item-with-icon img {
+  line-height: $topbar-height;
+}
+
 .top-bar-section {
   a.icon {
     &:hover {

--- a/app/assets/stylesheets/darkswarm/menu.css.scss
+++ b/app/assets/stylesheets/darkswarm/menu.css.scss
@@ -17,6 +17,19 @@ nav.top-bar {
   .top-bar__menu-item-with-icon span {
     display: none;
   }
+
+  .top-bar__current-hub-prefix,
+  .top-bar__current-hub-name {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .top-bar__current-hub-name {
+    max-width: 10em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .top-bar-section ul li > a.top-bar__menu-item-with-icon {

--- a/app/assets/stylesheets/darkswarm/variables.css.scss
+++ b/app/assets/stylesheets/darkswarm/variables.css.scss
@@ -14,7 +14,7 @@ $brand-colour: #f27052;
 
 // Topbar
 $topbar-height: rem-calc(64);
-$topbar-link-padding: $topbar-height / 3;
+$topbar-link-padding: $topbar-height / 4;
 $topbar-arrows: false;
 
 $topbar-bg: $white;

--- a/app/assets/stylesheets/darkswarm/variables.css.scss
+++ b/app/assets/stylesheets/darkswarm/variables.css.scss
@@ -15,6 +15,7 @@ $brand-colour: #f27052;
 // Topbar
 $topbar-height: rem-calc(64);
 $topbar-link-padding: $topbar-height / 3;
+$topbar-arrows: false;
 
 $topbar-bg: $white;
 $topbar-bg-color: $topbar-bg;

--- a/app/views/shared/menu/_language_selector.html.haml
+++ b/app/views/shared/menu/_language_selector.html.haml
@@ -1,5 +1,5 @@
 %li.language-switcher.has-dropdown
-  %a{href: '#'}
+  %a{href: '#', class: "top-bar__menu-item-with-icon"}
     %i.ofn-i_071-globe
     %span= t 'language_name'
   %ul.dropdown

--- a/app/views/shared/menu/_language_selector.html.haml
+++ b/app/views/shared/menu/_language_selector.html.haml
@@ -1,5 +1,5 @@
 %li.language-switcher.has-dropdown
-  %a{href: '#', class: "top-bar__menu-item-with-icon"}
+  %a{href: '#', class: "top-bar--menu-item-with-icon"}
     %i.ofn-i_071-globe
     %span= t 'language_name'
   %ul.dropdown

--- a/app/views/shared/menu/_large_menu.html.haml
+++ b/app/views/shared/menu/_large_menu.html.haml
@@ -29,9 +29,9 @@
 
       %li.current_hub{"ng-controller" => "CurrentHubCtrl", "ng-show" => "CurrentHub.hub.id", "ng-cloak" => true}
         %a{href: main_app.shop_path}
-          %span{ class: "top-bar__current-hub-prefix" }
+          %span{ class: "top-bar--current-hub-prefix" }
             = t 'label_shopping'
             = '@'
-          %span{ class: "top-bar__current-hub-name" } {{ CurrentHub.hub.name | truncate:25 }}
+          %span{ class: "top-bar--current-hub-name" } {{ CurrentHub.hub.name | truncate:25 }}
       %li.cart{"ng-cloak" => true}
         = render partial: "shared/menu/cart"

--- a/app/views/shared/menu/_large_menu.html.haml
+++ b/app/views/shared/menu/_large_menu.html.haml
@@ -29,8 +29,9 @@
 
       %li.current_hub{"ng-controller" => "CurrentHubCtrl", "ng-show" => "CurrentHub.hub.id", "ng-cloak" => true}
         %a{href: main_app.shop_path}
-          = t 'label_shopping'
-          = '@'
-          %span {{ CurrentHub.hub.name | truncate:25 }}
+          %span{ class: "top-bar__current-hub-prefix" }
+            = t 'label_shopping'
+            = '@'
+          %span{ class: "top-bar__current-hub-name" } {{ CurrentHub.hub.name | truncate:25 }}
       %li.cart{"ng-cloak" => true}
         = render partial: "shared/menu/cart"

--- a/app/views/shared/menu/_signed_in.html.haml
+++ b/app/views/shared/menu/_signed_in.html.haml
@@ -6,7 +6,7 @@
 
 %li.user-menu.has-dropdown.not-click
 
-  %a{href: "#"}
+  %a{href: "#", class: "top-bar__menu-item-with-icon"}
     %img{ src: "/assets/menu/icn-profile.svg" }
     %span
       = t '.profile'

--- a/app/views/shared/menu/_signed_in.html.haml
+++ b/app/views/shared/menu/_signed_in.html.haml
@@ -6,7 +6,7 @@
 
 %li.user-menu.has-dropdown.not-click
 
-  %a{href: "#", class: "top-bar__menu-item-with-icon"}
+  %a{href: "#", class: "top-bar--menu-item-with-icon"}
     %img{ src: "/assets/menu/icn-profile.svg" }
     %span
       = t '.profile'


### PR DESCRIPTION
#### What? Why?

Closes #3967

We make the menu items compact for screens below 1600px (it was 1450px previously).
We should also make the mobile menu appear for screens below 1200px (it is around 1000px now) **but I can't find where this is done**. Any idea?

#### What should we test?
Issue will not happen and menu displays correctly for different screen widths with different data setups:
- logged in, not logged in
- shopping somewhere, not shopping anywhere
- different languages

#### Release notes
Changelog Category: Fixed
Fixed display problem with menu: the menu is not breaking in two lines now in some situations.

