### PR TITLE
Make product order deterministic

### DIFF
--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -66,7 +66,7 @@ class ProductsRenderer
         .split(",").map { |id| "spree_products.primary_taxon_id=#{id} DESC" }
         .join(", ") + ", spree_products.name ASC, spree_products.id ASC"
     else
-      "spree_products.name ASC"
+      "spree_products.name ASC, spree_products.id"
     end
   end
 


### PR DESCRIPTION

#### What? Why?

Closes #4537

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

When products are sorted by name and two products have the same name,
their order is undefined. With pagination, two pages can have a
different order of products with the same name which then means that two
pages can return the same product.

Sorting by product id makes sure that the result is always in the same
order, for every page.

I didn't add any automated tests for this because we can't create an "undefined" order returned from the database that would reliably fail.

#### What should we test?
<!-- List which features should be tested and how. -->

Create a shopfront with more than 10 products. The 10th and 11th product in the shopfront should have the same name. Do all products load?

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a bug where two products with same name could limit the number of products displayed in the shopfront.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed



