### PR TITLE
4239 Do one thing at a time in feature spec for product cloning

### DIFF
--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -415,14 +415,17 @@ feature '
 
     expect(page).to have_selector "a.clone-product", count: 1
     find("a.clone-product").click
+    expect(page).to have_field "product_name", with: "COPY OF #{p.name}"
 
-    fill_in "product_name", with: "new product name"
+    within "#p_#{p.id}" do
+      fill_in "product_name", with: "new product name"
+    end
 
     within "#save-bar" do
       click_button 'Save Changes'
     end
-
     expect(page.find("#status-message")).to have_content "Changes saved."
+
     p.reload
     expect(p.name).to eq "new product name"
   end


### PR DESCRIPTION
#### What? Why?

- Closes #4239

In the spec, we clone a product, and then update the original product's name to test that the form is still usable after cloning. We don't wait for the table to be re-rendered before attempting to edit the name of the product.

The failure seems to be because the Angular binding is not finished yet when "Save Changes" is clicked.

This PR makes the spec wait for the table to be re-rendered before proceeding to set the product name. This makes the spec pass in 30 runs on my computer. Before the PR, it failed 3 out of 30 runs but with a different failure. (See below.) It's possible that the issue before was that binding is interrupted when the table is re-rendered.

```
  1)
  As an Administrator
  I want to be able to manage products in bulk
 updating a product after cloning a product
     Failure/Error: expect(page.find("#status-message")).to have_content "Changes saved."
       expected to find text "Changes saved." in "Changes to one product remain unsaved."
     # ./spec/features/admin/bulk_product_update_spec.rb:426:in `block (3 levels) in <top (required)>'
```

#### What should we test?

This only affects specs. The build should pass, but no manual tests needed.

#### Release notes

Make automated feature test for product cloning more reliable.

Changelog Category: Fixed