### PR TITLE
Finish transpec

### DIFF
--- a/spec/controllers/api/taxonomies_controller_spec.rb
+++ b/spec/controllers/api/taxonomies_controller_spec.rb
@@ -23,9 +23,9 @@ module Api
       it "gets the jstree-friendly version of a taxonomy" do
         api_get :jstree, id: taxonomy.id
 
-        json_response["data"].should eq(taxonomy.root.name)
-        json_response["attr"].should eq("id" => taxonomy.root.id, "name" => taxonomy.root.name)
-        json_response["state"].should eq("closed")
+        expect(json_response["data"]).to eq(taxonomy.root.name)
+        expect(json_response["attr"]).to eq("id" => taxonomy.root.id, "name" => taxonomy.root.name)
+        expect(json_response["state"]).to eq("closed")
       end
     end
   end

--- a/spec/controllers/api/taxons_controller_spec.rb
+++ b/spec/controllers/api/taxons_controller_spec.rb
@@ -44,9 +44,9 @@ describe Api::TaxonsController do
       api_get :jstree, taxonomy_id: taxonomy.id, id: taxon.id
 
       response = json_response.first
-      response["data"].should eq(taxon2.name)
-      response["attr"].should eq("name" => taxon2.name, "id" => taxon2.id)
-      response["state"].should eq("closed")
+      expect(response["data"]).to eq(taxon2.name)
+      expect(response["attr"]).to eq("name" => taxon2.name, "id" => taxon2.id)
+      expect(response["state"]).to eq("closed")
     end
 
     it "cannot create a new taxon if not an admin" do

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -13,7 +13,7 @@ feature "Authentication", js: true do
         fill_in "Email", with: user.email
         fill_in "Password", with: user.password
         click_login_button
-        page.should have_content "Find local producers"
+        expect(page).to have_content "Find local producers"
         expect(page).to have_current_path producers_path
       end
     end
@@ -28,20 +28,20 @@ feature "Authentication", js: true do
           open_login_modal
         end
         scenario "showing login" do
-          page.should have_login_modal
+          expect(page).to have_login_modal
         end
 
         scenario "failing to login" do
           fill_in "Email", with: user.email
           click_login_button
-          page.should have_content "Invalid email or password"
+          expect(page).to have_content "Invalid email or password"
         end
 
         scenario "logging in successfully" do
           fill_in "Email", with: user.email
           fill_in "Password", with: user.password
           click_login_button
-          page.should be_logged_in_as user
+          expect(page).to be_logged_in_as user
         end
 
         describe "signing up" do
@@ -53,7 +53,7 @@ feature "Authentication", js: true do
             fill_in "Email", with: "test@foo.com"
             fill_in "Choose a password", with: "short"
             click_signup_button
-            page.should have_content "too short"
+            expect(page).to have_content "too short"
           end
 
           scenario "Failing to sign up because email is already registered" do
@@ -94,16 +94,16 @@ feature "Authentication", js: true do
           scenario "failing to reset password" do
             fill_in "Your email", with: "notanemail@myemail.com"
             click_reset_password_button
-            page.should have_content "Email address not found"
+            expect(page).to have_content "Email address not found"
           end
 
           scenario "resetting password" do
             fill_in "Your email", with: user.email
             expect do
               click_reset_password_button
-              page.should have_reset_password
+              expect(page).to have_reset_password
             end.to enqueue_job Delayed::PerformableMethod
-            Delayed::Job.last.payload_object.method_name.should == :send_reset_password_instructions_without_delay
+            expect(Delayed::Job.last.payload_object.method_name).to eq(:send_reset_password_instructions_without_delay)
           end
         end
       end
@@ -117,7 +117,7 @@ feature "Authentication", js: true do
         scenario "showing login" do
           open_off_canvas
           open_login_modal
-          page.should have_login_modal
+          expect(page).to have_login_modal
         end
       end
     end
@@ -133,7 +133,7 @@ feature "Authentication", js: true do
     scenario "Loggin by typing login/ redirects to /#/login" do
       visit "/login"
       uri = URI.parse(current_url)
-      (uri.path + "#" + uri.fragment).should == '/#/login'
+      expect(uri.path + "#" + uri.fragment).to eq('/#/login')
     end
   end
 end

--- a/spec/features/consumer/producers_spec.rb
+++ b/spec/features/consumer/producers_spec.rb
@@ -49,14 +49,14 @@ feature '
 
       toggle_filter 'Vegetables'
 
-      page.should_not have_content producer1.name
-      page.should     have_content producer2.name
+      expect(page).not_to have_content producer1.name
+      expect(page).to     have_content producer2.name
 
       toggle_filter 'Vegetables'
       toggle_filter 'Fruit'
 
-      page.should     have_content producer1.name
-      page.should_not have_content producer2.name
+      expect(page).to     have_content producer1.name
+      expect(page).not_to have_content producer2.name
     end
 
     describe "filtering by product property" do
@@ -65,23 +65,23 @@ feature '
 
         toggle_filter 'Organic'
 
-        page.should     have_content producer1.name
-        page.should_not have_content producer2.name
+        expect(page).to     have_content producer1.name
+        expect(page).not_to have_content producer2.name
 
         toggle_filter 'Organic'
         toggle_filter 'Biodynamic'
 
-        page.should_not have_content producer1.name
-        page.should     have_content producer2.name
+        expect(page).not_to have_content producer1.name
+        expect(page).to     have_content producer2.name
       end
     end
 
     it "shows all producers with expandable details" do
-      page.should have_content producer1.name
+      expect(page).to have_content producer1.name
       expand_active_table_node producer1.name
 
       # -- Taxons
-      page.should have_content 'Fruit'
+      expect(page).to have_content 'Fruit'
 
       # -- Properties
       expect(page).to have_content 'Organic' # Product property
@@ -89,7 +89,7 @@ feature '
     end
 
     it "doesn't show invisible producers" do
-      page.should_not have_content invisible_producer.name
+      expect(page).not_to have_content invisible_producer.name
     end
 
     it "links to places to buy produce" do

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -58,7 +58,7 @@ feature "Registration", js: true do
 
       # Filling in Contact Details
       fill_in 'enterprise_contact', with: 'Saskia Munroe'
-      page.should have_field 'enterprise_email_address', with: user.email
+      expect(page).to have_field 'enterprise_email_address', with: user.email
       fill_in 'enterprise_phone', with: '12 3456 7890'
       click_button "Continue"
       expect(page).to have_content 'Last step to add My Awesome Enterprise!'

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -133,7 +133,7 @@ feature "full-page cart", js: true do
       end
 
       it "shows the total tax for the order, including product tax and tax on fees" do
-        page.should have_selector '.tax-total', text: '11.00' # 10 + 1
+        expect(page).to have_selector '.tax-total', text: '11.00' # 10 + 1
       end
     end
 

--- a/spec/features/consumer/shopping/products_spec.rb
+++ b/spec/features/consumer/shopping/products_spec.rb
@@ -37,7 +37,7 @@ feature "As a consumer I want to view products", js: true do
         modal_should_be_open_for product
 
         within(".reveal-modal") do
-          html.should include("<p><b>Formatted</b> product description.</p>")
+          expect(html).to include("<p><b>Formatted</b> product description.</p>")
         end
       end
 
@@ -53,8 +53,8 @@ feature "As a consumer I want to view products", js: true do
         modal_should_be_open_for product
 
         within(".reveal-modal") do
-          html.should include("<p>Safe</p>")
-          html.should_not include("<script>alert('Dangerous!');</script>")
+          expect(html).to include("<p>Safe</p>")
+          expect(html).not_to include("<script>alert('Dangerous!');</script>")
         end
       end
     end

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -70,7 +70,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
           add_variant_to_order_cycle(exchange1, variant)
           visit shop_path
           expect(page).not_to have_content product.name
-          expect(Spree::Order.last.order_cycle).to.nil?
+          expect(Spree::Order.last.order_cycle).to be_nil
 
           select "frogs", from: "order_cycle_id"
           expect(page).to have_selector "products"

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -26,9 +26,9 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       # Then we should see the distributor and its logo
       visit shop_path
-      page.should have_text distributor.name
+      expect(page).to have_text distributor.name
       find("#tab_about a").click
-      first("distributor img")['src'].should include distributor.logo.url(:thumb)
+      expect(first("distributor img")['src']).to include distributor.logo.url(:thumb)
     end
 
     it "shows the producers for a distributor" do
@@ -37,7 +37,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       visit shop_path
       find("#tab_producers a").click
-      page.should have_content supplier.name
+      expect(page).to have_content supplier.name
     end
 
     describe "selecting an order cycle" do
@@ -46,7 +46,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
       it "selects an order cycle if only one is open" do
         exchange1.update_attribute :pickup_time, "turtles"
         visit shop_path
-        page.should have_selector "option[selected]", text: 'turtles'
+        expect(page).to have_selector "option[selected]", text: 'turtles'
       end
 
       describe "with multiple order cycles" do
@@ -59,9 +59,9 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
         it "shows a select with all order cycles, but doesn't show the products by default" do
           visit shop_path
-          page.should have_selector "option", text: 'frogs'
-          page.should have_selector "option", text: 'turtles'
-          page.should_not have_selector("input.button.right", visible: true)
+          expect(page).to have_selector "option", text: 'frogs'
+          expect(page).to have_selector "option", text: 'turtles'
+          expect(page).not_to have_selector("input.button.right", visible: true)
         end
 
         it "shows products after selecting an order cycle" do
@@ -69,16 +69,16 @@ feature "As a consumer I want to shop with a distributor", js: true do
           variant.update_attribute(:display_as, "rabbit")
           add_variant_to_order_cycle(exchange1, variant)
           visit shop_path
-          page.should_not have_content product.name
-          Spree::Order.last.order_cycle.should.nil?
+          expect(page).not_to have_content product.name
+          expect(Spree::Order.last.order_cycle).to.nil?
 
           select "frogs", from: "order_cycle_id"
-          page.should have_selector "products"
-          page.should have_content "Next order closing in 2 days"
-          Spree::Order.last.order_cycle.should == oc1
-          page.should have_content product.name
-          page.should have_content variant.display_name
-          page.should have_content variant.display_as
+          expect(page).to have_selector "products"
+          expect(page).to have_content "Next order closing in 2 days"
+          expect(Spree::Order.last.order_cycle).to eq(oc1)
+          expect(page).to have_content product.name
+          expect(page).to have_content variant.display_name
+          expect(page).to have_content variant.display_as
 
           open_product_modal product
           modal_should_be_open_for product
@@ -94,26 +94,26 @@ feature "As a consumer I want to shop with a distributor", js: true do
             # -- Selecting an order cycle
             visit shop_path
             select "turtles", from: "order_cycle_id"
-            page.should have_content with_currency(1020.99)
+            expect(page).to have_content with_currency(1020.99)
 
             # -- Cart shows correct price
             fill_in "variants[#{variant.id}]", with: 1
             show_cart
-            within("li.cart") { page.should have_content with_currency(1020.99) }
+            within("li.cart") { expect(page).to have_content with_currency(1020.99) }
 
             # -- Changing order cycle
             accept_alert do
               select "frogs", from: "order_cycle_id"
             end
-            page.should have_content with_currency(19.99)
+            expect(page).to have_content with_currency(19.99)
 
             # -- Cart should be cleared
             # ng-animate means that the old product row is likely to be present, so we ensure
             # that we are not filling in the quantity on the outgoing row
