### PR TITLE
Don't test existence of a field used in next spec

### DIFF
--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -427,10 +427,6 @@ feature '
         visit_bulk_order_management
       end
 
-      it "displays a quick search input" do
-        expect(page).to have_field "quick_search"
-      end
-
       it "filters line items based on their attributes and the contents of the quick search input" do
         expect(page).to have_selector "tr#li_#{li1.id}"
         expect(page).to have_selector "tr#li_#{li2.id}"


### PR DESCRIPTION
#### What? Why?

If the next example doesn't find the quick_search field it will fail so
no need to duplicate it with the consequent costly test setup.

#### What should we test?

Nothing this affects the automated tests only.

#### Release notes

Remove duplicate feature spec for Bulk Order Management quick search

Changelog Category: Removed
