### PR TITLE
Backordered items can be shipped

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -15,6 +15,14 @@ module Spree
       end
     end
 
+    # Override of Spree method to allow `on_demand` items to be shipped
+    def determine_state(order)
+      return 'canceled' if order.canceled?
+      return 'pending' unless order.can_ship?
+      return 'shipped' if state == 'shipped'
+      order.paid? ? 'ready' : 'pending'
+    end
+
     # The shipment manifest is built by loading inventory units and variants from the DB
     # These variants come unscoped
     # So, we need to scope the variants just after the manifest is built

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -42,7 +42,7 @@ describe Spree::Shipment do
         pending_order.update!
       end
 
-      xit "can still be shipped" do
+      it "can still be shipped" do
         expect(pending_order.can_ship?).to be true
         expect(pending_order.ready_to_ship?).to be true
       end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -29,5 +29,23 @@ describe Spree::Shipment do
         expect(variants.sort_by(&:id)).to eq([deleted_variant, other_variant].sort_by(&:id))
       end
     end
+
+    context "when the order contains items with negative stock" do
+      let!(:on_demand_variant) { create(:variant, on_demand: true, on_hand: 1) }
+      let!(:pending_order) { create(:completed_order_with_totals) }
+      let!(:backordered_line_item) {
+        create(:line_item, order: pending_order, variant: on_demand_variant, quantity: 99)
+      }
+
+      before do
+        pending_order.payments << create(:payment, amount: pending_order.total, state: 'completed')
+        pending_order.update!
+      end
+
+      xit "can still be shipped" do
+        expect(pending_order.can_ship?).to be true
+        expect(pending_order.ready_to_ship?).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #4158

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Orders with backordered (negative stock) items could not be shipped. This included any orders with on_demand items. 

#### What should we test?
<!-- List which features should be tested and how. -->

- Set a product stock level to 1, save it, then set it to `on_demand`
- Place an order with a large amount of that product
- Check the order can be successfully shipped (via admin)

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed an issue with order shipment status getting stuck at 'pending' with on_demand items.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