-            page.should_not have_selector "tr.product-cart"
+            expect(page).not_to have_selector "tr.product-cart"
             within('product:not(.ng-leave)') { fill_in "variants[#{variant.id}]", with: 1 }
             show_cart
-            within("li.cart") { page.should have_content with_currency(19.99) }
+            within("li.cart") { expect(page).to have_content with_currency(19.99) }
           end
 
           describe "declining to clear the cart" do
@@ -130,11 +130,11 @@ feature "As a consumer I want to shop with a distributor", js: true do
               handle_js_confirm(false) do
                 select "frogs", from: "order_cycle_id"
                 show_cart
-                page.should have_selector "tr.product-cart"
-                page.should have_selector 'li.cart', text: '1'
+                expect(page).to have_selector "tr.product-cart"
+                expect(page).to have_selector 'li.cart', text: '1'
 
                 # The order cycle choice should not have changed
-                page.should have_select 'order_cycle_id', selected: 'turtles'
+                expect(page).to have_select 'order_cycle_id', selected: 'turtles'
               end
             end
           end
@@ -192,15 +192,15 @@ feature "As a consumer I want to shop with a distributor", js: true do
         visit shop_path
 
         # Page should not have product.price (with or without fee)
-        page.should_not have_price with_currency(10.00)
-        page.should_not have_price with_currency(33.00)
+        expect(page).not_to have_price with_currency(10.00)
+        expect(page).not_to have_price with_currency(33.00)
 
         # Page should have variant prices (with fee)
-        page.should have_price with_currency(43.00)
-        page.should have_price with_currency(53.00)
+        expect(page).to have_price with_currency(43.00)
+        expect(page).to have_price with_currency(53.00)
 
         # Product price should be listed as the lesser of these
-        page.should have_price with_currency(43.00)
+        expect(page).to have_price with_currency(43.00)
       end
 
       it "filters search results properly" do
@@ -208,12 +208,12 @@ feature "As a consumer I want to shop with a distributor", js: true do
         select "frogs", from: "order_cycle_id"
 
         fill_in "search", with: "74576345634XXXXXX"
-        page.should have_content "Sorry, no results found"
-        page.should_not have_content product2.name
+        expect(page).to have_content "Sorry, no results found"
+        expect(page).not_to have_content product2.name
 
         fill_in "search", with: "Meer"           # For product named "Meercats"
-        page.should have_content product2.name
-        page.should_not have_content product.name
+        expect(page).to have_content product2.name
+        expect(page).not_to have_content product.name
 
         fill_in "search", with: "Dome"           # For product with meta_keywords "Domestic"
         expect(page).to have_content product.name
@@ -227,10 +227,10 @@ feature "As a consumer I want to shop with a distributor", js: true do
         fill_in "search", with: "Badg"           # For variant with display_name "Badgers"
 
         within('div.pad-top') do
-          page.should have_content product.name
-          page.should have_content variant2.display_name
-          page.should_not have_content product2.name
-          page.should_not have_content variant3.display_name
+          expect(page).to have_content product.name
+          expect(page).to have_content variant2.display_name
+          expect(page).not_to have_content product2.name
+          expect(page).not_to have_content variant3.display_name
         end
       end
     end
@@ -252,23 +252,23 @@ feature "As a consumer I want to shop with a distributor", js: true do
         it "should save group buy data to the cart and display it on shopfront reload" do
           # -- Quantity
           fill_in "variants[#{variant.id}]", with: 6
-          page.should have_in_cart product.name
+          expect(page).to have_in_cart product.name
           wait_until { !cart_dirty }
 
           li = Spree::Order.order(:created_at).last.line_items.order(:created_at).last
-          li.quantity.should == 6
+          expect(li.quantity).to eq(6)
 
           # -- Max quantity
           fill_in "variant_attributes[#{variant.id}][max_quantity]", with: 7
           wait_until { !cart_dirty }
 
           li = Spree::Order.order(:created_at).last.line_items.order(:created_at).last
