### PR TITLE
Fix error during first run of docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       POSTGRES_PASSWORD: f00d
       POSTGRES_USER: ofn
+      POSTGRES_DB: open_food_network_dev
     volumes:
       - 'postgres:/var/lib/postgresql/data'
   web:


### PR DESCRIPTION
Prior to this commit, the db container would create a database named
“ofn” (the same as $POSTGRES_USER).

Then, when the web container started, it would run `rake db:reset`. This
would load the Rails environment, which ends up requiring some model
files, which eventually end up trying to connect to the
“open_food_network_dev” database, which doesn’t exist. Therefore setting
up the database fails, and it’s impossible to boot the web container.

As a side note, I’m not convinced that bootstrapping the database as
part of the container’s command is the best strategy (if for no other
reason that this will wipe my database every time I run `docker-compose
up`). But this commit doesn’t change that.

What it does is add the $POSTGRES_DB environment variable so that the db
container creates the “open_food_network_dev” database (which is blank).
Then, when `rake db:reset` runs, it’ll successfully connect to this
(empty) database while loading the environment, before deleting and recreating it.

Note that I had to manually delete the `openfoodnetwork_postgres` volume
in order to reset my local state, after making this change.