### PR TITLE
Navigation css

### DIFF
--- a/app/assets/stylesheets/darkswarm/branding.css.scss
+++ b/app/assets/stylesheets/darkswarm/branding.css.scss
@@ -35,5 +35,6 @@ $med-grey: #666;
 $med-drk-grey: #444;
 $dark-grey: #333;
 $light-grey: #ddd;
+$light-grey-transparency: rgba(0, 0, 0, .1);
 $black: #000;
 $white: #fff;

--- a/app/assets/stylesheets/darkswarm/menu.css.scss
+++ b/app/assets/stylesheets/darkswarm/menu.css.scss
@@ -42,7 +42,7 @@ nav.top-bar {
 }
 
 .top-bar-section {
-  border-bottom: 1px solid $light-grey;
+  border-bottom: 1px solid $light-grey-transparency;
 
   a.icon {
     &:hover {
@@ -169,11 +169,11 @@ nav.top-bar {
 // Mobile Menu
 
 .tab-bar {
-  border-bottom: 1px solid $light-grey;
   background-color: white;
+  border-bottom: 1px solid $light-grey-transparency;
+  height: 2.8em;
   position: fixed;
   width: 100%;
-  height: 2.8em;
   z-index: 1;
 
   .cart-span {

--- a/app/assets/stylesheets/darkswarm/menu.css.scss
+++ b/app/assets/stylesheets/darkswarm/menu.css.scss
@@ -169,6 +169,7 @@ nav.top-bar {
 // Mobile Menu
 
 .tab-bar {
+  border-bottom: 1px solid $light-grey;
   background-color: white;
   position: fixed;
   width: 100%;

--- a/app/assets/stylesheets/darkswarm/menu.css.scss
+++ b/app/assets/stylesheets/darkswarm/menu.css.scss
@@ -42,7 +42,7 @@ nav.top-bar {
 }
 
 .top-bar-section {
-  border-bottom: 1px solid $ofn-grey;
+  border-bottom: 1px solid $light-grey;
 
   a.icon {
     &:hover {

--- a/app/assets/stylesheets/darkswarm/shopping-cart.css.scss
+++ b/app/assets/stylesheets/darkswarm/shopping-cart.css.scss
@@ -1,6 +1,7 @@
 @import "mixins";
 @import "branding";
 @import "compass/css3/user-interface";
+@import 'variables';
 
 .cart {
   @include user-select(none);
@@ -15,8 +16,8 @@
 
   .joyride-tip-guide {
     display: block;
-    right: 10px;
-    top: 55px;
+    right: 0;
+    top: $topbar-height;
     width: 480px;
 
     @media screen and (min-width: 641px) {


### PR DESCRIPTION
#### What? Why?

- Updates the colour of the bottom border on the navigation bar (was much darker than in Zeplin)
- Adds a bit of transparency on the light grey so it looks nicer when scrolling past a section with a darker background 
- Adds bottom border to the navigation bar in mobile view (was missing)
- Updates position of the cart dropdown to be in line with the recent changes (was outdated)

#### What should we test?
<!-- List which features should be tested and how. -->

Visual display of navigation bar in desktop and mobile, positioning of cart dropdown in desktop.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Updated CSS on navigation bar and cart dropdown

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

### Screenshots

**Border colour before:**
![light-3](https://user-images.githubusercontent.com/9029026/62426374-dfc78a00-b6db-11e9-9ec3-a5f977c453d3.png)

**Border colour after:**
![light-2](https://user-images.githubusercontent.com/9029026/62426360-aabb3780-b6db-11e9-8607-42207aac0522.png)

**Border on dark background without transparency:**
![dark-1](https://user-images.githubusercontent.com/9029026/62426393-26b57f80-b6dc-11e9-95a6-98c1ab355358.png)

**Border on dark background with some transparency:**
![dark-2](https://user-images.githubusercontent.com/9029026/62426394-26b57f80-b6dc-11e9-84bd-3bed5ae48a22.png)

**Missing border added on mobile view:**
![light-mobile](https://user-images.githubusercontent.com/9029026/62426345-83fd0100-b6db-11e9-8eda-44f73ff5a521.png)

**Cart dropdown before:**
![cert-drop-2](https://user-images.githubusercontent.com/9029026/62426332-544df900-b6db-11e9-8011-d2845615106e.png)

**Cart dropdown after:**
![cart-drop](https://user-images.githubusercontent.com/9029026/62426331-5021db80-b6db-11e9-825f-fc731168292d.png)



