### PR TITLE
Disentangle on_demand and backordered

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -100,13 +100,13 @@ module VariantStock
   # Here we depend only on variant.total_on_hand and variant.on_demand.
   #   This way, variant_overrides only need to override variant.total_on_hand and variant.on_demand.
   def fill_status(quantity)
-    if on_hand >= quantity
-      on_hand = quantity
-      backordered = 0
-    else
-      on_hand = [0, total_on_hand].max
-      backordered = on_demand ? (quantity - on_hand) : 0
-    end
+    on_hand = if total_on_hand >= quantity || on_demand
+                quantity
+              else
+                [0, total_on_hand].max
+              end
+
+    backordered = 0
 
     [on_hand, backordered]
   end

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -117,6 +117,9 @@ module VariantStock
   def move(quantity, originator = nil)
     raise_error_if_no_stock_item_available
 
+    # Don't change variant stock if variant is on_demand
+    return if on_demand
+
     # Creates a stock movement: it updates stock_item.count_on_hand and fills backorders
     #
     # This is the original Spree::StockLocation#move,

--- a/db/migrate/20190906151259_reset_negative_stock_levels.rb
+++ b/db/migrate/20190906151259_reset_negative_stock_levels.rb
@@ -1,0 +1,6 @@
+class ResetNegativeStockLevels < ActiveRecord::Migration
+  def up
+    # Reset stock to zero for all on_demand variants that have negative stock
+    execute "UPDATE spree_stock_items SET count_on_hand = '0' WHERE count_on_hand < 0 AND backorderable IS TRUE"
+  end
+end

--- a/db/migrate/20190908183511_set_backordered_inventory_to_on_hand.rb
+++ b/db/migrate/20190908183511_set_backordered_inventory_to_on_hand.rb
@@ -1,0 +1,5 @@
+class SetBackorderedInventoryToOnHand < ActiveRecord::Migration
+  def up
+    execute("UPDATE spree_inventory_units SET state = 'on_hand' WHERE state = 'backordered'")
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -132,6 +132,54 @@ module Spree
       end
     end
 
+    describe "reducing stock levels on order completion" do
+      context "when the item is on_demand" do
+        let!(:hub) { create(:distributor_enterprise) }
+        let(:bill_address) { create(:address) }
+        let!(:variant_on_demand) { create(:variant, on_demand: true, on_hand: 1) }
+        let!(:order) {
+          create(:order_with_totals_and_distribution,
+                 distributor: hub,
+                 bill_address: bill_address,
+                 ship_address: bill_address)
+        }
+        let!(:shipping_method) { create(:shipping_method, distributors: [hub]) }
+        let!(:line_item) { create(:line_item, variant: variant_on_demand, quantity: 10, order: order) }
+
+        before do
+          order.update_totals
+          order.payments << create(:payment, amount: order.total)
+          until order.completed? do break unless order.next! end
+          order.payment_state = 'paid'
+          order.select_shipping_method(shipping_method.id)
+          order.shipment.update!(order)
+        end
+
+        it "creates a shipment with backordered items" do
+          expect(order.shipment.manifest.first.quantity).to eq 10
+          expect(order.shipment.manifest.first.states).to eq 'on_hand' => 1, 'backordered' => 9
+          expect(order.shipment.manifest.first.variant).to eq line_item.variant
+        end
+
+        it "reduces the variant's stock level" do
+          expect(variant_on_demand.reload.on_hand).to eq(-9)
+        end
+
+        it "marks the inventory units as backorderd" do
+          backordered_units = order.shipments.first.inventory_units.any?(&:backordered?)
+          expect(backordered_units).to be true
+        end
+
+        it "marks the shipment as backorderd" do
+          expect(order.shipments.first.backordered?).to be true
+        end
+
+        it "does not allow the order to be shipped" do
+          expect(order.ready_to_ship?).to be false
+        end
+      end
+    end
+
     describe "tracking stock when quantity is changed" do
       context "when the order is already complete" do
         let(:shop) { create(:distributor_enterprise) }
@@ -186,12 +234,18 @@ module Spree
       let!(:hub) { create(:distributor_enterprise) }
       let!(:o) { create(:order, distributor: hub) }
       let!(:v) { create(:variant, on_demand: false, on_hand: 10) }
+      let!(:v_on_demand) { create(:variant, on_demand: true, on_hand: 1) }
       let!(:li) { create(:line_item, variant: v, order: o, quantity: 5, max_quantity: 5) }
+      let!(:li_on_demand) { create(:line_item, variant: v_on_demand, order: o, quantity: 99, max_quantity: 99) }
 
       before do
         # li#scoper is memoised, and this makes it difficult to update test conditions
         # so we reset it after the line_item is created for each spec
         li.remove_instance_variable(:@scoper)
+      end
+
+      context "when the variant is on_demand" do
+        it { expect(li_on_demand.sufficient_stock?).to be true }
       end
 
       context "when stock on the variant is sufficient" do

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -161,8 +161,8 @@ module Spree
           expect(order.shipment.manifest.first.variant).to eq line_item.variant
         end
 
-        it "reduces the variant's stock level" do
-          expect(variant_on_demand.reload.on_hand).to eq(-9)
+        it "does not reduce the variant's stock level" do
+          expect(variant_on_demand.reload.on_hand).to eq 1
         end
 
         it "does not mark inventory units as backorderd" do
@@ -176,6 +176,11 @@ module Spree
 
         it "allows the order to be shipped" do
           expect(order.ready_to_ship?).to be true
+        end
+
+        it "does not change stock levels when cancelled" do
+          order.cancel!
+          expect(variant_on_demand.reload.on_hand).to eq 1
         end
       end
     end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -155,9 +155,9 @@ module Spree
           order.shipment.update!(order)
         end
 
-        it "creates a shipment with backordered items" do
+        it "creates a shipment without backordered items" do
           expect(order.shipment.manifest.first.quantity).to eq 10
-          expect(order.shipment.manifest.first.states).to eq 'on_hand' => 1, 'backordered' => 9
+          expect(order.shipment.manifest.first.states).to eq 'on_hand' => 10
           expect(order.shipment.manifest.first.variant).to eq line_item.variant
         end
 
@@ -165,17 +165,17 @@ module Spree
           expect(variant_on_demand.reload.on_hand).to eq(-9)
         end
 
-        it "marks the inventory units as backorderd" do
+        it "does not mark inventory units as backorderd" do
           backordered_units = order.shipments.first.inventory_units.any?(&:backordered?)
-          expect(backordered_units).to be true
+          expect(backordered_units).to be false
         end
 
-        it "marks the shipment as backorderd" do
-          expect(order.shipments.first.backordered?).to be true
+        it "does not mark the shipment as backorderd" do
+          expect(order.shipments.first.backordered?).to be false
         end
 
-        it "does not allow the order to be shipped" do
-          expect(order.ready_to_ship?).to be false
+        it "allows the order to be shipped" do
+          expect(order.ready_to_ship?).to be true
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #4217 (original bug report: #4157)

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adjusts `on_demand` logic so that shipments no longer decrement an `on_demand` variant's stock levels. This means that `on_demand` items will no longer go into negative stock levels, and `on_demand` variants and their associated shipments will no longer be marked by Spree as `backordered`, which triggers a lot of unwanted logic.

#### What should we test?
<!-- List which features should be tested and how. -->

Buying an `on_demand` variant does not reduce it's stock level.
Buying  large quantity of an `on_demand` variant does not cause the order to be unshippable.
Orders with `on_demand` variants do not get their shipment state marked as `backordered`.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Variants marked `on_demand` no longer reduce stock levels when sold, and are not marked as `backordered`

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
