### PR TITLE
Variant option_values

### DIFF
--- a/app/controllers/admin/bulk_line_items_controller.rb
+++ b/app/controllers/admin/bulk_line_items_controller.rb
@@ -4,9 +4,17 @@ module Admin
     #
     def index
       order_params = params[:q].andand.delete :order
-      orders = OpenFoodNetwork::Permissions.new(spree_current_user).editable_orders.ransack(order_params).result
-      line_items = OpenFoodNetwork::Permissions.new(spree_current_user).editable_line_items.where(order_id: orders).ransack(params[:q])
-      render_as_json line_items.result.reorder('order_id ASC, id ASC')
+
+      orders = OpenFoodNetwork::Permissions.new(spree_current_user).
+        editable_orders.ransack(order_params).result
+
+      line_items = OpenFoodNetwork::Permissions.new(spree_current_user).
+        editable_line_items.where(order_id: orders).
+        includes(variant: { option_values: :option_type }).
+        ransack(params[:q]).result.
+        reorder('spree_line_items.order_id ASC, spree_line_items.id ASC')
+
+      render_as_json line_items
     end
 
     # PUT /admin/bulk_line_items/:id.json

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -148,7 +148,8 @@ module Admin
 
         unless enterprises.empty?
           enterprises.includes(
-            supplied_products: [:supplier, :variants, master: [:images]]
+            supplied_products:
+              [:supplier, master: [:images], variants: { option_values: :option_type }]
           )
         end
       when :index

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -115,7 +115,8 @@ module Api
     def product_query_includes
       [
         master: [:images],
-        variants: [:default_price, :stock_locations, :stock_items, :variant_overrides]
+        variants: [:default_price, :stock_locations, :stock_items, :variant_overrides,
+                   { option_values: :option_type }]
       ]
     end
 

--- a/app/controllers/api/variants_controller.rb
+++ b/app/controllers/api/variants_controller.rb
@@ -6,12 +6,12 @@ module Api
     before_filter :product
 
     def index
-      @variants = scope.includes(:option_values).ransack(params[:q]).result
+      @variants = scope.includes(option_values: :option_type).ransack(params[:q]).result
       render json: @variants, each_serializer: Api::VariantSerializer
     end
 
     def show
-      @variant = scope.includes(:option_values).find(params[:id])
+      @variant = scope.includes(option_values: :option_type).find(params[:id])
       render json: @variant, serializer: Api::VariantSerializer
     end
 

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -35,6 +35,7 @@ class ProducerMailer < Spree::BaseMailer
 
   def line_items_from(order_cycle, producer)
     Spree::LineItem.
+      includes(variant: { option_values: :option_type }).
       from_order_cycle(order_cycle).
       sorted_by_name_and_unit_value.
       merge(Spree::Product.in_supplier(producer)).

--- a/lib/open_food_network/bulk_coop_report.rb
+++ b/lib/open_food_network/bulk_coop_report.rb
@@ -51,8 +51,7 @@ module OpenFoodNetwork
 
     def table_items
       return [] unless @render_table
-
-      Reports::LineItems.list(permissions, params)
+      Reports::LineItems.list(permissions, report_options)
     end
 
     def rules
@@ -122,9 +121,17 @@ module OpenFoodNetwork
 
     private
 
+    def report_options
+      @params.merge(line_item_includes: line_item_includes)
+    end
+
+    def line_item_includes
+      [{ order: [:bill_address],
+         variant: [{ option_values: :option_type }, { product: :supplier }] }]
+    end
+
     def permissions
       return @permissions unless @permissions.nil?
-
       @permissions = OpenFoodNetwork::Permissions.new(@user)
     end
   end

--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -190,7 +190,7 @@ module OpenFoodNetwork
       # rubocop:enable Metrics/PerceivedComplexity
 
       def line_item_includes
-        [{ variant: { product: :supplier },
+        [{ variant: [{ option_values: :option_type }, { product: :supplier }],
            order: [:bill_address, :ship_address, :order_cycle, :adjustments, :payments,
                    :user, :distributor, shipments: { shipping_rates: :shipping_method }] }]
       end

--- a/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
@@ -69,7 +69,7 @@ module OpenFoodNetwork
 
       def line_item_includes
         [{ order: [:distributor, :adjustments, shipments: { shipping_rates: :shipping_method }],
-           variant: { product: :supplier } }]
+           variant: [{ option_values: :option_type }, { product: :supplier }] }]
       end
     end
   end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
@@ -69,7 +69,8 @@ module OpenFoodNetwork
       # rubocop:enable Metrics/AbcSize
 
       def line_item_includes
-        [{ order: :distributor, variant: { product: :supplier } }]
+        [{ order: :distributor,
+           variant: [{ option_values: :option_type }, { product: :supplier }] }]
       end
     end
   end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -55,7 +55,7 @@ module OpenFoodNetwork
       # rubocop:enable Metrics/MethodLength
 
       def line_item_includes
-        [{ variant: { product: :supplier } }]
+        [{ variant: [{ option_values: :option_type }, { product: :supplier }] }]
       end
     end
   end

--- a/lib/open_food_network/packing_report.rb
+++ b/lib/open_food_network/packing_report.rb
@@ -43,8 +43,7 @@ module OpenFoodNetwork
 
     def table_items
       return [] unless @render_table
-
-      Reports::LineItems.list(permissions, params)
+      Reports::LineItems.list(permissions, report_options)
     end
 
     def rules
@@ -121,9 +120,17 @@ module OpenFoodNetwork
 
     private
 
+    def report_options
+      @params.merge(line_item_includes: line_item_includes)
+    end
+
+    def line_item_includes
+      [{ order: [:bill_address, :distributor],
+         variant: [{ option_values: :option_type }, { product: :supplier }] }]
+    end
+
     def permissions
       return @permissions unless @permissions.nil?
-
       @permissions = OpenFoodNetwork::Permissions.new(@user)
     end
 

--- a/lib/open_food_network/products_and_inventory_report_base.rb
+++ b/lib/open_food_network/products_and_inventory_report_base.rb
@@ -25,6 +25,7 @@ module OpenFoodNetwork
     def child_variants
       Spree::Variant.
         where(is_master: false).
+        includes(option_values: :option_type).
         joins(:product).
         merge(visible_products).
         order('spree_products.name')

--- a/lib/open_food_network/scope_variants_for_search.rb
+++ b/lib/open_food_network/scope_variants_for_search.rb
@@ -30,7 +30,9 @@ module OpenFoodNetwork
     end
 
     def query_scope
-      Spree::Variant.where(is_master: false).ransack(search_params.merge(m: 'or')).result
+      Spree::Variant.where(is_master: false).
+        includes(option_values: :option_type).
+        ransack(search_params.merge(m: 'or')).result
     end
 
     def distributor

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -43,6 +43,15 @@ module OpenFoodNetwork
 
     private
 
+    def report_options
+      @opts.merge(line_item_includes: line_item_includes)
+    end
+
+    def line_item_includes
+      [:bill_address, :adjustments,
+       line_items: { variant: [{ option_values: :option_type }, { product: :supplier }] }]
+    end
+
     def detail_rows_for_order(order, invoice_number, opts)
       rows = []
 


### PR DESCRIPTION
#### What? Why?

Closes #4006 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

- Adapts `lib/open_food_network/variant_and_line_item_naming.rb` so that it's methods work nicely with eager-loading.
- Eager-loads `option_values` objects wherever multiple variants are queried or serialized and the `#full_name` or `#product_and_full_name` methods are used.

#### What should we test?
<!-- List which features should be tested and how. -->

This PR mostly affects the way variants are loaded, in places where the variant's name/display_name/properties are shown in the UI, e.g: "Bread - Spelt Sourdough (1kg)".

Affected pages for testing:
- `/admin/reports`: basically all report types
- `/admin/orders/bulk_management`
- `/admin/order_cycles`: new order cycle, edit order cycle
- Producer email: order cycle report
- `/admin/products`
- Interactive search function with dropdown results for products/variants: subscriptions uses it to add items to a sub, order edit as admin uses it to add items to an order.

Also affects the endpoints: `/api/products/<product_id>/variants` and `/api/products/<product_id>/variants/<variant_id>/show`, but these don't seem to be used in app. Maybe zapier only? It could use a quick `dev-test`.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance in database queries relating to variants

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
