### PR TITLE
Sync subscription (create/update orders) when subscription is unpaused

### DIFF
--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -1,4 +1,5 @@
 require 'open_food_network/permissions'
+require 'open_food_network/proxy_order_syncer'
 
 module Admin
   class SubscriptionsController < ResourceController
@@ -67,8 +68,13 @@ module Admin
     end
 
     def unpause
-      @subscription.update_attributes(paused_at: nil)
-      render_as_json @subscription
+      params[:subscription][:paused_at] = nil
+      form = SubscriptionForm.new(@subscription, params[:subscription])
+      if form.save
+        render_as_json @subscription, order_update_issues: form.order_update_issues
+      else
+        render json: { errors: form.json_errors }, status: :unprocessable_entity
+      end
     end
 
     private

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -33,21 +33,11 @@ module Admin
     end
 
     def create
-      form = SubscriptionForm.new(@subscription, params[:subscription])
-      if form.save
-        render_as_json @subscription
-      else
-        render json: { errors: form.json_errors }, status: :unprocessable_entity
-      end
+      save_form_and_render(false)
     end
 
     def update
-      form = SubscriptionForm.new(@subscription, params[:subscription])
-      if form.save
-        render_as_json @subscription, order_update_issues: form.order_update_issues
-      else
-        render json: { errors: form.json_errors }, status: :unprocessable_entity
-      end
+      save_form_and_render
     end
 
     def cancel
@@ -69,15 +59,24 @@ module Admin
 
     def unpause
       params[:subscription][:paused_at] = nil
-      form = SubscriptionForm.new(@subscription, params[:subscription])
-      if form.save
-        render_as_json @subscription, order_update_issues: form.order_update_issues
-      else
-        render json: { errors: form.json_errors }, status: :unprocessable_entity
-      end
+      save_form_and_render
     end
 
     private
+
+    def save_form_and_render(render_issues = true)
+      form = SubscriptionForm.new(@subscription, params[:subscription])
+      unless form.save
+        render json: { errors: form.json_errors }, status: :unprocessable_entity
+        return
+      end
+
+      if render_issues
+        render_as_json @subscription, order_update_issues: form.order_update_issues
+      else
+        render_as_json @subscription
+      end
+    end
 
     def permissions
       return @permissions unless @permissions.nil?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1079,12 +1079,12 @@ en:
       orders:
         number: Number
         confirm_edit: Are you sure you want to edit this order? Doing so may make it more difficult to automatically sync changes to the subscription in the future.
-      confirm_cancel_msg: Are you sure you want to cancel this subscription? This action cannot be undone.
-      cancel_failure_msg: 'Sorry, cancellation failed!' 
-      confirm_pause_msg: Are you sure you want to pause this subscription?
-      pause_failure_msg: 'Sorry, pausing failed!'
-      confirm_unpause_msg: Are you sure you want to unpause this subscription?
-      unpause_failure_msg: 'Sorry, unpausing failed!'
+      confirm_cancel_msg: "Are you sure you want to cancel this subscription? This action cannot be undone."
+      cancel_failure_msg: "Sorry, cancellation failed!"
+      confirm_pause_msg: "Are you sure you want to pause this subscription?"
+      pause_failure_msg: "Sorry, pausing failed!"
+      confirm_unpause_msg: "If you have an open Order Cycle in this subscription's schedule, an order will be created for this customer. Are you sure you want to unpause this subscription?"
+      unpause_failure_msg: "Sorry, unpausing failed!"
       confirm_cancel_open_orders_msg: "Some orders for this subscription are currently open. The customer has already been notified that the order will be placed. Would you like to cancel these order(s) or keep them?"
       resume_canceled_orders_msg: "Some orders for this subscription can be resumed right now. You can resume them from the orders dropdown."
       yes_cancel_them: Cancel them

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -583,7 +583,7 @@ describe Admin::SubscriptionsController, type: :controller do
     end
 
     context 'json' do
-      let(:params) { { format: :json, id: subscription.id } }
+      let(:params) { { format: :json, id: subscription.id, subscription: {} } }
 
       context 'as a regular user' do
         it 'redirects to unauthorized' do

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -664,6 +664,15 @@ describe Admin::SubscriptionsController, type: :controller do
               expect(json_response['id']).to eq subscription.id
               expect(subscription.reload.paused_at).to be nil
             end
+
+            context "when there is an open OC and no associated orders exist yet for it (OC was opened when the subscription was paused)" do
+              it "creates an associated order" do
+                spree_put :unpause, params
+
+                expect(subscription.reload.paused_at).to be nil
+                expect(subscription.proxy_orders.size).to be 1
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

Closes #2909 
Closes #2549

To fix #2909, when the user unpauses a subscription we are now running the same process as when the subscription is created and updated: it will create or update orders as necessary.

To fix #2549 I just updated the base translatable message with the extra warning.

#### What should we test?
We only need to test the pause/unpause process as the code is very isolated.


#### Release notes
Changelog Category: Fixed
When user unpauses a subscription, if there is an open OC for that subscriptions's schedule, orders will be automatically created.
