### PR TITLE
Updated shopfront message placeholder for home tab

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -758,8 +758,7 @@ en:
           enable_subscriptions_true: "Enabled"
           shopfront_message: "Shopfront Message"
           shopfront_message_placeholder: >
-            An optional explanation for customers detailing how your shopfront works,
-            to be displayed above the product list on your shop page.
+            An optional message to welcome customers and explain how to shop with you. If text is entered here it will be displayed in a home tab when customers first arrive at your shopfront.
           shopfront_message_link_tooltip: "Insert / edit link"
           shopfront_message_link_prompt: "Please enter a URL to insert"
           shopfront_closed_message: "Shopfront Closed Message"


### PR DESCRIPTION
Change required now that there is a home tab instead of a green shopfront message.

>An optional message to welcome customers and explain how to shop with you. If text is entered here it will be displayed in a home tab when customers first arrive at your shopfront.

#### What? Why?

Closes  #4702 

#### What should we test?
Test that the shopfront message field when empty has the updated message in it.

#### Release notes
Updated placeholder text in the shop preferences section of the backoffice admin to reflect the changes that are coming with the new homepage tab.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### How is this related to the Spree upgrade?
It isn't

#### Discourse thread
Nope

#### Dependencies
Must be in same release as #4568


#### Documentation updates
None

