### PR TITLE
Temporarily disable flaky line item spec

### DIFF
--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -155,7 +155,7 @@ module Spree
           order.shipment.update!(order)
         end
 
-        it "creates a shipment without backordered items" do
+        xit "creates a shipment without backordered items" do
           expect(order.shipment.manifest.first.quantity).to eq 10
           expect(order.shipment.manifest.first.states).to eq 'on_hand' => 10
           expect(order.shipment.manifest.first.variant).to eq line_item.variant


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/4457

This is causing almost all PRs to fail in CI and blocking our delivery
pipe. We're already working on a solution in
https://github.com/openfoodfoundation/openfoodnetwork/pull/4458.

#### What should we test?

Nothing
