### PR TITLE
Fix migration mismatch

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191023105006) do
+ActiveRecord::Schema.define(:version => 20191023172424) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"


### PR DESCRIPTION
It looks like this was probably changed whilst resolving a merge conflict somewhere. The number in the schema doesn't match the number in the last migration file, which is breaking the `ofn-install` CI build (as well as any new deployments on fresh servers).

https://travis-ci.org/openfoodfoundation/ofn-install/jobs/606429808#L2109