### PR TITLE
Preload primary font to speed up page rendering

### DIFF
--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -13,6 +13,7 @@
     - else
       = favicon_link_tag "/favicon-staging.ico"
     %link{href: "https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700", rel: "stylesheet", type: "text/css"}
+    %link{href: "/OFN-v2.woff?eslsji", rel: "preload", as: "font", crossorigin: "anonymous"}
 
     = yield :scripts
     %script{:src => "https://js.stripe.com/v3/", :type => "text/javascript"}


### PR DESCRIPTION
#### What? Why?

Related to #3860

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Preloads the main font file (a suggested by Google Pagespeed Insights)

![preload](https://user-images.githubusercontent.com/9029026/60511814-ca210800-9cca-11e9-9109-152f549a4584.png)


#### What should we test?
<!-- List which features should be tested and how. -->

Fonts render correctly?

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Use font preloading to improve page speed.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