-          li.max_quantity.should == 7
+          expect(li.max_quantity).to eq(7)
 
           # -- Reload
           visit shop_path
-          page.should have_field "variants[#{variant.id}]", with: 6
-          page.should have_field "variant_attributes[#{variant.id}][max_quantity]", with: 7
+          expect(page).to have_field "variants[#{variant.id}]", with: 6
+          expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: 7
         end
       end
     end
@@ -288,16 +288,16 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       it "lets us add and remove products from our cart" do
         fill_in "variants[#{variant.id}]", with: '1'
-        page.should have_in_cart product.name
+        expect(page).to have_in_cart product.name
         wait_until { !cart_dirty }
         li = Spree::Order.order(:created_at).last.line_items.order(:created_at).last
-        li.quantity.should == 1
+        expect(li.quantity).to eq(1)
 
         fill_in "variants[#{variant.id}]", with: '0'
-        within('li.cart') { page.should_not have_content product.name }
+        within('li.cart') { expect(page).not_to have_content product.name }
         wait_until { !cart_dirty }
 
-        Spree::LineItem.where(id: li).should be_empty
+        expect(Spree::LineItem.where(id: li)).to be_empty
       end
 
       it "lets us add a quantity greater than on_hand value if product is on_demand" do
@@ -306,7 +306,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
         fill_in "variants[#{variant.id}]", with: '10'
 
-        page.should have_field "variants[#{variant.id}]", with: '10'
+        expect(page).to have_field "variants[#{variant.id}]", with: '10'
       end
 
       it "alerts us when we enter a quantity greater than the stock available" do
@@ -317,7 +317,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
           fill_in "variants[#{variant.id}]", with: '10'
         end
 
-        page.should have_field "variants[#{variant.id}]", with: '5'
+        expect(page).to have_field "variants[#{variant.id}]", with: '5'
       end
 
       describe "when a product goes out of stock just before it's added to the cart" do
@@ -332,20 +332,20 @@ feature "As a consumer I want to shop with a distributor", js: true do
           wait_until { !cart_dirty }
 
           within(".out-of-stock-modal") do
-            page.should have_content "stock levels for one or more of the products in your cart have reduced"
-            page.should have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
+            expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+            expect(page).to have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
           end
 
           # -- Page updates
           # Update amount in cart
-          page.should have_field "variants[#{variant.id}]", with: '0', disabled: true
-          page.should have_field "variants[#{variant2.id}]", with: ''
+          expect(page).to have_field "variants[#{variant.id}]", with: '0', disabled: true
+          expect(page).to have_field "variants[#{variant2.id}]", with: ''
 
           # Update amount available in product list
           #   If amount falls to zero, variant should be greyed out and input disabled
-          page.should have_selector "#variant-#{variant.id}.out-of-stock"
-          page.should have_selector "#variants_#{variant.id}[ofn-on-hand='0']"
-          page.should have_selector "#variants_#{variant.id}[disabled='disabled']"
+          expect(page).to have_selector "#variant-#{variant.id}.out-of-stock"
+          expect(page).to have_selector "#variants_#{variant.id}[ofn-on-hand='0']"
+          expect(page).to have_selector "#variants_#{variant.id}[disabled='disabled']"
         end
 
         it 'does not show out of stock modal if product is on_demand' do
@@ -374,18 +374,18 @@ feature "As a consumer I want to shop with a distributor", js: true do
             wait_until { !cart_dirty }
 
             within(".out-of-stock-modal") do
-              page.should have_content "stock levels for one or more of the products in your cart have reduced"
-              page.should have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
+              expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+              expect(page).to have_content "#{product.name} - #{variant.unit_to_display} is now out of stock."
             end
 
             # -- Page updates
             # Update amount in cart
