### PR TITLE
4176 Fix saving of shipping method when automatically advancing subscription order state

### DIFF
--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -59,7 +59,7 @@ class SubscriptionPlacementJob
   end
 
   def move_to_completion(order)
-    until order.completed? do order.next! end
+    AdvanceOrderService.new(order).call!
   end
 
   def unavailable_stock_lines_for(order)

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -118,8 +118,12 @@ describe SubscriptionPlacementJob do
   end
 
   describe "processing a subscription order" do
-    let(:subscription) { create(:subscription, with_items: true) }
-    let(:shop) { subscription.shop }
+    let!(:shipping_method_created_earlier) { create(:shipping_method, distributors: [shop]) }
+    let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
+    let!(:shipping_method_created_later) { create(:shipping_method, distributors: [shop]) }
+
+    let(:shop) { create(:enterprise) }
+    let(:subscription) { create(:subscription, shop: shop, with_items: true) }
     let(:proxy_order) { create(:proxy_order, subscription: subscription) }
     let(:oc) { proxy_order.order_cycle }
     let(:ex) { oc.exchanges.outgoing.find_by_sender_id_and_receiver_id(shop.id, shop.id) }
@@ -146,6 +150,19 @@ describe SubscriptionPlacementJob do
     end
 
     context "when the order is not already complete" do
+      describe "selection of shipping method" do
+        let!(:subscription) do
+          create(:subscription, shop: shop, shipping_method: shipping_method, with_items: true)
+        end
+
+        pending "uses the same shipping method after advancing the order" do
+          job.send(:process, order)
+          expect(order.state).to eq "complete"
+          order.reload
+          expect(order.shipping_method).to eq(shipping_method)
+        end
+      end
+
       context "when no stock items are available after capping stock" do
         before do
           allow(job).to receive(:unavailable_stock_lines_for) { order.line_items }

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -155,7 +155,7 @@ describe SubscriptionPlacementJob do
           create(:subscription, shop: shop, shipping_method: shipping_method, with_items: true)
         end
 
-        pending "uses the same shipping method after advancing the order" do
+        it "uses the same shipping method after advancing the order" do
           job.send(:process, order)
           expect(order.state).to eq "complete"
           order.reload


### PR DESCRIPTION
#### What? Why?

- Closes #4176

When automatically advancing subscription orders from cart to completion, through `SubscriptionPlacementJob`, the original shipping method of the order is not retained.

We use `AdvanceOrderService` to wrap `order.next` with OFN-specific logic, such as retaining the shipping method when the order is transitioned to "delivery" state. `SubscriptionPlacementJob` still uses the `order.next` form, which loses the previously selected shipping method.

#### What should we test?

1. Create three shipping methods:
    * Volunteer discount with negative shipping fee.
    * Delivery, $1 shipping fee.
    * Express delivery, $2 shipping fee.
2. Create a subscription with the Express delivery as shipping method.
3. Open an order cycle for that subscription.
4. Wait six minutes for the order to be placed.
5. Check the shipping fee on the order. This should be $2 now.
6. Check other order details.
7. Repeat items 2 to 6 selecting Delivery as shipping method and expecting $1 shipping fee.

Now just double-checking:

- Close the order cycle.
- Wait six minutes for the confirmation emails to come through.
- Check the shipping fee.
- Check other order details.

#### Release notes

- Do not lose the previously selected shipping method for a subscription when automatically transitioning to "delivery" state through `SubscriptionPlacementJob`.

Changelog Category: Fixed