### PR TITLE
Rails 4 prep: admin dashboard route

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -66,7 +66,7 @@ module Admin
 
       if @enterprise.update_attributes(attributes)
         flash[:success] = I18n.t(:enterprise_register_success_notice, enterprise: @enterprise.name)
-        redirect_to admin_path
+        redirect_to admin_dashboard_path
       else
         flash[:error] = I18n.t(:enterprise_register_error, enterprise: @enterprise.name)
         render :welcome, layout: "spree/layouts/bare_admin"

--- a/app/controllers/admin/stripe_accounts_controller.rb
+++ b/app/controllers/admin/stripe_accounts_controller.rb
@@ -22,7 +22,7 @@ module Admin
       redirect_to main_app.edit_admin_enterprise_path(stripe_account.enterprise)
     rescue ActiveRecord::RecordNotFound
       flash[:error] = "Failed to disconnect Stripe."
-      redirect_to spree.admin_path
+      redirect_to spree.admin_dashboard_path
     end
 
     def status

--- a/app/views/enterprise_mailer/welcome.html.haml
+++ b/app/views/enterprise_mailer/welcome.html.haml
@@ -8,7 +8,7 @@
 %p
   = t(".email_userguide_html", link: link_to(t(".userguide"), ContentConfig.user_guide_link))
 %p
-  = t(".email_admin_html", link: link_to(t(".admin_panel"), spree.admin_url))
+  = t(".email_admin_html", link: link_to(t(".admin_panel"), spree.admin_dashboard_url))
 
 %p
   = t(".email_community_html", link: link_to(t(".join_community"), ContentConfig.community_forum_url))

--- a/app/views/shared/menu/_signed_in.html.haml
+++ b/app/views/shared/menu/_signed_in.html.haml
@@ -15,7 +15,7 @@
 
     - if admin_user? or enterprise_user?
       %li
-        %a{href: spree.admin_path, target:'_blank'}
+        %a{href: spree.admin_dashboard_path, target:'_blank'}
           %i.ofn-i_021-tools
           = t 'label_administration'
 

--- a/app/views/shared/menu/_signed_in_offcanvas.html.haml
+++ b/app/views/shared/menu/_signed_in_offcanvas.html.haml
@@ -7,7 +7,7 @@
 
 - if admin_user? or enterprise_user?
   %li
-    %a{href: spree.admin_path, target:'_blank'}
+    %a{href: spree.admin_dashboard_path, target:'_blank'}
       %i.ofn-i_021-tools
       = t 'label_admin'
 

--- a/app/views/spree/admin/shared/_tabs.html.haml
+++ b/app/views/spree/admin/shared/_tabs.html.haml
@@ -1,4 +1,4 @@
-= tab :dashboard, :route => :admin, :icon => 'icon-dashboard'
+= tab :overview, label: 'dashboard', url: spree.admin_dashboard_path, icon: 'icon-dashboard'
 = tab :products, :option_types, :properties, :variants, :product_properties, :taxons, :url => admin_products_path, :icon => 'icon-th-large'
 = tab :order_cycles, :url => main_app.admin_order_cycles_path, :icon => 'icon-refresh'
 = tab :orders, :payments, :creditcard_payments, :shipments, :credit_cards, :return_authorizations, :url => admin_orders_path('q[s]' => 'completed_at desc'), :icon => 'icon-shopping-cart'

--- a/app/views/spree/layouts/_admin_body.html.haml
+++ b/app/views/spree/layouts/_admin_body.html.haml
@@ -19,7 +19,7 @@
   %header#header{"data-hook" => ""}
     .container
       %figure.columns.five{"data-hook" => "logo-wrapper"}
-        = link_to image_tag(Spree::Config[:admin_interface_logo], :id => 'logo'), spree.admin_path
+        = link_to image_tag(Spree::Config[:admin_interface_logo], :id => 'logo'), spree.admin_dashboard_path
       %nav.columns.eleven{"data-hook" => "admin_login_navigation_bar"}
         = render :partial => 'spree/layouts/admin/login_nav'
 

