### PR TITLE
Add bugsnag notifications to both product_set and products_controller when stock update fails

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -49,7 +49,6 @@ Metrics/LineLength:
   - app/controllers/spree/admin/orders_controller_decorator.rb
   - app/controllers/spree/admin/payments_controller_decorator.rb
   - app/controllers/spree/admin/payment_methods_controller_decorator.rb
-  - app/controllers/spree/admin/products_controller_decorator.rb
   - app/controllers/spree/admin/reports_controller_decorator.rb
   - app/controllers/spree/api/products_controller_decorator.rb
   - app/controllers/spree/credit_cards_controller.rb
@@ -437,7 +436,6 @@ Metrics/AbcSize:
   - app/models/spree/order_decorator.rb
   - app/models/spree/payment_decorator.rb
   - app/models/spree/product_decorator.rb
-  - app/models/spree/product_set.rb
   - app/models/spree/taxon_decorator.rb
   - app/serializers/api/admin/enterprise_serializer.rb
   - app/serializers/api/product_serializer.rb
@@ -566,7 +564,6 @@ Metrics/CyclomaticComplexity:
   - app/models/spree/ability_decorator.rb
   - app/models/spree/payment_decorator.rb
   - app/models/spree/product_decorator.rb
-  - app/models/spree/product_set.rb
   - app/models/variant_override_set.rb
   - app/services/cart_service.rb
   - lib/discourse/single_sign_on.rb
@@ -594,7 +591,6 @@ Metrics/PerceivedComplexity:
   - app/models/spree/ability_decorator.rb
   - app/models/spree/order_decorator.rb
   - app/models/spree/product_decorator.rb
-  - app/models/spree/product_set.rb
   - lib/discourse/single_sign_on.rb
   - lib/open_food_network/bulk_coop_report.rb
   - lib/open_food_network/enterprise_issue_validator.rb
@@ -650,7 +646,6 @@ Metrics/MethodLength:
   - app/models/spree/payment_decorator.rb
   - app/models/spree/payment_method_decorator.rb
   - app/models/spree/product_decorator.rb
-  - app/models/spree/product_set.rb
   - app/serializers/api/admin/order_cycle_serializer.rb
   - app/serializers/api/cached_enterprise_serializer.rb
   - app/services/order_cycle_form.rb

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -48,19 +48,13 @@ Spree::Admin::ProductsController.class_eval do
   end
 
   def bulk_update
-    collection_hash = Hash[params[:products].each_with_index.map { |p, i| [i, p] }]
-    product_set = Spree::ProductSet.new(collection_attributes: collection_hash)
-
-    params[:filters] ||= {}
-    bulk_index_query = params[:filters].reduce("") do |string, filter|
-      "#{string}q[#{filter[:property][:db_column]}_#{filter[:predicate][:predicate]}]=#{filter[:value]};"
-    end
+    product_set = product_set_from_params(params)
 
     # Ensure we're authorised to update all products
     product_set.collection.each { |p| authorize! :update, p }
 
     if product_set.save
-      redirect_to "/api/products/bulk_products?page=1;per_page=500;#{bulk_index_query}"
+      redirect_to "/api/products/bulk_products?page=1;per_page=500;#{bulk_index_query(params)}"
     else
       if product_set.errors.present?
         render json: { errors: product_set.errors }, status: :bad_request
@@ -73,7 +67,8 @@ Spree::Admin::ProductsController.class_eval do
   protected
 
   def collection
-    # This method is copied directly from the spree product controller, except where we narrow the search below with the managed_by search to support
+    # This method is copied directly from the spree product controller
+    #   except where we narrow the search below with the managed_by search to support
     # enterprise users.
     # TODO: There has to be a better way!!!
     return @collection if @collection.present?
@@ -108,14 +103,38 @@ Spree::Admin::ProductsController.class_eval do
 
   private
 
+  def product_set_from_params(params)
+    collection_hash = Hash[params[:products].each_with_index.map { |p, i| [i, p] }]
+    Spree::ProductSet.new(collection_attributes: collection_hash)
+  end
+
+  def bulk_index_query(params)
+    params[:filters] ||= {}
+    params[:filters].reduce("") do |string, filter|
+      filter_db_column = filter[:property][:db_column]
+      filter_predicate = filter[:predicate][:predicate]
+      filter_value = filter[:value]
+      "#{string}q[#{filter_db_column}_#{filter_predicate}]=#{filter_value};"
+    end
+  end
+
   def load_form_data
-    @producers = OpenFoodNetwork::Permissions.new(spree_current_user).managed_product_enterprises.is_primary_producer.by_name
+    @producers = OpenFoodNetwork::Permissions.new(spree_current_user).
+      managed_product_enterprises.is_primary_producer.by_name
     @taxons = Spree::Taxon.order(:name)
     @import_dates = product_import_dates.uniq.to_json
   end
 
   def product_import_dates
