### PR TITLE
Improve truncate data process

### DIFF
--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -9,6 +9,9 @@ namespace :ofn do
 
       sql_delete_from "
         spree_inventory_units #{where_order_id_in_orders_to_delete}"
+      sql_delete_from "
+        spree_inventory_units
+        where shipment_id in (select id from spree_shipments #{where_order_id_in_orders_to_delete})"
 
       truncate_adjustments
 


### PR DESCRIPTION
#### What? Why?
Delete extra inventory_units that are for some unknown reason connected to shipments of orders to delete, but not connected to orders to delete

#### What should we test?
This problem appeared with uk live data and I tested it locally with UK live data. I dont think we need to validate this again.

#### Release notes
Changelog Category: Changed
Improved the data truncation process that we use to move data from live environments to other testing environments.
