### PR TITLE
Update Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supported by the Open Food Foundation and a network of global affiliates, we are
 
 We're part of global movement - get involved!
 
-* Join the conversation [on Slack](https://join.slack.com/t/openfoodnetwork/shared_invite/enQtMzU2Mjk5MDc2MjA5LTM4ZTAzZjIwNzIxMmU5ODFiNWY1MTU2ZWUyNzQwNjdjNTY0N2VhY2UwOGU4ZmVjNzYyZDU2NjY3NzZkZmQwYjk). Make sure you introduce yourself in the #general channel
+* Join the conversation [on Slack][slack-invite]. Make sure you introduce yourself in the #general channel
 * Head to [https://openfoodnetwork.org](https://openfoodnetwork.org) for more information about the global OFN project.
 * Check out the [User Guide](https://guide.openfoodnetwork.org/) for a list of features and tutorials.
 * Join our [discussion forum](https://community.openfoodnetwork.org).
@@ -35,7 +35,7 @@ We use [BrowserStack](https://www.browserstack.com/) as a manual testing tool. B
 Copyright (c) 2012 - 2019 Open Food Foundation, released under the AGPL licence.
 
 [survey]: https://docs.google.com/a/eaterprises.com.au/forms/d/1zxR5vSiU9CigJ9cEaC8-eJLgYid8CR8er7PPH9Mc-30/edit#
-[slack-invite]: https://openfoodnetwork.org/slack-invite
+[slack-invite]: https://join.slack.com/t/openfoodnetwork/shared_invite/enQtMzU2Mjk5MDc2MjA5LTM4ZTAzZjIwNzIxMmU5ODFiNWY1MTU2ZWUyNzQwNjdjNTY0N2VhY2UwOGU4ZmVjNzYyZDU2NjY3NzZkZmQwYjk
 [contributor-guide]: https://ofn-user-guide.gitbook.io/ofn-contributor-guide/who-are-we
 [ofn-install]: https://github.com/openfoodfoundation/ofn-install
 [super-admin-guide]: https://ofn-user-guide.gitbook.io/ofn-super-admin-guide

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supported by the Open Food Foundation and a network of global affiliates, we are
 
 We're part of global movement - get involved!
 
-* Join the conversation [on Slack][slack-invite]. Make sure you introduce yourself in the #general channel
+* Join the conversation [on Slack](https://join.slack.com/t/openfoodnetwork/shared_invite/enQtMzU2Mjk5MDc2MjA5LTM4ZTAzZjIwNzIxMmU5ODFiNWY1MTU2ZWUyNzQwNjdjNTY0N2VhY2UwOGU4ZmVjNzYyZDU2NjY3NzZkZmQwYjk). Make sure you introduce yourself in the #general channel
 * Head to [https://openfoodnetwork.org](https://openfoodnetwork.org) for more information about the global OFN project.
 * Check out the [User Guide](https://guide.openfoodnetwork.org/) for a list of features and tutorials.
 * Join our [discussion forum](https://community.openfoodnetwork.org).


### PR DESCRIPTION
#### What? Why?

Updated Slack invite link in README

#### Release notes

Slack invite link is fixed in the README file.

Changelog Category:  Fixed



