### PR TITLE
OC performance

### DIFF
--- a/app/serializers/api/admin/order_cycle_serializer.rb
+++ b/app/serializers/api/admin/order_cycle_serializer.rb
@@ -33,7 +33,7 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
   end
 
   def editable_variants_for_incoming_exchanges
-    sort_by_supplier_id(permissions.all_incoming_editable_variants.all)
+    variant_ids_by_supplier_id(permissions.all_incoming_editable_variants.all)
   end
 
   def editable_variants_for_outgoing_exchanges
@@ -79,17 +79,10 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
     @visible_enterprises ||= permissions.visible_enterprises
   end
 
-  def sort_by_supplier_id(variants)
-    collection = {}
-    variants.map do |variant|
-      supplier_id = variant.product.supplier_id
-
-      if collection.key? supplier_id
-        collection[supplier_id] << variant.id
-      else
-        collection[supplier_id] = [variant.id]
-      end
+  def variant_ids_by_supplier_id(variants)
+    grouped_by_supplier = variants.group_by(&:supplier_id)
+    grouped_by_supplier.each do |supplier_id, grouped_variants|
+      grouped_by_supplier[supplier_id] = grouped_variants.map(&:id)
     end
-    collection
   end
 end

--- a/app/serializers/api/admin/order_cycle_serializer.rb
+++ b/app/serializers/api/admin/order_cycle_serializer.rb
@@ -33,14 +33,7 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
   end
 
   def editable_variants_for_incoming_exchanges
-    # For each enterprise that the current user is able to see in this order cycle,
-    # work out which variants should be editable within incoming exchanges from that enterprise
-    editable = {}
-    visible_enterprises.each do |enterprise|
-      variants = permissions.editable_variants_for_incoming_exchanges_from(enterprise).pluck(:id)
-      editable[enterprise.id] = variants if variants.any?
-    end
-    editable
+    sort_by_supplier_id(permissions.all_incoming_editable_variants.all)
   end
 
   def editable_variants_for_outgoing_exchanges
@@ -84,5 +77,19 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
 
   def visible_enterprises
     @visible_enterprises ||= permissions.visible_enterprises
+  end
+
+  def sort_by_supplier_id(variants)
+    collection = {}
+    variants.map do |variant|
+      supplier_id = variant.product.supplier_id
+
+      if collection.key? supplier_id
+        collection[supplier_id] << variant.id
+      else
+        collection[supplier_id] = [variant.id]
+      end
+    end
+    collection
   end
 end

--- a/app/serializers/api/admin/order_cycle_serializer.rb
+++ b/app/serializers/api/admin/order_cycle_serializer.rb
@@ -25,10 +25,7 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
   end
 
   def exchanges
