### PR TITLE
Pluralize common variant unit names

### DIFF
--- a/app/assets/javascripts/admin/products/services/option_value_namer.js.coffee
+++ b/app/assets/javascripts/admin/products/services/option_value_namer.js.coffee
@@ -21,9 +21,7 @@ angular.module("admin.products").factory "OptionValueNamer", (VariantUnitManager
 
         else
           value = @variant.unit_value
-          unit_name = @variant.product.variant_unit_name
-          # TODO needs to add pluralize to line below
-          # unit_name = unit_name if value > 1
+          unit_name = @pluralize(@variant.product.variant_unit_name, value)
 
         value = parseInt(value, 10) if value == parseInt(value, 10)
 
@@ -31,6 +29,21 @@ angular.module("admin.products").factory "OptionValueNamer", (VariantUnitManager
         value = unit_name = null
 
       [value, unit_name]
+
+    pluralize: (unit_name, count) ->
+      return unit_name if count == undefined
+      unit_key = @unit_key(unit_name)
+      return unit_name unless unit_key
+      I18n.t(["unit_names", unit_key], {count: count, defaultValue: unit_name})
+
+    unit_key: (unit_name) ->
+      unless I18n.unit_keys
+        I18n.unit_keys = {}
+        for key, translations of I18n.t("unit_names")
+          for quantifier, translation of translations
+            I18n.unit_keys[translation.toLowerCase()] = key
+
+      I18n.unit_keys[unit_name.toLowerCase()]
 
     option_value_value_unit_scaled: ->
       [unit_scale, unit_name] = @scale_for_unit_value()

--- a/app/assets/javascripts/admin/products/services/option_value_namer.js.coffee
+++ b/app/assets/javascripts/admin/products/services/option_value_namer.js.coffee
@@ -34,12 +34,12 @@ angular.module("admin.products").factory "OptionValueNamer", (VariantUnitManager
       return unit_name if count == undefined
       unit_key = @unit_key(unit_name)
       return unit_name unless unit_key
-      I18n.t(["unit_names", unit_key], {count: count, defaultValue: unit_name})
+      I18n.t(["inflections", unit_key], {count: count, defaultValue: unit_name})
 
     unit_key: (unit_name) ->
       unless I18n.unit_keys
         I18n.unit_keys = {}
-        for key, translations of I18n.t("unit_names")
+        for key, translations of I18n.t("inflections")
           for quantifier, translation of translations
             I18n.unit_keys[translation.toLowerCase()] = key
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2721,7 +2721,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       have_an_account: "Already have an account?"
       action_login: "Log in now."
 
-  # Most popular names used in variant_unit_name.
+  # Singular and plural forms of commonly used words.
   # We use these entries to pluralize unit names in every language.
   #
   # Extracted with the following query:
@@ -2731,7 +2731,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   #   puts "      one: \"#{name}\""
   #   puts "      other: \"#{name}s\"";
   # }
-  unit_names:
+  inflections:
     each:
       one: "each"
       other: "each"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2786,6 +2786,24 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     tray:
       one: "tray"
       other: "trays"
+    piece:
+      one: "piece"
+      other: "pieces"
+    pot:
+      one: "pot"
+      other: "pots"
+    bundle:
+      one: "bundle"
+      other: "bundles"
+    flask:
+      one: "flask"
+      other: "flasks"
+    basket:
+      one: "basket"
+      other: "baskets"
+    sack:
+      one: "sack"
+      other: "sacks"
 
   producers:
     signup:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2732,86 +2732,57 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   #   puts "      other: \"#{name}s\"";
   # }
   unit_names:
-    # Used 379 times.
-    # Used 138 times.
     each:
       one: "each"
       other: "each"
-    # Used 332 times.
-    # Used 145 times.
-    # Used 93 times.
     bunch:
       one: "bunch"
       other: "bunches"
-    # Used 118 times.
-    # Used 63 times.
     pack:
       one: "pack"
       other: "packs"
-    # Used 90 times.
-    # Used 72 times.
     box:
       one: "box"
       other: "boxes"
-    # Used 81 times.
-    # Used 49 times.
     bottle:
       one: "bottle"
       other: "bottles"
-    # Used 71 times.
-    # Used 56 times.
     jar:
       one: "jar"
       other: "jars"
-    # Used 65 times.
     head:
       one: "head"
       other: "heads"
-    # Used 56 times.
-    # Used 41 times.
     bag:
       one: "bag"
       other: "bags"
-    # Used 53 times.
-    # Used 30 times.
     loaf:
       one: "loaf"
       other: "loaves"
-    # Used 43 times.
     single:
       one: "single"
       other: "singles"
-    # Used 41 times.
     tub:
       one: "tub"
       other: "tubs"
-    # Used 36 times.
     punnet:
       one: "punnet"
       other: "punnets"
-    # Used 32 times.
     packet:
       one: "packet"
       other: "packets"
-    # Used 30 times.
-    # Used 22 times.
     item:
       one: "item"
       other: "items"
-    # Used 29 times.
-    # Used 24 times.
     dozen:
       one: "dozen"
       other: "dozens"
-    # Used 26 times.
     unit:
       one: "unit"
       other: "units"
-    # Used 24 times.
     serve:
       one: "serve"
       other: "serves"
-    # Used 20 times.
     tray:
       one: "tray"
       other: "trays"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2721,6 +2721,101 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       have_an_account: "Already have an account?"
       action_login: "Log in now."
 
+  # Most popular names used in variant_unit_name.
+  # We use these entries to pluralize unit names in every language.
+  #
+  # Extracted with the following query:
+  # Spree::Product.group(:variant_unit_name).order("count_all DESC").count.each { |name, count|
+  #   puts "    # Used #{count} times."
+  #   puts "    #{name&.parameterize('_')}:"
+  #   puts "      one: \"#{name}\""
+  #   puts "      other: \"#{name}s\"";
+  # }
+  unit_names:
+    # Used 379 times.
+    # Used 138 times.
+    each:
+      one: "each"
+      other: "each"
+    # Used 332 times.
+    # Used 145 times.
+    # Used 93 times.
+    bunch:
+      one: "bunch"
+      other: "bunches"
+    # Used 118 times.
+    # Used 63 times.
+    pack:
+      one: "pack"
+      other: "packs"
+    # Used 90 times.
+    # Used 72 times.
+    box:
+      one: "box"
+      other: "boxes"
+    # Used 81 times.
+    # Used 49 times.
+    bottle:
+      one: "bottle"
+      other: "bottles"
+    # Used 71 times.
+    # Used 56 times.
+    jar:
+      one: "jar"
+      other: "jars"
+    # Used 65 times.
+    head:
+      one: "head"
+      other: "heads"
+    # Used 56 times.
+    # Used 41 times.
+    bag:
+      one: "bag"
+      other: "bags"
+    # Used 53 times.
+    # Used 30 times.
+    loaf:
+      one: "loaf"
+      other: "loaves"
+    # Used 43 times.
+    single:
+      one: "single"
+      other: "singles"
+    # Used 41 times.
+    tub:
+      one: "tub"
+      other: "tubs"
+    # Used 36 times.
+    punnet:
+      one: "punnet"
+      other: "punnets"
+    # Used 32 times.
+    packet:
+      one: "packet"
+      other: "packets"
+    # Used 30 times.
+    # Used 22 times.
+    item:
+      one: "item"
+      other: "items"
+    # Used 29 times.
+    # Used 24 times.
+    dozen:
+      one: "dozen"
+      other: "dozens"
+    # Used 26 times.
+    unit:
+      one: "unit"
+      other: "units"
+    # Used 24 times.
+    serve:
+      one: "serve"
+      other: "serves"
+    # Used 20 times.
+    tray:
+      one: "tray"
+      other: "trays"
+
   producers:
     signup:
       start_free_profile: "Start with a free profile, and expand when you're ready!"

--- a/lib/open_food_network/i18n_inflections.rb
+++ b/lib/open_food_network/i18n_inflections.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module OpenFoodNetwork
+  # Pluralize or singularize words.
+  #
+  # We store some inflection data in locales and use a reverse lookup of a word
+  # to find the plural or singular of the same word.
+  #
+  # Here is one example with a French user:
+  #
+  # - We have a product with the variant unit name "bouquet".
+  # - The I18n.locale is set to :fr.
+  # - The French locale contains:
+  #     bunch:
+  #       one: "bouquet"
+  #       other: "bouquets"
+  # - We create a table containing:
+  #     "bouquet" => "bunch"
+  #     "bouquets" => "bunch"
+  # - Looking up "bouquet" gives us the I18n key "bunch".
+  # - We find the right plural by calling I18n:
+  #
+  #     I18n.t("inflections.bunch", count: 2, default: "bouquet")
+  #
+  # - This returns the correct plural "bouquets".
+  # - It returns the original "bouquet" if the word is missing from the locale.
+  module I18nInflections
+    # Make this a singleton to cache lookup tables.
+    extend self
+
+    def pluralize(word, count)
+      return word if count.nil?
+
+      key = i18n_key(word)
+
+      return word unless key
+
+      I18n.t(key, scope: "inflections", count: count, default: word)
+    end
+
+    private
+
+    def i18n_key(word)
+      @lookup ||= {}
+
+      # The user may switch the locale. `I18n.t` is always using the current
+      # locale and we need a lookup table for each of them.
+      unless @lookup.key?(I18n.locale)
+        @lookup[I18n.locale] = build_i18n_key_lookup
+      end
+
+      @lookup[I18n.locale][word.downcase]
+    end
+
+    def build_i18n_key_lookup
+      lookup = {}
+      I18n.t("inflections")&.each do |key, translations|
+        translations.values.each do |translation|
+          lookup[translation.downcase] = key
+        end
+      end
+      lookup
+    end
+  end
+end

--- a/lib/open_food_network/option_value_namer.rb
+++ b/lib/open_food_network/option_value_namer.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "open_food_network/i18n_inflections"
+
 module OpenFoodNetwork
   class OptionValueNamer
     def initialize(variant = nil)
@@ -73,37 +77,7 @@ module OpenFoodNetwork
     end
 
     def pluralize(unit_name, count)
-      I18nUnitNames.instance.pluralize(unit_name, count)
-    end
-
-    # Provides efficient access to unit name inflections.
-    # The singleton property ensures that the init code is run once only.
-    # The OptionValueNamer is instantiated in loops.
-    class I18nUnitNames
-      include Singleton
-
-      def pluralize(unit_name, count)
-        return unit_name if count.nil?
-
-        @unit_keys ||= unit_key_lookup
-        key = @unit_keys[unit_name.downcase]
-
-        return unit_name unless key
-
-        I18n.t(key, scope: "unit_names", count: count, default: unit_name)
-      end
-
-      private
-
-      def unit_key_lookup
-        lookup = {}
-        I18n.t("unit_names").each do |key, translations|
-          translations.values.each do |translation|
-            lookup[translation.downcase] = key
-          end
-        end
-        lookup
-      end
+      I18nInflections.pluralize(unit_name, count)
     end
   end
 end

--- a/spec/javascripts/unit/admin/products/services/option_value_namer_spec.js.coffee
+++ b/spec/javascripts/unit/admin/products/services/option_value_namer_spec.js.coffee
@@ -1,0 +1,26 @@
+describe "OptionValueNamer", ->
+  subject = null
+
+  beforeEach ->
+    module('admin.products')
+    inject (_OptionValueNamer_) ->
+      subject = new _OptionValueNamer_
+
+  describe "pluralize a variant unit name", ->
+    it "returns the same word if no plural is known", ->
+      expect(subject.pluralize("foo", 2)).toEqual "foo"
+
+    it "returns the same word if we omit the quantity", ->
+      expect(subject.pluralize("loaf")).toEqual "loaf"
+
+    it "finds the plural of a word", ->
+      expect(subject.pluralize("loaf", 2)).toEqual "loaves"
+
+    it "finds the singular of a word", ->
+      expect(subject.pluralize("loaves", 1)).toEqual "loaf"
+
+    it "finds the zero form of a word", ->
+      expect(subject.pluralize("loaf", 0)).toEqual "loaves"
+
+    it "ignores upper case", ->
+      expect(subject.pluralize("Loaf", 2)).toEqual "loaves"

--- a/spec/lib/open_food_network/i18n_inflections_spec.rb
+++ b/spec/lib/open_food_network/i18n_inflections_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open_food_network/i18n_inflections'
+
+describe OpenFoodNetwork::I18nInflections do
+  let(:subject) { described_class }
+
+  it "returns the same word if no plural is known" do
+    expect(subject.pluralize("foo", 2)).to eq "foo"
+  end
+
+  it "finds the plural of a word" do
+    expect(subject.pluralize("bunch", 2)).to eq "bunches"
+  end
+
+  it "finds the singular of a word" do
+    expect(subject.pluralize("bunch", 1)).to eq "bunch"
+  end
+
+  it "ignores upper case" do
+    expect(subject.pluralize("Bunch", 2)).to eq "bunches"
+  end
+
+  it "switches locales" do
+    skip "French plurals not available yet"
+    I18n.with_locale(:fr) do
+      expect(subject.pluralize("bouquet", 2)).to eq "bouquets"
+    end
+  end
+
+  it "builds the lookup table once" do
+    # Cache the table:
+    subject.pluralize("bunch", 2)
+
+    # Expect only one call for the plural:
+    expect(I18n).to receive(:t).once.and_call_original
+    subject.pluralize("bunch", 2)
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #4172

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This adds the most popular unit names as singular and plural to our
locale for translation. The added Javascript performs a reverse lookup
to find the right singular/plural form of a unit name in that language.

I explained why I chose this solution on the issue: https://github.com/openfoodfoundation/openfoodnetwork/issues/4172#issuecomment-577447644

#### What should we test?
<!-- List which features should be tested and how. -->

Test in English because we haven't translated this yet.

* Go to admin -> products.
* Change a product to items instead of weight or volume.
* Add a unit name like `bunch` or `loaf`.
* Change the quantity including `0`, `1` and `2` of the variant and observe the change in the description.
* Save the changes.
* Go to the shopfront and verify the product description there.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Unit descriptions like "1 bunch" or "4 boxes" can now be translated more accurately. The previous logic would sometimes fail to find the right plural, especially in languages other than English.


Changelog Category: Changed

