### PR TITLE
Merge duplicated product_sub_menu partials

### DIFF
--- a/app/views/admin/enterprise_groups/index.html.haml
+++ b/app/views/admin/enterprise_groups/index.html.haml
@@ -1,4 +1,4 @@
-= content_for :page_title do
+- content_for :page_title do
   = t 'admin_enterprise_groups'
 
 - if admin_user?

--- a/app/views/admin/order_cycles/index.html.haml
+++ b/app/views/admin/order_cycles/index.html.haml
@@ -1,4 +1,4 @@
-= content_for :page_title do
+- content_for :page_title do
   = t :admin_order_cycles
 
 - content_for :main_ng_app_name do

--- a/app/views/admin/product_import/import.html.haml
+++ b/app/views/admin/product_import/import.html.haml
@@ -2,7 +2,7 @@
   #{t('admin.product_import.title')}
 
 = render partial: 'ams_data'
-= render partial: 'admin/shared/product_sub_menu'
+= render partial: 'spree/admin/shared/product_sub_menu'
 
 .import-wrapper{ng: {app: 'admin.productImport', controller: 'ImportFormCtrl'}}
 

--- a/app/views/admin/product_import/index.html.haml
+++ b/app/views/admin/product_import/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   #{t('admin.product_import.title')}
 
-= render partial: 'admin/shared/product_sub_menu'
+= render partial: 'spree/admin/shared/product_sub_menu'
 
 = render 'upload_sidebar'
 

--- a/app/views/admin/shared/_enterprises_sub_menu.html.haml
+++ b/app/views/admin/shared/_enterprises_sub_menu.html.haml
@@ -1,4 +1,4 @@
-= content_for :sub_menu do
+- content_for :sub_menu do
   %ul#sub_nav.inline-menu{"data-hook" => "admin_enterprise_sub_tabs"}
     = tab :enterprises, url: main_app.admin_enterprises_path
     = tab :enterprise_relationships, url: main_app.admin_enterprise_relationships_path

--- a/app/views/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/admin/shared/_product_sub_menu.html.haml
@@ -1,8 +1,0 @@
-= content_for :sub_menu do
-  %ul#sub_nav.inline-menu
-    = tab :products, match_path: '/products'
-    = tab :option_types, match_path: '/option_types'
-    = tab :properties
-    = tab :prototypes
-    = tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'
-    = tab :import, url: main_app.admin_product_import_path, match_path: '/product_import'

--- a/app/views/admin/shared/_users_sub_menu.html.haml
+++ b/app/views/admin/shared/_users_sub_menu.html.haml
@@ -1,4 +1,4 @@
-= content_for :sub_menu do
+- content_for :sub_menu do
   %ul#sub_nav.inline-menu{"data-hook" => "admin_user_sub_tabs"}
     = tab :users, url: spree.admin_users_path
     = tab :roles, url: main_app.admin_enterprise_roles_path, match_path: '/enterprise_roles'

--- a/app/views/admin/variant_overrides/_header.html.haml
+++ b/app/views/admin/variant_overrides/_header.html.haml
@@ -5,4 +5,4 @@
   %h1.page-title= t("admin.variant_overrides.index.title")
   %a.with-tip{ 'data-powertip' => "#{t("admin.variant_overrides.index.description")}" }=t('admin.whats_this')
 
-= render partial: 'admin/shared/product_sub_menu'
+= render partial: 'spree/admin/shared/product_sub_menu'

--- a/app/views/spree/admin/products/group_buy_options.html.haml
+++ b/app/views/spree/admin/products/group_buy_options.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'admin/shared/product_sub_menu'
+= render partial: 'spree/admin/shared/product_sub_menu'
 = render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Group Buy Options' }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 

--- a/app/views/spree/admin/products/index/_header.html.haml
+++ b/app/views/spree/admin/products/index/_header.html.haml
@@ -7,6 +7,6 @@
       %li#new_product_link
         = button_link_to t(:new_product), new_object_url, { :remote => true, :icon => 'icon-plus', :id => 'admin_new_product' }
 
-= render partial: 'admin/shared/product_sub_menu'
+= render partial: 'spree/admin/shared/product_sub_menu'
 
 %div#new_product(data-hook)

--- a/app/views/spree/admin/products/seo.html.haml
+++ b/app/views/spree/admin/products/seo.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'admin/shared/product_sub_menu'
+= render partial: 'spree/admin/shared/product_sub_menu'
 = render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => t(:Search) }
 = render :partial => 'spree/shared/error_messages', :locals => { :target => @product }
 

--- a/app/views/spree/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_product_sub_menu.html.haml
@@ -1,6 +1,8 @@
-- content_for :sub_menu do
+= content_for :sub_menu do
   %ul#sub_nav.inline-menu
     = tab :products, match_path: '/products'
     = tab :option_types, match_path: '/option_types'
     = tab :properties
     = tab :prototypes
+    = tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'
+    = tab :import, url: main_app.admin_product_import_path, match_path: '/product_import'

--- a/app/views/spree/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_product_sub_menu.html.haml
@@ -1,4 +1,4 @@
-= content_for :sub_menu do
+- content_for :sub_menu do
   %ul#sub_nav.inline-menu
     = tab :products, match_path: '/products'
     = tab :option_types, match_path: '/option_types'

--- a/app/views/spree/admin/shared/_product_tabs.html.haml
+++ b/app/views/spree/admin/shared/_product_tabs.html.haml
@@ -1,12 +1,12 @@
-= content_for :page_title do
+- content_for :page_title do
   = Spree.t(:editing_product)
   = "\"#{@product.name}\""
 
-= content_for :sidebar_title do
+- content_for :sidebar_title do
   %span.sku
     = @product.sku
 
-= content_for :sidebar do
+- content_for :sidebar do
   %nav.menu
     %ul
       - if can?(:admin, Spree::Product)

--- a/app/views/spree/admin/users/new.html.haml
+++ b/app/views/spree/admin/users/new.html.haml
@@ -1,7 +1,7 @@
-= content_for :page_title do
+- content_for :page_title do
   = Spree.t(:new_user)
 
-= content_for :page_actions do
+- content_for :page_actions do
   %li
     = button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, icon: 'icon-arrow-left'
 


### PR DESCRIPTION
#### What? Why?

Remove duplicated and outdated partial. The spree version did not include all entries, so, for example, when editing a product the sub menu entry for inventory was not there.

Before:
![Screenshot 2019-10-23 at 12 34 47](https://user-images.githubusercontent.com/1640378/67389055-bb1fd780-f591-11e9-895b-6596645b0adb.png)

After:
![Screenshot 2019-10-23 at 12 33 30](https://user-images.githubusercontent.com/1640378/67389075-c541d600-f591-11e9-8863-ee6da8495453.png)


#### What should we test?
MAke sure the product sub menu is showing correctly on all pages under product like edit variants, edit images, create product, etc.



#### Release notes
Changelog Category: Fixed
Product sub menu entries are now consistent in all pages under the Product menu.
