### PR TITLE
Fix flaky tag_rules spec

### DIFF
--- a/app/views/admin/enterprises/_form.html.haml
+++ b/app/views/admin/enterprises/_form.html.haml
@@ -55,6 +55,6 @@
   %legend {{menu.selected.label}}
   = render 'admin/enterprises/form/shop_preferences', f: f
 
-%fieldset.alpha.no-border-bottom{ ng: { if: "menu.selected.name=='tag_rules'" } }
+%fieldset.alpha.no-border-bottom{ ng: { show: "menu.selected.name=='tag_rules'" } }
   %legend {{menu.selected.label}}
   = render 'admin/enterprises/form/tag_rules', f: f

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -13,7 +13,7 @@ feature 'Tag Rules', js: true do
     end
 
     it "allows creation of rules of each type" do
-      click_link "Tag Rules"
+      open_tag_rules_tab
 
       # Creating a new tag
       expect(page).to have_no_selector '.customer_tag'
@@ -120,7 +120,7 @@ feature 'Tag Rules', js: true do
     end
 
     it "saves changes to rules of each type" do
-      click_link "Tag Rules"
+      open_tag_rules_tab
 
       # Tag groups exist
       expect(page).to have_selector '.customer_tag .header', text: "For customers tagged:", count: 4
@@ -228,7 +228,7 @@ feature 'Tag Rules', js: true do
     end
 
     it "deletes both default and customer rules from the database" do
-      click_link "Tag Rules"
+      open_tag_rules_tab
 
       expect do
         accept_alert do
@@ -241,5 +241,12 @@ feature 'Tag Rules', js: true do
         expect(page).to have_no_selector "#tr_0"
       end.to change{ TagRule.count }.by(-2)
     end
+  end
+
+  private
+
+  def open_tag_rules_tab
+    click_link "Tag Rules"
+    expect(page).to have_selector ".default_rules"
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #4490 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

At the point where the test fails: we click a button in the Enterprise Edit page that then loads the Tag Rules panel content. The next bit of the test executes before Angular has finished loading the elements into the DOM. Hopefully this will fix it.

#### What should we test?
<!-- List which features should be tested and how. -->

`spec/features/admin/tag_rules_spec.rb` is no longer flaky :crossed_fingers: 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a flaky tag rules spec in the test suite

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
