### PR TITLE
Rescue unknown checkout errors

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -68,6 +68,10 @@ class CheckoutController < Spree::CheckoutController
         render json: { path: order_path(@order) }, status: :ok
       end
     end
+  rescue StandardError => error
+    Bugsnag.notify(error)
+    flash[:error] = I18n.t("checkout.failed")
+    update_failed
   end
 
   # Clears the cached order. Required for #current_order to return a new order

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -68,6 +68,9 @@ class CheckoutController < Spree::CheckoutController
         render json: { path: order_path(@order) }, status: :ok
       end
     end
+  rescue Spree::Core::GatewayError => error
+    # This is done for all actions in the Spree::CheckoutController.
+    rescue_from_spree_gateway_error(error)
   rescue StandardError => error
     Bugsnag.notify(error)
     flash[:error] = I18n.t("checkout.failed")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1181,6 +1181,7 @@ en:
     already_ordered:
       cart: "cart"
       message_html: "You have an order for this order cycle already. Check the %{cart} to see the items you ordered before. You can also cancel items as long as the order cycle is open."
+    failed: "The checkout failed. Please let us know so that we can process your order."
   shops:
     hubs:
       show_closed_shops: "Show closed shops"

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -200,6 +200,14 @@ describe CheckoutController, type: :controller do
       expect(response.body).to eq({ path: spree.order_path(order) }.to_json)
     end
 
+    it "returns an error on unexpected failure" do
+      allow(order).to receive(:update_attributes).and_raise
+
+      spree_post :update, format: :json, order: {}
+      expect(response.status).to eq(400)
+      expect(response.body).to eq({ errors: {}, flash: {error: I18n.t("checkout.failed")} }.to_json)
+    end
+
     describe "stale object handling" do
       it "retries when a stale object error is encountered" do
         allow(ResetOrderService).to receive(:new).with(controller, order) { reset_order_service }


### PR DESCRIPTION
#### What? Why?

Closes #4696

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The user was not notified when the checkout button fails on the server. I now catch every possible standard error, send it to Bugsnag and return a generic message to the user.

#### What should we test?
<!-- List which features should be tested and how. -->

Go through the description of #4695 to trigger a failing checkout. You should see a red error message popping up.

![Screenshot from 2020-01-22 10-42-39](https://user-images.githubusercontent.com/3524483/72853123-9d831b00-3d04-11ea-8884-947d6f1c0263.png)


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Display an error message if the checkout fails due to an unknown bug.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

