### PR TITLE
Add tax category to sample products

### DIFF
--- a/lib/tasks/sample_data/product_factory.rb
+++ b/lib/tasks/sample_data/product_factory.rb
@@ -72,10 +72,18 @@ class ProductFactory
       variant_unit: "weight",
       variant_unit_scale: 1,
       unit_value: 1,
-      shipping_category: DefaultShippingCategory.find_or_create
+      shipping_category: DefaultShippingCategory.find_or_create,
+      tax_category_id: find_or_create_tax_category.id
     )
     product = Spree::Product.create_with(params).find_or_create_by_name!(params[:name])
     product.variants.first.update_attribute :on_demand, true
     product
+  end
+
+  def find_or_create_tax_category
+    tax_category_name = "Tax Category"
+    tax_category = Spree::TaxCategory.find_by_name(tax_category_name)
+    tax_category ||= Spree::TaxCategory.create!(name: tax_category_name)
+    tax_category
   end
 end


### PR DESCRIPTION
#### What? Why?

Sample data is broken on my local setup, for some unknown reason, Spree::Config.products_require_tax_category is true when loading sample data and so the script fails.

This Pr fixes that by adding a tax category to all products created.

#### What should we test?
Sample data now loads without errors related to tax category being mandatory.

#### Release notes
Changelog Category: Fixed
Fixed OFN sample data script.
