### PR TITLE
4315 Set default date range for Orders and Fulfillment report

### DIFF
--- a/app/controllers/spree/admin/reports_controller_decorator.rb
+++ b/app/controllers/spree/admin/reports_controller_decorator.rb
@@ -109,7 +109,7 @@ Spree::Admin::ReportsController.class_eval do
   end
 
   def orders_and_fulfillment
-    params[:q] ||= {}
+    params[:q] ||= orders_and_fulfillment_default_filters
 
     # -- Prepare Form Options
     permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
@@ -276,5 +276,11 @@ Spree::Admin::ReportsController.class_eval do
 
   def timestamp
     Time.zone.now.strftime("%Y%m%d")
+  end
+
+  def orders_and_fulfillment_default_filters
+    now = Time.zone.now
+    { completed_at_gt: (now - 1.month).beginning_of_day,
+      completed_at_lt: (now + 1.day).beginning_of_day }
   end
 end


### PR DESCRIPTION
#### What? Why?

- Closes #4315

Pre-fill the start and end date fields with default values, to encourage the user to set the date range they need. This is to avoid having users generate a report for all-time if they don't actually need that data.

The date range this PR uses is:

* Beginning of day, 1 year ago
* Beginning of day, today

When selecting a date and time in the datetime JS picker, the format of the date is e.g. `2019-09-26 00:00`. After submitting the form, the format becomes `2019-09-26 00:00:00 +1000`. This PR pre-fills the field with the longer datetime format. Best if these three states use the same format, but that is outside the scope of this PR.

I considered moving this inside `OrdersAndFulfillmentsReport`, but I think that's premature until we have another report using default filters.

#### What should we test?

Test that the date range fields are pre-filled with:

* Beginning of day, 1 year ago
* Beginning of day, today

Smoke test that the date range filter still works, and test that selecting another date range is not overwritten when submitting the form.

#### Release notes

- Set a default date range for the Orders and Fulfillment report.

Changelog Category: Changed