### PR TITLE
Enable trace & search analytics in Datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,5 +2,6 @@ if ENV['DATADOG_RAILS_APM']
   Datadog.configure do |c|
     c.use :rails, service_name: 'rails'
     c.use :delayed_job, service_name: 'delayed_job'
+    c.analytics_enabled = true
   end
 end


### PR DESCRIPTION
#### What? Why?

This will enrich the quality of the reported traces for all web frameworks in our stack. That means not only memcached as we did in https://github.com/openfoodfoundation/openfoodnetwork/pull/4266 but PostgreSQL and Rails too.

After enabling, the Trace Search & Analytics page populates which allows us to search traces and add APM queries to dashboards.

![Screenshot from 2019-09-21 14-07-34](https://user-images.githubusercontent.com/762088/65373154-05075c00-dc7a-11e9-99f9-62b998de33e8.png)


Hopefully, this will provide extra information that will allow us to better understand what are background workers spend their time on.

#### What should we test?

A dev should check the extra reported information in Datadog after deploying to production.

#### Release notes

Enable analysis of the spans produced by Datadog's Delayed Job integration

Changelog Category: Added