-            page.should have_field "variant_attributes[#{variant.id}][max_quantity]", with: '0', disabled: true
+            expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: '0', disabled: true
 
             # Update amount available in product list
             #   If amount falls to zero, variant should be greyed out and input disabled
-            page.should have_selector "#variant-#{variant.id}.out-of-stock"
-            page.should have_selector "#variants_#{variant.id}_max[disabled='disabled']"
+            expect(page).to have_selector "#variant-#{variant.id}.out-of-stock"
+            expect(page).to have_selector "#variants_#{variant.id}_max[disabled='disabled']"
           end
         end
 
@@ -400,8 +400,8 @@ feature "As a consumer I want to shop with a distributor", js: true do
             wait_until { !cart_dirty }
 
             within(".out-of-stock-modal") do
-              page.should have_content "stock levels for one or more of the products in your cart have reduced"
-              page.should have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
+              expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+              expect(page).to have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
             end
           end
 
@@ -418,12 +418,12 @@ feature "As a consumer I want to shop with a distributor", js: true do
               wait_until { !cart_dirty }
 
               within(".out-of-stock-modal") do
-                page.should have_content "stock levels for one or more of the products in your cart have reduced"
-                page.should have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
+                expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
+                expect(page).to have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
               end
 
-              page.should have_field "variants[#{variant.id}]", with: '1'
-              page.should have_field "variant_attributes[#{variant.id}][max_quantity]", with: '3'
+              expect(page).to have_field "variants[#{variant.id}]", with: '1'
+              expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: '3'
             end
           end
         end
@@ -433,17 +433,17 @@ feature "As a consumer I want to shop with a distributor", js: true do
     context "when no order cycles are available" do
       it "tells us orders are closed" do
         visit shop_path
-        page.should have_content "Orders are closed"
+        expect(page).to have_content "Orders are closed"
       end
       it "shows the last order cycle" do
         oc1 = create(:simple_order_cycle, distributors: [distributor], orders_open_at: 17.days.ago, orders_close_at: 10.days.ago)
         visit shop_path
-        page.should have_content "The last cycle closed 10 days ago"
+        expect(page).to have_content "The last cycle closed 10 days ago"
       end
       it "shows the next order cycle" do
         oc1 = create(:simple_order_cycle, distributors: [distributor], orders_open_at: 10.days.from_now, orders_close_at: 17.days.from_now)
         visit shop_path
-        page.should have_content "The next cycle opens in 10 days"
+        expect(page).to have_content "The next cycle opens in 10 days"
       end
     end
 

--- a/spec/features/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/features/consumer/shopping/variant_overrides_spec.rb
@@ -43,26 +43,26 @@ feature "shopping with variant overrides defined", js: true do
 
   describe "viewing products" do
     it "shows price and stock from the override" do
-      page.should have_price with_currency(61.11) # product1_variant1_override.price ($55.55) + 10% fee
-      page.should_not have_price with_currency(12.22) # product1_variant1.price ($11.11) + 10% fee
+      expect(page).to have_price with_currency(61.11) # product1_variant1_override.price ($55.55) + 10% fee
+      expect(page).not_to have_price with_currency(12.22) # product1_variant1.price ($11.11) + 10% fee
 
       # Product should appear but one of the variants is out of stock
-      page.should_not have_content product1_variant2.options_text
+      expect(page).not_to have_content product1_variant2.options_text
 
       # Entire product should not appear - no stock
-      page.should_not have_content product2.name
-      page.should_not have_content product2_variant1.options_text
+      expect(page).not_to have_content product2.name
+      expect(page).not_to have_content product2_variant1.options_text
 
       # On-demand product with VO of no stock should NOT appear
-      page.should_not have_content product3_variant1.options_text
+      expect(page).not_to have_content product3_variant1.options_text
     end
 
     it "calculates fees correctly" do
       page.find("#variant-#{product1_variant1.id} .graph-button").click
       page.find(".price_breakdown a").click
