### PR TITLE
remove group link from shop menu when there are no groups

### DIFF
--- a/app/helpers/shop_helper.rb
+++ b/app/helpers/shop_helper.rb
@@ -20,12 +20,27 @@ module ShopHelper
     )
   end
 
-  def shop_tabs
+  def base_shop_tabs(column_sizes)
     [
-      { name: 'about', title: t(:shopping_tabs_about, distributor: current_distributor.name), cols: 6 },
-      { name: 'producers', title: t(:label_producers), cols: 2 },
-      { name: 'contact', title: t(:shopping_tabs_contact), cols: 2 },
-      { name: 'groups', title: t(:label_groups), cols: 2 },
+      { name: 'about', cols: column_sizes[0],
+        title: t(:shopping_tabs_about, distributor: current_distributor.name) },
+      { name: 'producers', cols: column_sizes[1],
+        title: t(:label_producers) },
+      { name: 'contact', cols: column_sizes[2],
+        title: t(:shopping_tabs_contact) }
     ]
+  end
+
+  def tabs_with_groups
+    tabs = base_shop_tabs([6, 2, 2])
+    tabs << { name: 'groups', title: t(:label_groups), cols: 2 }
+  end
+
+  def tabs_without_groups
+    base_shop_tabs([4, 4, 4])
+  end
+
+  def shop_tabs
+    current_distributor.groups.present? ? tabs_with_groups : tabs_without_groups
   end
 end

--- a/spec/helpers/shop_helper_spec.rb
+++ b/spec/helpers/shop_helper_spec.rb
@@ -7,4 +7,46 @@ describe ShopHelper, type: :helper do
 
     expect(helper.order_cycles_name_and_pickup_times([o1])).to eq([[helper.pickup_time(o1), o1.id]])
   end
+
+  describe "shop_tabs" do
+    context "distributor with groups" do
+      let(:group) { create(:enterprise_group) }
+      let(:distributor) { create(:distributor_enterprise, groups: [group]) }
+      let(:expectation) {
+        [
+          { name: 'about', title: t(:shopping_tabs_about, distributor: distributor.name), cols: 6 },
+          { name: 'producers', title: t(:label_producers), cols: 2 },
+          { name: 'contact', title: t(:shopping_tabs_contact), cols: 2 },
+          { name: 'groups', title: t(:label_groups), cols: 2 }
+        ]
+      }
+
+      before do
+        allow(helper).to receive(:current_distributor).and_return distributor
+      end
+
+      it "should return the groups tab" do
+        expect(helper.shop_tabs).to eq(expectation)
+      end
+    end
+
+    context "distributor without groups" do
+      let(:distributor) { create(:distributor_enterprise) }
+      let(:expectation) {
+        [
+          { name: 'about', title: t(:shopping_tabs_about, distributor: distributor.name), cols: 4 },
+          { name: 'producers', title: t(:label_producers), cols: 4 },
+          { name: 'contact', title: t(:shopping_tabs_contact), cols: 4 }
+        ]
+      }
+
+      before do
+        allow(helper).to receive(:current_distributor).and_return distributor
+      end
+
+      it "should not return the groups tab" do
+        expect(helper.shop_tabs).to eq(expectation)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #4533 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

I changed the method `shop_tabs` (`shop_helper.rb`) used inside `app/views/shopping_shared/_tabs.html.haml` creating new methods to return the right output to the view if the shop has groups and when it does not have.

#### What should we test?
<!-- List which features should be tested and how. -->

Only the `shop_tabs` method inside `app/helpers/shop_helper.rb`

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Do not show the Groups tabs inside the shop menu when the shop does not have any groups.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->

https://github.com/openfoodfoundation/openfoodnetwork/issues/4533