### PR TITLE
4210 Fetch and scope variants for shop in ProductsRenderer only once

### DIFF
--- a/lib/open_food_network/products_renderer.rb
+++ b/lib/open_food_network/products_renderer.rb
@@ -54,14 +54,16 @@ module OpenFoodNetwork
     end
 
     def all_variants_for_shop
-      # We use the in_stock? method here instead of the in_stock scope because we need to
-      # look up the stock as overridden by VariantOverrides, and the scope method is not affected
-      # by them.
-      scoper = OpenFoodNetwork::ScopeVariantToHub.new(@distributor)
-      Spree::Variant.
-        for_distribution(@order_cycle, @distributor).
-        each { |v| scoper.scope(v) }.
-        select(&:in_stock?)
+      @all_variants_for_shop ||= begin
+                                   # We use the in_stock? method here instead of the in_stock scope
+                                   # because we need to look up the stock as overridden by
+                                   # VariantOverrides, and the scope method is not affected by them.
+                                   scoper = OpenFoodNetwork::ScopeVariantToHub.new(@distributor)
+                                   Spree::Variant.
+                                     for_distribution(@order_cycle, @distributor).
+                                     each { |v| scoper.scope(v) }.
+                                     select(&:in_stock?)
+                                 end
     end
 
     def variants_for_shop_by_id


### PR DESCRIPTION
#### What? Why?

- References #4210 

This caches in instance variable `ProductsRenderer#all_variants_for_shop` so that the variants do not have to be fetched and scoped twice for the two times that this method is called.

This is a small code change that could considerably reduce the RAM and processing done for `RefreshProductsCacheJob`. It takes some time for Ruby garbage collection to happen, so for a shop that has thousands of variants in their order cycle, this could mean `number_of_variants + number_of_variant_overrides` fewer objects in memory, in addition to the I think only slightly reduced number of SQL queries.

(Maybe garbage collection is something we could look into too, if we're not doing this already.)

#### What should we test?

For below:

- Supplier stock settings - What you can set in Bulk Edit Products page
- Variant override stock settings - What you can set in Inventory page

Do the following with an open OC:

1. Create a new variant with unlimited stock (supplier).
2. Add the variant to the OC. The variant should be available in the shop.
3. Test the following:
    - 0 limited stock (supplier) - not available in shop
    - Positive limited stock (supplier) - available in the shop
4. In the Inventory page, add a variant override for the variant.
5. Test the following:
    - 0 limited stock (variant override) - not available in shop
    - Positive limited stock (variant override) - available in shop
    - 0 limited stock (variant override) again - wait for variant to disappear again
    - Unlimited stock (variant override) - available in shop

#### Release notes

- Fetch and scope variants for shop in `ProductsRenderer` used in `RefreshProductsCacheJob` only once.

Changelog Category: Changed