### PR TITLE
Load DB2Fog configuration from file if it exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ public/stylesheets
 public/images
 public/spree
 config/abr.yml
+config/db2fog.yml
 config/initializers/feature_toggle.rb
 NERD_tree*
 coverage

--- a/config/db2fog.yml.example
+++ b/config/db2fog.yml.example
@@ -1,0 +1,6 @@
+---
+:aws_access_key_id: "AYAYAYAYAAAAAAAAA"
+:aws_secret_access_key: "ThisIsAnExampleKeyWhichIsAtLeastFourtyCharsLong"
+:directory: "ofn-global-production-backup"
+:provider: "AWS"
+:region: "ap-southeast-2"

--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -1,11 +1,16 @@
 require_relative 'spree'
 
-# See: https://github.com/yob/db2fog
-DB2Fog.config = {
-    :aws_access_key_id     => Spree::Config[:s3_access_key],
-    :aws_secret_access_key => Spree::Config[:s3_secret],
-    :directory             => ENV['S3_BACKUPS_BUCKET'],
-    :provider              => 'AWS'
-}
+# Use a config file provided by ofn-install if available.
+if File.exists?(Rails.root.join("config", "db2fog.yml"))
+  DB2Fog.config = YAML.load_file(Rails.root.join("config", "db2fog.yml"))
+else
+  # See: https://github.com/yob/db2fog
+  DB2Fog.config = {
+      :aws_access_key_id     => Spree::Config[:s3_access_key],
+      :aws_secret_access_key => Spree::Config[:s3_secret],
+      :directory             => ENV['S3_BACKUPS_BUCKET'],
+      :provider              => 'AWS'
+  }
 
-DB2Fog.config[:region] = ENV['S3_REGION'] if ENV['S3_REGION']
+  DB2Fog.config[:region] = ENV['S3_REGION'] if ENV['S3_REGION']
+end


### PR DESCRIPTION
#### What? Why?

This pull request is a request for comments. I would like to configure backups independently to
- avoid moving the AU backups bucket,
- enable France to start a new backups bucket in Europe more easily,
- have the freedom to choose non-Amazon backups and
- avoid replicating DB2Fog's config interface.

What do you think about the following approach? Do you have a better idea?

This enables us to define a custom configuration file in ofn-install
(not yet implemented yet).

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

At the moment, the AWS S3 configuration for assets and backups are tightly coupled. This is an issue when buckets have different access keys or are in different regions. Since the Australian server was setup with backups in a different region to the assets, we need a way to configure this or move the bucket.

#### What should we test?
<!-- List which features should be tested and how. -->

Dev test:

- Use a staging server with backups configured.
- Copy the example file to create a db2fog configuration.
- Run: `RAILS_ENV=staging bundle exec rake db2fog:backup`
- Verify that the backup has been uploaded.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added: The backup location can now be configured independently. Backups can be stored in another country and with different access keys than images.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

Backups don't depend on the Spree configuration anymore.

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

This will require a change in ofn-install to be fully automated.

#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

Documentation updates should be done with the ofn-install pull request.