### PR TITLE
Add missing translation for order.shipment.state "on hand" (with a space between on and hand)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,7 @@ en:
   maestro_or_solo_cards: "Maestro/Solo cards"
   backordered: "Backordered"
   on_hand: "On Hand"
+  "on hand": "On Hand"
   ship: "Ship"
 
   actions:


### PR DESCRIPTION
#### What? Why?

Closes #4302
Adds the missing translation key.

#### What should we test?
Verify the issue is fixed now.

#### Release notes
Changelog Category: Added
Added missing translation.