### PR TITLE
Add missing translations on product edit page

### DIFF
--- a/app/views/spree/admin/product_properties/index.html.haml
+++ b/app/views/spree/admin/product_properties/index.html.haml
@@ -7,7 +7,7 @@
 - content_for :page_actions do
   %ul.tollbar.inline-menu
     %li
-      = link_to_add_fields t(:add_product_properties), 'tbody#product_properties', class: 'icon-plus button'
+      = link_to_add_fields t('.add_product_properties'), 'tbody#product_properties', class: 'icon-plus button'
 
 = form_for @product, url: admin_product_url(@product), method: :put do |f|
   %fieldset.no-border-top
@@ -27,7 +27,7 @@
           = render partial: 'product_property_fields', locals: { f: pp_form }
 
     = f.check_box :inherits_properties
-    = f.label :inherits_properties, t(".inherits_properties_checkbox_hint", supplier: @product.supplier.name)
+    = f.label :inherits_properties, t('.inherits_properties_checkbox_hint', supplier: @product.supplier.name)
     %br
     %br
 

--- a/app/views/spree/admin/product_properties/index.html.haml
+++ b/app/views/spree/admin/product_properties/index.html.haml
@@ -7,7 +7,7 @@
 - content_for :page_actions do
   %ul.tollbar.inline-menu
     %li
-      = link_to_add_fields Spree.t(:add_product_properties), 'tbody#product_properties', class: 'icon-plus button'
+      = link_to_add_fields t(:add_product_properties), 'tbody#product_properties', class: 'icon-plus button'
 
 = form_for @product, url: admin_product_url(@product), method: :put do |f|
   %fieldset.no-border-top

--- a/app/views/spree/admin/products/_seo_form.html.haml
+++ b/app/views/spree/admin/products/_seo_form.html.haml
@@ -1,12 +1,12 @@
 .row{"data-hook" => "admin_product_meta_form"}
   .alpha.eleven.columns
     = f.field_container :meta_keywords do
-      = f.label :meta_keywords, t(:product_search_keywords)
+      = f.label :meta_keywords, t('admin.products.product_search_keywords')
       %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.product_search_tip') }
       %br/
       = f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6
     = f.field_container :meta_description do
-      = f.label :meta_description, t(:SEO_keywords)
+      = f.label :meta_description, t('admin.products.SEO_keywords')
       %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.seo_tip') }
       %br/
       = f.text_field :meta_description, :class => 'fullwidth', :rows => 6

--- a/app/views/spree/admin/products/_seo_form.html.haml
+++ b/app/views/spree/admin/products/_seo_form.html.haml
@@ -1,13 +1,13 @@
 .row{"data-hook" => "admin_product_meta_form"}
   .alpha.eleven.columns
     = f.field_container :meta_keywords do
-      = f.label :meta_keywords, t('admin.products.product_search_keywords')
-      %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.product_search_tip') }
+      = f.label :meta_keywords, t('admin.products.seo.product_search_keywords')
+      %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.seo.product_search_tip') }
       %br/
       = f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6
     = f.field_container :meta_description do
-      = f.label :meta_description, t('admin.products.SEO_keywords')
-      %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.seo_tip') }
+      = f.label :meta_description, t('admin.products.seo.SEO_keywords')
+      %span.icon-question-sign{ 'ofn-with-tip' => t('admin.products.seo.seo_tip') }
       %br/
       = f.text_field :meta_description, :class => 'fullwidth', :rows => 6
   .alpha.eleven.columns

--- a/app/views/spree/admin/products/seo.html.haml
+++ b/app/views/spree/admin/products/seo.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'spree/admin/shared/product_sub_menu'
-= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => t(:Search) }
+= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => t(:search) }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 
 %div{ 'ng-app' => 'ofn.admin' }

--- a/app/views/spree/admin/shared/_edit_resource_links.html.haml
+++ b/app/views/spree/admin/shared/_edit_resource_links.html.haml
@@ -1,4 +1,4 @@
 .form-buttons.filter-actions.actions
-  = button Spree.t('actions.update'), 'icon-refresh'
-  %span.or= Spree.t(:or)
-  = button_link_to Spree.t('actions.cancel'), collection_url, icon: 'icon-remove'
+  = button t('update'), 'icon-refresh'
+  %span.or= t(:or)
+  = button_link_to t('cancel'), collection_url, icon: 'icon-remove'

--- a/app/views/spree/admin/shared/_edit_resource_links.html.haml
+++ b/app/views/spree/admin/shared/_edit_resource_links.html.haml
@@ -1,4 +1,4 @@
 .form-buttons.filter-actions.actions
-  = button t('update'), 'icon-refresh'
+  = button t(:update), 'icon-refresh'
   %span.or= t(:or)
-  = button_link_to t('cancel'), collection_url, icon: 'icon-remove'
+  = button_link_to t(:cancel), collection_url, icon: 'icon-remove'

--- a/app/views/spree/admin/shared/_product_tabs.html.haml
+++ b/app/views/spree/admin/shared/_product_tabs.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  = t(:editing_product)
+  = t('admin.products.editing_product')
   = "\"#{@product.name}\""
 
 - content_for :sidebar_title do
@@ -12,22 +12,22 @@
       - if can?(:admin, Spree::Product)
         - klass = current == 'Product Details' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-edit', t(:product_details), edit_admin_product_url(@product)
+          = link_to_with_icon 'icon-edit', t('admin.products.tabs.product_details'), edit_admin_product_url(@product)
       - if can?(:admin, Spree::Image)
         - klass = current == 'Images' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-picture', t(:images), admin_product_images_url(@product)
+          = link_to_with_icon 'icon-picture', t('admin.products.tabs.images'), admin_product_images_url(@product)
       - if can?(:admin, Spree::Variant)
         - klass = current == 'Variants' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-th-large', t(:variants),  admin_product_variants_url(@product)
+          = link_to_with_icon 'icon-th-large', t('admin.products.tabs.variants'),  admin_product_variants_url(@product)
       - if can?(:admin, Spree::ProductProperty)
         - klass = current == 'Product Properties' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-tasks', t(:product_properties), admin_product_product_properties_url(@product)
+          = link_to_with_icon 'icon-tasks', t('admin.products.tabs.product_properties'), admin_product_product_properties_url(@product)
       - klass = current == 'Group Buy Options' ? 'active' : ''
       %li{:class => klass}
-        = link_to_with_icon 'icon-tasks', t('admin.products.group_buy_options'), group_buy_options_admin_product_url(@product)
+        = link_to_with_icon 'icon-tasks', t('admin.products.tabs.group_buy_options'), group_buy_options_admin_product_url(@product)
       - klass = current == t(:search) ? 'active' : ''
       %li{:class => klass}
         = link_to_with_icon 'icon-tasks', t(:search), seo_admin_product_url(@product)

--- a/app/views/spree/admin/shared/_product_tabs.html.haml
+++ b/app/views/spree/admin/shared/_product_tabs.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  = Spree.t(:editing_product)
+  = t(:editing_product)
   = "\"#{@product.name}\""
 
 - content_for :sidebar_title do
@@ -12,22 +12,22 @@
       - if can?(:admin, Spree::Product)
         - klass = current == 'Product Details' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-edit', Spree.t(:product_details), edit_admin_product_url(@product)
+          = link_to_with_icon 'icon-edit', t(:product_details), edit_admin_product_url(@product)
       - if can?(:admin, Spree::Image)
         - klass = current == 'Images' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-picture', Spree.t(:images), admin_product_images_url(@product)
+          = link_to_with_icon 'icon-picture', t(:images), admin_product_images_url(@product)
       - if can?(:admin, Spree::Variant)
         - klass = current == 'Variants' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-th-large', Spree.t(:variants),  admin_product_variants_url(@product)
+          = link_to_with_icon 'icon-th-large', t(:variants),  admin_product_variants_url(@product)
       - if can?(:admin, Spree::ProductProperty)
         - klass = current == 'Product Properties' ? 'active' : ''
         %li{:class => klass}
-          = link_to_with_icon 'icon-tasks', Spree.t(:product_properties), admin_product_product_properties_url(@product)
+          = link_to_with_icon 'icon-tasks', t(:product_properties), admin_product_product_properties_url(@product)
       - klass = current == 'Group Buy Options' ? 'active' : ''
       %li{:class => klass}
         = link_to_with_icon 'icon-tasks', t('admin.products.group_buy_options'), group_buy_options_admin_product_url(@product)
-      - klass = current == t(:Search) ? 'active' : ''
+      - klass = current == t(:search) ? 'active' : ''
       %li{:class => klass}
-        = link_to_with_icon 'icon-tasks', t(:Search), seo_admin_product_url(@product)
+        = link_to_with_icon 'icon-tasks', t(:search), seo_admin_product_url(@product)

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -1,9 +1,9 @@
 .label-block.left.six.columns.alpha{'ng-app' => 'admin.products'}
   .field
-    = f.label :display_name, t(:display_name)
+    = f.label :display_name, t('.display_name')
     = f.text_field :display_name, class: "fullwidth"
   .field
-    = f.label :display_as, t(:display_as)
+    = f.label :display_as, t('.display_as')
     = f.text_field :display_as, class: "fullwidth"
 
   - if product_has_variant_unit_option_type?(@product)

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -29,13 +29,13 @@
             - if opt = @variant.option_values.detect {|o| o.option_type == option_type }.try(:presentation)
               = text_field(:new_variant, option_type.presentation, value: opt, disabled: 'disabled', class: 'fullwidth')
     .field
-      = f.label :sku, t(:sku)
+      = f.label :sku, t('.sku')
       = f.text_field :sku, class: 'fullwidth'
     .field
-      = f.label :price, t(:price)
+      = f.label :price, t('.price')
       = f.text_field :price, value: number_to_currency(@variant.price, unit: ''), class: 'fullwidth'
     .field
-      = f.label :cost_price, t(:cost_price)
+      = f.label :cost_price, t('.cost_price')
       = f.text_field :cost_price, value: number_to_currency(@variant.cost_price, unit: ''), class: 'fullwidth'
 
     %div{ 'set-on-demand' => '' }
@@ -53,7 +53,7 @@
 .right.six.columns.omega.label-block
   - if @product.variant_unit != 'weight'
     .field
-      = f.label 'weight', t('weight')+' (kg)'
+      = f.label 'weight', t(:weight)+' (kg)'
       - value = number_with_precision(@variant.weight, precision: 2)
       = f.text_field 'weight', value: value, class: 'fullwidth'
 

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -29,13 +29,13 @@
             - if opt = @variant.option_values.detect {|o| o.option_type == option_type }.try(:presentation)
               = text_field(:new_variant, option_type.presentation, value: opt, disabled: 'disabled', class: 'fullwidth')
     .field
-      = f.label :sku, Spree.t(:sku)
+      = f.label :sku, t(:sku)
       = f.text_field :sku, class: 'fullwidth'
     .field
-      = f.label :price, Spree.t(:price)
+      = f.label :price, t(:price)
       = f.text_field :price, value: number_to_currency(@variant.price, unit: ''), class: 'fullwidth'
     .field
-      = f.label :cost_price, Spree.t(:cost_price)
+      = f.label :cost_price, t(:cost_price)
       = f.text_field :cost_price, value: number_to_currency(@variant.cost_price, unit: ''), class: 'fullwidth'
 
     %div{ 'set-on-demand' => '' }

--- a/app/views/spree/admin/variants/index.html.haml
+++ b/app/views/spree/admin/variants/index.html.haml
@@ -14,9 +14,9 @@
       %col{style: "width: 15%"}/
     %thead
       %tr
-        %th{colspan: "2"}= Spree.t(:options)
-        %th= Spree.t(:price)
-        %th= Spree.t(:sku)
+        %th{colspan: "2"}= t(:options)
+        %th= t(:price)
+        %th= t(:sku)
         %th.actions
     %tbody
       - @variants.each do |variant|
@@ -35,7 +35,7 @@
 
 - else
   .alpha.twelve.columns.no-objects-found
-    = Spree.t(:no_results)
+    = t(:no_results)
     \.
 
 - if @product.empty_option_values?
@@ -49,6 +49,6 @@
   - content_for :page_actions do
     %ul.inline-menu
       %li#new_var_link
-        = link_to_with_icon('icon-plus', Spree.t(:new_variant), new_admin_product_variant_url(@product), remote: true, 'data-update' => 'new_variant', class: 'button')
+        = link_to_with_icon('icon-plus', t(:new_variant), new_admin_product_variant_url(@product), remote: true, 'data-update' => 'new_variant', class: 'button')
 
-      %li= link_to_with_icon('icon-filter', @deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active), admin_product_variants_url(@product, deleted: @deleted.blank? ? "on" : "off"), class: 'button')
+      %li= link_to_with_icon('icon-filter', @deleted.blank? ? t(:show_deleted) : t(:show_active), admin_product_variants_url(@product, deleted: @deleted.blank? ? "on" : "off"), class: 'button')

--- a/app/views/spree/admin/variants/index.html.haml
+++ b/app/views/spree/admin/variants/index.html.haml
@@ -14,9 +14,9 @@
       %col{style: "width: 15%"}/
     %thead
       %tr
-        %th{colspan: "2"}= t(:options)
-        %th= t(:price)
-        %th= t(:sku)
+        %th{colspan: "2"}= t('.options')
+        %th= t('.price')
+        %th= t('.sku')
         %th.actions
     %tbody
       - @variants.each do |variant|
@@ -31,24 +31,24 @@
             = link_to_delete(variant, no_text: true) unless variant.deleted?
     - unless @product.has_variants?
       %tr
-        %td{colspan: "5"}= Spree.t(:none)
+        %td{colspan: "5"}= t(:none)
 
 - else
   .alpha.twelve.columns.no-objects-found
-    = t(:no_results)
+    = t('.no_results')
     \.
 
 - if @product.empty_option_values?
   %p.first_add_option_types.no-objects-found
-    = Spree.t(:to_add_variants_you_must_first_define)
-    = link_to Spree.t(:option_types), admin_product_url(@product)
-    = Spree.t(:and)
-    = link_to Spree.t(:option_values), admin_option_types_url
+    = t('.to_add_variants_you_must_first_define')
+    = link_to t('.option_types'), admin_product_url(@product)
+    = t('.and')
+    = link_to t('.option_values'), admin_option_types_url
 
 - else
   - content_for :page_actions do
     %ul.inline-menu
       %li#new_var_link
-        = link_to_with_icon('icon-plus', t(:new_variant), new_admin_product_variant_url(@product), remote: true, 'data-update' => 'new_variant', class: 'button')
+        = link_to_with_icon('icon-plus', t('.new_variant'), new_admin_product_variant_url(@product), remote: true, 'data-update' => 'new_variant', class: 'button')
 
-      %li= link_to_with_icon('icon-filter', @deleted.blank? ? t(:show_deleted) : t(:show_active), admin_product_variants_url(@product, deleted: @deleted.blank? ? "on" : "off"), class: 'button')
+      %li= link_to_with_icon('icon-filter', @deleted.blank? ? t('.show_deleted') : t('.show_active'), admin_product_variants_url(@product, deleted: @deleted.blank? ? "on" : "off"), class: 'button')

--- a/app/views/spree/admin/variants/new.html.haml
+++ b/app/views/spree/admin/variants/new.html.haml
@@ -2,6 +2,6 @@
 
 = form_for [:admin, @product, @variant] do |f|
   %fieldset{'data-hook' => "admin_variant_new_form"}
-    %legend{align: "center"}= t(:new_variant)
+    %legend{align: "center"}= t('.new_variant')
     = render partial: 'form', locals: { f: f }
     = render partial: 'spree/admin/shared/new_resource_links'

--- a/app/views/spree/admin/variants/new.html.haml
+++ b/app/views/spree/admin/variants/new.html.haml
@@ -2,6 +2,6 @@
 
 = form_for [:admin, @product, @variant] do |f|
   %fieldset{'data-hook' => "admin_variant_new_form"}
-    %legend{align: "center"}= Spree.t(:new_variant)
+    %legend{align: "center"}= t(:new_variant)
     = render partial: 'form', locals: { f: f }
     = render partial: 'spree/admin/shared/new_resource_links'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -486,13 +486,14 @@ en:
       variants:
         infinity: "Infinity"
         to_order_tip: "Items made to order do not have a set stock level, such as loaves of bread made fresh to order."
-      group_buy_options: "Group Buy Options"
       back_to_products_list: "Back to products list"
       editing_product: "Editing Product"
-      product_details: "Product Details"
-      images: "Images"
-      variants: "Variants"
-      product_properties: "Product Properties"
+      tabs:
+        product_details: "Product Details"
+        group_buy_options: "Group Buy Options"
+        images: "Images"
+        variants: "Variants"
+        product_properties: "Product Properties"
 
     product_import:
       title: Product Import

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -478,7 +478,7 @@ en:
       product_search_tip: Type words to help search your products in the shops. Use space to separate each keyword.
       SEO_keywords: SEO Keywords
       seo_tip: Type words to help search your products in the web. Use space to separate each keyword.
-      Search: Search
+      search: Search
       properties:
         property_name: Property Name
         inherited_property: Inherited Property
@@ -487,6 +487,11 @@ en:
         to_order_tip: "Items made to order do not have a set stock level, such as loaves of bread made fresh to order."
       group_buy_options: "Group Buy Options"
       back_to_products_list: "Back to products list"
+      editing_product: "Editing Product"
+      product_details: "Product Details"
+      images: "Images"
+      variants: "Variants"
+      product_properties: "Product Properties"
 
     product_import:
       title: Product Import
@@ -2944,6 +2949,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     zipcode: Postcode
     weight: Weight (per kg)
     error_user_destroy_with_orders: "Users with completed orders may not be deleted"
