### PR TITLE
Fix failing migration by clearing schema cache

### DIFF
--- a/db/migrate/20180910155506_add_uniqueness_of_order_id_to_spree_shipments.rb
+++ b/db/migrate/20180910155506_add_uniqueness_of_order_id_to_spree_shipments.rb
@@ -1,6 +1,9 @@
 # This migration is an OFN specific migration that enforces an order to have a single shipment at all times
 class AddUniquenessOfOrderIdToSpreeShipments < ActiveRecord::Migration
   def change
+    Spree::InventoryUnit.connection.schema_cache.clear!
+    Spree::InventoryUnit.reset_column_information
+
     destroy_all_but_latest_shipments
 
     remove_index :spree_shipments, :order_id


### PR DESCRIPTION
#### What? Why?

Closes #3980 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Fixes a failing migration for the v2 rollout which appeared with French data. 

I confirmed the issue using a combination of ofn-install, Vagrant and French production data. Added this change and ran the migrations again (after resetting the database to the pre-migration state) and it's now proceeding without error.

More info here: https://github.com/openfoodfoundation/openfoodnetwork/issues/3980#issuecomment-508058021

#### What should we test?
<!-- List which features should be tested and how. -->

Maybe @mkllnk can test the migrations again?