### PR TITLE
Bulk Edit Products pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,10 @@ gem 'delayed_job_web'
 # When merged, revert to upstream gem
 gem 'simple_form', github: 'RohanM/simple_form'
 
+# Spree's default pagination gem (locked to the current version used by Spree)
+# We use it's methods in OFN code as well, so this is a direct dependency
+gem 'kaminari', '~> 0.14.1'
+
 gem 'andand'
 gem 'angularjs-rails', '1.5.5'
 gem 'aws-sdk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -808,6 +808,7 @@ DEPENDENCIES
   jquery-rails (= 3.0.4)
   json_spec (~> 1.1.4)
   jwt (~> 2.2)
+  kaminari (~> 0.14.1)
   knapsack
   letter_opener (>= 1.4.1)
   listen (= 3.0.8)

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -54,6 +54,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     $scope.fetchProducts()
 
   $scope.fetchProducts = ->
+    removeClearedValues()
     params = {
       'q[name_cont]': $scope.query,
       'q[supplier_id_eq]': $scope.producerFilter,
@@ -64,6 +65,11 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     }
     RequestMonitor.load(BulkProducts.fetch(params).$promise).then ->
       $scope.resetProducts()
+
+  removeClearedValues = ->
+    delete $scope.producerFilter if $scope.producerFilter == "0"
+    delete $scope.categoryFilter if $scope.categoryFilter == "0"
+    delete $scope.importDateFilter if $scope.importDateFilter == "0"
 
   $timeout ->
     if $scope.showLatestImport

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -1,267 +1,267 @@
 angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout, $http, $window, BulkProducts, DisplayProperties, dataFetcher, DirtyProducts, VariantUnitManager, StatusMessage, producers, Taxons, SpreeApiAuth, Columns, tax_categories) ->
+  $scope.loading = true
+  $scope.loadingAllPages = true
+
+  $scope.StatusMessage = StatusMessage
+
+  $scope.columns = Columns.columns
+
+  $scope.variant_unit_options = VariantUnitManager.variantUnitOptions()
+
+  $scope.filterableColumns = [
+    { name: t("label_producers"),       db_column: "producer_name" },
+    { name: t("name"),           db_column: "name" }
+  ]
+
+  $scope.filterTypes = [
+    { name: t("equals"),         predicate: "eq" },
+    { name: t("contains"),       predicate: "cont" }
+  ]
+
+  $scope.optionTabs =
+    filters:        { title: t("filter_products"),   visible: false }
+
+
+  $scope.producers = producers
+  $scope.taxons = Taxons.all
+  $scope.tax_categories = tax_categories
+  $scope.filterProducers = [{id: "0", name: ""}].concat $scope.producers
+  $scope.filterTaxons = [{id: "0", name: ""}].concat $scope.taxons
+  $scope.producerFilter = "0"
+  $scope.categoryFilter = "0"
+  $scope.importDateFilter = "0"
+  $scope.products = BulkProducts.products
+  $scope.filteredProducts = []
+  $scope.currentFilters = []
+  $scope.limit = 15
+  $scope.query = ""
+  $scope.DisplayProperties = DisplayProperties
+
+  $scope.initialise = ->
+    SpreeApiAuth.authorise()
+    .then ->
+      $scope.spree_api_key_ok = true
+      $scope.fetchProducts()
+    .catch (message) ->
+      $scope.api_error_msg = message
+
+  $scope.$watchCollection '[query, producerFilter, categoryFilter, importDateFilter]', ->
+    $scope.limit = 15 # Reset limit whenever searching
+
+  $scope.fetchProducts = ->
     $scope.loading = true
     $scope.loadingAllPages = true
+    BulkProducts.fetch($scope.currentFilters, ->
+      $scope.loadingAllPages = false
+    ).then ->
+      $scope.resetProducts()
+      $scope.loading = false
 
-    $scope.StatusMessage = StatusMessage
+  $timeout ->
+    if $scope.showLatestImport
+      $scope.importDateFilter = $scope.importDates[1].id
 
-    $scope.columns = Columns.columns
+  $scope.resetProducts = ->
+    DirtyProducts.clear()
+    StatusMessage.clear()
 
-    $scope.variant_unit_options = VariantUnitManager.variantUnitOptions()
+  $scope.updateOnHand = (product) ->
+    on_demand_variants = []
+    if product.variants
+      on_demand_variants = (variant for id, variant of product.variants when variant.on_demand)
 
-    $scope.filterableColumns = [
-      { name: t("label_producers"),       db_column: "producer_name" },
-      { name: t("name"),           db_column: "name" }
-    ]
-
-    $scope.filterTypes = [
-      { name: t("equals"),         predicate: "eq" },
-      { name: t("contains"),       predicate: "cont" }
-    ]
-
-    $scope.optionTabs =
-      filters:        { title: t("filter_products"),   visible: false }
+    unless product.on_demand || on_demand_variants.length > 0
+      product.on_hand = $scope.onHand(product)
 
 
-    $scope.producers = producers
-    $scope.taxons = Taxons.all
-    $scope.tax_categories = tax_categories
-    $scope.filterProducers = [{id: "0", name: ""}].concat $scope.producers
-    $scope.filterTaxons = [{id: "0", name: ""}].concat $scope.taxons
+  $scope.onHand = (product) ->
+    onHand = 0
+    if product.hasOwnProperty("variants") and product.variants instanceof Object
+      for id, variant of product.variants
+        onHand = onHand + parseInt(if variant.on_hand > 0 then variant.on_hand else 0)
+    else
+      onHand = "error"
+    onHand
+
+  $scope.shiftTab = (tab) ->
+    $scope.visibleTab.visible = false unless $scope.visibleTab == tab || $scope.visibleTab == undefined
+    tab.visible = !tab.visible
+    $scope.visibleTab = tab
+
+  $scope.resetSelectFilters = ->
+    $scope.query = ""
     $scope.producerFilter = "0"
     $scope.categoryFilter = "0"
     $scope.importDateFilter = "0"
-    $scope.products = BulkProducts.products
-    $scope.filteredProducts = []
-    $scope.currentFilters = []
-    $scope.limit = 15
-    $scope.query = ""
-    $scope.DisplayProperties = DisplayProperties
 
