### PR TITLE
Variant overrides with on_demand

### DIFF
--- a/lib/open_food_network/scope_variant_to_hub.rb
+++ b/lib/open_food_network/scope_variant_to_hub.rb
@@ -41,7 +41,11 @@ module OpenFoodNetwork
       #   - updates variant_override.count_on_hand
       #   - does not create stock_movement
       #   - does not update stock_item.count_on_hand
+      # If it is a variant override with on_demand:
+      #   - don't change stock or call super (super would change the variant's stock)
       def move(quantity, originator = nil)
+        return if @variant_override.andand.on_demand
+
         if @variant_override.andand.stock_overridden?
           @variant_override.move_stock! quantity
         else


### PR DESCRIPTION
#### What? Why?

Closes #4122 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

When an override had `on_demand: true`, the variant's stock was being decremented when it was sold.

#### What should we test?
<!-- List which features should be tested and how. -->

When a distributor sells a variant override with `on_demand`set to `true`, it doesn't reduce the stock levels of the producer's variant.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a stock issue with inventory using `on_demand`

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

