### PR TITLE
Reload order before checking spec expectations

### DIFF
--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -155,10 +155,12 @@ module Spree
           order.shipment.update!(order)
         end
 
-        xit "creates a shipment without backordered items" do
-          expect(order.shipment.manifest.first.quantity).to eq 10
-          expect(order.shipment.manifest.first.states).to eq 'on_hand' => 10
-          expect(order.shipment.manifest.first.variant).to eq line_item.variant
+        it "creates a shipment without backordered items" do
+          manifest = order.reload.shipment.manifest.first
+
+          expect(manifest.quantity).to eq 10
+          expect(manifest.states).to eq 'on_hand' => 10
+          expect(manifest.variant).to eq line_item.variant
         end
 
         it "does not reduce the variant's stock level" do


### PR DESCRIPTION
#### What? Why?

Closes #4457

The spec wasn't picking up the latest state of the DB thus no reflecting the change in the line item's quantity.

#### What should we test?

Nothing this is just fixing the automated test suite.

#### Release notes

Fix flaky model spec related to line item.

Changelog Category: Fixed

