### PR TITLE
Db2fog region

### DIFF
--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -8,4 +8,8 @@ DB2Fog.config = {
     :provider              => 'AWS'
 }
 
-DB2Fog.config[:region] = ENV['S3_REGION'] if ENV['S3_REGION']
+region = ENV['S3_BACKUPS_REGION'] || ENV['S3_REGION']
+
+# If no region is defined we leave this config key undefined (instead of nil),
+# so that db2fog correctly applies it's default
+DB2Fog.config[:region] = region if region

--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -1,6 +1,6 @@
 require_relative 'spree'
 
-# See: https://github.com/yob/db2fog
+# See: https://github.com/itbeaver/db2fog
 DB2Fog.config = {
     :aws_access_key_id     => Spree::Config[:s3_access_key],
     :aws_secret_access_key => Spree::Config[:s3_secret],


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/ofn-install/issues/555

Allows setting an alternate region for `db2fog` backups.

#### What should we test?
<!-- List which features should be tested and how. -->

Backups can be made to a region different to the one used for images, if `ENV['S3_BACKUPS_REGION']` is set. 

If the environment variable is not set, all current server configurations will behave exactly the same as before. 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Allow S3 backups in different region than image storage.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added
