### PR TITLE
Remove order cycle distributed products N+1

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -170,6 +170,7 @@ class OrderCycle < ActiveRecord::Base
 
   def variants_distributed_by(distributor)
     return Spree::Variant.where("1=0") if distributor.blank?
+
     Spree::Variant.
       joins(:exchanges).
       merge(distributor.inventory_variants).

--- a/app/queries/products_with_obsolete_master_query.rb
+++ b/app/queries/products_with_obsolete_master_query.rb
@@ -1,0 +1,66 @@
+# Returns the products that have an obsolete master those that:
+# * their master is in distribution in an order cycle
+# * their variants are not in distribution
+class ProductsWithObsoleteMasterQuery
+  def initialize(relation = Spree::Product, order_cycle_id)
+    @relation = relation
+    @order_cycle_id = order_cycle_id
+  end
+
+  # This gets the variants, including master, for each product and then picks
+  # the ones that match the criteria for being obsolete through the HAVING
+  # clause.
+  def all
+    products = relation
+      .joins(left_join_variants)
+      .joins(left_join_exchange_variants)
+      .joins(left_join_exchanges)
+      .where(not_incoming_exchanges)
+      .group('spree_products.id')
+      .having(master_distributed_but_not_variants)
+
+    SuppliedInOrderCycleQuery.new(products, order_cycle_id).call
+  end
+
+  private
+
+  attr_reader :relation, :order_cycle_id
+
+  def left_join_variants
+    <<-SQL.strip_heredoc
+      LEFT JOIN "spree_variants"
+      ON "spree_variants"."product_id" = "spree_products"."id"
+        AND "spree_variants"."deleted_at" IS NULL
+    SQL
+  end
+
+  def left_join_exchange_variants
+    <<-SQL.strip_heredoc
+      LEFT JOIN "exchange_variants"
+      ON "exchange_variants"."variant_id" = "spree_variants"."id"
+    SQL
+  end
+
+  def left_join_exchanges
+    <<-SQL.strip_heredoc
+      LEFT JOIN "exchanges" AS obsolete_exchanges
+      ON "obsolete_exchanges"."id" = "exchange_variants"."exchange_id"
+    SQL
+  end
+
+  def not_incoming_exchanges
+    'obsolete_exchanges.incoming = false OR obsolete_exchanges.incoming IS NULL'
+  end
+
+  # Selects the groups that have more than a row, aka. product with variants
+  # whose master is not distributed through the PostgreSQL bool_or function.
+  # Lastly, it checks that the only the master is being distributed through an
+  # exchange.
+  def master_distributed_but_not_variants
+    <<-SQL.strip_heredoc
+      COUNT(*) > 1
+      AND bool_or(is_master = true AND exchange_variants.id IS NOT NULL)
+      AND COUNT(exchange_variants.id) = 1
+    SQL
+  end
+end

--- a/app/queries/products_with_obsolete_master_query.rb
+++ b/app/queries/products_with_obsolete_master_query.rb
@@ -2,6 +2,8 @@
 # * their master is in distribution in an order cycle
 # * their variants are not in distribution
 class ProductsWithObsoleteMasterQuery
+  delegate :to_sql, to: :all
+
   def initialize(relation = Spree::Product, order_cycle_id)
     @relation = relation
     @order_cycle_id = order_cycle_id

--- a/app/queries/products_with_obsolete_master_query.rb
+++ b/app/queries/products_with_obsolete_master_query.rb
@@ -53,7 +53,7 @@ class ProductsWithObsoleteMasterQuery
   end
 
   # Selects the groups that have more than a row, aka. product with variants
-  # whose master is not distributed through the PostgreSQL bool_or function.
+  # whose master is not distributed using the PostgreSQL `bool_or` function.
   # Lastly, it checks that the only the master is being distributed through an
   # exchange.
   def master_distributed_but_not_variants

--- a/app/queries/supplied_in_order_cycle_query.rb
+++ b/app/queries/supplied_in_order_cycle_query.rb
@@ -1,0 +1,26 @@
+# Scopes a passed AR relation to the products supplied in the specified order
+# cycle
+class SuppliedInOrderCycleQuery
+  def initialize(relation, order_cycle_id)
+    @relation = relation
+    @order_cycle_id = order_cycle_id
+  end
+
+  def call
+    relation
+      .joins(suppliers_exchanges)
+      .where('suppliers_exchanges.order_cycle_id = ?', order_cycle_id)
+  end
+
+  private
+
+  attr_reader :relation, :order_cycle_id
+
+  def suppliers_exchanges
+    <<-SQL.strip_heredoc
+      INNER JOIN exchanges AS suppliers_exchanges
+      ON suppliers_exchanges.sender_id = spree_products.supplier_id
+    SQL
+  end
+end
+

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -34,6 +34,7 @@ class OrderCycleDistributedProducts
       .group(:product_id)
   end
 
+  # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.
   def products_with_obsolete_master
     query = <<-SQL
 SELECT "spree_products".*

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -43,14 +43,13 @@ class OrderCycleDistributedProducts
     Spree::Product
       .joins('LEFT JOIN "spree_variants" ON "spree_variants"."product_id" = "spree_products"."id" AND "spree_variants"."deleted_at" IS NULL')
       .joins('LEFT JOIN "exchange_variants" ON "exchange_variants"."variant_id" = "spree_variants"."id"')
-      .joins('LEFT JOIN "exchanges" ON "exchanges"."id" = "exchange_variants"."exchange_id"')
       .merge(distributor.inventory_variants)
       .group('"spree_products"."id"')
       .having(<<-SQL)
         COUNT(*) > 1
         AND bool_or(is_master = true
-        AND exchanges.id IS NOT NULL)
-        AND COUNT(exchanges.id) = 1
+        AND exchange_variants.id IS NOT NULL)
+        AND COUNT(exchange_variants.id) = 1
       SQL
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,8 +15,8 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
-    valid_product_ids = Spree::Variant
-      .joins(:exchanges)
+    valid_product_ids = order_cycle
+      .variants_distributed_by(distributor)
       .joins(<<-SQL.strip_heredoc)
         LEFT JOIN (
           #{products_with_obsolete_master.select('spree_products.id').to_sql}
@@ -24,10 +24,6 @@ class OrderCycleDistributedProducts
         ON spree_variants.product_id = products_with_obsolete_master.id
       SQL
       .where('products_with_obsolete_master.id IS NULL')
-      .merge(distributor.inventory_variants)
-      .merge(Exchange.in_order_cycle(order_cycle))
-      .merge(Exchange.outgoing)
-      .merge(Exchange.to_enterprise(distributor))
       .select(:product_id)
       .group(:product_id)
 

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,8 +15,11 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
+    products = Spree::Product
+      .joins(:variants_including_master)
+      .merge(order_cycle.variants_distributed_by(distributor))
+
     variants = order_cycle.variants_distributed_by(distributor)
-    products = variants.map(&:product).uniq
 
     valid_products = products.reject do |product|
       product_has_only_obsolete_master_in_distribution?(product, variants)

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -55,6 +55,6 @@ class OrderCycleDistributedProducts
   def distributed_current_variants(product)
     order_cycle
       .variants_distributed_by(distributor)
-      .merge(product.variants)
+      .where(id: product.variants)
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,12 +15,8 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
-    all_distributed_product_ids = all_distributed_products
-      .select(:product_id)
-      .map(&:product_id)
-
-    product_ids_with_obsolete_master = products_with_obsolete_master
-        .map(&:id)
+    all_distributed_product_ids = all_distributed_products.map(&:product_id)
+    product_ids_with_obsolete_master = products_with_obsolete_master.map(&:id)
 
     valid_product_ids = all_distributed_product_ids - product_ids_with_obsolete_master
 
@@ -32,12 +28,15 @@ class OrderCycleDistributedProducts
   attr_reader :order_cycle, :distributor
 
   def all_distributed_products
-    order_cycle.variants_distributed_by(distributor)
+    order_cycle
+      .variants_distributed_by(distributor)
+      .select(:product_id)
+      .group(:product_id)
   end
 
   def products_with_obsolete_master
     query = <<-SQL
-SELECT "spree_products".id
+SELECT "spree_products".*
   FROM "spree_products"
   LEFT
   JOIN "spree_variants"

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,45 +15,20 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
-    valid_products = Spree::Product
-      .joins(variants: :exchanges)
-      .merge(order_cycle.variants_distributed_by(distributor))
-      .where('spree_variants.is_master = false')
-
     product_ids = valid_products.map(&:id)
-
     Spree::Product.where(id: product_ids)
   end
 
-  # If a product without variants is added to an order cycle, and then some variants are added
-  # to that product, but not the order cycle, then the master variant should not available for
-  # customers to purchase.
-  def product_has_only_obsolete_master_in_distribution?(product, distributed_variants)
-    if product.has_variants?
-      order_cycle.variants_distributed_by(distributor).where(id: product.variants_including_master).size == 1 &&
-        order_cycle.variants_distributed_by(distributor).where(id: product.variants_including_master).first.id == product.master.id
-    else
-      false
-    end
+  def valid_products
+    Spree::Product
+      .joins(variants: { exchange_variants: :exchange })
+      .merge(distributor.inventory_variants)
+      .merge(Exchange.in_order_cycle(order_cycle))
+      .merge(Exchange.outgoing)
+      .merge(Exchange.to_enterprise(distributor))
   end
 
   private
 
   attr_reader :order_cycle, :distributor
-
-  def distributed_variants_include_master?(product)
-    order_cycle
-      .variants_distributed_by(distributor)
-      .where(id: product.master.id)
-  end
-
-  # Returns the product variants that are currently under distribution, aka.
-  # are present in a exchange
-  #
-  # ActiveRecord::Relation<Spree::Variant>
-  def distributed_current_variants(product)
-    order_cycle
-      .variants_distributed_by(distributor)
-      .where(id: product.variants)
-  end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,25 +15,17 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
-    Rails.logger.debug "====== relation ======="
     products = Spree::Product
       .joins(:variants_including_master)
       .merge(order_cycle.variants_distributed_by(distributor))
 
-    Rails.logger.debug "====== variants ======="
     variants = order_cycle.variants_distributed_by(distributor)
 
-    Rails.logger.debug "====== reject ======="
     valid_products = products.reject do |product|
       product_has_only_obsolete_master_in_distribution?(product, variants)
     end
-    Rails.logger.debug "====== end reject ======="
-
     product_ids = valid_products.map(&:id)
 
-    Rails.logger.debug "====== end variants ======="
-
-    Rails.logger.debug "====== end relation ======="
     Spree::Product.where(id: product_ids)
   end
 

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -46,8 +46,11 @@ class OrderCycleDistributedProducts
       .joins('LEFT JOIN "exchanges" ON "exchanges"."id" = "exchange_variants"."exchange_id"')
       .merge(distributor.inventory_variants)
       .group('"spree_products"."id"')
-      .having(
-        'COUNT(*) > 1 AND bool_or(is_master = true AND exchanges.id IS NOT NULL) AND COUNT(exchanges.id) = 1'
-    )
+      .having(<<-SQL)
+        COUNT(*) > 1
+        AND bool_or(is_master = true
+        AND exchanges.id IS NOT NULL)
+        AND COUNT(exchanges.id) = 1
+      SQL
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -19,22 +19,8 @@ class OrderCycleDistributedProducts
       .unscoped
       .select('DISTINCT(spree_products.*)')
       .joins(variants_including_master: :exchanges)
-      .joins(<<-SQL)
-        LEFT OUTER JOIN (
-          SELECT * FROM inventory_items WHERE enterprise_id = #{distributor.id}
-        ) AS o_inventory_items
-        ON o_inventory_items.variant_id = variants_including_masters_spree_products.id
-      SQL
-      .where("o_inventory_items.id IS NULL OR o_inventory_items.visible = true")
-      .merge(Exchange.in_order_cycle(order_cycle.id))
-      .merge(Exchange.outgoing)
-      .merge(Exchange.to_enterprise(distributor))
-      .joins(<<-SQL.strip_heredoc)
-        LEFT JOIN (
-          #{products_with_obsolete_master.to_sql}
-        ) AS products_with_obsolete_master
-        ON variants_including_masters_spree_products.product_id = products_with_obsolete_master.id
-      SQL
+      .merge(variants_distributed_by_distributor)
+      .joins(left_join_products_with_obsolete_master)
       .where('products_with_obsolete_master.id IS NULL')
       .where('spree_products.deleted_at IS NULL')
       .where('variants_including_masters_spree_products.deleted_at IS NULL')
@@ -43,6 +29,33 @@ class OrderCycleDistributedProducts
   private
 
   attr_reader :order_cycle, :distributor
+
+  def variants_distributed_by_distributor
+    distributor_inventory_variants
+      .merge(Exchange.in_order_cycle(order_cycle.id))
+      .merge(Exchange.outgoing)
+      .merge(Exchange.to_enterprise(distributor))
+  end
+
+  def distributor_inventory_variants
+    Spree::Product
+      .joins(<<-SQL)
+        LEFT OUTER JOIN (
+          SELECT * FROM inventory_items WHERE enterprise_id = #{distributor.id}
+        ) AS o_inventory_items
+        ON o_inventory_items.variant_id = variants_including_masters_spree_products.id
+      SQL
+      .where("o_inventory_items.id IS NULL OR o_inventory_items.visible = true")
+  end
+
+  def left_join_products_with_obsolete_master
+    <<-SQL.strip_heredoc
+        LEFT JOIN (#{products_with_obsolete_master.to_sql})
+        AS products_with_obsolete_master
+        ON variants_including_masters_spree_products.product_id
+          = products_with_obsolete_master.id
+    SQL
+  end
 
   # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.
   def products_with_obsolete_master

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -59,19 +59,6 @@ class OrderCycleDistributedProducts
 
   # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.
   def products_with_obsolete_master
-    Spree::Product
-      .joins('INNER JOIN exchanges AS exchanges_suppliers ON exchanges_suppliers.sender_id = spree_products.supplier_id')
-      .joins('LEFT JOIN "spree_variants" ON "spree_variants"."product_id" = "spree_products"."id" AND "spree_variants"."deleted_at" IS NULL')
-      .joins('LEFT JOIN "exchange_variants" ON "exchange_variants"."variant_id" = "spree_variants"."id"')
-      .joins('LEFT JOIN "exchanges" AS obsolete_exchanges ON "obsolete_exchanges"."id" = "exchange_variants"."exchange_id"')
-      .where('exchanges_suppliers.order_cycle_id = ?', order_cycle.id)
-      .where('obsolete_exchanges.incoming = false OR obsolete_exchanges.incoming IS NULL')
-      .group('"spree_products"."id"')
-      .having(<<-SQL.strip_heredoc)
-        COUNT(*) > 1
-        AND bool_or(is_master = true
-        AND exchange_variants.id IS NOT NULL)
-        AND COUNT(exchange_variants.id) = 1
-      SQL
+    ProductsWithObsoleteMasterQuery.new(order_cycle.id).all
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,11 +15,52 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
-    product_ids = valid_products.map(&:id)
+    product_ids = valid_products_relation.map(&:id)
     Spree::Product.where(id: product_ids)
   end
 
-  def valid_products
+  def relation_with_sql
+    product_ids = valid_products_sql.map(&:id)
+    Spree::Product.where(id: product_ids)
+  end
+
+  def valid_products_sql
+    query = <<-SQL
+SELECT "spree_products".*
+  FROM "spree_products"
+ LEFT
+  JOIN "spree_variants"
+    ON "spree_variants"."product_id"    = "spree_products"."id"
+   AND "spree_variants"."is_master"     = 'f'
+   AND "spree_variants"."deleted_at" IS NULL
+ LEFT
+  JOIN "exchange_variants"
+    ON "exchange_variants"."variant_id" = "spree_variants"."id"
+ LEFT
+  JOIN "exchanges"
+    ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
+  LEFT OUTER
+  JOIN (
+    SELECT *
+      from inventory_items
+ WHERE enterprise_id                    = ?) AS o_inventory_items
+    ON o_inventory_items.variant_id     = spree_variants.id
+ WHERE "exchanges"."order_cycle_id"     = ? OR "exchanges"."order_cycle_id" IS NULL
+   AND "exchanges"."incoming"           = 'f' OR "exchanges"."incoming" IS NULL
+   AND "exchanges"."receiver_id"        = ? OR "exchanges"."receiver_id" IS NULL
+   AND ("spree_products".deleted_at IS NULL)
+   AND ("spree_variants".deleted_at IS NULL)
+   AND (o_inventory_items.id IS NULL
+    OR o_inventory_items.visible        = ('t'))
+    SQL
+    Spree::Product.find_by_sql([query, distributor.id, order_cycle.id, distributor.id])
+  end
+
+  private
+
+  attr_reader :order_cycle, :distributor
+
+  def valid_products_relation
     Spree::Product
       .joins(variants: { exchange_variants: :exchange })
       .merge(distributor.inventory_variants)
@@ -27,8 +68,4 @@ class OrderCycleDistributedProducts
       .merge(Exchange.outgoing)
       .merge(Exchange.to_enterprise(distributor))
   end
-
-  private
-
-  attr_reader :order_cycle, :distributor
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,17 +15,25 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
+    Rails.logger.debug "====== relation ======="
     products = Spree::Product
       .joins(:variants_including_master)
       .merge(order_cycle.variants_distributed_by(distributor))
 
+    Rails.logger.debug "====== variants ======="
     variants = order_cycle.variants_distributed_by(distributor)
 
+    Rails.logger.debug "====== reject ======="
     valid_products = products.reject do |product|
       product_has_only_obsolete_master_in_distribution?(product, variants)
     end
+    Rails.logger.debug "====== end reject ======="
+
     product_ids = valid_products.map(&:id)
 
+    Rails.logger.debug "====== end variants ======="
+
+    Rails.logger.debug "====== end relation ======="
     Spree::Product.where(id: product_ids)
   end
 

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -39,6 +39,16 @@ class OrderCycleDistributedProducts
   def product_has_only_obsolete_master_in_distribution?(product, distributed_variants)
     product.has_variants? &&
       distributed_variants.include?(product.master) &&
-      (product.variants & distributed_variants).empty?
+      distributed_current_variants(product).empty?
+  end
+
+  # Returns the product variants that are currently under distribution, aka.
+  # are present in a exchange
+  #
+  # ActiveRecord::Relation<Spree::Variant>
+  def distributed_current_variants(product)
+    order_cycle
+      .variants_distributed_by(distributor)
+      .merge(product.variants)
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -45,7 +45,7 @@ class OrderCycleDistributedProducts
       .joins('LEFT JOIN "exchange_variants" ON "exchange_variants"."variant_id" = "spree_variants"."id"')
       .merge(distributor.inventory_variants)
       .group('"spree_products"."id"')
-      .having(<<-SQL)
+      .having(<<-SQL.strip_heredoc)
         COUNT(*) > 1
         AND bool_or(is_master = true
         AND exchange_variants.id IS NOT NULL)

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -36,37 +36,14 @@ class OrderCycleDistributedProducts
 
   # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.
   def products_with_obsolete_master
-    query = <<-SQL
-SELECT "spree_products".*
-  FROM "spree_products"
-  LEFT
-  JOIN "spree_variants"
-    ON "spree_variants"."product_id"    = "spree_products"."id"
-   AND "spree_variants"."deleted_at" IS NULL
-  LEFT
-  JOIN "exchange_variants"
-    ON "exchange_variants"."variant_id" = "spree_variants"."id"
-  LEFT
-  JOIN "exchanges"
-    ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
-  LEFT OUTER
-  JOIN (
-    SELECT *
-      from inventory_items
- WHERE enterprise_id                    = ?) AS o_inventory_items
-    ON o_inventory_items.variant_id     = spree_variants.id
-   AND ("spree_products".deleted_at IS NULL)
-   AND ("spree_variants".deleted_at IS NULL)
-   AND (o_inventory_items.id IS NULL
-    OR o_inventory_items.visible        = ('t'))
- GROUP BY "spree_products"."id"
-HAVING COUNT(*) > 1
-   AND bool_or(is_master = true AND exchanges.id IS NOT NULL)
-   AND COUNT(exchanges.id) = 1
-    SQL
-
-    Spree::Product.find_by_sql(
-      [query, distributor.id]
+    Spree::Product
+      .joins('LEFT JOIN "spree_variants" ON "spree_variants"."product_id" = "spree_products"."id" AND "spree_variants"."deleted_at" IS NULL')
+      .joins('LEFT JOIN "exchange_variants" ON "exchange_variants"."variant_id" = "spree_variants"."id"')
+      .joins('LEFT JOIN "exchanges" ON "exchanges"."id" = "exchange_variants"."exchange_id"')
+      .merge(distributor.inventory_variants)
+      .group('"spree_products"."id"')
+      .having(
+        'COUNT(*) > 1 AND bool_or(is_master = true AND exchanges.id IS NOT NULL) AND COUNT(exchanges.id) = 1'
     )
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -38,8 +38,14 @@ class OrderCycleDistributedProducts
   # customers to purchase.
   def product_has_only_obsolete_master_in_distribution?(product, distributed_variants)
     product.has_variants? &&
-      distributed_variants.include?(product.master) &&
+      distributed_variants_include_master?(product) &&
       distributed_current_variants(product).empty?
+  end
+
+  def distributed_variants_include_master?(product)
+    order_cycle
+      .variants_distributed_by(distributor)
+      .exists?(product.master.id)
   end
 
   # Returns the product variants that are currently under distribution, aka.

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -43,7 +43,6 @@ class OrderCycleDistributedProducts
     Spree::Product
       .joins('LEFT JOIN "spree_variants" ON "spree_variants"."product_id" = "spree_products"."id" AND "spree_variants"."deleted_at" IS NULL')
       .joins('LEFT JOIN "exchange_variants" ON "exchange_variants"."variant_id" = "spree_variants"."id"')
-      .merge(distributor.inventory_variants)
       .group('"spree_products"."id"')
       .having(<<-SQL.strip_heredoc)
         COUNT(*) > 1

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,10 +15,8 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
-    all_distributed_product_ids = all_distributed_products.map(&:product_id)
-    product_ids_with_obsolete_master = products_with_obsolete_master.map(&:id)
-
-    valid_product_ids = all_distributed_product_ids - product_ids_with_obsolete_master
+    valid_product_ids = all_distributed_products
+      .where("product_id NOT IN (#{products_with_obsolete_master_query})")
 
     Spree::Product.where(id: valid_product_ids)
   end
@@ -32,6 +30,12 @@ class OrderCycleDistributedProducts
       .variants_distributed_by(distributor)
       .select(:product_id)
       .group(:product_id)
+  end
+
+  def products_with_obsolete_master_query
+    products_with_obsolete_master
+      .select('spree_products.id')
+      .to_sql
   end
 
   # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,45 +15,8 @@ class OrderCycleDistributedProducts
   #
   # @return [ActiveRecord::Relation<Spree::Product>]
   def relation
-    product_ids = valid_products_relation.map(&:id)
+    product_ids = (valid_products_sql).map(&:id)
     Spree::Product.where(id: product_ids)
-  end
-
-  def relation_with_sql
-    product_ids = valid_products_sql.map(&:id)
-    Spree::Product.where(id: product_ids)
-  end
-
-  def valid_products_sql
-    query = <<-SQL
-SELECT "spree_products".*
-  FROM "spree_products"
- LEFT
-  JOIN "spree_variants"
-    ON "spree_variants"."product_id"    = "spree_products"."id"
-   AND "spree_variants"."is_master"     = 'f'
-   AND "spree_variants"."deleted_at" IS NULL
- LEFT
-  JOIN "exchange_variants"
-    ON "exchange_variants"."variant_id" = "spree_variants"."id"
- LEFT
-  JOIN "exchanges"
-    ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
-  LEFT OUTER
-  JOIN (
-    SELECT *
-      from inventory_items
- WHERE enterprise_id                    = ?) AS o_inventory_items
-    ON o_inventory_items.variant_id     = spree_variants.id
- WHERE "exchanges"."order_cycle_id"     = ? OR "exchanges"."order_cycle_id" IS NULL
-   AND "exchanges"."incoming"           = 'f' OR "exchanges"."incoming" IS NULL
-   AND "exchanges"."receiver_id"        = ? OR "exchanges"."receiver_id" IS NULL
-   AND ("spree_products".deleted_at IS NULL)
-   AND ("spree_variants".deleted_at IS NULL)
-   AND (o_inventory_items.id IS NULL
-    OR o_inventory_items.visible        = ('t'))
-    SQL
-    Spree::Product.find_by_sql([query, distributor.id, order_cycle.id, distributor.id])
   end
 
   private
@@ -67,5 +30,39 @@ SELECT "spree_products".*
       .merge(Exchange.in_order_cycle(order_cycle))
       .merge(Exchange.outgoing)
       .merge(Exchange.to_enterprise(distributor))
+  end
+
+  def products_with_obsolete_master
+    query = <<-SQL
+SELECT "spree_products".*
+  FROM "spree_products"
+  LEFT
+  JOIN "spree_variants"
+    ON "spree_variants"."product_id"    = "spree_products"."id"
+   AND "spree_variants"."deleted_at" IS NULL
+  LEFT
+  JOIN "exchange_variants"
+    ON "exchange_variants"."variant_id" = "spree_variants"."id"
+  LEFT
+  JOIN "exchanges"
+    ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
+  LEFT OUTER
+  JOIN (
+    SELECT *
+      from inventory_items
+ WHERE enterprise_id                    = ?) AS o_inventory_items
+    ON o_inventory_items.variant_id     = spree_variants.id
+   AND ("spree_products".deleted_at IS NULL)
+   AND ("spree_variants".deleted_at IS NULL)
+   AND (o_inventory_items.id IS NULL
+    OR o_inventory_items.visible        = ('t'))
+ GROUP BY "spree_products"."id"
+HAVING COUNT(*) > 1
+   AND bool_or(is_master = true AND exchanges.id IS NOT NULL)
+    SQL
+
+    Spree::Product.find_by_sql(
+      [query, distributor.id, distributor.id]
+    )
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -50,15 +50,10 @@ class OrderCycleDistributedProducts
 
   def left_join_products_with_obsolete_master
     <<-SQL.strip_heredoc
-        LEFT JOIN (#{products_with_obsolete_master.to_sql})
+        LEFT JOIN (#{ProductsWithObsoleteMasterQuery.new(order_cycle.id).to_sql})
         AS products_with_obsolete_master
         ON variants_including_masters_spree_products.product_id
           = products_with_obsolete_master.id
     SQL
-  end
-
-  # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.
-  def products_with_obsolete_master
-    ProductsWithObsoleteMasterQuery.new(order_cycle.id).all
   end
 end

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -34,19 +34,6 @@ class OrderCycleDistributedProducts
 
   attr_reader :order_cycle, :distributor
 
-  def all_distributed_products
-    order_cycle
-      .variants_distributed_by(distributor)
-      .select(:product_id)
-      .group(:product_id)
-  end
-
-  def products_with_obsolete_master_query
-    products_with_obsolete_master
-      .select('spree_products.id')
-      .to_sql
-  end
-
   # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.
   def products_with_obsolete_master
     Spree::Product

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -50,8 +50,12 @@ class OrderCycleDistributedProducts
   # TODO: filter by products supplied by the OC suppliers so we don't go through the whole products table.
   def products_with_obsolete_master
     Spree::Product
+      .joins('INNER JOIN exchanges AS exchanges_suppliers ON exchanges_suppliers.sender_id = spree_products.supplier_id')
       .joins('LEFT JOIN "spree_variants" ON "spree_variants"."product_id" = "spree_products"."id" AND "spree_variants"."deleted_at" IS NULL')
       .joins('LEFT JOIN "exchange_variants" ON "exchange_variants"."variant_id" = "spree_variants"."id"')
+      .joins('LEFT JOIN "exchanges" AS obsolete_exchanges ON "obsolete_exchanges"."id" = "exchange_variants"."exchange_id"')
+      .where('exchanges_suppliers.order_cycle_id = ?', order_cycle.id)
+      .where('obsolete_exchanges.incoming = false OR obsolete_exchanges.incoming IS NULL')
       .group('"spree_products"."id"')
       .having(<<-SQL.strip_heredoc)
         COUNT(*) > 1

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 Openfoodnetwork::Application.configure do
+  ActiveSupport::Deprecation.silenced = true
   # Settings specified here will take precedence over those in config/application.rb
 
   # The test environment is used exclusively to run your application's

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,4 @@
 Openfoodnetwork::Application.configure do
-  ActiveSupport::Deprecation.silenced = true
   # Settings specified here will take precedence over those in config/application.rb
 
   # The test environment is used exclusively to run your application's

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,11 +21,11 @@ end
 set_mail_configuration
 
 # -- Spree
-unless Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
+# unless Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
   puts "[db:seed] Seeding Spree"
   Spree::Core::Engine.load_seed if defined?(Spree::Core)
   Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
-end
+# end
 
 country = Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
 puts "Country is #{country.to_s}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,11 +21,11 @@ end
 set_mail_configuration
 
 # -- Spree
-# unless Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
+unless Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
   puts "[db:seed] Seeding Spree"
   Spree::Core::Engine.load_seed if defined?(Spree::Core)
   Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
-# end
+end
 
 country = Spree::Country.find_by_iso(ENV['DEFAULT_COUNTRY_CODE'])
 puts "Country is #{country.to_s}"

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe OrderCycleDistributedProducts do
-  let(:order_cycle) { OrderCycle.new }
+  let(:order_cycle) { build(:order_cycle) }
   let(:distributor) { create(:enterprise) }
   let(:exchange) do
     create(
@@ -57,7 +57,7 @@ describe OrderCycleDistributedProducts do
 
     it 'returns the product' do
       distributed_valid_products = described_class.new(order_cycle, distributor)
-      expect(distributed_valid_products.relation).to eq([product])
+      expect(distributed_valid_products.relation_with_sql).to eq([product])
     end
   end
 

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -89,6 +89,11 @@ describe OrderCycleDistributedProducts do
     end
   end
 
+  def output(name, result)
+    puts "\n#{name}"
+    result.each { |r| puts r }
+  end
+
   def with_execution_tags(method)
     Rails.logger.debug "\n==== BEGIN #{method}"
     yield

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -26,8 +26,7 @@ describe OrderCycleDistributedProducts do
     )
 
     distributed_valid_products = described_class.new(order_cycle, distributor)
-
-    expect(distributed_valid_products.relation).to eq([valid_product])
+    expect(distributed_valid_products.relation.map(&:id)).to eq([valid_product.id])
   end
 
   context 'when the product has only an obsolete master variant in a distribution' do

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -115,7 +115,7 @@ HAVING COUNT(*)                         > 1
 
     it 'returns the product' do
       distributed_valid_products = described_class.new(order_cycle, distributor)
-      expect(distributed_valid_products.relation_with_sql).to eq([product])
+      expect(distributed_valid_products.relation).to eq([product])
     end
   end
 

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -21,6 +21,7 @@ describe OrderCycleDistributedProducts do
     distributor = create(:distributor_enterprise)
     order_cycle = create(
       :simple_order_cycle,
+      suppliers: [valid_product.supplier],
       distributors: [distributor],
       variants: [valid_variant, invalid_product.master]
     )

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -89,4 +89,10 @@ describe OrderCycleDistributedProducts do
       expect(distributed_valid_products.relation).to eq([product])
     end
   end
+
+  def with_execution_tags(method)
+    Rails.logger.debug "\n==== BEGIN #{method}"
+    yield
+    Rails.logger.debug "==== END #{method}\n"
+  end
 end

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -13,64 +13,6 @@ describe OrderCycleDistributedProducts do
     )
   end
 
-  it 'allows me to test the variants' do
-    valid_product = create(:product)
-    invalid_product = create(:product)
-    valid_variant = valid_product.variants.first
-
-    distributor = create(:distributor_enterprise)
-    order_cycle = create(
-      :simple_order_cycle,
-      distributors: [distributor],
-      variants: [valid_variant, invalid_product.master]
-    )
-
-    query = <<-SQL
-SELECT "spree_variants".product_id
-  FROM "spree_variants"
- LEFT
-  JOIN "exchange_variants"
-    ON "exchange_variants"."variant_id" = "spree_variants"."id"
- LEFT
-  JOIN "exchanges"
-    ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
-   AND ("spree_variants".deleted_at IS NULL)
-   GROUP BY product_id
-    SQL
-
-    subquery = <<-SQL
-SELECT "spree_variants".product_id
-  FROM "spree_variants"
-  LEFT 
-  JOIN "exchange_variants"
-    ON "exchange_variants"."variant_id" = "spree_variants"."id"
-  LEFT 
-  JOIN "exchanges"
-    ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
-   AND ("spree_variants".deleted_at IS NULL)
- INNER 
-  JOIN spree_products
-    ON spree_products.id                = spree_variants.product_id
- WHERE spree_products.supplier_id IN (
-   #{valid_product.supplier_id}, #{invalid_product.supplier_id}
- )
- GROUP BY product_id
-HAVING COUNT(*)                         > 1
-   AND bool_or(is_master                = true
-   AND exchanges.id IS NOT NULL)
- ORDER BY product_id
-    SQL
-
-    subquery_result = ActiveRecord::Base.connection.execute(subquery)
-    subquery_result = subquery_result.map { |r| r['product_id'].to_i }
-
-    result = ActiveRecord::Base.connection.execute(query)
-    result = result.map { |r| r['product_id'].to_i }
-
-    expect(subquery_result).to eq([invalid_product.id])
-    expect(result - subquery_result).to eq([valid_product.id])
-  end
-
   it 'returns valid products but not invalid products' do
     valid_product = create(:product)
     invalid_product = create(:product)

--- a/spec/services/order_cycle_distributed_products_spec.rb
+++ b/spec/services/order_cycle_distributed_products_spec.rb
@@ -83,6 +83,52 @@ describe OrderCycleDistributedProducts do
       variant.exchanges << exchange
     end
 
+    xit 'lets me test the variants' do
+      query = <<-SQL
+      SELECT "spree_variants".product_id,
+              spree_variants.id AS variant_id,
+              spree_variants.is_master,
+              exchanges.id AS exchange_id
+        FROM "spree_variants"
+       LEFT
+        JOIN "exchange_variants"
+          ON "exchange_variants"."variant_id" = "spree_variants"."id"
+       LEFT
+        JOIN "exchanges"
+          ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
+         AND ("spree_variants".deleted_at IS NULL)
+      SQL
+
+      subquery = <<-SQL
+      SELECT "spree_variants".product_id
+        FROM "spree_variants"
+        LEFT
+        JOIN "exchange_variants"
+          ON "exchange_variants"."variant_id" = "spree_variants"."id"
+        LEFT
+        JOIN "exchanges"
+          ON "exchanges"."id"                 = "exchange_variants"."exchange_id"
+         AND ("spree_variants".deleted_at IS NULL)
+       GROUP BY product_id
+       HAVING COUNT(*)                         > 1
+          AND bool_or(is_master                = true
+          AND exchanges.id IS NOT NULL)
+          AND COUNT(exchanges.id) = 1
+        ORDER BY product_id
+      SQL
+
+      subquery_result = ActiveRecord::Base.connection.execute(subquery)
+      output('SUBQUERY', subquery_result)
+      subquery_result = subquery_result.map { |r| r['product_id'].to_i }
+
+      result = ActiveRecord::Base.connection.execute(query)
+      output('QUERY', result)
+      result = result.map { |r| r['product_id'].to_i }
+
+      distributed_valid_products = described_class.new(order_cycle, distributor)
+      expect(distributed_valid_products.relation.map(&:id) - subquery_result).to eq([product.id])
+    end
+
     it 'returns the product' do
       distributed_valid_products = described_class.new(order_cycle, distributor)
       expect(distributed_valid_products.relation).to eq([product])


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/3853

Totally rewrites the logic to fetch products to be displayed in the shopfront; those that don't have an obsolete master. It does so by rewriting the slow and imperative Ruby logic with the following single pretty big SQL query.

```sql
SELECT DISTINCT(spree_products.*)
 FROM "spree_products"
INNER 
 JOIN "spree_variants" "variants_including_masters_spree_products"
   ON "variants_including_masters_spree_products"."product_id" = "spree_products"."id"
INNER 
 JOIN "exchange_variants" "exchange_variants_spree_variants_join"
   ON "exchange_variants_spree_variants_join"."variant_id"     = "variants_including_masters_spree_products"."id"
INNER 
 JOIN "exchanges"
   ON "exchanges"."id"                                         = "exchange_variants_spree_variants_join"."exchange_id"
 LEFT OUTER
 JOIN (
   SELECT *
     FROM inventory_items
WHERE enterprise_id                                            = 6701
      ) AS o_inventory_items
   ON o_inventory_items.variant_id                             = variants_including_masters_spree_products.id
 LEFT 
 JOIN (
   SELECT "spree_products".*
     FROM "spree_products"
    INNER 
     JOIN exchanges AS exchanges_suppliers
       ON exchanges_suppliers.sender_id                            = spree_products.supplier_id
     LEFT 
     JOIN "spree_variants"
       ON "spree_variants"."product_id"                            = "spree_products"."id"
      AND "spree_variants"."deleted_at" IS NULL
     LEFT 
     JOIN "exchange_variants"
       ON "exchange_variants"."variant_id"                         = "spree_variants"."id"
     LEFT 
     JOIN "exchanges" AS obsolete_exchanges
       ON "obsolete_exchanges"."id"                                = "exchange_variants"."exchange_id"
    WHERE ("spree_products".deleted_at IS NULL)
      AND (exchanges_suppliers.order_cycle_id                      = 2017)
      AND (
            obsolete_exchanges.incoming                              = false
       OR obsolete_exchanges.incoming IS NULL
          )
    GROUP BY "spree_products"."id"
   HAVING COUNT(*)                                                 > 1
      AND bool_or(
            is_master                                                = true
      AND exchange_variants.id IS NOT NULL
          )
  AND COUNT(exchange_variants.id)                              = 1
      ) AS products_with_obsolete_master
   ON variants_including_masters_spree_products.product_id     = products_with_obsolete_master.id
WHERE "exchanges"."order_cycle_id"                             = 2017
  AND "exchanges"."incoming"                                   = 'f'
  AND "exchanges"."receiver_id"                                = 6701
  AND (
        o_inventory_items.id IS NULL
   OR o_inventory_items.visible                                = true
      )
  AND (products_with_obsolete_master.id IS NULL)
  AND (spree_products.deleted_at IS NULL)
  AND (variants_including_masters_spree_products.deleted_at IS NULL)
```

:page_with_curl: http://tatiyants.com/pev/#/plans/plan_1565624404628 is its execution plan for Katuma production.

We still follow the previous code's idea of removing the invalid products (products with an obsolete master) from the result, but this time through a LEFT JOIN between variants and `products_with_obsolete_master`.

although tests are passing and the shopfront seems to render properly, the readability of the changed class needs to be improved **so this is still WIP**. Any hints and comments that could help on that are very welcome.

I literally suffered to get this query due to the complexity of the data model and the quality of our codebase, please be kind.

:information_source: **Please, leave any questions so I can help everyone understand**. I'll try to document the result of all these `JOIN`s somehow.

#### What should we test?

TBD

#### Release notes

Fetching the valid order cycle products for a shop does not perform N+1
Changelog Category: Changed
