### PR TITLE
Enable (optional) APM with Datadog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,10 @@ gem 'jquery-rails', '3.0.4'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c'
 
+group :production, :staging do
+  gem 'ddtrace'
+end
+
 group :test, :development do
   # Pretty printed test output
   gem 'atomic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
       activerecord (>= 3.2.0, < 5.0)
       fog (~> 1.0)
       rails (>= 3.2.0, < 5.0)
+    ddtrace (0.26.0)
+      msgpack
     debugger-linecache (1.2.0)
     deface (1.0.2)
       colorize (>= 0.5.8)
@@ -505,6 +507,7 @@ GEM
       railties (>= 3.1)
     money (5.1.1)
       i18n (~> 0.6.0)
+    msgpack (1.3.1)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -775,6 +778,7 @@ DEPENDENCIES
   dalli
   database_cleaner (= 0.7.1)
   db2fog
+  ddtrace
   debugger-linecache
   deface (= 1.0.2)
   delayed_job_active_record

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
 if ENV['DATADOG_RAILS_APM']
   Datadog.configure do |c|
     c.use :rails, service_name: 'rails'
+    c.use :delayed_job, service_name: 'delayed_job'
   end
 end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,5 @@
+if ENV['DATADOG_RAILS_APM']
+  Datadog.configure do |c|
+    c.use :rails, service_name: 'rails'
+  end
+end


### PR DESCRIPTION
#### What? Why?

Part one of https://github.com/openfoodfoundation/ofn-install/issues/496

Closes https://github.com/openfoodfoundation/ofn-install/issues/318

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Add option for using Rails APM with Datadog. Disabled by default.

#### What should we test?
<!-- List which features should be tested and how. -->

I'll have to test this myself. Datadog APM should work.