-    scoped_exchanges =
-      OpenFoodNetwork::OrderCyclePermissions.
-        new(options[:current_user], object).
-        visible_exchanges.by_enterprise_name
+    scoped_exchanges = permissions.visible_exchanges.by_enterprise_name
 
     ActiveModel::ArraySerializer.
       new(scoped_exchanges, each_serializer: Api::Admin::ExchangeSerializer,
@@ -39,9 +36,7 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
     # For each enterprise that the current user is able to see in this order cycle,
     # work out which variants should be editable within incoming exchanges from that enterprise
     editable = {}
-    permissions = OpenFoodNetwork::OrderCyclePermissions.new(options[:current_user], object)
-    enterprises = permissions.visible_enterprises
-    enterprises.each do |enterprise|
+    visible_enterprises.each do |enterprise|
       variants = permissions.editable_variants_for_incoming_exchanges_from(enterprise).pluck(:id)
       editable[enterprise.id] = variants if variants.any?
     end
@@ -52,9 +47,7 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
     # For each enterprise that the current user is able to see in this order cycle,
     # work out which variants should be editable within incoming exchanges from that enterprise
     editable = {}
-    permissions = OpenFoodNetwork::OrderCyclePermissions.new(options[:current_user], object)
-    enterprises = permissions.visible_enterprises
-    enterprises.each do |enterprise|
+    visible_enterprises.each do |enterprise|
       variants = permissions.editable_variants_for_outgoing_exchanges_to(enterprise).pluck(:id)
       editable[enterprise.id] = variants if variants.any?
     end
@@ -65,9 +58,7 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
     # For each enterprise that the current user is able to see in this order cycle,
     # work out which variants should be visible within outgoing exchanges from that enterprise
     visible = {}
-    permissions = OpenFoodNetwork::OrderCyclePermissions.new(options[:current_user], object)
-    enterprises = permissions.visible_enterprises
-    enterprises.each do |enterprise|
+    visible_enterprises.each do |enterprise|
       # This is hopefully a temporary measure, pending the arrival of multiple named inventories
       # for shops. We need this here to allow hubs to restrict visible variants to only those in
       # their inventory if they so choose
@@ -83,5 +74,15 @@ class Api::Admin::OrderCycleSerializer < ActiveModel::Serializer
       visible[enterprise.id] = variants if variants.any?
     end
     visible
+  end
+
+  private
+
+  def permissions
+    @permissions ||= OpenFoodNetwork::OrderCyclePermissions.new(options[:current_user], object)
+  end
+
+  def visible_enterprises
+    @visible_enterprises ||= permissions.visible_enterprises
   end
 end

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -164,14 +164,6 @@ module OpenFoodNetwork
       if user_manages_coordinator_or(hub)
         # TODO: Use variants_stockable_by(hub) for this?
 
-        # Any variants produced by the coordinator, for outgoing exchanges with itself
-        # TODO: isn't this completely redundant given the assignment of hub_variants below?
-        coordinator_variants = []
-        if hub == @coordinator
-          coordinator_variants = Spree::Variant.joins(:product).
-            where('spree_products.supplier_id = (?)', @coordinator)
-        end
-
         # Any variants of any producers that have granted the hub P-OC
         producer_ids = related_enterprises_granting(:add_to_order_cycle,
                                                     to: [hub.id],
@@ -185,7 +177,7 @@ module OpenFoodNetwork
         active_variants = active_outgoing_variants(hub)
 
         Spree::Variant.
-          where(id: coordinator_variants | hub_variants | permitted_variants | active_variants)
+          where(id: hub_variants | permitted_variants | active_variants)
       else
         # Variants produced by MY PRODUCERS that are in this OC,
         #   where my producer has granted P-OC to the hub
@@ -213,13 +205,6 @@ module OpenFoodNetwork
       return Spree::Variant.where("1=0") unless @order_cycle
 
       if user_manages_coordinator_or(hub)
-        # Any variants produced by the coordinator, for outgoing exchanges with itself
-        coordinator_variants = []
-        if hub == @coordinator
-          coordinator_variants = Spree::Variant.joins(:product).
-            where('spree_products.supplier_id = (?)', @coordinator)
-        end
-
         # Any variants of any producers that have granted the hub P-OC
         producer_ids = related_enterprises_granting(:add_to_order_cycle,
                                                     to: [hub.id],
@@ -233,7 +218,7 @@ module OpenFoodNetwork
         active_variants = active_outgoing_variants(hub)
 
         Spree::Variant.
-          where(id: coordinator_variants | hub_variants | permitted_variants | active_variants)
+          where(id: hub_variants | permitted_variants | active_variants)
       else
         # Any of my managed producers in this order cycle granted P-OC by the hub
         granted_producers = related_enterprises_granted(:add_to_order_cycle,

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -153,11 +153,12 @@ module OpenFoodNetwork
     end
 
     def all_incoming_editable_variants
-      valid_suppliers = visible_enterprises.map do |enterprise|
-        enterprise.id if user_manages_coordinator_or(enterprise)
-      end
+      valid_suppliers = visible_enterprises.select do |enterprise|
+        user_manages_coordinator_or(enterprise)
+      end.map(&:id)
 
       Spree::Variant.includes(product: :supplier).
+        select("spree_variants.id, spree_products.supplier_id").
         joins(:product).where(spree_products: { supplier_id: valid_suppliers })
     end
 

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -236,8 +236,12 @@ module OpenFoodNetwork
     end
 
     def user_manages_coordinator_or(enterprise)
-      managed_enterprises.pluck(:id).include?(@coordinator.id) ||
-        managed_enterprises.pluck(:id).include?(enterprise.id)
+      managed_enterprise_ids.include?(@coordinator.id) ||
+        managed_enterprise_ids.include?(enterprise.id)
+    end
+
+    def managed_enterprise_ids
+      @managed_enterprise_ids ||= managed_enterprises.pluck(:id)
     end
 
     def managed_participating_enterprises

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -235,11 +235,13 @@ module OpenFoodNetwork
     end
 
     def active_outgoing_variants(hub)
-      active_variants = []
-      @order_cycle.exchanges.outgoing.where(receiver_id: hub).limit(1).each do |exchange|
-        active_variants = exchange.variants
+      @active_outgoing_variants ||= begin
+        active_variants = []
+        @order_cycle.exchanges.outgoing.where(receiver_id: hub).limit(1).each do |exchange|
+          active_variants = exchange.variants
+        end
+        active_variants
       end
-      active_variants
     end
 
     def user_manages_coordinator_or(enterprise)

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -236,11 +236,7 @@ module OpenFoodNetwork
 
     def active_outgoing_variants(hub)
       @active_outgoing_variants ||= begin
-        active_variants = []
-        @order_cycle.exchanges.outgoing.where(receiver_id: hub).limit(1).each do |exchange|
-          active_variants = exchange.variants
-        end
-        active_variants
+        @order_cycle.exchanges.outgoing.where(receiver_id: hub).first.andand.variants || []
       end
     end
 

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -182,11 +182,7 @@ module OpenFoodNetwork
         hub_variants = Spree::Variant.joins(:product).where('spree_products.supplier_id = (?)', hub)
 
         # PLUS variants that are already in an outgoing exchange of this hub, so things don't break
-        # TODO: Remove this when all P-OC are sorted out
-        active_variants = []
-        @order_cycle.exchanges.outgoing.where(receiver_id: hub).limit(1).each do |exchange|
-          active_variants = exchange.variants
-        end
+        active_variants = active_outgoing_variants(hub)
 
         Spree::Variant.
           where(id: coordinator_variants | hub_variants | permitted_variants | active_variants)
@@ -234,11 +230,7 @@ module OpenFoodNetwork
         hub_variants = Spree::Variant.joins(:product).where('spree_products.supplier_id = (?)', hub)
 
         # PLUS variants that are already in an outgoing exchange of this hub, so things don't break
-        # TODO: Remove this when all P-OC are sorted out
-        active_variants = []
-        @order_cycle.exchanges.outgoing.where(receiver_id: hub).limit(1).each do |exchange|
-          active_variants = exchange.variants
-        end
+        active_variants = active_outgoing_variants(hub)
 
         Spree::Variant.
           where(id: coordinator_variants | hub_variants | permitted_variants | active_variants)
@@ -261,6 +253,14 @@ module OpenFoodNetwork
     end
 
     private
+
+    def active_outgoing_variants(hub)
+      active_variants = []
+      @order_cycle.exchanges.outgoing.where(receiver_id: hub).limit(1).each do |exchange|
+        active_variants = exchange.variants
+      end
+      active_variants
+    end
 
     def user_manages_coordinator_or(enterprise)
       managed_enterprises.pluck(:id).include?(@coordinator.id) ||

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -154,6 +154,15 @@ module OpenFoodNetwork
       end
     end
 
+    def all_incoming_editable_variants
+      valid_suppliers = visible_enterprises.map do |enterprise|
+        enterprise.id if user_manages_coordinator_or(enterprise)
+      end
+
+      Spree::Variant.includes(product: :supplier).
+        joins(:product).where('spree_products.supplier_id IN (?)', valid_suppliers)
+    end
+
     # Find the variants that a user is permitted see within outgoing exchanges
     # Note that this does not determine whether they actually appear in outgoing exchanges
     # as this requires first that the variant is included in an incoming exchange

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -158,7 +158,7 @@ module OpenFoodNetwork
       end
 
       Spree::Variant.includes(product: :supplier).
-        joins(:product).where('spree_products.supplier_id IN (?)', valid_suppliers)
+        joins(:product).where(spree_products: { supplier_id: valid_suppliers })
     end
 
     # Find the variants that a user is permitted see within outgoing exchanges
@@ -231,7 +231,7 @@ module OpenFoodNetwork
     end
 
     def variants_from_suppliers(supplier_ids)
-      Spree::Variant.joins(:product).where('spree_products.supplier_id IN (?)', supplier_ids)
+      Spree::Variant.joins(:product).where(spree_products: { supplier_id: supplier_ids })
     end
 
     def active_outgoing_variants(hub)
@@ -304,10 +304,10 @@ module OpenFoodNetwork
               @order_cycle).pluck(:id).uniq
 
       product_ids = Spree::Product.joins(:variants_including_master).
-        where("spree_variants.id IN (?)", variant_ids).pluck(:id).uniq
+        where(spree_variants: { id: variant_ids }).pluck(:id).uniq
 
       producer_ids = Enterprise.joins(:supplied_products).
-        where("spree_products.id IN (?)", product_ids).pluck(:id).uniq
+        where(spree_products: { id: product_ids }).pluck(:id).uniq
 
       active_exchange_ids = @order_cycle.exchanges.incoming.where(sender_id: producer_ids).pluck :id
 

--- a/spec/lib/open_food_network/order_cycle_permissions_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_permissions_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'open_food_network/order_cycle_permissions'
 
 module OpenFoodNetwork


### PR DESCRIPTION
#### What? Why?

Closes #4007

Poor performance with the endpoint: `/admin/order_cycles/<order_cycle_id>.json`.

I've tidied up some of the related code a bit, and removed some repeating queries. There's still a _lot_ of refactoring needed in these two files (tech debt):

[lib/open_food_network/order_cycle_permissions.rb](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/lib/open_food_network/order_cycle_permissions.rb)
[app/serializers/api/order_cycle_serializer.rb](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/serializers/api/order_cycle_serializer.rb)

I used an OC with ~20 producers and ~500 products. Initially this endpoint was making `651` queries, it's now at `375`. I don't know if I can get it down much further. 

`Before:`
![Screenshot from 2019-08-09 09-16-41](https://user-images.githubusercontent.com/9029026/62803976-ceb7b800-bae3-11e9-9216-ad3873bdd65b.png)
`After:`
![Screenshot from 2019-08-09 11-43-59](https://user-images.githubusercontent.com/9029026/62803977-ceb7b800-bae3-11e9-9dfc-ea2e7d71913d.png)

~42% less queries :tada: 

#### What should we test?
<!-- List which features should be tested and how. -->

Order Cycles admin functionality is working as before (create, view, update, etc).

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance on an order cycles API endpoint.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
