### PR TITLE
Add timestamp to log entries

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,13 +34,14 @@ Openfoodnetwork::Application.configure do
   config.action_mailer.default_url_options = { protocol: 'https' }
 
   # See everything in the log (default is :info)
-  config.log_level = :info
+  # config.log_level = :debug
 
-  # Configure logging
-  Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-  Rails.logger.formatter = Logger::Formatter.new
-  Rails.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
-  config.logger = Rails.logger
+  # Configure logging for Rails 3.2:
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(Rails.root.join("log", "#{Rails.env}.log")))
+  config.logger.formatter = Logger::Formatter.new
+  config.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
+  # Once we get to Rails 4.0, we can replace the above with:
+  #config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
 
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,8 +36,11 @@ Openfoodnetwork::Application.configure do
   # See everything in the log (default is :info)
   config.log_level = :info
 
-  # Use a different logger for distributed setups
-  # config.logger = SyslogLogger.new
+  # Configure logging
+  Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  Rails.logger.formatter = Logger::Formatter.new
+  Rails.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
+  config.logger = Rails.logger
 
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -36,8 +36,11 @@ Openfoodnetwork::Application.configure do
   # See everything in the log (default is :info)
   # config.log_level = :debug
 
-  # Use a different logger for distributed setups
-  # config.logger = SyslogLogger.new
+  # Configure logging
+  Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  Rails.logger.formatter = Logger::Formatter.new
+  Rails.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
+  config.logger = Rails.logger
 
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -36,11 +36,12 @@ Openfoodnetwork::Application.configure do
   # See everything in the log (default is :info)
   # config.log_level = :debug
 
-  # Configure logging
-  Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-  Rails.logger.formatter = Logger::Formatter.new
-  Rails.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
-  config.logger = Rails.logger
+  # Configure logging for Rails 3.2:
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(Rails.root.join("log", "#{Rails.env}.log")))
+  config.logger.formatter = Logger::Formatter.new
+  config.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
+  # Once we get to Rails 4.0, we can replace the above with:
+  #config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
 
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i


### PR DESCRIPTION
#### What? Why?

In addition to #4527

Add timestamp to Rails logger in staging and prod so that info in logs can be accurately compared with data in the DB while debbuging. Logs will look like this now:
`I, [2019-12-05 10:49:57#13624]  INFO -- : Syncing Proxy Orders of subscription 1`

#### What should we test?
Make sure that the logs include a timestamp in staging.
Make sure the logs are on log/staging.log

#### Release notes
Changelog Category: Added
Added timestamp to log entries to improve accuracy on analysis.
