### PR TITLE
Add missing translations for orders

### DIFF
--- a/app/views/spree/admin/adjustments/index.html.haml
+++ b/app/views/spree/admin/adjustments/index.html.haml
@@ -2,12 +2,12 @@
 
 - content_for :page_title do
   %i.icon-arrow-right
-  = Spree.t(:adjustments)
+  = t(:adjustments)
 
 - content_for :page_actions do
-  %li= button_link_to Spree.t(:new_adjustment), new_admin_order_adjustment_url(@order), :icon => 'icon-plus'
-  %li= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
+  %li= button_link_to t(:new_adjustment), new_admin_order_adjustment_url(@order), :icon => 'icon-plus'
+  %li= button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
 = render :partial => 'adjustments_table'
 
-= button_link_to Spree.t(:continue), @order.cart? ? new_admin_order_payment_url(@order) : admin_orders_url, :icon => 'icon-arrow-right'
+= button_link_to t(:continue), @order.cart? ? new_admin_order_payment_url(@order) : admin_orders_url, :icon => 'icon-arrow-right'

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -8,7 +8,7 @@
         = Spree.t("shipment_states.#{shipment.state}")
       - if shipment.ready? and can? :update, shipment
         = "-"
-        = link_to 'ship', '#', :class => 'ship button icon-arrow-right', :data => { 'shipment-number' => shipment.number }
+        = link_to t(:ship), '#', :class => 'ship button icon-arrow-right', :data => { 'shipment-number' => shipment.number }
 
   %table.stock-contents.index{ "data-hook" => "stock-contents" }
     %colgroup

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -10,7 +10,7 @@
       = line_item.single_money.to_html
     %td.item-qty-show.align-center
       - item.states.each do |state,count|
-        = "#{count} x #{state.humanize.downcase}"
+        = "#{count} x #{t(state.humanize.downcase)}"
     - unless shipment.shipped?
       %td.item-qty-edit.hidden
         = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -6,7 +6,7 @@
     %li= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'icon-email'
   %li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
   - if can?(:admin, Spree::Order)
-    %li= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
+    %li= button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
 = render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Order Details' }
 

--- a/app/views/spree/admin/payments/_list.html.haml
+++ b/app/views/spree/admin/payments/_list.html.haml
@@ -2,9 +2,9 @@
   %thead
     %tr
       %th= "#{Spree.t('date')}/#{Spree.t('time')}"
-      %th= Spree.t(:amount)
-      %th= Spree.t(:payment_method)
-      %th= Spree.t(:payment_state)
+      %th= t(:amount)
+      %th= t(:payment_method)
+      %th= t(:payment_state)
       %th.actions
   %tbody
     - payments.each do |payment|
@@ -13,7 +13,7 @@
         %td.align-center= payment.display_amount.to_html
         %td.align-center= link_to payment_method_name(payment), spree.admin_order_payment_path(@order, payment)
         %td.align-center
-          %span{class: "state #{payment.state}"}= Spree.t(payment.state, scope: :payment_states, default: payment.state.capitalize)
+          %span{class: "state #{payment.state}"}= t(payment.state, scope: :payment_states, default: payment.state.capitalize)
         %td.actions
           - payment.actions.each do |action|
             = link_to_with_icon "icon-#{action}", Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: {action: action}

--- a/app/views/spree/admin/payments/index.html.haml
+++ b/app/views/spree/admin/payments/index.html.haml
@@ -3,20 +3,20 @@
 - content_for :page_actions do
   - if @order.outstanding_balance?
     %li#new_payment_section
-      = button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order), icon: 'icon-plus'
-  %li= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, icon: 'icon-arrow-left'
+      = button_link_to t(:new_payment), new_admin_order_payment_url(@order), icon: 'icon-plus'
+  %li= button_link_to t(:back_to_orders_list), admin_orders_path, icon: 'icon-arrow-left'
 
 - content_for :page_title do
   %i.icon-arrow-right
-  = Spree.t(:payments)
+  = t(:payments)
 
 - if @order.outstanding_balance?
   %h5.outstanding-balance
-    = @order.outstanding_balance < 0 ? Spree.t(:credit_owed) : Spree.t(:balance_due)
+    = @order.outstanding_balance < 0 ? t(:credit_owed) : t(:balance_due)
     \:
     %strong= @order.display_outstanding_balance
 
 - if @payments.any?
   = render partial: 'list', locals: { payments: @payments }
 - else
-  .alpha.twelve.columns.no-objects-found= Spree.t(:order_has_no_payments)
+  .alpha.twelve.columns.no-objects-found= t(:order_has_no_payments)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,6 +276,9 @@ en:
   expired: has expired, please request a new one
   back_to_payments_list: "Back to Payments List"
   maestro_or_solo_cards: "Maestro/Solo cards"
+  backordered: "Backordered"
+  on_hand: "On Hand"
+  ship: "Ship"
 
   actions:
     create_and_add_another: "Create and Add Another"
@@ -2771,6 +2774,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     name_or_sku: "Name or SKU (enter at least first 4 characters of product name)"
     resend: Resend
     back_to_orders_list: Back To Orders List
+    return_authorizations: Return Authorizations
+    cannot_create_returns: Cannot create returns as this order has no shipped units.
     select_stock: "Select stock"
     location: "Location"
     count_on_hand: "Count On Hand"


### PR DESCRIPTION
#### What? Why?

Closes #4090 

Add missing translations for order pages. Same, most of them where already here but not used. I overide a few of Spree's.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Missing translations now have keys in en.yml.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added missing translations for order pages.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added
#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

