### PR TITLE
Fix shipping_rate fetching in customer_totals_report

### DIFF
--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -198,8 +198,13 @@ module OpenFoodNetwork
       private
 
       def shipping_method(line_items)
-        line_items.first.order.shipments.first.
-          andand.shipping_rates.andand.first.andand.shipping_method
+        shipping_rates = line_items.first.order.shipments.first.
+          andand.shipping_rates
+
+        return unless shipping_rates
+
+        shipping_rate = shipping_rates.find(&:selected) || shipping_rates.first
+        shipping_rate.try(:shipping_method)
       end
     end
   end

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
@@ -2,14 +2,7 @@ require "spec_helper"
 
 RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::CustomerTotalsReport do
   let!(:distributor) { create(:distributor_enterprise) }
-
   let!(:customer) { create(:customer, enterprise: distributor) }
-
-  let!(:order) do
-    create(:completed_order_with_totals, line_items_count: 1, user: customer.user,
-                                         customer: customer, distributor: distributor)
-  end
-
   let(:current_user) { distributor.owner }
   let(:permissions) { OpenFoodNetwork::Permissions.new(current_user) }
 
@@ -22,18 +15,51 @@ RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::CustomerTotalsRepor
     OpenFoodNetwork::OrderGrouper.new(report.rules, report.columns).table(report.table_items)
   end
 
-  it "generates the report" do
-    expect(report_table.length).to eq(2)
+  context "viewing the report" do
+    let!(:order) do
+      create(:completed_order_with_totals, line_items_count: 1, user: customer.user,
+             customer: customer, distributor: distributor)
+    end
+
+    it "generates the report" do
+      expect(report_table.length).to eq(2)
+    end
+
+    it "has a line item row" do
+      distributor_name_field = report_table.first[0]
+      expect(distributor_name_field).to eq distributor.name
+
+      customer_name_field = report_table.first[1]
+      expect(customer_name_field).to eq order.bill_address.full_name
+
+      total_field = report_table.last[5]
+      expect(total_field).to eq I18n.t("admin.reports.total")
+    end
   end
 
-  it "has a line item row" do
-    distributor_name_field = report_table.first[0]
-    expect(distributor_name_field).to eq distributor.name
+  context "loading shipping methods" do
+    let!(:shipping_method1) {
+      create(:shipping_method, distributors: [distributor], name: "First")
+    }
+    let!(:shipping_method2) {
+      create(:shipping_method, distributors: [distributor], name: "Second")
+    }
+    let!(:shipping_method3) {
+      create(:shipping_method, distributors: [distributor], name: "Third")
+    }
+    let!(:order) do
+      create(:completed_order_with_totals, line_items_count: 1, user: customer.user,
+             customer: customer, distributor: distributor)
+    end
 
-    customer_name_field = report_table.first[1]
-    expect(customer_name_field).to eq order.bill_address.full_name
+    before do
+      order.shipments.each(&:refresh_rates)
+      order.select_shipping_method(shipping_method2.id)
+    end
 
-    total_field = report_table.last[5]
-    expect(total_field).to eq I18n.t("admin.reports.total")
+    xit "displays the correct shipping_method" do
+      shipping_method_name_field = report_table.first[15]
+      expect(shipping_method_name_field).to eq shipping_method2.name
+    end
   end
 end

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::CustomerTotalsRepor
       order.select_shipping_method(shipping_method2.id)
     end
 
-    xit "displays the correct shipping_method" do
+    it "displays the correct shipping_method" do
       shipping_method_name_field = report_table.first[15]
       expect(shipping_method_name_field).to eq shipping_method2.name
     end


### PR DESCRIPTION
#### What? Why?

Closes #4468 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Fixes querying of shipping methods in customer and totals reports.

#### What should we test?
<!-- List which features should be tested and how. -->

Orders where there are several shipping methods available to the producer and the one selected for the order was not the first one; should display correctly in customer and totals reports.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Patched displaying of shipping method information in customer and totals reports

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

