### PR TITLE
4103 Add specs for referencing of shipments to deleted variants

### DIFF
--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -365,16 +365,15 @@ feature '
       end
 
       context "when an included variant has been deleted" do
-        before do
-          @deleted_variant = order.line_items.first.variant
-          @deleted_variant.delete
-
-          visit spree.edit_admin_order_path(order)
+        let!(:deleted_variant) do
+          order.line_items.first.variant.tap do |record|
+            record.delete
+          end
         end
 
         it "still lists the variant in the order page" do
           within ".stock-contents" do
-            expect(page).to have_content @deleted_variant.product_and_full_name
+            expect(page).to have_content deleted_variant.product_and_full_name
           end
         end
       end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -363,6 +363,21 @@ feature '
 
         expect(page.find("td.amount")).to have_content "$5.00"
       end
+
+      context "when an included variant has been deleted" do
+        before do
+          @deleted_variant = @order.line_items.first.variant
+          @deleted_variant.delete
+
+          visit spree.edit_admin_order_path(@order)
+        end
+
+        it "still lists the variant in the order page" do
+          within ".stock-contents" do
+            expect(page).to have_content @deleted_variant.product_and_full_name
+          end
+        end
+      end
     end
 
     scenario "creating an order with distributor and order cycle" do

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -223,25 +223,25 @@ feature '
       let!(:different_shipping_method_for_distributor1) { create(:shipping_method, name: "Different", distributors: [distributor1]) }
       let!(:shipping_method_for_distributor2) { create(:shipping_method, name: "Other", distributors: [distributor2]) }
 
+      let!(:order) do
+        create(:order_with_taxes, distributor: distributor1, ship_address: create(:address),
+                                  product_price: 110, tax_rate_amount: 0.1,
+                                  tax_rate_name: "Tax 1").tap do |record|
+                                    Spree::TaxRate.adjust(record)
+                                    record.update_shipping_fees!
+                                  end
+      end
+
       background do
         Spree::Config[:enable_receipt_printing?] = true
-
         distributor1.update_attribute(:abn, '12345678')
-        @order = create(:order_with_taxes,
-                        distributor: distributor1,
-                        ship_address: create(:address),
-                        product_price: 110,
-                        tax_rate_amount: 0.1,
-                        tax_rate_name: "Tax 1")
-        Spree::TaxRate.adjust(@order)
-        @order.update_shipping_fees!
 
-        visit spree.edit_admin_order_path(@order)
+        visit spree.edit_admin_order_path(order)
       end
 
       scenario "shows a list of line_items" do
         within('table.index tbody', match: :first) do
-          @order.line_items.each do |item|
+          order.line_items.each do |item|
             expect(page).to have_selector "td", match: :first, text: item.full_name
             expect(page).to have_selector "td.item-price", text: item.single_display_amount
             expect(page).to have_selector "input#quantity[value='#{item.quantity}']", visible: false
@@ -252,13 +252,13 @@ feature '
 
       scenario "shows the order items total" do
         within('fieldset#order-total') do
-          expect(page).to have_selector "span.order-total", text: @order.display_item_total
+          expect(page).to have_selector "span.order-total", text: order.display_item_total
         end
       end
 
       scenario "shows the order non-tax adjustments" do
         within('table.index tbody') do
-          @order.adjustments.eligible.each do |adjustment|
+          order.adjustments.eligible.each do |adjustment|
             expect(page).to have_selector "td", match: :first, text: adjustment.label
             expect(page).to have_selector "td.total", text: adjustment.display_amount
           end
@@ -266,7 +266,7 @@ feature '
       end
 
       scenario "shows the order total" do
-        expect(page).to have_selector "fieldset#order-total", text: @order.display_total
+        expect(page).to have_selector "fieldset#order-total", text: order.display_total
       end
 
       scenario "shows the order tax adjustments" do
@@ -279,10 +279,10 @@ feature '
       scenario "shows the dropdown menu" do
         find("#links-dropdown .ofn-drop-down").click
         within "#links-dropdown" do
-          expect(page).to have_link "Resend Confirmation", href: spree.resend_admin_order_path(@order)
-          expect(page).to have_link "Send Invoice", href: spree.invoice_admin_order_path(@order)
-          expect(page).to have_link "Print Invoice", href: spree.print_admin_order_path(@order)
-          expect(page).to have_link "Cancel Order", href: spree.fire_admin_order_path(@order, e: 'cancel')
+          expect(page).to have_link "Resend Confirmation", href: spree.resend_admin_order_path(order)
+          expect(page).to have_link "Send Invoice", href: spree.invoice_admin_order_path(order)
+          expect(page).to have_link "Print Invoice", href: spree.print_admin_order_path(order)
+          expect(page).to have_link "Cancel Order", href: spree.fire_admin_order_path(order, e: 'cancel')
         end
       end
 
