### PR TITLE
Fix typo on 'no payment methods' translation keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -693,7 +693,7 @@ en:
           name: Name
           applies: Applies?
           manage: Manage Payment Methods
-          not_method_yet: You don't have any payment methods yet.
+          no_method_yet: You don't have any payment methods yet.
           create_button: Create New Payment Method
           create_one_button: Create One Now
         primary_details:


### PR DESCRIPTION
#### What? Why?

Closes #4110

Fixes a typo in the `en` source file, and the existing translation files, for  /admin/enterprises/SHOPNAME/edit#/payment_methods where `no_method_yet` was keyed as `not_method_yet`.

Since a translation for `no_method_yet` did not exist in the yml, all languages were displaying "No Method Yet" as formatted text.

#### What should we test?

Specs don't exist for individual translations. This can be tested from the front end: 
- Pull up a test account
- Remove all saved payment methods at /admin/payment_methods
- Navigate to /admin/enterprises
- Select Settings (any shop where Payment Methods (0) is displayed)
- Select Payment Methods. The correct translation should be displayed.

#### Release notes

This is my first contribution to OFN and I hope it's helpful! Look forward to contributing more in the future!

Changelog Category: Fixed