### PR TITLE
4233 Add missing Spree route for Paypal

### DIFF
--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -117,6 +117,9 @@ Spree::Core::Engine.routes.prepend do
 
   resources :products
 
+  # Used by spree_paypal_express
+  get '/checkout/:state', :to => 'checkout#edit', :as => :checkout_state
+
   get '/unauthorized', :to => 'home#unauthorized', :as => :unauthorized
   get '/content/cvv', :to => 'content#cvv', :as => :cvv
   get '/content/*path', :to => 'content#show', :as => :content

--- a/spec/features/consumer/shopping/checkout_paypal_spec.rb
+++ b/spec/features/consumer/shopping/checkout_paypal_spec.rb
@@ -43,8 +43,6 @@ feature "Checking out with Paypal", js: true do
 
   describe "as a guest" do
     it "fails with an error message" do
-      pending "The checkout_state_path is missing."
-
       visit checkout_path
       complete_the_form
 

--- a/spec/features/consumer/shopping/checkout_paypal_spec.rb
+++ b/spec/features/consumer/shopping/checkout_paypal_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+
+feature "Checking out with Paypal", js: true do
+  include ShopWorkflow
+  include CheckoutWorkflow
+
+  let(:distributor) { create(:distributor_enterprise) }
+  let(:supplier) { create(:supplier_enterprise) }
+  let(:product) { create(:simple_product, supplier: supplier) }
+  let(:variant) { product.variants.first }
+  let(:order_cycle) {
+    create(
+      :simple_order_cycle,
+      suppliers: [supplier],
+      distributors: [distributor],
+      coordinator: distributor,
+      variants: [variant]
+    )
+  }
+  let(:order) {
+    create(
+      :order,
+      order_cycle: order_cycle,
+      distributor: distributor,
+      bill_address_id: nil,
+      ship_address_id: nil
+    )
+  }
+  let(:free_shipping) { create(:shipping_method) }
+  let!(:paypal) do
+    Spree::Gateway::PayPalExpress.create!(
+      name: "Paypal",
+      environment: "test",
+      distributor_ids: [distributor.id]
+    )
+  end
+
+  before do
+    distributor.shipping_methods << free_shipping
+    set_order order
+    add_product_to_cart order, product
+  end
+
+  describe "as a guest" do
+    it "fails with an error message" do
+      pending "The checkout_state_path is missing."
+
+      visit checkout_path
+      complete_the_form
+
+      paypal_response = double(:response, success?: false, errors: [])
+      paypal_provider = double(
+        :provider,
+        build_set_express_checkout: nil,
+        set_express_checkout: paypal_response
+      )
+      allow_any_instance_of(Spree::PaypalController).to receive(:provider).
+        and_return(paypal_provider)
+
+      place_order
+      expect(page).to have_content "PayPal failed."
+    end
+  end
+
+  def complete_the_form
+    checkout_as_guest
+
+    within "#details" do
+      fill_in "First Name", with: "Will"
+      fill_in "Last Name", with: "Marshall"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Phone", with: "0468363090"
+    end
+
+    within "#billing" do
+      fill_in "City", with: "Melbourne"
+      fill_in "Postcode", with: "3066"
+      fill_in "Address", with: "123 Your Head"
+      select "Australia", from: "Country"
+      select "Victoria", from: "State"
+    end
+
+    within "#shipping" do
+      choose free_shipping.name
+    end
+    within "#payment" do
+      choose paypal.name
+    end
+  end
+end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -55,9 +55,9 @@ feature "As a consumer I want to check out my cart", js: true do
       it "returns me to the cart with an error message" do
         visit checkout_path
 
-        page.should_not have_selector 'closing', text: "Checkout now"
-        page.should have_selector 'closing', text: "Your shopping cart"
-        page.should have_content "An item in your cart has become unavailable"
+        expect(page).not_to have_selector 'closing', text: "Checkout now"
+        expect(page).to have_selector 'closing', text: "Your shopping cart"
+        expect(page).to have_content "An item in your cart has become unavailable"
       end
     end
 
@@ -75,23 +75,23 @@ feature "As a consumer I want to check out my cart", js: true do
         end
 
         it "allows user to save default billing address and shipping address" do
-          user.bill_address.should be_nil
-          user.ship_address.should be_nil
+          expect(user.bill_address).to be_nil
+          expect(user.ship_address).to be_nil
 
-          order.bill_address.should be_nil
-          order.ship_address.should be_nil
+          expect(order.bill_address).to be_nil
+          expect(order.ship_address).to be_nil
 
           place_order
