### PR TITLE
makes edit button action open a new tab

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -110,7 +110,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
 
   $scope.editWarn = (product, variant) ->
     if (DirtyProducts.count() > 0 and confirm(t("unsaved_changes_confirmation"))) or (DirtyProducts.count() == 0)
-      window.location = "/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit"
+      window.open("/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit", "_blank")
 
 
   $scope.toggleShowAllVariants = ->

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -108,9 +108,13 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     $scope.categoryFilter = "0"
     $scope.importDateFilter = "0"
 
+  confirm_unsaved_changes = () -> (DirtyProducts.count() > 0 and confirm(t("unsaved_changes_confirmation"))) or (DirtyProducts.count() == 0)
+  
+  editProductUrl = (product, variant) -> "/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit"
+
   $scope.editWarn = (product, variant) ->
-    if (DirtyProducts.count() > 0 and confirm(t("unsaved_changes_confirmation"))) or (DirtyProducts.count() == 0)
-      window.open("/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit", "_blank")
+    if confirm_unsaved_changes()
+      window.open(editProductUrl(product, variant), "_blank")
 
 
   $scope.toggleShowAllVariants = ->

--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -108,9 +108,11 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     $scope.categoryFilter = "0"
     $scope.importDateFilter = "0"
 
-  confirm_unsaved_changes = () -> (DirtyProducts.count() > 0 and confirm(t("unsaved_changes_confirmation"))) or (DirtyProducts.count() == 0)
+  confirm_unsaved_changes = () ->
+    (DirtyProducts.count() > 0 and confirm(t("unsaved_changes_confirmation"))) or (DirtyProducts.count() == 0)
   
-  editProductUrl = (product, variant) -> "/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit"
+  editProductUrl = (product, variant) ->
+    "/admin/products/" + product.permalink_live + ((if variant then "/variants/" + variant.id else "")) + "/edit"
 
   $scope.editWarn = (product, variant) ->
     if confirm_unsaved_changes()

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -513,7 +513,7 @@ feature '
         visit spree.admin_products_path
       end
 
-      it "shows an edit button for products, which takes the user to the standard edit page for that product" do
+      it "shows an edit button for products, which takes the user to the standard edit page for that product in a new window" do
         expect(page).to have_selector "a.edit-product", count: 2
 
         new_window = window_opened_by do 
@@ -528,7 +528,7 @@ feature '
         end
       end
 
-      it "shows an edit button for variants, which takes the user to the standard edit page for that variant" do
+      it "shows an edit button for variants, which takes the user to the standard edit page for that variant in a new window" do
         expect(page).to have_selector "a.view-variants"
         all("a.view-variants").each(&:click)
 

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -516,11 +516,16 @@ feature '
       it "shows an edit button for products, which takes the user to the standard edit page for that product" do
         expect(page).to have_selector "a.edit-product", count: 2
 
-        within "tr#p_#{p1.id}" do
-          find("a.edit-product").click
+        new_window = window_opened_by do 
+          within "tr#p_#{p1.id}" do
+            find("a.edit-product").click
+          end
         end
 
-        expect(URI.parse(current_url).path).to eq "/admin/products/#{p1.permalink}/edit"
+        within_window new_window do
+          expect(URI.parse(current_url).path).to eq "/admin/products/#{p1.permalink}/edit"
+          page.execute_script('window.close()')
+        end
       end
 
       it "shows an edit button for variants, which takes the user to the standard edit page for that variant" do
@@ -529,11 +534,16 @@ feature '
 
         expect(page).to have_selector "a.edit-variant", count: 2
 
-        within "tr#v_#{v1.id}" do
-          find("a.edit-variant").click
+        new_window = window_opened_by do 
+          within "tr#v_#{v1.id}" do
+            find("a.edit-variant").click
+          end
         end
 
-        expect(URI.parse(current_url).path).to eq "/admin/products/#{v1.product.permalink}/variants/#{v1.id}/edit"
+        within_window new_window do
+          expect(URI.parse(current_url).path).to eq "/admin/products/#{v1.product.permalink}/variants/#{v1.id}/edit"
+          page.execute_script('window.close()')
+        end
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #4338

This PR changes the `window.location...` action attached to the admin/product edit buttons to use `window.open('...', '_blank')` instead, which has the effect of opening a new tab. 

This was requested as a short term solution to losing page filters when editing a product.

#### What should we test?
Click the edit button for a product on the admin/products page to confirm new tab.


#### Release notes
Updates the edit button action on the admin/products page to open a new tab, in order to preserve filters on the products page.

Changelog Category: Changed