### PR TITLE
Use strings for all environment variables

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -28,7 +28,7 @@ CURRENCY: AUD
 # Mail settings
 MAIL_HOST: 'example.com'
 MAIL_DOMAIN: 'example.com'
-MAIL_PORT: 25
+MAIL_PORT: '25'
 SMTP_USERNAME: 'ofn'
 SMTP_PASSWORD: 'f00d'
 
@@ -57,4 +57,4 @@ SMTP_PASSWORD: 'f00d'
 # STRIPE_CLIENT_ID: "ca_xxxx" # This can be a development ID or a production ID
 # STRIPE_ENDPOINT_SECRET: "whsec_xxxx"
 
-MEMCACHED_VALUE_MAX_MEGABYTES: 4
+MEMCACHED_VALUE_MAX_MEGABYTES: '4'


### PR DESCRIPTION
#### What? Why?

When using a fresh setup with the example application config, Figaro complained:

    WARNING: Use strings for Figaro configuration. 25 was converted to "25".
    WARNING: Use strings for Figaro configuration. 4 was converted to "4".

Those numbers have been converted to strings in our example config.



#### What should we test?
<!-- List which features should be tested and how. -->

No test, this doesn't affect any production code.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed syntax of an example config file.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

