### PR TITLE
4160 Fix product report filters

### DIFF
--- a/lib/open_food_network/products_and_inventory_report_base.rb
+++ b/lib/open_food_network/products_and_inventory_report_base.rb
@@ -65,7 +65,15 @@ module OpenFoodNetwork
     def filter_to_order_cycle(variants)
       if params[:order_cycle_id].to_i > 0
         order_cycle = OrderCycle.find params[:order_cycle_id]
-        variants.where(id: order_cycle.variants)
+        # There are two quirks here:
+        #
+        # 1. Rails 3 uses only the last `where` clause of a column. So we can't
+        #    use `variants.where(id: order_cycle.variants)` until we upgrade to
+        #    Rails 4.
+        #
+        # 2. `order_cycle.variants` returns an array. So we need to use map
+        #    instead of pluck.
+        variants.where("spree_variants.id in (?)", order_cycle.variants.map(&:id))
       else
         variants
       end

--- a/spec/lib/open_food_network/products_and_inventory_report_spec.rb
+++ b/spec/lib/open_food_network/products_and_inventory_report_spec.rb
@@ -171,7 +171,6 @@ module OpenFoodNetwork
         end
 
         it "should do all the filters at once" do
-          pending "the order cycle filter is overriden by the distributor filter"
           # The following data ensures that this spec fails if any of the
           # filters fail. It's testing the filters are not impacting each other.
           distributor = create(:distributor_enterprise)

--- a/spec/lib/open_food_network/products_and_inventory_report_spec.rb
+++ b/spec/lib/open_food_network/products_and_inventory_report_spec.rb
@@ -222,6 +222,9 @@ module OpenFoodNetwork
           )
 
           expect(subject.filter(variants)).to match_array [not_filtered_variant]
+
+          # And it integrates with the ordering of the `variants` method.
+          expect(subject.variants).to match_array [not_filtered_variant]
         end
       end
 


### PR DESCRIPTION
#### What? Why?

Closes #4160.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

When filtering the LettuceShare report by distributor and order cycle, the order cycle filter was ignored. Too many variants ended up in the report.

#### What should we test?
<!-- List which features should be tested and how. -->

All three Products & Inventory reports are affected by this change:

1. All products (same as Products & Inventory)
2. Inventory (on hand)
3. LettuceShare

These three reports share the same logic for filtering variants by:

- supplier
- order cycle
- distributor

Each combination of filters should be checked.

- no filters (test with "All products" report)
- filter by supplier and order cycle (test with "All products" report)
- filter by supplier and distributor (test with "Inventory (on hand)" report)
- filter by order cycle and distributor (test with "LettuceShare" report)

You will need at least two order cycles to test the order cycle filter. One of the order cycles should have multiple suppliers and multiple distributors to test those filters as well. And not all distributors should sell all products.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: The Products & Inventory reports can be filtered by distributor and order cycle again. The latter got overridden by the former.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