--- a/app/views/spree/layouts/bare_admin.html.haml
+++ b/app/views/spree/layouts/bare_admin.html.haml
@@ -17,7 +17,7 @@
 
       %header#header{"data-hook" => ""}
         .container
-          %figure.columns.five{"data-hook" => "logo-wrapper"}= link_to image_tag(Spree::Config[:admin_interface_logo], :id => 'logo'), spree.admin_path
+          %figure.columns.five{"data-hook" => "logo-wrapper"}= link_to image_tag(Spree::Config[:admin_interface_logo], :id => 'logo'), spree.admin_dashboard_path
           %nav.columns.eleven{"data-hook" => "admin_login_navigation_bar"}
             = render partial: "spree/layouts/admin/login_nav"
 

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -45,9 +45,10 @@ Spree::Core::Engine.routes.prepend do
   match '/admin/reports/products_and_inventory' => 'admin/reports#products_and_inventory', :as => "products_and_inventory_admin_reports",  :via  => [:get, :post]
   match '/admin/reports/customers' => 'admin/reports#customers', :as => "customers_admin_reports",  :via  => [:get, :post]
   match '/admin/reports/xero_invoices' => 'admin/reports#xero_invoices', :as => "xero_invoices_admin_reports",  :via  => [:get, :post]
-  match '/admin', :to => 'admin/overview#index', :as => :admin
   match '/admin/payment_methods/show_provider_preferences' => 'admin/payment_methods#show_provider_preferences', :via => :get
   put 'credit_cards/new_from_token', to: 'credit_cards#new_from_token'
+
+  match '/admin', to: 'admin/overview#index', as: :admin_dashboard, via: :get
 
   resources :credit_cards
 

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -319,7 +319,7 @@ module Admin
         context "setting 'sells' to 'none'" do
           it "is allowed" do
             spree_post :register, id: enterprise, sells: 'none'
-            expect(response).to redirect_to spree.admin_path
+            expect(response).to redirect_to spree.admin_dashboard_path
             expect(flash[:success]).to eq "Congratulations! Registration for #{enterprise.name} is complete!"
             expect(enterprise.reload.sells).to eq 'none'
           end
@@ -328,7 +328,7 @@ module Admin
         context "setting producer_profile_only" do
           it "is ignored" do
             spree_post :register, id: enterprise, sells: 'none', producer_profile_only: true
-            expect(response).to redirect_to spree.admin_path
+            expect(response).to redirect_to spree.admin_dashboard_path
             expect(enterprise.reload.producer_profile_only).to be false
           end
         end
@@ -341,7 +341,7 @@ module Admin
 
           it "is allowed" do
             spree_post :register, id: enterprise, sells: 'own'
-            expect(response).to redirect_to spree.admin_path
+            expect(response).to redirect_to spree.admin_dashboard_path
             expect(flash[:success]).to eq "Congratulations! Registration for #{enterprise.name} is complete!"
             expect(enterprise.reload.sells).to eq 'own'
           end
@@ -350,7 +350,7 @@ module Admin
         context "setting 'sells' to any" do
           it "is allowed" do
             spree_post :register, id: enterprise, sells: 'any'
-            expect(response).to redirect_to spree.admin_path
+            expect(response).to redirect_to spree.admin_dashboard_path
             expect(flash[:success]).to eq "Congratulations! Registration for #{enterprise.name} is complete!"
             expect(enterprise.reload.sells).to eq 'any'
           end

--- a/spec/features/admin/authentication_spec.rb
+++ b/spec/features/admin/authentication_spec.rb
@@ -11,13 +11,13 @@ feature "Authentication", js: true do
   scenario "logging into admin redirects home, then back to admin" do
     # This is the first admin spec, so give a little extra load time for slow systems
     Capybara.using_wait_time(120) do
-      visit spree.admin_path
+      visit spree.admin_dashboard_path
 
       fill_in "Email", with: user.email
       fill_in "Password", with: user.password
       click_login_button
       expect(page).to have_content "DASHBOARD"
-      expect(page).to have_current_path spree.admin_path
+      expect(page).to have_current_path spree.admin_dashboard_path
       expect(page).to have_no_content "CONFIGURATION"
     end
   end

