### PR TITLE
Brings in the latest Spree fork's Git commit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 46d6f8f5fd434105b0c69958276d1727a3066a97
+  revision: 8a8585a43cd04d1a50dc65227f337a91b18d66d5
   branch: 2-0-4-stable
   specs:
     spree_api (2.0.4)


### PR DESCRIPTION
#### What? Why?

This successfully closes #3903 by bringing in the changes done in https://github.com/openfoodfoundation/spree/pull/41.

#### What should we test?

Nothing. Changes were tested already in https://github.com/openfoodfoundation/openfoodnetwork/pull/3938


#### Release notes

Orders listing products that got deleted after the purchase can still be edited from the admin section

Changelog Category: Fixed
