### PR TITLE
Remove product from Order Cycles if product supplier changes

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -50,7 +50,7 @@ Spree::Admin::ProductsController.class_eval do
 
     delete_stock_params_and_set_after do
       super
-      remove_product_from_order_cycles if original_supplier != @product.supplier_id
+      ExchangeVariantDeleter.new.delete(@product) if original_supplier != @product.supplier_id
     end
   end
 
@@ -191,13 +191,6 @@ Spree::Admin::ProductsController.class_eval do
     else
       product.master
     end
-  end
-
-  def remove_product_from_order_cycles
-    variant_ids = @product.variants.map(&:id)
-    ExchangeVariant.
-      where(variant_id: variant_ids).
-      delete_all
   end
 
   def set_product_master_variant_price_to_zero

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -46,11 +46,11 @@ Spree::Admin::ProductsController.class_eval do
   end
 
   def update
-    original_supplier = @product.supplier_id
+    original_supplier_id = @product.supplier_id
 
     delete_stock_params_and_set_after do
       super
-      ExchangeVariantDeleter.new.delete(@product) if original_supplier != @product.supplier_id
+      ExchangeVariantDeleter.new.delete(@product) if original_supplier_id != @product.supplier_id
     end
   end
 

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -46,8 +46,11 @@ Spree::Admin::ProductsController.class_eval do
   end
 
   def update
+    original_supplier = @product.supplier_id
+
     delete_stock_params_and_set_after do
       super
+      remove_product_from_order_cycles if original_supplier != @product.supplier_id
     end
   end
 
@@ -188,6 +191,13 @@ Spree::Admin::ProductsController.class_eval do
     else
       product.master
     end
+  end
+
+  def remove_product_from_order_cycles
+    variant_ids = @product.variants.map(&:id)
+    ExchangeVariant.
+      where(variant_id: variant_ids).
+      delete_all
   end
 
   def set_product_master_variant_price_to_zero

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -57,7 +57,6 @@ class Spree::ProductSet < ModelSet
   def update_product_only_attributes(product, attributes)
     variant_related_attrs = [:id, :variants_attributes, :master_attributes]
     product_related_attrs = attributes.except(*variant_related_attrs)
-
     return true if product_related_attrs.blank?
 
     original_supplier = product.supplier_id
@@ -66,9 +65,10 @@ class Spree::ProductSet < ModelSet
     product.variants.each do |variant|
       validate_presence_of_unit_value(product, variant)
     end
-    product.save if errors.empty?
+    return false unless product.errors.empty? && product.save
 
     ExchangeVariantDeleter.new.delete(product) if original_supplier != product.supplier_id
+    true
   end
 
   def validate_presence_of_unit_value(product, variant)

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -33,7 +33,7 @@ class Spree::ProductSet < ModelSet
   def update_attributes(attributes)
     split_taxon_ids!(attributes)
 
-    product = find_product(attributes[:id])
+    product = find_model(@collection, attributes[:id])
     if product.nil?
       @klass.new(attributes).save unless @reject_if.andand.call(attributes)
     else
@@ -43,12 +43,6 @@ class Spree::ProductSet < ModelSet
 
   def split_taxon_ids!(attributes)
     attributes[:taxon_ids] = attributes[:taxon_ids].split(',') if attributes[:taxon_ids].present?
-  end
-
-  def find_product(product_id)
-    @collection.find do |model|
-      model.id.to_s == product_id.to_s && model.persisted?
-    end
   end
 
   def update_product(product, attributes)
@@ -102,17 +96,11 @@ class Spree::ProductSet < ModelSet
   end
 
   def create_or_update_variant(product, variant_attributes)
-    variant = find_variant(product, variant_attributes[:id])
+    variant = find_model(product.variants_including_master, variant_attributes[:id])
     if variant.present?
       variant.update_attributes(variant_attributes.except(:id))
     else
       create_variant(product, variant_attributes)
-    end
-  end
-
-  def find_variant(product, variant_id)
-    product.variants_including_master.find do |variant|
-      variant.id.to_s == variant_id.to_s && variant.persisted?
     end
   end
 
@@ -138,6 +126,12 @@ class Spree::ProductSet < ModelSet
       report.add_tab(:variant_attributes, variant_attributes)
       report.add_tab(:variant, variant.attributes)
       report.add_tab(:variant_error, variant.errors.first) unless variant.valid?
+    end
+  end
+
+  def find_model(collection, model_id)
+    collection.find do |model|
+      model.id.to_s == model_id.to_s && model.persisted?
     end
   end
 end

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -3,6 +3,20 @@ class Spree::ProductSet < ModelSet
     super(Spree::Product, [], attributes, proc { |attrs| attrs[:product_id].blank? })
   end
 
+  def save
+    @collection_hash.each_value.all? do |product_attributes|
+      update_attributes(product_attributes)
+    end
+  end
+
+  def collection_attributes=(attributes)
+    @collection = Spree::Product
+      .where(id: attributes.each_value.map { |product| product[:id] })
+    @collection_hash = attributes
+  end
+
+  private
+
   # A separate method of updating products was required due to an issue with
   # the way Rails' assign_attributes and updates_attributes behave when
   # delegated attributes of a nested object are updated via the parent object
@@ -114,18 +128,6 @@ class Spree::ProductSet < ModelSet
       report.add_tab(:variant_attributes, variant_attributes)
       report.add_tab(:variant, variant.attributes)
       report.add_tab(:variant_error, variant.errors.first) unless variant.valid?
-    end
-  end
-
-  def collection_attributes=(attributes)
-    @collection = Spree::Product
-      .where(id: attributes.each_value.map { |product| product[:id] })
-    @collection_hash = attributes
-  end
-
-  def save
-    @collection_hash.each_value.all? do |product_attributes|
-      update_attributes(product_attributes)
     end
   end
 end

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -62,16 +62,21 @@ class Spree::ProductSet < ModelSet
     original_supplier = product.supplier_id
     product.assign_attributes(product_related_attrs)
 
-    product.variants.each do |variant|
-      validate_presence_of_unit_value(product, variant)
-    end
+    validate_presence_of_unit_value_in_product(product)
+
     return false unless product.errors.empty? && product.save
 
     ExchangeVariantDeleter.new.delete(product) if original_supplier != product.supplier_id
     true
   end
 
-  def validate_presence_of_unit_value(product, variant)
+  def validate_presence_of_unit_value_in_product(product)
+    product.variants.each do |variant|
+      validate_presence_of_unit_value_in_variant(product, variant)
+    end
+  end
+
+  def validate_presence_of_unit_value_in_variant(product, variant)
     return unless %w(weight volume).include?(product.variant_unit)
     return if variant.unit_value.present?
 

--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -54,7 +54,7 @@ class Spree::ProductSet < ModelSet
     end
     product.save if errors.empty?
 
-    remove_product_from_order_cycles(product) if original_supplier != product.supplier_id
+    ExchangeVariantDeleter.new.delete(product) if original_supplier != product.supplier_id
   end
 
   def validate_presence_of_unit_value(product, variant)
@@ -62,13 +62,6 @@ class Spree::ProductSet < ModelSet
     return if variant.unit_value.present?
 
     product.errors.add(:unit_value, "can't be blank")
-  end
-
-  def remove_product_from_order_cycles(product)
-    variant_ids = product.variants.map(&:id)
-    ExchangeVariant.
-      where(variant_id: variant_ids).
-      delete_all
   end
 
   def update_product_variants(product, attributes)

--- a/app/services/exchange_variant_deleter.rb
+++ b/app/services/exchange_variant_deleter.rb
@@ -1,0 +1,8 @@
+class ExchangeVariantDeleter
+  def delete(product)
+    variant_ids = product.variants.map(&:id)
+    ExchangeVariant.
+      where(variant_id: variant_ids).
+      delete_all
+  end
+end

--- a/app/services/exchange_variant_deleter.rb
+++ b/app/services/exchange_variant_deleter.rb
@@ -1,8 +1,7 @@
 class ExchangeVariantDeleter
   def delete(product)
-    variant_ids = product.variants.map(&:id)
     ExchangeVariant.
-      where(variant_id: variant_ids).
+      where(variant_id: product.variants.select(:id)).
       delete_all
   end
 end

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -177,6 +177,19 @@ describe Spree::Admin::ProductsController, type: :controller do
       login_as_enterprise_user [producer]
     end
 
+    describe "change product supplier" do
+      let(:distributor) { create(:distributor_enterprise) }
+      let!(:order_cycle) { create(:simple_order_cycle, variants: [product.variants.first], coordinator: distributor, distributors: [distributor]) }
+
+      it "should remove product from existing Order Cycles" do
+        new_producer = create(:enterprise)
+        spree_put :update, id: product, product: { supplier_id: new_producer.id }
+
+        expect(product.reload.supplier.id).to eq new_producer.id
+        expect(order_cycle.reload.distributed_variants).to_not include product.variants.first
+      end
+    end
+
     describe "product stock setting with errors" do
       it "notifies bugsnag and still raise error" do
         # forces an error in the variant

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -104,6 +104,17 @@ describe Spree::ProductSet do
           let!(:product) { create(:simple_product) }
           let(:collection_hash) { { 0 => { id: product.id } } }
 
+          context 'when :variants_attributes are passed' do
+            let(:variants_attributes) { [{ sku: '123', id: product.variants.first.id.to_s }] }
+
+            it 'updates the attributes of the variant' do
+              collection_hash[0][:variants_attributes] = variants_attributes
+              product_set.save
+
+              expect(product.reload.variants.first[:sku]).to eq variants_attributes.first[:sku]
+            end
+          end
+
           context 'when :master_attributes is passed' do
             let(:master_attributes) { { sku: '123' } }
 

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -100,54 +100,57 @@ describe Spree::ProductSet do
           end
         end
 
-        context 'when :master_attributes is passed' do
+        context 'when attributes of the variants are passed' do
           let!(:product) { create(:simple_product) }
           let(:collection_hash) { { 0 => { id: product.id } } }
-          let(:master_attributes) { { sku: '123' } }
 
-          before do
-            collection_hash[0][:master_attributes] = master_attributes
-          end
+          context 'when :master_attributes is passed' do
+            let(:master_attributes) { { sku: '123' } }
 
-          context 'and the variant does exist' do
-            let!(:variant) { create(:variant, product: product) }
-
-            before { master_attributes[:id] = variant.id }
-
-            it 'updates the attributes of the master variant' do
-              product_set.save
-              expect(variant.reload.sku).to eq('123')
+            before do
+              collection_hash[0][:master_attributes] = master_attributes
             end
-          end
 
-          context 'and the variant does not exist' do
-            context 'and attributes provided are valid' do
-              let(:master_attributes) do
-                attributes_for(:variant).merge(sku: '123')
-              end
+            context 'and the variant does exist' do
+              let!(:variant) { create(:variant, product: product) }
 
-              it 'creates it with the specified attributes' do
-                number_of_variants = Spree::Variant.all.size
+              before { master_attributes[:id] = variant.id }
+
+              it 'updates the attributes of the master variant' do
                 product_set.save
-                expect(Spree::Variant.last.sku).to eq('123')
-                expect(Spree::Variant.all.size).to eq number_of_variants + 1
+                expect(variant.reload.sku).to eq('123')
               end
             end
 
-            context 'and attributes provided are not valid' do
-              let(:master_attributes) do
-                # unit_value nil makes the variant invalid
-                # on_hand with a value would make on_hand be updated and fail with exception
-                attributes_for(:variant).merge(unit_value: nil, on_hand: 1, sku: '321')
+            context 'and the variant does not exist' do
+              context 'and attributes provided are valid' do
+                let(:master_attributes) do
+                  attributes_for(:variant).merge(sku: '123')
+                end
+
+                it 'creates it with the specified attributes' do
+                  number_of_variants = Spree::Variant.all.size
+                  product_set.save
+                  expect(Spree::Variant.last.sku).to eq('123')
+                  expect(Spree::Variant.all.size).to eq number_of_variants + 1
+                end
               end
 
-              it 'does not create variant and notifies bugsnag still raising the exception' do
-                expect(Bugsnag).to receive(:notify)
-                number_of_variants = Spree::Variant.all.size
-                expect { product_set.save }
-                  .to raise_error(StandardError)
-                expect(Spree::Variant.all.size).to eq number_of_variants
-                expect(Spree::Variant.last.sku).not_to eq('321')
+              context 'and attributes provided are not valid' do
+                let(:master_attributes) do
+                  # unit_value nil makes the variant invalid
+                  # on_hand with a value would make on_hand be updated and fail with exception
+                  attributes_for(:variant).merge(unit_value: nil, on_hand: 1, sku: '321')
+                end
+
+                it 'does not create variant and notifies bugsnag still raising the exception' do
+                  expect(Bugsnag).to receive(:notify)
+                  number_of_variants = Spree::Variant.all.size
+                  expect { product_set.save }
+                    .to raise_error(StandardError)
+                  expect(Spree::Variant.all.size).to eq number_of_variants
+                  expect(Spree::Variant.last.sku).not_to eq('321')
+                end
               end
             end
           end

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -96,7 +96,7 @@ describe Spree::ProductSet do
             expect(product.reload.attributes).to include(
               'supplier_id' => producer.id
             )
-            expect(order_cycle.reload.distributed_variants).to_not include product.variants.first
+            expect(order_cycle.distributed_variants).to_not include product.variants.first
           end
         end
 
@@ -107,11 +107,25 @@ describe Spree::ProductSet do
           context 'when :variants_attributes are passed' do
             let(:variants_attributes) { [{ sku: '123', id: product.variants.first.id.to_s }] }
 
+            before { collection_hash[0][:variants_attributes] = variants_attributes }
+
             it 'updates the attributes of the variant' do
-              collection_hash[0][:variants_attributes] = variants_attributes
               product_set.save
 
               expect(product.reload.variants.first[:sku]).to eq variants_attributes.first[:sku]
+            end
+
+            context 'and when product attributes are also passed' do
+              it 'updates product and variant attributes' do
+                collection_hash[0][:permalink] = "test_permalink"
+
+                product_set.save
+
+                expect(product.reload.variants.first[:sku]).to eq variants_attributes.first[:sku]
+                expect(product.reload.attributes).to include(
+                  'permalink' => "test_permalink"
+                )
+              end
             end
           end
 

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -75,6 +75,31 @@ describe Spree::ProductSet do
           end
         end
 
+        context 'when a different supplier is passed' do
+          let!(:producer) { create(:enterprise) }
+          let!(:product) { create(:simple_product) }
+          let(:collection_hash) do
+            {
+              0 => {
+                id: product.id,
+                supplier_id: producer.id
+              }
+            }
+          end
+
+          let(:distributor) { create(:distributor_enterprise) }
+          let!(:order_cycle) { create(:simple_order_cycle, variants: [product.variants.first], coordinator: distributor, distributors: [distributor]) }
+
+          it 'updates the product and removes the product from order cycles' do
+            product_set.save
+
+            expect(product.reload.attributes).to include(
+              'supplier_id' => producer.id
+            )
+            expect(order_cycle.reload.distributed_variants).to_not include product.variants.first
+          end
+        end
+
         context 'when :master_attributes is passed' do
           let!(:product) { create(:simple_product) }
           let(:collection_hash) { { 0 => { id: product.id } } }


### PR DESCRIPTION
#### What? Why?
Closes #4366 
With a new supplier the rules/permissions to add a product to an Order Cycle may be different and also the reports may break because of inconsistent data, SO we need to remove all the product variants from all Order Cycles if the supplier of a product is changed.

#### What should we test?
We only need to test editing a product in two places: the edit individual product page and the bulk product edit page.
- Add a product to an Order Cycle
- Change supplier of product
- Verify all the variants of the product are removed from the Order Cycle

Also make sure changing other product attributes still works correctly.

#### Release notes
Changelog Category: Fixed
When the supplier of a product is changed the product is automatically removed from all Order Cycles so that data remains consistent. The product can be manually re-added to the Order Cycle.