### PR TITLE
Show counts including all variants in order cycle exchanges

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -58,9 +58,8 @@ angular.module('admin.orderCycles')
 
       incoming = true if $scope.view == 'incoming'
       params = { exchange_id: exchange.id, enterprise_id: exchange.enterprise_id, order_cycle_id: $scope.order_cycle.id, incoming: incoming, page: page}
-      ExchangeProduct.index params, (products, num_of_pages, num_of_products) ->
+      ExchangeProduct.index params, (products, num_of_pages) ->
         enterprise.num_of_pages = num_of_pages
-        enterprise.num_of_products = num_of_products
         enterprise.supplied_products.push products...
 
     $scope.loadMoreExchangeProducts = (exchange) ->

--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -8,13 +8,6 @@ angular.module('admin.orderCycles')
     $scope.productsLoading = ->
       RequestMonitor.loading
 
-    $scope.exchangeLoadedVariants = (exchange) ->
-      loaded_variants = 0
-      angular.forEach $scope.enterprises[exchange.enterprise_id].supplied_products, (product) ->
-        loaded_variants += product.variants.length
-
-      loaded_variants
-
     $scope.setSelectAllVariantsCheckboxValue = (exchange, totalNumberOfVariants) ->
       exchange.select_all_variants = $scope.exchangeSelectedVariants(exchange) >= totalNumberOfVariants
 
@@ -55,12 +48,15 @@ angular.module('admin.orderCycles')
 
       return if enterprise.last_page_loaded? && enterprise.last_page_loaded >= page
       enterprise.last_page_loaded = page
+      enterprise.loaded_variants ?= 0
 
       incoming = true if $scope.view == 'incoming'
       params = { exchange_id: exchange.id, enterprise_id: exchange.enterprise_id, order_cycle_id: $scope.order_cycle.id, incoming: incoming, page: page}
       ExchangeProduct.index params, (products, num_of_pages) ->
         enterprise.num_of_pages = num_of_pages
         enterprise.supplied_products.push products...
+        angular.forEach products, (product) ->
+          enterprise.loaded_variants += product.variants.length
 
     $scope.loadMoreExchangeProducts = (exchange) ->
       $scope.loadExchangeProducts(exchange, $scope.enterprises[exchange.enterprise_id].last_page_loaded + 1)

--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -8,6 +8,13 @@ angular.module('admin.orderCycles')
     $scope.productsLoading = ->
       RequestMonitor.loading
 
+    $scope.exchangeLoadedVariants = (exchange) ->
+      loaded_variants = 0
+      angular.forEach $scope.enterprises[exchange.enterprise_id].supplied_products, (product) ->
+        loaded_variants += product.variants.length
+
+      loaded_variants
+
     $scope.setSelectAllVariantsCheckboxValue = (exchange, totalNumberOfVariants) ->
       exchange.select_all_variants = $scope.exchangeSelectedVariants(exchange) >= totalNumberOfVariants
 

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_distributed.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_distributed.html.haml
@@ -9,7 +9,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'setExchangeVariants(exchange, incomingExchangeVariantsFor(exchange.enterprise_id), exchange.select_all_variants)',
           'id' => 'order_cycle_outgoing_exchange_{{ $parent.$index }}_select_all_variants' }
-        {{ 'js.admin.panels.exchange_products.select_all_products' | t:{ total_number_of_products: enterprises[exchange.enterprise_id].num_of_products } }}
+        {{ 'js.admin.panels.exchange_products.select_all_products' | t:{ total_number_of_products: exchangeTotalVariants(exchange) } }}
 
     .exchange-products{ 'ng-hide' => 'productsLoading()' }
       .exchange-product{'ng-repeat' => 'product in enterprises[exchange.enterprise_id].supplied_products | filter:visibleProducts:exchange:order_cycle.visible_variants_for_outgoing_exchanges' }

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_distributed.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_distributed.html.haml
@@ -9,7 +9,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'setExchangeVariants(exchange, incomingExchangeVariantsFor(exchange.enterprise_id), exchange.select_all_variants)',
           'id' => 'order_cycle_outgoing_exchange_{{ $parent.$index }}_select_all_variants' }
-        {{ 'js.admin.panels.exchange_products.select_all_products' | t:{ total_number_of_products: exchangeTotalVariants(exchange) } }}
+        {{ 'js.admin.panels.exchange_products.select_all_variants' | t:{ total_number_of_variants: exchangeTotalVariants(exchange) } }}
 
     .exchange-products{ 'ng-hide' => 'productsLoading()' }
       .exchange-product{'ng-repeat' => 'product in enterprises[exchange.enterprise_id].supplied_products | filter:visibleProducts:exchange:order_cycle.visible_variants_for_outgoing_exchanges' }

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_panel_footer.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_panel_footer.html.haml
@@ -1,11 +1,11 @@
 .pagination{ 'ng-show' => 'enterprises[exchange.enterprise_id].last_page_loaded < enterprises[exchange.enterprise_id].num_of_pages && !productsLoading()'}
   .button{ 'ng-click' => 'loadMoreExchangeProducts(exchange)' }
