### PR TITLE
Convert order_cycle.rabl to Api::OrderCycleSerializer

### DIFF
--- a/app/controllers/admin/tag_rules_controller.rb
+++ b/app/controllers/admin/tag_rules_controller.rb
@@ -9,8 +9,8 @@ module Admin
     def map_by_tag
       respond_to do |format|
         format.json do
-          serialiser = ActiveModel::ArraySerializer.new(collection)
-          render json: serialiser.to_json
+          serializer = ActiveModel::ArraySerializer.new(collection)
+          render json: serializer.to_json
         end
       end
     end

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -27,12 +27,12 @@ class ShopController < BaseController
       if oc = OrderCycle.with_distributor(@distributor).active.find_by_id(params[:order_cycle_id])
         current_order(true).set_order_cycle! oc
         @current_order_cycle = oc
-        render partial: "json/order_cycle"
+        render json: @current_order_cycle, serializer: Api::OrderCycleSerializer
       else
         render status: :not_found, json: ""
       end
     else
-      render partial: "json/order_cycle"
+      render json: current_order_cycle, serializer: Api::OrderCycleSerializer
     end
   end
 

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -62,7 +62,9 @@ module InjectionHelper
   end
 
   def inject_current_order_cycle
-    inject_json_ams "orderCycleData", current_order_cycle, Api::OrderCycleSerializer
+    serializer = Api::OrderCycleSerializer.new(current_order_cycle)
+    json = serializer.object.present? ? serializer.to_json : "{}"
+    render partial: "json/injection_ams", locals: { name: "orderCycleData", json: json }
   end
 
   def inject_available_shipping_methods

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -61,6 +61,10 @@ module InjectionHelper
     inject_json_ams "currentOrder", current_order, Api::CurrentOrderSerializer, current_distributor: current_distributor, current_order_cycle: current_order_cycle
   end
 
+  def inject_current_order_cycle
+    inject_json_ams "orderCycleData", current_order_cycle, Api::OrderCycleSerializer
+  end
+
   def inject_available_shipping_methods
     inject_json_ams "shippingMethods", available_shipping_methods,
                     Api::ShippingMethodSerializer, current_order: current_order

--- a/app/serializers/api/order_cycle_serializer.rb
+++ b/app/serializers/api/order_cycle_serializer.rb
@@ -1,0 +1,11 @@
+class Api::OrderCycleSerializer < ActiveModel::Serializer
+  attributes :order_cycle_id, :orders_close_at
+
+  def order_cycle_id
+    object.id
+  end
+
+  def orders_close_at
+    object.orders_close_at.to_s
+  end
+end

--- a/app/serializers/api/order_cycle_serializer.rb
+++ b/app/serializers/api/order_cycle_serializer.rb
@@ -1,11 +1,13 @@
-class Api::OrderCycleSerializer < ActiveModel::Serializer
-  attributes :order_cycle_id, :orders_close_at
+module Api
+  class OrderCycleSerializer < ActiveModel::Serializer
+    attributes :order_cycle_id, :orders_close_at
 
-  def order_cycle_id
-    object.id
-  end
+    def order_cycle_id
+      object.id
+    end
 
-  def orders_close_at
-    object.orders_close_at.to_s
+    def orders_close_at
+      object.orders_close_at.to_s
+    end
   end
 end

--- a/app/views/json/_order_cycle.rabl
+++ b/app/views/json/_order_cycle.rabl
@@ -1,3 +1,0 @@
-object current_order_cycle
-attributes :orders_close_at
-attribute id: :order_cycle_id

