### PR TITLE
Remove logic related to master variants in Exchanges and migrate data

### DIFF
--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -1,6 +1,5 @@
 # Returns a (paginatable) AR object for the products or variants in stock for a given shop and OC.
 # The stock-checking includes on_demand and stock level overrides from variant_overrides.
-
 class OrderCycleDistributedProducts
   def initialize(distributor, order_cycle)
     @distributor = distributor

--- a/db/migrate/20190918105234_remove_all_master_variants_from_exchanges.rb
+++ b/db/migrate/20190918105234_remove_all_master_variants_from_exchanges.rb
@@ -1,0 +1,53 @@
+class RemoveAllMasterVariantsFromExchanges < ActiveRecord::Migration
+  def up
+    # 1. We add standard variants of the products of "lonely masters" into the Exchanges where the master variants are lonely
+    match_master_variants
+
+    # 2. We delete all master variants from Exchanges
+    delete_master_variants
+  end
+
+  def down
+  end
+
+  private
+
+  def match_master_variants
+    # Master variants that are distributed in Exchanges and their product doesnt have any other variant in those Exchanges
+    lonely_masters_sql = "
+      SELECT e.id exchange_id, v.id master_variant_id
+      FROM exchanges e
+      JOIN exchange_variants ev ON (e.id = ev.exchange_id)
+      JOIN spree_variants v ON (ev.variant_id = v.id)
+      WHERE v.is_master = true
+      AND not exists (SELECT 1
+                      FROM exchanges e_std
+                      JOIN exchange_variants ev_std ON (e_std.id = ev_std.exchange_id)
+                      JOIN spree_variants v_std ON (ev_std.variant_id = v_std.id)
+                      WHERE v_std.is_master = false AND e.order_cycle_id = e_std.order_cycle_id)"
+
+    # List of all Master Variant IDs with respective max (latest) Standard Variant ID
+    latest_standard_variants_sql = "
+      SELECT v_master.id master_variant_id, max(v.id) standard_variant_id
+      FROM spree_variants v
+      JOIN spree_variants v_master ON (v.product_id = v_master.product_id and v_master.is_master = true)
+      WHERE v.is_master = false
+      GROUP BY v_master.id"
+
+    # Insert latest standard variant of each lonely_master into the Exchanges where the lonely_masters are
+    execute(
+      "INSERT INTO exchange_variants (exchange_id, variant_id, created_at, updated_at)
+      SELECT lonely_masters.exchange_id, latest_standard_variants.standard_variant_id, now(), now()
+      FROM (#{lonely_masters_sql}) lonely_masters
+      JOIN (#{latest_standard_variants_sql}) latest_standard_variants on (lonely_masters.master_variant_id = latest_standard_variants.master_variant_id)" )
+  end
+
+  def delete_master_variants
+    execute("
+      DELETE
+      FROM exchange_variants ev
+      USING spree_variants v
+      WHERE ev.variant_id = v.id
+        AND v.is_master = true")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190916110029) do
+ActiveRecord::Schema.define(:version => 20190918105234) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"


### PR DESCRIPTION
#### What? Why?
Closes #4251 

Master variants cannot be added to Exchanges so this code was catering for a situation that never happens now and impacting performance. We remove the code in this PR and run a migration to ensure old data is also correct by replacing master variants with a standard variant.

I tested the migration on local copies of both AUS and UK live databases. It works.

#### What should we test?
We need to test adding variants to Order Cycles and then seeing them in the shopfront.
Because we are just removing code, I don't think there's nothing else that needs verification.

EDITED: this code change was done in another PR, here we just need to see that the data migration works in staging. that's it.

#### Release notes
Changelog Category: Changed
Improved performance of shopfront/products list by removing unnecessary code.
