### PR TITLE
LineItems can always access soft-deleted variants

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -20,7 +20,7 @@ Spree::LineItem.class_eval do
 
   before_destroy :update_inventory_before_destroy
 
-  delegate :unit_description, to: :variant
+  delegate :product, :unit_description, to: :variant
 
   # -- Scopes
   scope :managed_by, lambda { |user|
@@ -73,6 +73,11 @@ Spree::LineItem.class_eval do
           AND spree_adjustments.originator_type='Spree::TaxRate')").
       where('spree_adjustments.id IS NULL')
   }
+
+  def variant
+    # Overridden so that LineItems always have access to soft-deleted Variant attributes
+    Spree::Variant.unscoped { super }
+  end
 
   def cap_quantity_at_stock!
     scoper.scope(variant)

--- a/spec/features/admin/reports/packing_report_spec.rb
+++ b/spec/features/admin/reports/packing_report_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+feature "Packing Reports", js: true do
+  include AuthenticationWorkflow
+  include WebHelper
+
+  let(:distributor) { create(:distributor_enterprise) }
+  let(:oc) { create(:simple_order_cycle) }
+  let(:order) { create(:order, completed_at: 1.day.ago, order_cycle: oc, distributor: distributor) }
+  let(:li1) { build(:line_item_with_shipment) }
+  let(:li2) { build(:line_item_with_shipment) }
+
+  before do
+    order.line_items << li1
+    order.line_items << li2
+    quick_login_as_admin
+  end
+
+  describe "viewing a report" do
+    context "when an associated variant has been soft-deleted" do
+      it "shows line items" do
+        li1.variant.delete
+
+        visit spree.admin_reports_path
+
+        click_on I18n.t("admin.reports.packing.name")
+        select oc.name, from: "q_order_cycle_id_in"
+
+        find('#q_completed_at_gt').click
+        select_date(Time.zone.today - 1.days)
+
+        find('#q_completed_at_lt').click
+        select_date(Time.zone.today)
+
+        find("button[type='submit']").click
+
+        expect(page).to have_content li1.product.name
+        expect(page).to have_content li2.product.name
+      end
+    end
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -585,5 +585,17 @@ module Spree
         }.to change(Spree::OptionValue, :count).by(0)
       end
     end
+
+    describe "when the associated variant is soft-deleted" do
+      let!(:variant) { create(:variant) }
+      let!(:line_item) { create(:line_item, variant: variant) }
+
+      it "returns the associated variant or product" do
+        line_item.variant.delete
+
+        expect(line_item.variant).to eq variant
+        expect(line_item.product).to eq variant.product
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #4016

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Looking at errors around soft-deleted variants and ways to work around them in the context of reports, I ended up with the question: "should a `LineItem` _always_ have access to it's soft-deleted variant so it can check it's attributes?". I think the answer is probably "yes"?

Options for working around soft-deleted associated objects with the paranoia gem are here: https://github.com/rubysherpas/paranoia#usage

It looks like there's a nicer way of doing this by applying a scope directly on the associations, but it's not available until Rails 4...

#### What should we test?
<!-- List which features should be tested and how. -->

Reports should display correctly even if a purchased variant has been deleted. From the bug report, this affects: "packing report, orders and distributors report, and all of the orders and fulfilment reports". 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Ensure LineItem can always access it's soft-deleted Variant.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed