### PR TITLE
Add asterisks to required fields in New Order Cycle form

### DIFF
--- a/app/views/admin/order_cycles/_name_and_timing_form.html.haml
+++ b/app/views/admin/order_cycles/_name_and_timing_form.html.haml
@@ -1,6 +1,7 @@
 .row
   .alpha.two.columns
     = f.label :name, t('.name')
+    %span.required *
   .six.columns.omega
     - if viewing_as_coordinator_of?(@order_cycle)
       = f.text_field :name, 'ng-model' => 'order_cycle.name', 'required' => true, 'ng-disabled' => '!loaded()'
@@ -8,6 +9,7 @@
       {{ order_cycle.name }}
   .two.columns
     = f.label :orders_open_at, t('.orders_open')
+    %span.required *
   .omega.six.columns
     - if viewing_as_coordinator_of?(@order_cycle)
       = f.text_field :orders_open_at, 'datetimepicker' => 'order_cycle.orders_open_at', 'ng-model' => 'order_cycle.orders_open_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'
@@ -21,6 +23,7 @@
     = @order_cycle.coordinator.name
   .two.columns
     = f.label :orders_close, t('.orders_close')
+    %span.required *
   .six.columns.omega
     - if viewing_as_coordinator_of?(@order_cycle)
       = f.text_field :orders_close_at, 'datetimepicker' => 'order_cycle.orders_close_at', 'ng-model' => 'order_cycle.orders_close_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'

--- a/app/views/admin/order_cycles/_name_and_timing_form.html.haml
+++ b/app/views/admin/order_cycles/_name_and_timing_form.html.haml
@@ -9,7 +9,6 @@
       {{ order_cycle.name }}
   .two.columns
     = f.label :orders_open_at, t('.orders_open')
-    %span.required *
   .omega.six.columns
     - if viewing_as_coordinator_of?(@order_cycle)
       = f.text_field :orders_open_at, 'datetimepicker' => 'order_cycle.orders_open_at', 'ng-model' => 'order_cycle.orders_open_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'
@@ -23,7 +22,6 @@
     = @order_cycle.coordinator.name
   .two.columns
     = f.label :orders_close, t('.orders_close')
-    %span.required *
   .six.columns.omega
     - if viewing_as_coordinator_of?(@order_cycle)
       = f.text_field :orders_close_at, 'datetimepicker' => 'order_cycle.orders_close_at', 'ng-model' => 'order_cycle.orders_close_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'

--- a/app/views/admin/order_cycles/_simple_form.html.haml
+++ b/app/views/admin/order_cycles/_simple_form.html.haml
@@ -3,6 +3,7 @@
 .row
   .alpha.two.columns
     = label_tag t('.ready_for')
+    %span.required *
   .six.columns
     = text_field_tag 'order_cycle_outgoing_exchange_0_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_0_pickup_time', 'required' => 'required', 'placeholder' => t('.ready_for_placeholder'), 'ng-model' => 'outgoing_exchange.pickup_time', 'size' => 30, 'maxlength' => 35
     %span.icon-question-sign{'ofn-with-tip' => t('admin.order_cycles.exchange_form.pickup_time_tip')}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -928,7 +928,7 @@ en:
         new_schedule: New Schedule
       name_and_timing_form:
         name: Name
-        orders_open: Orders open at
+        orders_open: Orders open
         coordinator: Coordinator
         orders_close: Orders close
       row:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -928,7 +928,7 @@ en:
         new_schedule: New Schedule
       name_and_timing_form:
         name: Name
-        orders_open: Orders open
+        orders_open: Orders open at
         coordinator: Coordinator
         orders_close: Orders close
       row:

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -181,10 +181,16 @@ feature '
       select2_select 'My coordinator', from: 'coordinator_id'
       click_button "Continue >"
 
