### PR TITLE
Remove tabs from cart and checkout

### DIFF
--- a/app/views/checkout/edit.html.haml
+++ b/app/views/checkout/edit.html.haml
@@ -15,7 +15,7 @@
       %strong
         = pickup_time current_order_cycle
 
-  = render partial: "shopping_shared/details"
+  = render partial: "shopping_shared/header"
 
   %accordion{"close-others" => "false"}
     %checkout.row{"ng-controller" => "CheckoutCtrl"}

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -36,6 +36,7 @@
 
 
 
-  = render partial: "shopping_shared/details"
+  = render partial: "shopping_shared/header"
+  = render partial: "shopping_shared/tabs"
 
 = render partial: "shared/footer"

--- a/app/views/shopping_shared/_header.html.haml
+++ b/app/views/shopping_shared/_header.html.haml
@@ -13,6 +13,3 @@
 
     .small-12.medium-6.large-6.columns
       = render partial: "shopping_shared/order_cycles"
-
-
-= render partial: "shopping_shared/tabs" if distributor == current_distributor

--- a/app/views/shopping_shared/_tabs.html.haml
+++ b/app/views/shopping_shared/_tabs.html.haml
@@ -1,11 +1,13 @@
-- shop_tabs.each do |tab|
-  = render "shopping_shared/tabs/#{tab[:name]}"
+- if (@order.andand.distributor || current_distributor) == current_distributor
 
-.tabset-ctrl#shop-tabs{ navigate: 'true', alwaysopen: 'true', selected: shop_tabs.first[:name], prefix: 'shop', ng: { cloak: true } }
-  .tab-buttons
-    .row
-      - shop_tabs.each do |tab|
-        .tab{ id: "tab_#{tab[:name]}", name: tab[:name] }
-          %a{ href: 'javascript:void(0)' }=tab[:title]
+  - shop_tabs.each do |tab|
+    = render "shopping_shared/tabs/#{tab[:name]}"
 
-  .tab-view
+  .tabset-ctrl#shop-tabs{ navigate: 'true', alwaysopen: 'true', selected: shop_tabs.first[:name], prefix: 'shop', ng: { cloak: true } }
+    .tab-buttons
+      .row
+        - shop_tabs.each do |tab|
+          .tab{ id: "tab_#{tab[:name]}", name: tab[:name] }
+            %a{ href: 'javascript:void(0)' }=tab[:title]
+
+    .tab-view

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -16,7 +16,7 @@
         - else
           = @order.distributor.next_collection_at
 
-  = render partial: "shopping_shared/details"
+  = render partial: "shopping_shared/header"
 
   %fieldset.footer-pad
     - if @order.line_items.empty?

--- a/app/views/spree/orders/show.html.haml
+++ b/app/views/spree/orders/show.html.haml
@@ -5,7 +5,7 @@
   = inject_enterprise_and_relatives if current_distributor.present?
 
 .darkswarm
-  = render "shopping_shared/details" if current_distributor.present?
+  = render "shopping_shared/header" if current_distributor.present?
 
   %fieldset#order_summary.footer-pad{"data-hook" => ""}
     .row


### PR DESCRIPTION

#### What? Why?

Closes #4706

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Splits up the `shopping_shared/details` partial into `shopping_shared_header` and `shopping_shared/tabs`, and includes the tabs only in the shop page (not in cart and checkout).

#### What should we test?
<!-- List which features should be tested and how. -->

Cart and checkout pages are working ok (not displaying shop page content).

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Removed shop content tabs from cart and checkout.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

