### PR TITLE
Delete prototypes tables and all references in pages

### DIFF
--- a/app/views/spree/admin/product_properties/index.html.haml
+++ b/app/views/spree/admin/product_properties/index.html.haml
@@ -8,14 +8,10 @@
   %ul.tollbar.inline-menu
     %li
       = link_to_add_fields Spree.t(:add_product_properties), 'tbody#product_properties', class: 'icon-plus button'
-    %li
-      %span#new_ptype_link
-        = link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, remote: true, 'data-update' => 'prototypes', class: 'button icon-copy'
 
 = form_for @product, url: admin_product_url(@product), method: :put do |f|
   %fieldset.no-border-top
     .add_product_properties
-    #prototypes
     = image_tag 'select2-spinner.gif', plugin: 'spree', style: 'display:none;', id: 'busy_indicator'
 
     %table.index.sortable{"data-sortable-link" => update_positions_admin_product_product_properties_url}

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -101,19 +101,3 @@
   angular.element(document.getElementById("new_product")).ready(function() {
     angular.bootstrap(document.getElementById("new_product"), ['admin.products']);
   });
-:javascript
-    (function($){
-      var base_url = "#{admin_prototypes_url}";
-      var prototype_select = $('#product_prototype_id');
-      prototype_select.change(function() {
-        var id = prototype_select.val();
-        if (id.length) {
-          $('#product-from-prototype').load([ base_url, id ].join("/"));
-        } else {
-          $('#product-from-prototype').empty();
-        }
-      })
-      if (prototype_select.html() == "") {
-        prototype_select.change();
-      }
-    })(jQuery);

--- a/app/views/spree/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_product_sub_menu.html.haml
@@ -3,6 +3,5 @@
     = tab :products, match_path: '/products'
     = tab :option_types, match_path: '/option_types'
     = tab :properties
-    = tab :prototypes
     = tab :variant_overrides, url: main_app.admin_inventory_path, match_path: '/inventory'
     = tab :import, url: main_app.admin_product_import_path, match_path: '/product_import'

--- a/app/views/spree/admin/shared/_tabs.html.haml
+++ b/app/views/spree/admin/shared/_tabs.html.haml
@@ -1,5 +1,5 @@
 = tab :dashboard, :route => :admin, :icon => 'icon-dashboard'
-= tab :products , :option_types, :properties, :prototypes, :variants, :product_properties, :taxons, :url => admin_products_path, :icon => 'icon-th-large'
+= tab :products, :option_types, :properties, :variants, :product_properties, :taxons, :url => admin_products_path, :icon => 'icon-th-large'
 = tab :order_cycles, :url => main_app.admin_order_cycles_path, :icon => 'icon-refresh'
 = tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :url => admin_orders_path('q[s]' => 'completed_at desc'), :icon => 'icon-shopping-cart'
 = tab :reports, :icon => 'icon-file'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2963,7 +2963,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         products: "Products"
         option_types: "Option Types"
         properties: "Properties"
-        prototypes: "Prototypes"
         variant_overrides: "Inventory"
         reports: "Reports"
         configuration: "Configuration"

--- a/db/migrate/20191023105006_drop_prototypes_tables.rb
+++ b/db/migrate/20191023105006_drop_prototypes_tables.rb
@@ -1,0 +1,25 @@
+class DropPrototypesTables < ActiveRecord::Migration
+  def up
+    drop_table :spree_option_types_prototypes
+    drop_table :spree_properties_prototypes
+    drop_table :spree_prototypes
+  end
+
+  def down
+    create_table :spree_prototypes do |t|
+      t.string   :name
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+    end
+
+    create_table :spree_option_types_prototypes, id: false do |t|
+      t.integer :prototype_id
+      t.integer :option_type_id
+    end
+
+    create_table :spree_properties_prototypes, id: false do |t|
+      t.integer :prototype_id
+      t.integer :property_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191023172424) do
+ActiveRecord::Schema.define(:version => 20191023105006) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -521,11 +521,6 @@ ActiveRecord::Schema.define(:version => 20191023172424) do
     t.integer  "position",                    :default => 0, :null => false
   end
 
-  create_table "spree_option_types_prototypes", :id => false, :force => true do |t|
-    t.integer "prototype_id"
-    t.integer "option_type_id"
-  end
-
   create_table "spree_option_values", :force => true do |t|
     t.integer  "position"
     t.string   "name"
@@ -783,17 +778,6 @@ ActiveRecord::Schema.define(:version => 20191023172424) do
     t.string   "presentation", :null => false
     t.datetime "created_at",   :null => false
     t.datetime "updated_at",   :null => false
-  end
-
-  create_table "spree_properties_prototypes", :id => false, :force => true do |t|
-    t.integer "prototype_id"
-    t.integer "property_id"
-  end
-
-  create_table "spree_prototypes", :force => true do |t|
-    t.string   "name"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
   end
 
   create_table "spree_return_authorizations", :force => true do |t|
@@ -1292,9 +1276,6 @@ ActiveRecord::Schema.define(:version => 20191023172424) do
   add_foreign_key "spree_line_items", "spree_orders", name: "spree_line_items_order_id_fk", column: "order_id"
   add_foreign_key "spree_line_items", "spree_variants", name: "spree_line_items_variant_id_fk", column: "variant_id"
 
-  add_foreign_key "spree_option_types_prototypes", "spree_option_types", name: "spree_option_types_prototypes_option_type_id_fk", column: "option_type_id"
-  add_foreign_key "spree_option_types_prototypes", "spree_prototypes", name: "spree_option_types_prototypes_prototype_id_fk", column: "prototype_id"
-
   add_foreign_key "spree_option_values", "spree_option_types", name: "spree_option_values_option_type_id_fk", column: "option_type_id"
 
   add_foreign_key "spree_option_values_variants", "spree_option_values", name: "spree_option_values_variants_option_value_id_fk", column: "option_value_id"
@@ -1335,9 +1316,6 @@ ActiveRecord::Schema.define(:version => 20191023172424) do
   add_foreign_key "spree_promotion_actions", "spree_activators", name: "spree_promotion_actions_activator_id_fk", column: "activator_id"
 
   add_foreign_key "spree_promotion_rules", "spree_activators", name: "spree_promotion_rules_activator_id_fk", column: "activator_id"
-
-  add_foreign_key "spree_properties_prototypes", "spree_properties", name: "spree_properties_prototypes_property_id_fk", column: "property_id"
-  add_foreign_key "spree_properties_prototypes", "spree_prototypes", name: "spree_properties_prototypes_prototype_id_fk", column: "prototype_id"
 
   add_foreign_key "spree_return_authorizations", "spree_orders", name: "spree_return_authorizations_order_id_fk", column: "order_id"
 


### PR DESCRIPTION
#### What? Why?

Prototypes is a dead feature. Only one prototype create in 2012 in the AUS live database. All other instances have no prototypes. It's actually not working with the mix with option types.

#### What should we test?
We can test that product properties feature is working correctly.
Add producer properties and product properties and use them in products and the shopfront.


#### Release notes
Changelog Category: Removed
MAkes app and code simpler by removing unused feature "prototypes," a feature implemented in Spree but never used in OFN.