-      page.should have_selector 'li.cost div', text: with_currency(55.55)
-      page.should have_selector 'li.packing-fee div', text: with_currency(5.56)
-      page.should have_selector 'li.total div', text: "= #{with_currency(61.11)}"
+      expect(page).to have_selector 'li.cost div', text: with_currency(55.55)
+      expect(page).to have_selector 'li.packing-fee div', text: with_currency(5.56)
+      expect(page).to have_selector 'li.total div', text: "= #{with_currency(61.11)}"
     end
 
     it "shows the correct prices when products are in the cart" do
@@ -70,7 +70,7 @@ feature "shopping with variant overrides defined", js: true do
       show_cart
       wait_until_enabled 'li.cart a.button'
       visit shop_path
-      page.should have_price with_currency(61.11)
+      expect(page).to have_price with_currency(61.11)
     end
 
     # The two specs below reveal an unrelated issue with fee calculation. See:
@@ -79,30 +79,30 @@ feature "shopping with variant overrides defined", js: true do
     it "shows the overridden price with fees in the quick cart" do
       fill_in "variants[#{product1_variant1.id}]", with: "2"
       show_cart
-      page.should have_selector "#cart-variant-#{product1_variant1.id} .quantity", text: '2'
-      page.should have_selector "#cart-variant-#{product1_variant1.id} .price", text: with_currency(61.11)
-      page.should have_selector "#cart-variant-#{product1_variant1.id} .total-price", text: with_currency(122.22)
+      expect(page).to have_selector "#cart-variant-#{product1_variant1.id} .quantity", text: '2'
+      expect(page).to have_selector "#cart-variant-#{product1_variant1.id} .price", text: with_currency(61.11)
+      expect(page).to have_selector "#cart-variant-#{product1_variant1.id} .total-price", text: with_currency(122.22)
     end
 
     it "shows the correct prices in the shopping cart" do
       fill_in "variants[#{product1_variant1.id}]", with: "2"
       add_to_cart
 
-      page.should have_selector "tr.line-item.variant-#{product1_variant1.id} .cart-item-price", text: with_currency(61.11)
-      page.should have_field "order[line_items_attributes][0][quantity]", with: '2'
-      page.should have_selector "tr.line-item.variant-#{product1_variant1.id} .cart-item-total", text: with_currency(122.22)
+      expect(page).to have_selector "tr.line-item.variant-#{product1_variant1.id} .cart-item-price", text: with_currency(61.11)
+      expect(page).to have_field "order[line_items_attributes][0][quantity]", with: '2'
+      expect(page).to have_selector "tr.line-item.variant-#{product1_variant1.id} .cart-item-total", text: with_currency(122.22)
 
-      page.should have_selector "#edit-cart .item-total", text: with_currency(122.22)
-      page.should have_selector "#edit-cart .grand-total", text: with_currency(122.22)
+      expect(page).to have_selector "#edit-cart .item-total", text: with_currency(122.22)
+      expect(page).to have_selector "#edit-cart .grand-total", text: with_currency(122.22)
     end
 
     it "shows the correct prices in the checkout" do
       fill_in "variants[#{product1_variant1.id}]", with: "2"
       click_checkout
 
-      page.should have_selector 'form.edit_order .cart-total', text: with_currency(122.22)
-      page.should have_selector 'form.edit_order .shipping', text: with_currency(0.00)
-      page.should have_selector 'form.edit_order .total', text: with_currency(122.22)
+      expect(page).to have_selector 'form.edit_order .cart-total', text: with_currency(122.22)
+      expect(page).to have_selector 'form.edit_order .shipping', text: with_currency(0.00)
+      expect(page).to have_selector 'form.edit_order .total', text: with_currency(122.22)
     end
   end
 
@@ -114,8 +114,8 @@ feature "shopping with variant overrides defined", js: true do
       complete_checkout
 
       o = Spree::Order.complete.last
