### PR TITLE
4490 tag rules spec

### DIFF
--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -231,6 +231,13 @@ feature 'Tag Rules', js: true do
         end
         expect(page).to have_no_selector "#tr_0"
       end.to change{ TagRule.count }.by(-2)
+
+      # After deleting tags, the form is dirty and we need to confirm leaving
+      # the page. If we don't do it here, Capybara may timeout waiting for the
+      # confirmation while resetting the session.
+      accept_confirm do
+        visit("about:blank")
+      end
     end
   end
 

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -8,13 +8,10 @@ feature 'Tag Rules', js: true do
 
   context "creating" do
     before do
-      login_to_admin_section
-      visit main_app.edit_admin_enterprise_path(enterprise)
+      visit_tag_rules
     end
 
     it "allows creation of rules of each type" do
-      click_link "Tag Rules"
-
       # Creating a new tag
       expect(page).to have_no_selector '.customer_tag'
       expect(page).to have_content 'No tags apply to this enterprise yet'
@@ -115,13 +112,10 @@ feature 'Tag Rules', js: true do
     # let!(:do_tag_rule) { create(:tag_rule, enterprise: enterprise, preferred_customer_tags: "member" ) }
 
     before do
-      login_to_admin_section
-      visit main_app.edit_admin_enterprise_path(enterprise)
+      visit_tag_rules
     end
 
     it "saves changes to rules of each type" do
-      click_link "Tag Rules"
-
       # Tag groups exist
       expect(page).to have_selector '.customer_tag .header', text: "For customers tagged:", count: 4
       expect(page).to have_selector '.customer_tag .header tags-input .tag-list ti-tag-item', text: "member", count: 1
@@ -223,13 +217,10 @@ feature 'Tag Rules', js: true do
     let!(:default_rule) { create(:filter_products_tag_rule, is_default: true, enterprise: enterprise ) }
 
     before do
-      login_to_admin_section
-      visit main_app.edit_admin_enterprise_path(enterprise)
+      visit_tag_rules
     end
 
     it "deletes both default and customer rules from the database" do
-      click_link "Tag Rules"
-
       expect do
         accept_alert do
           within "#tr_1" do first("a.delete-tag-rule").click end
@@ -241,5 +232,11 @@ feature 'Tag Rules', js: true do
         expect(page).to have_no_selector "#tr_0"
       end.to change{ TagRule.count }.by(-2)
     end
+  end
+
+  def visit_tag_rules
+    login_to_admin_section
+    visit main_app.edit_admin_enterprise_path(enterprise)
+    click_link "Tag Rules"
   end
 end

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -237,6 +237,7 @@ feature 'Tag Rules', js: true do
   def visit_tag_rules
     login_to_admin_section
     visit main_app.edit_admin_enterprise_path(enterprise)
+    expect(page).to have_content "PRIMARY DETAILS"
     click_link "Tag Rules"
   end
 end

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -13,8 +13,8 @@ feature 'Tag Rules', js: true do
 
     it "allows creation of rules of each type" do
       # Creating a new tag
-      expect(page).to have_no_selector '.customer_tag'
       expect(page).to have_content 'No tags apply to this enterprise yet'
+      expect(page).to have_no_selector '.customer_tag'
       click_button '+ Add A New Tag'
       find(:css, "tags-input .tags input").set "volunteer\n"
 


### PR DESCRIPTION
#### What? Why?

Closes #4490

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This is another attempt to fix the tag rules spec. It's failing randomly. Well, master fails in at least 10% of builds because of this spec. But trying to make it fail intentionally hasn't worked yet.

While previous attempts waited for the "Tag Rules" tab to load, I thought that it's maybe the initial page load that hasn't finished which could mean that clicking on the "Tag Rules" tab doesn't do anything. We will see how that goes...

#### What should we test?
<!-- List which features should be tested and how. -->

No manual testing required.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: Made our automated tests more robust.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