-    import_dates = Spree::Variant.
+    options = [{ id: '0', name: '' }]
+    product_import_dates_query.collect(&:import_date).
+      map { |i| options.push(id: i.to_date, name: i.to_date.to_formatted_s(:long)) }
+
+    options
+  end
+
+  def product_import_dates_query
+    Spree::Variant.
       select('DISTINCT spree_variants.import_date').
       joins(:product).
       where('spree_products.supplier_id IN (?)', editable_enterprises.collect(&:id)).
@@ -123,18 +142,14 @@ Spree::Admin::ProductsController.class_eval do
       where(spree_variants: { is_master: false }).
       where(spree_variants: { deleted_at: nil }).
       order('spree_variants.import_date DESC')
-
-    options = [{ id: '0', name: '' }]
-    import_dates.collect(&:import_date).map { |i| options.push(id: i.to_date, name: i.to_date.to_formatted_s(:long)) }
-
-    options
   end
 
   def strip_new_properties
-    unless spree_current_user.admin? || params[:product][:product_properties_attributes].nil?
-      names = Spree::Property.pluck(:name)
-      params[:product][:product_properties_attributes].each do |key, property|
-        params[:product][:product_properties_attributes].delete key unless names.include? property[:property_name]
+    return if spree_current_user.admin? || params[:product][:product_properties_attributes].nil?
+    names = Spree::Property.pluck(:name)
+    params[:product][:product_properties_attributes].each do |key, property|
+      unless names.include? property[:property_name]
+        params[:product][:product_properties_attributes].delete key
       end
     end
   end
@@ -155,14 +170,17 @@ Spree::Admin::ProductsController.class_eval do
       variant.on_demand = on_demand if on_demand.present?
       variant.on_hand = on_hand.to_i if on_hand.present?
     rescue StandardError => error
-      Bugsnag.notify(error) do |report|
-        report.add_tab(:product, product.attributes)
-        report.add_tab(:product_error, product.errors.first) unless product.valid?
-        report.add_tab(:variant_attributes, variant_attributes)
-        report.add_tab(:variant, variant.attributes)
-        report.add_tab(:variant_error, variant.errors.first) unless variant.valid?
-      end
+      notify_bugsnag(error, product, variant)
       raise error
+    end
+  end
+
+  def notify_bugsnag(error, product, variant)
+    Bugsnag.notify(error) do |report|
+      report.add_tab(:product, product.attributes)
+      report.add_tab(:product_error, product.errors.first) unless product.valid?
+      report.add_tab(:variant, variant.attributes)
+      report.add_tab(:variant_error, variant.errors.first) unless variant.valid?
     end
   end
 

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -101,6 +101,7 @@ class Spree::ProductSet < ModelSet
       variant.on_hand = on_hand.to_i if on_hand.present?
     rescue StandardError => error
       notify_bugsnag(error, product, variant, variant_attributes)
+      raise error
     end
   end
 

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -17,9 +17,7 @@ class Spree::ProductSet < ModelSet
   #   variant.update_attributes( { price: xx.x } )
   #
   def update_attributes(attributes)
-    if attributes[:taxon_ids].present?
-      attributes[:taxon_ids] = attributes[:taxon_ids].split(',')
-    end
+    split_taxon_ids!(attributes)
 
     found_model = @collection.find do |model|
       model.id.to_s == attributes[:id].to_s && model.persisted?
@@ -28,10 +26,18 @@ class Spree::ProductSet < ModelSet
     if found_model.nil?
       @klass.new(attributes).save unless @reject_if.andand.call(attributes)
     else
-      update_product_only_attributes(found_model, attributes) &&
-        update_product_variants(found_model, attributes) &&
-        update_product_master(found_model, attributes)
+      update_product(found_model, attributes)
     end
+  end
+
+  def split_taxon_ids!(attributes)
+    attributes[:taxon_ids] = attributes[:taxon_ids].split(',') if attributes[:taxon_ids].present?
+  end
+
+  def update_product(found_model, attributes)
+    update_product_only_attributes(found_model, attributes) &&
+      update_product_variants(found_model, attributes) &&
+      update_product_master(found_model, attributes)
   end
 
   def update_product_only_attributes(product, attributes)
@@ -94,13 +100,17 @@ class Spree::ProductSet < ModelSet
       variant.on_demand = on_demand if on_demand.present?
       variant.on_hand = on_hand.to_i if on_hand.present?
     rescue StandardError => error
-      Bugsnag.notify(error) do |report|
-        report.add_tab(:product, product.attributes)
-        report.add_tab(:product_error, product.errors.first) unless product.valid?
-        report.add_tab(:variant_attributes, variant_attributes)
-        report.add_tab(:variant, variant.attributes)
-        report.add_tab(:variant_error, variant.errors.first) unless variant.valid?
-      end
+      notify_bugsnag(error, product, variant, variant_attributes)
+    end
+  end
+
+  def notify_bugsnag(error, product, variant, variant_attributes)
+    Bugsnag.notify(error) do |report|
+      report.add_tab(:product, product.attributes)
+      report.add_tab(:product_error, product.errors.first) unless product.valid?
+      report.add_tab(:variant_attributes, variant_attributes)
+      report.add_tab(:variant, variant.attributes)
+      report.add_tab(:variant_error, variant.errors.first) unless variant.valid?
     end
   end
 

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -89,6 +89,7 @@ class Spree::ProductSet < ModelSet
     on_demand = variant_attributes.delete(:on_demand)
 
     variant = product.variants.create(variant_attributes)
