### PR TITLE
Missing translations inventory page

### DIFF
--- a/app/views/admin/variant_overrides/_products.html.haml
+++ b/app/views/admin/variant_overrides/_products.html.haml
@@ -1,6 +1,6 @@
 %form{ name: 'variant_overrides_form', ng: { show: "views.inventory.visible" } }
   %save-bar{ dirty: "customers_form.$dirty", persist: "false" }
-    %input.red{ type: "button", value: "Save Changes", ng: { click: "update()", disabled: "!variant_overrides_form.$dirty" } }
+    %input.red{ type: "button", value: t(:save_changes), ng: { click: "update()", disabled: "!variant_overrides_form.$dirty" } }
   %table.index.bulk#variant-overrides
     %col.producer{ width: "20%", ng: { show: 'columns.producer.visible' } }
     %col.product{ width: "20%", ng: { show: 'columns.product.visible' } }

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -14,7 +14,7 @@
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}
   %td.reset{ ng: { show: 'columns.reset.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-default_stock', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].default_stock'}, placeholder: '{{ variant.default_stock ? variant.default_stock : "Default stock"}}', 'ofn-track-variant-override' => 'default_stock'}
+    %input{name: 'variant-overrides-{{ variant.id }}-default_stock', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].default_stock'}, placeholder: '{{ variant.default_stock ? variant.default_stock : t(admin.variant_overrides.index.default_stock)}}', 'ofn-track-variant-override' => 'default_stock'}
   %td.inheritance{ ng: { show: 'columns.inheritance.visible' } }
     %input.field{ :type => 'checkbox', name: 'variant-overrides-{{ variant.id }}-inherit', ng: { model: 'inherit' }, 'track-inheritance' => true }
   %td.tags{ ng: { show: 'columns.tags.visible' } }

--- a/app/views/admin/variant_overrides/_products_variants.html.haml
+++ b/app/views/admin/variant_overrides/_products_variants.html.haml
@@ -14,7 +14,7 @@
   %td.reset{ ng: { show: 'columns.reset.visible' } }
     %input{name: 'variant-overrides-{{ variant.id }}-resettable', type: 'checkbox', ng: {model: 'variantOverrides[hub_id][variant.id].resettable'}, placeholder: '{{ variant.resettable }}', 'ofn-track-variant-override' => 'resettable'}
   %td.reset{ ng: { show: 'columns.reset.visible' } }
-    %input{name: 'variant-overrides-{{ variant.id }}-default_stock', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].default_stock'}, placeholder: '{{ variant.default_stock ? variant.default_stock : t(admin.variant_overrides.index.default_stock)}}', 'ofn-track-variant-override' => 'default_stock'}
+    %input{name: 'variant-overrides-{{ variant.id }}-default_stock', type: 'text', ng: {model: 'variantOverrides[hub_id][variant.id].default_stock'}, placeholder: '{{ variant.default_stock ? variant.default_stock : ("admin.variant_overrides.index.default_stock" | t)}}', 'ofn-track-variant-override' => 'default_stock'}
   %td.inheritance{ ng: { show: 'columns.inheritance.visible' } }
     %input.field{ :type => 'checkbox', name: 'variant-overrides-{{ variant.id }}-inherit', ng: { model: 'inherit' }, 'track-inheritance' => true }
   %td.tags{ ng: { show: 'columns.tags.visible' } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -592,6 +592,7 @@ en:
         title: Inventory
         description: Use this page to manage inventories for your enterprises. Any product details set here will override those set on the 'Products' page
         enable_reset?: Enable Stock Reset?
+        default_stock: "Default stock"
         inherit?: Inherit?
         add: Add
         hide: Hide


### PR DESCRIPTION
#### What? Why?

Closes #4105 

Uses save_changes translation for the Save Changes button on the admin/inventory page.

Adds a default_stock placeholder translation to be also used on the admin/inventory page.

#### What should we test?

Add products on the admin/inventory page to be saved. Test translations are displaying correctly.

#### Release notes

Add missing translations.

Changelog Category: Added | Changed 

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->


#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

#### Screenshots

Before
<img width="1399" alt="Screen Shot 2019-10-19 at 4 45 33 PM" src="https://user-images.githubusercontent.com/22504617/67152651-e6ec4600-f28f-11e9-8d2b-238b40a3b7eb.png">


After
<img width="1385" alt="Screen Shot 2019-10-19 at 4 36 59 PM" src="https://user-images.githubusercontent.com/22504617/67152633-6b8a9480-f28f-11e9-978a-ad29d017290e.png">