--- a/spec/features/admin/configuration/general_settings_spec.rb
+++ b/spec/features/admin/configuration/general_settings_spec.rb
@@ -5,7 +5,7 @@ describe "General Settings" do
 
   before(:each) do
     quick_login_as_admin
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
     click_link "Configuration"
     click_link "General Settings"
   end

--- a/spec/features/admin/configuration/image_settings_spec.rb
+++ b/spec/features/admin/configuration/image_settings_spec.rb
@@ -5,7 +5,7 @@ describe "image settings" do
 
   before do
     quick_login_as_admin
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
     click_link "Configuration"
     click_link "Image Settings"
   end

--- a/spec/features/admin/configuration/mail_methods_spec.rb
+++ b/spec/features/admin/configuration/mail_methods_spec.rb
@@ -5,7 +5,7 @@ describe "Mail Methods" do
 
   before(:each) do
     quick_login_as_admin
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
     click_link "Configuration"
   end
 

--- a/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/spec/features/admin/configuration/tax_categories_spec.rb
@@ -5,7 +5,7 @@ describe "Tax Categories" do
 
   before(:each) do
     quick_login_as_admin
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
     click_link "Configuration"
   end
 

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -8,7 +8,7 @@ describe "Tax Rates" do
 
   before do
     quick_login_as_admin
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
     click_link "Configuration"
   end
 

--- a/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/spec/features/admin/configuration/taxonomies_spec.rb
@@ -5,7 +5,7 @@ describe "Taxonomies" do
 
   before(:each) do
     quick_login_as_admin
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
     click_link "Configuration"
   end
 

--- a/spec/features/admin/configuration/zones_spec.rb
+++ b/spec/features/admin/configuration/zones_spec.rb
@@ -6,7 +6,7 @@ describe "Zones" do
   before(:each) do
     quick_login_as_admin
     Spree::Zone.delete_all
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
     click_link "Configuration"
   end
 

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -44,7 +44,7 @@ feature '
 
     expect(page).to have_content 'Your content has been successfully updated!'
 
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
 
     expect(page).to have_link('User Guide', href: 'http://www.openfoodnetwork.org/platform/user-guide/')
     expect(find_link('User Guide')[:target]).to eq('_blank')

--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -113,7 +113,7 @@ feature '
 
     it "lets me access enterprise groups" do
       quick_login_as user
-      visit spree.admin_path
+      visit spree.admin_dashboard_path
       click_link 'Groups'
       expect(page).to have_content 'My Group'
     end

--- a/spec/features/admin/enterprise_relationships_spec.rb
+++ b/spec/features/admin/enterprise_relationships_spec.rb
@@ -18,7 +18,7 @@ feature '
       create(:enterprise_relationship, parent: e3, child: e4, permissions_list: [:add_to_order_cycle, :manage_products])
 
       # When I go to the relationships page
-      visit spree.admin_path
+      visit spree.admin_dashboard_path
       click_link 'Enterprises'
       click_link 'Permissions'
 

--- a/spec/features/admin/multilingual_spec.rb
+++ b/spec/features/admin/multilingual_spec.rb
@@ -9,7 +9,7 @@ feature 'Multilingual', js: true do
   background do
     admin_user.spree_roles << admin_role
     quick_login_as admin_user
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
   end
 
   it 'has two locales available' do
@@ -24,7 +24,7 @@ feature 'Multilingual', js: true do
     expect(page).to have_content 'My Enterprises'
     expect(admin_user.locale).to be_nil
 
-    visit spree.admin_path(locale: 'es')
+    visit spree.admin_dashboard_path(locale: 'es')
     expect(get_i18n_locale).to eq 'es'
     expect(get_i18n_translation('spree_admin_overview_enterprises_header')).to eq 'Mis Organizaciones'
     expect(page).to have_content 'Mis Organizaciones'
@@ -38,7 +38,7 @@ feature 'Multilingual', js: true do
     # inside core/app/views/spree/admin/shared/_translations.html.erb
 
     # I18n-js fallsback to 'en'
