### PR TITLE
4308 Eager-load associations in Orders and Fulfillment reports

### DIFF
--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -26,7 +26,9 @@ module OpenFoodNetwork
 
     def table_items
       return [] unless @render_table
-      Reports::LineItems.list(permissions, options)
+
+      list_options = options.merge(line_item_includes: report.line_item_includes)
+      Reports::LineItems.list(permissions, list_options)
     end
 
     private

--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -188,6 +188,10 @@ module OpenFoodNetwork
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/PerceivedComplexity
+
+      def line_item_includes
+        [{ variant: :product, order: [:bill_address, :shipments] }]
+      end
     end
   end
 end

--- a/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
@@ -54,6 +54,10 @@ module OpenFoodNetwork
       end
       # rubocop:enable Metrics/AbcSize
 
+      def line_item_includes
+        []
+      end
+
       private
 
       attr_reader :context

--- a/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
@@ -66,6 +66,10 @@ module OpenFoodNetwork
          proc { |_line_items| I18n.t(:report_header_shipping_method) }]
       end
       # rubocop:enable Metrics/AbcSize
+
+      def line_item_includes
+        [:order, { variant: :product }]
+      end
     end
   end
 end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
@@ -67,6 +67,10 @@ module OpenFoodNetwork
         ]
       end
       # rubocop:enable Metrics/AbcSize
+
+      def line_item_includes
+        [:order, { variant: :product }]
+      end
     end
   end
 end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -53,6 +53,10 @@ module OpenFoodNetwork
         ]
       end
       # rubocop:enable Metrics/MethodLength
+
+      def line_item_includes
+        [{ variant: { product: :supplier } }]
+      end
     end
   end
 end

--- a/lib/open_food_network/reports/line_items.rb
+++ b/lib/open_food_network/reports/line_items.rb
@@ -12,6 +12,10 @@ module OpenFoodNetwork
         line_items = permissions.visible_line_items.merge(Spree::LineItem.where(order_id: orders))
         line_items = line_items.supplied_by_any(params[:supplier_id_in]) if params[:supplier_id_in].present?
 
+        if params[:line_item_includes].present?
+          line_items = line_items.includes(*params[:line_item_includes])
+        end
+
         hidden_line_items = line_items_with_hidden_details(permissions, line_items)
 
         line_items.select{ |li|


### PR DESCRIPTION
#### What? Why?

- Closes #4308 

We are adding n queries for each line item involved in the report. Eager-loading, we significantly reduce the number of queries and the response time.

#### What should we test?

Please do a minor smoke test of all Orders and Fulfillment report subtypes. Just make sure that data is exported.

#### Release notes

- Eager-load associations for the Orders and Fulfillment report subtypes, improving performance when generating the reports.

Changelog Category: Changed

#### Dependencies

This includes changes in #4364. This should be rebased upon master after that is merged. This PR actually introduces only one commit (https://github.com/openfoodfoundation/openfoodnetwork/pull/4365/commits/38a476d1623a8024f9fd65ea3edf7a666997a3dc).