### PR TITLE
Sort products alphabetically in OC edit page

### DIFF
--- a/app/assets/javascripts/templates/admin/panels/exchange_distributed_products.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_distributed_products.html.haml
@@ -11,7 +11,7 @@
 
     .exchange-products
       -# Scope product list based on permissions the current user has to view variants in this exchange
-      .exchange-product{'ng-repeat' => 'product in supplied_products | filter:productSuppliedToOrderCycle | visibleProducts:exchange:order_cycle.visible_variants_for_outgoing_exchanges | orderBy:"name"' }
+      .exchange-product{'ng-repeat' => 'product in supplied_products | filter:productSuppliedToOrderCycle | visibleProducts:exchange:order_cycle.visible_variants_for_outgoing_exchanges' }
         .exchange-product-details
           %label
             %img{'ng-src' => '{{ product.image_url }}'}

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -34,11 +34,11 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
   private
 
   def products_scope
+    products_relation = object.supplied_products
     if order_cycle.prefers_product_selection_from_coordinator_inventory_only?
-      object.supplied_products.visible_for(order_cycle.coordinator)
-    else
-      object.supplied_products
+      products_relation = products_relation.visible_for(order_cycle.coordinator)
     end
+    products_relation
   end
 
   def products

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -38,7 +38,7 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
     if order_cycle.prefers_product_selection_from_coordinator_inventory_only?
       products_relation = products_relation.visible_for(order_cycle.coordinator)
     end
-    products_relation
+    products_relation.order(:name)
   end
 
   def products


### PR DESCRIPTION
#### What? Why?

This makes the list of products in the OC page sorted alphabetically.

#### What should we test?
Verify the order of the products is alphabetical.


#### Release notes
Changelog Category: Changed
The lists of products in the OC create/edit pages are sorted alphabetically.
