### PR TITLE
4489 Improve waiting in feature spec for edit Order Cycle page

### DIFF
--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -328,9 +328,12 @@ feature '
       expect(page).to have_content 'Your order cycle has been updated.'
 
       # And I add a supplier and some products
+      expect(page).to have_selector("table.exchanges tr.supplier")
       select 'My supplier', from: 'new_supplier_id'
       click_button 'Add supplier'
+      expect(page).to have_selector("table.exchanges tr.supplier", text: "My supplier")
       page.all("table.exchanges tr.supplier td.products").each(&:click)
+
 
       expect(page).to have_selector "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}", visible: true
       page.find("#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}", visible: true).click # uncheck (with visible:true filter)
@@ -352,6 +355,7 @@ feature '
       # And I add a distributor and some products
       select 'My distributor', from: 'new_distributor_id'
       click_button 'Add distributor'
+      expect(page).to have_field("order_cycle_outgoing_exchange_2_pickup_time")
 
       fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'New time 0'
       fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'New instructions 0'


### PR DESCRIPTION
#### What? Why?

- Closes #4489

This just adds waiting in the feature spec.

#### What should we test?

This only affects specs. The build should pass, but no manual tests needed.

#### Release notes

Make automated feature test for editing order cycle more reliable.

Changelog Category: Fixed