### PR TITLE
Remove N+1 while fetching distributors of OCs

### DIFF
--- a/app/controllers/spree/admin/base_controller_decorator.rb
+++ b/app/controllers/spree/admin/base_controller_decorator.rb
@@ -61,7 +61,7 @@ Spree::Admin::BaseController.class_eval do
 
   def active_distributors_not_ready_for_checkout
     ocs = OrderCycle.managed_by(spree_current_user).active
-    distributors = ocs.map(&:distributors).flatten.uniq
+    distributors = ocs.includes(:distributors).map(&:distributors).flatten.uniq
     Enterprise.where('enterprises.id IN (?)', distributors).not_ready_for_checkout
   end
 


### PR DESCRIPTION
#### What? Why?

Closely related to  #4077. `/api/products/bulk_products` and `/admin/products` get always executed together. 

What used to be done as

```sql
SELECT "order_cycles".* FROM "order_cycles"
WHERE (order_cycles.orders_open_at <= '2019-07-29 17:45:20.137294'
  AND order_cycles.orders_close_at >= '2019-07-29 17:45:20.137333')

SELECT DISTINCT "enterprises".* FROM "enterprises"
INNER JOIN "exchanges" ON "enterprises"."id" = "exchanges"."receiver_id"
WHERE "exchanges"."order_cycle_id" = 1
  AND "exchanges"."incoming" = 'f'
(...)
SELECT DISTINCT "enterprises".* FROM "enterprises"
INNER JOIN "exchanges" ON "enterprises"."id" = "exchanges"."receiver_id"
WHERE "exchanges"."order_cycle_id" = 4
  AND "exchanges"."incoming" = 'f'
```
(notice we have N queries which just change the order_cycle_id)

It's now

```sql
SELECT "order_cycles".* FROM "order_cycles"
WHERE (order_cycles.orders_open_at <= '2019-07-29 17:45:20.137294'
  AND order_cycles.orders_close_at >= '2019-07-29 17:45:20.137333')

SELECT "exchanges".* FROM "exchanges"
WHERE "exchanges"."incoming" = 'f'
  AND "exchanges"."order_cycle_id" IN (1, 2, 3, 4)

SELECT "enterprises".* FROM "enterprises"
WHERE "enterprises"."id" IN (3, 4, 5, 6)
```

This has noticeable impact since the changed method belongs to the
`BaseController` seems to be executed in all HTML requests as it gets
called by

```ruby
before_filter :warn_invalid_order_cycles, if: :html_request?
```

#### What should we test?

The Bulk Edit Products (/admin/products) page should render exactly the same.

#### Release notes

The Bulk Edit Products page no longer loads distributors with N+1 queries.

Changelog Category: Changed