### PR TITLE
4308 Refactor Orders and Fulfillment report subtypes

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -148,7 +148,6 @@ Metrics/LineLength:
   - lib/open_food_network/order_cycle_form_applicator.rb
   - lib/open_food_network/order_cycle_management_report.rb
   - lib/open_food_network/order_grouper.rb
-  - lib/open_food_network/orders_and_fulfillments_report.rb
   - lib/open_food_network/payments_report.rb
   - lib/open_food_network/permalink_generator.rb
   - lib/open_food_network/products_cache.rb
@@ -454,7 +453,6 @@ Metrics/AbcSize:
   - lib/open_food_network/order_cycle_form_applicator.rb
   - lib/open_food_network/order_cycle_management_report.rb
   - lib/open_food_network/order_cycle_permissions.rb
-  - lib/open_food_network/orders_and_fulfillments_report.rb
   - lib/open_food_network/packing_report.rb
   - lib/open_food_network/payments_report.rb
   - lib/open_food_network/permissions.rb
@@ -532,7 +530,6 @@ Metrics/CyclomaticComplexity:
   - lib/discourse/single_sign_on.rb
   - lib/open_food_network/bulk_coop_report.rb
   - lib/open_food_network/enterprise_issue_validator.rb
-  - lib/open_food_network/orders_and_fulfillments_report.rb
   - lib/spree/core/controller_helpers/order_decorator.rb
   - lib/spree/core/controller_helpers/respond_with_decorator.rb
   - lib/spree/localized_number.rb
@@ -557,7 +554,6 @@ Metrics/PerceivedComplexity:
   - lib/discourse/single_sign_on.rb
   - lib/open_food_network/bulk_coop_report.rb
   - lib/open_food_network/enterprise_issue_validator.rb
-  - lib/open_food_network/orders_and_fulfillments_report.rb
   - lib/spree/core/controller_helpers/order_decorator.rb
   - lib/spree/core/controller_helpers/respond_with_decorator.rb
   - lib/spree/localized_number.rb
@@ -627,7 +623,6 @@ Metrics/MethodLength:
   - lib/open_food_network/order_cycle_management_report.rb
   - lib/open_food_network/order_cycle_permissions.rb
   - lib/open_food_network/order_grouper.rb
-  - lib/open_food_network/orders_and_fulfillments_report.rb
   - lib/open_food_network/packing_report.rb
   - lib/open_food_network/payments_report.rb
   - lib/open_food_network/permissions.rb
@@ -671,7 +666,6 @@ Metrics/ClassLength:
   - lib/open_food_network/order_cycle_form_applicator.rb
   - lib/open_food_network/order_cycle_management_report.rb
   - lib/open_food_network/order_cycle_permissions.rb
-  - lib/open_food_network/orders_and_fulfillments_report.rb
   - lib/open_food_network/packing_report.rb
   - lib/open_food_network/payments_report.rb
   - lib/open_food_network/permissions.rb

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -9,17 +9,17 @@ include Spree::ReportsHelper
 
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
-    attr_reader :options
+    attr_reader :options, :report_type
 
     def initialize(permissions, options = {}, render_table = false)
       @options = options
+      @report_type = options[:report_type]
       @permissions = permissions
       @render_table = render_table
     end
 
     def header
-      case options[:report_type]
-
+      case report_type
       when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).header
       when SupplierTotalsByDistributorReport::REPORT_TYPE
@@ -43,7 +43,7 @@ module OpenFoodNetwork
     end
 
     def rules
-      case options[:report_type]
+      case report_type
       when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).rules
       when SupplierTotalsByDistributorReport::REPORT_TYPE
@@ -60,7 +60,7 @@ module OpenFoodNetwork
     # Returns a proc for each column displayed in each report type containing
     # the logic to compute the value for each cell.
     def columns
-      case options[:report_type]
+      case report_type
       when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).columns
       when SupplierTotalsByDistributorReport::REPORT_TYPE

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -1,4 +1,5 @@
 require "open_food_network/reports/line_items"
+require "open_food_network/orders_and_fulfillments_report/supplier_totals_report"
 require 'open_food_network/orders_and_fulfillments_report/default_report'
 
 include Spree::ReportsHelper
@@ -17,9 +18,7 @@ module OpenFoodNetwork
       case options[:report_type]
 
       when "order_cycle_supplier_totals"
-        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
-         I18n.t(:report_header_total_units), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
-         I18n.t(:report_header_status), I18n.t(:report_header_incoming_transport)]
+        SupplierTotalsReport.new(self).header
       when "order_cycle_supplier_totals_by_distributor"
         [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
          I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
@@ -59,20 +58,7 @@ module OpenFoodNetwork
     def rules
       case options[:report_type]
       when "order_cycle_supplier_totals"
-        [
-          {
-            group_by: proc { |line_item| line_item.variant.product.supplier },
-            sort_by: proc { |supplier| supplier.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.product },
-            sort_by: proc { |product| product.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.full_name },
-            sort_by: proc { |full_name| full_name }
-          }
-        ]
+        SupplierTotalsReport.new(self).rules
       when "order_cycle_supplier_totals_by_distributor"
         [
           {
@@ -207,17 +193,7 @@ module OpenFoodNetwork
     def columns
       case options[:report_type]
       when "order_cycle_supplier_totals"
-        [
-          supplier_name,
-          product_name,
-          line_items_name,
-          proc { |line_items| line_items.sum(&:quantity) },
-          proc { |line_items| total_units(line_items) },
-          proc { |line_items| line_items.first.price },
-          proc { |line_items| line_items.sum(&:amount) },
-          proc { |_line_items| "" },
-          proc { |_line_items| I18n.t(:report_header_incoming_transport) }
-        ]
+        SupplierTotalsReport.new(self).columns
       when "order_cycle_supplier_totals_by_distributor"
         [
           supplier_name,

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -1,5 +1,6 @@
 require "open_food_network/reports/line_items"
 require "open_food_network/orders_and_fulfillments_report/supplier_totals_report"
+require "open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report"
 require 'open_food_network/orders_and_fulfillments_report/default_report'
 
 include Spree::ReportsHelper
@@ -19,10 +20,8 @@ module OpenFoodNetwork
 
       when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).header
-      when "order_cycle_supplier_totals_by_distributor"
-        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
-         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
-         I18n.t(:report_header_shipping_method)]
+      when SupplierTotalsByDistributorReport::REPORT_TYPE
+        SupplierTotalsByDistributorReport.new(self).header
       when "order_cycle_distributor_totals_by_supplier"
         [I18n.t(:report_header_hub), I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant),
          I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
@@ -59,35 +58,8 @@ module OpenFoodNetwork
       case options[:report_type]
       when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).rules
-      when "order_cycle_supplier_totals_by_distributor"
-        [
-          {
-            group_by: proc { |line_item| line_item.variant.product.supplier },
-            sort_by: proc { |supplier| supplier.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.product },
-            sort_by: proc { |product| product.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.full_name },
-            sort_by: proc { |full_name| full_name },
-            summary_columns: [
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| I18n.t('admin.reports.total') },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |line_items| line_items.sum(&:amount) },
-              proc { |_line_items| "" }
-            ]
-          },
-          {
-            group_by: proc { |line_item| line_item.order.distributor },
-            sort_by: proc { |distributor| distributor.name }
-          }
-        ]
+      when SupplierTotalsByDistributorReport::REPORT_TYPE
+        SupplierTotalsByDistributorReport.new(self).rules
       when "order_cycle_distributor_totals_by_supplier"
         [
           {
@@ -194,17 +166,8 @@ module OpenFoodNetwork
       case options[:report_type]
       when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).columns
-      when "order_cycle_supplier_totals_by_distributor"
-        [
-          supplier_name,
-          proc { |line_items| line_items.first.variant.product.name },
-          proc { |line_items| line_items.first.variant.full_name },
-          proc { |line_items| line_items.first.order.distributor.name },
-          proc { |line_items| line_items.sum(&:quantity) },
-          proc { |line_items| line_items.first.price },
-          proc { |line_items| line_items.sum(&:amount) },
-          proc { |_line_items| I18n.t(:report_header_shipping_method) }
-        ]
+      when SupplierTotalsByDistributorReport::REPORT_TYPE
+        SupplierTotalsByDistributorReport.new(self).columns
       when "order_cycle_distributor_totals_by_supplier"
         [proc { |line_items| line_items.first.order.distributor.name },
          proc { |line_items| line_items.first.variant.product.supplier.name },

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -11,15 +11,13 @@ module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     attr_reader :options, :report_type
 
+    delegate :header, :rules, :columns, to: :report
+
     def initialize(permissions, options = {}, render_table = false)
       @options = options
       @report_type = options[:report_type]
       @permissions = permissions
       @render_table = render_table
-    end
-
-    def header
-      report.header
     end
 
     def search
@@ -29,16 +27,6 @@ module OpenFoodNetwork
     def table_items
       return [] unless @render_table
       Reports::LineItems.list(permissions, options)
-    end
-
-    def rules
-      report.rules
-    end
-
-    # Returns a proc for each column displayed in each report type containing
-    # the logic to compute the value for each cell.
-    def columns
-      report.columns
     end
 
     private

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -5,15 +5,16 @@ include Spree::ReportsHelper
 
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
-    attr_reader :params
-    def initialize(permissions, params = {}, render_table = false)
-      @params = params
+    attr_reader :options
+
+    def initialize(permissions, options = {}, render_table = false)
+      @options = options
       @permissions = permissions
       @render_table = render_table
     end
 
     def header
-      case params[:report_type]
+      case options[:report_type]
 
       when "order_cycle_supplier_totals"
         [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
@@ -47,16 +48,16 @@ module OpenFoodNetwork
     end
 
     def search
-      Reports::LineItems.search_orders(permissions, params)
+      Reports::LineItems.search_orders(permissions, options)
     end
 
     def table_items
       return [] unless @render_table
-      Reports::LineItems.list(permissions, params)
+      Reports::LineItems.list(permissions, options)
     end
 
     def rules
-      case params[:report_type]
+      case options[:report_type]
       when "order_cycle_supplier_totals"
         [
           {
@@ -204,7 +205,7 @@ module OpenFoodNetwork
     # Returns a proc for each column displayed in each report type containing
     # the logic to compute the value for each cell.
     def columns
-      case params[:report_type]
+      case options[:report_type]
       when "order_cycle_supplier_totals"
         [
           supplier_name,

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -19,18 +19,7 @@ module OpenFoodNetwork
     end
 
     def header
-      case report_type
-      when SupplierTotalsReport::REPORT_TYPE
-        SupplierTotalsReport.new(self).header
-      when SupplierTotalsByDistributorReport::REPORT_TYPE
-        SupplierTotalsByDistributorReport.new(self).header
-      when DistributorTotalsBySupplierReport::REPORT_TYPE
-        DistributorTotalsBySupplierReport.new(self).header
-      when CustomerTotalsReport::REPORT_TYPE
-        CustomerTotalsReport.new(self).header
-      else
-        DefaultReport.new(self).header
-      end
+      report_klass.new(self).header
     end
 
     def search
@@ -43,40 +32,33 @@ module OpenFoodNetwork
     end
 
     def rules
-      case report_type
-      when SupplierTotalsReport::REPORT_TYPE
-        SupplierTotalsReport.new(self).rules
-      when SupplierTotalsByDistributorReport::REPORT_TYPE
-        SupplierTotalsByDistributorReport.new(self).rules
-      when DistributorTotalsBySupplierReport::REPORT_TYPE
-        DistributorTotalsBySupplierReport.new(self).rules
-      when CustomerTotalsReport::REPORT_TYPE
-        CustomerTotalsReport.new(self).rules
-      else
-        DefaultReport.new(self).rules
-      end
+      report_klass.new(self).rules
     end
 
     # Returns a proc for each column displayed in each report type containing
     # the logic to compute the value for each cell.
     def columns
-      case report_type
-      when SupplierTotalsReport::REPORT_TYPE
-        SupplierTotalsReport.new(self).columns
-      when SupplierTotalsByDistributorReport::REPORT_TYPE
-        SupplierTotalsByDistributorReport.new(self).columns
-      when DistributorTotalsBySupplierReport::REPORT_TYPE
-        DistributorTotalsBySupplierReport.new(self).columns
-      when CustomerTotalsReport::REPORT_TYPE
-        CustomerTotalsReport.new(self).columns
-      else
-        DefaultReport.new(self).columns
-      end
+      report_klass.new(self).columns
     end
 
     private
 
     attr_reader :permissions
+
+    def report_klass
+      case report_type
+      when SupplierTotalsReport::REPORT_TYPE
+        SupplierTotalsReport
+      when SupplierTotalsByDistributorReport::REPORT_TYPE
+        SupplierTotalsByDistributorReport
+      when DistributorTotalsBySupplierReport::REPORT_TYPE
+        DistributorTotalsBySupplierReport
+      when CustomerTotalsReport::REPORT_TYPE
+        CustomerTotalsReport
+      else
+        DefaultReport
+      end
+    end
 
     def supplier_name
       proc { |line_items| line_items.first.variant.product.supplier.name }

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -39,14 +39,10 @@ module OpenFoodNetwork
 
     def report_klass
       case report_type
-      when SupplierTotalsReport::REPORT_TYPE
-        SupplierTotalsReport
-      when SupplierTotalsByDistributorReport::REPORT_TYPE
-        SupplierTotalsByDistributorReport
-      when DistributorTotalsBySupplierReport::REPORT_TYPE
-        DistributorTotalsBySupplierReport
-      when CustomerTotalsReport::REPORT_TYPE
-        CustomerTotalsReport
+      when SupplierTotalsReport::REPORT_TYPE then SupplierTotalsReport
+      when SupplierTotalsByDistributorReport::REPORT_TYPE then SupplierTotalsByDistributorReport
+      when DistributorTotalsBySupplierReport::REPORT_TYPE then DistributorTotalsBySupplierReport
+      when CustomerTotalsReport::REPORT_TYPE then CustomerTotalsReport
       else
         DefaultReport
       end

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -17,7 +17,7 @@ module OpenFoodNetwork
     def header
       case options[:report_type]
 
-      when "order_cycle_supplier_totals"
+      when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).header
       when "order_cycle_supplier_totals_by_distributor"
         [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
@@ -57,7 +57,7 @@ module OpenFoodNetwork
 
     def rules
       case options[:report_type]
-      when "order_cycle_supplier_totals"
+      when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).rules
       when "order_cycle_supplier_totals_by_distributor"
         [
@@ -192,7 +192,7 @@ module OpenFoodNetwork
     # the logic to compute the value for each cell.
     def columns
       case options[:report_type]
-      when "order_cycle_supplier_totals"
+      when SupplierTotalsReport::REPORT_TYPE
         SupplierTotalsReport.new(self).columns
       when "order_cycle_supplier_totals_by_distributor"
         [

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -1,6 +1,7 @@
 require "open_food_network/reports/line_items"
 require "open_food_network/orders_and_fulfillments_report/supplier_totals_report"
 require "open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report"
+require "open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report"
 require 'open_food_network/orders_and_fulfillments_report/default_report'
 
 include Spree::ReportsHelper
@@ -22,10 +23,8 @@ module OpenFoodNetwork
         SupplierTotalsReport.new(self).header
       when SupplierTotalsByDistributorReport::REPORT_TYPE
         SupplierTotalsByDistributorReport.new(self).header
-      when "order_cycle_distributor_totals_by_supplier"
-        [I18n.t(:report_header_hub), I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant),
-         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
-         I18n.t(:report_header_total_shipping_cost), I18n.t(:report_header_shipping_method)]
+      when DistributorTotalsBySupplierReport::REPORT_TYPE
+        DistributorTotalsBySupplierReport.new(self).header
       when "order_cycle_customer_totals"
         [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email), I18n.t(:report_header_phone),
          I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
@@ -60,36 +59,8 @@ module OpenFoodNetwork
         SupplierTotalsReport.new(self).rules
       when SupplierTotalsByDistributorReport::REPORT_TYPE
         SupplierTotalsByDistributorReport.new(self).rules
-      when "order_cycle_distributor_totals_by_supplier"
-        [
-          {
-            group_by: proc { |line_item| line_item.order.distributor },
-            sort_by: proc { |distributor| distributor.name },
-            summary_columns: [
-              proc { |_line_items| "" },
-              proc { |_line_items| I18n.t('admin.reports.total') },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |line_items| line_items.sum(&:amount) },
-              proc { |line_items| line_items.map(&:order).uniq.sum(&:ship_total) },
-              proc { |_line_items| "" }
-            ]
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.product.supplier },
-            sort_by: proc { |supplier| supplier.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.product },
-            sort_by: proc { |product| product.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.full_name },
-            sort_by: proc { |full_name| full_name }
-          }
-        ]
+      when DistributorTotalsBySupplierReport::REPORT_TYPE
+        DistributorTotalsBySupplierReport.new(self).rules
       when "order_cycle_customer_totals"
         [
           {
@@ -168,16 +139,8 @@ module OpenFoodNetwork
         SupplierTotalsReport.new(self).columns
       when SupplierTotalsByDistributorReport::REPORT_TYPE
         SupplierTotalsByDistributorReport.new(self).columns
-      when "order_cycle_distributor_totals_by_supplier"
-        [proc { |line_items| line_items.first.order.distributor.name },
-         proc { |line_items| line_items.first.variant.product.supplier.name },
-         proc { |line_items| line_items.first.variant.product.name },
-         proc { |line_items| line_items.first.variant.full_name },
-         proc { |line_items| line_items.sum(&:quantity) },
-         proc { |line_items| line_items.first.price },
-         proc { |line_items| line_items.sum(&:amount) },
-         proc { |_line_items| "" },
-         proc { |_line_items| I18n.t(:report_header_shipping_method) }]
+      when DistributorTotalsBySupplierReport::REPORT_TYPE
+        DistributorTotalsBySupplierReport.new(self).columns
       when "order_cycle_customer_totals"
         rsa = proc { |line_items| line_items.first.order.shipping_method.andand.delivery? }
         [

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -19,7 +19,7 @@ module OpenFoodNetwork
     end
 
     def header
-      report_klass.new(self).header
+      report.header
     end
 
     def search
@@ -32,18 +32,22 @@ module OpenFoodNetwork
     end
 
     def rules
-      report_klass.new(self).rules
+      report.rules
     end
 
     # Returns a proc for each column displayed in each report type containing
     # the logic to compute the value for each cell.
     def columns
-      report_klass.new(self).columns
+      report.columns
     end
 
     private
 
     attr_reader :permissions
+
+    def report
+      @report ||= report_klass.new(self)
+    end
 
     def report_klass
       case report_type

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -2,6 +2,7 @@ require "open_food_network/reports/line_items"
 require "open_food_network/orders_and_fulfillments_report/supplier_totals_report"
 require "open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report"
 require "open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report"
+require "open_food_network/orders_and_fulfillments_report/customer_totals_report"
 require 'open_food_network/orders_and_fulfillments_report/default_report'
 
 include Spree::ReportsHelper
@@ -25,20 +26,8 @@ module OpenFoodNetwork
         SupplierTotalsByDistributorReport.new(self).header
       when DistributorTotalsBySupplierReport::REPORT_TYPE
         DistributorTotalsBySupplierReport.new(self).header
-      when "order_cycle_customer_totals"
-        [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email), I18n.t(:report_header_phone),
-         I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
-         I18n.t(:report_header_item_price, currency: currency_symbol),
-         I18n.t(:report_header_item_fees_price, currency: currency_symbol),
-         I18n.t(:report_header_admin_handling_fees, currency: currency_symbol),
-         I18n.t(:report_header_ship_price, currency: currency_symbol),
-         I18n.t(:report_header_pay_fee_price, currency: currency_symbol),
-         I18n.t(:report_header_total_price, currency: currency_symbol),
-         I18n.t(:report_header_paid), I18n.t(:report_header_shipping), I18n.t(:report_header_delivery),
-         I18n.t(:report_header_ship_street), I18n.t(:report_header_ship_street_2), I18n.t(:report_header_ship_city), I18n.t(:report_header_ship_postcode), I18n.t(:report_header_ship_state),
-         I18n.t(:report_header_comments), I18n.t(:report_header_sku),
-         I18n.t(:report_header_order_cycle), I18n.t(:report_header_payment_method), I18n.t(:report_header_customer_code), I18n.t(:report_header_tags),
-         I18n.t(:report_header_billing_street), I18n.t(:report_header_billing_street_2), I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode), I18n.t(:report_header_billing_state),]
+      when CustomerTotalsReport::REPORT_TYPE
+        CustomerTotalsReport.new(self).header
       else
         DefaultReport.new(self).header
       end
@@ -61,71 +50,8 @@ module OpenFoodNetwork
         SupplierTotalsByDistributorReport.new(self).rules
       when DistributorTotalsBySupplierReport::REPORT_TYPE
         DistributorTotalsBySupplierReport.new(self).rules
-      when "order_cycle_customer_totals"
-        [
-          {
-            group_by: proc { |line_item| line_item.order.distributor },
-            sort_by: proc { |distributor| distributor.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.order },
-            sort_by: proc { |order| order.bill_address.full_name_reverse },
-            summary_columns: [
-              proc { |line_items| line_items.first.order.distributor.name },
-              proc { |line_items| line_items.first.order.bill_address.full_name },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| I18n.t('admin.reports.total') },
-              proc { |_line_items| "" },
-
-              proc { |_line_items| "" },
-              proc { |line_items| line_items.sum(&:amount) },
-              proc { |line_items| line_items.sum(&:amount_with_adjustments) },
-              proc { |line_items| line_items.first.order.admin_and_handling_total },
-              proc { |line_items| line_items.first.order.ship_total },
-              proc { |line_items| line_items.first.order.payment_fee },
-              proc { |line_items| line_items.first.order.total },
-              proc { |line_items| line_items.first.order.paid? ? I18n.t(:yes) : I18n.t(:no) },
-
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-
-              proc { |line_items| line_items.first.order.special_instructions },
-              proc { |_line_items| "" },
-
-              proc { |line_items| line_items.first.order.order_cycle.andand.name },
-              proc { |line_items|
-                line_items.first.order.payments.first.andand.payment_method.andand.name
-              },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" },
-              proc { |_line_items| "" }
-            ]
-          },
-          {
-            group_by: proc { |line_item| line_item.variant.product },
-            sort_by: proc { |product| product.name }
-          },
-          {
-            group_by: proc { |line_item| line_item.variant },
-            sort_by: proc { |variant| variant.full_name }
-          },
-          {
-            group_by: line_item_name,
-            sort_by: proc { |full_name| full_name }
-          }
-        ]
+      when CustomerTotalsReport::REPORT_TYPE
+        CustomerTotalsReport.new(self).rules
       else
         DefaultReport.new(self).rules
       end
@@ -141,49 +67,8 @@ module OpenFoodNetwork
         SupplierTotalsByDistributorReport.new(self).columns
       when DistributorTotalsBySupplierReport::REPORT_TYPE
         DistributorTotalsBySupplierReport.new(self).columns
-      when "order_cycle_customer_totals"
-        rsa = proc { |line_items| line_items.first.order.shipping_method.andand.delivery? }
-        [
-          proc { |line_items| line_items.first.order.distributor.name },
-          proc { |line_items| line_items.first.order.bill_address.firstname + " " + line_items.first.order.bill_address.lastname },
-          proc { |line_items| line_items.first.order.email },
-          proc { |line_items| line_items.first.order.bill_address.phone },
-          proc { |line_items| line_items.first.variant.product.supplier.name },
-          proc { |line_items| line_items.first.variant.product.name },
-          proc { |line_items| line_items.first.variant.full_name },
-
-          proc { |line_items| line_items.sum(&:quantity) },
-          proc { |line_items| line_items.sum(&:amount) },
-          proc { |line_items| line_items.sum(&:amount_with_adjustments) },
-          proc { |_line_items| "" },
-          proc { |_line_items| "" },
-          proc { |_line_items| "" },
-          proc { |_line_items| "" },
-          proc { |line_items| line_items.all? { |li| li.order.paid? } ? I18n.t(:yes) : I18n.t(:no) },
-
-          proc { |line_items| line_items.first.order.shipping_method.andand.name },
-          proc { |line_items| rsa.call(line_items) ? I18n.t(:yes) : I18n.t(:no) },
-
-          proc { |line_items| line_items.first.order.ship_address.andand.address1 if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.address2 if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.city if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.zipcode if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.state if rsa.call(line_items) },
-
-          proc { |_line_items| "" },
-          proc { |line_items| line_items.first.variant.sku },
-
-          proc { |line_items| line_items.first.order.order_cycle.andand.name },
-          proc { |line_items| line_items.first.order.payments.first.andand.payment_method.andand.name },
-          proc { |line_items| line_items.first.order.user.andand.customer_of(line_items.first.order.distributor).andand.code },
-          proc { |line_items| line_items.first.order.user.andand.customer_of(line_items.first.order.distributor).andand.tags.andand.join(', ') },
-
-          proc { |line_items| line_items.first.order.bill_address.andand.address1 },
-          proc { |line_items| line_items.first.order.bill_address.andand.address2 },
-          proc { |line_items| line_items.first.order.bill_address.andand.city },
-          proc { |line_items| line_items.first.order.bill_address.andand.zipcode },
-          proc { |line_items| line_items.first.order.bill_address.andand.state }
-        ]
+      when CustomerTotalsReport::REPORT_TYPE
+        CustomerTotalsReport.new(self).columns
       else
         DefaultReport.new(self).columns
       end

--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -1,0 +1,143 @@
+module OpenFoodNetwork
+  class OrdersAndFulfillmentsReport
+    class CustomerTotalsReport
+      REPORT_TYPE = "order_cycle_customer_totals"
+
+      attr_reader :context
+
+      delegate :line_item_name, to: :context
+
+      def initialize(context)
+        @context = context
+      end
+
+      def header
+        [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email), I18n.t(:report_header_phone),
+         I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
+         I18n.t(:report_header_item_price, currency: currency_symbol),
+         I18n.t(:report_header_item_fees_price, currency: currency_symbol),
+         I18n.t(:report_header_admin_handling_fees, currency: currency_symbol),
+         I18n.t(:report_header_ship_price, currency: currency_symbol),
+         I18n.t(:report_header_pay_fee_price, currency: currency_symbol),
+         I18n.t(:report_header_total_price, currency: currency_symbol),
+         I18n.t(:report_header_paid), I18n.t(:report_header_shipping), I18n.t(:report_header_delivery),
+         I18n.t(:report_header_ship_street), I18n.t(:report_header_ship_street_2), I18n.t(:report_header_ship_city), I18n.t(:report_header_ship_postcode), I18n.t(:report_header_ship_state),
+         I18n.t(:report_header_comments), I18n.t(:report_header_sku),
+         I18n.t(:report_header_order_cycle), I18n.t(:report_header_payment_method), I18n.t(:report_header_customer_code), I18n.t(:report_header_tags),
+         I18n.t(:report_header_billing_street), I18n.t(:report_header_billing_street_2), I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode), I18n.t(:report_header_billing_state),]
+      end
+
+      def rules
+        [
+          {
+            group_by: proc { |line_item| line_item.order.distributor },
+            sort_by: proc { |distributor| distributor.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.order },
+            sort_by: proc { |order| order.bill_address.full_name_reverse },
+            summary_columns: [
+              proc { |line_items| line_items.first.order.distributor.name },
+              proc { |line_items| line_items.first.order.bill_address.full_name },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| I18n.t('admin.reports.total') },
+              proc { |_line_items| "" },
+
+              proc { |_line_items| "" },
+              proc { |line_items| line_items.sum(&:amount) },
+              proc { |line_items| line_items.sum(&:amount_with_adjustments) },
+              proc { |line_items| line_items.first.order.admin_and_handling_total },
+              proc { |line_items| line_items.first.order.ship_total },
+              proc { |line_items| line_items.first.order.payment_fee },
+              proc { |line_items| line_items.first.order.total },
+              proc { |line_items| line_items.first.order.paid? ? I18n.t(:yes) : I18n.t(:no) },
+
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+
+              proc { |line_items| line_items.first.order.special_instructions },
+              proc { |_line_items| "" },
+
+              proc { |line_items| line_items.first.order.order_cycle.andand.name },
+              proc { |line_items|
+                line_items.first.order.payments.first.andand.payment_method.andand.name
+              },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" }
+            ]
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.variant },
+            sort_by: proc { |variant| variant.full_name }
+          },
+          {
+            group_by: line_item_name,
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
+      end
+
+      def columns
+        rsa = proc { |line_items| line_items.first.order.shipping_method.andand.delivery? }
+        [
+          proc { |line_items| line_items.first.order.distributor.name },
+          proc { |line_items| line_items.first.order.bill_address.firstname + " " + line_items.first.order.bill_address.lastname },
+          proc { |line_items| line_items.first.order.email },
+          proc { |line_items| line_items.first.order.bill_address.phone },
+          proc { |line_items| line_items.first.variant.product.supplier.name },
+          proc { |line_items| line_items.first.variant.product.name },
+          proc { |line_items| line_items.first.variant.full_name },
+
+          proc { |line_items| line_items.sum(&:quantity) },
+          proc { |line_items| line_items.sum(&:amount) },
+          proc { |line_items| line_items.sum(&:amount_with_adjustments) },
+          proc { |_line_items| "" },
+          proc { |_line_items| "" },
+          proc { |_line_items| "" },
+          proc { |_line_items| "" },
+          proc { |line_items| line_items.all? { |li| li.order.paid? } ? I18n.t(:yes) : I18n.t(:no) },
+
+          proc { |line_items| line_items.first.order.shipping_method.andand.name },
+          proc { |line_items| rsa.call(line_items) ? I18n.t(:yes) : I18n.t(:no) },
+
+          proc { |line_items| line_items.first.order.ship_address.andand.address1 if rsa.call(line_items) },
+          proc { |line_items| line_items.first.order.ship_address.andand.address2 if rsa.call(line_items) },
+          proc { |line_items| line_items.first.order.ship_address.andand.city if rsa.call(line_items) },
+          proc { |line_items| line_items.first.order.ship_address.andand.zipcode if rsa.call(line_items) },
+          proc { |line_items| line_items.first.order.ship_address.andand.state if rsa.call(line_items) },
+
+          proc { |_line_items| "" },
+          proc { |line_items| line_items.first.variant.sku },
+
+          proc { |line_items| line_items.first.order.order_cycle.andand.name },
+          proc { |line_items| line_items.first.order.payments.first.andand.payment_method.andand.name },
+          proc { |line_items| line_items.first.order.user.andand.customer_of(line_items.first.order.distributor).andand.code },
+          proc { |line_items| line_items.first.order.user.andand.customer_of(line_items.first.order.distributor).andand.tags.andand.join(', ') },
+
+          proc { |line_items| line_items.first.order.bill_address.andand.address1 },
+          proc { |line_items| line_items.first.order.bill_address.andand.address2 },
+          proc { |line_items| line_items.first.order.bill_address.andand.city },
+          proc { |line_items| line_items.first.order.bill_address.andand.zipcode },
+          proc { |line_items| line_items.first.order.bill_address.andand.state }
+        ]
+      end
+    end
+  end
+end

--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -12,19 +12,26 @@ module OpenFoodNetwork
       end
 
       def header
-        [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email), I18n.t(:report_header_phone),
-         I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
+        [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email),
+         I18n.t(:report_header_phone), I18n.t(:report_header_producer),
+         I18n.t(:report_header_product), I18n.t(:report_header_variant),
+         I18n.t(:report_header_amount),
          I18n.t(:report_header_item_price, currency: currency_symbol),
          I18n.t(:report_header_item_fees_price, currency: currency_symbol),
          I18n.t(:report_header_admin_handling_fees, currency: currency_symbol),
          I18n.t(:report_header_ship_price, currency: currency_symbol),
          I18n.t(:report_header_pay_fee_price, currency: currency_symbol),
          I18n.t(:report_header_total_price, currency: currency_symbol),
-         I18n.t(:report_header_paid), I18n.t(:report_header_shipping), I18n.t(:report_header_delivery),
-         I18n.t(:report_header_ship_street), I18n.t(:report_header_ship_street_2), I18n.t(:report_header_ship_city), I18n.t(:report_header_ship_postcode), I18n.t(:report_header_ship_state),
+         I18n.t(:report_header_paid), I18n.t(:report_header_shipping),
+         I18n.t(:report_header_delivery), I18n.t(:report_header_ship_street),
+         I18n.t(:report_header_ship_street_2), I18n.t(:report_header_ship_city),
+         I18n.t(:report_header_ship_postcode), I18n.t(:report_header_ship_state),
          I18n.t(:report_header_comments), I18n.t(:report_header_sku),
-         I18n.t(:report_header_order_cycle), I18n.t(:report_header_payment_method), I18n.t(:report_header_customer_code), I18n.t(:report_header_tags),
-         I18n.t(:report_header_billing_street), I18n.t(:report_header_billing_street_2), I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode), I18n.t(:report_header_billing_state),]
+         I18n.t(:report_header_order_cycle), I18n.t(:report_header_payment_method),
+         I18n.t(:report_header_customer_code), I18n.t(:report_header_tags),
+         I18n.t(:report_header_billing_street), I18n.t(:report_header_billing_street_2),
+         I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode),
+         I18n.t(:report_header_billing_state)]
       end
 
       def rules
