### PR TITLE
On checkout of pickup orders, set ship_address to shipping_address_from_distributor instead of empty Spree::Address.default

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -152,6 +152,7 @@ class CheckoutController < Spree::CheckoutController
   end
 
   def update_failed
+    current_order.updater.shipping_address_from_distributor
     RestartCheckout.new(@order).call
 
     respond_to do |format|

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -152,7 +152,6 @@ class CheckoutController < Spree::CheckoutController
   end
 
   def update_failed
-    clear_ship_address
     RestartCheckout.new(@order).call
 
     respond_to do |format|
@@ -162,15 +161,6 @@ class CheckoutController < Spree::CheckoutController
       format.json do
         render json: { errors: @order.errors, flash: flash.to_hash }.to_json, status: :bad_request
       end
-    end
-  end
-
-  # When we have a pickup Shipping Method,
-  #   we clone the distributor address into ship_address before_save
-  # We don't want this data in the form, so we clear it out
-  def clear_ship_address
-    unless current_order.shipping_method.andand.require_ship_address
-      current_order.ship_address = Spree::Address.default
     end
   end
 

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -78,28 +78,17 @@ describe CheckoutController, type: :controller do
       allow(controller).to receive(:current_order).and_return(order)
     end
 
-    it "does not clone the ship address from distributor when shipping method requires address" do
-      get :edit
-      expect(assigns[:order].ship_address.address1).to be_nil
-    end
-
-    it "clears the ship address when re-rendering edit" do
-      expect(controller).to receive(:clear_ship_address).and_return true
+    it "set shipping_address_from_distributor when re-rendering edit" do
+      expect(order.updater).to receive(:shipping_address_from_distributor)
       allow(order).to receive(:update_attributes).and_return false
       spree_post :update, format: :json, order: {}
     end
 
-    it "clears the ship address when the order state cannot be advanced" do
-      expect(controller).to receive(:clear_ship_address).and_return true
+    it "set shipping_address_from_distributor when the order state cannot be advanced" do
+      expect(order.updater).to receive(:shipping_address_from_distributor)
       allow(order).to receive(:update_attributes).and_return true
       allow(order).to receive(:next).and_return false
       spree_post :update, format: :json, order: {}
-    end
-
-    it "only clears the ship address with a pickup shipping method" do
-      allow(order).to receive_message_chain(:shipping_method, :andand, :require_ship_address).and_return false
-      expect(order).to receive(:ship_address=)
-      controller.send(:clear_ship_address)
     end
 
     context "#update with shipping_method_id" do
@@ -266,10 +255,11 @@ describe CheckoutController, type: :controller do
     before do
       controller.instance_variable_set(:@order, order)
       allow(RestartCheckout).to receive(:new) { restart_checkout }
+      allow(controller).to receive(:current_order) { order }
     end
 
-    it "clears the shipping address and restarts the checkout" do
-      expect(controller).to receive(:clear_ship_address)
+    it "set shipping_address_from_distributor and restarts the checkout" do
+      expect(order.updater).to receive(:shipping_address_from_distributor)
       expect(restart_checkout).to receive(:call)
       expect(controller).to receive(:respond_to)
 


### PR DESCRIPTION
#### What? Why?

Closes #4005 and probably #4003 

In CheckoutController#update, instead of clearing ship address by setting it to empty Spree::Address.default, we set shipping_address_from_distributor which is what's done already when order is finalized.

#4005 was happening because an **empty** ship address (set in clear_ship_address) makes restart_checkout fail. restart_checkout_spec was not detecting this because it was using a **nil** ship_address.
We now set the distributor ship address on ship_address and also test that scenario in both restart_checkout_spec and checkout_controller.

#### What should we test?
We need to test checkout manually. The scenario that changed was when checking out using a pick up ship method without ship address and using a broken bogus credit card, the user was getting a sail or just not seeing any errors, now the user should see an flash error: credit card payment failed.

Added by Maikel:
Verify every way the checkout can fail:
- Out of stock
- Payment method not set up correctly
- Invalid credit card
Test these with a shipping method that needs an address and without. Then try to checkout again and make sure that the right shipping address is either preserved or blank and needs filling in.

Extra scenario added by Luis:
On checkout:
- ship method is pickup, no ship address form
- checkout with failed payment and see payment error
- go back to ship methods and change to some delivery ship method
- make sure the ship address shown by default is not the distributor's address

#### Release notes
Changelog Category: Fixed
Fixed problem in user checkout when payment validation failed. User is now being informed of what is wrong in the checkout form.