+    no_images_found: "No Images Found"
+    new_image: "New Image"
+    options: "Options"
 
     actions:
       update: "Update"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,10 +474,11 @@ en:
         av_on: "Av. On"
         import_date: Imported
         upload_an_image: Upload an image
-      product_search_keywords: Product Search Keywords
-      product_search_tip: Type words to help search your products in the shops. Use space to separate each keyword.
-      SEO_keywords: SEO Keywords
-      seo_tip: Type words to help search your products in the web. Use space to separate each keyword.
+      seo:
+        product_search_keywords: Product Search Keywords
+        product_search_tip: Type words to help search your products in the shops. Use space to separate each keyword.
+        SEO_keywords: SEO Keywords
+        seo_tip: Type words to help search your products in the web. Use space to separate each keyword.
       search: Search
       properties:
         property_name: Property Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3187,6 +3187,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           new_variant: "New Variant"
           show_active: "Show Active"
           show_deleted: "Show Deleted"
+        new:
+          new_variant: "New Variant"
         form:
           cost_price: "Cost Price"
           sku: "SKU"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3175,6 +3175,18 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         email_confirmation:
           confirmation_pending: "Email confirmation is pending. We've sent a confirmation email to %{address}."
       variants:
+        index:
+          sku: "SKU"
+          price: "Price"
+          options: "Options"
+          no_results: "No results"
+          to_add_variants_you_must_first_define: "To add variants, you must first define"
+          option_types: "Option Types"
+          option_values: "Option Values"
+          and: "and"
+          new_variant: "New Variant"
+          show_active: "Show Active"
+          show_deleted: "Show Deleted"
         form:
           cost_price: "Cost Price"
           sku: "SKU"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3175,6 +3175,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         email_confirmation:
           confirmation_pending: "Email confirmation is pending. We've sent a confirmation email to %{address}."
       variants:
+        form:
+          cost_price: "Cost Price"
+          sku: "SKU"
+          price: "Price"
         autocomplete:
           producer_name: "Producer"
           unit: "Unit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2984,6 +2984,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       product_properties:
         index:
           inherits_properties_checkbox_hint: "Inherit properties from %{supplier}? (unless overridden above)"
+          add_product_properties: "Add Product Properties"
+          select_from_prototype: "Select From Prototype"
       orders:
         index:
           listing_orders: "Listing Orders"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,14 +475,14 @@ en:
         import_date: Imported
         upload_an_image: Upload an image
       seo:
-        product_search_keywords: Product Search Keywords
-        product_search_tip: Type words to help search your products in the shops. Use space to separate each keyword.
-        SEO_keywords: SEO Keywords
-        seo_tip: Type words to help search your products in the web. Use space to separate each keyword.
-      search: Search
+        product_search_keywords: "Product Search Keywords"
+        product_search_tip: "Type words to help search your products in the shops. Use space to separate each keyword."
+        SEO_keywords: "SEO Keywords"
+        seo_tip: "Type words to help search your products in the web. Use space to separate each keyword."
+      search: "Search"
       properties:
-        property_name: Property Name
-        inherited_property: Inherited Property
+        property_name: "Property Name"
+        inherited_property: "Inherited Property"
       variants:
         infinity: "Infinity"
         to_order_tip: "Items made to order do not have a set stock level, such as loaves of bread made fresh to order."
@@ -2938,6 +2938,13 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     normal_amount: "Normal Amount"
     discount_amount: "Discount Amount"
 
+    no_images_found: "No Images Found"
+    new_image: "New Image"
+    filename: "Filename"
+    alt_text: "Alternative Text"
+    thumbnail: "Thumbnail"
+    back_to_images_list: "Back To Images List"
+
     # TODO: remove `email` key once we get to Spree 2.0
     email: Email
     # TODO: remove 'account_updated' key once we get to Spree 2.0
@@ -2951,8 +2958,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     zipcode: Postcode
     weight: Weight (per kg)
     error_user_destroy_with_orders: "Users with completed orders may not be deleted"
-    no_images_found: "No Images Found"
-    new_image: "New Image"
     options: "Options"
 
     actions:
@@ -3193,6 +3198,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           cost_price: "Cost Price"
           sku: "SKU"
           price: "Price"
+          display_as: "Display As"
+          display_name: "Display Name"
         autocomplete:
           producer_name: "Producer"
           unit: "Unit"


### PR DESCRIPTION
#### What? Why?

Closes #4106 

Add missing keys for translations and override Spree keys to use our own.

#### What should we test?
Missing translations should now appear. Verify all pages mentioned in the issue are rendering correctly in English.

#### Release notes
Adding missing translations in edit product pages.
Changelog Category: Added | Changed