### PR TITLE
4138 Avoid infinite loop when updating products

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -464,9 +464,11 @@ class Enterprise < ActiveRecord::Base
     self.permalink = Enterprise.find_available_permalink(name)
   end
 
+  # Touch distributors without them touching their distributors.
+  # We avoid an infinite loop and don't need to touch the whole distributor tree.
   def touch_distributors
     Enterprise.distributing_products(supplied_products.select(:id)).
       where('enterprises.id != ?', id).
-      find_each(&:touch)
+      update_all(updated_at: Time.zone.now)
   end
 end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -533,7 +533,7 @@ module Spree
         )
       end
 
-      pending "saves without infinite loop" do
+      it "saves without infinite loop" do
         expect(variant1.update_attributes(cost_price: 1)).to be_truthy
       end
     end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -515,6 +515,28 @@ module Spree
 
       it_behaves_like "a model using the LocalizedNumber module", [:price, :cost_price, :weight]
     end
+
+    context "in a circular order cycle setup" do
+      let(:enterprise1) { create(:distributor_enterprise, is_primary_producer: true) }
+      let(:enterprise2) { create(:distributor_enterprise, is_primary_producer: true) }
+      let(:variant1) { create(:variant) }
+      let(:variant2) { create(:variant) }
+      let!(:order_cycle) do
+        enterprise1.supplied_products << variant1.product
+        enterprise2.supplied_products << variant2.product
+        create(
+          :simple_order_cycle,
+          coordinator: enterprise1,
+          suppliers: [enterprise1, enterprise2],
+          distributors: [enterprise1, enterprise2],
+          variants: [variant1, variant2]
+        )
+      end
+
+      pending "saves without infinite loop" do
+        expect(variant1.update_attributes(cost_price: 1)).to be_truthy
+      end
+    end
   end
 
   describe "destruction" do


### PR DESCRIPTION

#### What? Why?

Closes #4138.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Rails supports caching based on the `updated_at` timestamp of records. The timestamp is updated on each save or manually via the `touch` method. When one record is updated, it can also touch other records to invalidate caches based on those records.

For example, when a variant is changed, we touch the producer enterprise. And when a producer is changed we touch all distributors of that producer's variants. Unfortunately, that can result in an infinite loop if an enterprise is a producer and a distributor and it sells products of another enterprise it also supplies to. Or simply: when two enterprises are selling each other's products.

When touching all distributors of a producer, we don't need to update all of the distributors' distributors as well. At least I can't think of a use case for that and it's not covered by specs.

So I changed the logic to stop the cascade of touching enterprises and only touch those enterprises which are direct distributors of a changed producer without further callbacks. It's also faster than before.

As far as I know, the timestamp is only used in the `Api::EnterpriseSerializer`. That serializer is used on these pages:

- `app/views/producers/index.html.haml`
- `app/views/shops/index.html.haml`
- `app/views/groups/show.html.haml`
- `app/views/checkout/edit.html.haml`
- `app/views/spree/orders/edit.html.haml`
- `app/views/spree/orders/show.html.haml`

I'm not sure though if we use all this information on all of these pages and it may be possible to clean up the serializer and reduce the number of events that cause cache invalidation which would simplify the code.

#### What should we test?
<!-- List which features should be tested and how. -->

We need to make sure that the following pages are updated correctly:

- /producers
- /shops
- /groups -> select a group, check tabs
- /checkout/edit
- /orders/Order-Number and edit

These pages should update when changing the following information:

- A product changes its category (taxons, filters change).
- A product's properties change (I don't know what that is either).
- An enterprise's producer properties change.
- The owner of a product changes.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a bug that could lead to certain enterprises not being able to update their products.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

