### PR TITLE
Fix test example name

### DIFF
--- a/spec/lib/open_food_network/subscription_summarizer_spec.rb
+++ b/spec/lib/open_food_network/subscription_summarizer_spec.rb
@@ -105,7 +105,7 @@ module OpenFoodNetwork
       end
     end
 
-    describe "#send_placement_summary_emails" do
+    describe "#send_confirmation_summary_emails" do
       let(:summary1) { double(:summary) }
       let(:summary2) { double(:summary) }
       let(:summaries) { { 1 => summary1, 2 => summary2 } }


### PR DESCRIPTION
#### What? Why?

The name wasn't reflecting the method being tested.

#### What should we test?

Nothing. It just affects the automated test suite.


#### Release notes

Reflect the method being tested in test example's name.

Changelog Category: Changed