### PR TITLE
Seed user

### DIFF
--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -56,6 +56,7 @@ def create_admin_user
     say "\nWARNING: There is already a user with the email: #{email}, so no account changes were made.  If you wish to create an additional admin user, please run rake spree_auth:admin:create again with a different email.\n\n"
   else
     admin = Spree::User.new(attributes)
+    admin.skip_confirmation!
     if admin.save
       role = Spree::Role.find_or_create_by_name 'admin'
       admin.spree_roles << role

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -34,7 +34,7 @@ def prompt_for_admin_email
 end
 
 def create_admin_user
-  if ENV['AUTO_ACCEPT']
+  if ENV.fetch("AUTO_ACCEPT", true)
     password = 'spree123'
     email = 'spree@example.com'
   else

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -35,8 +35,8 @@ end
 
 def create_admin_user
   if ENV.fetch("AUTO_ACCEPT", true)
-    password = 'spree123'
-    email = 'spree@example.com'
+    password = ENV.fetch("ADMIN_PASSWORD", "spree123")
+    email = ENV.fetch("ADMIN_EMAIL", "spree@example.com")
   else
     puts 'Create the admin user (press enter for defaults).'
     #name = prompt_for_admin_name unless name

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,4 @@ end
 # Create users:
 require File.join(File.dirname(__FILE__), 'default', 'users')
 
-spree_user = Spree::User.first
-spree_user && spree_user.confirm!
-
 DefaultStockLocation.find_or_create

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,6 +48,9 @@ states.each do |state|
   end
 end
 
+# Create users:
+require File.join(File.dirname(__FILE__), 'default', 'users')
+
 spree_user = Spree::User.first
 spree_user && spree_user.confirm!
 


### PR DESCRIPTION
#### What? Why?

Since we merged #3700 the first default admin user hasn't been created when seeding the database. We were missing a login and couldn't create the sample data.

It was very easy now to also solve https://github.com/openfoodfoundation/openfoodnetwork/issues/3202 and get rid of the confirmation email (which is annoying for developers).

#### What should we test?
<!-- List which features should be tested and how. -->

No testing required.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Developers don't need to confirm admin user details when setting up the database.
Changed: The first automatically created admin user is not notified by email any more.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