-          page.should have_content "Your order has been processed successfully"
+          expect(page).to have_content "Your order has been processed successfully"
 
-          order.reload.bill_address.address1.should eq '123 Your Head'
-          order.reload.ship_address.address1.should eq '123 Your Head'
+          expect(order.reload.bill_address.address1).to eq '123 Your Head'
+          expect(order.reload.ship_address.address1).to eq '123 Your Head'
 
-          order.customer.bill_address.address1.should eq '123 Your Head'
-          order.customer.ship_address.address1.should eq '123 Your Head'
+          expect(order.customer.bill_address.address1).to eq '123 Your Head'
+          expect(order.customer.ship_address.address1).to eq '123 Your Head'
 
-          user.reload.bill_address.address1.should eq '123 Your Head'
-          user.reload.ship_address.address1.should eq '123 Your Head'
+          expect(user.reload.bill_address.address1).to eq '123 Your Head'
+          expect(user.reload.ship_address.address1).to eq '123 Your Head'
         end
 
         it "it doesn't tell about previous orders" do
@@ -127,7 +127,7 @@ feature "As a consumer I want to check out my cart", js: true do
 
           expect do
             place_order
-            page.should have_content "Your order has been processed successfully"
+            expect(page).to have_content "Your order has been processed successfully"
           end.to enqueue_job ConfirmOrderJob
         end
       end
@@ -215,8 +215,8 @@ feature "As a consumer I want to check out my cart", js: true do
         visit shop_path
         # The presence of the control product ensures the list of products is fully loaded
         #   before we verify the sold product is not present
-        page.should have_content control_product.name
-        page.should_not have_content product.name
+        expect(page).to have_content control_product.name
+        expect(page).not_to have_content product.name
       end
     end
 
@@ -228,25 +228,25 @@ feature "As a consumer I want to check out my cart", js: true do
 
       it "shows the current distributor" do
         visit checkout_path
-        page.should have_content distributor.name
+        expect(page).to have_content distributor.name
       end
 
       it 'does not show the save as default address checkbox' do
-        page.should_not have_content "Save as default billing address"
-        page.should_not have_content "Save as default shipping address"
+        expect(page).not_to have_content "Save as default billing address"
+        expect(page).not_to have_content "Save as default shipping address"
       end
 
       it "shows a breakdown of the order price" do
         choose sm2.name
 
-        page.should have_selector 'orderdetails .cart-total', text: with_currency(11.23)
-        page.should have_selector 'orderdetails .shipping', text: with_currency(4.56)
-        page.should have_selector 'orderdetails .total', text: with_currency(15.79)
+        expect(page).to have_selector 'orderdetails .cart-total', text: with_currency(11.23)
+        expect(page).to have_selector 'orderdetails .shipping', text: with_currency(4.56)
+        expect(page).to have_selector 'orderdetails .total', text: with_currency(15.79)
 
         # Tax should not be displayed in checkout, as the customer's choice of shipping method
         # affects the tax and we haven't written code to live-update the tax amount when they
         # make a change.
-        page.should_not have_content product.tax_category.name
+        expect(page).not_to have_content product.tax_category.name
       end
 
       it "shows all shipping methods in order by name" do
@@ -265,7 +265,7 @@ feature "As a consumer I want to check out my cart", js: true do
         end
         it "shows ship address forms when 'same as billing address' is unchecked" do
           uncheck "Shipping address same as billing address?"
-          find("#ship_address > div.visible").visible?.should be true
+          expect(find("#ship_address > div.visible").visible?).to be true
         end
       end
 
@@ -275,9 +275,9 @@ feature "As a consumer I want to check out my cart", js: true do
 
         it "shows shipping methods allowed by the rule" do
           # No rules in effect
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).to have_content "Local"
 
           create(:filter_shipping_methods_tag_rule,
                  enterprise: distributor,
@@ -293,25 +293,25 @@ feature "As a consumer I want to check out my cart", js: true do
           checkout_as_guest
 
           # Default rule in effect, disallows access to 'Local'
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should_not have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).not_to have_content "Local"
 
           quick_login_as(user)
           visit checkout_path
 
           # Default rule in still effect, disallows access to 'Local'
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should_not have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).not_to have_content "Local"
 
           customer.update_attribute(:tag_list, "local")
           visit checkout_path
 
           # #local Customer can access 'Local' shipping method
-          page.should have_content "Frogs"
-          page.should have_content "Donkeys"
-          page.should have_content "Local"
+          expect(page).to have_content "Frogs"
+          expect(page).to have_content "Donkeys"
+          expect(page).to have_content "Local"
         end
       end
     end
