### PR TITLE
Subscriptions - When editing subscriptions, check stock levels when changing orders in current OC

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -127,10 +127,8 @@ Metrics/LineLength:
   - app/services/cart_service.rb
   - app/services/default_stock_location.rb
   - app/services/embedded_page_service.rb
-  - app/services/line_item_syncer.rb
   - app/services/order_cycle_form.rb
   - app/services/order_factory.rb
-  - app/services/order_syncer.rb
   - app/services/subscriptions_count.rb
   - app/services/variants_stock_levels.rb
   - app/views/json/_groups.rabl
@@ -159,7 +157,6 @@ Metrics/LineLength:
   - lib/open_food_network/permissions.rb
   - lib/open_food_network/products_cache.rb
   - lib/open_food_network/products_renderer.rb
-  - lib/open_food_network/proxy_order_syncer.rb
   - lib/open_food_network/reports/bulk_coop_allocation_report.rb
   - lib/open_food_network/reports/line_items.rb
   - lib/open_food_network/sales_tax_report.rb
@@ -346,7 +343,6 @@ Metrics/LineLength:
   - spec/models/tag_rule/filter_shipping_methods_spec.rb
   - spec/models/variant_override_spec.rb
   - spec/performance/orders_controller_spec.rb
-  - spec/performance/proxy_order_syncer_spec.rb
   - spec/performance/shop_controller_spec.rb
   - spec/requests/checkout/failed_checkout_spec.rb
   - spec/requests/checkout/paypal_spec.rb

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -22,9 +22,15 @@ class LineItemSyncer
   def update_item_quantities(order)
     changed_subscription_line_items.each do |sli|
       line_item = order.line_items.find_by_variant_id(sli.variant_id)
-      next if update_quantity(line_item, sli)
 
-      add_order_update_issue(order, line_item)
+      if line_item.blank?
+        order_update_issues.add(order, sli.variant.product_and_full_name)
+        next
+      end
+
+      unless update_quantity(line_item, sli)
+        add_order_update_issue(order, line_item)
+      end
     end
   end
 

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -37,14 +37,7 @@ class LineItemSyncer
       next if skip_stock_check?(order) || new_line_item.sufficient_stock?
 
       order.line_items.delete(new_line_item)
-
-      issue_description = "#{new_line_item.product.name} - #{new_line_item.full_name}"
-      if new_line_item.variant.in_stock?
-        issue_description << I18n.t("spree.orders.line_item.insufficient_stock", on_hand: new_line_item.variant.on_hand)
-      else
-        issue_description << I18n.t("spree.orders.line_item.out_of_stock")
-      end
-      order_update_issues.add(order, issue_description)
+      add_order_update_issue(order, new_line_item)
     end
   end
 
@@ -74,5 +67,15 @@ class LineItemSyncer
 
   def skip_stock_check?(order)
     !order.complete?
+  end
+
+  def add_order_update_issue(order, line_item)
+    issue_description = "#{line_item.product.name} - #{line_item.full_name}"
+    if line_item.variant.in_stock?
+      issue_description << I18n.t("spree.orders.line_item.insufficient_stock", on_hand: line_item.variant.on_hand)
+    else
+      issue_description << I18n.t("spree.orders.line_item.out_of_stock")
+    end
+    order_update_issues.add(order, issue_description)
   end
 end

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -30,13 +30,19 @@ class LineItemSyncer
 
   def create_new_items(order)
     new_subscription_line_items.each do |sli|
-      new_line_item = order.line_items.create(variant_id: sli.variant_id, quantity: sli.quantity, skip_stock_check: skip_stock_check?(order))
+      new_line_item = order.line_items.create(variant_id: sli.variant_id,
+                                              quantity: sli.quantity,
+                                              skip_stock_check: skip_stock_check?(order))
       new_line_item.destroy if !skip_stock_check?(order) && new_line_item.insufficient_stock?
     end
   end
 
   def destroy_obsolete_items(order)
-    order.line_items.where(variant_id: subscription_line_items.select(&:marked_for_destruction?).map(&:variant_id)).destroy_all
+    order.line_items.
+      where(variant_id: subscription_line_items.
+                        select(&:marked_for_destruction?).
+                        map(&:variant_id)).
+      destroy_all
   end
 
   def changed_subscription_line_items
@@ -49,7 +55,8 @@ class LineItemSyncer
 
   def update_quantity(line_item, sli)
     if line_item.quantity == sli.quantity_was
-      return line_item.update_attributes(quantity: sli.quantity, skip_stock_check: skip_stock_check?(line_item.order))
+      return line_item.update_attributes(quantity: sli.quantity,
+                                         skip_stock_check: skip_stock_check?(line_item.order))
     end
     line_item.quantity == sli.quantity
   end

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -30,7 +30,8 @@ class LineItemSyncer
 
   def create_new_items(order)
     new_subscription_line_items.each do |sli|
