### PR TITLE
Enable Delayed Job analytics in Datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,6 +1,6 @@
 if ENV['DATADOG_RAILS_APM']
   Datadog.configure do |c|
     c.use :rails, service_name: 'rails'
-    c.use :delayed_job, service_name: 'delayed_job'
+    c.use :delayed_job, service_name: 'delayed_job', analytics_enabled: true
   end
 end


### PR DESCRIPTION
#### What? Why?

Hopefully, this will provide extra information that will allow us to
better understand what are background workers spend their time on.

According to the docs

> Enable analytics for spans produced by this integration. true for on, nil to
> defer to global setting, false for off.

This is all the Delayed Job Datadog integration can do.

#### What should we test?

A dev should check the extra reported information in Datadog after deploying to production.

#### Release notes

Enable analysis of the spans produced by Datadog's Delayed Job integration

Changelog Category: Added