### PR TITLE
4238 Do not assume order in spec for taxons list

### DIFF
--- a/spec/controllers/api/taxons_controller_spec.rb
+++ b/spec/controllers/api/taxons_controller_spec.rb
@@ -30,7 +30,8 @@ describe Api::TaxonsController do
     it "gets all taxons" do
       api_get :index
 
-      expect(json_response.first['name']).to eq taxonomy.root.name
+      json_names = json_response.map { |taxon_data| taxon_data["name"] }
+      expect(json_names).to include(taxon.name, taxon2.name)
     end
 
     it "can search for a single taxon" do


### PR DESCRIPTION
#### What? Why?

- Closes #4238

There is no default order for taxons, so results are (in effect) random.

This PR makes the spec not depend on the order of results.

#### What should we test?

This only affects specs. The build should pass, but no manual tests needed.

#### Release notes

Make automated test for API endpoint more reliable.

Changelog Category: Fixed