### PR TITLE
Update end date on delivery report

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -2,7 +2,7 @@ require 'open_food_network/user_balance_calculator'
 
 module OpenFoodNetwork
   class OrderCycleManagementReport
-    DEFAULT_DATE_INTERVAL = 1.month
+    DEFAULT_DATE_INTERVAL = { from: -1.month, to: 1.day }.freeze
     attr_reader :params
     def initialize(user, params = {}, render_table = false)
       @params = sanitize_params(params)
@@ -137,8 +137,8 @@ module OpenFoodNetwork
 
     def sanitize_params(params)
       params[:q] ||= {}
-      params[:q][:completed_at_gt] ||= Time.zone.today - DEFAULT_DATE_INTERVAL
-      params[:q][:completed_at_lt] ||= Time.zone.today + 1.day
+      params[:q][:completed_at_gt] ||= Time.zone.today + DEFAULT_DATE_INTERVAL[:from]
+      params[:q][:completed_at_lt] ||= Time.zone.today + DEFAULT_DATE_INTERVAL[:to]
       params
     end
   end

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -138,7 +138,7 @@ module OpenFoodNetwork
     def sanitize_params(params)
       params[:q] ||= {}
       params[:q][:completed_at_gt] ||= Time.zone.today - DEFAULT_DATE_INTERVAL
-      params[:q][:completed_at_lt] ||= Time.zone.today
+      params[:q][:completed_at_lt] ||= Time.zone.today + 1.day
       params
     end
   end

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -27,8 +27,8 @@ module OpenFoodNetwork
 
         context "default date range" do
           it "fetches orders completed in the past month" do
-            o1 = create(:order, completed_at: Time.zone.today - OrderCycleManagementReport::DEFAULT_DATE_INTERVAL - 1.day)
-            o2 = create(:order, completed_at: Time.zone.today - OrderCycleManagementReport::DEFAULT_DATE_INTERVAL + 1.day)
+            o1 = create(:order, completed_at: 1.month.ago - 1.day)
+            o2 = create(:order, completed_at: 1.month.ago + 1.day)
             expect(subject.orders).to eq([o2])
           end
         end


### PR DESCRIPTION
#### What? Why?

Update the enddate on the date range of the delivery report to ensure that all of today's orders are included.

Closes #4184 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Small extension to another change to add the date range to this report.


#### What should we test?
<!-- List which features should be tested and how. -->
Delivery report
The Delivery report default date range inludes today in the results.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Include today's orders in delivery report default date range


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category:  Fixed 
