### PR TITLE
Add rake tasks to remove OCs

### DIFF
--- a/lib/tasks/order_cycles.rake
+++ b/lib/tasks/order_cycles.rake
@@ -1,0 +1,19 @@
+namespace :ofn do
+  desc 'destroys the specified order cycle'
+  task :remove_order_cycle, [:order_cycle_id] => :environment do |_task, args|
+    remove_order_cycle(args.order_cycle_id)
+  end
+
+  desc 'destroys all order cycles of the specified coordinator'
+  task :remove_coordinated_order_cycles, [:coordinator_id] => :environment do |_task, args|
+    order_cycles = OrderCycle.where(coordinator_id: args.coordinator_id)
+    order_cycles.each { |order_cycle| remove_order_cycle(order_cycle.id) }
+  end
+
+  private
+
+  def remove_order_cycle(order_cycle_id)
+    CoordinatorFee.where(order_cycle_id: order_cycle_id).delete_all
+    OrderCycle.find(order_cycle_id).destroy
+  end
+end

--- a/spec/lib/tasks/order_cycles_rake_spec.rb
+++ b/spec/lib/tasks/order_cycles_rake_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'order_cycles.rake' do
+  describe ':remove_order_cycle' do
+    before do
+      Rake.application.rake_require 'tasks/order_cycles'
+      Rake::Task.define_task(:environment)
+      Rake::Task["ofn:remove_order_cycle"].reenable
+    end
+
+    context 'when the order cycle exists' do
+      let!(:order_cycle) { create(:order_cycle) }
+
+      it 'removes the specified order cycle' do
+        expect {
+          Rake.application.invoke_task "ofn:remove_order_cycle[#{order_cycle.id}]"
+        }.to change(OrderCycle, :count).by(-1)
+      end
+
+      it 'removes the order cycle coordinator fees' do
+        expect {
+          Rake.application.invoke_task "ofn:remove_order_cycle[#{order_cycle.id}]"
+        }.to change(CoordinatorFee, :count).by(-1)
+      end
+    end
+
+    context 'when the order cycle does not exist' do
+      it 'raises' do
+        expect {
+          Rake.application.invoke_task "ofn:remove_order_cycle[-1]"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe ':remove_coordinated_order_cycles' do
+    before do
+      Rake.application.rake_require 'tasks/order_cycles'
+      Rake::Task.define_task(:environment)
+      Rake::Task["ofn:remove_coordinated_order_cycles"].reenable
+    end
+
+    it 'removes all order cycles of the specified coordinator' do
+      order_cycle = create(:simple_order_cycle)
+      coordinator = order_cycle.coordinator
+
+      Rake.application.invoke_task "ofn:remove_coordinated_order_cycles[#{coordinator.id}]"
+
+      expect(OrderCycle.where(coordinator_id: coordinator.id)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Adds one to remove a single order cycle and another one that removes all the order cycles of the specified coordinator.

This is useful for the case of a hub that's been trying the platform and then wants to clean up the mess to proceed to regular operation. This also ensures we don't charge them for these initial tests.

#### What should we test?

Nothing. It's not user-facing and this has been done in Katuma already.

#### Release notes

Rake tasks to remove a single order cycle or all the ones belonging to a coordinator enterprise.

Changelog Category: Added