### PR TITLE
Move CSS rule to SCSS and remove broken css file reference

### DIFF
--- a/app/assets/stylesheets/admin/all.scss
+++ b/app/assets/stylesheets/admin/all.scss
@@ -10,7 +10,6 @@
  *= require jquery-ui-timepicker-addon
  *= require shared/textAngular
  *= require shared/ng-tags-input.min
- *= require admin/custom
 
  *= require_self
 */

--- a/app/assets/stylesheets/admin/components/timepicker.css.scss
+++ b/app/assets/stylesheets/admin/components/timepicker.css.scss
@@ -1,2 +1,1 @@
-/* Custom fix */
 .ui-timepicker-div.ui-timepicker-oneLine dl dd { width: 25%; }


### PR DESCRIPTION
#### What? Why?

Closes #3759

Some broken CSS references were causing 404 errors.

I've moved the CSS rule to an scss file under components (it applies to a specific jquery timepicker) and removed the broken reference causing the 404 errors.

#### What should we test?
<!-- List which features should be tested and how. -->

404 errors should be gone.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a missing CSS error.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

