### PR TITLE
Convert several fields from string to text

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -90,7 +90,6 @@ class Enterprise < ActiveRecord::Base
   validates :permalink, uniqueness: true, presence: true
   validate :shopfront_taxons
   validate :enforce_ownership_limit, if: lambda { owner_id_changed? && !owner_id.nil? }
-  validates :description, length: { maximum: 255 }
 
   before_validation :initialize_permalink, if: lambda { permalink.nil? }
   before_validation :ensure_owner_is_manager, if: lambda { owner_id_changed? && !owner_id.nil? }

--- a/db/migrate/20190701002454_convert_string_fields_to_text.rb
+++ b/db/migrate/20190701002454_convert_string_fields_to_text.rb
@@ -1,0 +1,17 @@
+class ConvertStringFieldsToText < ActiveRecord::Migration
+  def up
+    change_column :enterprises, :description, :text
+    change_column :enterprises, :pickup_times, :text
+    change_column :exchanges, :pickup_time, :text
+    change_column :exchanges, :pickup_instructions, :text
+    change_column :exchanges, :receival_instructions, :text
+  end
+
+  def down
+    change_column :enterprises, :description, :string
+    change_column :enterprises, :pickup_times, :string
+    change_column :exchanges, :pickup_time, :string
+    change_column :exchanges, :pickup_instructions, :string
+    change_column :exchanges, :receival_instructions, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190506194625) do
+ActiveRecord::Schema.define(:version => 20190701002454) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -175,7 +175,7 @@ ActiveRecord::Schema.define(:version => 20190506194625) do
 
   create_table "enterprises", :force => true do |t|
     t.string   "name"
-    t.string   "description"
+    t.text     "description"
     t.text     "long_description"
     t.boolean  "is_primary_producer"
     t.string   "contact_name"
@@ -185,7 +185,7 @@ ActiveRecord::Schema.define(:version => 20190506194625) do
     t.string   "abn"
     t.string   "acn"
     t.integer  "address_id"
-    t.string   "pickup_times"
+    t.text     "pickup_times"
     t.string   "next_collection_at"
     t.datetime "created_at",                                   :null => false
     t.datetime "updated_at",                                   :null => false
@@ -247,12 +247,12 @@ ActiveRecord::Schema.define(:version => 20190506194625) do
     t.integer  "order_cycle_id"
     t.integer  "sender_id"
     t.integer  "receiver_id"
-    t.string   "pickup_time"
-    t.string   "pickup_instructions"
+    t.text     "pickup_time"
+    t.text     "pickup_instructions"
     t.datetime "created_at",                               :null => false
     t.datetime "updated_at",                               :null => false
     t.boolean  "incoming",              :default => false, :null => false
-    t.string   "receival_instructions"
+    t.text     "receival_instructions"
   end
 
   add_index "exchanges", ["order_cycle_id"], :name => "index_exchanges_on_order_cycle_id"

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -114,7 +114,6 @@ describe Enterprise do
     subject { FactoryBot.create(:distributor_enterprise) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:permalink) }
-    it { is_expected.to ensure_length_of(:description).is_at_most(255) }
 
     it "requires an owner" do
       expect{


### PR DESCRIPTION
#### What? Why?

See discussion here:
https://github.com/openfoodfoundation/openfoodnetwork/pull/3751#issuecomment-503416955

Fixes #3192 to enable exchange pickup instructions to exceed 255 characters.

I have also done a pass over the schema to identify other fields which
would benefit from being a text rather than a string. However, I ignored
all `spree_*` tables because I didn’t want to mess up the ‘default’
Spree schema.

#### What should we test?

That the fields below can be longer than 255 characters.

#### Release notes

Enable several fields to contain more than 255 characters. These are:
enterprise description, enterprise pickup times, exchange pickup time, exchange
pickup instructions, exchange receival instructions.

Changelog Category: Fixed