### PR TITLE
Cart link in header on mobile leads to cart page instead of checkout …

### DIFF
--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -10,7 +10,7 @@
 
   %section.right{"ng-cloak" => true}
     %span.cart-span{"ng-controller" => "CartCtrl", "ng-class" => "{ dirty: Cart.dirty || Cart.empty(), 'pure-dirty': Cart.dirty }"}
-      %a.icon{href: main_app.checkout_path}
+      %a.icon{href: main_app.cart_path}
         %span
           = t '.cart'
         %span.count


### PR DESCRIPTION
#### What? Why?

Closes #4532 

Cart link in header on mobile had unexpected behaviour. It led to checkout page instead of cart page. I have changed link. 

#### What should we test?
You should click on cart icon in the header nav on mobile device and sure than you are at the cart page.

#### Release notes
Fixed cart link on mobile in header section.

Changelog Category:  Fixed

