### PR TITLE
Apply 2.1.1 hotfix to master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ group :test, :development do
   gem 'capybara', '>= 2.15.4'
   gem 'database_cleaner', '0.7.1', require: false
   gem "factory_bot_rails", require: false
-  gem 'fuubar', '~> 2.4.0'
+  gem 'fuubar', '~> 2.4.1'
   gem 'json_spec', '~> 1.1.4'
   gem 'knapsack'
   gem 'letter_opener', '>= 1.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,7 +447,7 @@ GEM
     foundation-rails (5.5.2.1)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
-    fuubar (2.4.0)
+    fuubar (2.4.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     geocoder (1.1.8)
@@ -809,7 +809,7 @@ DEPENDENCIES
   foundation-icons-sass-rails
   foundation-rails
   foundation_rails_helper!
-  fuubar (~> 2.4.0)
+  fuubar (~> 2.4.1)
   geocoder
   gmaps4rails
   guard


### PR DESCRIPTION
#### What? Why?

This is applying the hotfix 2.1.1 to master.
https://github.com/openfoodfoundation/openfoodnetwork/releases/tag/v2.1.1

The hotfix was built from branch 2.1.0 and needs to be put into master. Original PR against 2.1.0 branch #4008
