### PR TITLE
Lower integrity checker job interval

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,7 +12,7 @@ job_type :run_file, "cd :path; :environment_variable=:environment bundle exec sc
 job_type :enqueue_job,  "cd :path; :environment_variable=:environment bundle exec script/enqueue :task :priority :output"
 
 
-every 1.hour do
+every 1.day, at: '01:00am' do
   rake 'ofn:cache:check_products_integrity'
 end
 


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Lowers the interval for running the products cache integrity checker from hourly to daily. This will generate less alerts and save resources.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Decreased frequency of ProductsCacheIntegrityChecker job

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed