### PR TITLE
Remove Skylight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,6 @@ gem 'paperclip', '~> 3.4.1'
 gem 'rack-rewrite'
 gem 'rack-ssl', require: 'rack/ssl'
 gem 'roadie-rails', '~> 1.1.1'
-gem 'skylight', '< 2.0'
 gem 'spinjs-rails'
 
 gem 'combine_pdf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -685,8 +685,6 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    skylight (1.7.2)
-      activesupport (>= 3.0.0)
     spinjs-rails (1.4)
       rails (>= 3.1)
     spreadsheet (1.1.7)
@@ -843,7 +841,6 @@ DEPENDENCIES
   shoulda-matchers
   simple_form!
   simplecov
-  skylight (< 2.0)
   spinjs-rails
   spree_api!
   spree_backend!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://semaphoreci.com/api/v1/openfoodfoundation/openfoodnetwork-2/branches/master/badge.svg)](https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2)
 [![Code Climate](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork.png)](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork)
-[![View performance data on Skylight](https://badges.skylight.io/status/EiXQ6sSKij8y.svg)](https://oss.skylight.io/app/applications/EiXQ6sSKij8y)
 
 # Open Food Network
 

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -146,13 +146,3 @@
               = t '.footer_data_text_without_privacy_policy_html', {cookies_policy: cookies_policy_link.html_safe }
       .medium-2.columns.text-center
         / Placeholder
-    -if ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL'].present?
-      .row
-        .small-12.medium-8.medium-offset-2.columns.text-center
-          %hr.hr-light
-          %br
-
-      .row
-        .small-12.medium-8.medium-offset-2.columns.text-center
-          .text.small
-            = t '.footer_skylight_dashboard_html', {dashboard: link_to('Skylight', ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL'], target: "_blank")}

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,13 +25,6 @@ module Openfoodnetwork
       end
     end
 
-    # Activate the Skylight agent in staging. You need to provision the
-    # SKYLIGHT_AUTHENTICATION env var in your OFN instance for this to work.
-    #
-    # Check https://github.com/openfoodfoundation/openfoodnetwork/pull/2070 for
-    # details
-    config.skylight.environments += ["staging"]
-
     # Settings dependent on locale
     #
     # We need to set this config before the promo environment gets loaded and

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -48,12 +48,6 @@ SMTP_PASSWORD: 'f00d'
 # see: https://developers.google.com/maps/documentation/javascript/get-api-key
 # GOOGLE_MAPS_API_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# optional, see: https://www.skylight.io/oss
-# SKYLIGHT_AUTHENTICATION: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Should be set if using Skylight, adds a link to Skylight dashboard to our footer
-# SKYLIGHT_PUBLIC_DASHBOARD_URL: "https://oss.skylight.io/app/applications/xxxxxxxxxx"
-
 # Stripe Connect details for instance account
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings
 # Under 'Connect', the Redirect URI should be set to https://YOUR_SERVER_URL/stripe/callbacks (e.g. https://openfoodnetwork.org.uk/stripe/callbacks)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1187,7 +1187,6 @@ en:
       footer_data_text_without_privacy_policy_html: "We take good care of your data. See our %{cookies_policy}"
       footer_data_privacy_policy: "privacy policy"
       footer_data_cookies_policy: "cookies policy"
-      footer_skylight_dashboard_html: Performance data is available on %{dashboard}.
   shop:
     messages:
       login: "login"


### PR DESCRIPTION
#### What? Why?

Since we adopted Skylight to get response times across endpoints and
instances, we failed to get accurate numbers. Our Rails version is not
supported and thus Skylight fails to provide data for the slowest
endpoints, the ones we care about the most. Even with a supported one, we
could potentially hit any limits on tracing and have the same problem.

Recently, we started paying for Datadog's APM and the experience,
although it's still early, has been better. It makes it possible to
correlate between services and other metrics which helps to spot the
underlying issues.

Therefore, having two agents running on the server consumes system
resources so we better get rid of Skylight's one.

#### What should we test?

It does not affect the codebase.

#### Release notes

Remove response time profiling with Skylight

Changelog Category: Removed

#### Dependencies

It needs https://github.com/openfoodfoundation/ofn-install/pull/507