### PR TITLE
Make subscription line items handle soft deleted variants

### DIFF
--- a/app/models/subscription_line_item.rb
+++ b/app/models/subscription_line_item.rb
@@ -10,6 +10,11 @@ class SubscriptionLineItem < ActiveRecord::Base
     (price_estimate || 0) * (quantity || 0)
   end
 
+  # Ensure SubscriptionLineItem always has access to soft-deleted Variant attribute
+  def variant
+    Spree::Variant.unscoped { super }
+  end
+
   # Used to calculators to estimate fees
   alias_method :amount, :total_estimate
 

--- a/spec/serializers/api/admin/subscription_line_item_serializer_spec.rb
+++ b/spec/serializers/api/admin/subscription_line_item_serializer_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Api
+  module Admin
+    describe SubscriptionLineItemSerializer do
+      let(:subscription_line_item) { create(:subscription_line_item) }
+      
+      it "serializes a subscription line item with the product name" do
+        serializer = described_class.new(subscription_line_item)
+
+        expect(serializer.to_json).to match subscription_line_item.variant.product.name
+      end
+
+      context "when the variant of the subscription line item is soft deleted" do
+        it "serializers the subscription line item with the product name" do
+          subscription_line_item.variant.update_attribute :deleted_at, Time.zone.now
+
+          serializer = described_class.new(subscription_line_item.reload)
+
+          expect(serializer.to_json).to match subscription_line_item.variant.product.name
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ensures subscription list page works. The variant can be removed from the subscription by the user in the edit subscription page

#### What? Why?

Closes #4062

This makes the subs list page work. It keeps the deleted variant in the subscription.
According to my manual test it looks good because when the user goes to edit the order, the deleted variant shows up but it is flagged it is not available in any order cycle, so the user will be able to remove it from the subscription.

#### What should we test?
Verify that the issue is fixed.
Additionally verify that the variant can be removed from the subscription by the user.


#### Release notes
Changelog Category: Fixed
Subscriptions list page can now handle subscriptions with deleted products.