+    return unless variant.valid?
 
     variant.on_demand = on_demand if on_demand.present?
     variant.on_hand = on_hand.to_i if on_hand.present?

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -168,12 +168,29 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
   end
 
-  describe "updating" do
+  describe "updating a product" do
     let(:producer) { create(:enterprise) }
     let!(:product) { create(:simple_product, supplier: producer) }
 
     before do
       login_as_enterprise_user [producer]
+    end
+
+    describe "product stock setting with errors" do
+      it "notifies bugsnag and still raise error" do
+        # forces an error in the variant
+        product.variants.first.stock_items = []
+
+        expect(Bugsnag).to receive(:notify)
+
+        expect do
+          spree_put :update,
+                    id: product,
+                    product: {
+                      on_hand: 1
+                    }
+        end.to raise_error(StandardError)
+      end
     end
 
     describe "product variant unit is items" do

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -112,15 +112,17 @@ describe Spree::ProductSet do
             context 'and attributes provided are not valid' do
               let(:master_attributes) do
                 # unit_value nil makes the variant invalid
-                # on_hand with a value would make on_hand be updated and fail with exception (no stock item)
-                attributes_for(:variant).merge(unit_value: nil, on_hand: 1)
+                # on_hand with a value would make on_hand be updated and fail with exception
+                attributes_for(:variant).merge(unit_value: nil, on_hand: 1, sku: '321')
               end
 
-              it 'does not create variant and does not raise exception' do
+              it 'does not create variant and notifies bugsnag without raising exception' do
+                expect(Bugsnag).to receive(:notify)
                 number_of_variants = Spree::Variant.all.size
                 expect { product_set.save }
                   .not_to raise_error(StandardError)
                 expect(Spree::Variant.all.size).to eq number_of_variants
+                expect(Spree::Variant.last.sku).not_to eq('321')
               end
             end
           end

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -96,13 +96,32 @@ describe Spree::ProductSet do
           end
 
           context 'and the variant does not exist' do
-            let(:master_attributes) do
-              attributes_for(:variant).merge(sku: '123')
+            context 'and attributes provided are valid' do
+              let(:master_attributes) do
+                attributes_for(:variant).merge(sku: '123')
+              end
+
+              it 'creates it with the specified attributes' do
+                number_of_variants = Spree::Variant.all.size
+                product_set.save
+                expect(Spree::Variant.last.sku).to eq('123')
+                expect(Spree::Variant.all.size).to eq number_of_variants + 1
+              end
             end
 
-            it 'creates it with the specified attributes' do
-              product_set.save
-              expect(Spree::Variant.last.sku).to eq('123')
+            context 'and attributes provided are not valid' do
+              let(:master_attributes) do
+                # unit_value nil makes the variant invalid
+                # on_hand with a value would make on_hand be updated and fail with exception (no stock item)
+                attributes_for(:variant).merge(unit_value: nil, on_hand: 1)
+              end
+
+              it 'does not create variant and does not raise exception' do
+                number_of_variants = Spree::Variant.all.size
+                expect { product_set.save }
+                  .not_to raise_error(StandardError)
+                expect(Spree::Variant.all.size).to eq number_of_variants
+              end
             end
           end
         end

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -116,11 +116,11 @@ describe Spree::ProductSet do
                 attributes_for(:variant).merge(unit_value: nil, on_hand: 1, sku: '321')
               end
 
-              it 'does not create variant and notifies bugsnag without raising exception' do
+              it 'does not create variant and notifies bugsnag still raising the exception' do
                 expect(Bugsnag).to receive(:notify)
                 number_of_variants = Spree::Variant.all.size
                 expect { product_set.save }
-                  .not_to raise_error(StandardError)
+                  .to raise_error(StandardError)
                 expect(Spree::Variant.all.size).to eq number_of_variants
                 expect(Spree::Variant.last.sku).not_to eq('321')
               end


### PR DESCRIPTION
#### What? Why?

To try to debug  #4138 here we add bugsnag notifications to both product set (bulk product update) and products controller (product create and edit) when failing to update stock. This will give us more info about what's going on and in what cases this code is failing to create stock items. Adds more info to these bugsnag events: 21 events in [uk](https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/5d4062fde75241001ce7c207) so far and  a few more in [ca](https://app.bugsnag.com/open-food-network-canada-1/open-food-network-canada/errors/5d4b6cfdd5b544001a5a9e26?filters%5Bevent.since%5D%5B0%5D=30d&filters%5Berror.status%5D%5B0%5D=open)

#### What should we test?
We should make sure we can create a product as usually, edit a product and use the bulk product update page normally: change product and variant attributes and create new variants.

#### Release notes
Changelog Category: Changed
Added notifications in case of error to the bulk product update page and the create/edit product page.