### PR TITLE
Add constraint to validate unit_value and unit_description are not null at the same time for a given variant

### DIFF
--- a/db/migrate/20191003091125_add_variant_unit_value_unit_description_not_null_constraint.rb
+++ b/db/migrate/20191003091125_add_variant_unit_value_unit_description_not_null_constraint.rb
@@ -1,0 +1,10 @@
+# Ensures variant.unit_value and variant.unit_description are not null at the same time for a given variant
+class AddVariantUnitValueUnitDescriptionNotNullConstraint < ActiveRecord::Migration
+  def up
+    execute "ALTER TABLE spree_variants ADD CONSTRAINT unit_value_or_unit_desc CHECK (unit_value is not null or unit_description is not null);"
+  end
+
+  def down
+    execute "ALTER TABLE spree_variants DROP CONSTRAINT unit_value_or_unit_desc;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190916110029) do
+ActiveRecord::Schema.define(:version => 20191003091125) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"


### PR DESCRIPTION
This is already done at AR Variant model level [here](https://github.com/openfoodfoundation/openfoodnetwork/blob/e6408161dbefc7da320b247ed5ac97472602c325/app/models/spree/variant_decorator.rb#L23)

#### What? Why?

Closes #4216

This will prevent 4216 from happening again. If the situation happens again, it will not break the OC page and we will see a bugsnag message with the SQL error.

#### What should we test?
There were no examples in live DBs with the problem so we can just verify the deployment works in staging.

#### Release notes
Changelog Category: Fixed
Added verification to avoid issue #4216 from happening again.
