### PR TITLE
Rails 4 prep: subqueries

### DIFF
--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -63,7 +63,8 @@ class SubscriptionPlacementJob
   end
 
   def unavailable_stock_lines_for(order)
-    order.line_items.where('variant_id NOT IN (?)', available_variants_for(order))
+    order.line_items.where.
+      not(variant_id: available_variants_for(order).select('spree_variants.id'))
   end
 
   def available_variants_for(order)

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -317,7 +317,7 @@ class Enterprise < ActiveRecord::Base
   def distributed_taxons
     Spree::Taxon.
       joins(:products).
-      where('spree_products.id IN (?)', Spree::Product.in_distributor(self)).
+      where(spree_products: { id: Spree::Product.in_distributor(self).select(:id) }).
       select('DISTINCT spree_taxons.*')
   end
 
@@ -333,7 +333,7 @@ class Enterprise < ActiveRecord::Base
   def supplied_taxons
     Spree::Taxon.
       joins(:products).
-      where('spree_products.id IN (?)', Spree::Product.in_supplier(self)).
+      where(spree_products: { id: Spree::Product.in_supplier(self).select(:id) }).
       select('DISTINCT spree_taxons.*')
   end
 

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -317,7 +317,7 @@ class Enterprise < ActiveRecord::Base
   def distributed_taxons
     Spree::Taxon.
       joins(:products).
-      where(spree_products: { id: Spree::Product.in_distributor(self).select(:id) }).
+      where(spree_products: { id: Spree::Product.select(:id).in_distributor(self) }).
       select('DISTINCT spree_taxons.*')
   end
 
@@ -333,7 +333,7 @@ class Enterprise < ActiveRecord::Base
   def supplied_taxons
     Spree::Taxon.
       joins(:products).
-      where(spree_products: { id: Spree::Product.in_supplier(self).select(:id) }).
+      where(spree_products: { id: Spree::Product.select(:id).in_supplier(self) }).
       select('DISTINCT spree_taxons.*')
   end
 

--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -27,7 +27,7 @@ class EnterpriseFee < ActiveRecord::Base
     if user.has_spree_role?('admin')
       scoped
     else
-      where('enterprise_id IN (?)', user.enterprises)
+      where('enterprise_id IN (?)', user.enterprises.select('enterprises.id').map(&:id))
     end
   }
 

--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -22,7 +22,8 @@ class EnterpriseRelationship < ActiveRecord::Base
   }
 
   scope :involving_enterprises, ->(enterprises) {
-    where('parent_id IN (?) OR child_id IN (?)', enterprises, enterprises)
+    enterprise_ids = enterprises.map(&:id)
+    where('parent_id IN (?) OR child_id IN (?)', enterprise_ids, enterprise_ids)
   }
 
   scope :permitting, ->(enterprise_ids) { where('child_id IN (?)', enterprise_ids) }

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -48,8 +48,9 @@ class Exchange < ActiveRecord::Base
       select('DISTINCT exchanges.*')
   }
   scope :with_product, lambda { |product|
+    exchange_variant_ids = product.variants_including_master.select('spree_variants.id').map(&:id)
     joins(:exchange_variants).
-      where('exchange_variants.variant_id IN (?)', product.variants_including_master)
+      where('exchange_variants.variant_id IN (?)', exchange_variant_ids)
   }
   scope :by_enterprise_name, -> {
     joins('INNER JOIN enterprises AS sender   ON (sender.id   = exchanges.sender_id)').

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -55,8 +55,10 @@ Spree::Order.class_eval do
     else
       # Find orders that are distributed by the user or have products supplied by the user
       # WARNING: This only filters orders, you'll need to filter line items separately using LineItem.managed_by
+      user_enterprise_ids = user.enterprises.select("enterprises.id").to_a
       with_line_items_variants_and_products_outer.
-        where('spree_orders.distributor_id IN (?) OR spree_products.supplier_id IN (?)', user.enterprises, user.enterprises).
+        where('spree_orders.distributor_id IN (?) OR spree_products.supplier_id IN (?)',
+              user_enterprise_ids, user_enterprise_ids).
         select('DISTINCT spree_orders.*')
     end
   }

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -67,7 +67,8 @@ Spree::Order.class_eval do
     if user.has_spree_role?('admin')
       scoped
     else
-      where('spree_orders.distributor_id IN (?)', user.enterprises)
+      distributor_ids = user.enterprises.select('enterprises.id').map(&:id)
+      where(spree_orders: { distributor_id: distributor_ids })
     end
   }
 

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -19,8 +19,9 @@ Spree::PaymentMethod.class_eval do
     if user.has_spree_role?('admin')
       scoped
     else
+      user_enterprise_ids = user.enterprises.select('enterprises.id').map(&:id)
       joins(:distributors).
-        where('distributors_payment_methods.distributor_id IN (?)', user.enterprises).
+        where('distributors_payment_methods.distributor_id IN (?)', user_enterprise_ids).
         select('DISTINCT spree_payment_methods.*')
     end
   }

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -14,8 +14,9 @@ Spree::ShippingMethod.class_eval do
     if user.has_spree_role?('admin')
       scoped
     else
+      user_enterprise_ids = user.enterprises.select('enterprises.id').map(&:id)
       joins(:distributors).
-        where('distributors_shipping_methods.distributor_id IN (?)', user.enterprises).
+        where('distributors_shipping_methods.distributor_id IN (?)', user_enterprise_ids).
         select('DISTINCT spree_shipping_methods.*')
     end
   }

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -49,7 +49,9 @@ Spree::Variant.class_eval do
   }
 
   scope :for_distribution, lambda { |order_cycle, distributor|
-    where('spree_variants.id IN (?)', order_cycle.variants_distributed_by(distributor))
+    distributed_variant_ids = order_cycle.variants_distributed_by(distributor).
+      select('spree_variants.id').map(&:id)
+    where('spree_variants.id IN (?)', distributed_variant_ids)
   }
 
   scope :visible_for, lambda { |enterprise|


### PR DESCRIPTION
#### What? Why?

Closes #3708 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Fixes all remaining issues related to the Postgres error: `PG::SyntaxError: subquery has too many columns` in preparation for Rails 4.

#### What should we test?
<!-- List which features should be tested and how. -->

A green build should be enough.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Updated lack of `select` in subqueries in preparation for Rails 4.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
