### PR TITLE
4310 Do not count order shipments in Order#shipping_method

### DIFF
--- a/app/models/concerns/order_shipment.rb
+++ b/app/models/concerns/order_shipment.rb
@@ -19,7 +19,7 @@ module OrderShipment
   #
   # @return [ShippingMethod]
   def shipping_method
-    return if shipments.empty?
+    return if shipments.blank?
     shipments.first.shipping_method
   end
 


### PR DESCRIPTION
#### What? Why?

- Closes #4310

Counting the number of shipments for the order before fetching the max 1 matching shipment is unnecessary. We should just pre-fetch the shipment already when we need to know if there is a shipment.

Before PR:

```
irb(main):002:0> order.shipping_method
   (0.7ms)  SELECT COUNT(*) FROM "spree_shipments" WHERE "spree_shipments"."order_id" = 232
  Spree::Shipment Load (0.5ms)  SELECT "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."order_id" = 232 LIMIT 1
  Spree::ShippingRate Load (0.5ms)  SELECT "spree_shipping_rates".* FROM "spree_shipping_rates" WHERE "spree_shipping_rates"."shipment_id" = 232 AND "spree_shipping_rates"."selected" = 't' LIMIT 1
  Spree::ShippingMethod Load (0.5ms)  SELECT "spree_shipping_methods".* FROM "spree_shipping_methods" WHERE "spree_shipping_methods"."deleted_at" IS NULL AND "spree_shipping_methods"."id" = 9 LIMIT 1
```

After PR:

```
irb(main):002:0> order.shipping_method
  Spree::Shipment Load (1.6ms)  SELECT "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."order_id" = 232
  Spree::ShippingRate Load (0.4ms)  SELECT "spree_shipping_rates".* FROM "spree_shipping_rates" WHERE "spree_shipping_rates"."shipment_id" = 232 AND "spree_shipping_rates"."selected" = 't' LIMIT 1
  Spree::ShippingMethod Load (0.3ms)  SELECT "spree_shipping_methods".* FROM "spree_shipping_methods" WHERE "spree_shipping_methods"."deleted_at" IS NULL AND "spree_shipping_methods"."id" = 9 LIMIT 1
```

#### What should we test?

I think we can tag this `pr-no-test`. We have enough tests using orders and shipping methods, and I think a problem with this change would cause spec failures and problems when release testing.

#### Release notes

- Reduce the number of SQL queries needed when determining the shipping method for an order. This should result in small or minor performance improvements in different parts of the application.

Changelog Category: Changed