### PR TITLE
Replace deprecated validates_presence_of

### DIFF
--- a/app/services/subscription_validator.rb
+++ b/app/services/subscription_validator.rb
@@ -9,8 +9,8 @@ class SubscriptionValidator
 
   attr_reader :subscription
 
-  validates_presence_of :shop, :customer, :schedule, :shipping_method, :payment_method
-  validates_presence_of :bill_address, :ship_address, :begins_at
+  validates :shop, :customer, :schedule, :shipping_method, :payment_method, presence: true
+  validates :bill_address, :ship_address, :begins_at, presence: true
   validate :shipping_method_allowed?
   validate :payment_method_allowed?
   validate :payment_method_type_allowed?


### PR DESCRIPTION

#### What? Why?

Related to #3708.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Before we upgrade to Rails 4 we should remove all usages of deprecated code in Rails 3. This validation syntax is the only deprecation I found so far:
https://guides.rubyonrails.org/3_0_release_notes.html#patches-and-deprecations


#### What should we test?
<!-- List which features should be tested and how. -->

- Create a subscription.
- Try to omit required fields like the address or the shop.
- It should not proceed when required fields are missing.
- Creating a subscription with all required fields should succeed.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed: Updated the syntax of our code to prepare for the next upgrades.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

This may help during the next Spree upgrade.
