### PR TITLE
4256 Configure dalli store value max bytes from env variable

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -56,3 +56,5 @@ SMTP_PASSWORD: 'f00d'
 # STRIPE_INSTANCE_PUBLISHABLE_KEY: "pk_test_xxxx" # This can be a test key or a live key
 # STRIPE_CLIENT_ID: "ca_xxxx" # This can be a development ID or a production ID
 # STRIPE_ENDPOINT_SECRET: "whsec_xxxx"
+
+MEMCACHED_VALUE_MAX_MEGABYTES: 4

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,9 @@ Openfoodnetwork::Application.configure do
   # config.logger = SyslogLogger.new
 
   # Use a different cache store in production
-  config.cache_store = :dalli_store
+  memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i
+  memcached_value_max_bytes = memcached_value_max_megabytes * 1024 * 1024
+  config.cache_store = :dalli_store, { value_max_bytes: memcached_value_max_bytes }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -40,7 +40,9 @@ Openfoodnetwork::Application.configure do
   # config.logger = SyslogLogger.new
 
   # Use a different cache store in production
-  config.cache_store = :dalli_store
+  memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i
+  memcached_value_max_bytes = memcached_value_max_megabytes * 1024 * 1024
+  config.cache_store = :dalli_store, { value_max_bytes: memcached_value_max_bytes }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"


### PR DESCRIPTION
#### What? Why?

- References #4256

We need larger data to be stored in the Rails cache. PR https://github.com/openfoodfoundation/ofn-install/pull/531 takes care of configuring the memcached server to use 4 MB. But additionally, the memcached client which in this case is `dalli` also needs to be configured to allow storing values up to this size.

The `ofn-install` PR is not a requirement for this PR - we use the default value of 1 MB when no `MEMCACHED_VALUE_MAX_MEGABYTES` environment variable is specified, so we should be okay.

In the `dalli` gem, the default value of `value_max_bytes` is 1 MB (`1 * 1024 * 1024`). See [here](https://github.com/petergoldstein/dalli/blob/v2.7.10/lib/dalli/server.rb#L25-L26).

#### What should we test?

`dev-test`: Test that storing objects up to 4 MB works. The following code for 1 MB will be helpful:

```
cache_key = "sample-test"
megabytes = 1

Rails.cache.fetch(cache_key)
# => nil
Rails.cache.write(cache_key, "." * (megabytes * 1024 * 1024 - 100))
# => 6064378373231083520
Rails.cache.fetch(cache_key).length
# => 1048476
Rails.cache.write(cache_key, "." * (megabytes * 1024 * 1024 + 100))
# => false
Rails.cache.fetch(cache_key).length
# => 1048476
Rails.cache.delete(cache_key)
Rails.cache.fetch(cache_key)
# => nil
```

A quick manual test also that shopfront loads fine should be done as well.

#### Release notes

- Allow maximum `memcached` value size to be specified as an environment variable, to allow data of larger shops to be cached in order to improve performance.

Changelog Category: Changed

#### Dependencies

Ideal if https://github.com/openfoodfoundation/ofn-install/pull/531 could be merged and provisioned before this PR is deployed, but not required.