### PR TITLE
Add icon to OC menu entry

### DIFF
--- a/app/views/spree/admin/shared/_tabs.html.haml
+++ b/app/views/spree/admin/shared/_tabs.html.haml
@@ -1,6 +1,6 @@
 = tab :dashboard, :route => :admin, :icon => 'icon-dashboard'
 = tab :products , :option_types, :properties, :prototypes, :variants, :product_properties, :taxons, :url => admin_products_path, :icon => 'icon-th-large'
-= tab :order_cycles, :url => main_app.admin_order_cycles_path
+= tab :order_cycles, :url => main_app.admin_order_cycles_path, :icon => 'icon-refresh'
 = tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :url => admin_orders_path('q[s]' => 'completed_at desc'), :icon => 'icon-shopping-cart'
 = tab :reports, :icon => 'icon-file'
 = tab :configurations, :general_settings, :mail_methods, :tax_categories, :zones, :states, :payment_methods, :inventory_settings, :taxonomies, :shipping_methods, :trackers, :label => 'configuration', :icon => 'icon-wrench', :url => edit_admin_general_settings_path


### PR DESCRIPTION
#### What? Why?

After moving the menu items we realize it's better to add an icon to the OC menu.
Before:
![Screenshot 2019-07-23 at 18 42 23](https://user-images.githubusercontent.com/1640378/61750911-95badc00-ad9e-11e9-98c2-6ab8d7172345.png)
After:
![Screenshot 2019-07-23 at 18 49 08](https://user-images.githubusercontent.com/1640378/61750953-af5c2380-ad9e-11e9-8e00-d5da7880d3b4.png)



I am not sure how to add a new icon to the list... so we re-use the same icon from products as a quick improvement.

#### What should we test?
Check the icon and the menu renders correcyly.

#### Release notes

Changelog Category: Changed
Re-organized main menu order, Order Cycles is now just after Products. The Order Cycles menu has an icon now.