### PR TITLE
Avoid asking the cloud if an image exists

### DIFF
--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -62,7 +62,7 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
   #   #   medium: LOGO_MEDIUM_URL
   #   # }
   def attachment_urls(attachment, versions)
-    return unless attachment.exists?
+    return unless attachment.file?
 
     versions.each_with_object({}) do |version, urls|
       urls[version] = attachment.url(version)


### PR DESCRIPTION
#### What? Why?

Closes #4392

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Amazon's DNS is failing at the moment and some users can't access the admin panel because of this error.

Here I'm avoiding the network query.
While `exists?` asks the storage server if the file is actually there,
`file?` just checks if we have the file name stored in the database
and the file should be there. It's much faster and less error prone.

There is also the `present?` method which does the same as `file?` but Rubocop complains about `unless ...present?`. It's probably a good idea to use a different method name as it's not exactly the same as Rails' `present?`.



#### What should we test?
<!-- List which features should be tested and how. -->

- You need a staging server with Amazon S3 setup, e.g. Australian staging, UK staging. *Not* French staging.
- You need an enterprise with a logo or promo image.
- Just visit the edit enterprise page and it should display.
- If the Amazon servers are up(if you can see https://s3.amazonaws.com/ofn-prod/public/images/enterprises/logos/19/original/pots_empil_C3_A9s_3.jpg?1535969877), you can test uploading a new image.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: Don't crash on enterprise admin page when Amazon S3 is down.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

