### PR TITLE
Checkout is not refreshing products cache

### DIFF
--- a/app/models/spree/stock_movement_decorator.rb
+++ b/app/models/spree/stock_movement_decorator.rb
@@ -1,0 +1,10 @@
+Spree::StockMovement.class_eval do
+  after_save :refresh_products_cache
+
+  private
+
+  def refresh_products_cache
+    return if stock_item.variant.blank?
+    OpenFoodNetwork::ProductsCache.variant_changed stock_item.variant
+  end
+end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -64,31 +64,6 @@ feature "As a consumer I want to check out my cart", js: true do
     context 'login in as user' do
       let(:user) { create(:user) }
 
-      def fill_out_form
-        choose sm1.name
-        choose pm1.name
-
-        within "#details" do
-          fill_in "First Name", with: "Will"
-          fill_in "Last Name", with: "Marshall"
-          fill_in "Email", with: "test@test.com"
-          fill_in "Phone", with: "0468363090"
-        end
-
-        check "Save as default billing address"
-
-        within "#billing" do
-          fill_in "City", with: "Melbourne"
-          fill_in "Postcode", with: "3066"
-          fill_in "Address", with: "123 Your Head"
-          select "Australia", from: "Country"
-          select "Victoria", from: "State"
-        end
-
-        check "Shipping address same as billing address?"
-        check "Save as default shipping address"
-      end
-
       before do
         quick_login_as(user)
       end
@@ -216,7 +191,7 @@ feature "As a consumer I want to check out my cart", js: true do
         page.should have_content distributor.name
       end
 
-      it 'does not show the save as defalut address checkbox' do
+      it 'does not show the save as default address checkbox' do
         page.should_not have_content "Save as default billing address"
         page.should_not have_content "Save as default shipping address"
       end
@@ -315,20 +290,8 @@ feature "As a consumer I want to check out my cart", js: true do
 
       describe "purchasing" do
         it "takes us to the order confirmation page when we submit a complete form" do
-          within "#details" do
-            fill_in "First Name", with: "Will"
-            fill_in "Last Name", with: "Marshall"
-            fill_in "Email", with: "test@test.com"
-            fill_in "Phone", with: "0468363090"
-          end
-
-          within "#billing" do
-            fill_in "Address", with: "123 Your Face"
-            select "Australia", from: "Country"
-            select "Victoria", from: "State"
-            fill_in "City", with: "Melbourne"
-            fill_in "Postcode", with: "3066"
-          end
+          fill_out_details
+          fill_out_billing_address
 
           within "#shipping" do
             choose sm2.name
@@ -365,22 +328,8 @@ feature "As a consumer I want to check out my cart", js: true do
           before do
             choose sm1.name
             choose pm1.name
-
-            within "#details" do
-              fill_in "First Name", with: "Will"
-              fill_in "Last Name", with: "Marshall"
-              fill_in "Email", with: "test@test.com"
-              fill_in "Phone", with: "0468363090"
-            end
-
-            within "#billing" do
-              fill_in "City", with: "Melbourne"
-              fill_in "Postcode", with: "3066"
-              fill_in "Address", with: "123 Your Face"
-              select "Australia", from: "Country"
-              select "Victoria", from: "State"
-            end
-
+            fill_out_details
+            fill_out_billing_address
             check "Shipping address same as billing address?"
           end
 
@@ -474,5 +423,37 @@ feature "As a consumer I want to check out my cart", js: true do
         end
       end
     end
+  end
+
+  def fill_out_details
+    within "#details" do
+      fill_in "First Name", with: "Will"
+      fill_in "Last Name", with: "Marshall"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Phone", with: "0468363090"
+    end
+  end
+
+  def fill_out_billing_address
+    within "#billing" do
+      fill_in "City", with: "Melbourne"
+      fill_in "Postcode", with: "3066"
+      fill_in "Address", with: "123 Your Head"
+      select "Australia", from: "Country"
+      select "Victoria", from: "State"
+    end
+  end
+
+  def fill_out_form
+    choose sm1.name
+    choose pm1.name
+
+    fill_out_details
+    check "Save as default billing address"
+
+    fill_out_billing_address
+
+    check "Shipping address same as billing address?"
+    check "Save as default shipping address"
   end
 end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -194,6 +194,7 @@ feature "As a consumer I want to check out my cart", js: true do
       it "does not show item after all stock of an item is checked out (tesging cache update on checkout)" do
         Spree::Config[:enable_products_cache?] = true
         variant.update_attributes on_hand: 5
+        flush_jobs
         visit shop_path
 
         fill_in "variants[#{variant.id}]", with: '5'
@@ -210,6 +211,7 @@ feature "As a consumer I want to check out my cart", js: true do
         place_order
         expect(page).to have_content "Your order has been processed successfully"
 
+        flush_jobs
         visit shop_path
         # The presence of the control product ensures the list of products is fully loaded
         #   before we verify the sold product is not present

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -180,6 +180,30 @@ feature "As a consumer I want to check out my cart", js: true do
       end
     end
 
+    context "in the shopfront" do
+      it "does not show item after all stock of an item is checked out (tesging cache update on checkout)" do
+        variant.update_attributes on_hand: 5
+        visit shop_path
+
+        fill_in "variants[#{variant.id}]", with: '5'
+        wait_until { !cart_dirty }
+
+        visit checkout_path
+        checkout_as_guest
+
+        fill_out_details
+        fill_out_billing_address
+        choose sm1.name
+        choose pm1.name
+
+        place_order
+        expect(page).to have_content "Your order has been processed successfully"
+
+        visit shop_path
+        page.should_not have_content variant.product.name
+      end
+    end
+
     context "on the checkout page" do
       before do
         visit checkout_path


### PR DESCRIPTION
#### What? Why?

- Closes #4020 

#### What should we test?

As admin:

1. Create a new variant with limited stock (e.g. 5) supplied by Supplier A.
2. Create Shop A.
3. Set up an open OC for Shop A that includes this variant. Do not create a variant override for the variant.
4. Create Shop B.
5. Set up an open OC for Shop B that includes this variant. Do not create a variant override for the variant.
6. Create Shop C.
7. Set up an open OC for Shop C that includes this variant.
8. Create a variant override with different limited stock level (e.g. 8).

As customer:

1. Purchase all the stock of the variant (e.g. 5 from above) from Shop A, and check out.
2. Wait around 1 minute. Check that the variant is no longer visible in Shop A and Shop B. Check that the variant is still in Shop C.
3. Purchase all the stock of the variant (e.g. 8 from above) from Shop C, and check out.
4. Wait around 1 minute. Check that the variant is no longer in Shop C.

#### Release notes

- Refresh the variant cache when the supplier stock level for a non-override limited stock variant is updated without saving the variant. This fixes the issue of non-override limited stock variants still appearing in the shopfront after a customer purchases the last available stock.

Changelog Category: Fixed