### PR TITLE
adds the full_name of the customer ordering beneath email

### DIFF
--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -73,6 +73,8 @@
           {{'js.admin.orders.shipment_states.' + order.shipment_state | t}}
       %td
         = mail_to "{{order.email}}"
+        %br
+        {{order.full_name}}
       %td.align-center
         %span{'ng-bind-html' => 'order.display_total'}
       %td.actions


### PR DESCRIPTION
#### What? Why?

Closes #4378 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This attempts to close Issue #4378. It includes the full name of the customer from the billing address if available. This change only updates a view and does not introduce any new logic. 


#### What should we test?
<!-- List which features should be tested and how. -->
1. Create a new order complete with customer billing information. 
2. View the orders table.
3. Uncheck the `show only completed orders` checkbox and re-filter. 
4. Ensure that the full name listed in the billing information is shown below the email address


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Taking from the issue description. "Often the email is not that useful for identifying the customer, and it is time-consuming to have to open orders to see who they are" Here, we're adding a full name to the table for a better admin experience. 


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added 

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
No known conflicts 


#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->
https://community.openfoodnetwork.org/t/enable-to-identify-customer-on-orders-view/1482/21


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
No dependencies


#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
No documentation updates necessary

#### Screenshot
<img width="1792" alt="Screen Shot 2019-10-19 at 12 25 59 PM" src="https://user-images.githubusercontent.com/7292/67151982-86173a80-f29c-11e9-8351-b8b9c2d98baa.png">
