### PR TITLE
adds missing :spree to i18n scopes

### DIFF
--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -10,7 +10,7 @@
       = line_item.single_money.to_html
     %td.item-qty-show.align-center
       - item.states.each do |state,count|
-        = "#{count} x #{t(state.humanize.downcase)}"
+        = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
     - unless shipment.shipped?
       %td.item-qty-edit.hidden
         = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -33,14 +33,14 @@
         %dd#shipment_status
           - shipment_state_classes = "state #{@order.shipment_state}"
           %span{ class: shipment_state_classes }
-            = t(@order.shipment_state, scope: :shipment_states, default: [:missing, "none"])
+            = t(@order.shipment_state, scope: [:spree, :shipment_states], default: [:missing, "none"])
         %dt
           = t(:payment)
           \:
         %dd#payment_status
           - payment_state_classes = "state #{@order.payment_state}"
           %span{ class: payment_state_classes }
-            = t(@order.payment_state, scope: :payment_states, default: [:missing, "none"])
+            = t(@order.payment_state, scope: [:spree, :payment_states], default: [:missing, "none"])
         %dt
           = t(:date_completed)
           \:


### PR DESCRIPTION
#### What? Why?

Closes #4304 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This attempts to fix issue #4304 where translations for shipping and payment states were displayed as the default `none`. The solution here is to ensure that we're scoping the translation in the yaml file correctly in the `t()` helper. 

For more, see the following in the rails guides on i18n. 
https://guides.rubyonrails.org/i18n.html#how-to-store-your-custom-translations


#### What should we test?
1. Go to /orders?q[s]=completed_at+desc
1. Ship an order if none is shipped yet
1. Go to the edit order page

Ensure that states are reflected properly.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Fixes missing translations

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->
Possibly related since the translations are under the `spree` heading


#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->
None or Unknown


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

None.

#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

None.

#### Screenshots
Before
<img width="1011" alt="Screen Shot 2019-10-19 at 1 26 31 PM" src="https://user-images.githubusercontent.com/7292/67149425-2b201c00-f279-11e9-9c68-1e906ac62cfe.png">
After
<img width="1000" alt="Screen Shot 2019-10-19 at 1 56 49 PM" src="https://user-images.githubusercontent.com/7292/67149426-2b201c00-f279-11e9-86a1-5ca01195c960.png">
