### PR TITLE
Use .ruby-version when building Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,19 @@ RUN apt-get update && apt-get install -y curl git build-essential software-prope
 # Setup ENV variables
 ENV PATH /usr/local/src/rbenv/shims:/usr/local/src/rbenv/bin:$PATH
 ENV RBENV_ROOT /usr/local/src/rbenv
-ENV RUBY_VERSION 2.1.9
 ENV CONFIGURE_OPTS --disable-install-doc
+ENV BUNDLE_PATH /bundles
+
+WORKDIR /usr/src/app
+COPY .ruby-version .
 
 # Rbenv & Ruby part
 RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
     git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build && \
     ${RBENV_ROOT}/plugins/ruby-build/install.sh && \
     echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh && \
-    rbenv install $RUBY_VERSION && \
-    rbenv global $RUBY_VERSION && \
+    rbenv install $(cat .ruby-version) && \
+    rbenv global $(cat .ruby-version) && \
     gem install bundler --version=1.17.2
 
 # Postgres
@@ -24,8 +27,4 @@ RUN sh -c "echo 'deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main'
     apt-get update && \
     apt-get install -yqq --no-install-recommends postgresql-client-9.5 libpq-dev
 
-ENV BUNDLE_PATH /bundles
-
 COPY . /usr/src/app/
-
-WORKDIR /usr/src/app


### PR DESCRIPTION
The Ruby version was updated, but the Dockerfile wasn’t. This meant that
the Docker environment was broken. This change should prevent similar
breakage in the future by making .ruby-version the source of truth about
the correct version.