-    $scope.initialise = ->
-      SpreeApiAuth.authorise()
-      .then ->
-        $scope.spree_api_key_ok = true
-        $scope.fetchProducts()
-      .catch (message) ->
-        $scope.api_error_msg = message
-
-    $scope.$watchCollection '[query, producerFilter, categoryFilter, importDateFilter]', ->
-      $scope.limit = 15 # Reset limit whenever searching
-
-    $scope.fetchProducts = ->
-      $scope.loading = true
-      $scope.loadingAllPages = true
-      BulkProducts.fetch($scope.currentFilters, ->
-        $scope.loadingAllPages = false
-      ).then ->
-        $scope.resetProducts()
-        $scope.loading = false
-
-    $timeout ->
-      if $scope.showLatestImport
-        $scope.importDateFilter = $scope.importDates[1].id
-
-    $scope.resetProducts = ->
-      DirtyProducts.clear()
-      StatusMessage.clear()
-
-    $scope.updateOnHand = (product) ->
-      on_demand_variants = []
-      if product.variants
-        on_demand_variants = (variant for id, variant of product.variants when variant.on_demand)
-
-      unless product.on_demand || on_demand_variants.length > 0
-        product.on_hand = $scope.onHand(product)
+  $scope.editWarn = (product, variant) ->
+    if (DirtyProducts.count() > 0 and confirm(t("unsaved_changes_confirmation"))) or (DirtyProducts.count() == 0)
+      window.location = "/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit"
 
 
-    $scope.onHand = (product) ->
-      onHand = 0
-      if product.hasOwnProperty("variants") and product.variants instanceof Object
-        for id, variant of product.variants
-          onHand = onHand + parseInt(if variant.on_hand > 0 then variant.on_hand else 0)
-      else
-        onHand = "error"
-      onHand
+  $scope.toggleShowAllVariants = ->
+    showVariants = !DisplayProperties.showVariants 0
+    $scope.filteredProducts.forEach (product) ->
+      DisplayProperties.setShowVariants product.id, showVariants
+    DisplayProperties.setShowVariants 0, showVariants
 
-    $scope.shiftTab = (tab) ->
-      $scope.visibleTab.visible = false unless $scope.visibleTab == tab || $scope.visibleTab == undefined
-      tab.visible = !tab.visible
-      $scope.visibleTab = tab
-
-    $scope.resetSelectFilters = ->
-      $scope.query = ""
-      $scope.producerFilter = "0"
-      $scope.categoryFilter = "0"
-      $scope.importDateFilter = "0"
-
-    $scope.editWarn = (product, variant) ->
-      if (DirtyProducts.count() > 0 and confirm(t("unsaved_changes_confirmation"))) or (DirtyProducts.count() == 0)
-        window.location = "/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit"
+  $scope.addVariant = (product) ->
+    product.variants.push
+      id: $scope.nextVariantId()
+      unit_value: null
+      unit_description: null
+      on_demand: false
+      display_as: null
+      display_name: null
+      on_hand: null
+      price: null
+    DisplayProperties.setShowVariants product.id, true
 
 
-    $scope.toggleShowAllVariants = ->
-      showVariants = !DisplayProperties.showVariants 0
-      $scope.filteredProducts.forEach (product) ->
-        DisplayProperties.setShowVariants product.id, showVariants
-      DisplayProperties.setShowVariants 0, showVariants
+  $scope.nextVariantId = ->
+    $scope.variantIdCounter = 0 unless $scope.variantIdCounter?
+    $scope.variantIdCounter -= 1
+    $scope.variantIdCounter
 
-    $scope.addVariant = (product) ->
-      product.variants.push
-        id: $scope.nextVariantId()
-        unit_value: null
-        unit_description: null
-        on_demand: false
-        display_as: null
-        display_name: null
-        on_hand: null
-        price: null
-      DisplayProperties.setShowVariants product.id, true
-
-
-    $scope.nextVariantId = ->
-      $scope.variantIdCounter = 0 unless $scope.variantIdCounter?
-      $scope.variantIdCounter -= 1
-      $scope.variantIdCounter
-
-    $scope.deleteProduct = (product) ->
-      if confirm("Are you sure?")
-        $http(
-          method: "DELETE"
-          url: "/api/products/" + product.id + "/soft_delete"
-        ).success (data) ->
-          $scope.products.splice $scope.products.indexOf(product), 1
-          DirtyProducts.deleteProduct product.id
-          $scope.displayDirtyProducts()
-
-
-    $scope.deleteVariant = (product, variant) ->
-      if product.variants.length > 1
-        if !$scope.variantSaved(variant)
-          $scope.removeVariant(product, variant)
-        else
-          if confirm(t("are_you_sure"))
-            $http(
-              method: "DELETE"
-              url: "/api/products/" + product.permalink_live + "/variants/" + variant.id + "/soft_delete"
-            ).success (data) ->
-              $scope.removeVariant(product, variant)
-      else
-        alert(t("delete_product_variant"))
-
-    $scope.removeVariant = (product, variant) ->
-      product.variants.splice product.variants.indexOf(variant), 1
-      DirtyProducts.deleteVariant product.id, variant.id
-      $scope.displayDirtyProducts()
-
-
-    $scope.cloneProduct = (product) ->
-      BulkProducts.cloneProduct product
-
-    $scope.hasVariants = (product) ->
-      product.variants.length > 0
-
-
-    $scope.hasUnit = (product) ->
-      product.variant_unit_with_scale?
-
-
-    $scope.variantSaved = (variant) ->
-      variant.hasOwnProperty('id') && variant.id > 0
-
-
-    $scope.hasOnDemandVariants = (product) ->
-      (variant for id, variant of product.variants when variant.on_demand).length > 0
-
-
-    $scope.submitProducts = ->
-      # Pack pack $scope.products, so they will match the list returned from the server,
-      # then pack $scope.dirtyProducts, ensuring that the correct product info is sent to the server.
-      $scope.packProduct product for id, product of $scope.products
-      $scope.packProduct product for id, product of DirtyProducts.all()
-
-      productsToSubmit = filterSubmitProducts(DirtyProducts.all())
-      if productsToSubmit.length > 0
-        $scope.updateProducts productsToSubmit # Don't submit an empty list
-      else
-        StatusMessage.display 'alert', t("products_change")
-
-
-    $scope.updateProducts = (productsToSubmit) ->
-      $scope.displayUpdating()
+  $scope.deleteProduct = (product) ->
+    if confirm("Are you sure?")
       $http(
-        method: "POST"
-        url: "/admin/products/bulk_update"
-        data:
-          products: productsToSubmit
-          filters: $scope.currentFilters
-      ).success((data) ->
-        DirtyProducts.clear()
-        BulkProducts.updateVariantLists(data.products || [])
-        $timeout -> $scope.displaySuccess()
-      ).error (data, status) ->
-        if status == 400 && data.errors? && data.errors.length > 0
-          errors = error + "\n" for error in data.errors
-          alert t("products_update_error") + "\n" + errors
-          $scope.displayFailure t("products_update_error")
-        else
-          $scope.displayFailure t("products_update_error_data") + status
+        method: "DELETE"
+        url: "/api/products/" + product.id + "/soft_delete"
+      ).success (data) ->
+        $scope.products.splice $scope.products.indexOf(product), 1
+        DirtyProducts.deleteProduct product.id
+        $scope.displayDirtyProducts()
 
-    $scope.cancel = (destination) ->
-      $window.location = destination
 
-    $scope.packProduct = (product) ->
-      if product.variant_unit_with_scale
-        match = product.variant_unit_with_scale.match(/^([^_]+)_([\d\.]+)$/)
-        if match
-          product.variant_unit = match[1]
-          product.variant_unit_scale = parseFloat(match[2])
-        else
-          product.variant_unit = product.variant_unit_with_scale
-          product.variant_unit_scale = null
+  $scope.deleteVariant = (product, variant) ->
+    if product.variants.length > 1
+      if !$scope.variantSaved(variant)
+        $scope.removeVariant(product, variant)
       else
-        product.variant_unit = product.variant_unit_scale = null
+        if confirm(t("are_you_sure"))
+          $http(
+            method: "DELETE"
+            url: "/api/products/" + product.permalink_live + "/variants/" + variant.id + "/soft_delete"
+          ).success (data) ->
+            $scope.removeVariant(product, variant)
+    else
+      alert(t("delete_product_variant"))
 
-      $scope.packVariant product, product.master if product.master
-
-      if product.variants
-        for id, variant of product.variants
-          $scope.packVariant product, variant
-
-
-    $scope.packVariant = (product, variant) ->
-      if variant.hasOwnProperty("unit_value_with_description")
-        match = variant.unit_value_with_description.match(/^([\d\.]+(?= |$)|)( |)(.*)$/)
-        if match
-          product = BulkProducts.find product.id
-          variant.unit_value  = parseFloat(match[1])
-          variant.unit_value  = null if isNaN(variant.unit_value)
-          variant.unit_value *= product.variant_unit_scale if variant.unit_value && product.variant_unit_scale
-          variant.unit_description = match[3]
-
-    $scope.incrementLimit = ->
-      if $scope.limit < $scope.products.length
-        $scope.limit = $scope.limit + 5
+  $scope.removeVariant = (product, variant) ->
+    product.variants.splice product.variants.indexOf(variant), 1
+    DirtyProducts.deleteVariant product.id, variant.id
+    $scope.displayDirtyProducts()
 
 
-    $scope.displayUpdating = ->
-      StatusMessage.display 'progress', t("saving")
+  $scope.cloneProduct = (product) ->
+    BulkProducts.cloneProduct product
+
+  $scope.hasVariants = (product) ->
+    product.variants.length > 0
 
 
-    $scope.displaySuccess = ->
-      StatusMessage.display 'success',t("products_changes_saved")
-      $scope.bulk_product_form.$setPristine()
+  $scope.hasUnit = (product) ->
+    product.variant_unit_with_scale?
 
 
-    $scope.displayFailure = (failMessage) ->
-      StatusMessage.display  'failure', t("products_update_error_msg") + "#{failMessage}"
+  $scope.variantSaved = (variant) ->
+    variant.hasOwnProperty('id') && variant.id > 0
 
 
-    $scope.displayDirtyProducts = ->
-      count = DirtyProducts.count()
-      switch count
-        when 0 then StatusMessage.clear()
-        when 1 then StatusMessage.display 'notice', t("one_product_unsaved")
-        else StatusMessage.display 'notice', t("products_unsaved", n: count)
+  $scope.hasOnDemandVariants = (product) ->
+    (variant for id, variant of product.variants when variant.on_demand).length > 0
+
+
+  $scope.submitProducts = ->
+    # Pack pack $scope.products, so they will match the list returned from the server,
+    # then pack $scope.dirtyProducts, ensuring that the correct product info is sent to the server.
+    $scope.packProduct product for id, product of $scope.products
+    $scope.packProduct product for id, product of DirtyProducts.all()
+
+    productsToSubmit = filterSubmitProducts(DirtyProducts.all())
+    if productsToSubmit.length > 0
+      $scope.updateProducts productsToSubmit # Don't submit an empty list
+    else
+      StatusMessage.display 'alert', t("products_change")
+
+
+  $scope.updateProducts = (productsToSubmit) ->
+    $scope.displayUpdating()
+    $http(
+      method: "POST"
+      url: "/admin/products/bulk_update"
+      data:
+        products: productsToSubmit
+        filters: $scope.currentFilters
+    ).success((data) ->
+      DirtyProducts.clear()
+      BulkProducts.updateVariantLists(data.products || [])
+      $timeout -> $scope.displaySuccess()
+    ).error (data, status) ->
+      if status == 400 && data.errors? && data.errors.length > 0
+        errors = error + "\n" for error in data.errors
+        alert t("products_update_error") + "\n" + errors
+        $scope.displayFailure t("products_update_error")
+      else
+        $scope.displayFailure t("products_update_error_data") + status
+
+  $scope.cancel = (destination) ->
+    $window.location = destination
+
+  $scope.packProduct = (product) ->
+    if product.variant_unit_with_scale
+      match = product.variant_unit_with_scale.match(/^([^_]+)_([\d\.]+)$/)
+      if match
+        product.variant_unit = match[1]
+        product.variant_unit_scale = parseFloat(match[2])
+      else
+        product.variant_unit = product.variant_unit_with_scale
+        product.variant_unit_scale = null
+    else
+      product.variant_unit = product.variant_unit_scale = null
+
+    $scope.packVariant product, product.master if product.master
+
+    if product.variants
+      for id, variant of product.variants
+        $scope.packVariant product, variant
+
+
+  $scope.packVariant = (product, variant) ->
+    if variant.hasOwnProperty("unit_value_with_description")
+      match = variant.unit_value_with_description.match(/^([\d\.]+(?= |$)|)( |)(.*)$/)
+      if match
+        product = BulkProducts.find product.id
+        variant.unit_value  = parseFloat(match[1])
+        variant.unit_value  = null if isNaN(variant.unit_value)
+        variant.unit_value *= product.variant_unit_scale if variant.unit_value && product.variant_unit_scale
+        variant.unit_description = match[3]
+
+  $scope.incrementLimit = ->
+    if $scope.limit < $scope.products.length
+      $scope.limit = $scope.limit + 5
+
+
+  $scope.displayUpdating = ->
+    StatusMessage.display 'progress', t("saving")
+
+
+  $scope.displaySuccess = ->
+    StatusMessage.display 'success',t("products_changes_saved")
+    $scope.bulk_product_form.$setPristine()
+
+
+  $scope.displayFailure = (failMessage) ->
+    StatusMessage.display  'failure', t("products_update_error_msg") + "#{failMessage}"
+
+
+  $scope.displayDirtyProducts = ->
+    count = DirtyProducts.count()
+    switch count
+      when 0 then StatusMessage.clear()
+      when 1 then StatusMessage.display 'notice', t("one_product_unsaved")
+      else StatusMessage.display 'notice', t("products_unsaved", n: count)
 
 
 filterSubmitProducts = (productsToFilter) ->

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -46,7 +46,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     .catch (message) ->
       $scope.api_error_msg = message
 
-  $scope.$watchCollection '[query, producerFilter, categoryFilter, importDateFilter]', ->
+  $scope.$watchCollection '[query, producerFilter, categoryFilter, importDateFilter, per_page]', ->
     $scope.page = 1 # Reset page when changing filters for new search
 
   $scope.changePage = (newPage) ->

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -26,15 +26,14 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
   $scope.optionTabs =
     filters:        { title: t("filter_products"),   visible: false }
 
-
   $scope.producers = producers
   $scope.taxons = Taxons.all
   $scope.tax_categories = tax_categories
-  $scope.filterProducers = [{id: "0", name: ""}].concat $scope.producers
-  $scope.filterTaxons = [{id: "0", name: ""}].concat $scope.taxons
-  $scope.producerFilter = "0"
-  $scope.categoryFilter = "0"
-  $scope.importDateFilter = "0"
+  $scope.producerFilter = ""
+  $scope.categoryFilter = ""
+  $scope.importDateFilter = ""
+  $scope.page = 1
+  $scope.per_page = 15
   $scope.products = BulkProducts.products
   $scope.query = ""
   $scope.DisplayProperties = DisplayProperties

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -207,7 +207,13 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
       url: "/admin/products/bulk_update"
       data:
         products: productsToSubmit
-        filters: $scope.currentFilters
+        filters:
+          'q[name_cont]': $scope.query
+          'q[supplier_id_eq]': $scope.producerFilter
+          'q[primary_taxon_id_eq]': $scope.categoryFilter
+          import_date: $scope.importDateFilter
+        page: $scope.page
+        per_page: $scope.per_page
     ).success((data) ->
       DirtyProducts.clear()
       BulkProducts.updateVariantLists(data.products || [])

--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -23,7 +23,7 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, RequestMonitor,
 
   $scope.fetchResults = (page=1) ->
     $scope.resetSelected()
-    Orders.index({
+    params = {
       'q[completed_at_lt]': $scope['q']['completed_at_lt'],
       'q[completed_at_gt]': $scope['q']['completed_at_gt'],
       'q[state_eq]': $scope['q']['state_eq'],
@@ -39,7 +39,8 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, RequestMonitor,
       'q[s]': $scope.sorting || 'completed_at desc',
       per_page: $scope.per_page,
       page: page
-    })
+    }
+    RequestMonitor.load(Orders.index(params).$promise)
 
   $scope.resetSelected = ->
     $scope.selected_orders.length = 0

--- a/app/assets/javascripts/admin/resources/resources/product_resource.js.coffee
+++ b/app/assets/javascripts/admin/resources/resources/product_resource.js.coffee
@@ -1,0 +1,6 @@
+angular.module("admin.resources").factory 'ProductResource', ($resource) ->
+  $resource('/admin/product/:id/:action.json', {}, {
+    'index':
+      url: '/api/products/bulk_products.json'
+      method: 'GET'
+  })

--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -1,15 +1,13 @@
-angular.module("ofn.admin").factory "BulkProducts", (PagedFetcher, dataFetcher, $http) ->
+angular.module("ofn.admin").factory "BulkProducts", (ProductResource, dataFetcher, $http) ->
   new class BulkProducts
     products: []
+    pagination: {}
 
-    fetch: (filters, onComplete) ->
-      queryString = filters.reduce (qs,f) ->
-        return qs + "q[#{f.property.db_column}_#{f.predicate.predicate}]=#{f.value};"
-      , ""
-
-      url = "/api/products/bulk_products?page=::page::;per_page=20;#{queryString}"
-      processData = (data) => @addProducts data.products
-      PagedFetcher.fetch url, processData, onComplete
+    fetch: (params) ->
+      ProductResource.index params, (data) =>
+        @products.length = 0
+        @addProducts data.products
+        angular.extend(@pagination, data.pagination)
 
     cloneProduct: (product) ->
       $http.post("/api/products/" + product.id + "/clone").success (data) =>

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -47,9 +47,14 @@ module Api
 
     # TODO: This should be named 'managed'. Is the action above used? Maybe we should remove it.
     def bulk_products
-      @products = OpenFoodNetwork::Permissions.new(current_api_user).editable_products.
-        merge(product_scope).
-        order('created_at DESC').
+      product_query = OpenFoodNetwork::Permissions.new(current_api_user).
+        editable_products.merge(product_scope)
+
+      if params[:import_date].present?
+        product_query = product_query.joins(:variants).merge(import_date_scope).group_by_products_id
+      end
+
+      @products = product_query.order('created_at DESC').
         ransack(params[:q]).result.
         page(params[:page]).per(params[:per_page])
 
@@ -104,8 +109,8 @@ module Api
     end
 
     def import_date_scope
-      return if params[:import_date].blank?
-      Spree::Variant.where(import_date: params[:import_date])
+      import_date = params[:import_date].to_datetime
+      Spree::Variant.where(import_date: import_date..import_date + 24.hours)
     end
 
     def paged_products_for_producers(producers)

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -118,7 +118,15 @@ module Api
         each_serializer: Api::Admin::ProductSerializer
       )
 
-      render text: { products: serializer, pages: products.num_pages }.to_json
+      render text: {
+        products: serializer,
+        pagination: {
+          results: products.total_count,
+          pages: products.num_pages,
+          page: params[:page].to_i,
+          per_page: params[:per_page].to_i
+        }
+      }.to_json
     end
   end
 end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -125,13 +125,17 @@ module Api
 
       render text: {
         products: serializer,
-        pagination: {
-          results: products.total_count,
-          pages: products.num_pages,
-          page: params[:page].to_i,
-          per_page: params[:per_page].to_i
-        }
+        pagination: pagination_data(products)
       }.to_json
+    end
+
+    def pagination_data(results)
+      {
+        results: results.total_count,
+        pages: results.num_pages,
+        page: params[:page].to_i,
+        per_page: params[:per_page].to_i
+      }
     end
   end
 end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -53,7 +53,7 @@ module Api
         editable_products.merge(product_scope)
 
       if params[:import_date].present?
-        product_query = product_query.joins(:variants).merge(import_date_scope).group_by_products_id
+        product_query = product_query.imported_on(params[:import_date]).group_by_products_id
       end
 
       @products = product_query.order('created_at DESC').
