### PR TITLE
Fix route on "continue" button on admin adjustments page

### DIFF
--- a/app/views/spree/admin/adjustments/index.html.haml
+++ b/app/views/spree/admin/adjustments/index.html.haml
@@ -10,4 +10,4 @@
 
 = render :partial => 'adjustments_table'
 
-= button_link_to t(:continue), @order.cart? ? new_admin_order_payment_url(@order) : admin_orders_url, :icon => 'icon-arrow-right'
+= button_link_to t(:continue), admin_order_payments_url(@order), :icon => 'icon-arrow-right'


### PR DESCRIPTION
#### What? Why?

Closes #4128 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The route on the "continue" button on the admin order adjustments was incorrect, and redirected to the orders index page in some cases, which was breaking the admin order creation workflow.

The previous logic was branching: if the order is in cart state, link to the new payments page, otherwise link to the orders index page (which is really unhelpful).

It turns out the main payments route will show the new payment form if no payments currently exist, and show the existing payments if there are existing payments. So the branching was not needed, the single route works well for both cases.

#### What should we test?
<!-- List which features should be tested and how. -->

Admin order creation workflow from the adjustments page. For both new orders without payments, and completed orders with payments, the "continue" button (from adjustments) should redirect correctly to the payments page. If the order has no payments, it should show the new payments form. If the order already has payments it should show the existing payments.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed "continue" button route on admin order adjustments page.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

