### PR TITLE
Add missing translation in non English enterprise welcome email

### DIFF
--- a/app/views/enterprise_mailer/welcome.html.haml
+++ b/app/views/enterprise_mailer/welcome.html.haml
@@ -1,18 +1,17 @@
 %h3
-  = "#{t(:email_welcome)}!"
+  = "#{t(".email_welcome")}!"
 %p.lead
   %strong
     = @enterprise.name
-  = "#{t(:email_registered)} #{ Spree::Config.site_name }!"
+  = "#{t(".email_registered")} #{ Spree::Config.site_name }!"
 
 %p
-  = t :email_userguide_html, link: link_to(t(:userguide), ContentConfig.user_guide_link)
+  = t(".email_userguide_html", link: link_to(t(".userguide"), ContentConfig.user_guide_link))
+%p
+  = t(".email_admin_html", link: link_to(t(".admin_panel"), spree.admin_url))
 
 %p
-  = t :email_admin_html, link: link_to(t(:admin_panel), spree.admin_url)
-
-%p
-  = t :email_community_html, link: link_to(t(:join_community), ContentConfig.community_forum_url)
+  = t(".email_community_html", link: link_to(t(".join_community"), ContentConfig.community_forum_url))
 
 = render 'shared/mailers/signoff'
 

--- a/app/views/enterprise_mailer/welcome.html.haml
+++ b/app/views/enterprise_mailer/welcome.html.haml
@@ -6,10 +6,10 @@
   = "#{t(:email_registered)} #{ Spree::Config.site_name }!"
 
 %p
-  = t :email_userguide_html, link: link_to('Open Food Network User Guide', ContentConfig.user_guide_link)
+  = t :email_userguide_html, link: link_to(t(:userguide), ContentConfig.user_guide_link)
 
 %p
-  = t :email_admin_html, link: link_to('Admin Panel', spree.admin_url)
+  = t :email_admin_html, link: link_to(t(:admin_panel), spree.admin_url)
 
 %p
   = t :email_community_html, link: link_to(t(:join_community), ContentConfig.community_forum_url)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,14 @@ en:
       subject: "Please confirm the email address for %{enterprise}"
     welcome:
       subject: "%{enterprise} is now on %{sitename}"
+      email_welcome: "Welcome"
+      email_registered: "is now part of"
+      email_userguide_html: "The User Guide with detailed support for setting up your Producer or Hub is here: %{link}"
+      userguide: "Open Food Network User Guide"
+      email_admin_html: "You can manage your account by logging into the %{link} or by clicking on the cog in the top right hand side of the homepage, and selecting Administration."
+      admin_panel: "Admin Panel"
+      email_community_html: "We also have an online forum for community discussion related to OFN software and the unique challenges of running a food enterprise. You are encouraged to join in. We are constantly evolving and your input into this forum will shape what happens next. %{link}"
+      join_community: "Join the community"
     invite_manager:
       subject: "%{enterprise} has invited you to be a manager"
   producer_mailer:
@@ -1476,17 +1484,7 @@ en:
   products_at: "at %{distributor}"
   products_elsewhere: "Products found elsewhere"
 
-  email_welcome: "Welcome"
   email_confirmed: "Thank you for confirming your email address."
-  email_registered: "is now part of"
-  email_userguide_html: "The User Guide with detailed support for setting up your Producer or Hub is here:
-%{link}"
-  userguide: "Open Food Network User Guide"
-  email_admin_html: "You can manage your account by logging into the %{link} or by clicking on the cog in the top right hand side of the homepage, and selecting Administration."
-  admin_panel: "Admin Panel"
-  email_community_html: "We also have an online forum for community discussion related to OFN software and the unique challenges of running a food enterprise. You are encouraged to join in. We are constantly evolving and your input into this forum will shape what happens next.
-%{link}"
-  join_community: "Join the community"
   email_confirmation_activate_account: "Before we can activate your new account, we need to confirm your email address."
   email_confirmation_greeting: "Hi, %{contact}!"
   email_confirmation_profile_created: "A profile for %{name} has been successfully created!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1481,7 +1481,9 @@ en:
   email_registered: "is now part of"
   email_userguide_html: "The User Guide with detailed support for setting up your Producer or Hub is here:
 %{link}"
+  userguide: "Open Food Network User Guide"
   email_admin_html: "You can manage your account by logging into the %{link} or by clicking on the cog in the top right hand side of the homepage, and selecting Administration."
+  admin_panel: "Admin Panel"
   email_community_html: "We also have an online forum for community discussion related to OFN software and the unique challenges of running a food enterprise. You are encouraged to join in. We are constantly evolving and your input into this forum will shape what happens next.
 %{link}"
   join_community: "Join the community"


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/4100

Two strings are not translated in the welcome email an enterprise receive when a new enterprise is created on the OFN

#### What should we test?

In Rails console, call `EnterpriseMailer.welcome` to any enterprise account.
```ruby
enterprise = Enterprise.first
EnterpriseMailer.welcome(enterprise).deliver
```
Check the result in `tmp/letter_opener/.../rich.html`

![Captura de tela de 2019-10-05 17-04-48](https://user-images.githubusercontent.com/31378037/66260289-1d579a80-e793-11e9-9093-4cc97689ede4.png)

Added by @kristinalim:

Limited testing can be done for this in staging, because translations for other locales will not be available yet until this PR is merged into master and translations from Transifex are pulled in.

For now, we can only test the `en` locale, which staging Australia has as "English". You can deploy this in Australia staging, then:

1. Switch to English there (`en`).
2. Create a new enterprise.
3. Check the welcome email. There should be no obvious issues.

#### Release notes

Changelog Category: Added
Added translation to _"Open Food Network User Guidefred"_ and _"Admin Panel"_ links
