### PR TITLE
Change in English locale to add "end" term

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2790,6 +2790,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   status: "status"
   new: "New"
   start: "Start"
+  end: "End"
   stop: "Stop"
   first: "First"
   previous: "Previous"


### PR DESCRIPTION
#### What? Why?

Closes #4412
The "end" term is used in _date_range_form.html.haml, but there is no entry in the English locale. Added this entry so that it can start being translated with Transifex.


#### What should we test?
No testing necessary.


Changelog Category: Fixed