-      order.line_items.create(variant_id: sli.variant_id, quantity: sli.quantity, skip_stock_check: skip_stock_check?(order))
+      new_line_item = order.line_items.create(variant_id: sli.variant_id, quantity: sli.quantity, skip_stock_check: skip_stock_check?(order))
+      new_line_item.destroy if !skip_stock_check?(order) && new_line_item.insufficient_stock?
     end
   end
 

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -30,7 +30,7 @@ class LineItemSyncer
 
   def create_new_items(order)
     new_subscription_line_items.each do |sli|
-      order.line_items.create(variant_id: sli.variant_id, quantity: sli.quantity, skip_stock_check: true)
+      order.line_items.create(variant_id: sli.variant_id, quantity: sli.quantity, skip_stock_check: skip_stock_check?(order))
     end
   end
 
@@ -48,8 +48,12 @@ class LineItemSyncer
 
   def update_quantity(line_item, sli)
     if line_item.quantity == sli.quantity_was
-      return line_item.update_attributes(quantity: sli.quantity, skip_stock_check: true)
+      return line_item.update_attributes(quantity: sli.quantity, skip_stock_check: skip_stock_check?(line_item.order))
     end
     line_item.quantity == sli.quantity
+  end
+
+  def skip_stock_check?(order)
+    !order.complete?
   end
 end

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -69,14 +69,16 @@ class LineItemSyncer
   end
 
   def add_order_update_issue(order, line_item)
-    issue_description = "#{line_item.product.name} - #{line_item.variant.full_name} - "
-    if line_item.insufficient_stock?
-      if line_item.variant.in_stock?
-        issue_description << I18n.t("spree.orders.line_item.insufficient_stock", on_hand: line_item.variant.on_hand)
-      else
-        issue_description << I18n.t("spree.orders.line_item.out_of_stock")
-      end
-    end
+    issue_description = "#{line_item.product.name} - #{line_item.variant.full_name}"
+    issue_description << " - #{stock_issue_description(line_item)}" if line_item.insufficient_stock?
     order_update_issues.add(order, issue_description)
+  end
+
+  def stock_issue_description(line_item)
+    if line_item.variant.in_stock?
+      I18n.t("spree.orders.line_item.insufficient_stock", on_hand: line_item.variant.on_hand)
+    else
+      I18n.t("spree.orders.line_item.out_of_stock")
+    end
   end
 end

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -24,8 +24,7 @@ class LineItemSyncer
       line_item = order.line_items.find_by_variant_id(sli.variant_id)
       next if update_quantity(line_item, sli)
 
-      product_name = "#{line_item.product.name} - #{line_item.full_name}"
-      order_update_issues.add(order, product_name)
+      add_order_update_issue(order, line_item)
     end
   end
 
@@ -70,11 +69,13 @@ class LineItemSyncer
   end
 
   def add_order_update_issue(order, line_item)
-    issue_description = "#{line_item.product.name} - #{line_item.full_name}"
-    if line_item.variant.in_stock?
-      issue_description << I18n.t("spree.orders.line_item.insufficient_stock", on_hand: line_item.variant.on_hand)
-    else
-      issue_description << I18n.t("spree.orders.line_item.out_of_stock")
+    issue_description = "#{line_item.product.name} - #{line_item.variant.full_name} - "
+    if line_item.insufficient_stock?
+      if line_item.variant.in_stock?
+        issue_description << I18n.t("spree.orders.line_item.insufficient_stock", on_hand: line_item.variant.on_hand)
+      else
+        issue_description << I18n.t("spree.orders.line_item.out_of_stock")
+      end
     end
     order_update_issues.add(order, issue_description)
   end

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -35,8 +35,8 @@ class LineItemSyncer
                                               skip_stock_check: skip_stock_check?(order))
       next if skip_stock_check?(order) || new_line_item.sufficient_stock?
 
+      order.line_items.delete(new_line_item)
       add_order_update_issue(order, new_line_item)
-      new_line_item.update_attributes(quantity: 0)
     end
   end
 

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -78,7 +78,7 @@ class LineItemSyncer
     if line_item.variant.in_stock?
       I18n.t("admin.subscriptions.stock.insufficient_stock")
     else
-      I18n.t("admin.subscriptions.stock..out_of_stock")
+      I18n.t("admin.subscriptions.stock.out_of_stock")
     end
   end
 end

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -76,9 +76,9 @@ class LineItemSyncer
 
   def stock_issue_description(line_item)
     if line_item.variant.in_stock?
-      I18n.t("spree.orders.line_item.insufficient_stock", on_hand: line_item.variant.on_hand)
+      I18n.t("admin.subscriptions.stock.insufficient_stock")
     else