-    {{ 'js.admin.panels.exchange_products.load_more_products' | t }}
+    {{ 'js.admin.panels.exchange_products.load_more_variants' | t }}
   .button{ 'ng-click' => 'loadAllExchangeProducts(exchange)' }
-    {{ 'js.admin.panels.exchange_products.load_all_products' | t }}
+    {{ 'js.admin.panels.exchange_products.load_all_variants' | t }}
 
 .sixteen.columns.alpha#loading{ 'ng-show' => 'productsLoading()' }
   %br
   %img.spinner{ src: "/assets/spinning-circles.svg" }
   %h1
-    {{ 'js.admin.panels.exchange_products.loading_products' | t }}
+    {{ 'js.admin.panels.exchange_products.loading_variants' | t }}

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
@@ -1,5 +1,5 @@
 .exchange-load-all-variants
   %div
-    {{ 'js.admin.panels.exchange_products.variants_loaded' | t:{ num_of_variants_loaded: exchangeLoadedVariants(exchange), total_number_of_variants: exchangeTotalVariants(exchange) } }}
+    {{ 'js.admin.panels.exchange_products.variants_loaded' | t:{ num_of_variants_loaded: enterprises[exchange.enterprise_id].loaded_variants, total_number_of_variants: exchangeTotalVariants(exchange) } }}
     %a{ 'ng-click' => 'loadAllExchangeProducts(exchange)', 'ng-show' => 'enterprises[exchange.enterprise_id].last_page_loaded < enterprises[exchange.enterprise_id].num_of_pages' }
       {{ 'js.admin.panels.exchange_products.load_all_variants' | t }}

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
@@ -1,5 +1,5 @@
 .exchange-load-all-variants
   %div
-    {{ 'js.admin.panels.exchange_products.products_loaded' | t:{ num_of_products_loaded: exchangeLoadedVariants(exchange), total_number_of_products: exchangeTotalVariants(exchange) } }}
+    {{ 'js.admin.panels.exchange_products.variants_loaded' | t:{ num_of_variants_loaded: exchangeLoadedVariants(exchange), total_number_of_variants: exchangeTotalVariants(exchange) } }}
     %a{ 'ng-click' => 'loadAllExchangeProducts(exchange)', 'ng-show' => 'enterprises[exchange.enterprise_id].last_page_loaded < enterprises[exchange.enterprise_id].num_of_pages' }
-      {{ 'js.admin.panels.exchange_products.load_all_products' | t }}
+      {{ 'js.admin.panels.exchange_products.load_all_variants' | t }}

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_panel_header.html.haml
@@ -1,5 +1,5 @@
 .exchange-load-all-variants
   %div
-    {{ 'js.admin.panels.exchange_products.products_loaded' | t:{ num_of_products_loaded: enterprises[exchange.enterprise_id].supplied_products.length, total_number_of_products: enterprises[exchange.enterprise_id].num_of_products } }}
+    {{ 'js.admin.panels.exchange_products.products_loaded' | t:{ num_of_products_loaded: exchangeLoadedVariants(exchange), total_number_of_products: exchangeTotalVariants(exchange) } }}
     %a{ 'ng-click' => 'loadAllExchangeProducts(exchange)', 'ng-show' => 'enterprises[exchange.enterprise_id].last_page_loaded < enterprises[exchange.enterprise_id].num_of_pages' }
       {{ 'js.admin.panels.exchange_products.load_all_products' | t }}

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_supplied.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_supplied.html.haml
@@ -9,7 +9,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'selectAllVariants(exchange, exchange.select_all_variants)',
           'id' => 'order_cycle_incoming_exchange_{{ $index }}_select_all_variants' }
-        {{ 'js.admin.panels.exchange_products.select_all_products' | t:{ total_number_of_products: exchangeTotalVariants(exchange) } }}
+        {{ 'js.admin.panels.exchange_products.select_all_variants' | t:{ total_number_of_variants: exchangeTotalVariants(exchange) } }}
 
     %div{ 'ng-include' => "'admin/panels/exchange_products_supplied_list.html'" }
 

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_supplied.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_supplied.html.haml
@@ -9,7 +9,7 @@
           'ng-model' => 'exchange.select_all_variants',
           'ng-change' => 'selectAllVariants(exchange, exchange.select_all_variants)',
           'id' => 'order_cycle_incoming_exchange_{{ $index }}_select_all_variants' }