@@ -108,11 +108,6 @@ module Api
       end
 
       scope.includes(:master)
-    end
-
-    def import_date_scope
-      import_date = params[:import_date].to_datetime
-      Spree::Variant.where(import_date: import_date..import_date + 24.hours)
     end
 
     def paged_products_for_producers(producers)

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -103,6 +103,11 @@ module Api
       scope.includes(:master)
     end
 
+    def import_date_scope
+      return if params[:import_date].blank?
+      Spree::Variant.where(import_date: params[:import_date])
+    end
+
     def paged_products_for_producers(producers)
       Spree::Product.scoped.
         merge(product_scope).

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -3,6 +3,8 @@ require 'open_food_network/permissions'
 module Api
   class ProductsController < Api::BaseController
     respond_to :json
+    DEFAULT_PAGE = 1
+    DEFAULT_PER_PAGE = 15
 
     skip_authorization_check only: [:show, :bulk_products, :overridable]
 
@@ -56,7 +58,7 @@ module Api
 
       @products = product_query.order('created_at DESC').
         ransack(params[:q]).result.
-        page(params[:page] || 1).per(params[:per_page] || 50)
+        page(params[:page] || DEFAULT_PAGE).per(params[:per_page] || DEFAULT_PER_PAGE)
 
       render_paged_products @products
     end
@@ -138,8 +140,8 @@ module Api
       {
         results: results.total_count,
         pages: results.num_pages,
-        page: params[:page].to_i,
-        per_page: params[:per_page].to_i
+        page: (params[:page].to_i || DEFAULT_PAGE).to_i,
+        per_page: (params[:per_page].to_i || DEFAULT_PER_PAGE).to_i
       }
     end
   end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -56,7 +56,7 @@ module Api
 
       @products = product_query.order('created_at DESC').
         ransack(params[:q]).result.
-        page(params[:page]).per(params[:per_page])
+        page(params[:page] || 1).per(params[:per_page] || 50)
 
       render_paged_products @products
     end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -140,8 +140,8 @@ module Api
       {
         results: results.total_count,
         pages: results.num_pages,
-        page: (params[:page].to_i || DEFAULT_PAGE).to_i,
-        per_page: (params[:per_page].to_i || DEFAULT_PER_PAGE).to_i
+        page: (params[:page] || DEFAULT_PAGE).to_i,
+        per_page: (params[:per_page] || DEFAULT_PER_PAGE).to_i
       }
     end
   end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -122,7 +122,7 @@ module Api
     def render_paged_products(products)
       serializer = ActiveModel::ArraySerializer.new(
         products,
-        each_serializer: Api::Admin::ProductSerializer
+        each_serializer: ::Api::Admin::ProductSerializer
       )
 
       render text: {

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -55,7 +55,7 @@ Spree::Admin::ProductsController.class_eval do
     product_set.collection.each { |p| authorize! :update, p }
 
     if product_set.save
-      redirect_to bulk_products_api_products_path( bulk_index_query(params) )
+      redirect_to main_app.bulk_products_api_products_path( bulk_index_query(params) )
     else
       if product_set.errors.present?
         render json: { errors: product_set.errors }, status: :bad_request

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -55,7 +55,7 @@ Spree::Admin::ProductsController.class_eval do
     product_set.collection.each { |p| authorize! :update, p }
 
     if product_set.save
-      redirect_to "/api/products/bulk_products?page=1;per_page=500;#{bulk_index_query(params)}"
+      redirect_to bulk_products_api_products_path( bulk_index_query(params) )
     else
       if product_set.errors.present?
         render json: { errors: product_set.errors }, status: :bad_request
@@ -110,13 +110,7 @@ Spree::Admin::ProductsController.class_eval do
   end
 
   def bulk_index_query(params)
-    params[:filters] ||= {}
-    params[:filters].reduce("") do |string, filter|
-      filter_db_column = filter[:property][:db_column]
-      filter_predicate = filter[:predicate][:predicate]
-      filter_value = filter[:value]
-      "#{string}q[#{filter_db_column}_#{filter_predicate}]=#{filter_value};"
-    end
+    params[:filters].to_h.merge(page: params[:page], per_page: params[:per_page])
   end
 
   def load_form_data

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -56,6 +56,11 @@ Spree::Product.class_eval do
           ON (o_order_cycles.id = o_exchanges.order_cycle_id)")
   }
 
+  scope :imported_on, lambda { |date|
+    import_date = date.to_datetime
+    joins(:variants).merge(Spree::Variant.where(import_date: import_date..import_date + 24.hours))
+  }
+
   scope :with_order_cycles_inner, -> {
     joins(variants_including_master: { exchanges: :order_cycle })
   }

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -56,9 +56,10 @@ Spree::Product.class_eval do
           ON (o_order_cycles.id = o_exchanges.order_cycle_id)")
   }
 