@@ -98,7 +105,10 @@ module OpenFoodNetwork
         rsa = proc { |line_items| line_items.first.order.shipping_method.andand.delivery? }
         [
           proc { |line_items| line_items.first.order.distributor.name },
-          proc { |line_items| line_items.first.order.bill_address.firstname + " " + line_items.first.order.bill_address.lastname },
+          proc { |line_items|
+            bill_address = line_items.first.order.bill_address
+            bill_address.firstname + " " + bill_address.lastname
+          },
           proc { |line_items| line_items.first.order.email },
           proc { |line_items| line_items.first.order.bill_address.phone },
           proc { |line_items| line_items.first.variant.product.supplier.name },
@@ -112,24 +122,47 @@ module OpenFoodNetwork
           proc { |_line_items| "" },
           proc { |_line_items| "" },
           proc { |_line_items| "" },
-          proc { |line_items| line_items.all? { |li| li.order.paid? } ? I18n.t(:yes) : I18n.t(:no) },
+          proc { |line_items|
+            line_items.all? { |li| li.order.paid? } ? I18n.t(:yes) : I18n.t(:no)
+          },
 
           proc { |line_items| line_items.first.order.shipping_method.andand.name },
           proc { |line_items| rsa.call(line_items) ? I18n.t(:yes) : I18n.t(:no) },
 
-          proc { |line_items| line_items.first.order.ship_address.andand.address1 if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.address2 if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.city if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.zipcode if rsa.call(line_items) },
-          proc { |line_items| line_items.first.order.ship_address.andand.state if rsa.call(line_items) },
+          proc { |line_items|
+            line_items.first.order.ship_address.andand.address1 if rsa.call(line_items)
+          },
+          proc { |line_items|
+            line_items.first.order.ship_address.andand.address2 if rsa.call(line_items)
+          },
+          proc { |line_items|
+            line_items.first.order.ship_address.andand.city if rsa.call(line_items)
+          },
+          proc { |line_items|
+            line_items.first.order.ship_address.andand.zipcode if rsa.call(line_items)
+          },
+          proc { |line_items|
+            line_items.first.order.ship_address.andand.state if rsa.call(line_items)
+          },
 
           proc { |_line_items| "" },
           proc { |line_items| line_items.first.variant.sku },
 
           proc { |line_items| line_items.first.order.order_cycle.andand.name },
-          proc { |line_items| line_items.first.order.payments.first.andand.payment_method.andand.name },
-          proc { |line_items| line_items.first.order.user.andand.customer_of(line_items.first.order.distributor).andand.code },
-          proc { |line_items| line_items.first.order.user.andand.customer_of(line_items.first.order.distributor).andand.tags.andand.join(', ') },
+          proc { |line_items|
+            payment = line_items.first.order.payments.first
+            payment.andand.payment_method.andand.name
+          },
+          proc { |line_items|
+            distributor = line_items.first.order.distributor
+            user = line_items.first.order.user
+            user.andand.customer_of(distributor).andand.code
+          },
+          proc { |line_items|
+            distributor = line_items.first.order.distributor
+            user = line_items.first.order.user
+            user.andand.customer_of(distributor).andand.tags.andand.join(', ')
+          },
 
           proc { |line_items| line_items.first.order.bill_address.andand.address1 },
           proc { |line_items| line_items.first.order.bill_address.andand.address2 },

--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -1,7 +1,7 @@
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     class CustomerTotalsReport
-      REPORT_TYPE = "order_cycle_customer_totals"
+      REPORT_TYPE = "order_cycle_customer_totals".freeze
 
       attr_reader :context
 

--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     class CustomerTotalsReport
@@ -11,6 +12,8 @@ module OpenFoodNetwork
         @context = context
       end
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def header
         [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email),
          I18n.t(:report_header_phone), I18n.t(:report_header_producer),
@@ -33,7 +36,11 @@ module OpenFoodNetwork
          I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode),
          I18n.t(:report_header_billing_state)]
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def rules
         [
           {
@@ -100,7 +107,13 @@ module OpenFoodNetwork
           }
         ]
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/PerceivedComplexity
       def columns
         rsa = proc { |line_items| line_items.first.order.shipping_method.andand.delivery? }
         [
@@ -171,6 +184,11 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.order.bill_address.andand.state }
         ]
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/PerceivedComplexity
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
@@ -17,6 +17,8 @@ module OpenFoodNetwork
          I18n.t(:report_header_shipping_method)]
       end
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def rules
         [
           {
@@ -48,7 +50,10 @@ module OpenFoodNetwork
           }
         ]
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
+      # rubocop:disable Metrics/AbcSize
       def columns
         [proc { |line_items| line_items.first.order.distributor.name },
          proc { |line_items| line_items.first.variant.product.supplier.name },
@@ -60,6 +65,7 @@ module OpenFoodNetwork
          proc { |_line_items| "" },
          proc { |_line_items| I18n.t(:report_header_shipping_method) }]
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
@@ -10,9 +10,11 @@ module OpenFoodNetwork
       end
 
       def header
