### PR TITLE
Improve user email change flash alert message

### DIFF
--- a/app/controllers/spree/admin/users_controller.rb
+++ b/app/controllers/spree/admin/users_controller.rb
@@ -46,11 +46,12 @@ module Spree
             @user.spree_roles = roles.reject(&:blank?).collect{ |r| Spree::Role.find(r) }
           end
 
-          if params[:user][:email] != @user.email
-            flash.now[:success] = Spree.t(:email_updated)
-          else
-            flash.now[:success] = Spree.t(:account_updated)
-          end
+          message = if params[:user][:email] != @user.email
+                      Spree.t(:email_updated)
+                    else
+                      Spree.t(:account_updated)
+                    end
+          flash.now[:success] = message
         end
         render :edit
       end

--- a/app/controllers/spree/admin/users_controller.rb
+++ b/app/controllers/spree/admin/users_controller.rb
@@ -46,7 +46,11 @@ module Spree
             @user.spree_roles = roles.reject(&:blank?).collect{ |r| Spree::Role.find(r) }
           end
 
-          flash.now[:success] = Spree.t(:account_updated)
+          if params[:user][:email] != @user.email
+            flash.now[:success] = Spree.t(:email_updated)
+          else
+            flash.now[:success] = Spree.t(:account_updated)
+          end
         end
         render :edit
       end

--- a/app/controllers/spree/admin/users_controller.rb
+++ b/app/controllers/spree/admin/users_controller.rb
@@ -46,7 +46,7 @@ module Spree
             @user.spree_roles = roles.reject(&:blank?).collect{ |r| Spree::Role.find(r) }
           end
 
-          message = if params[:user][:email] != @user.email
+          message = if new_email_unconfirmed?
                       Spree.t(:email_updated)
                     else
                       Spree.t(:account_updated)
@@ -130,6 +130,10 @@ module Spree
 
       def load_roles
         @roles = Spree::Role.scoped
+      end
+
+      def new_email_unconfirmed?
+        params[:user][:email] != @user.email
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2943,6 +2943,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     email: Email
     # TODO: remove 'account_updated' key once we get to Spree 2.0
     account_updated: "Account updated!"
+    email_updated: "The account will be updated once the new email is confirmed."
     my_account: "My account"
     date: "Date"
     time: "Time"

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -64,6 +64,13 @@ feature "Managing users" do
 
           expect(page).to have_content("Account updated")
         end
+
+        it "should let me edit the user email" do
+          fill_in "Email", with: "newemail@example.org"
+          click_button "Update"
+
+          expect(page).to have_content("The account will be updated once the new email is confirmed.")
+        end
       end
     end
 


### PR DESCRIPTION
Closes #4031

When editing a user as super admin requires a confirmation on the new email. However the superadmin may not know that and see only that his email changes have not be taken into account. This changes the message from "Account Updated!" to "The account will be updated once the new email is confirmed."


Changelog Category: Changed