@@ -327,27 +327,27 @@ feature '
             print_data = page.evaluate_script('printData');
             elements_in_print_data =
               [
-                @order.distributor.name,
-                @order.distributor.address.address_part1,
-                @order.distributor.address.address_part2,
-                @order.distributor.contact.email,
-                @order.number,
-                @order.line_items.map { |line_item|
+                order.distributor.name,
+                order.distributor.address.address_part1,
+                order.distributor.address.address_part2,
+                order.distributor.contact.email,
+                order.number,
+                order.line_items.map { |line_item|
                   [line_item.quantity.to_s,
                    line_item.product.name,
                    line_item.single_display_amount_with_adjustments.format(symbol: false, with_currency: false),
                    line_item.display_amount_with_adjustments.format(symbol: false, with_currency: false)]
                 },
-                checkout_adjustments_for(@order, exclude: [:line_item]).reject { |a| a.amount == 0 }.map { |adjustment|
+                checkout_adjustments_for(order, exclude: [:line_item]).reject { |a| a.amount == 0 }.map { |adjustment|
                   [raw(adjustment.label),
                    display_adjustment_amount(adjustment).format(symbol: false, with_currency: false)]
                 },
-                @order.display_total.format(with_currency: false),
-                display_checkout_taxes_hash(@order).map { |tax_rate, tax_value|
+                order.display_total.format(with_currency: false),
+                display_checkout_taxes_hash(order).map { |tax_rate, tax_value|
                   [tax_rate,
                    tax_value.format(with_currency: false)]
                 },
-                display_checkout_total_less_tax(@order).format(with_currency: false)
+                display_checkout_total_less_tax(order).format(with_currency: false)
               ]
             expect(print_data.join).to include(*elements_in_print_data.flatten)
           end
@@ -366,10 +366,10 @@ feature '
 
       context "when an included variant has been deleted" do
         before do
-          @deleted_variant = @order.line_items.first.variant
+          @deleted_variant = order.line_items.first.variant
           @deleted_variant.delete
 
-          visit spree.edit_admin_order_path(@order)
+          visit spree.edit_admin_order_path(order)
         end
 
         it "still lists the variant in the order page" do

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe Spree::Shipment do
+  describe "manifest" do
+    let!(:product) { create(:product) }
+    let!(:order) { create(:order, distributor: product.supplier) }
+    let!(:deleted_variant) { create(:variant, product: product) }
+    let!(:other_variant) { create(:variant, product: product) }
+    let!(:line_item_for_deleted) { create(:line_item, order: order, variant: deleted_variant) }
+    let!(:line_item_for_other) { create(:line_item, order: order, variant: other_variant) }
+    let!(:shipment) { create(:shipment_with, :shipping_method, order: order) }
+
+    context "when the variant is soft-deleted" do
+      before { deleted_variant.delete }
+
+      it "can still access the variant" do
+        shipment.reload
+        variants = shipment.manifest.map(&:variant).uniq
+        expect(variants.sort_by(&:id)).to eq([deleted_variant, other_variant].sort_by(&:id))
+      end
+    end
+
+    context "when the product is soft-deleted" do
+      before { deleted_variant.product.delete }
+
+      it "can still access the variant" do
+        shipment.reload
+        variants = shipment.manifest.map(&:variant)
+        expect(variants.sort_by(&:id)).to eq([deleted_variant, other_variant].sort_by(&:id))
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Relates to #4103

Issue #4103 is expected to be fixed already in v2.2.2, but should be closed within the issue after deployment of the release and verifying that if is no longer a problem.

This adds specs for referencing of shipments to deleted variants. The specs added in this PR fail in v2.2.1, but pass in `master`.

I attempted to recreate the specific error quoted here thinking it was for a specific order state: https://github.com/openfoodfoundation/openfoodnetwork/issues/3903#issuecomment-499960499 But later realized that might be the previous error for the same scenario which could have been fixed in/before v2.2.1.

#### What should we test?

Nothing to test - this only adds specs.

#### Release notes

- Add specs for referencing of shipments to deleted variants to avoid regression.

Changelog Category: Added