-        [I18n.t(:report_header_hub), I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant),
-         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
-         I18n.t(:report_header_total_shipping_cost), I18n.t(:report_header_shipping_method)]
+        [I18n.t(:report_header_hub), I18n.t(:report_header_producer),
+         I18n.t(:report_header_product), I18n.t(:report_header_variant),
+         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit),
+         I18n.t(:report_header_total_cost), I18n.t(:report_header_total_shipping_cost),
+         I18n.t(:report_header_shipping_method)]
       end
 
       def rules

--- a/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
@@ -1,0 +1,63 @@
+module OpenFoodNetwork
+  class OrdersAndFulfillmentsReport
+    class DistributorTotalsBySupplierReport
+      REPORT_TYPE = "order_cycle_distributor_totals_by_supplier"
+
+      attr_reader :context
+
+      def initialize(context)
+        @context = context
+      end
+
+      def header
+        [I18n.t(:report_header_hub), I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant),
+         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
+         I18n.t(:report_header_total_shipping_cost), I18n.t(:report_header_shipping_method)]
+      end
+
+      def rules
+        [
+          {
+            group_by: proc { |line_item| line_item.order.distributor },
+            sort_by: proc { |distributor| distributor.name },
+            summary_columns: [
+              proc { |_line_items| "" },
+              proc { |_line_items| I18n.t('admin.reports.total') },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |line_items| line_items.sum(&:amount) },
+              proc { |line_items| line_items.map(&:order).uniq.sum(&:ship_total) },
+              proc { |_line_items| "" }
+            ]
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.full_name },
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
+      end
+
+      def columns
+        [proc { |line_items| line_items.first.order.distributor.name },
+         proc { |line_items| line_items.first.variant.product.supplier.name },
+         proc { |line_items| line_items.first.variant.product.name },
+         proc { |line_items| line_items.first.variant.full_name },
+         proc { |line_items| line_items.sum(&:quantity) },
+         proc { |line_items| line_items.first.price },
+         proc { |line_items| line_items.sum(&:amount) },
+         proc { |_line_items| "" },
+         proc { |_line_items| I18n.t(:report_header_shipping_method) }]
+      end
+    end
+  end
+end

