### PR TITLE
Remove all usages of Spree Config track_inventory_levels

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -31,16 +31,11 @@ module VariantStock
   end
 
   # Sets the stock level of the variant.
-  # This will only work if `track_inventory_levels` config is set
-  #   and if there is a stock item for the variant.
+  # This will only work if there is a stock item for the variant.
   #
-  # @raise [StandardError] when the track_inventory_levels config key is not set
-  #   and when the variant has no stock item
+  # @raise [StandardError] when the variant has no stock item
   def on_hand=(new_level)
     warn_deprecation(__method__, '#total_on_hand')
-
-    error = 'Cannot set on_hand value when Spree::Config[:track_inventory_levels] is false'
-    raise error unless Spree::Config.track_inventory_levels
 
     raise_error_if_no_stock_item_available
 
@@ -48,10 +43,6 @@ module VariantStock
   end
 
   # Checks whether this variant is produced on demand.
-  #
-  # In Spree 2.0 this attribute is removed in favour of
-  # track_inventory_levels only. It was initially introduced in
-  # https://github.com/openfoodfoundation/spree/commit/20b5ad9835dca7f41a40ad16c7b45f987eea6dcc
   def on_demand
     warn_deprecation(__method__, 'StockItem#backorderable?')
 
@@ -89,8 +80,6 @@ module VariantStock
   # Here we depend only on variant.total_on_hand and variant.on_demand.
   #   This way, variant_overrides only need to override variant.total_on_hand and variant.on_demand.
   def can_supply?(quantity)
-    return true unless Spree::Config[:track_inventory_levels]
-
     on_demand || total_on_hand >= quantity
   end
 

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -32,7 +32,7 @@ module Spree
     # NOTE: This is an override of spree's method, needed to allow orders
     # without line items (ie. user invoices) to not have inventory units
     def require_inventory
-      return false unless Spree::Config[:track_inventory_levels] && line_items.count > 0 # This line altered
+      return false unless line_items.count > 0 # This line altered
       order.completed? && !order.canceled?
     end
   end

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -53,18 +53,17 @@
         = f.label :sku, t(:sku)
         = f.text_field :sku, :size => 16
 
-      - if Spree::Config[:track_inventory_levels]
-        .alpha.two.columns
-          = f.field_container :on_hand do
-            = f.label :on_hand, t(:on_hand)
-            = f.number_field :on_hand, :min => 0
-        .omega.two.columns
-          = f.field_container :on_demand, :class => ['checkbox'] do
-            %label
-              = f.check_box :on_demand
-              = t(:on_demand)
+      .alpha.two.columns
+        = f.field_container :on_hand do
+          = f.label :on_hand, t(:on_hand)
+          = f.number_field :on_hand, :min => 0
+      .omega.two.columns
+        = f.field_container :on_demand, :class => ['checkbox'] do
+          %label
+            = f.check_box :on_demand
+            = t(:on_demand)
 
-        .clear
+      .clear
 
       %ul#shipping_specs
         %li#shipping_specs_weight_field.field.alpha.two.columns

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -38,18 +38,17 @@
       = f.label :cost_price, Spree.t(:cost_price)
       = f.text_field :cost_price, value: number_to_currency(@variant.cost_price, unit: ''), class: 'fullwidth'
 
-    - if Spree::Config[:track_inventory_levels]
-      %div{ 'set-on-demand' => '' }
-        .field.checkbox
-          %label
-            = f.check_box :on_demand
-            = t(:on_demand)
-          %div{'ofn-with-tip' => t('admin.products.variants.to_order_tip')}
-            %a= t('admin.whats_this')
-        .field
-          = f.label :on_hand, t(:on_hand)
-          .fullwidth
-            = f.text_field :on_hand
+    %div{ 'set-on-demand' => '' }
+      .field.checkbox
+        %label
+          = f.check_box :on_demand
+          = t(:on_demand)
+        %div{'ofn-with-tip' => t('admin.products.variants.to_order_tip')}
+          %a= t('admin.whats_this')
+      .field
+        = f.label :on_hand, t(:on_hand)
+        .fullwidth
+          = f.text_field :on_hand
 
 .right.six.columns.omega.label-block
   - if @product.variant_unit != 'weight'

--- a/spec/models/concerns/variant_stock_spec.rb
+++ b/spec/models/concerns/variant_stock_spec.rb
@@ -45,33 +45,14 @@ describe VariantStock do
   end
 
   describe '#on_hand=' do
-    context 'when track_inventory_levels is set' do
-      before do
-        allow(Spree::Config)
-          .to receive(:track_inventory_levels) { true }
-      end
-
-      it 'sets the new level as the stock item\'s count_on_hand' do
-        variant.on_hand = 3
-        unique_stock_item = variant.stock_items.first
-        expect(unique_stock_item.count_on_hand).to eq(3)
-      end
-
-      context 'when the variant has no stock item' do
-        let(:variant) { build(:variant) }
-
-        it 'raises' do
-          expect { variant.on_hand = 3 }
-            .to raise_error(StandardError)
-        end
-      end
+    it 'sets the new level as the stock item\'s count_on_hand' do
+      variant.on_hand = 3
+      unique_stock_item = variant.stock_items.first
+      expect(unique_stock_item.count_on_hand).to eq(3)
     end
 
-    context 'when track_inventory_levels is not set' do
-      before do
-        allow(Spree::Config)
-          .to receive(:track_inventory_levels) { false }
-      end
+    context 'when the variant has no stock item' do
+      let(:variant) { build(:variant) }
 
       it 'raises' do
         expect { variant.on_hand = 3 }


### PR DESCRIPTION
#### What? Why?

Related to #3649

This removes all usages of the config in OFN code, the value is always true since v2.0.0

#### What should we test?
I'd say this doesnt need manual testing. The auto specs are enough.

#### Release notes
Changelog Category: Removed
Removed unused spree config related to inventory management thus making the OFN code simpler.
