### PR TITLE
Clickable steps on the OC edit page

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/create.js.coffee
@@ -2,8 +2,6 @@ angular.module('admin.orderCycles')
   .controller 'AdminCreateOrderCycleCtrl', ($scope, $controller, $filter, $window, OrderCycle, Enterprise, EnterpriseFee, Schedules, RequestMonitor, ocInstance, StatusMessage) ->
     $controller('AdminOrderCycleBasicCtrl', {$scope: $scope, ocInstance: ocInstance})
 
-    $scope.view = 'general_settings'
-
     $scope.order_cycle = OrderCycle.new({ coordinator_id: ocInstance.coordinator_id})
     $scope.enterprises = Enterprise.index(coordinator_id: ocInstance.coordinator_id)
     $scope.enterprise_fees = EnterpriseFee.index(coordinator_id: ocInstance.coordinator_id)

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -2,8 +2,6 @@ angular.module('admin.orderCycles')
   .controller 'AdminEditOrderCycleCtrl', ($scope, $controller, $filter, $location, $window, OrderCycle, Enterprise, EnterpriseFee, StatusMessage, Schedules, RequestMonitor, ocInstance) ->
     $controller('AdminOrderCycleBasicCtrl', {$scope: $scope, ocInstance: ocInstance})
 
-    $scope.view = 'general_settings'
-
     order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
     $scope.order_cycle = OrderCycle.load(order_cycle_id)
     $scope.enterprises = Enterprise.index(order_cycle_id: order_cycle_id)

--- a/app/assets/javascripts/admin/order_cycles/controllers/incoming_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/incoming_controller.js.coffee
@@ -1,7 +1,5 @@
 angular.module('admin.orderCycles').controller 'AdminOrderCycleIncomingCtrl', ($scope, $controller, $location, Enterprise, ocInstance) ->
   $controller('AdminOrderCycleExchangesCtrl', {$scope: $scope, ocInstance: ocInstance, $location: $location})
 
-  $scope.view = 'incoming'
-
   $scope.enterpriseTotalVariants = (enterprise) ->
     Enterprise.totalVariants(enterprise)

--- a/app/assets/javascripts/admin/order_cycles/controllers/outgoing_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/outgoing_controller.js.coffee
@@ -1,8 +1,6 @@
 angular.module('admin.orderCycles').controller 'AdminOrderCycleOutgoingCtrl', ($scope, $controller, $filter, $location, OrderCycle, ocInstance, StatusMessage) ->
   $controller('AdminOrderCycleExchangesCtrl', {$scope: $scope, ocInstance: ocInstance, $location: $location})
 
-  $scope.view = 'outgoing'
-
   $scope.productSuppliedToOrderCycle = (product) ->
     OrderCycle.productSuppliedToOrderCycle(product)
 

--- a/app/assets/stylesheets/admin/components/wizard_progress.css.scss
+++ b/app/assets/stylesheets/admin/components/wizard_progress.css.scss
@@ -19,6 +19,9 @@ ul.wizard-progress {
 		line-height: 30px;
 		padding: 0 25px 0 40px;
 		position: relative;
+		a {
+		  color: #494949;
+		}
 		&:first-child {
 			padding-left: 25px;
 			border-top-left-radius: 3px;
@@ -62,6 +65,9 @@ ul.wizard-progress {
 		&.current {
 			background-color: $color_selected;
 			color: #fff;
+			a {
+			  color: #fff;
+			}
 			&:after {
 				background-color: $color_selected;
 			}

--- a/app/views/admin/order_cycles/_form.html.haml
+++ b/app/views/admin/order_cycles/_form.html.haml
@@ -1,7 +1,7 @@
 = render 'wizard_progress'
 
 %fieldset.no-border-bottom
-  %legend{ align: 'center'}= t('spree.general_settings')
+  %legend{ align: 'center'}= t('.general_settings')
 
 = render 'name_and_timing_form', f: f
 

--- a/app/views/admin/order_cycles/_wizard_progress.html.haml
+++ b/app/views/admin/order_cycles/_wizard_progress.html.haml
@@ -8,11 +8,11 @@
       = t("admin.order_cycles.wizard_progress.outgoing")
   - else
     %li{ class: "#{'current' if action_name == 'edit'}" }
-      %a{href: "#{main_app.edit_admin_order_cycle_path(@order_cycle)}"}
+      %a{ href: main_app.edit_admin_order_cycle_path(@order_cycle) }
         = t("admin.order_cycles.wizard_progress.edit")
     %li{ class: "#{'current' if action_name == 'incoming'}" }
-      %a{href: "#{main_app.admin_order_cycle_incoming_path(@order_cycle)}"}
+      %a{ href: main_app.admin_order_cycle_incoming_path(@order_cycle) }
         = t("admin.order_cycles.wizard_progress.incoming")
     %li{ class: "#{'current' if action_name == 'outgoing'}" }
-      %a{href: "#{main_app.admin_order_cycle_outgoing_path(@order_cycle)}"}
+      %a{ href: main_app.admin_order_cycle_outgoing_path(@order_cycle) }
         = t("admin.order_cycles.wizard_progress.outgoing")

--- a/app/views/admin/order_cycles/_wizard_progress.html.haml
+++ b/app/views/admin/order_cycles/_wizard_progress.html.haml
@@ -1,3 +1,18 @@
 %ul.wizard-progress
-  %li{ ng: { repeat: "step in ['general_settings','incoming','outgoing']", class: '{current: view==step}' } }
-    {{ "admin.order_cycles.wizard_progress."+ step | t }}
+  - if action_name == 'new'
+    %li{ class: "current" }
+      = t("admin.order_cycles.wizard_progress.edit")
+    %li
+      = t("admin.order_cycles.wizard_progress.incoming")
+    %li
+      = t("admin.order_cycles.wizard_progress.outgoing")
+  - else
+    %li{ class: "#{'current' if action_name == 'edit'}" }
+      %a{href: "#{main_app.edit_admin_order_cycle_path(@order_cycle)}"}
+        = t("admin.order_cycles.wizard_progress.edit")
+    %li{ class: "#{'current' if action_name == 'incoming'}" }
+      %a{href: "#{main_app.admin_order_cycle_incoming_path(@order_cycle)}"}
+        = t("admin.order_cycles.wizard_progress.incoming")
+    %li{ class: "#{'current' if action_name == 'outgoing'}" }
+      %a{href: "#{main_app.admin_order_cycle_outgoing_path(@order_cycle)}"}
+        = t("admin.order_cycles.wizard_progress.outgoing")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -915,7 +915,7 @@ en:
         cancel: "Cancel"
         back_to_list: "Back To List"
       wizard_progress:
-        general_settings: "1. General Settings"
+        edit: "1. General Settings"
         incoming: "2. Incoming Products"
         outgoing: "3. Outgoing Products"
       exchange_form:
@@ -944,6 +944,7 @@ en:
         any_enterprise: "Any Enterprise"
         any_schedule: "Any Schedule"
       form:
+        general_settings: "General Settings"
         incoming: Incoming
         supplier: Supplier
         products: Products


### PR DESCRIPTION
#### What? Why?

This PR makes the steps in the OC edit page clicable. The user can jump to a specific step now by clicking the name of the step: General Settings, Incoming or Outgoing.

#### What should we test?
Verify the step names are clickable and the destination pages are correct.

#### Release notes
Changelog Category: Changed
The steps in the Order Cycle edit page are now clickable so it easier for the user to go to the page desired: General Settings, Incoming or Outgoing.
