### PR TITLE
Remove obsolete Javascript test script

### DIFF
--- a/script/ng-test.sh
+++ b/script/ng-test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-BASE_DIR=`dirname $0`
-
-echo ""
-echo "Starting Karma Server"
-echo "-------------------------------------------------------------------"
-
-karma start $BASE_DIR/../config/ng-test.conf.js $*


### PR DESCRIPTION
#### What? Why?

This script has been replaced by a rake task a long time ago:

    bundle exec rake karma:run   # to run the specs once
    bundle exec rake karma:start # to run the specs after each change

We don't need it any more and it doesn't work on my machine.


#### What should we test?
<!-- List which features should be tested and how. -->

Nothing.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Removed obsolete test script.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Removed
