### PR TITLE
Translation: "Add new credit card"

### DIFF
--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -16,7 +16,7 @@
 
       .small-12.medium-6.columns
         .new_card{ ng: { show: 'CreditCard.visible', class: '{visible: CreditCard.visible}' } }
-          %h3= t(:add_a_new_card)
+          %h3= t(:add_new_credit_card)
           = render 'new_card_form'
         .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible' } }
           %h3


### PR DESCRIPTION
#### What? Why?

Closes #4190

An incorrect key was provided in the HAML, preventing this heading from being translated.

#### What should we test?

No updates to the spec. The change is visible at `/account?#/cards` after clicking "Add A Card". The add card form was previously titled "Add A New Card", which was not translating.

#### Release notes

Fixed translation for adding a new credit card on the profile page.

Changelog Category: Fixed

#### Further comments

I'll work on a script to identify `t(:foo)` patterns that don't have a match in `en.yml` in hopes of fixing a larger number of these at once.
