### PR TITLE
Make "Ready for" field show a red border when added to the list of outgoing exchanges

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -1,5 +1,5 @@
 angular.module('admin.orderCycles')
-  .controller 'AdminOrderCycleExchangesCtrl', ($scope, $controller, $filter, $window, $location, OrderCycle, Enterprise, EnterpriseFee, Schedules, RequestMonitor, ocInstance, StatusMessage) ->
+  .controller 'AdminOrderCycleExchangesCtrl', ($scope, $controller, $filter, $window, $location, $timeout, OrderCycle, Enterprise, EnterpriseFee, Schedules, RequestMonitor, ocInstance, StatusMessage) ->
     $controller('AdminEditOrderCycleCtrl', {$scope: $scope, ocInstance: ocInstance, $location: $location})
 
     $scope.supplier_enterprises = Enterprise.producer_enterprises
@@ -38,11 +38,9 @@ angular.module('admin.orderCycles')
       OrderCycle.addDistributor($scope.new_distributor_id)
 
     $scope.setPickupTimeFieldDirty = (index) ->
-      setTimeout ->
-        last_outgoing_exchange_pickup_time_field_name = "order_cycle_outgoing_exchange_" + index + "_pickup_time"
-        $scope.order_cycle_form[last_outgoing_exchange_pickup_time_field_name].$setDirty()
-        $scope.$apply()
-      , 1
+      $timeout ->
+        pickup_time_field_name = "order_cycle_outgoing_exchange_" + index + "_pickup_time"
+        $scope.order_cycle_form[pickup_time_field_name].$setDirty()
 
     $scope.removeDistributionOfVariant = (variant_id) ->
       OrderCycle.removeDistributionOfVariant(variant_id)

--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -37,5 +37,12 @@ angular.module('admin.orderCycles')
       $event.preventDefault()
       OrderCycle.addDistributor($scope.new_distributor_id)
 
+    $scope.setPickupTimeFieldDirty = (index) ->
+      setTimeout ->
+        last_outgoing_exchange_pickup_time_field_name = "order_cycle_outgoing_exchange_" + index + "_pickup_time"
+        $scope.order_cycle_form[last_outgoing_exchange_pickup_time_field_name].$setDirty()
+        $scope.$apply()
+      , 1
+
     $scope.removeDistributionOfVariant = (variant_id) ->
       OrderCycle.removeDistributionOfVariant(variant_id)

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -14,7 +14,7 @@
     %td.tags.panel-toggle.text-center{ name: "tags", ng: { if: 'enterprises[exchange.enterprise_id].managed || order_cycle.viewing_as_coordinator' } }
       {{ exchange.tags.length }}
     %td.collection-details
-      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
+      = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', '', 'ng-init' => 'setPickupTimeFieldDirty($index)', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_time', 'required' => 'required', 'placeholder' => t('.pickup_time_placeholder'), 'ng-model' => 'exchange.pickup_time', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator', 'maxlength' => 35
       %span.icon-question-sign{'ofn-with-tip' => t('.pickup_time_tip')}
       %br/
       = text_field_tag 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', '', 'id' => 'order_cycle_outgoing_exchange_{{ $index }}_pickup_instructions', 'placeholder' => t('.pickup_instructions_placeholder'), 'ng-model' => 'exchange.pickup_instructions', 'ng-disabled' => '!enterprises[exchange.enterprise_id].managed && !order_cycle.viewing_as_coordinator'


### PR DESCRIPTION
#### What? Why?
This PR makes the red border on the pick up time (ready for) show immediately after a new distributor is added to the list of outgoing exchanges.

Tech comment: I tried quite a few things but the new form entry was not picking up the state (dirty). setTimeout was the only way to make this work...

#### What should we test?
Add a new distributor to the OC, the save button doesn't become active and now it's obvious why: the ready for field has a red border.

#### Release notes
Changelog Category: Changed
The "Ready for" field in the outgoing settings of the Order Cycle shows a red border indicating clearly it is a mandatory field.
