### PR TITLE
Replace update_prod_image.rabl with ImageSerializer in api/product_image_controller

### DIFF
--- a/app/controllers/api/product_images_controller.rb
+++ b/app/controllers/api/product_images_controller.rb
@@ -8,11 +8,11 @@ module Api
 
       if @product.images.first.nil?
         @image = Spree::Image.create(attachment: params[:file], viewable_id: @product.master.id, viewable_type: 'Spree::Variant')
-        respond_with(@image, status: 201)
+        render json: @image, serializer: ImageSerializer, status: :created
       else
         @image = @product.images.first
         @image.update_attributes(attachment: params[:file])
-        respond_with(@image, status: 200)
+        render json: @image, serializer: ImageSerializer, status: :ok
       end
     end
   end

--- a/app/controllers/api/product_images_controller.rb
+++ b/app/controllers/api/product_images_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class ProductImagesController < Spree::Api::BaseController
+  class ProductImagesController < BaseController
     respond_to :json
 
     def update_product_image

--- a/app/serializers/api/image_serializer.rb
+++ b/app/serializers/api/image_serializer.rb
@@ -1,8 +1,16 @@
 class Api::ImageSerializer < ActiveModel::Serializer
-  attributes :id, :alt, :small_url, :large_url
+  attributes :id, :alt, :thumb_url, :small_url, :image_url, :large_url
+
+  def thumb_url
+    object.attachment.url(:mini, false)
+  end
 
   def small_url
     object.attachment.url(:small, false)
+  end
+
+  def image_url
+    object.attachment.url(:product, false)
   end
 
   def large_url

--- a/app/views/api/product_images/update_product_image.v1.rabl
+++ b/app/views/api/product_images/update_product_image.v1.rabl
@@ -1,5 +1,0 @@
-object @image
-attributes(*image_attributes)
-attributes :viewable_type, :viewable_id
-node( :thumb_url ) { @product.images.first.attachment.url(:mini) }
-node( :image_url ) { @product.images.first.attachment.url(:product) }

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -742,7 +742,7 @@ feature '
     end
   end
 
-  describe "Updating product image with new upload interface" do
+  describe "Updating product image" do
     let!(:product) { create(:simple_product, name: "Carrots") }
 
     it "displays product images and image upload modal" do
@@ -755,6 +755,7 @@ feature '
 
         # Shows default image when no image set
         expect(page).to have_css "img[src='/assets/noimage/mini.png']"
+        @old_thumb_src = page.find("a.image-modal img")['src']
 
         # Click image
         page.find("a.image-modal").click
@@ -780,7 +781,7 @@ feature '
       within "table#listing_products tr#p_#{product.id}" do
         # New thumbnail is shown in image column
         @new_thumb_src = page.find("a.image-modal img")['src']
-        expect(@old_thumb_src) != @new_thumb_src
+        expect(@old_thumb_src).not_to eq @new_thumb_src
 
         page.find("a.image-modal").click
       end


### PR DESCRIPTION
#### What? Why?

Part of #4060 

Removing rabl file and using existing ImageSerializer.

A summary of my problem and Maikel's discovery: the Spree::Api::BaseController has [the Rabl responder activated](https://github.com/openfoodfoundation/spree/blob/8a8585a43cd04d1a50dc65227f337a91b18d66d5/api/app/controllers/spree/api/base_controller.rb#L10) because spree_api only uses rabl and the OFN Api::BaseController [does have AMS activated](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/controllers/api/base_controller.rb#L1-L11). So, as we convert rabl to AMS, we need to [switch the base_controller from Spree::Api::BaseController to Api::BaseController](https://github.com/openfoodfoundation/openfoodnetwork/pull/4073/commits/11a77043eb66f6b0e6548924a5472fffff4d0ca2) 💪

#### What should we test?
Upload product image in the bulk product edit page.

#### Release notes
Changelog Category: Changed
Converted one more rabl file to AMS (modernizing tech stack) when user uploads product image.

#### ARCHIVE
Initial report when I was blocked:
This is blocking all progress as I cant figure out how to convert these rabl template controllers to ams serializers.

Switching from respond_with for rabl under app/views to render :json with a serializer under app/serializers.
This works perfectly in an non-api controller: https://github.com/openfoodfoundation/openfoodnetwork/pull/4064/files#diff-b6e332682a5b8fba45654e386d82d12eR21
and the same does not work in an api controller, see change in this PR.

Any thoughts?

The build error is:
```
#<ActionView::MissingTemplate: Missing template api/product_images/update_product_image, spree/api/base/update_product_image with {:locale=>[:en], :formats=>[:js, :html], :handlers=>[:erb, :builder, :coffee, :haml, :rabl], :versions=>[:v1]}. Searched in:
  * "/Users/luisramos/dev/ofn/openfoodnetwork/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/bundler/gems/spree-8a8585a43cd0/api/app/views"
  * "/Users/luisramos/dev/ofn/openfoodnetwork/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/gems/foundation-rails-5.5.2.1/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/gems/gmaps4rails-1.5.6/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/bundler/gems/better_spree_paypal_express-27ad7165ea4c/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/bundler/gems/spree_auth_devise-0181835fb6ac/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/gems/devise-2.2.8/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/bundler/gems/spree-8a8585a43cd0/backend/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/bundler/gems/spree-8a8585a43cd0/api/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/bundler/gems/spree-8a8585a43cd0/core/app/views"
  * "/Users/luisramos/.rvm/gems/ruby-2.1.5@openfoodnetwork/gems/kaminari-0.14.1/app/views"
  * "/Users/luisramos/dev/ofn/openfoodnetwork/engines/web/app/views"
```
