### PR TITLE
3149 Fix tooltips in orders list

### DIFF
--- a/app/assets/stylesheets/admin/components/tooltip.css.scss
+++ b/app/assets/stylesheets/admin/components/tooltip.css.scss
@@ -1,0 +1,4 @@
+#powerTip {
+  max-width: 240px;
+  white-space: normal;
+}

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -47,7 +47,7 @@
 
       %th.actions
   %tbody
-    %tr{ng: {repeat: 'order in orders track by $index', class: {even: "'even'", odd: "'odd'"}}, 'ng-class' => "'state-{{order.state}}'"}
+    %tr{ng: {repeat: 'order in orders track by order.id', class: {even: "'even'", odd: "'odd'"}}, 'ng-class' => "'state-{{order.state}}'"}
       %td.align-center
         %input{type: 'checkbox', 'ng-model' => 'checkboxes[order.id]', 'ng-change' => 'toggleSelection(order.id)'}
       %td.align-center


### PR DESCRIPTION
#### What? Why?

- Closes #3149 

This does two things:

* Set max width and enable text wrapping for the tooltip content
* Fix how the tooltips are associated with orders in the orders table

The 2nd is accomplished by fixing Angular tracking of rows in the orders list. `ng-repeat` was tracking items by table row index. As far as `ng-repeat` was concerned, rows with the same table row index in any page (pagination) were for the same item, so it wouldn't bother relinking the `ofn-with-tip` directive.

Example scenario: Order A in row 1 of the first page and Order B in row 1 of the second page have special instructions. Navigate to the second page, and notice that the tooltip for Order B uses the special instructions for Order A.

#### What should we test?

In the Orders page, find a table row number for which there are multiple pages (pagination) where the order has special instructions (e.g. row 2 in both pages 1 and 3 have special instructions). The tooltip for the order in the later page should not use the special instructions of the order in the earlier page.

Also test wrapping of text for long special instructions.

Smoke test of these in the "Orders" page is also needed:

* The link to edit order still works
* Selection of orders for "Print Invoices" works

This change affects all similar looking tooltips, e.g. "Edit" and "Capture" in the Orders page. But I can't think of any special tooltips that need to be tested.

#### Release notes

- Fix text wrapping and using of the correct order for the special instructions tooltip in the Orders page.

Changelog Category: Fixed