### PR TITLE
Remove unused field orders.shipping_method_id

### DIFF
--- a/db/migrate/20190922201034_drop_orders_shipping_method_id.rb
+++ b/db/migrate/20190922201034_drop_orders_shipping_method_id.rb
@@ -1,0 +1,9 @@
+class DropOrdersShippingMethodId < ActiveRecord::Migration
+  def up
+    remove_column :spree_orders, :shipping_method_id
+  end
+
+  def down
+    add_column :spree_orders, :shipping_method_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190918105234) do
+ActiveRecord::Schema.define(:version => 20190922201034) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -563,7 +563,6 @@ ActiveRecord::Schema.define(:version => 20190918105234) do
     t.integer  "bill_address_id"
     t.integer  "ship_address_id"
     t.decimal  "payment_total",                      :precision => 10, :scale => 2, :default => 0.0
-    t.integer  "shipping_method_id"
     t.string   "shipment_state"
     t.string   "payment_state"
     t.string   "email"


### PR DESCRIPTION
#### What? Why?

Dead field since v2...

#### What should we test?
- Sanity check of checkout related to shipping methods selection.
- Updating old orders and make sure shipping method selection is preserved.
- Verify that Subscription Orders get the correct subscription shipping method

#### Release notes
Changelog Category: Removed
Remove unused database field: order.shipping_method.id.

