### PR TITLE
Ensure variants returned in #variant_relation are DISTINCT

### DIFF
--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -15,7 +15,8 @@ class OrderCycleDistributedProducts
   def variants_relation
     order_cycle.
       variants_distributed_by(distributor).
-      merge(stocked_variants_and_overrides)
+      merge(stocked_variants_and_overrides).
+      select("DISTINCT spree_variants.*")
   end
 
   private

--- a/app/services/order_cycle_distributed_products.rb
+++ b/app/services/order_cycle_distributed_products.rb
@@ -9,7 +9,7 @@ class OrderCycleDistributedProducts
   end
 
   def products_relation
-    Spree::Product.where(id: stocked_products)
+    Spree::Product.where(id: stocked_products).group("spree_products.id")
   end
 
   def variants_relation

--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -63,10 +63,10 @@ class ProductsRenderer
     if distributor.preferred_shopfront_taxon_order.present?
       distributor
         .preferred_shopfront_taxon_order
-        .split(",").map { |id| "primary_taxon_id=#{id} DESC" }
-        .join(",") + ", name ASC"
+        .split(",").map { |id| "spree_products.primary_taxon_id=#{id} DESC" }
+        .join(", ") + ", spree_products.name ASC"
     else
-      "name ASC"
+      "spree_products.name ASC"
     end
   end
 

--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -64,7 +64,7 @@ class ProductsRenderer
       distributor
         .preferred_shopfront_taxon_order
         .split(",").map { |id| "spree_products.primary_taxon_id=#{id} DESC" }
-        .join(", ") + ", spree_products.name ASC"
+        .join(", ") + ", spree_products.name ASC, spree_products.id ASC"
     else
       "spree_products.name ASC"
     end

--- a/spec/controllers/api/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/order_cycles_controller_spec.rb
@@ -187,6 +187,46 @@ module Api
       end
     end
 
+    context "with custom taxon ordering applied and duplicate product names in the order cycle" do
+      let!(:supplier) { create(:supplier_enterprise) }
+      let!(:product5) { create(:product, name: "Duplicate name", primary_taxon: taxon3, supplier: supplier) }
+      let!(:product6) { create(:product, name: "Duplicate name", primary_taxon: taxon3, supplier: supplier) }
+      let!(:product7) { create(:product, name: "Duplicate name", primary_taxon: taxon2, supplier: supplier) }
+      let!(:product8) { create(:product, name: "Duplicate name", primary_taxon: taxon2, supplier: supplier) }
+
+      before do
+        distributor.preferred_shopfront_taxon_order = "#{taxon2.id},#{taxon3.id},#{taxon1.id}"
+        exchange.variants << product5.variants.first
+        exchange.variants << product6.variants.first
+        exchange.variants << product7.variants.first
+        exchange.variants << product8.variants.first
+      end
+
+      it "displays products in new order" do
+        api_get :products, id: order_cycle.id, distributor: distributor.id
+
+        expect(product_ids.length).to eq 7
+        expect(product_ids).to eq [product7.id, product8.id, product2.id, product3.id, product5.id, product6.id, product1.id]
+      end
+
+      xit "displays products in correct order across multiple pages" do
+        api_get :products, id: order_cycle.id, distributor: distributor.id, per_page: 3
+
+        expect(product_ids.length).to eq 3
+        expect(product_ids).to eq [product7.id, product8.id, product2.id]
+
+        api_get :products, id: order_cycle.id, distributor: distributor.id, per_page: 3, page: 2
+
+        expect(product_ids.length).to eq 3
+        expect(product_ids).to eq [product3.id, product5.id, product6.id]
+
+        api_get :products, id: order_cycle.id, distributor: distributor.id, per_page: 3, page: 3
+
+        expect(product_ids.length).to eq 1
+        expect(product_ids).to eq [product1.id]
+      end
+    end
+
     private
 
     def product_ids

--- a/spec/controllers/api/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/order_cycles_controller_spec.rb
@@ -204,25 +204,17 @@ module Api
 
       it "displays products in new order" do
         api_get :products, id: order_cycle.id, distributor: distributor.id
-
-        expect(product_ids.length).to eq 7
         expect(product_ids).to eq [product7.id, product8.id, product2.id, product3.id, product5.id, product6.id, product1.id]
       end
 
-      xit "displays products in correct order across multiple pages" do
+      it "displays products in correct order across multiple pages" do
         api_get :products, id: order_cycle.id, distributor: distributor.id, per_page: 3
-
-        expect(product_ids.length).to eq 3
         expect(product_ids).to eq [product7.id, product8.id, product2.id]
 
         api_get :products, id: order_cycle.id, distributor: distributor.id, per_page: 3, page: 2
-
-        expect(product_ids.length).to eq 3
         expect(product_ids).to eq [product3.id, product5.id, product6.id]
 
         api_get :products, id: order_cycle.id, distributor: distributor.id, per_page: 3, page: 3
-
-        expect(product_ids.length).to eq 1
         expect(product_ids).to eq [product1.id]
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #4413

Fixes an issue with shopfront pagination where duplicates were sometimes returned in the results. This was present in OCs where; 1) multiple products from the same supplier in the OC had the exact same name and 2) the hub was using the feature for reordering products by a custom taxon list.

The issue was discovered on UK production. It probably had minimal impact beyond a single OC where both of these conditions were met.

#### What should we test?
<!-- List which features should be tested and how. -->

Deploying `v2.6.0` to UK Staging will show the bug, when viewing the shopfront for Tamar Valley Food Hub and scrolling down far enough. The javascript console will show an error and the loading spinner will be stuck, when reaching the `goats milk` product.

Deploying this PR to UK Staging will fix the issue. Scrolling to the bottom of the full product list is possible. Both versions of the duplicate `goats milk` product will be displayed correctly.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed an issue with duplicate product names affecting shopfront pagination

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed