### PR TITLE
Use arel in order permissions visible orders and editable orders so that we dont have queries with gigantic IN clauses

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -114,7 +114,6 @@ Metrics/LineLength:
   - lib/open_food_network/enterprise_issue_validator.rb
   - lib/open_food_network/group_buy_report.rb
   - lib/open_food_network/lettuce_share_report.rb
-  - lib/open_food_network/order_and_distributor_report.rb
   - lib/open_food_network/order_cycle_form_applicator.rb
   - lib/open_food_network/order_cycle_management_report.rb
   - lib/open_food_network/payments_report.rb

--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -9,15 +9,7 @@ module Permissions
     def visible_orders
       Spree::Order.
         with_line_items_variants_and_products_outer.
-        where(
-          Spree::Order.arel_table.
-            # Grouping keeps the 2 where clauses from produced_orders_where_values inside parentheses
-            #   This way it makes the OR work between the 3 types of orders:
-            #     produced, managed and coordinated
-            grouping(produced_orders_where_values).
-            or(managed_orders_where_values).
-            or(coordinated_orders_where_values)
-        )
+        where(visible_orders_where_values)
     end
 
     # Any orders that the user can edit
@@ -40,6 +32,16 @@ module Permissions
     end
 
     private
+
+    def visible_orders_where_values
+      # Grouping keeps the 2 where clauses from produced_orders_where_values inside parentheses
+      #   This way it makes the OR work between the 3 types of orders:
+      #     produced, managed and coordinated
+      Spree::Order.arel_table.
+        grouping(produced_orders_where_values).
+        or(managed_orders_where_values).
+        or(coordinated_orders_where_values)
+    end
 
     # Any orders placed through any hub that I manage
     def managed_orders_where_values

--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -44,7 +44,7 @@ module OpenFoodNetwork
 
       # If empty array is passed in, the where clause will return all line_items, which is bad
       orders_with_hidden_details =
-        @permissions.editable_orders.empty? ? orders : orders.where('id NOT IN (?)', @permissions.editable_orders)
+        @permissions.editable_orders.empty? ? orders : orders.where('spree_orders.id NOT IN (?)', @permissions.editable_orders)
 
       orders.select{ |order| orders_with_hidden_details.include? order }.each do |order|
         # TODO We should really be hiding customer code here too, but until we


### PR DESCRIPTION
#### What? Why?

Relates and improves the situation of #4547
Problem: the | operators here were converting the relations to long lists of IDs, in our current particular issue, an IN clause with 100k order_ids.
Now we use arel and build one single query for visible_orders and editable_orders.

#### What should we test?
We need to make sure the report is working correctly and hiding line items for producers who are not distributors. One particular case that makes the code slightly more complicated is that these producers should only see their line items, not all the line_items in the orders they have access to: so a producer should only see their products in the orders.

This PR improves the performance of the report from 50secs to 42secs in my tests.

There's a small change in order_and_distributor report as well. I think we can make a verification of this report as well.

#### Release notes
Changelog Category: Changed
Improved query of Orders and Fulfillment customer totals report and the performance of the report.