-    visit spree.admin_path(locale: 'it')
+    visit spree.admin_dashboard_path(locale: 'it')
     expect(get_i18n_locale).to eq 'it'
     expect(get_i18n_translation('spree_admin_overview_enterprises_header')).to eq 'My Enterprises'
     expect(admin_user.locale).to be_nil

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -714,7 +714,7 @@ feature '
         oc_user_coordinating = create(:simple_order_cycle, suppliers: [supplier_managed, supplier_unmanaged], coordinator: distributor_managed, distributors: [distributor_managed, distributor_unmanaged], name: 'Order Cycle 1' )
         oc_for_other_user = create(:simple_order_cycle, coordinator: supplier_unmanaged, name: 'Order Cycle 2' )
 
-        visit spree.admin_path
+        visit spree.admin_dashboard_path
         click_link "Order Cycles"
 
         # I should see only the order cycle I am coordinating

--- a/spec/features/admin/schedules_spec.rb
+++ b/spec/features/admin/schedules_spec.rb
@@ -20,7 +20,7 @@ feature 'Schedules', js: true do
 
     describe "Adding a new Schedule" do
       it "immediately shows the schedule in the order cycle list once created" do
-        visit spree.admin_path
+        visit spree.admin_dashboard_path
         click_link 'Order Cycles'
         expect(page).to have_selector ".order-cycle-#{oc1.id}"
         find('a', text: 'NEW SCHEDULE').click

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -26,7 +26,7 @@ feature 'Subscriptions' do
       end
 
       it "passes the smoke test" do
-        visit spree.admin_path
+        visit spree.admin_dashboard_path
         click_link 'Orders'
         click_link 'Subscriptions'
 

--- a/spec/features/admin/tax_settings_spec.rb
+++ b/spec/features/admin/tax_settings_spec.rb
@@ -21,7 +21,7 @@ feature 'Account and Billing Settings' do
 
     context "as an admin user" do
       it "loads the page" do
-        visit spree.admin_path
+        visit spree.admin_dashboard_path
         click_link "Configuration"
         click_link "Tax Settings"
 

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -15,7 +15,7 @@ feature "Managing users" do
         create(:user, email: "a@example.com")
         create(:user, email: "b@example.com")
 
-        visit spree.admin_path
+        visit spree.admin_dashboard_path
         click_link "Users"
       end
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -35,7 +35,7 @@ feature "
       } # This er should not confer ability to create VOs for hub2
 
       it "displays a list of hub choices (ie. only those managed by the user)" do
-        visit spree.admin_path
+        visit spree.admin_dashboard_path
         click_link 'Products'
         click_link 'Inventory'
 

--- a/spec/requests/embedded_shopfronts_headers_spec.rb
+++ b/spec/requests/embedded_shopfronts_headers_spec.rb
@@ -54,7 +54,7 @@ describe "setting response headers for embedded shopfronts", type: :request do
         expect(response.headers['X-Frame-Options']).to be_nil
         expect(response.headers['Content-Security-Policy']).to eq "frame-ancestors 'self' external-site.com"
 
-        get spree.admin_path
+        get spree.admin_dashboard_path
 
         expect(response.status).to be 200
         expect(response.headers['X-Frame-Options']).to eq 'DENY'

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -21,7 +21,7 @@ module AuthenticationWorkflow
 
   def login_to_admin_section
     quick_login_as_admin
-    visit spree.admin_path
+    visit spree.admin_dashboard_path
   end
 
   # TODO: Should probably just rename this to create_user
@@ -34,8 +34,8 @@ module AuthenticationWorkflow
 
   def login_to_admin_as(user)
     quick_login_as user
-    visit spree.admin_path
-    # visit spree.admin_path
+    visit spree.admin_dashboard_path
+    # visit spree.admin_dashboard_path
     # fill_in 'spree_user_email', :with => user.email
     # fill_in 'spree_user_password', :with => user.password
     # click_button 'Login'


### PR DESCRIPTION
#### What? Why?

Adjusts the name of the default admin dashboard route in preparation for Rails 4, when the logic for named route declarations will be more strict.

The named route for the admin "home" page is changed from `:admin` to `:admin_dashboard`.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

A green build will be enough to validate these changes.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Adapted admin home page route declaration for Rails 4.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
