### PR TITLE
Replace therubyracer with mini_racer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,10 @@ group :assets do
   gem 'coffee-rails', '~> 3.2.1'
   gem 'compass-rails'
 
-  gem 'therubyracer', '=0.12.0'
+  gem 'mini_racer', '0.1.15'
+  # Previously we found that libv8 6.7.288.46.1 breakis the compilation of mini_racer.
+  # Now we see that we need to set the version explicitly. Nothing else depends on libv8.
+  gem 'libv8', '6.3.292.48.1'
 
   gem 'uglifier', '>= 1.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,7 +465,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.19)
+    libv8 (6.3.292.48.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -476,6 +476,8 @@ GEM
     mime-types (1.25.1)
     mini_mime (1.0.1)
     mini_portile2 (2.1.0)
+    mini_racer (0.1.15)
+      libv8 (~> 6.3)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     money (5.1.1)
@@ -579,7 +581,6 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.5.0)
-    ref (2.0.0)
     request_store (1.4.1)
       rack (>= 1.4)
     roadie (3.4.0)
@@ -670,9 +671,6 @@ GEM
     stripe (4.24.0)
       faraday (~> 0.13)
       net-http-persistent (~> 3.0)
-    therubyracer (0.12.0)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.20.3)
     tilt (1.4.1)
     timecop (0.9.1)
@@ -773,7 +771,9 @@ DEPENDENCIES
   kaminari (~> 0.14.1)
   knapsack
   letter_opener (>= 1.4.1)
+  libv8 (= 6.3.292.48.1)
   listen (= 3.0.8)
+  mini_racer (= 0.1.15)
   momentjs-rails
   newrelic_rpm (~> 3.0)
   nokogiri (>= 1.6.7.1)
@@ -814,7 +814,6 @@ DEPENDENCIES
   spring (= 1.7.2)
   spring-commands-rspec
   stripe
-  therubyracer (= 0.12.0)
   timecop
   truncate_html
   turbo-sprockets-rails3


### PR DESCRIPTION
#### What? Why?
With ruby 2.1.9 I gave this a new try without success but a little bit more google time and I found the solution 🎉  in this [blog post](https://blog.driftingruby.com/updated-to-mojave/).

Closes #2100
Redos #2424 (that was reverted in #3244)

This is being replaced to increase the reliability and speed of asset compilation.

#### What should we test?
Assets are compiled in staging.
A successful deploy to a staging server is enough.

#### Release notes
Changelog Category: Changed
Move from therubyracer to mini_racer to reduce deploy time.
