### PR TITLE
Cart dropdown now closes when clicking outside it.

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/cart_popover.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/cart_popover.js.coffee
@@ -1,8 +1,0 @@
-Darkswarm.directive "cart", ->
-  # Toggles visibility of the "cart" popover
-  restrict: 'A'
-  link: (scope, elem, attr)->
-    scope.open = false
-    elem.bind 'click', ->
-      scope.$apply ->
-        scope.open = !scope.open

--- a/app/assets/javascripts/darkswarm/directives/cart_toggle.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/cart_toggle.js.coffee
@@ -1,0 +1,19 @@
+Darkswarm.directive "cartToggle", ($document) ->
+  # Toggles visibility of the "cart" popover
+  restrict: 'A'
+  link: (scope, elem, attr)->
+    scope.open = false
+
+    $document.bind 'click', (event) ->
+      cart_button = elem[0]
+      element_and_parents = [event.target, event.target.parentElement, event.target.parentElement.parentElement]
+      cart_button_clicked = (element_and_parents.indexOf(cart_button) != -1)
+
+      if cart_button_clicked
+        scope.$apply ->
+          scope.open = !scope.open
+      else
+        scope.$apply ->
+          scope.open = false
+
+      return

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -1,5 +1,5 @@
 %span.cart-span{"ng-controller" => "CartCtrl", "ng-class" => "{ dirty: Cart.dirty || Cart.empty(), 'pure-dirty': Cart.dirty }"}
-  %a#cart.icon{cart: true}
+  %a#cart.icon{"cart-toggle" => true}
     %span
       = t '.cart'
     %span.count

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -112,6 +112,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
             # that we are not filling in the quantity on the outgoing row
             page.should_not have_selector "tr.product-cart"
             within('product:not(.ng-leave)') { fill_in "variants[#{variant.id}]", with: 1 }
+            show_cart
             within("li.cart") { page.should have_content with_currency(19.99) }
           end
 


### PR DESCRIPTION
#### What? Why?

Closes #1255

Warm-up PR for Mobile Ready work. The cart dropdown now closes when clicking outside of it! :tada:

#### What should we test?
<!-- List which features should be tested and how. -->

The cart dropdown closes when clicking outside of it.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Cart dropdown is now more easily collapsible

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

#### Animated GIF

![omg-it-closes](https://user-images.githubusercontent.com/9029026/62496241-3f06c680-b7d0-11e9-8491-0e913b22a505.gif)