-      # And I fill in the basic fields
+      # I cannot save before filling in the required fields
+      expect(page).to have_button("Create", disabled: true)
+
+      # After I fill in the basic fields
       fill_in 'order_cycle_name', with: 'Plums & Avos'
       fill_in 'order_cycle_orders_open_at', with: order_cycle_opening_time
       fill_in 'order_cycle_orders_close_at', with: order_cycle_closing_time
+
+      # I can save the form
+      expect(page).to have_button("Create", disabled: false)
 
       # And I add a coordinator fee
       click_button 'Add coordinator fee'
@@ -998,12 +1004,18 @@ feature '
       visit admin_order_cycles_path
       click_link 'New Order Cycle'
 
-      # And I fill in the basic fields
+      # I cannot save without the required fields
+      expect(page).to have_button('Create', disabled: true)
+
+      # After I fill in the basic fields
       fill_in 'order_cycle_name', with: 'Plums & Avos'
       fill_in 'order_cycle_orders_open_at', with: '2040-10-17 06:00:00'
       fill_in 'order_cycle_orders_close_at', with: '2040-10-24 17:00:00'
       fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
       fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
+
+      # I can save the form
+      expect(page).to have_button('Create', disabled: false)
 
       # Then my products / variants should already be selected
       expect(page).to have_checked_field "order_cycle_incoming_exchange_0_variants_#{v1.id}"

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -153,7 +153,7 @@ feature '
     let(:order_cycle_opening_time) { Time.zone.local(2040, 11, 0o6, 0o6, 0o0, 0o0).strftime("%F %T %z") }
     let(:order_cycle_closing_time) { Time.zone.local(2040, 11, 13, 17, 0o0, 0o0).strftime("%F %T %z") }
 
-    scenario "creating an order cycle", js: true do
+    scenario "creating an order cycle with full interface", js: true do
       # Given coordinating, supplying and distributing enterprises with some products with variants
       coordinator = create(:distributor_enterprise, name: 'My coordinator')
       supplier = create(:supplier_enterprise, name: 'My supplier')
@@ -184,13 +184,13 @@ feature '
       # I cannot save before filling in the required fields
       expect(page).to have_button("Create", disabled: true)
 
-      # After I fill in the basic fields
+      # The Create button is enabled once Name is entered
       fill_in 'order_cycle_name', with: 'Plums & Avos'
+      expect(page).to have_button("Create", disabled: false)
+
+      # If I fill in the basic fields
       fill_in 'order_cycle_orders_open_at', with: order_cycle_opening_time
       fill_in 'order_cycle_orders_close_at', with: order_cycle_closing_time
-
-      # I can save the form
-      expect(page).to have_button("Create", disabled: false)
 
       # And I add a coordinator fee
       click_button 'Add coordinator fee'
@@ -1007,15 +1007,15 @@ feature '
       # I cannot save without the required fields
       expect(page).to have_button('Create', disabled: true)
 
-      # After I fill in the basic fields
+      # The Create button is enabled once the mandatory fields are entered
       fill_in 'order_cycle_name', with: 'Plums & Avos'
+      fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
+      expect(page).to have_button('Create', disabled: false)
+
+      # If I fill in the basic fields
       fill_in 'order_cycle_orders_open_at', with: '2040-10-17 06:00:00'
       fill_in 'order_cycle_orders_close_at', with: '2040-10-24 17:00:00'
-      fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
       fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
-
-      # I can save the form
-      expect(page).to have_button('Create', disabled: false)
 
       # Then my products / variants should already be selected
       expect(page).to have_checked_field "order_cycle_incoming_exchange_0_variants_#{v1.id}"


### PR DESCRIPTION
#### Closes #3910

Although the "Create" button is not enabled unless these required fields are complete, this clarifies workflow for users/admins while creating a new order cycle.

#### What should we test?

One item to look out for is an adjustment to an `en.yml` value - the English translation of "Orders Open At" was trimmed to "Orders Open" to match "Orders Close" and to keep this on one line with the asterisk.

#### Release notes

I believe this covers both user and admin use cases - let me know if any changes are needed!

Changelog Category: Added