-      I18n.t("spree.orders.line_item.out_of_stock")
+      I18n.t("admin.subscriptions.stock..out_of_stock")
     end
   end
 end

--- a/app/services/line_item_syncer.rb
+++ b/app/services/line_item_syncer.rb
@@ -35,8 +35,8 @@ class LineItemSyncer
                                               skip_stock_check: skip_stock_check?(order))
       next if skip_stock_check?(order) || new_line_item.sufficient_stock?
 
-      order.line_items.delete(new_line_item)
       add_order_update_issue(order, new_line_item)
+      new_line_item.update_attributes(quantity: 0)
     end
   end
 

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -11,7 +11,7 @@ class OrderSyncer
   end
 
   def sync!
-    future_and_undated_orders.all? do |order|
+    orders_in_order_cycles_not_closed.all? do |order|
       order.assign_attributes(customer_id: customer_id, email: customer.andand.email, distributor_id: shop_id)
       update_associations_for(order)
       line_item_syncer.sync!(order)
@@ -36,9 +36,9 @@ class OrderSyncer
     update_payment_for(order) if payment_method_id_changed?
   end
 
-  def future_and_undated_orders
-    return @future_and_undated_orders unless @future_and_undated_orders.nil?
-    @future_and_undated_orders = orders.joins(:order_cycle).merge(OrderCycle.not_closed).readonly(false)
+  def orders_in_order_cycles_not_closed
+    return @orders_in_order_cycles_not_closed unless @orders_in_order_cycles_not_closed.nil?
+    @orders_in_order_cycles_not_closed = orders.joins(:order_cycle).merge(OrderCycle.not_closed).readonly(false)
   end
 
   def update_bill_address_for(order)

--- a/app/services/order_syncer.rb
+++ b/app/services/order_syncer.rb
@@ -1,6 +1,5 @@
 # Responsible for ensuring that any updates to a Subscription are propagated to any
 # orders belonging to that Subscription which have been instantiated
-
 class OrderSyncer
   attr_reader :order_update_issues
 
@@ -12,7 +11,8 @@ class OrderSyncer
 
   def sync!
     orders_in_order_cycles_not_closed.all? do |order|
-      order.assign_attributes(customer_id: customer_id, email: customer.andand.email, distributor_id: shop_id)
+      order.assign_attributes(customer_id: customer_id, email: customer.andand.email,
+                              distributor_id: shop_id)
       update_associations_for(order)
       line_item_syncer.sync!(order)
       order.save
@@ -25,7 +25,8 @@ class OrderSyncer
 
   delegate :orders, :bill_address, :ship_address, :subscription_line_items, to: :subscription
   delegate :shop_id, :customer, :customer_id, to: :subscription
-  delegate :shipping_method, :shipping_method_id, :payment_method, :payment_method_id, to: :subscription
+  delegate :shipping_method, :shipping_method_id,
+           :payment_method, :payment_method_id, to: :subscription
   delegate :shipping_method_id_changed?, :shipping_method_id_was, to: :subscription
   delegate :payment_method_id_changed?, :payment_method_id_was, to: :subscription
 
@@ -38,7 +39,8 @@ class OrderSyncer
 
   def orders_in_order_cycles_not_closed
     return @orders_in_order_cycles_not_closed unless @orders_in_order_cycles_not_closed.nil?
-    @orders_in_order_cycles_not_closed = orders.joins(:order_cycle).merge(OrderCycle.not_closed).readonly(false)
+    @orders_in_order_cycles_not_closed = orders.joins(:order_cycle).
+      merge(OrderCycle.not_closed).readonly(false)
   end
 
   def update_bill_address_for(order)
@@ -49,7 +51,8 @@ class OrderSyncer
   end
 
   def update_payment_for(order)
-    payment = order.payments.with_state('checkout').where(payment_method_id: payment_method_id_was).last
+    payment = order.payments.
+      with_state('checkout').where(payment_method_id: payment_method_id_was).last
     if payment
       payment.andand.void_transaction!
       order.payments.create(payment_method_id: payment_method_id, amount: order.reload.total)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1076,6 +1076,9 @@ en:
         saving: "SAVING"
         saved: "SAVED"
       product_already_in_order: This product has already been added to the order. Please edit the quantity directly.
+      stock:
+        insufficient_stock: "Insufficient stock available"
+        out_of_stock: "Out of Stock"
       orders:
         number: Number
         confirm_edit: Are you sure you want to edit this order? Doing so may make it more difficult to automatically sync changes to the subscription in the future.

--- a/lib/open_food_network/proxy_order_syncer.rb
+++ b/lib/open_food_network/proxy_order_syncer.rb
@@ -11,7 +11,8 @@ module OpenFoodNetwork
       when ActiveRecord::Relation
         @subscriptions = subscriptions.not_ended.not_canceled
       else
