### PR TITLE
Eager-load variant associations in admin ProductsController

### DIFF
--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -109,7 +109,14 @@ module Api
         scope = Spree::Product.active
       end
 
-      scope.includes(:master)
+      scope.includes(product_query_includes)
+    end
+
+    def product_query_includes
+      [
+        master: [:images],
+        variants: [:default_price, :stock_locations, :stock_items, :variant_overrides]
+      ]
     end
 
     def paged_products_for_producers(producers)


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

I noticed this whilst looking at something else in Datadog. There's no issue for it, but it took 5 minutes to do. Eager-loads some associated variant objects in product queries in admin pages. 

Reduces the huge numbers of queries in `/admin/inventory` by ~49%, and `/admin/products` by ~48%.

#### What should we test?
<!-- List which features should be tested and how. -->

`/admin/inventory` and `/admin/products` are working as normal. Basically they should load and display products / overrides correctly.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance on admin products and inventory pages

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed