### PR TITLE
3978 Optimise products cache

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -121,11 +121,6 @@ Naming/AccessorMethodName:
     - 'spec/support/request/web_helper.rb'
 
 # Offense count: 1
-Naming/BinaryOperatorParameterName:
-  Exclude:
-    - 'app/models/exchange.rb'
-
-# Offense count: 1
 # Configuration parameters: Blacklist.
 # Blacklist: (?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))
 Naming/HeredocDelimiterNaming:
@@ -173,7 +168,6 @@ Naming/UncommunicativeMethodParamName:
     - 'app/helpers/admin/injection_helper.rb'
     - 'app/helpers/spree/admin/base_helper_decorator.rb'
     - 'app/helpers/spree/base_helper_decorator.rb'
-    - 'app/models/exchange.rb'
     - 'app/services/subscription_validator.rb'
     - 'lib/open_food_network/reports/bulk_coop_report.rb'
     - 'lib/open_food_network/xero_invoices_report.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,7 +61,6 @@ Lint/IneffectiveAccessModifier:
     - 'app/models/column_preference.rb'
     - 'app/services/mail_configuration.rb'
     - 'lib/open_food_network/feature_toggle.rb'
-    - 'lib/open_food_network/products_cache.rb'
     - 'spec/lib/open_food_network/reports/report_spec.rb'
 
 # Offense count: 1
@@ -87,7 +86,6 @@ Lint/UselessAccessModifier:
     - 'app/models/column_preference.rb'
     - 'app/services/mail_configuration.rb'
     - 'lib/open_food_network/feature_toggle.rb'
-    - 'lib/open_food_network/products_cache.rb'
     - 'lib/open_food_network/reports/bulk_coop_report.rb'
     - 'spec/lib/open_food_network/reports/report_spec.rb'
 
@@ -433,7 +431,6 @@ Style/GuardClause:
     - 'app/services/order_syncer.rb'
     - 'lib/discourse/single_sign_on.rb'
     - 'lib/open_food_network/order_cycle_form_applicator.rb'
-    - 'lib/open_food_network/products_cache.rb'
     - 'lib/open_food_network/products_renderer.rb'
     - 'lib/open_food_network/rack_request_blocker.rb'
     - 'lib/open_food_network/variant_and_line_item_naming.rb'

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -38,7 +38,7 @@ class Exchange < ActiveRecord::Base
   }
   scope :with_any_variant, lambda { |variant_ids|
     joins(:exchange_variants).
-      where('exchange_variants.variant_id IN (?)', variant_ids).
+      where(exchange_variants: { variant_id: variant_ids }).
       select('DISTINCT exchanges.*')
   }
   scope :with_product, lambda { |product|

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -1,3 +1,12 @@
+# Representation of an enterprise being part of an order cycle.
+#
+# A producer can be part as supplier. The supplier's products can be selected to
+# be available in the order cycle (incoming products).
+#
+# A selling enterprise can be part as distributor. The order cycle then appears
+# in its shopfront. Any incoming product can be selected to be shown in the
+# shopfront (outgoing products). But the set of shown products can be smaller
+# than all incoming products.
 class Exchange < ActiveRecord::Base
   acts_as_taggable
 

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -99,21 +99,6 @@ class Exchange < ActiveRecord::Base
     incoming? ? sender : receiver
   end
 
-  def to_h(core_only = false)
-    h = attributes.merge('variant_ids' => variant_ids.sort,
-                         'enterprise_fee_ids' => enterprise_fee_ids.sort)
-    h.reject! { |k| %w(id order_cycle_id created_at updated_at).include? k } if core_only
-    h
-  end
-
-  def eql?(e)
-    if e.respond_to? :to_h
-      to_h(true) == e.to_h(true)
-    else
-      super e
-    end
-  end
-
   def refresh_products_cache
     OpenFoodNetwork::ProductsCache.exchange_changed self
   end

--- a/lib/open_food_network/products_cache.rb
+++ b/lib/open_food_network/products_cache.rb
@@ -170,7 +170,8 @@ module OpenFoodNetwork
           incoming_exchange.order_cycle,
           incoming_exchange.variant_ids
         )
-      end.flatten.uniq
+      end.flatten.uniq { |ex| [ex.receiver_id, ex.order_cycle_id]}
+      # Comparing only on these two ids is much faster.
     end
     private_class_method :outgoing_exchanges_affected_by
 

--- a/lib/open_food_network/products_cache.rb
+++ b/lib/open_food_network/products_cache.rb
@@ -165,13 +165,13 @@ module OpenFoodNetwork
     private_class_method :incoming_exchanges
 
     def self.outgoing_exchanges_affected_by(exchanges)
-      incoming_exchanges(exchanges).map do |incoming_exchange|
-        outgoing_exchanges_with_variants(
-          incoming_exchange.order_cycle,
-          incoming_exchange.variant_ids
-        )
-      end.flatten.uniq { |ex| [ex.receiver_id, ex.order_cycle_id]}
-      # Comparing only on these two ids is much faster.
+      incoming = incoming_exchanges(exchanges)
+      order_cycle_ids = incoming.select(:order_cycle_id)
+      variant_ids = ExchangeVariant.where(exchange_id: incoming).select(:variant_id)
+      Exchange.outgoing.
+        in_order_cycle(order_cycle_ids).
+        with_any_variant(variant_ids).
+        except(:select).select("DISTINCT receiver_id, order_cycle_id")
     end
     private_class_method :outgoing_exchanges_affected_by
 

--- a/lib/open_food_network/products_cache.rb
+++ b/lib/open_food_network/products_cache.rb
@@ -116,12 +116,7 @@ module OpenFoodNetwork
     private_class_method :exchanges_featuring_variants
 
     def self.refresh_incoming_exchanges(exchanges)
-      incoming_exchanges(exchanges).map do |incoming_exchange|
-        outgoing_exchanges_with_variants(
-          incoming_exchange.order_cycle,
-          incoming_exchange.variant_ids
-        )
-      end.flatten.uniq.each do |outgoing_exchange|
+      outgoing_exchanges_affected_by(exchanges).each do |outgoing_exchange|
         refresh_cache(outgoing_exchange.receiver, outgoing_exchange.order_cycle)
       end
     end
@@ -168,6 +163,16 @@ module OpenFoodNetwork
         merge(OrderCycle.not_closed)
     end
     private_class_method :incoming_exchanges
+
+    def self.outgoing_exchanges_affected_by(exchanges)
+      incoming_exchanges(exchanges).map do |incoming_exchange|
+        outgoing_exchanges_with_variants(
+          incoming_exchange.order_cycle,
+          incoming_exchange.variant_ids
+        )
+      end.flatten.uniq
+    end
+    private_class_method :outgoing_exchanges_affected_by
 
     def self.outgoing_exchanges_with_variants(order_cycle, variant_ids)
       order_cycle.exchanges.outgoing.

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -285,61 +285,15 @@ describe Exchange do
     ex1.update_attribute(:tag_list, "wholesale")
     ex2 = ex1.clone! new_oc
 
-    expect(ex1.eql?(ex2)).to be true
+    expect(ex1.sender_id).to eq ex2.sender_id
+    expect(ex1.receiver_id).to eq ex2.receiver_id
+    expect(ex1.pickup_time).to eq ex2.pickup_time
+    expect(ex1.pickup_instructions).to eq ex2.pickup_instructions
+    expect(ex1.incoming).to eq ex2.incoming
+    expect(ex1.receival_instructions).to eq ex2.receival_instructions
+    expect(ex1.variant_ids).to eq ex2.variant_ids
+    expect(ex1.enterprise_fee_ids).to eq ex2.enterprise_fee_ids
+
     expect(ex2.reload.tag_list).to eq ["wholesale"]
-  end
-
-  describe "converting to hash" do
-    let(:oc) { create(:order_cycle) }
-    let(:exchange) do
-      exchange = oc.exchanges.last
-      exchange.save!
-      allow(exchange).to receive(:variant_ids) { [1835, 1834] } # Test id ordering
-      allow(exchange).to receive(:enterprise_fee_ids) { [1493, 1492] } # Test id ordering
-      exchange
-    end
-
-    it "converts to a hash" do
-      expect(exchange.to_h).to eq(
-        'id' => exchange.id, 'order_cycle_id' => oc.id,
-        'sender_id' => exchange.sender_id, 'receiver_id' => exchange.receiver_id,
-        'incoming' => exchange.incoming,
-        'variant_ids' => exchange.variant_ids.sort,
-        'enterprise_fee_ids' => exchange.enterprise_fee_ids.sort,
-        'pickup_time' => exchange.pickup_time, 'pickup_instructions' => exchange.pickup_instructions,
-        'receival_instructions' => exchange.receival_instructions,
-        'created_at' => exchange.created_at, 'updated_at' => exchange.updated_at
-      )
-    end
-
-    it "converts to a hash of core attributes only" do
-      expect(exchange.to_h(true)).to eq(
-        'sender_id' => exchange.sender_id, 'receiver_id' => exchange.receiver_id,
-        'incoming' => exchange.incoming,
-        'variant_ids' => exchange.variant_ids.sort,
-        'enterprise_fee_ids' => exchange.enterprise_fee_ids.sort,
-        'pickup_time' => exchange.pickup_time, 'pickup_instructions' => exchange.pickup_instructions,
-        'receival_instructions' => exchange.receival_instructions
-      )
-    end
-  end
-
-  describe "comparing equality" do
-    it "compares Exchanges using to_h" do
-      e1 = Exchange.new
-      e2 = Exchange.new
-
-      allow(e1).to receive(:to_h) { { 'sender_id' => 456 } }
-      allow(e2).to receive(:to_h) { { 'sender_id' => 456 } }
-
-      expect(e1.eql?(e2)).to be true
-    end
-
-    it "compares other objects using super" do
-      exchange = Exchange.new
-      exchange_fee = ExchangeFee.new
-
-      expect(exchange.eql?(exchange_fee)).to be false
-    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3978.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Updating enterprise fees became so slow that timeouts were reached and people couldn't change fees any more. I found this to be an issue between inefficient code in the ProductsCache and a very inefficient and almost unused override of `Exchange#eql?`. I approached the problem from two sides:

1. I made the ProductsCache more efficient, not using `exchanges.uniq` which is using `eql?`.
2. I removed the override of `eql?` to avoid similar mistakes in the future.

The increased performance affects updating fees and adding and removing products from order cycles.

#### What should we test?
<!-- List which features should be tested and how. -->

Order cycles and product caching have been touched.

1. Activate products cache if not active on the current staging server (Settings / Caching).
1. Create an order cycle with multiple incoming and outgoing enterprises. Check the shopfront.
2. Change the products in the order cycle and check that they carry through to the shop.
2. Remove a producer from the order cycle and check the shop.
3. Change fees in the order cycle and make sure they carry through.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: In rare circumstances a shopfront would not update after changing enterprise fees.
Fixed: Performance issues when updating enterprise fees.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

