### PR TITLE
Improve Subscriptions logging

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -389,7 +389,6 @@ Metrics/AbcSize:
   - app/helpers/spree/admin/base_helper.rb
   - app/helpers/spree/admin/zones_helper.rb
   - app/helpers/spree/orders_helper.rb
-  - app/jobs/subscription_placement_job.rb
   - app/mailers/producer_mailer.rb
   - app/models/calculator/flat_percent_per_item.rb
   - app/models/column_preference.rb

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -6,6 +6,7 @@ class SubscriptionConfirmJob
     ids = proxy_orders.pluck(:id)
     proxy_orders.update_all(confirmed_at: Time.zone.now)
     ProxyOrder.where(id: ids).each do |proxy_order|
+      Rails.logger.info "Confirming Order for Proxy Order #{proxy_order.id}"
       @order = proxy_order.order
       process!
     end

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -5,6 +5,7 @@ class SubscriptionPlacementJob
     ids = proxy_orders.pluck(:id)
     proxy_orders.update_all(placed_at: Time.zone.now)
     ProxyOrder.where(id: ids).each do |proxy_order|
+      Rails.logger.info "Placing Order for Proxy Order #{proxy_order.id}"
       proxy_order.initialise_order!
       process(proxy_order.order)
     end

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -5,9 +5,7 @@ class SubscriptionPlacementJob
     ids = proxy_orders.pluck(:id)
     proxy_orders.update_all(placed_at: Time.zone.now)
     ProxyOrder.where(id: ids).each do |proxy_order|
-      Rails.logger.info "Placing Order for Proxy Order #{proxy_order.id}"
-      proxy_order.initialise_order!
-      process(proxy_order.order)
+      place_order_for(proxy_order)
     end
 
     send_placement_summary_emails
@@ -29,16 +27,18 @@ class SubscriptionPlacementJob
       .joins(:subscription).merge(Subscription.not_canceled.not_paused)
   end
 
-  def process(order)
+  def place_order_for(proxy_order)
+    Rails.logger.info "Placing Order for Proxy Order #{proxy_order.id}"
+    proxy_order.initialise_order!
+    place_order(proxy_order.order)
+  end
+
+  def place_order(order)
     record_order(order)
     return record_issue(:complete, order) if order.completed?
 
     changes = cap_quantity_and_store_changes(order)
-    if order.line_items.where('quantity > 0').empty?
-      order.reload.adjustments.destroy_all
-      order.update!
-      return send_empty_email(order, changes)
-    end
+    return handle_empty_order(order, changes) if order.line_items.where('quantity > 0').empty?
 
     move_to_completion(order)
     send_placement_email(order, changes)
@@ -57,6 +57,12 @@ class SubscriptionPlacementJob
       line_item.update_attributes(quantity: 0)
     end
     changes
+  end
+
+  def handle_empty_order(order, changes)
+    order.reload.adjustments.destroy_all
+    order.update!
+    send_empty_email(order, changes)
   end
 
   def move_to_completion(order)

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -17,6 +17,7 @@ class OrderCycle < ActiveRecord::Base
   has_many :distributors, source: :receiver, through: :cached_outgoing_exchanges, uniq: true
 
   has_and_belongs_to_many :schedules, join_table: 'order_cycle_schedules'
+  has_paper_trail meta: { custom_data: :schedule_ids }
 
   attr_accessor :incoming_exchanges, :outgoing_exchanges
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,7 @@
 class Schedule < ActiveRecord::Base
   has_and_belongs_to_many :order_cycles, join_table: 'order_cycle_schedules'
+  has_paper_trail meta: { custom_data: :order_cycle_ids }
+
   has_many :coordinators, uniq: true, through: :order_cycles
 
   attr_accessible :name, :order_cycle_ids

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,7 @@
 PaperTrail.config.track_associations = false
+
+module PaperTrail
+  class Version < ActiveRecord::Base
+    attr_accessible :custom_data
+  end
+end

--- a/db/migrate/20191202165700_add_custom_data_to_versions.rb
+++ b/db/migrate/20191202165700_add_custom_data_to_versions.rb
@@ -1,0 +1,5 @@
+class AddCustomDataToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :custom_data, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1202,6 +1202,7 @@ ActiveRecord::Schema.define(:version => 20191023172424) do
     t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"
+    t.string   "custom_data"
   end
 
   add_index "versions", ["item_type", "item_id"], :name => "index_versions_on_item_type_and_item_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191023172424) do
+ActiveRecord::Schema.define(:version => 20191202165700) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -1196,9 +1196,9 @@ ActiveRecord::Schema.define(:version => 20191023172424) do
   add_index "variant_overrides", ["variant_id", "hub_id"], :name => "index_variant_overrides_on_variant_id_and_hub_id"
 
   create_table "versions", :force => true do |t|
-    t.string   "item_type",  :null => false
-    t.integer  "item_id",    :null => false
-    t.string   "event",      :null => false
+    t.string   "item_type",   :null => false
+    t.integer  "item_id",     :null => false
+    t.string   "event",       :null => false
     t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"

--- a/lib/open_food_network/proxy_order_syncer.rb
+++ b/lib/open_food_network/proxy_order_syncer.rb
@@ -17,27 +17,34 @@ module OpenFoodNetwork
     end
 
     def sync!
-      return sync_all! if @subscriptions
+      return sync_subscriptions! if @subscriptions
+
       return initialise_proxy_orders! unless @subscription.id
 
