### PR TITLE
Add rake task to empty a distributor enterprise

### DIFF
--- a/lib/tasks/enterprises.rake
+++ b/lib/tasks/enterprises.rake
@@ -1,6 +1,17 @@
 require 'csv'
 
 namespace :ofn do
+  desc 'deletes all orders and associated entities of an enterprise'
+  task :truncate_distributor, [:distributor_id] => :environment do |_task, args|
+    orders = Spree::Order.where(distributor_id: args.distributor_id)
+
+    inventory_units = Spree::InventoryUnit.where(order_id: orders.pluck(:id))
+    inventory_units.delete_all
+
+    ProxyOrder.where(order_id: orders.pluck(:id)).destroy_all
+    orders.destroy_all
+  end
+
   namespace :dev do
     desc 'export enterprises to CSV'
     task export_enterprises: :environment do

--- a/spec/lib/tasks/enterprises_rake_spec.rb
+++ b/spec/lib/tasks/enterprises_rake_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'enterprises.rake' do
+  describe ':truncate_distributor' do
+    let!(:distributor) { create(:enterprise) }
+    let!(:order) { create(:order, distributor: distributor) }
+
+    before do
+      Rake.application.rake_require 'tasks/enterprises'
+      Rake::Task.define_task(:environment)
+      Rake::Task["ofn:truncate_distributor"].reenable
+    end
+
+    it 'destroys all orders of the specified distributor' do
+      Rake.application.invoke_task "ofn:truncate_distributor[#{distributor.id}]"
+
+      expect(Spree::Order.where(distributor_id: order.distributor_id)).to be_empty
+    end
+
+    it 'deletes all their inventory units' do
+      inventory_unit = create(:inventory_unit, order: order)
+
+      Rake.application.invoke_task "ofn:truncate_distributor[#{distributor.id}]"
+
+      expect(Spree::InventoryUnit.where(order_id: order.id)).to be_empty
+    end
+
+    it 'destroys their line items' do
+      create(:line_item, order: order)
+
+      Rake.application.invoke_task "ofn:truncate_distributor[#{distributor.id}]"
+
+      expect(Spree::LineItem.where(order_id: order.id)).to be_empty
+    end
+
+    it 'destroys their proxy orders' do
+      create(:proxy_order, order: order)
+
+      Rake.application.invoke_task "ofn:truncate_distributor[#{distributor.id}]"
+
+      expect(ProxyOrder.where(order_id: order.id)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

This wipes out all proxy orders, orders, inventory units and line items of the specified distributor enterprise.

This is useful for the case of a hub that's been trying the platform and then wants to clean up the mess to proceed to regular operation. This also ensures we don't charge them for these initial tests.

#### What should we test?

Nothing. It's not user-facing and this has been done in Katuma already.

#### Release notes

Rake task to remove proxy orders, orders, inventory units and line items of a distributor enterprise.

Changelog Category: Added