### PR TITLE
Add order_cycle_id and distributor_id indexes to spree_orders table

### DIFF
--- a/db/migrate/20191023172424_add_indexes_to_spree_orders.rb
+++ b/db/migrate/20191023172424_add_indexes_to_spree_orders.rb
@@ -1,0 +1,6 @@
+class AddIndexesToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_index :spree_orders, :order_cycle_id
+    add_index :spree_orders, :distributor_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190922201034) do
+ActiveRecord::Schema.define(:version => 20191023172424) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -577,7 +577,9 @@ ActiveRecord::Schema.define(:version => 20190922201034) do
 
   add_index "spree_orders", ["completed_at", "user_id", "created_by_id", "created_at"], :name => "spree_orders_completed_at_user_id_created_by_id_created_at_idx"
   add_index "spree_orders", ["customer_id"], :name => "index_spree_orders_on_customer_id"
+  add_index "spree_orders", ["distributor_id"], :name => "index_spree_orders_on_distributor_id"
   add_index "spree_orders", ["number"], :name => "index_orders_on_number"
+  add_index "spree_orders", ["order_cycle_id"], :name => "index_spree_orders_on_order_cycle_id"
 
   create_table "spree_payment_methods", :force => true do |t|
     t.string   "type"


### PR DESCRIPTION
#### What? Why?

Closes #4318 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds missing indexes to the `spree_orders` table.

#### What should we test?
<!-- List which features should be tested and how. -->

.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added database indexes for order_cycle_id and distributor_id to spree_orders table

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added
