### PR TITLE
Remove option types menu entry

### DIFF
--- a/app/views/spree/admin/shared/_product_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_product_sub_menu.html.haml
@@ -1,6 +1,5 @@
 - content_for :sub_menu do
   %ul#sub_nav.inline-menu
     = tab :products, match_path: '/products'
-    = tab :option_types, match_path: '/option_types'
     = tab :properties
     = tab :prototypes


### PR DESCRIPTION
#### What? Why?

It's not possible to create custom option types in OFN and use them in products/variants. In OFN we have static list of option types that can be used in products: weight, volume and items.
This page is a legacy spree page for when the option types could be associated with products.

#### What should we test?
We are only removing the menu entry, make sure the menu entry is not there under the Products menu.

#### Release notes
Changelog Category: Removed
Remove Option Types menu entry, this is a legacy feature from Spree that is not usable in OFN.
