### PR TITLE
Add default date range to Delivery Report

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -2,9 +2,10 @@ require 'open_food_network/user_balance_calculator'
 
 module OpenFoodNetwork
   class OrderCycleManagementReport
+    DEFAULT_DATE_INTERVAL = 1.month
     attr_reader :params
     def initialize(user, params = {}, render_table = false)
-      @params = params
+      @params = sanitize_params(params)
       @user = user
       @render_table = render_table
     end
@@ -132,6 +133,13 @@ module OpenFoodNetwork
     def customer_code(email)
       customer = Customer.where(email: email).first
       customer.nil? ? "" : customer.code
+    end
+
+    def sanitize_params(params)
+      params[:q] ||= {}
+      params[:q][:completed_at_gt] ||= Time.zone.today - DEFAULT_DATE_INTERVAL
+      params[:q][:completed_at_lt] ||= Time.zone.today
+      params
     end
   end
 end

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -24,6 +24,14 @@ module OpenFoodNetwork
           o2 = create(:order, completed_at: 1.day.ago)
           expect(subject.orders).to eq([o2])
         end
+
+        context "default date range" do
+          it "fetches orders completed in the past month" do
+            o1 = create(:order, completed_at: Time.zone.today - OrderCycleManagementReport::DEFAULT_DATE_INTERVAL - 1.day)
+            o2 = create(:order, completed_at: Time.zone.today - OrderCycleManagementReport::DEFAULT_DATE_INTERVAL + 1.day)
+            expect(subject.orders).to eq([o2])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
 **What? Why?**

Closes #4184 

This adds a default date range, the most recent month, to the parameters sent to the `OrderCycleManagementReport`.

I think putting the work here in a background job would make more sense but given the context maybe that isn't necessary?


**What should we test?**

Delivery report, payment methods report, with and without dates.




**Release notes**
Assigns a default date range from one month ago to today for the delivery report and payment methods report.

Changelog Category: Fixed


Woo first OFN PR!