### PR TITLE
Adapt db truncate task to ofn v2 by removing db tables from v1

### DIFF
--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -15,8 +15,6 @@ namespace :ofn do
       sql_delete_from "spree_line_items #{where_order_id_in_orders_to_delete}"
       sql_delete_from "spree_payments #{where_order_id_in_orders_to_delete}"
       sql_delete_from "spree_shipments #{where_order_id_in_orders_to_delete}"
-      sql_delete_from "billable_periods"
-      sql_delete_from "account_invoices"
       Spree::ReturnAuthorization.delete_all
 
       truncate_order_cycle_data


### PR DESCRIPTION
#### What? Why?

We dont have any v1 database any more so now we can have a truncate task that can truncate v2 dbs if needed at some point.

#### What should we test?
This task should run successfully against a dunp of a v2 db.

#### Release notes
Changelog Category: Changed
Database truncate task is now runs against v2 dbs not legacy v1 dbs.
