### PR TITLE
Make states/new.js template depend on the states/new.haml template in OFN (not the states/new.erb in spree)

### DIFF
--- a/app/views/spree/admin/states/new.js.erb
+++ b/app/views/spree/admin/states/new.js.erb
@@ -1,2 +1,2 @@
-$("#new_state").html("<%= escape_javascript(render :template => 'spree/admin/states/new', :formats => [:html], :handlers => [:erb]) %>");
+$("#new_state").html("<%= escape_javascript(render :template => 'spree/admin/states/new', :formats => [:html], :handlers => [:haml]) %>");
 $("#new_state_link").parent().hide();


### PR DESCRIPTION
#### What? Why?

Fixes a problem when removing spree_backend, we now depend on the template already in OFN.

#### What should we test?
Create a new state in the backoffice.

#### Release notes
Changelog Category: Changed
Minor fix to remove dependency to spree_backend in page to create a new state.
