### PR TITLE
4033 Remove line item adjustments when line item removed

### DIFF
--- a/app/models/concerns/line_item_based_adjustment_handling.rb
+++ b/app/models/concerns/line_item_based_adjustment_handling.rb
@@ -1,0 +1,8 @@
+module LineItemBasedAdjustmentHandling
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :adjustments_for_which_source, class_name: "Spree::Adjustment", as: :source,
+                                            dependent: :destroy
+  end
+end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -3,6 +3,7 @@ require 'open_food_network/variant_and_line_item_naming'
 
 Spree::LineItem.class_eval do
   include OpenFoodNetwork::VariantAndLineItemNaming
+  include LineItemBasedAdjustmentHandling
   has_and_belongs_to_many :option_values, join_table: 'spree_option_values_line_items', class_name: 'Spree::OptionValue'
 
   # Redefining here to add the inverse_of option

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -398,7 +398,7 @@ describe Spree::Order do
         expect(order.line_items(:reload).map(&:variant)).to eq([v2])
       end
 
-      pending "removes the variant's adjustment" do
+      it "removes the variant's adjustment" do
         line_item = order.line_items.where(variant_id: v1.id).first
         adjustment_scope = Spree::Adjustment.where(source_type: "Spree::LineItem",
                                                    source_id: line_item.id)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -366,6 +366,8 @@ describe Spree::Order do
     before do
       order.add_variant v1
       order.add_variant v2
+
+      order.update_distribution_charge!
     end
 
     it "removes the variant's line item" do
@@ -377,6 +379,34 @@ describe Spree::Order do
       expect do
         order.remove_variant v3
       end.to change(order.line_items(:reload), :count).by(0)
+    end
+
+    context "when the item has an associated adjustment" do
+      let(:distributor) { create(:distributor_enterprise) }
+
+      let(:order_cycle) do
+        create(:order_cycle).tap do |record|
+          create(:exchange, variants: [v1], incoming: true)
+          create(:exchange, variants: [v1], incoming: false, receiver: distributor)
+        end
+      end
+
+      let(:order) { create(:order, distributor: distributor, order_cycle: order_cycle) }
+
+      it "removes the variant's line item" do
+        order.remove_variant v1
+        expect(order.line_items(:reload).map(&:variant)).to eq([v2])
+      end
+
+      pending "removes the variant's adjustment" do
+        line_item = order.line_items.where(variant_id: v1.id).first
+        adjustment_scope = Spree::Adjustment.where(source_type: "Spree::LineItem",
+                                                   source_id: line_item.id)
+        expect(adjustment_scope.count).to eq(1)
+        adjustment = adjustment_scope.first
+        order.remove_variant v1
+        expect { adjustment.reload }.to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #4033 

This is a simple solution to removing the line item adjustments left behind when the line items for which they are source have been deleted.

#### What should we test?

To set up the OC:

1. Add at least two variants to an OC.
2. Set up a coordinator, an incoming, and an outgoing _line item based_ enterprise fee. You can use "Flat Percent (per item)" or other calculators except the following:
      - `Spree::Calculator::FlatRate`
      - `Spree::Calculator::FlexiRate`
      - `Spree::Calculator::PriceSack`
      - `Spree::Calculator::PerItem` (See [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/4033#issuecomment-511062897) why.)

As customer:

1. Add two variants with associated enterprise fees in the order cycle.
2. Remove the first line item.
3. Go to the checkout page. Check that the order total is correct.

As admin:

1. Go to the order page for the order that is still in "Cart" state.
2. Check that the adjustments for the removed line item are not there.
3. Check that the order total does not include these adjustments.

As customer:

1. Go back to the cart page.
2. Change the quantity for the remaining line item, and click on "Update". Reload the page, and check that it worked.
3. Click on "Empty Cart". Check that it worked.

#### Release notes

- Delete line item adjustments when the line items for which they are source have been deleted. #4033

Changelog Category: Fixed