### PR TITLE
Task to remove an unused enterprise

### DIFF
--- a/lib/tasks/enterprises.rake
+++ b/lib/tasks/enterprises.rake
@@ -1,6 +1,15 @@
 require 'csv'
 
 namespace :ofn do
+  # Note this task is still rather naive and only covers the simple case where
+  # an enterprise was created but never used and thus, does not have any
+  # associated entities like orders.
+  desc 'remove the specified enterprise'
+  task :remove_enterprise, [:enterprise_id] => :environment do |_task, args|
+    enterprise = Enterprise.find(args.enterprise_id)
+    enterprise.destroy
+  end
+
   namespace :dev do
     desc 'export enterprises to CSV'
     task export_enterprises: :environment do

--- a/spec/lib/tasks/enterprises_rake_spec.rb
+++ b/spec/lib/tasks/enterprises_rake_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'enterprises.rake' do
+  describe ':remove_enterprise' do
+    context 'when the enterprises exists' do
+      it 'removes the enterprise' do
+        enterprise = create(:enterprise)
+
+        Rake.application.rake_require 'tasks/enterprises'
+        Rake::Task.define_task(:environment)
+
+        expect {
+          Rake.application.invoke_task "ofn:remove_enterprise[#{enterprise.id}]"
+        }.to change(Enterprise, :count).by(-1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Note this task is still rather naive and only covers the simple case where an enterprise was created but never used and thus, does not have any associated entities like orders.

This is enough for the case I have at hand where a hub's manager created an enterprise while he wanted to create a user account #ux. He ended up with an enterprise named after him and now he asked us to clean that up.

#### What should we test?

Nothing. It's not user-facing and this has been done in Katuma already.

#### Release notes
Rake task to remove an unused enterprise that doesn't have any entities associated to it.

Changelog Category: Added