### PR TITLE
Upgrade fuubar to 241 to skip yanked 240

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ group :test, :development do
   gem 'capybara', '>= 2.15.4'
   gem 'database_cleaner', '0.7.1', require: false
   gem "factory_bot_rails", require: false
-  gem 'fuubar', '~> 2.4.0'
+  gem 'fuubar', '~> 2.4.1'
   gem 'json_spec', '~> 1.1.4'
   gem 'knapsack'
   gem 'letter_opener', '>= 1.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,7 +456,7 @@ GEM
     foundation-rails (5.5.2.1)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
-    fuubar (2.4.0)
+    fuubar (2.4.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     geocoder (1.1.8)
@@ -817,7 +817,7 @@ DEPENDENCIES
   foundation-icons-sass-rails
   foundation-rails
   foundation_rails_helper!
-  fuubar (~> 2.4.0)
+  fuubar (~> 2.4.1)
   geocoder
   gmaps4rails
   guard


### PR DESCRIPTION
#### What? Why?

Fixes fuubar 2.4.0 missing dependency.

#### What should we test?
Green build is enough.

#### Release notes
This is an hotfix to 2.1.0 to fix the missing dependency of fuubar: fuubar 2.4.0 was yanked making our deployment process fail. Fuubar is only used in test code so no changes to production code in this hotfix.

Changelog Category: Fixed
