### PR TITLE
Handle validation messages when saving new fees

### DIFF
--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -28,15 +28,12 @@ module Admin
 
     def bulk_update
       @enterprise_fee_set = EnterpriseFeeSet.new(params[:enterprise_fee_set])
-      if @enterprise_fee_set.save
-        redirect_path = main_app.admin_enterprise_fees_path
-        if params.key? :enterprise_id
-          redirect_path = main_app.admin_enterprise_fees_path(enterprise_id: params[:enterprise_id])
-        end
-        redirect_to redirect_path, notice: I18n.t(:enterprise_fees_update_notice)
 
+      if @enterprise_fee_set.save
+        redirect_to redirect_path, notice: I18n.t(:enterprise_fees_update_notice)
       else
-        render :index
+        redirect_to redirect_path,
+                    flash: { error: @enterprise_fee_set.errors.full_messages.to_sentence }
       end
     end
 
@@ -72,6 +69,14 @@ module Admin
 
     def current_enterprise
       Enterprise.find params[:enterprise_id] if params.key? :enterprise_id
+    end
+
+    def redirect_path
+      if params.key? :enterprise_id
+        return main_app.admin_enterprise_fees_path(enterprise_id: params[:enterprise_id])
+      end
+
+      main_app.admin_enterprise_fees_path
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
   language_name: "English" # Localised name of this language
   activerecord:
     attributes:
+      enterprise_fee:
+        fee_type: Fee Type
       spree/order:
         payment_state: Payment State
         shipment_state: Shipment State
@@ -69,6 +71,8 @@ en:
         shipping_method_ids: "Shipping Methods"
         payment_method_ids: "Payment Methods"
     errors:
+      messages:
+        inclusion: "is not included in the list"
       models:
         subscription_validator:
           attributes:


### PR DESCRIPTION
#### What? Why?

Closes #3307 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds missing error handling to `EnterpriseFeesController`. The user now gets a relevant validation error message, and doesn't see the dreaded snail.

#### What should we test?
<!-- List which features should be tested and how. -->

Saving a new enterprise fee when the fee type has not been selected. Shows an error message instead of the snail.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed validation messages when saving new enterprise fees.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
