### PR TITLE
Remove Product import code for xls suppport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ gem 'wkhtmltopdf-binary'
 gem 'foreigner'
 gem 'immigrant'
 gem 'roo', '~> 2.8.2'
-gem 'roo-xls', '~> 1.1.0'
 
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -587,10 +587,6 @@ GEM
     roo (2.8.2)
       nokogiri (~> 1)
       rubyzip (>= 1.2.1, < 2.0.0)
-    roo-xls (1.1.0)
-      nokogiri
-      roo (>= 2.0.0beta1, < 3)
-      spreadsheet (> 0.9.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -653,8 +649,6 @@ GEM
       tilt (>= 1.3, < 3)
     spinjs-rails (1.4)
       rails (>= 3.1)
-    spreadsheet (1.1.7)
-      ruby-ole (>= 1.0)
     spring (1.7.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -791,7 +785,6 @@ DEPENDENCIES
   redcarpet
   roadie-rails (~> 1.3.0)
   roo (~> 2.8.2)
-  roo-xls (~> 1.1.0)
   rspec-rails (>= 3.5.2)
   rspec-retry
   rubocop


### PR DESCRIPTION
#### What? Why?
PI only works with csv right now: see [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/4625#issuecomment-569228696)

This can be reverted if we start supporting xls and ods in the future

btw, roo-xls is only needed to support legacy xls types, roo itself supports xlsx.

Relates to #4625

#### What should we test?
Verify csv upload works as normal. A simple test should be enough.

#### Release notes
Changelog Category: Removed
Removed code to support xls file upload in product import. We dont support xls uploads.
