### PR TITLE
Update libv8 and keep it only in Gemfile.lock as a dependency of mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,9 +107,6 @@ group :assets do
   gem 'compass-rails'
 
   gem 'mini_racer', '0.2.4'
-  # Previously we found that libv8 6.7.288.46.1 breakis the compilation of mini_racer.
-  # Now we see that we need to set the version explicitly. Nothing else depends on libv8.
-  gem 'libv8', '6.3.292.48.1'
 
   gem 'uglifier', '>= 1.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,7 +465,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libv8 (6.3.292.48.1)
+    libv8 (7.3.492.27.1)
     mail (2.5.5)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -766,7 +766,6 @@ DEPENDENCIES
   kaminari (~> 0.14.1)
   knapsack
   letter_opener (>= 1.4.1)
-  libv8 (= 6.3.292.48.1)
   mini_racer (= 0.2.4)
   momentjs-rails
   newrelic_rpm (~> 3.0)


### PR DESCRIPTION
#### What? Why?

I tried doing this in #4576 but failed. I dont understand why.

Anyway, instead of upgrading libv8 in the gemfile #4624, we can now move it back to gemfile lock only, it's not a direct dependency, it's only used by mini_racer.

#### What should we test?
We need to stage this and make sure assets compilation works correctly and the website renders correctly.

#### Release notes
Changelog Category: Changed
Upgraded libv8 dependency.
