### PR TITLE
Add SKU to order confirmation email

### DIFF
--- a/app/views/spree/order_mailer/_order_summary.html.haml
+++ b/app/views/spree/order_mailer/_order_summary.html.haml
@@ -1,16 +1,16 @@
 %table.order-summary{:width => "100%"}
   %thead
     %tr
-      %th{:align => "left"}
+      %th{align: "left"}
         %h4
           = t :email_order_summary_item
-      %th{:align => "left"}
+      %th{align: "left"}
         %h4
           = t :email_order_summary_sku
-      %th{:align => "right"}
+      %th{align: "right"}
         %h4
           = t :email_order_summary_quantity
-      %th{:align => "right", :width => "25%"}
+      %th{align: "right", width: "25%"}
         %h4
           = t :email_order_summary_price
   %tbody
@@ -26,37 +26,37 @@
             \-
           - else
             = item.variant.sku
-        %td{:align => "right"}
+        %td{align: "right"}
           - if @changes && @changes[item.id].present?
             %del.quantity_was= @changes[item.id]
           = item.quantity
           -# Report changes made to subscriptions
 
-        %td{:align => "right"}
+        %td{align: "right"}
           = item.display_amount_with_adjustments
   %tfoot
     %tr
-      %td{:align => "right", :colspan => "2"}
+      %td{align: "right", colspan: "3"}
         = t :email_order_summary_subtotal
-      %td{:align => "right"}
+      %td{align: "right"}
         = display_checkout_subtotal(@order)
     - checkout_adjustments_for(@order, exclude: [:line_item]).reject{ |a| a.amount == 0 }.reverse_each do |adjustment|
       %tr
-        %td{:align => "right", :colspan => "2"}
+        %td{align: "right", colspan: "3"}
           = "#{raw(adjustment.label)}:"
-        %td{:align => "right"}
+        %td{align: "right"}
           = adjustment.display_amount
     %tr
-      %td{:align => "right", :colspan => "2"}
+      %td{align: "right", colspan: "3"}
         %strong
           = t :email_order_summary_total
-      %td{:align => "right"}
+      %td{align: "right"}
         %strong= @order.display_total
 
     - if @order.total_tax > 0
       %tr
-        %td{:align => "right", :colspan => "2"}
+        %td{align: "right", colspan: "3"}
           = t :email_order_summary_includes_tax
-        %td{:align => "right"}
+        %td{align: "right"}
           = display_checkout_tax_total(@order)
 %p &nbsp;

--- a/app/views/spree/order_mailer/_order_summary.html.haml
+++ b/app/views/spree/order_mailer/_order_summary.html.haml
@@ -4,7 +4,10 @@
       %th{:align => "left"}
         %h4
           = t :email_order_summary_item
-      %th{:align => "right", :width => "25%"}
+      %th{:align => "left"}
+        %h4
+          = t :email_order_summary_sku
+      %th{:align => "right"}
         %h4
           = t :email_order_summary_quantity
       %th{:align => "right", :width => "25%"}
@@ -18,6 +21,11 @@
           %br
           %small
             %em= raw(item.variant.product.supplier.name)
+        %td
+          - if item.variant.sku.blank?
+            \-
+          - else
+            = item.variant.sku
         %td{:align => "right"}
           - if @changes && @changes[item.id].present?
             %del.quantity_was= @changes[item.id]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1496,6 +1496,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   email_confirm_shop_number_html: "Order confirmation <strong>#%{number}</strong>"
   email_order_summary_item: "Item"
   email_order_summary_quantity: "Qty"
+  email_order_summary_sku: "SKU"
   email_order_summary_price: "Price"
   email_order_summary_subtotal: "Subtotal:"
   email_order_summary_total: "Total:"

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -4,6 +4,16 @@ describe Spree::OrderMailer do
   include OpenFoodNetwork::EmailHelper
 
   describe "order confimation" do
+    let(:bill_address) { create(:address) }
+    let(:distributor_address) { create(:address, address1: "distributor address", city: 'The Shire', zipcode: "1234") }
+    let(:distributor) { create(:distributor_enterprise, address: distributor_address) }
+    let(:shipping_instructions) { "pick up on thursday please!" }
+    let(:ship_address) { create(:address, address1: "distributor address", city: 'The Shire', zipcode: "1234") }
+    let(:order) {
+      create(:order_with_line_items, distributor: distributor, bill_address: bill_address, ship_address: ship_address,
+                     special_instructions: shipping_instructions)
+    }
+
     after do
       ActionMailer::Base.deliveries.clear
     end
@@ -13,41 +23,39 @@ describe Spree::OrderMailer do
       ActionMailer::Base.delivery_method = :test
       ActionMailer::Base.perform_deliveries = true
       ActionMailer::Base.deliveries = []
-
-      @bill_address = create(:address)
-      @distributor_address = create(:address, address1: "distributor address", city: 'The Shire', zipcode: "1234")
-      @distributor = create(:distributor_enterprise, address: @distributor_address)
-      product = create(:product)
-      @shipping_instructions = "pick up on thursday please!"
-      ship_address = create(:address, address1: "distributor address", city: 'The Shire', zipcode: "1234")
-      @order1 = create(:order, distributor: @distributor, bill_address: @bill_address, ship_address: ship_address, special_instructions: @shipping_instructions)
-      ActionMailer::Base.deliveries = []
     end
 
     describe "for customers" do
       it "should send an email to the customer when given an order" do
-        Spree::OrderMailer.confirm_email_for_customer(@order1.id).deliver
+        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver
         expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first.to).to eq([@order1.email])
+        expect(ActionMailer::Base.deliveries.first.to).to eq([order.email])
+      end
+
+      it "should include SKUs" do
+        mail = Spree::OrderMailer.confirm_email_for_customer(order.id)
+
+        expect(mail.body.encoded).to include "SKU"
+        expect(mail.body.encoded).to include order.line_items.first.variant.sku
       end
 
       it "sets a reply-to of the enterprise email" do
-        Spree::OrderMailer.confirm_email_for_customer(@order1.id).deliver
-        expect(ActionMailer::Base.deliveries.first.reply_to).to eq([@distributor.contact.email])
+        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver
+        expect(ActionMailer::Base.deliveries.first.reply_to).to eq([distributor.contact.email])
       end
     end
 
     describe "for shops" do
       it "sends an email to the shop owner when given an order" do
-        Spree::OrderMailer.confirm_email_for_shop(@order1.id).deliver
+        Spree::OrderMailer.confirm_email_for_shop(order.id).deliver
         expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first.to).to eq([@distributor.contact.email])
+        expect(ActionMailer::Base.deliveries.first.to).to eq([distributor.contact.email])
       end
 
       it "sends an email even if a footer_email is given" do
         # Testing bug introduced by a9c37c162e1956028704fbdf74ce1c56c5b3ce7d
         ContentConfig.footer_email = "email@example.com"
-        Spree::OrderMailer.confirm_email_for_shop(@order1.id).deliver
+        Spree::OrderMailer.confirm_email_for_shop(order.id).deliver
         expect(ActionMailer::Base.deliveries.count).to eq(1)
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #4102 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Add SKU to order confirmation emails.

#### What should we test?
<!-- List which features should be tested and how. -->

SKUs display in order emails. Shows a `-` in the column where they are missing.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added product SKUs to order confirmation emails

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added