### PR TITLE
Docker rspec fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 # Install all the requirements
-RUN apt-get update && apt-get install -y curl git build-essential software-properties-common wget zlib1g-dev libssl1.0-dev libreadline-dev libyaml-dev libffi-dev libxml2-dev libxslt1-dev wait-for-it
+RUN apt-get update && apt-get install -y curl git build-essential software-properties-common wget zlib1g-dev libssl1.0-dev libreadline-dev libyaml-dev libffi-dev libxml2-dev libxslt1-dev wait-for-it imagemagick unzip
 
 # Setup ENV variables
 ENV PATH /usr/local/src/rbenv/shims:/usr/local/src/rbenv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,15 @@ RUN sh -c "echo 'deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main'
     apt-get update && \
     apt-get install -yqq --no-install-recommends postgresql-client-9.5 libpq-dev
 
+# Install Chrome
+RUN wget --quiet -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    sh -c "echo 'deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list" && \
+    apt-get update && \
+    apt-get install -fy google-chrome-stable
+
+# Install Chromedriver
+RUN wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && \
+    unzip chromedriver_linux64.zip -d /usr/bin && \
+    chmod u+x /usr/bin/chromedriver
+
 COPY . /usr/src/app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
     command: >
       bash -c "(bundle check || bundle install) &&
                wait-for-it -t 30 db:5432 &&
-               bundle exec rake db:reset db:test:prepare &&
-               bundle exec rake ofn:sample_data || true &&
+               bundle exec rake db:reset &&
+               bundle exec rake db:test:prepare ofn:sample_data || true &&
                rm -f tmp/pids/server.pid &&
                bundle exec rails s -p 3000 -b '0.0.0.0'"
 


### PR DESCRIPTION
#### What? Why?

The current docker configuration does not install imagemagick, chrome, and chromedriver. This means that the rspec tests can't run out of the box.

https://github.com/openfoodfoundation/openfoodnetwork/commit/8a0ffe1890ae995e80236bbab0d64a75708899a3 adds imagemagick and unzip to the list of installed debian packages.
https://github.com/openfoodfoundation/openfoodnetwork/commit/0ec0d3fd817d730e660bcf37500a51ac9013979a are the commands to install Chrome and Chromedriver. These commands were adapted from the [Development Environment Setup: Ubuntu](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup:-Ubuntu#step-7-install-chrome-for-capybaraselenium-testing-if-required) wiki page.
https://github.com/openfoodfoundation/openfoodnetwork/commit/8df0e2c66edcedb9595c67bda7d908736c3bc4c5 appears to be required as the `db:test:prepare` task doesn't seem to run properly if it's run in the same exec instance as `db:reset`. I couldn't find a reason why this is the case, but if you attempt to run the tests without this change, you'll get errors like:

```
An error occurred while loading ./spec/features/consumer/authentication_spec.rb.
Failure/Error: if Spree::Country.scoped.empty?

ActiveRecord::StatementInvalid:
  PG::UndefinedTable: ERROR:  relation "spree_countries" does not exist
  LINE 5:              WHERE a.attrelid = '"spree_countries"'::regclas...
                                          ^
  :             SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                       pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
                FROM pg_attribute a LEFT JOIN pg_attrdef d
                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
               WHERE a.attrelid = '"spree_countries"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
```

#### What should we test?
Run the following:

1. `docker-compose build`
2. `docker-compose up`
3. Once the container is up, `docker exec -it openfoodnetwork_web_1 bash`
4. In the container, run `bundle exec rspec spec` 

#### Release notes
Docker environment now supports running rspec tests out of the box

Changelog Category: Added

#### How is this related to the Spree upgrade?
No

