### PR TITLE
Remove obsolete backup script

### DIFF
--- a/script/backup.sh
+++ b/script/backup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Usage: script/backup.sh [ofn-staging1|ofn-staging2|ofn-prod]
-
-set -e
-
-mkdir -p db/backup
-ssh $1 "pg_dump -h localhost -U openfoodweb openfoodweb_production |gzip" > db/backup/$1-`date +%Y%m%d`.sql.gz


### PR DESCRIPTION
#### What? Why?

This script doesn't work anymore. It was written for old an Australian
production server. We have automatic backups now. And if we wanted to
take a backup manually, we should probably give it a meaningful name,
not using a script.


#### What should we test?
<!-- List which features should be tested and how. -->

Nothing.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Removed obsolete backup script.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Removed

