### PR TITLE
Replace use of spree.root_path and root_url with main_app.root_path and main_app.root_url

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -39,7 +39,6 @@ Metrics/LineLength:
   - app/controllers/admin/variant_overrides_controller.rb
   - app/controllers/api/enterprise_attachment_controller.rb
   - app/controllers/api/product_images_controller.rb
-  - app/controllers/application_controller.rb
   - app/controllers/checkout_controller.rb
   - app/controllers/spree/admin/adjustments_controller_decorator.rb
   - app/controllers/spree/admin/orders_controller_decorator.rb
@@ -642,6 +641,7 @@ Metrics/ClassLength:
   - app/controllers/admin/order_cycles_controller.rb
   - app/controllers/admin/subscriptions_controller.rb
   - app/controllers/api/products_controller.rb
+  - app/controllers/application_controller.rb
   - app/controllers/checkout_controller.rb
   - app/controllers/spree/admin/base_controller.rb
   - app/controllers/spree/admin/payment_methods_controller.rb

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,7 +93,8 @@ class ApplicationController < ActionController::Base
     if current_distributor_closed?
       current_order.empty!
       current_order.set_distribution! nil, nil
-      flash[:info] = "The hub you have selected is temporarily closed for orders. Please try again later."
+      flash[:info] = "The hub you have selected is temporarily closed for orders. "\
+        "Please try again later."
       redirect_to main_app.root_url
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource_or_scope)
     return session[:shopfront_redirect] if session[:shopfront_redirect]
 
-    stored_location_for(resource_or_scope) || signed_in_root_path(resource_or_scope)
+    stored_location_for(resource_or_scope) || main_app.root_path
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
     referer_path = OpenFoodNetwork::RefererParser.path(request.referer)
     if referer_path
       is_checkout_path_the_referer = [main_app.checkout_path].include?(referer_path)
-      session["spree_user_return_to"] = is_checkout_path_the_referer ? referer_path : root_path
+      session["spree_user_return_to"] = is_checkout_path_the_referer ? referer_path : main_app.root_path
     end
   end
 
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(_resource_or_scope)
-    session[:shopfront_redirect] || root_path
+    session[:shopfront_redirect] || main_app.root_path
   end
 
   private
@@ -74,7 +74,7 @@ class ApplicationController < ActionController::Base
 
   def require_distributor_chosen
     unless @distributor = current_distributor
-      redirect_to spree.root_path
+      redirect_to main_app.root_path
       false
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,7 +95,7 @@ class ApplicationController < ActionController::Base
       current_order.empty!
       current_order.set_distribution! nil, nil
       flash[:info] = "The hub you have selected is temporarily closed for orders. Please try again later."
-      redirect_to root_url
+      redirect_to main_app.root_url
     end
   end
 
@@ -105,7 +105,7 @@ class ApplicationController < ActionController::Base
       current_order.empty!
       current_order.set_order_cycle! nil
       flash[:info] = "The order cycle you've selected has just closed. Please try again!"
-      redirect_to root_url
+      redirect_to main_app.root_url
     end
   end
 

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -30,7 +30,7 @@ module Spree
           redirect_to '/unauthorized'
         else
           store_location
-          redirect_to root_path(anchor: "login?after_login=#{request.env['PATH_INFO']}")
+          redirect_to main_app.root_path(anchor: "login?after_login=#{request.env['PATH_INFO']}")
         end
       end
 

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -71,7 +71,7 @@ module Spree
       @order = order_to_update
       unless @order
         flash[:error] = t(:order_not_found)
-        redirect_to(root_path) && return
+        redirect_to(main_app.root_path) && return
       end
 
       if @order.update_attributes(params[:order])

--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -32,7 +32,7 @@ module Spree
           session[:guest_token] = nil
         end
 
-        redirect_back_or_default(root_url)
+        redirect_back_or_default(main_app.root_url)
       else
         render :new
       end

--- a/app/mailers/spree/base_mailer_decorator.rb
+++ b/app/mailers/spree/base_mailer_decorator.rb
@@ -9,6 +9,6 @@ Spree::BaseMailer.class_eval do
 
   def roadie_options
     # This lets us specify assets using relative paths in email templates
-    super.merge(url_options: { host: URI(spree.root_url).host })
+    super.merge(url_options: { host: URI(main_app.root_url).host })
   end
 end

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -54,7 +54,7 @@
   .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
     .three.columns.alpha
       = f.label :permalink, t('.permalink')
-      %div{'ofn-with-tip' => t('.permalink_tip', link: spree.root_url)}
+      %div{'ofn-with-tip' => t('.permalink_tip', link: main_app.root_url)}
         %a= t('admin.whats_this')
     .six.columns
       = f.text_field :permalink, { 'ng-model' => "Enterprise.permalink", placeholder: "eg. your-shop-name", 'ng-model-options' => "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }" }
@@ -69,7 +69,7 @@
       %div{'ofn-with-tip' => t('.link_to_front_tip')}
         %a= t('admin.whats_this')
     .eight.columns.omega
-      = surround spree.root_url, "/shop" do
+      = surround main_app.root_url, "/shop" do
         {{Enterprise.permalink}}
   .row
     .three.columns.alpha

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -42,10 +42,10 @@
               %tr
                 %td{:align => "center"}
                   %p
-                    %a{:href => "#{ URI.join(spree.root_url, Spree::Config.footer_tos_url).to_s }", :target => "_blank"}
+                    %a{:href => "#{ URI.join(main_app.root_url, Spree::Config.footer_tos_url).to_s }", :target => "_blank"}
                       = t :terms_of_service
                     |
