### PR TITLE
Disable two codeclimate SCSS rules

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,6 +12,10 @@ plugins:
         enabled: false
       VendorPrefix:
         enabled: false
+      LeadingZero:
+        enabled: false
+      PropertySortOrder:
+        enabled: false
   duplication:
     enabled: true
     exclude_patterns:


### PR DESCRIPTION
#### What? Why?

Disables the following two `codeclimate` SCSS rules:

- **All properties have to be ordered alphabetically.** This is really time-consuming and doesn't really add anything.
- **Decimals have to be written without the preceding zero**. Time consuming and pointless. Also makes the rules slightly less readable.

![lint-order](https://user-images.githubusercontent.com/9029026/72733451-3183a400-3b98-11ea-911b-55aeb95e625a.png)
![leading-zero](https://user-images.githubusercontent.com/9029026/72732933-2419ea00-3b97-11ea-8ef1-dd08479418c3.png)

These two rules get triggered almost any time our CSS is touched.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Relaxed some SCSS rules

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
