### PR TITLE
Add doctype declaration in layouts/admin view

### DIFF
--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -29,8 +29,5 @@
     %div{"data-hook" => "admin_order_edit_form"}
       = render :partial => 'form', :locals => { :order => @order }
 
-- content_for :head do
-  = javascript_tag 'var expand_variants = true;'
-
 :coffee
   angular.bootstrap(document.getElementById("links-dropdown"),['admin.dropdown'])

--- a/app/views/spree/admin/orders/new.html.haml
+++ b/app/views/spree/admin/orders/new.html.haml
@@ -21,6 +21,3 @@
   - unless @order.line_items.any?
     %div
       = render 'form'
-
-- content_for :head do
-  = javascript_tag 'var expand_variants = true;'

--- a/app/views/spree/admin/shared/_head.html.haml
+++ b/app/views/spree/admin/shared/_head.html.haml
@@ -21,4 +21,7 @@
   = "jQuery.alerts.dialogClass = 'spree';"
   = raw "var AUTH_TOKEN = \"#{form_authenticity_token}\";"
 
+= render "layouts/bugherd_script"
+%link{'data-require' => "font-awesome@*", 'data-semver'=>"4.2.0", 'rel' => "stylesheet", 'href' => "//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css"}
+
 = yield :head

--- a/app/views/spree/layouts/admin.html.haml
+++ b/app/views/spree/layouts/admin.html.haml
@@ -3,9 +3,6 @@
   %head{"data-hook" => "admin_inside_head"}
     = render :partial => 'spree/admin/shared/head'
 
-    = render "layouts/bugherd_script"
-    %link{'data-require' => "font-awesome@*", 'data-semver'=>"4.2.0", 'rel' => "stylesheet", 'href' => "//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css"}
-
   %body.admin
     = admin_inject_currency_config
     = render "layouts/i18n_script"

--- a/app/views/spree/layouts/admin.html.haml
+++ b/app/views/spree/layouts/admin.html.haml
@@ -1,3 +1,4 @@
+!!!
 %html{:lang => "en"}
   %head{"data-hook" => "admin_inside_head"}
     = render :partial => 'spree/admin/shared/head'

--- a/app/views/spree/layouts/admin.html.haml
+++ b/app/views/spree/layouts/admin.html.haml
@@ -17,69 +17,69 @@
       - if flash[:success]
         .flash.success= flash[:success]
 
-    #progress
-      .wrapper
-        #spinner
-        .progress-message
-          = Spree.t(:loading)
-          \...
+      #progress
+        .wrapper
+          #spinner
+          .progress-message
+            = Spree.t(:loading)
+            \...
 
-    = render :partial => 'spree/admin/shared/alert', :collection => session[:alerts]
+      = render :partial => 'spree/admin/shared/alert', :collection => session[:alerts]
 
-    %header#header{"data-hook" => ""}
-      .container
-        %figure.columns.five{"data-hook" => "logo-wrapper"}
-          = link_to image_tag(Spree::Config[:admin_interface_logo], :id => 'logo'), spree.admin_path
-        %nav.columns.eleven{"data-hook" => "admin_login_navigation_bar"}
-
-    %nav#admin-menu{"data-hook" => ""}
-      .container
-        .sixteen.columns.main-menu-wrapper
-          %ul.inline-menu.fullwidth-menu{"data-hook" => "admin_tabs"}
-            = render :partial => 'spree/admin/shared/tabs'
-
-    - if content_for?(:sub_menu)
-      %nav#sub-menu{"data-hook" => ""}
+      %header#header{"data-hook" => ""}
         .container
-          .sixteen.columns
-            = yield :sub_menu
+          %figure.columns.five{"data-hook" => "logo-wrapper"}
+            = link_to image_tag(Spree::Config[:admin_interface_logo], :id => 'logo'), spree.admin_path
+          %nav.columns.eleven{"data-hook" => "admin_login_navigation_bar"}
 
-    - if content_for?(:page_title) || content_for?(:page_actions)
-      #content-header{"data-hook" => ""}
+      %nav#admin-menu{"data-hook" => ""}
         .container
-          .sixteen.columns
-            .block-table
-              - if content_for?(:page_title)
-                .table-cell
-                  %h1{:class => "page-title"}= yield :page_title
-              - if content_for?(:page_actions)
-                .page-actions.table-cell.toolbar{"data-hook" => "toolbar"}
-                  %ul.inline-menu
-                    = yield :page_actions
+          .sixteen.columns.main-menu-wrapper
+            %ul.inline-menu.fullwidth-menu{"data-hook" => "admin_tabs"}
+              = render :partial => 'spree/admin/shared/tabs'
 
-    .container
-      .row
-        - content_class = content_for?(:sidebar) ? "with-sidebar" : ""
-        #content{:class => content_class, "data-hook" => ""}
-          - if content_for?(:table_filter)
-            - table_filter_class = content_for?(:sidebar) ? 'twelve columns' : 'sixteen columns'
-            #table-filter{:class => table_filter_class, "data-hook" => ""}
-              %fieldset
-                %legend{:align => "center"}= yield :table_filter_title
-                = yield :table_filter
-          - div_class = content_for?(:sidebar) ? 'twelve columns' : 'sixteen columns'
-          %div{:class => div_class}
-            = yield
-          - if content_for?(:sidebar)
-            %aside#sidebar.four.columns{"data-hook" => ""}
-              - if content_for?(:sidebar_title)
-                %h5.sidebar-title
-                  %span= yield :sidebar_title
-              = yield :sidebar
+      - if content_for?(:sub_menu)
+        %nav#sub-menu{"data-hook" => ""}
+          .container
+            .sixteen.columns
+              = yield :sub_menu
 
-  %div{"data-hook" => "admin_footer_scripts"}
+      - if content_for?(:page_title) || content_for?(:page_actions)
+        #content-header{"data-hook" => ""}
+          .container
+            .sixteen.columns
+              .block-table
+                - if content_for?(:page_title)
+                  .table-cell
+                    %h1{:class => "page-title"}= yield :page_title
+                - if content_for?(:page_actions)
+                  .page-actions.table-cell.toolbar{"data-hook" => "toolbar"}
+                    %ul.inline-menu
+                      = yield :page_actions
 
-  = render 'spree/shared/google_analytics'
+      .container
+        .row
+          - content_class = content_for?(:sidebar) ? "with-sidebar" : ""
+          #content{:class => content_class, "data-hook" => ""}
+            - if content_for?(:table_filter)
+              - table_filter_class = content_for?(:sidebar) ? 'twelve columns' : 'sixteen columns'
+              #table-filter{:class => table_filter_class, "data-hook" => ""}
+                %fieldset
+                  %legend{:align => "center"}= yield :table_filter_title
+                  = yield :table_filter
+            - div_class = content_for?(:sidebar) ? 'twelve columns' : 'sixteen columns'
+            %div{:class => div_class}
+              = yield
+            - if content_for?(:sidebar)
+              %aside#sidebar.four.columns{"data-hook" => ""}
+                - if content_for?(:sidebar_title)
+                  %h5.sidebar-title
+                    %span= yield :sidebar_title
+                = yield :sidebar
 
-  %script
-    = raw "Spree.api_key = \"#{try_spree_current_user.try(:spree_api_key).to_s}\";"
+    %div{"data-hook" => "admin_footer_scripts"}
+
+    = render 'spree/shared/google_analytics'
+
+    %script
+      = raw "Spree.api_key = \"#{try_spree_current_user.try(:spree_api_key).to_s}\";"


### PR DESCRIPTION
#### What? Why?

Closes #4088 
4808 was caused by the [missing doctype declaration](https://github.com/openfoodfoundation/openfoodnetwork/pull/4089/commits/9bc81f236c26f6025a04e8a80a45f8392d7bc302), this declaration tells the browser to read OFN pages as html5. Problem solved.

I used this PR to make a few more improvements:
- fix indentation problem and keep existing html structure - I dont think this has a functional impact
- remove dead code related to expand_variants, related to product auto complete which is the ancestor of variant_autocomplete - old code, no need to test manually
- move head script from admin layout to head partial - fonts


#### What should we test?
Verify 4088 is fixed and that the fonts are rendering as before.


#### Release notes
This is fixing a problem introduced in another PR of this release, no release notes.