-                    %a{:href => "#{ spree.root_url }"}
+                    %a{:href => "#{ main_app.root_url }"}
                       = Spree::Config[:site_name]
                     / | <a href="#"><unsubscribe>Unsubscribe</unsubscribe></a>
         %td

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -126,7 +126,7 @@
 
     .row
       .small-12.medium-3.medium-offset-2.columns.text-left
-        %a{href: root_path}
+        %a{href: main_app.root_path}
           %img{src: ContentConfig.footer_logo.url, width: "220"}
       .small-12.medium-5.columns.text-left
         %p.text-small

--- a/app/views/shared/menu/_large_menu.html.haml
+++ b/app/views/shared/menu/_large_menu.html.haml
@@ -2,7 +2,7 @@
   %section.top-bar-section
     %ul.left
       %li.ofn-logo
-        %a{href: root_path}
+        %a{href: main_app.root_path}
           %img{src: ContentConfig.logo.url}
       %li.powered-by
         %img{src: '/favicon.ico'}

--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -5,7 +5,7 @@
 
   %section.left
     .ofn-logo
-      %a{href: root_path}
+      %a{href: main_app.root_path}
         %img{src: ContentConfig.logo_mobile.url, srcset: ContentConfig.logo_mobile_svg.url, width: "75", height: "26"}
 
   %section.right{"ng-cloak" => true}

--- a/app/views/shared/menu/_offcanvas_menu.html.haml
+++ b/app/views/shared/menu/_offcanvas_menu.html.haml
@@ -1,7 +1,7 @@
 %aside.left-off-canvas-menu.show-for-medium-down{ ng: { controller: "OffcanvasCtrl" } }
   %ul.off-canvas-list
     %li.ofn-logo
-      %a{href: root_path}
+      %a{href: main_app.root_path}
         %img{src: ContentConfig.logo_mobile.url, srcset: ContentConfig.logo_mobile_svg.url, width: "75", height: "26"}
     - [*1..7].each do |menu_number|
       - menu_name = "menu_#{menu_number}"

--- a/app/views/shop/_blocked_cookies.html.haml
+++ b/app/views/shop/_blocked_cookies.html.haml
@@ -9,6 +9,6 @@
 .alert-box.blocked-cookies.hidden
   %p= t('blocked_cookies_alert')
 
-  %a.button.allow{target: '_blank', href: "#{spree.root_url}embedded_shopfront/shopfront_session/"}
+  %a.button.allow{target: '_blank', href: "#{main_app.root_url}embedded_shopfront/shopfront_session/"}
     = t('allow_cookies')
     

--- a/app/views/spree/layouts/admin/_login_nav.html.haml
+++ b/app/views/spree/layouts/admin/_login_nav.html.haml
@@ -8,7 +8,7 @@
       = link_to t(:account), account_path
     %li{"data-hook" => "user-logout-link"}
       %i.icon-signout
-      = link_to t(:logout), spree.logout_path
+      = link_to t(:logout), logout_path
     %li{"data-hook" => "store-frontend-link"}
       %i.icon-external-link
-      = link_to t(".header.store"), spree.root_path, target: "_blank"
+      = link_to t(".header.store"), main_app.root_path, target: "_blank"

--- a/app/views/spree/layouts/bare_admin.html.haml
+++ b/app/views/spree/layouts/bare_admin.html.haml
@@ -1,6 +1,6 @@
 %html{ lang: "en" }
   %head{"data-hook" => "admin_inside_head"}= render :partial => 'spree/admin/shared/head'
-  %body.admin{"data-ajax-root-path" => spree.root_path}
+  %body.admin{"data-ajax-root-path" => main_app.root_path}
     #wrapper{"data-hook" => ""}
       - if flash[:error]
         .flash.error= flash[:error]

--- a/app/views/spree/user_mailer/signup_confirmation.html.haml
+++ b/app/views/spree/user_mailer/signup_confirmation.html.haml
@@ -9,7 +9,7 @@
   = t :email_signup_confirmed_email
 %p
   -# Remove http:// and trailing slashes from root url if they exist
-  = t :email_signup_shop_html, link: link_to(spree.root_url.sub(/http:\/\//,"").sub(/\/$/,""), spree.root_url, target: '_blank')
+  = t :email_signup_shop_html, link: link_to(main_app.root_url.sub(/http:\/\//,"").sub(/\/$/,""), main_app.root_url, target: '_blank')
 %p &nbsp;
 %hr/
 %p &nbsp;

--- a/lib/spree/core/controller_helpers/auth_decorator.rb
+++ b/lib/spree/core/controller_helpers/auth_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Core::ControllerHelpers::Auth.class_eval do
   def require_login_then_redirect_to(url)
-    redirect_to root_path(anchor: "login?after_login=#{url}")
+    redirect_to main_app.root_path(anchor: "login?after_login=#{url}")
   end
 end


### PR DESCRIPTION
#### What? Why?

Continues #4595

This change will enable us to stop depending on spree_backend and some of the base spree routes that come with it.

Here I also adapt an unnecessary call to a devise method related to routes in after_sign_in_path_for. This was breaking the build without spree_backend.

#### What should we test?
I dont think we need to test all the changes to main_app.root_path.
I suggest we validate manually the change in after_sign_in_path_for by testing the redirection process after login:
1 - type __domain__/admin directly on the browser, like https://staging.openfoodnetwork.org.au/admin
2 - logout if you are logged in and repeat step 1
3 - after step 2 you will see the login box
4 - login
5 - expect to land in the backoffice at /admin

#### Release notes
Changelog Category: Changed
Switched some routes from spree base routes to ofn (main_app) routes to enable removing spree_backend dependency.