-  scope :imported_on, lambda { |date|
-    import_date = date.to_datetime
-    joins(:variants).merge(Spree::Variant.where(import_date: import_date..import_date + 24.hours))
+  scope :imported_on, lambda { |import_date|
+    import_date = Time.zone.parse import_date if import_date.is_a? String
+    import_date = import_date.to_date
+    joins(:variants).merge(Spree::Variant.where(import_date: import_date.beginning_of_day..import_date.end_of_day))
   }
 
   scope :with_order_cycles_inner, -> {

--- a/app/views/spree/admin/orders/_per_page_controls.html.haml
+++ b/app/views/spree/admin/orders/_per_page_controls.html.haml
@@ -1,5 +1,5 @@
 .per-page{'ng-show' => '!RequestMonitor.loading && orders.length > 0'}
-  %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
+  %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'min-search' => 999, 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
 
   %span.per-page-feedback
     {{ 'spree.admin.orders.index.results_found' | t:{number: pagination.results} }}

--- a/app/views/spree/admin/products/index.html.haml
+++ b/app/views/spree/admin/products/index.html.haml
@@ -4,7 +4,6 @@
 %div{ ng: { app: 'ofn.admin', controller: 'AdminProductEditCtrl', init: 'initialise()' } }
 
   = render 'spree/admin/products/index/filters'
-  %hr.divider.sixteen.columns.alpha.omega
   = render 'spree/admin/products/index/actions'
   = render 'spree/admin/products/index/indicators'
   = render 'spree/admin/products/index/products'

--- a/app/views/spree/admin/products/index.html.haml
+++ b/app/views/spree/admin/products/index.html.haml
@@ -8,3 +8,6 @@
   = render 'spree/admin/products/index/actions'
   = render 'spree/admin/products/index/indicators'
   = render 'spree/admin/products/index/products'
+
+  %div{'ng-show' => "!RequestMonitor.loading && products.length > 0" }
+    = render partial: 'admin/shared/angular_pagination'

--- a/app/views/spree/admin/products/index/_actions.html.haml
+++ b/app/views/spree/admin/products/index/_actions.html.haml
@@ -1,3 +1,11 @@
-.controls.sixteen.columns.alpha{ 'ng-hide' => 'loading || products.length == 0' }
-  .thirteen.columns
-  %columns-dropdown{ action: "#{controller_name}_#{action_name}" }
+.controls.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0' }
+  .ten.columns.alpha.index-controls
+    .per-page{'ng-show' => '!RequestMonitor.loading && products.length > 0'}
+      %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
+
+      %span.per-page-feedback
+        {{ 'spree.admin.orders.index.results_found' | t:{number: pagination.results} }}
+        {{ 'spree.admin.orders.index.viewing' | t:{start: ((pagination.page -1) * pagination.per_page) +1, end: ((pagination.page -1) * pagination.per_page) + products.length} }}
+
+  .six.columns.omega
+    %columns-dropdown{ action: "#{controller_name}_#{action_name}" }

--- a/app/views/spree/admin/products/index/_actions.html.haml
+++ b/app/views/spree/admin/products/index/_actions.html.haml
@@ -1,7 +1,7 @@
 .controls.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0' }
   .ten.columns.alpha.index-controls
     .per-page{'ng-show' => '!RequestMonitor.loading && products.length > 0'}
-      %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'min-search' => 999, 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
+      %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'min-search' => 999, 'ng-model' => 'per_page', 'ng-change' => 'fetchProducts()'}
 
       %span.per-page-feedback
         {{ 'spree.admin.orders.index.results_found' | t:{number: pagination.results} }}

--- a/app/views/spree/admin/products/index/_actions.html.haml
+++ b/app/views/spree/admin/products/index/_actions.html.haml
@@ -1,7 +1,7 @@
 .controls.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0' }
   .ten.columns.alpha.index-controls
     .per-page{'ng-show' => '!RequestMonitor.loading && products.length > 0'}
-      %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
+      %input.per-page-select.ofn-select2{type: 'number', data: 'per_page_options', 'min-search' => 999, 'ng-model' => 'per_page', 'ng-change' => 'fetchResults()'}
 
       %span.per-page-feedback
         {{ 'spree.admin.orders.index.results_found' | t:{number: pagination.results} }}

--- a/app/views/spree/admin/products/index/_filters.html.haml
+++ b/app/views/spree/admin/products/index/_filters.html.haml
@@ -7,16 +7,16 @@
   .filter_select.three.columns
     %label{ for: 'producer_filter' }= t 'producer'
     %br
-    %select.fullwidth{ id: 'producer_filter', 'ofn-select2-min-search' => 5, ng: {model: 'producerFilter', options: 'producer.id as producer.name for producer in filterProducers'} }
+    %select.fullwidth{ id: 'producer_filter', 'ofn-select2-min-search' => 5, ng: {model: 'producerFilter', options: 'producer.id as producer.name for producer in producers'} }
   .filter_select.three.columns
     %label{ for: 'category_filter' }= t 'category'
     %br
-    %select.fullwidth{ id: 'category_filter', 'ofn-select2-min-search' => 5, ng: {model: 'categoryFilter', options: 'taxon.id as taxon.name for taxon in filterTaxons'} }
+    %select.fullwidth{ id: 'category_filter', 'ofn-select2-min-search' => 5, ng: {model: 'categoryFilter', options: 'taxon.id as taxon.name for taxon in taxons'} }
   .filter_select.three.columns
     %label{ for: 'import_filter' } Import Date
     %br
     %select.fullwidth{ id: 'import_date_filter', 'ofn-select2-min-search' => 5, ng: {model: 'importDateFilter', init: "importDates = #{@import_dates}; showLatestImport = #{@show_latest_import}"}}
-      %option{value: "{{date.id}}", ng: {repeat: "date in importDates track by date.id" }}
+      %option{value: "{{date.id}}", ng: {repeat: "date in importDates" }}
         {{date.name}}
 
   .filter_clear.three.columns.omega

--- a/app/views/spree/admin/products/index/_filters.html.haml
+++ b/app/views/spree/admin/products/index/_filters.html.haml
@@ -1,25 +1,35 @@
-.filters.sixteen.columns.alpha.omega
-  .quick_search.three.columns.alpha
-    %label{ for: 'quick_filter' }
-    %br
-    %input.quick-search.fullwidth{ ng: {model: 'query'}, name: "quick_filter", type: 'text', placeholder: t('admin.quick_search') }
-  .one.columns &nbsp;
-  .filter_select.three.columns
-    %label{ for: 'producer_filter' }= t 'producer'
-    %br
-    %select.fullwidth{ id: 'producer_filter', 'ofn-select2-min-search' => 5, ng: {model: 'producerFilter', options: 'producer.id as producer.name for producer in producers'} }
-  .filter_select.three.columns
-    %label{ for: 'category_filter' }= t 'category'
-    %br
-    %select.fullwidth{ id: 'category_filter', 'ofn-select2-min-search' => 5, ng: {model: 'categoryFilter', options: 'taxon.id as taxon.name for taxon in taxons'} }
-  .filter_select.three.columns
-    %label{ for: 'import_filter' } Import Date
-    %br
-    %select.fullwidth{ id: 'import_date_filter', 'ofn-select2-min-search' => 5, ng: {model: 'importDateFilter', init: "importDates = #{@import_dates}; showLatestImport = #{@show_latest_import}"}}
-      %option{value: "{{date.id}}", ng: {repeat: "date in importDates" }}
-        {{date.name}}
+%fieldset
+  %legend{align: 'center'}= t(:search)
 
-  .filter_clear.three.columns.omega
-    %label{ for: 'clear_all_filters' }
-    %br
-    %input.fullwidth.red{ :type => 'button', :id => 'clear_all_filters', :value => t('admin.clear_filters'), 'ng-click' => "resetSelectFilters()" }
+  .filters.sixteen.columns.alpha.omega
+    .quick_search.three.columns.alpha
+      %label{ for: 'quick_filter' }
+      %br
+      %input.quick-search.fullwidth{ ng: {model: 'query'}, name: "quick_filter", type: 'text', placeholder: t('admin.quick_search') }
+    .one.columns &nbsp;
+    .filter_select.three.columns
+      %label{ for: 'producer_filter' }= t 'producer'
+      %br
+      %select.fullwidth{ id: 'producer_filter', 'ofn-select2-min-search' => 5, ng: {model: 'producerFilter', options: 'producer.id as producer.name for producer in producers'} }
+    .filter_select.three.columns
+      %label{ for: 'category_filter' }= t 'category'
+      %br
+      %select.fullwidth{ id: 'category_filter', 'ofn-select2-min-search' => 5, ng: {model: 'categoryFilter', options: 'taxon.id as taxon.name for taxon in taxons'} }
+    .filter_select.three.columns
+      %label{ for: 'import_filter' } Import Date
+      %br
+      %select.fullwidth{ id: 'import_date_filter', 'ofn-select2-min-search' => 5, ng: {model: 'importDateFilter', init: "importDates = #{@import_dates}; showLatestImport = #{@show_latest_import}"}}
+        %option{value: "{{date.id}}", ng: {repeat: "date in importDates" }}
+          {{date.name}}
+
+    .filter_clear.three.columns.omega
+      %label{ for: 'clear_all_filters' }
+      %br
+      %input.fullwidth.red{ :type => 'button', :id => 'clear_all_filters', :value => t('admin.clear_filters'), 'ng-click' => "resetSelectFilters()" }
+
+  .clearfix
+
+  .actions.filter-actions
+    %div
+      %a.button.icon-search{'ng-click' => 'fetchProducts()'}
+        = t(:filter_results)

--- a/app/views/spree/admin/products/index/_indicators.html.haml
+++ b/app/views/spree/admin/products/index/_indicators.html.haml
@@ -2,6 +2,7 @@
   {{ api_error_msg }}
 
 %div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
+  %br
   %img.spinner{ src: "/assets/spinning-circles.svg" }
   %h1= t('.title')
 

--- a/app/views/spree/admin/products/index/_indicators.html.haml
+++ b/app/views/spree/admin/products/index/_indicators.html.haml
@@ -1,14 +1,14 @@
 %div{ 'ng-show' => '!spree_api_key_ok' }
   {{ api_error_msg }}
 
-%div.sixteen.columns.alpha#loading{ 'ng-if' => 'loading' }
+%div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
   %img.spinner{ src: "/assets/spinning-circles.svg" }
   %h1= t('.title')
 
-%div.sixteen.columns.alpha{ 'ng-show' => '!loadingAllPages && filteredProducts.length == 0 && query.length==0' }
+%div.sixteen.columns.alpha{ 'ng-show' => '!RequestMonitor.loading && products.length == 0 && query.length==0' }
   %h1#no_results= t('.no_products')
 
-%div.sixteen.columns.alpha{ 'ng-show' => '!loadingAllPages && filteredProducts.length == 0 && query.length!=0' }
+%div.sixteen.columns.alpha{ 'ng-show' => '!RequestMonitor.loading && products.length == 0 && query.length!=0' }
   %h1#no_results
     = t('.no_results')
     '

--- a/app/views/spree/admin/products/index/_products.html.haml
+++ b/app/views/spree/admin/products/index/_products.html.haml
@@ -1,14 +1,14 @@
-%div.sixteen.columns.alpha{ 'ng-hide' => 'loading || filteredProducts.length == 0' }
+%div.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0' }
   %form{ name: 'bulk_product_form' }
     %save-bar{ dirty: "bulk_product_form.$dirty", persist: "false" }
       %input.red{ type: "button", value: t(:save_changes), ng: { click: "submitProducts()", disabled: "!bulk_product_form.$dirty" } }
       %input{ type: "button", value: t(:close), 'ng-click' => "cancel('#{admin_products_path}')" }
 
-    %table.index#listing_products.bulk{ "infinite-scroll" => "incrementLimit()", "infinite-scroll-distance" => "1" }
+    %table.index#listing_products.bulk
 
       = render 'spree/admin/products/index/products_head'
 
-      %tbody{ 'ng-repeat' => 'product in filteredProducts = ( products | filter:query | producer: producerFilter | category: categoryFilter | importDate: importDateFilter | limitTo:limit )', 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'" }
+      %tbody{ 'ng-repeat' => 'product in products', 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'" }
 
         = render 'spree/admin/products/index/products_product'
         = render 'spree/admin/products/index/products_variant'

--- a/app/views/spree/admin/products/index/_save_button_row.html.haml
+++ b/app/views/spree/admin/products/index/_save_button_row.html.haml
@@ -1,3 +1,3 @@
-%div.sixteen.columns.alpha{ 'ng-hide' => 'loading || products.length == 0', style: "margin-bottom: 10px" }
+%div.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0', style: "margin-bottom: 10px" }
   %div.four.columns.alpha
     %input.four.columns.alpha{ :type => 'button', :value => t(:save_changes), 'ng-click' => 'submitProducts()'}

--- a/config/initializers/kaminari.rb
+++ b/config/initializers/kaminari.rb
@@ -1,0 +1,5 @@
+# Sets a maximum number of returned records when Kaminari pagination is used on a query but no
+# per_page value has been passed to the #per method.
+Kaminari.configure do |config|
+  config.max_per_page = 100
+end

--- a/spec/controllers/api/products_controller_spec.rb
+++ b/spec/controllers/api/products_controller_spec.rb
@@ -225,49 +225,49 @@ describe Api::ProductsController, type: :controller do
         before { current_api_user.enterprise_roles.create(enterprise: supplier2) }
 
         it "returns a list of products" do
-          spree_get :bulk_products, { page: 1, per_page: 15 }, format: :json
-          expect(returned_product_ids).to eq [product4.id, product3.id, product2.id, product1.id]
+          api_get :bulk_products, { page: 1, per_page: 15 }, format: :json
+          expect(returned_product_ids).to eq [product4.id, product3.id, product2.id, inactive_product.id, product.id]
         end
 
         it "returns pagination data" do
-          spree_get :bulk_products, { page: 1, per_page: 15 }, format: :json
-          expect(json_response['pagination']).to eq "results" => 4, "pages" => 1, "page" => 1, "per_page" => 15
+          api_get :bulk_products, { page: 1, per_page: 15 }, format: :json
+          expect(json_response['pagination']).to eq "results" => 5, "pages" => 1, "page" => 1, "per_page" => 15
         end
 
         it "uses defaults when page and per_page are not supplied" do
-          spree_get :bulk_products, format: :json
-          expect(json_response['pagination']).to eq "results" => 4, "pages" => 1, "page" => 1, "per_page" => 15
+          api_get :bulk_products, format: :json
+          expect(json_response['pagination']).to eq "results" => 5, "pages" => 1, "page" => 1, "per_page" => 15
         end
 
         it "returns paginated products by page" do
-          spree_get :bulk_products, { page: 1, per_page: 2 }, format: :json
+          api_get :bulk_products, { page: 1, per_page: 2 }, format: :json
           expect(returned_product_ids).to eq [product4.id, product3.id]
 
-          spree_get :bulk_products, { page: 2, per_page: 2 }, format: :json
-          expect(returned_product_ids).to eq [product2.id, product1.id]
+          api_get :bulk_products, { page: 2, per_page: 2 }, format: :json
+          expect(returned_product_ids).to eq [product2.id, inactive_product.id]
         end
 
         it "filters results by supplier" do
-          spree_get :bulk_products, { page: 1, per_page: 15, q: {supplier_id_eq: supplier.id} }, format: :json
-          expect(returned_product_ids).to eq [product2.id, product1.id]
+          api_get :bulk_products, { page: 1, per_page: 15, q: {supplier_id_eq: supplier.id} }, format: :json
+          expect(returned_product_ids).to eq [product2.id, inactive_product.id, product.id]
         end
 
         it "filters results by product category" do
-          spree_get :bulk_products, { page: 1, per_page: 15, q: {primary_taxon_id_eq: taxon.id} }, format: :json
+          api_get :bulk_products, { page: 1, per_page: 15, q: {primary_taxon_id_eq: taxon.id} }, format: :json
           expect(returned_product_ids).to eq [product3.id, product2.id]
         end
 
         it "filters results by import_date" do
-          product1.variants.first.import_date = 1.day.ago
+          product.variants.first.import_date = 1.day.ago
           product2.variants.first.import_date = 2.days.ago
           product3.variants.first.import_date = 1.day.ago
 
-          product1.save
+          product.save
           product2.save
           product3.save
 
-          spree_get :bulk_products, { page: 1, per_page: 15, import_date: 1.day.ago.to_date.to_s }, format: :json
-          expect(returned_product_ids).to eq [product3.id, product1.id]
+          api_get :bulk_products, { page: 1, per_page: 15, import_date: 1.day.ago.to_date.to_s }, format: :json
+          expect(returned_product_ids).to eq [product3.id, product.id]
         end
       end
     end

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -437,6 +437,7 @@ feature '
     visit spree.admin_products_path
 
     select2_select s1.name, from: "producer_filter"
+    apply_filters
 
     expect(page).to have_no_field "product_name", with: p2.name
     fill_in "product_name", with: "new product1"
@@ -609,6 +610,7 @@ feature '
 
         # Set a filter
         select2_select s1.name, from: "producer_filter"
+        apply_filters
 
         # Products are hidden when filtered out
         expect(page).to have_field "product_name", with: p1.name
@@ -616,6 +618,7 @@ feature '
 
         # Clearing filters
         click_button "Clear Filters"
+        apply_filters
 
         # All products are shown again
         expect(page).to have_field "product_name", with: p1.name
@@ -788,5 +791,9 @@ feature '
 
       expect(page).to have_selector "div.reveal-modal"
     end
+  end
+
+  def apply_filters
+    page.find('.button.icon-search').click
   end
 end

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -170,6 +170,7 @@ feature "Product Import", js: true do
       expect(page).to have_selector 'div#s2id_import_date_filter'
       import_time = carrots.import_date.to_date.to_formatted_s(:long)
       select2_select import_time, from: "import_date_filter"
+      page.find('.button.icon-search').click
 
       expect(page).to have_field "product_name", with: carrots.name
       expect(page).to have_field "product_name", with: potatoes.name

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -299,13 +299,6 @@ describe "AdminProductEditCtrl", ->
       $scope.$digest()
       expect($scope.resetProducts).toHaveBeenCalled()
 
-    it "sets the loading property to true before fetching products and unsets it when loading is complete", ->
-      $scope.fetchProducts()
-      expect($scope.loading).toEqual true
-      $scope.$digest()
-      expect($scope.loading).toEqual false
-
-
   describe "resetting products", ->
     beforeEach ->
       spyOn DirtyProducts, "clear"

--- a/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
@@ -8,35 +8,6 @@ describe "BulkProducts service", ->
     BulkProducts = _BulkProducts_
     $httpBackend = _$httpBackend_
 
-  describe "fetching products", ->
-    beforeEach ->
-      spyOn BulkProducts, 'addProducts'
-
-    it "makes a standard call to dataFetcher when no filters exist", ->
-      $httpBackend.expectGET("/api/products/bulk_products?page=1;per_page=20;").respond "list of products"
-      BulkProducts.fetch [], ->
-      $httpBackend.flush()
-
-    it "makes more calls to dataFetcher if more pages exist", ->
-      $httpBackend.expectGET("/api/products/bulk_products?page=1;per_page=20;").respond { products: [], pages: 2 }
-      $httpBackend.expectGET("/api/products/bulk_products?page=2;per_page=20;").respond { products: ["list of products"] }
-      BulkProducts.fetch [], ->
-      $httpBackend.flush()
-
-    it "applies filters when they are supplied", ->
-      filter =
-        property:
-          name: "Name"
-          db_column: "name"
-        predicate:
-          name: "Equals"
-          predicate: "eq"
-        value: "Product1"
-      $httpBackend.expectGET("/api/products/bulk_products?page=1;per_page=20;q[name_eq]=Product1;").respond "list of products"
-      BulkProducts.fetch [filter], ->
-      $httpBackend.flush()
-
-
   describe "cloning products", ->
     it "clones products using a http post request to /api/products/(id)/clone", ->
       BulkProducts.products = [

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -390,6 +390,17 @@ module Spree
           expect(stockable_products).to_not include p3
         end
       end
+
+      describe "imported_on" do
+        let!(:v1) { create(:variant, import_date: 1.day.ago) }
+        let!(:v2) { create(:variant, import_date: 2.days.ago) }
+        let!(:v3) { create(:variant, import_date: 1.day.ago) }
+
+        it "returns products imported on given day" do
+          imported_products = Spree::Product.imported_on(1.day.ago.to_date)
+          expect(imported_products).to include v1.product, v3.product
+        end
+      end
     end
 
     describe "properties" do


### PR DESCRIPTION
#### What? Why?

Closes #4076 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Pagination for Bulk Edit Products. Should resolve a number of BEP-related issues (there's a list somewhere).

#### What should we test?
<!-- List which features should be tested and how. -->

Admin Products page functionality is all working as before, but with paginated results.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added pagination to Admin Products page

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

### Screenshots

I've reused the elements from the orders page to try to get a bit of consistency, but it really feels like we need a UI person to design us a nice admin area...

`TOP:`
![BEP1](https://user-images.githubusercontent.com/9029026/61889518-78e8ea80-aefd-11e9-8c34-e8b1ae96366a.png)
`BOTTOM:`
![BEP2](https://user-images.githubusercontent.com/9029026/61889519-78e8ea80-aefd-11e9-9b91-d13ffc1f573a.png)
