### PR TITLE
Make whenever properly read the S3 bucket

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,11 +13,11 @@ job_type :enqueue_job,  "cd :path; :environment_variable=:environment bundle exe
 
 
 every 1.day, at: '2:45am' do
-  rake 'db2fog:clean' if ENV['S3_BACKUPS_BUCKET']
+  rake 'db2fog:clean' if app_config['S3_BACKUPS_BUCKET']
 end
 
 every 4.hours do
-  rake 'db2fog:backup' if ENV['S3_BACKUPS_BUCKET']
+  rake 'db2fog:backup' if app_config['S3_BACKUPS_BUCKET']
 end
 
 every 5.minutes do


### PR DESCRIPTION
#### What? Why?

For unknown reasons the magic [Figaro](https://github.com/laserlemon/figaro) does to turn keys in `config/application.yml` into ENV vars that can be read through Ruby's `ENV[]` is not working in `config/schedule.rb`.

As a result, the `db2fog` tasks are not translated into cron entries which led to **not having automatic backups**.

:warning: **UK, FR, AU and Katuma are all missing the backup entries in crontab.** So it must be affecting everyone. :warning: 

I checked the change directly in Katuma staging and backups now show up in S3.

I also took the time to see if we could get some output into a `log/cron.log` but the [gem we use](https://github.com/itbeaver/db2fog/blob/master/lib/db2fog.rb) doesn't seem to ouptut anything :see_no_evil: We could monitor the backups and set up an alert if we had it...

#### What should we test?

After the deploy, ssh into the staging server as `openfoodnetwork` and run  `crontab -e`. Then update the line that runs the backup (should be the 2nd one) to have the following content

```
* * * * * /bin/bash -l -c 'cd /home/openfoodnetwork/apps/openfoodnetwork/current && RAILS_ENV=staging bundle exec rake db2fog:backup --silent'
```
save and exit. Now go check S3. There should be a backup in a minute.

Deploy again when done to restore the backup frequency.

#### Release notes

Fixed automatic database backups to read the S3 bucket name. 

Changelog Category: Fixed
