### PR TITLE
Guard against malformed request referer

### DIFF
--- a/app/services/embedded_page_service.rb
+++ b/app/services/embedded_page_service.rb
@@ -73,7 +73,9 @@ class EmbeddedPageService
 
   def current_referer
     return if @request.referer.blank?
-    URI(@request.referer).host.downcase
+    uri = URI(@request.referer)
+    return if uri.host.blank?
+    uri.host.downcase
   end
 
   def current_referer_without_www

--- a/spec/services/embedded_page_service_spec.rb
+++ b/spec/services/embedded_page_service_spec.rb
@@ -59,5 +59,16 @@ describe EmbeddedPageService do
         expect(response.headers['X-Frame-Options']).to eq 'DENY'
       end
     end
+
+    context "when the request's referer is malformed" do
+      let(:request) { ActionController::TestRequest.new('HTTP_HOST' => 'ofn-instance.com', 'HTTP_REFERER' => 'hello')}
+      before do
+        service.embed!
+      end
+
+      it "returns a 200 status" do
+        expect(response.status).to eq 200
+      end
+    end
   end
 end


### PR DESCRIPTION
**What? Why?**

Closes #3979 
When a request comes in the app attempts to parse the referer URI. This was causing an error when the referer field is malformed because there is no check that it was successful before calling `#downcase` on the string. 


**What should we test?**
Requests with malformed referer strings. 
`curl -s -e "hello" http://localhost:3000/ | grep '<title>'`
I also added a test case for this.


**Release notes**
Added a guard for malformed request referer strings.


Changelog Category: Fixed