--- a/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
@@ -1,7 +1,7 @@
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     class DistributorTotalsBySupplierReport
-      REPORT_TYPE = "order_cycle_distributor_totals_by_supplier"
+      REPORT_TYPE = "order_cycle_distributor_totals_by_supplier".freeze
 
       attr_reader :context
 

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
@@ -12,9 +12,10 @@ module OpenFoodNetwork
       end
 
       def header
-        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
-         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
-         I18n.t(:report_header_shipping_method)]
+        [I18n.t(:report_header_producer), I18n.t(:report_header_product),
+         I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
+         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit),
+         I18n.t(:report_header_total_cost), I18n.t(:report_header_shipping_method)]
       end
 
       def rules

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
@@ -18,6 +18,8 @@ module OpenFoodNetwork
          I18n.t(:report_header_total_cost), I18n.t(:report_header_shipping_method)]
       end
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def rules
         [
           {
@@ -48,7 +50,10 @@ module OpenFoodNetwork
           }
         ]
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
 
+      # rubocop:disable Metrics/AbcSize
       def columns
         [
           supplier_name,
@@ -61,6 +66,7 @@ module OpenFoodNetwork
           proc { |_line_items| I18n.t(:report_header_shipping_method) }
         ]
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
@@ -1,0 +1,65 @@
+module OpenFoodNetwork
+  class OrdersAndFulfillmentsReport
+    class SupplierTotalsByDistributorReport
+      REPORT_TYPE = "order_cycle_supplier_totals_by_distributor"
+
+      attr_reader :context
+
+      delegate :supplier_name, to: :context
+
+      def initialize(context)
+        @context = context
+      end
+
+      def header
+        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
+         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
+         I18n.t(:report_header_shipping_method)]
+      end
+
+      def rules
+        [
+          {
+            group_by: proc { |line_item| line_item.variant.product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.full_name },
+            sort_by: proc { |full_name| full_name },
+            summary_columns: [
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |_line_items| I18n.t('admin.reports.total') },
+              proc { |_line_items| "" },
+              proc { |_line_items| "" },
+              proc { |line_items| line_items.sum(&:amount) },
+              proc { |_line_items| "" }
+            ]
+          },
+          {
+            group_by: proc { |line_item| line_item.order.distributor },
+            sort_by: proc { |distributor| distributor.name }
+          }
+        ]
+      end
+
+      def columns
+        [
+          supplier_name,
+          proc { |line_items| line_items.first.variant.product.name },
+          proc { |line_items| line_items.first.variant.full_name },
+          proc { |line_items| line_items.first.order.distributor.name },
+          proc { |line_items| line_items.sum(&:quantity) },
+          proc { |line_items| line_items.first.price },
+          proc { |line_items| line_items.sum(&:amount) },
+          proc { |_line_items| I18n.t(:report_header_shipping_method) }
+        ]
+      end
+    end
+  end
+end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
@@ -1,7 +1,7 @@
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     class SupplierTotalsByDistributorReport
-      REPORT_TYPE = "order_cycle_supplier_totals_by_distributor"
+      REPORT_TYPE = "order_cycle_supplier_totals_by_distributor".freeze
 
       attr_reader :context
 

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -1,7 +1,7 @@
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     class SupplierTotalsReport
-      REPORT_TYPE = "order_cycle_supplier_totals"
+      REPORT_TYPE = "order_cycle_supplier_totals".freeze
 
       attr_reader :context
 

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -1,6 +1,8 @@
 module OpenFoodNetwork
   class OrdersAndFulfillmentsReport
     class SupplierTotalsReport
+      REPORT_TYPE = "order_cycle_supplier_totals"
+
       attr_reader :context
 
       delegate :supplier_name, :product_name, :line_items_name, :total_units, to: :context

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -19,6 +19,7 @@ module OpenFoodNetwork
          I18n.t(:report_header_incoming_transport)]
       end
 
+      # rubocop:disable Metrics/MethodLength
       def rules
         [
           {
@@ -35,7 +36,9 @@ module OpenFoodNetwork
           }
         ]
       end
+      # rubocop:enable Metrics/MethodLength
 
+      # rubocop:disable Metrics/MethodLength
       def columns
         [
           supplier_name,
@@ -49,6 +52,7 @@ module OpenFoodNetwork
           proc { |_line_items| I18n.t(:report_header_incoming_transport) }
         ]
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -12,9 +12,11 @@ module OpenFoodNetwork
       end
 
       def header
-        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
-         I18n.t(:report_header_total_units), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
-         I18n.t(:report_header_status), I18n.t(:report_header_incoming_transport)]
+        [I18n.t(:report_header_producer), I18n.t(:report_header_product),
+         I18n.t(:report_header_variant), I18n.t(:report_header_amount),
+         I18n.t(:report_header_total_units), I18n.t(:report_header_curr_cost_per_unit),
+         I18n.t(:report_header_total_cost), I18n.t(:report_header_status),
+         I18n.t(:report_header_incoming_transport)]
       end
 
       def rules

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -1,0 +1,50 @@
+module OpenFoodNetwork
+  class OrdersAndFulfillmentsReport
+    class SupplierTotalsReport
+      attr_reader :context
+
+      delegate :supplier_name, :product_name, :line_items_name, :total_units, to: :context
+
+      def initialize(context)
+        @context = context
+      end
+
+      def header
+        [I18n.t(:report_header_producer), I18n.t(:report_header_product), I18n.t(:report_header_variant), I18n.t(:report_header_amount),
+         I18n.t(:report_header_total_units), I18n.t(:report_header_curr_cost_per_unit), I18n.t(:report_header_total_cost),
+         I18n.t(:report_header_status), I18n.t(:report_header_incoming_transport)]
+      end
+
+      def rules
+        [
+          {
+            group_by: proc { |line_item| line_item.variant.product.supplier },
+            sort_by: proc { |supplier| supplier.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.product },
+            sort_by: proc { |product| product.name }
+          },
+          {
+            group_by: proc { |line_item| line_item.variant.full_name },
+            sort_by: proc { |full_name| full_name }
+          }
+        ]
+      end
+
+      def columns
+        [
+          supplier_name,
+          product_name,
+          line_items_name,
+          proc { |line_items| line_items.sum(&:quantity) },
+          proc { |line_items| total_units(line_items) },
+          proc { |line_items| line_items.first.price },
+          proc { |line_items| line_items.sum(&:amount) },
+          proc { |_line_items| "" },
+          proc { |_line_items| I18n.t(:report_header_incoming_transport) }
+        ]
+      end
+    end
+  end
+end

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::CustomerTotalsReport do
+  let!(:distributor) { create(:distributor_enterprise) }
+
+  let!(:customer) { create(:customer, enterprise: distributor) }
+
+  let!(:order) do
+    create(:completed_order_with_totals, line_items_count: 1, user: customer.user,
+                                         customer: customer, distributor: distributor)
+  end
+
+  let(:current_user) { distributor.owner }
+  let(:permissions) { OpenFoodNetwork::Permissions.new(current_user) }
+
+  let(:report) do
+    report_options = { report_type: described_class::REPORT_TYPE }
+    OpenFoodNetwork::OrdersAndFulfillmentsReport.new(permissions, report_options, true)
+  end
+
+  let(:report_table) do
+    OpenFoodNetwork::OrderGrouper.new(report.rules, report.columns).table(report.table_items)
+  end
+
+  it "generates the report" do
+    expect(report_table.length).to eq(2)
+  end
+
+  it "has a line item row" do
+    distributor_name_field = report_table.first[0]
+    expect(distributor_name_field).to eq distributor.name
+
+    customer_name_field = report_table.first[1]
+    expect(customer_name_field).to eq order.bill_address.full_name
+
+    total_field = report_table.last[5]
+    expect(total_field).to eq I18n.t("admin.reports.total")
+  end
+end

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::DistributorTotalsBySupplierReport do
+  let!(:distributor) { create(:distributor_enterprise) }
+
+  let!(:order) do
+    create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
+  end
+
+  let(:current_user) { distributor.owner }
+  let(:permissions) { OpenFoodNetwork::Permissions.new(current_user) }
+
+  let(:report) do
+    report_options = { report_type: described_class::REPORT_TYPE }
+    OpenFoodNetwork::OrdersAndFulfillmentsReport.new(permissions, report_options, true)
+  end
+
+  let(:report_table) do
+    OpenFoodNetwork::OrderGrouper.new(report.rules, report.columns).table(report.table_items)
+  end
+
+  it "generates the report" do
+    expect(report_table.length).to eq(2)
+  end
+
+  it "has a variant row under the distributor" do
+    distributor_name_field = report_table.first[0]
+    expect(distributor_name_field).to eq distributor.name
+
+    supplier = order.line_items.first.variant.product.supplier
+    supplier_name_field = report_table.first[1]
+    expect(supplier_name_field).to eq supplier.name
+
+    total_field = report_table.last[1]
+    expect(total_field).to eq I18n.t("admin.reports.total")
+  end
+end

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::SupplierTotalsByDistributorReport do
+  let!(:distributor) { create(:distributor_enterprise) }
+
+  let!(:order) do
+    create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
+  end
+
+  let(:current_user) { distributor.owner }
+  let(:permissions) { OpenFoodNetwork::Permissions.new(current_user) }
+
+  let(:report) do
+    report_options = { report_type: described_class::REPORT_TYPE }
+    OpenFoodNetwork::OrdersAndFulfillmentsReport.new(permissions, report_options, true)
+  end
+
+  let(:report_table) do
+    OpenFoodNetwork::OrderGrouper.new(report.rules, report.columns).table(report.table_items)
+  end
+
+  it "generates the report" do
+    expect(report_table.length).to eq(2)
+  end
+
+  it "has a variant row under the distributor" do
+    supplier = order.line_items.first.variant.product.supplier
+    supplier_name_field = report_table.first[0]
+    expect(supplier_name_field).to eq supplier.name
+
+    distributor_name_field = report_table.first[3]
+    expect(distributor_name_field).to eq distributor.name
+
+    total_field = report_table.last[3]
+    expect(total_field).to eq I18n.t("admin.reports.total")
+  end
+end

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::SupplierTotalsRepor
   let(:permissions) { OpenFoodNetwork::Permissions.new(current_user) }
 
   let(:report) do