-      create_proxy_orders!
-      remove_orphaned_proxy_orders!
+      sync_subscription!
     end
 
     private
 
-    def sync_all!
+    def sync_subscriptions!
       @subscriptions.each do |subscription|
         @subscription = subscription
-        create_proxy_orders!
-        remove_orphaned_proxy_orders!
+        sync_subscription!
       end
     end
 
     def initialise_proxy_orders!
       uninitialised_order_cycle_ids.each do |order_cycle_id|
+        Rails.logger.info "Initializing Proxy Order " \
+          "of subscription #{@subscription.id} in order cycle #{order_cycle_id}"
         proxy_orders << ProxyOrder.new(subscription: subscription, order_cycle_id: order_cycle_id)
       end
+    end
+
+    def sync_subscription!
+      Rails.logger.info "Syncing Proxy Orders of subscription #{@subscription.id}"
+      create_proxy_orders!
+      remove_orphaned_proxy_orders!
     end
 
     def create_proxy_orders!
@@ -58,6 +65,8 @@ module OpenFoodNetwork
       orphaned_proxy_orders.scoped.delete_all
     end
 
+    # Remove Proxy Orders that have not been placed yet
+    #   and are in Order Cycles that are out of range
     def orphaned_proxy_orders
       orphaned = proxy_orders.where(placed_at: nil)
       order_cycle_ids = in_range_order_cycles.pluck(:id)

--- a/lib/open_food_network/subscription_summarizer.rb
+++ b/lib/open_food_network/subscription_summarizer.rb
@@ -17,6 +17,7 @@ module OpenFoodNetwork
     end
 
     def record_issue(type, order, message = nil)
+      Rails.logger.info "Issue in Subscription Order #{order.id}: #{type}"
       summary_for(order).record_issue(type, order, message)
     end
 

--- a/spec/lib/open_food_network/subscription_summarizer_spec.rb
+++ b/spec/lib/open_food_network/subscription_summarizer_spec.rb
@@ -1,9 +1,12 @@
+require 'spec_helper'
 require 'open_food_network/subscription_summarizer'
 
 module OpenFoodNetwork
   describe SubscriptionSummarizer do
     let(:order) { create(:order) }
     let(:summarizer) { OpenFoodNetwork::SubscriptionSummarizer.new }
+
+    before { allow(Rails.logger).to receive(:info) }
 
     describe "#summary_for" do
       let(:order) { double(:order, distributor_id: 123) }
@@ -53,6 +56,7 @@ module OpenFoodNetwork
 
       describe "#record_issue" do
         it "requests a summary for the order and calls #record_issue on it" do
+          expect(order).to receive(:id)
           expect(summary).to receive(:record_issue).with(:type, order, "message").once
           summarizer.record_issue(:type, order, "message")
         end
@@ -69,7 +73,6 @@ module OpenFoodNetwork
           end
 
           it "sends error info to the rails logger and calls #record_issue on itself with an error message" do
-            expect(Rails.logger).to receive(:info)
             expect(summarizer).to receive(:record_issue).with(:processing, order, "Errors: Some error")
             summarizer.record_and_log_error(:processing, order)
           end
@@ -81,7 +84,6 @@ module OpenFoodNetwork
           end
 
           it "falls back to calling record_issue" do
-            expect(Rails.logger).to_not receive(:info)
             expect(summarizer).to receive(:record_issue).with(:processing, order)
             summarizer.record_and_log_error(:processing, order)
           end


### PR DESCRIPTION
#### What? Why?

Progresses #4462 but we will need to check if linking schedules to OCs is fully tracked now.

Add paper_trail to OCs and Schedules and add extra logging to Subscriptions background processes.

Here we do a few different things (I keep it in one PR because this is all related and it makes the review and test process easier, I think):

A - Add paper_trail to OCs and Schedules: this enables us to see what changes were done to these models and when they were created/updated/deleted. We also add a custom_data field to paper_trail versions table so we can have extra info for whatever we need, in this case, we are adding: for Schedules, the OCs they are associated with, and for OCs, the schedules they are associated with. (I thought this is a lighter solution that introducing gem paper_trail-association_tracking).
This addresses the problem in the S2 that led to #4462: when did the user linked the schedule with the OC? I don think it will cover 100% of the cases: I think the user will still be able to associated a schedule to an OC without any trace on the DB. That's why I dont think this issue will close #4462

B - Add different log statements in the proxy orders sync process and in the subs placement and confirmation background jobs so that we know what subs and orders were processed in each run. These statements are not going to solve all our debugging needs but it's a start, these basic ones are specially useful when the process fails to run, we will be able to check the logs and see if it didn't run or if it did run without producing the expected output.

#### What should we test?
This PR can only be tested by a dev and doesnt require a testers to verify anything.

A - We should edit the OC and edit a schedule and verify the table versions contain the previous data on those models.

B - We should setup a subscription or two, edit them and verify that the sync process worked and there are logs mentioning what happened. After that, when the OC opens, we need to verify the placement job worked and there are logs mentioning what happened, including what emails were sent. After that, when the OC closes, we need to verify the confirmation job worked and there are logs mentioning what happened, including what emails were sent.

#### Release notes
Changelog Category: Added
Subscriptions module now has much better logging and it will be easier from now on to debug and explain what happened in specific cases.