-        {{ 'js.admin.panels.exchange_products.select_all_products' | t:{ total_number_of_products: enterprises[exchange.enterprise_id].num_of_products } }}
+        {{ 'js.admin.panels.exchange_products.select_all_products' | t:{ total_number_of_products: exchangeTotalVariants(exchange) } }}
 
     %div{ 'ng-include' => "'admin/panels/exchange_products_supplied_list.html'" }
 

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -31,10 +31,10 @@
 - if type == 'supplier'
   %tr.panel-row{ object: "exchange",
     panels: "{products: 'exchange_products_supplied'}",
-    locals: "$index,exchangeLoadedVariants,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,selectAllVariants,suppliedVariants,removeDistributionOfVariant,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
+    locals: "$index,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,selectAllVariants,suppliedVariants,removeDistributionOfVariant,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
     colspan: 4 }
 - if type == 'distributor'
   %tr.panel-row{ object: "exchange",
     panels: "{products: 'exchange_products_distributed', tags: 'exchange_tags'}",
-    locals: "$index,exchangeLoadedVariants,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,incomingExchangeVariantsFor,variantSuppliedToOrderCycle,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
+    locals: "$index,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,incomingExchangeVariantsFor,variantSuppliedToOrderCycle,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
     colspan: 5 }

--- a/app/views/admin/order_cycles/_exchange_form.html.haml
+++ b/app/views/admin/order_cycles/_exchange_form.html.haml
@@ -31,10 +31,10 @@
 - if type == 'supplier'
   %tr.panel-row{ object: "exchange",
     panels: "{products: 'exchange_products_supplied'}",
-    locals: "$index,order_cycle,exchange,enterprises,setExchangeVariants,selectAllVariants,suppliedVariants,removeDistributionOfVariant,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
+    locals: "$index,exchangeLoadedVariants,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,selectAllVariants,suppliedVariants,removeDistributionOfVariant,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
     colspan: 4 }
 - if type == 'distributor'
   %tr.panel-row{ object: "exchange",
     panels: "{products: 'exchange_products_distributed', tags: 'exchange_tags'}",
-    locals: "$index,order_cycle,exchange,enterprises,setExchangeVariants,incomingExchangeVariantsFor,variantSuppliedToOrderCycle,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
+    locals: "$index,exchangeLoadedVariants,exchangeTotalVariants,order_cycle,exchange,enterprises,setExchangeVariants,incomingExchangeVariantsFor,variantSuppliedToOrderCycle,initializeExchangeProductsPanel,loadMoreExchangeProducts,loadAllExchangeProducts,productsLoading",
     colspan: 5 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2557,11 +2557,11 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           description: Description
           resolve: Resolve
         exchange_products:
-          load_more_products: "Load More Products"
-          load_all_products: "Load All Products"
-          select_all_products: "Select All %{total_number_of_products} Products"
-          products_loaded: "%{num_of_products_loaded} of %{total_number_of_products} Products Loaded"
-          loading_products: "Loading Products"
+          load_more_variants: "Load More Variants"
+          load_all_variants: "Load All Variants"
+          select_all_variants: "Select All %{total_number_of_variants} Variants"
+          variants_loaded: "%{num_of_variants_loaded} of %{total_number_of_variants} Variants Loaded"
+          loading_variants: "Loading Variants"
       tag_rules:
         shipping_method_tagged_top: "Shipping methods tagged"
         shipping_method_tagged_bottom: "are:"

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -542,7 +542,7 @@ feature '
       page.find("tr.supplier-#{supplier_enterprise.id} td.products").click
       expect(page).to have_selector ".exchange-product-details"
 
-      expect(page).to have_content "1 of 2 Products Loaded"
+      expect(page).to have_content "1 of 2 Variants Loaded"
       expect(page).to_not have_content new_product.name
     end
 
@@ -562,7 +562,7 @@ feature '
 
     def expect_all_products_loaded
       expect(page).to have_content new_product.name.upcase
-      expect(page).to have_content "2 of 2 Products Loaded"
+      expect(page).to have_content "2 of 2 Variants Loaded"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #4594 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adapts order cycle exchange panels to show full count of all variants.

#### What should we test?
<!-- List which features should be tested and how. -->

Editing an order cycle: exchanges show full count of all variants.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Changed pagination counts in order cycle exchange UI

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

![all_variants](https://user-images.githubusercontent.com/9029026/71523754-a7af2680-28ca-11ea-9d26-a71b57e9e361.png)
