### PR TITLE
Display enterprise ID in profile

### DIFF
--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -63,13 +63,6 @@
       %span{ ng: { class: 'availability.toLowerCase()', hide: "checking" } }
         {{ availability }}
         %i{ ng: { class: "{'icon-ok-sign': availability == 'Available', 'icon-remove-sign': availability == 'Unavailable'}" } }
-  .row
-    .three.columns.alpha
-      = f.label :id, t('.ofn_uid')
-      %div{'ofn-with-tip' => t('.ofn_uid_tip')}
-        %a= t('admin.whats_this')
-    .six.columns
-      {{Enterprise.id}}
   .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
     .three.columns.alpha
       %label= t('.link_to_front')
@@ -78,3 +71,10 @@
     .eight.columns.omega
       = surround spree.root_url, "/shop" do
         {{Enterprise.permalink}}
+  .row
+    .three.columns.alpha
+      = f.label :id, t('.ofn_uid')
+      %div{'ofn-with-tip' => t('.ofn_uid_tip')}
+        %a= t('admin.whats_this')
+    .six.columns
+      {{Enterprise.id}}

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -69,7 +69,7 @@
       %div{'ofn-with-tip' => t('.ofn_uid_tip')}
         %a= t('admin.whats_this')
     .six.columns
-      = f.text_field :id, value: f.object.id, disabled: true
+      {{Enterprise.id}}
   .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
     .three.columns.alpha
       %label= t('.link_to_front')

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -63,13 +63,13 @@
       %span{ ng: { class: 'availability.toLowerCase()', hide: "checking" } }
         {{ availability }}
         %i{ ng: { class: "{'icon-ok-sign': availability == 'Available', 'icon-remove-sign': availability == 'Unavailable'}" } }
-  .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
+  .row
     .three.columns.alpha
-      = f.label :permalink, t('.ofn_uid')
-      %div{'ofn-with-tip' => t('.ofn_uid_tip', link: spree.root_url)}
+      = f.label :id, t('.ofn_uid')
+      %div{'ofn-with-tip' => t('.ofn_uid_tip')}
         %a= t('admin.whats_this')
     .six.columns
-      = f.text_field :id, { 'ng-model' => "Enterprise.id", 'ng-model-options' => "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }", 'ng-disabled' => true }
+      = f.text_field :id, value: f.object.id, disabled: true
   .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
     .three.columns.alpha
       %label= t('.link_to_front')

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -65,6 +65,13 @@
         %i{ ng: { class: "{'icon-ok-sign': availability == 'Available', 'icon-remove-sign': availability == 'Unavailable'}" } }
   .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
     .three.columns.alpha
+      = f.label :permalink, t('.ofn_uid')
+      %div{'ofn-with-tip' => t('.ofn_uid_tip', link: spree.root_url)}
+        %a= t('admin.whats_this')
+    .six.columns
+      = f.text_field :id, { 'ng-model' => "Enterprise.id", 'ng-model-options' => "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }", 'ng-disabled' => true }
+  .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
+    .three.columns.alpha
       %label= t('.link_to_front')
       %div{'ofn-with-tip' => t('.link_to_front_tip')}
         %a= t('admin.whats_this')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -705,6 +705,8 @@ en:
           permalink_tip: "This permalink is used to create the url to your shop: %{link}your-shop-name/shop"
           link_to_front: Link to shop front
           link_to_front_tip: A direct link to your shopfront on the Open Food Network.
+          ofn_uid: OFN UID
+          ofn_uid_tip: The uniq id used to identify the enterprise on Open Food Network.
         shipping_methods:
           name: Name
           applies: Applies?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -706,7 +706,7 @@ en:
           link_to_front: Link to shop front
           link_to_front_tip: A direct link to your shopfront on the Open Food Network.
           ofn_uid: OFN UID
-          ofn_uid_tip: The uniq id used to identify the enterprise on Open Food Network.
+          ofn_uid_tip: The unique id used to identify the enterprise on Open Food Network.
         shipping_methods:
           name: Name
           applies: Applies?


### PR DESCRIPTION
This ID is used by people to setup Zapier for example. It can also be used to cross-check values.

Closes #3990

We could get this ID from the Web Console or from the API, but we can also just add it here, it costs very less and people can focus on other things.



#### What should we test?
The enterprise profile should be tested to be sure the value is display properly on the Primary Details section.


#### Release notes
- Display enterprise ID on enterprise profile


Changelog Category: Added