-    report_options = { report_type: "order_cycle_supplier_totals" }
+    report_options = { report_type: described_class::REPORT_TYPE }
     OpenFoodNetwork::OrdersAndFulfillmentsReport.new(permissions, report_options, true)
   end
 

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::SupplierTotalsReport do
+  let!(:distributor) { create(:distributor_enterprise) }
+
+  let!(:order) do
+    create(:completed_order_with_totals, line_items_count: 1, distributor: distributor)
+  end
+
+  let(:current_user) { distributor.owner }
+  let(:permissions) { OpenFoodNetwork::Permissions.new(current_user) }
+
+  let(:report) do
+    report_options = { report_type: "order_cycle_supplier_totals" }
+    OpenFoodNetwork::OrdersAndFulfillmentsReport.new(permissions, report_options, true)
+  end
+
+  let(:report_table) do
+    OpenFoodNetwork::OrderGrouper.new(report.rules, report.columns).table(report.table_items)
+  end
+
+  it "generates the report" do
+    expect(report_table.length).to eq(1)
+  end
+
+  it "has a variant row" do
+    supplier = order.line_items.first.variant.product.supplier
+    supplier_name_field = report_table.first[0]
+    expect(supplier_name_field).to eq supplier.name
+  end
+end


### PR DESCRIPTION
#### What? Why?

- Relates to #4308

The `OrdersAndFulfillmentReports` class is very long and difficult to read. This PR cleans up a lot of it, in preparation for the next #4308 PR.

This also adds some smoke tests for the reports subtypes.

This PR has many commits, but the commits are small and easy to review.

#### What should we test?

Do a smoke test of all Orders and Fulfillment report subtypes. Just make sure that data is exported, and that the generated data per report are different from each other (different report format and data) and look okay.

#### Release notes

- Refactor Orders and Fulfillment report subtypes, to make changes to the reports easier to do.

Changelog Category: Changed