### PR TITLE
Fix bug in frontoffice order details where the product image was a broken link

### DIFF
--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -17,9 +17,9 @@
 
         %div.item-thumb-image
           - if variant.images.length == 0
-            = link_to mini_image(variant.product), variant.product
+            = mini_image(variant.product)
           - else
-            = link_to image_tag(variant.images.first.attachment.url(:mini)), variant.product
+            = image_tag(variant.images.first.attachment.url(:mini))
 
         = render 'spree/shared/line_item_name', line_item: line_item
         %span.already-confirmed= t(:orders_bought_already_confirmed)

--- a/app/views/spree/orders/_summary.html.haml
+++ b/app/views/spree/orders/_summary.html.haml
@@ -17,9 +17,9 @@
 
           %div.item-thumb-image{"data-hook" => "order_item_image"}
             - if item.variant.images.length == 0
-              = link_to mini_image(item.variant.product), item.variant.product
+              = mini_image(item.variant.product)
             - else
-              = link_to image_tag(item.variant.images.first.attachment.url(:mini)), item.variant.product
+              = image_tag(item.variant.images.first.attachment.url(:mini))
 
 
           = render 'spree/shared/line_item_name', line_item: item


### PR DESCRIPTION
#### What? Why?

Closes #4632

This PR make the product image non-clickable.
This is an very low priority bug but it was blocking progress of #4050 so I fixed it now.

#### What should we test?
Make sure the image is not clickable.

#### Release notes
Changelog Category: Fixed
Fixed a bug in order details page by making product images non-clickable (the link was broken).

