### PR TITLE
Replace adjustment.open with adjustment.fire_events(open) to avoid method name conflict

### DIFF
--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -176,7 +176,7 @@ module Spree
       previous_states = @order.adjustments.each_with_object({}) do |adjustment, hash|
         hash[adjustment.id] = adjustment.state
       end
-      @order.adjustments.each(&:open)
+      @order.adjustments.each { |adjustment| adjustment.fire_events(:open) }
 
       yield
 


### PR DESCRIPTION
#### What? Why?

Closes #4581

We make this change although we cant replicate the problem. We believe this will fix the conflict and therefore the bug.


#### What should we test?
Try to replicate the problem. Probably only verifiable in OFN_CAN live where the problem exists.

#### Release notes
Changelog Category: Fix
Fixed a bug when editing quantities in the cart.

