### PR TITLE
 #3832 - Added color to links in WYSIWYG editor

### DIFF
--- a/app/assets/stylesheets/admin/openfoodnetwork.css.scss
+++ b/app/assets/stylesheets/admin/openfoodnetwork.css.scss
@@ -255,6 +255,9 @@ text-angular {
       background-color: #4583bf;
     }
   }
+  a {
+    color: $spree-green
+  }
 }
 
 span.required {


### PR DESCRIPTION
#### What? Why?

The links weren't highlighted, so links were difficult to detect when the text was being edited unless you hover over the word.

Closes #3832 

This change is needed for a better experience using the WYSIWYG editor

#### What should we test?
You should test it as the issue says: 

1.  Go to the settings page for an enterprise. Open the "About" tab.
2. Insert a link in the WYSIWYG editor for "About Us". You should see now the link highlighted, even without hovering over it

![Screenshot from 2019-10-07 12-19-35](https://user-images.githubusercontent.com/20052127/66327617-7e9d7c00-e901-11e9-96f9-ae37afc6550b.png)


#### Release notes

Added color to links in WYSIWYG editor in admin.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added 

#### Discourse thread

No.

#### Dependencies

No.

#### Documentation updates

No.

