### PR TITLE
Billing address in pdf invoice fixed

### DIFF
--- a/app/views/spree/admin/orders/invoice2.html.haml
+++ b/app/views/spree/admin/orders/invoice2.html.haml
@@ -44,14 +44,14 @@
       %td{ :align => "right" }
         = t :invoice_billing_address
         %br
-        %strong= @order.ship_address.full_name
+        %strong= @order.bill_address.full_name
         - if @order.andand.customer.andand.code.present?
           %br
           = "Code: #{@order.customer.code}"
         %br
-        = @order.ship_address.address_part1
+        = @order.bill_address.address_part1
         %br
-        = @order.ship_address.address_part2
+        = @order.bill_address.address_part2
 
 = render 'spree/admin/orders/invoice_table2'
 


### PR DESCRIPTION
#### What? Why?

Closes #4473 

Shipping address was displayed in PDF invoice instead of billing address. I've changed the code to display billing address.


#### What should we test?
1. **PRINT INVOICES** button on `admin/orders` page. Should be displayed billing address in the generated invoice.
2. **Actions - Print invoice** button on particular order's page in Admin area. Should be displayed billing address in the generated invoice.



#### Release notes

PDF invoices now show the billing address instead of the shipping address. Please let us know if you need the shipping address on your invoices.

Changelog Category: Fixed | Changed