-        raise "ProxyOrderSyncer must be initialized with an instance of Subscription or ActiveRecord::Relation"
+        raise "ProxyOrderSyncer must be initialized with " \
+                "an instance of Subscription or ActiveRecord::Relation"
       end
     end
 
@@ -74,7 +75,9 @@ module OpenFoodNetwork
     end
 
     def in_range_order_cycles
-      order_cycles.where('orders_close_at >= ? AND orders_close_at <= ?', begins_at, ends_at || 100.years.from_now)
+      order_cycles.where("orders_close_at >= ? AND orders_close_at <= ?",
+                         begins_at,
+                         ends_at || 100.years.from_now)
     end
   end
 end

--- a/spec/performance/proxy_order_syncer_spec.rb
+++ b/spec/performance/proxy_order_syncer_spec.rb
@@ -7,7 +7,8 @@ module OpenFoodNetwork
 
     let!(:order_cycles) do
       Array.new(10) do |i|
-        create(:simple_order_cycle, orders_open_at: start + i.days, orders_close_at: start + (i + 1).days )
+        create(:simple_order_cycle, orders_open_at: start + i.days,
+                                    orders_close_at: start + (i + 1).days )
       end
     end
 

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -510,7 +510,7 @@ describe OrderSyncer do
           expect(syncer.sync!).to be true
 
           line_items = Spree::LineItem.where(order_id: subscription.orders, variant_id: variant.id)
-          expect(line_items.map(&:quantity)).to eq [0]
+          expect(line_items.map(&:quantity)).to eq []
           expect(order.reload.total.to_f).to eq 59.97
           expect(syncer.order_update_issues[order.id]).to include "#{variant.product.name} - #{variant.full_name} - Insufficient stock available"
         end

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -500,7 +500,7 @@ describe OrderSyncer do
           expect(syncer.sync!).to be true
 
           line_items = Spree::LineItem.where(order_id: subscription.orders, variant_id: variant.id)
-          expect(line_items.map(&:quantity)).to eq []
+          expect(line_items.map(&:quantity)).to eq [0]
           expect(order.reload.total.to_f).to eq 59.97
           expect(syncer.order_update_issues[order.id]).to include "#{variant.product.name} - #{variant.full_name} - Insufficient stock available, only 5 remaining"
         end

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -416,8 +416,7 @@ describe OrderSyncer do
           expect(line_items.map(&:quantity)).to eq [1]
           expect(order.reload.total.to_f).to eq 59.97
           line_item = order.line_items.find_by_variant_id(sli.variant_id)
-          # when we complete the order in this test case, the one item in the original order is taken from stock, this moved the available stock to 1
-          expect(syncer.order_update_issues[order.id]).to include "#{line_item.product.name} - #{line_item.variant.full_name} - Insufficient stock available, only 1 remaining"
+          expect(syncer.order_update_issues[order.id]).to include "#{line_item.product.name} - #{line_item.variant.full_name} - Insufficient stock available"
         end
       end
     end
@@ -502,7 +501,7 @@ describe OrderSyncer do
           line_items = Spree::LineItem.where(order_id: subscription.orders, variant_id: variant.id)
           expect(line_items.map(&:quantity)).to eq [0]
           expect(order.reload.total.to_f).to eq 59.97
-          expect(syncer.order_update_issues[order.id]).to include "#{variant.product.name} - #{variant.full_name} - Insufficient stock available, only 5 remaining"
+          expect(syncer.order_update_issues[order.id]).to include "#{variant.product.name} - #{variant.full_name} - Insufficient stock available"
         end
       end
     end

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -493,12 +493,13 @@ describe OrderSyncer do
       context "when order is complete" do
         before { AdvanceOrderService.new(order).call }
 
-        it "does not add line_item and keeps totals on all orders" do
+        it "does not add line_item and adds the order to order_update_issues" do
           expect(syncer.sync!).to be true
 
           line_items = Spree::LineItem.where(order_id: subscription.orders, variant_id: variant.id)
           expect(line_items.map(&:quantity)).to eq []
           expect(order.reload.total.to_f).to eq 59.97
+          expect(syncer.order_update_issues[order.id]).to include "#{variant.product.name} - Insufficient stock available, only 5 remaining"
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #2505
When editing orders and adding items or updating quantities, it will check stock levels if order is placed already (complete) in current OC.
It will set quantity to zero when adding a new line item to the order if stock is insufficient.
It will not update line item quantity if stock is insufficient.

#### What should we test?
Make sure issue 2505 is solved.
Please see two test cases described in comments below: [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/4037#issuecomment-511196181) and [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/4037#issuecomment-511233846).


#### Release notes
Changelog Category: Fixed
Fixes subscriptions when updating subscriptions with open orders in current OC, stock levels we ignored and manager could end up with negative stock levels. This is now fixed.