--- a/app/views/shopping_shared/_order_cycles.html.haml
+++ b/app/views/shopping_shared/_order_cycles.html.haml
@@ -1,6 +1,5 @@
-- content_for :scripts do
-  :javascript
-    angular.module('Darkswarm').value('orderCycleData', #{render "json/order_cycle"})
+- content_for :injection_data do
+  = inject_current_order_cycle
 
 %ordercycle{"ng-controller" => "OrderCycleCtrl"}
 

--- a/spec/helpers/injection_helper_spec.rb
+++ b/spec/helpers/injection_helper_spec.rb
@@ -49,6 +49,18 @@ describe InjectionHelper, type: :helper do
     expect(helper.inject_current_order).to match order.id.to_s
   end
 
+  describe "injects current order cycle" do
+    it "injects empty json object (not nil) when current OC is null" do
+      allow(helper).to receive(:current_order_cycle).and_return nil
+      expect(helper.inject_current_order_cycle).to match "{}"
+    end
+
+    it "injects current OC when OC not null" do
+      allow(helper).to receive(:current_order_cycle).and_return order_cycle = create(:simple_order_cycle)
+      expect(helper.inject_current_order_cycle).to match order_cycle.id.to_s
+    end
+  end
+
   it "injects taxons" do
     taxon = create(:taxon)
     expect(helper.inject_taxons).to match taxon.name

--- a/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
+++ b/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
@@ -32,17 +32,17 @@ describe Api::EnterpriseShopfrontSerializer do
     expect(serializer.serializable_hash[:delivery]).to eq true
   end
 
-  it "serialises an array of hubs" do
+  it "serializes an array of hubs" do
     expect(serializer.serializable_hash[:hubs]).to be_a ActiveModel::ArraySerializer
     expect(serializer.serializable_hash[:hubs].to_json).to match hub.name
   end
 
-  it "serialises an array of producers" do
+  it "serializes an array of producers" do
     expect(serializer.serializable_hash[:producers]).to be_a ActiveModel::ArraySerializer
     expect(serializer.serializable_hash[:producers].to_json).to match producer.name
   end
 
-  it "serialises taxons" do
+  it "serializes taxons" do
     expect(serializer.serializable_hash[:taxons]).to be_a ActiveModel::ArraySerializer
     expect(serializer.serializable_hash[:taxons].to_json).to match 'Meat'
     expect(serializer.serializable_hash[:taxons].to_json).to match 'Veg'

--- a/spec/serializers/api/group_list_serializer_spec.rb
+++ b/spec/serializers/api/group_list_serializer_spec.rb
@@ -18,7 +18,7 @@ describe Api::GroupListSerializer do
     expect(serializer.serializable_hash[:state]).to eq group.address.state.abbr
   end
 
-  it "serialises an array of enterprises" do
+  it "serializes an array of enterprises" do
     expect(serializer.serializable_hash[:enterprises]).to be_a ActiveModel::ArraySerializer
     expect(serializer.serializable_hash[:enterprises].to_json).to match producer.name
   end

--- a/spec/serializers/api/order_cycle_serializer_spec.rb
+++ b/spec/serializers/api/order_cycle_serializer_spec.rb
@@ -4,7 +4,7 @@ describe Api::OrderCycleSerializer do
   let(:order_cycle) { create(:simple_order_cycle) }
   let(:serializer) { Api::OrderCycleSerializer.new(order_cycle).to_json }
 
-  it "serializers the OC id as order_cycle_id" do
+  it "serializes the OC id as order_cycle_id" do
     expect(serializer).to match "order_cycle_id"
     expect(serializer).to match order_cycle.id.to_s
   end

--- a/spec/serializers/api/order_cycle_serializer_spec.rb
+++ b/spec/serializers/api/order_cycle_serializer_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Api::OrderCycleSerializer do
+  let(:order_cycle) { create(:simple_order_cycle) }
+  let(:serializer) { Api::OrderCycleSerializer.new(order_cycle).to_json }
+
+  it "serializers the OC id as order_cycle_id" do
+    expect(serializer).to match "order_cycle_id"
+    expect(serializer).to match order_cycle.id.to_s
+  end
+
+  it "includes orders_close_at" do
+    expect(serializer).to match "orders_close_at"
+    expect(serializer).to match order_cycle.orders_close_at.to_date.to_s
+  end
+end


### PR DESCRIPTION
#### What? Why?

Part of #4060

We replace order_cycle.rabl with Api::OrderCycleSerializer and we use the serializer in both the haml view and the controller.

#### What should we test?
- change OC in the frontoffice and check product list updates correctly
- change from one shop to another in the frontoffice and make sure that, on the shop page you change to, the OC is correctly selected if there is only or the select box is empty if there is more than one open OC for that shop. For each OC selection make sure the product list is displaying correctly
- create and edit order cycles in the backoffice

#### Release notes
Changelog Category: Changed
Converted some of the last files in OFN in RABL to AMS.
