### PR TITLE
Make translations in new product page relative and specific to the page

### DIFF
--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -3,17 +3,17 @@
 = form_for [:admin, @product], :html => { :multipart => true } do |f|
   .twelve.columns.alpha
     %fieldset.no-border-bottom{ id: "new_product" }
-      %legend{align: "center"}= t(:new_product)
+      %legend{align: "center"}= t(".new_product")
       .twelve.columns.alpha
         .six.columns.alpha
           = f.field_container :supplier do
-            = f.label :supplier_id, t(:supplier)
+            = f.label :supplier_id, t(".supplier")
             %span.required *
             = f.collection_select(:supplier_id, @producers, :id, :name, {:include_blank => true}, {:class => "select2 fullwidth"})
             = f.error_message_on :supplier
         .six.columns.omega
           = f.field_container :name do
-            = f.label :name, t(:product_name)
+            = f.label :name, t(".product_name")
             %span.required *
             %br/
             = f.text_field :name, :class => 'fullwidth title'
@@ -21,7 +21,7 @@
       .twelve.columns.alpha{ 'ng-controller' => 'unitsCtrl' }
         .six.columns.alpha
           = f.field_container :units do
-            = f.label :variant_unit_with_scale, t(:units)
+            = f.label :variant_unit_with_scale, t(".units")
             %span.required *
             %select.select2.fullwidth{ id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options' }
               %option{'value' => '', 'ng-hide' => "hasUnit(product)"}
@@ -29,7 +29,7 @@
             %input{ type: 'hidden', 'ng-value' => 'product.variant_unit_scale', name: 'product[variant_unit_scale]' }
         .three.columns
           = f.field_container :unit_value do
-            = f.label :product_unit_value_with_description, t(:value), 'ng-disabled' => "!hasUnit(product)"
+            = f.label :product_unit_value_with_description, t(".value"), 'ng-disabled' => "!hasUnit(product)"
             %span.required *
             %input.fullwidth{ id: 'product_unit_value_with_description', 'ng-model' => 'product.master.unit_value_with_description', :type => 'text', placeholder: "eg. 2", 'ng-disabled' => "!hasUnit(product)" }
             %input{ type: 'hidden', 'ng-value' => 'product.master.unit_value', name: 'product[unit_value]' }
@@ -37,28 +37,28 @@
         = render 'display_as', f: f
         .three.columns.omega{ 'ng-show' => "product.variant_unit_with_scale == 'items'" }
           = f.field_container :unit_name do
-            = f.label :product_variant_unit_name, t(:unit_name)
+            = f.label :product_variant_unit_name, t(".unit_name")
             %input.fullwidth{ id: 'product_variant_unit_name','ng-model' => 'product.variant_unit_name', :name => 'product[variant_unit_name]', :placeholder => t('admin.products.unit_name_placeholder'), :type => 'text' }
       .twelve.columns.alpha
         .six.columns.alpha
           = render 'spree/admin/products/primary_taxon_form', f: f
         .two.columns
           = f.field_container :price do
-            = f.label :price, t(:price)
+            = f.label :price, t(".price")
             %span.required *
             %br/
             = f.text_field :price, class: 'fullwidth'
             = f.error_message_on :price
         .two.columns
           = f.field_container :on_hand do
-            = f.label :on_hand, t(:on_hand)
+            = f.label :on_hand, t(".on_hand")
             %span.required *
             %br/
             = f.text_field :on_hand, class: 'fullwidth'
             = f.error_message_on :on_hand
         .two.columns.omega
           = f.field_container :on_demand do
-            = f.label :on_demand, t(:on_demand)
+            = f.label :on_demand, t(".on_demand")
             %br/
             = f.check_box :on_demand
             = f.error_message_on :on_demand
@@ -74,13 +74,13 @@
 
       .twelve.columns.alpha
         = f.field_container :description do
-          = f.label :product_description, t(:product_description)
+          = f.label :product_description, t(".product_description")
           %br/
           %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', "textangular-links-target-blank" => true, 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]"}
           = f.error_message_on :description
   .four.columns.omega{ style: "text-align: center" }
     %fieldset.no-border-bottom{ id: "image" }
-      %legend{align: "center"}= t(:image)
+      %legend{align: "center"}= t(".image")
       .row
         = image_tag "noimage/product.png", class: "four columns alpha"
       .row
@@ -90,10 +90,10 @@
     .form-buttons.filter-actions.actions
       = button t('actions.create'), 'icon-ok', :submit, value: "create"
       %span.or
-        = t(:or)
+        = t(".or")
       = button t('actions.create_and_add_another'), 'icon-repeat', :submit, value: 'add_another'
       %span.or
-        = t(:or)
+        = t(".or")
       = link_to_with_icon 'icon-remove', t('actions.cancel'), admin_products_path, :class => 'button'
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3091,9 +3091,20 @@ See the %{link} to find out more about %{sitename}'s features and to start using
             submitting_payment: Submitting payment...
       products:
         image_upload_error: "The product image was not recognised. Please upload an image in PNG or JPG format."
-
         new:
-          title: 'New Product'
+          title: "New Product"
+          new_product: "New Product"
+          supplier: "Supplier"
+          product_name: "Product Name"
+          units: "Unit Size"
+          value: "Value"
+          unit_name: "Unit name"
+          price: "Price"
+          on_hand: "On Hand"
+          on_demand: "On Demand"
+          product_description: "Product Description"
+          image: "Image"
+          or: "or"
         unit_name_placeholder: 'eg. bunches'
         index:
           header:


### PR DESCRIPTION
#### What? Why?

Closes #4276

Make translations in new product page lazylookups and specific to this page.

#### What should we test?
The new product page should render correctly in English. Translations can only be tested afterwards.

#### Release notes
Changelog Category: Added
Added missing translation.