@@ -323,9 +323,9 @@ feature "As a consumer I want to check out my cart", js: true do
       end
 
       it "shows all available payment methods" do
-        page.should have_content pm1.name
-        page.should have_content pm2.name
-        page.should have_content pm3.name
+        expect(page).to have_content pm1.name
+        expect(page).to have_content pm2.name
+        expect(page).to have_content pm3.name
       end
 
       describe "purchasing" do
@@ -375,7 +375,7 @@ feature "As a consumer I want to check out my cart", js: true do
 
           it "takes us to the order confirmation page when submitted with 'same as billing address' checked" do
             place_order
-            page.should have_content "Your order has been processed successfully"
+            expect(page).to have_content "Your order has been processed successfully"
           end
 
           it "takes us to the cart page with an error when a product becomes out of stock just before we purchase", js: true do
@@ -385,9 +385,9 @@ feature "As a consumer I want to check out my cart", js: true do
 
             place_order
 
-            page.should_not have_content "Your order has been processed successfully"
-            page.should have_selector 'closing', text: "Your shopping cart"
-            page.should have_content "An item in your cart has become unavailable."
+            expect(page).not_to have_content "Your order has been processed successfully"
+            expect(page).to have_selector 'closing', text: "Your shopping cart"
+            expect(page).to have_content "An item in your cart has become unavailable."
           end
 
           context "when we are charged a shipping fee" do
@@ -395,12 +395,12 @@ feature "As a consumer I want to check out my cart", js: true do
 
             it "creates a payment for the full amount inclusive of shipping" do
               place_order
-              page.should have_content "Your order has been processed successfully"
+              expect(page).to have_content "Your order has been processed successfully"
 
               # There are two orders - our order and our new cart
               o = Spree::Order.complete.first
-              o.adjustments.shipping.first.amount.should == 4.56
-              o.payments.first.amount.should == 10 + 1.23 + 4.56 # items + fees + shipping
+              expect(o.adjustments.shipping.first.amount).to eq(4.56)
+              expect(o.payments.first.amount).to eq(10 + 1.23 + 4.56) # items + fees + shipping
             end
           end
 
@@ -437,11 +437,11 @@ feature "As a consumer I want to check out my cart", js: true do
                   fill_in 'Security Code', with: '123'
 
                   place_order
-                  page.should have_content "Your order has been processed successfully"
+                  expect(page).to have_content "Your order has been processed successfully"
 
                   # Order should have a payment with the correct amount
                   o = Spree::Order.complete.first
-                  o.payments.first.amount.should == 11.23
+                  expect(o.payments.first.amount).to eq(11.23)
                 end
 
                 it "shows the payment processing failed message when submitted with an invalid credit card" do
@@ -451,11 +451,11 @@ feature "As a consumer I want to check out my cart", js: true do
                   fill_in 'Security Code', with: '123'
 
                   place_order
-                  page.should have_content 'Bogus Gateway: Forced failure'
+                  expect(page).to have_content 'Bogus Gateway: Forced failure'
 
                   # Does not show duplicate shipping fee
                   visit checkout_path
-                  page.should have_selector "th", text: "Shipping", count: 1
+                  expect(page).to have_selector "th", text: "Shipping", count: 1
                 end
               end
             end


### PR DESCRIPTION
#### What? Why?

Closes #4233

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Commit c56486d7aeaee822adc93f1f6d43be282a178a89 removed a couple of Spree routes that are not used in our code. But one of them is used by spree_paypal_express to redirect when something goes wrong. I added the needed route back in.

I also added a new feature spec for this case. Automated testing of a successful Paypal checkout may be difficult because it includes redirects to the Paypal website. Maybe we can fake it but I would do that in a separate task. I also think that an automated integration test for staging would be easier to set up and give us more value because it would test the real integration with the Paypal website.

The new spec adds 10 seconds to the test suite but I don't see a better way. A unit test would be on controller level within spree_paypal_express. But within that gem the test would pass. The problem is that the gem depends on Spree and we connect it to our lightweight version of Spree. That's a case for an integration test what I did here.

And I did some styling of the current checkout spec when I was analysing what we are testing already.

#### What should we test?
<!-- List which features should be tested and how. -->

We should validate two scenarios:

Failed payment:

- Set up a Paypal payment method with invalid details (just don't enter a key).
- Checkout using that payment method.
- You should see an error message.

Successful payment:

- Set up a Paypal payment method with valid details, connected to a real testing account.
- Checkout using that payment method.
- The order should be successful and paid.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: Buyers see a useful error message when Paypal isn't set up correctly.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