-      o.line_items.first.price.should == 55.55
-      o.total.should == 122.22
+      expect(o.line_items.first.price).to eq(55.55)
+      expect(o.total).to eq(122.22)
     end
 
     it "subtracts stock from the override" do
@@ -146,7 +146,7 @@ feature "shopping with variant overrides defined", js: true do
       expect do
         complete_checkout
       end.to change { product1_variant1.reload.on_hand }.by(-2)
-      product1_variant1_override.reload.count_on_hand.should be_nil
+      expect(product1_variant1_override.reload.count_on_hand).to be_nil
     end
 
     it "does not subtract stock from variants where the override has on_demand: true" do
@@ -165,7 +165,7 @@ feature "shopping with variant overrides defined", js: true do
 
       complete_checkout
 
-      page.should_not have_content "Out of Stock"
+      expect(page).not_to have_content "Out of Stock"
     end
   end
 

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -494,11 +494,11 @@ describe Enterprise do
     end
 
     it "gets all taxons of all distributed products in open order cycles" do
-      Spree::Product.stub(:in_distributor).and_return [product1, product2, product3]
+      allow(Spree::Product).to receive(:in_distributor).and_return [product1, product2, product3]
       ex.variants << product1.variants.first
       ex.variants << product3.variants.first
 
-      distributor.current_distributed_taxons.should match_array [taxon1, taxon3]
+      expect(distributor.current_distributed_taxons).to match_array [taxon1, taxon3]
     end
 
     it "gets all taxons of all supplied products" do

--- a/spec/performance/shop_controller_spec.rb
+++ b/spec/performance/shop_controller_spec.rb
@@ -6,8 +6,8 @@ describe ShopController, type: :controller, performance: true do
   let(:order_cycle) { create(:simple_order_cycle, distributors: [d], coordinator_fees: [enterprise_fee]) }
 
   before do
-    controller.stub(:current_distributor) { d }
-    controller.stub(:current_order_cycle) { order_cycle }
+    allow(controller).to receive(:current_distributor) { d }
+    allow(controller).to receive(:current_order_cycle) { order_cycle }
     Spree::Config.currency = 'AUD'
   end
 
@@ -36,7 +36,7 @@ describe ShopController, type: :controller, performance: true do
     it "returns products via json" do
       results = multi_benchmark(3, cache_key_patterns: cache_key_patterns) do
         xhr :get, :products
-        response.should be_success
+        expect(response).to be_success
       end
     end
   end

--- a/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
+++ b/spec/serializers/api/admin/for_order_cycle/supplied_product_serializer_spec.rb
@@ -1,4 +1,6 @@
-describe Api::Admin::ForOrderCycle::EnterpriseSerializer do
+require "spec_helper"
+
+describe Api::Admin::ForOrderCycle::SuppliedProductSerializer do
   let(:coordinator)         { create(:distributor_enterprise) }
   let(:order_cycle)         { double(:order_cycle, coordinator: coordinator) }
   let!(:product) { create(:simple_product) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,6 +91,11 @@ RSpec.configure do |config|
   # Retry
   config.verbose_retry = true
 
+  # Force use of expect (over should)
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+
   # DatabaseCleaner
   config.before(:suite)          { DatabaseCleaner.clean_with :deletion, except: ['spree_countries', 'spree_states'] }
   config.before(:each)           { DatabaseCleaner.strategy = :transaction }


### PR DESCRIPTION
#### What? Why?
With the upgrade to ruby 2.1.9 I gave it a try to my local feature specs. Still a few errors but good enough to finish transpec'ing all our specs 🎉 

Result:Expect is mandatory now!
![Screenshot 2019-09-20 at 10 34 18](https://user-images.githubusercontent.com/1640378/65316624-3ad11580-db92-11e9-9887-15030cff5019.png)


Closes #2097

#### What should we test?
No test, spec changes only.

#### Release notes
Changelog Category: Changed
All OFN tests are now using modern rspec syntax.
