### PR TITLE
Task to remove limit of ent. that can be created

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,27 @@
+require 'csv'
+
+namespace :ofn do
+  desc 'remove the limit of enterprises a user can create'
+  task :remove_enterprise_limit, [:user_id] => :environment do |_task, args|
+    RemoveEnterpriseLimit.new(args.user_id).call
+  end
+
+  class RemoveEnterpriseLimit
+    # rubocop:disable Style/NumericLiterals
+    MAX_INTEGER = 2147483647
+    # rubocop:enable Style/NumericLiterals
+
+    def initialize(user_id)
+      @user_id = user_id
+    end
+
+    def call
+      user = Spree::User.find(user_id)
+      user.update_attribute(:enterprise_limit, MAX_INTEGER)
+    end
+
+    private
+
+    attr_reader :user_id
+  end
+end

--- a/spec/lib/tasks/users_rake_spec.rb
+++ b/spec/lib/tasks/users_rake_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'users.rake' do
+  describe ':remove_enterprise_limit' do
+    context 'when the user exists' do
+      it 'sets the enterprise_limit to the maximum integer' do
+        Rake.application.rake_require 'tasks/users'
+        Rake::Task.define_task(:environment)
+
+        max_integer = 2147483647
+        user = create(:user)
+
+        Rake.application.invoke_task "ofn:remove_enterprise_limit[#{user.id}]"
+
+        expect(user.reload.enterprise_limit).to eq(max_integer)
+      end
+    end
+
+    context 'when the user does not exist' do
+      it 'raises' do
+        expect {
+          RemoveEnterpriseLimit.new(-1).call
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

It does so by updating a user's enterprise_limit attribute to the maximum integer the database supports.

This is used at least in Katuma to remove the limitation of the number of enterprises a user can create. This is the agreement the community reached for the pricing plans.

Eventually, this logic could be triggered with a button from the UI but for now this is for internal usage only.

This is the result

![Screenshot from 2019-10-24 13-31-31](https://user-images.githubusercontent.com/762088/67481665-9c3d4600-f662-11e9-928c-7258462de510.png)

I followed https://blog.10pines.com/2019/01/14/testing-rake-tasks/ and https://thoughtbot.com/blog/test-rake-tasks-like-a-boss to tests the rake task.

#### What should we test?

Nothing. It's not user-facing and this has been done in Katuma already.


#### Release notes

Rake task to remove the limit of enterprises a user can create.

Changelog Category: Added

