### PR TITLE
Add implicit #bulk_management including filter

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -3,7 +3,6 @@ require 'open_food_network/spree_api_key_loader'
 Spree::Admin::OrdersController.class_eval do
   include OpenFoodNetwork::SpreeApiKeyLoader
   helper CheckoutHelper
-  before_filter :load_spree_api_key, only: :bulk_management
   before_filter :load_order, only: %i[show edit update fire resend invoice print print_ticket]
 
   before_filter :load_distribution_choices, only: [:new, :edit, :update]
@@ -25,6 +24,10 @@ Spree::Admin::OrdersController.class_eval do
   def index
     # Overriding the action so we only render the page template. An angular request
     # within the page then fetches the data it needs from Api::OrdersController
+  end
+
+  def bulk_management
+    load_spree_api_key
   end
 
   def edit


### PR DESCRIPTION
#### What? Why?

OFN it's hard enough. No need to abuse implicitness making things very
hard to follow.

I've spent around 20min trying to find out where this controller action
was implemented until I realized Rails renders the matching view if no
controller action is defined.

Making it git-greppable makes it a bit easier next time.

#### What should we test?

`/admin/orders/bulk_management` should render the appropriate information when using the filters.


#### Release notes

Added implicit `bulk_management` controller action to increase readability.

Changelog Category: Changed

