### PR TITLE
Make weight calculator work for SubscriptionLineItems

### DIFF
--- a/app/assets/javascripts/admin/subscriptions/controllers/products_panel_controller.js.coffee
+++ b/app/assets/javascripts/admin/subscriptions/controllers/products_panel_controller.js.coffee
@@ -20,4 +20,4 @@ angular.module("admin.subscriptions").controller "ProductsPanelController", ($sc
         keys = Object.keys(response.data.errors)
         StatusMessage.display 'failure', response.data.errors[keys[0]][0]
       else
-        StatusMessage.display 'success', t('js.changes_saved')
+        StatusMessage.display 'failure', t('js.admin.subscriptions.error_saving')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2642,6 +2642,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           customer_placeholder: "customer@example.org"
           valid_email_error: "Please enter a valid email address"
       subscriptions:
+        error_saving: "Error saving subscription"
         new:
           please_select_a_shop: "Please select a shop"
     insufficient_stock: "Insufficient stock available, only %{on_hand} remaining"

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -68,10 +68,7 @@ feature 'Subscriptions' do
         expect(page).to have_no_content subscription.customer.email
 
         # Viewing Products
-        within "tr#so_#{subscription.id}" do
-          expect(page).to have_selector "td.items.panel-toggle", text: 3
-          page.find("td.items.panel-toggle").click
-        end
+        open_subscription_products_panel
 
         within "#subscription-line-items" do
           expect(page).to have_selector "span#order_subtotal", text: "$15.00" # 3 x $5 items
@@ -136,6 +133,28 @@ feature 'Subscriptions' do
         within "tr#so_#{subscription.id}" do
           expect(page).to have_selector ".state.canceled", text: "CANCELLED"
           expect(subscription.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
+        end
+      end
+
+      context "editing subscription products quantity" do
+        it "updates quantity" do
+          visit admin_subscriptions_path
+          select2_select shop.name, from: "shop_id"
+          open_subscription_products_panel
+
+          within "#sli_0" do
+            fill_in 'quantity', with: "5"
+          end
+
+          page.find("a.button.update").click
+          expect(page).to have_content 'SAVED'
+        end
+      end
+
+      def open_subscription_products_panel
+        within "tr#so_#{subscription.id}" do
+          expect(page).to have_selector "td.items.panel-toggle", text: 3
+          page.find("td.items.panel-toggle").click
         end
       end
     end

--- a/spec/javascripts/unit/admin/subscriptions/controllers/products_panel_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/subscriptions/controllers/products_panel_controller_spec.js.coffee
@@ -1,0 +1,44 @@
+describe "ProductsPanelController", ->
+  scope = null
+  StatusMessage = null
+  subscription = { shop_id: 1 }
+
+  beforeEach ->
+    module('admin.subscriptions')
+    inject ($controller, $rootScope, _StatusMessage_) ->
+      scope = $rootScope
+      scope.object =  subscription
+      StatusMessage = _StatusMessage_
+      $controller 'ProductsPanelController', {$scope: scope, StatusMessage: _StatusMessage_}
+
+  describe "saving subscription", ->
+    update_promise_resolve = null
+    update_promise_reject = null
+    update_promise = null
+
+    beforeEach ->
+      update_promise = new Promise (resolve, reject) ->
+        update_promise_resolve = resolve
+        update_promise_reject = reject
+      subscription.update = jasmine.createSpy('update').and.returnValue(update_promise)
+      StatusMessage.display = jasmine.createSpy('display')
+
+    it "updates subscription and updates status message while in progress and on success", ->
+      scope.save()
+
+      expect(subscription.update).toHaveBeenCalled()
+      expect(StatusMessage.display).toHaveBeenCalledWith('progress', 'Saving...')
+      expect(scope.saving).toEqual(true)
+
+      update_promise.then ->
+        expect(StatusMessage.display.calls.all()[1].args).toEqual(['success', 'Changes saved.'])
+        expect(scope.saving).toEqual(false)
+      update_promise_resolve()
+
+    it "updates status message on errors", ->
+      scope.save()
+
+      update_promise.catch ->
+        expect(StatusMessage.display.calls.all()[1].args).toEqual(['failure', 'Error saving subscription'])
+        expect(scope.saving).toEqual(false)
+      update_promise_reject("error")


### PR DESCRIPTION
#### What? Why?

Closes #4410 and #4322 

Make weight calculator work for SubscriptionLineItems.
We do this by making the calculator test if line_item responds to final_weight_volume field. See commit messages for more details.

#### What should we test?
Create subscription with a shipping method with a weight based calculator. Make sure you can now edit the subscription in both the subs list and the edit subs page. Make sure you can paused/unpaused the subscription.

#### Release notes
Changelog Category: Fixed
Fixed bug in subscriptions with shipping methods with price based on weight. These subscriptions can now be edited and paused/unpaused.