### PR TITLE
Add spec for api/admin/order_cycle_serializer

### DIFF
--- a/spec/serializers/api/admin/order_cycle_serializer_spec.rb
+++ b/spec/serializers/api/admin/order_cycle_serializer_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+module Api
+  module Admin
+    describe OrderCycleSerializer do
+      let(:order_cycle) { create(:order_cycle) }
+      let(:serializer) { Api::Admin::OrderCycleSerializer.new order_cycle, current_user: order_cycle.coordinator.owner }
+
+      it "serializes an order cycle" do
+        expect(serializer.to_json).to include order_cycle.name
+      end
+
+      it "serializes the order cycle with exchanges" do
+        expect(serializer.exchanges.to_json).to include "\"#{order_cycle.variants.first.id}\":true"
+      end
+
+      it "serializes the order cycle with editable_variants_for_incoming_exchanges" do
+        expect(serializer.editable_variants_for_incoming_exchanges.to_json).to include order_cycle.variants.first.id.to_s
+        expect(serializer.editable_variants_for_incoming_exchanges.to_json).to_not include order_cycle.distributors.first.id.to_s
+      end
+
+      it "serializes the order cycle with editable_variants_for_outgoing_exchanges" do
+        expect(serializer.editable_variants_for_outgoing_exchanges.to_json).to include order_cycle.variants.first.id.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Relates to #4007
Adds some simple specs to complex and untested order_cycle_serializer.

I thought I'd grow this one as I worked on OC page but actually, these visible_* and editable_* methods on the OC will go (#4480 etc) so I'll skip adding more unit tests for them. We can keep this small spec in the meantime.

#### What should we test?
This is adding specs.

#### Release notes
Changelog Category: Added
Added new automated tests to a serializer.
