### PR TITLE
Make StripeSCA payment method work with existing credit cards (the ones saved through the Stripe Charges API)

### DIFF
--- a/app/controllers/spree/credit_cards_controller.rb
+++ b/app/controllers/spree/credit_cards_controller.rb
@@ -56,15 +56,9 @@ module Spree
 
     private
 
-    # Currently can only destroy the whole customer object
+    # It destroys the whole customer object
     def destroy_at_stripe
-      if @credit_card.payment_method &&
-         @credit_card.payment_method.type == "Spree::Gateway::StripeSCA"
-        options = { stripe_account: stripe_account_id }
-      end
-
-      stripe_customer = Stripe::Customer.retrieve(@credit_card.gateway_customer_profile_id,
-                                                  options || {})
+      stripe_customer = Stripe::Customer.retrieve(@credit_card.gateway_customer_profile_id, {})
       stripe_customer.delete if stripe_customer
     end
 

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -71,11 +71,9 @@ module Spree
         options[:currency] = gateway_options[:currency]
         options[:stripe_account] = stripe_account_id
 
-        Stripe::CreditCardCloner.new.clone!(creditcard, stripe_account_id)
-        options[:customer] = creditcard.gateway_customer_profile_id
-        payment_method = creditcard.gateway_payment_profile_id
-
-        [money, payment_method, options]
+        connected_acct_customer_id, connected_acct_payment_method_id = Stripe::CreditCardCloner.new.clone(creditcard, stripe_account_id)
+        options[:customer] = connected_acct_customer_id
+        [money, connected_acct_payment_method_id, options]
       end
 
       def failed_activemerchant_billing_response(error_message)

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'stripe/profile_storer'
+require 'stripe/credit_card_cloner'
 require 'active_merchant/billing/gateways/stripe_payment_intents'
 require 'active_merchant/billing/gateways/stripe_decorator'
 
@@ -52,7 +53,7 @@ module Spree
       def create_profile(payment)
         return unless payment.source.gateway_customer_profile_id.nil?
 
-        profile_storer = Stripe::ProfileStorer.new(payment, provider, stripe_account_id)
+        profile_storer = Stripe::ProfileStorer.new(payment, provider)
         profile_storer.create_customer_from_token
       end
 

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -71,9 +71,10 @@ module Spree
         options[:currency] = gateway_options[:currency]
         options[:stripe_account] = stripe_account_id
 
-        connected_acct_customer_id, connected_acct_payment_method_id = Stripe::CreditCardCloner.new.clone(creditcard, stripe_account_id)
-        options[:customer] = connected_acct_customer_id
-        [money, connected_acct_payment_method_id, options]
+        customer_id, payment_method_id = Stripe::CreditCardCloner.new.clone(creditcard,
+                                                                            stripe_account_id)
+        options[:customer] = customer_id
+        [money, payment_method_id, options]
       end
 
       def failed_activemerchant_billing_response(error_message)

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -70,10 +70,24 @@ module Spree
         options[:currency] = gateway_options[:currency]
         options[:stripe_account] = stripe_account_id
 
-        options[:customer] = creditcard.gateway_customer_profile_id
-        creditcard = creditcard.gateway_payment_profile_id
+        convert_to_payment_method!(creditcard) if creditcard.gateway_payment_profile_id.starts_with?('card_')
 
-        [money, creditcard, options]
+        options[:customer] = creditcard.gateway_customer_profile_id
+        payment_method = creditcard.gateway_payment_profile_id
+
+        [money, payment_method, options]
+      end
+
+      def convert_to_payment_method!(creditcard)
+        card_id = creditcard.gateway_payment_profile_id
+        customer_id = creditcard.gateway_customer_profile_id
+        new_payment_method = Stripe::PaymentMethod.create({ customer: customer_id, payment_method: card_id }, { stripe_account: stripe_account_id })
+
+        new_customer = Stripe::Customer.create({ email: creditcard.user.email }, { stripe_account: stripe_account_id })
+        Stripe::PaymentMethod.attach(new_payment_method.id, { customer: new_customer.id }, { stripe_account: stripe_account_id })
+
+        creditcard.update_attributes gateway_customer_profile_id: new_customer.id, gateway_payment_profile_id: new_payment_method.id
+        creditcard
       end
 
       def failed_activemerchant_billing_response(error_message)

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -70,7 +70,7 @@ module Spree
         options[:currency] = gateway_options[:currency]
         options[:stripe_account] = stripe_account_id
 
-        Stripe::CardCloner.new.clone!(creditcard, stripe_account_id)
+        Stripe::CreditCardCloner.new.clone!(creditcard, stripe_account_id)
         options[:customer] = creditcard.gateway_customer_profile_id
         payment_method = creditcard.gateway_payment_profile_id
 

--- a/app/views/spree/admin/payments/source_forms/_stripe_sca.html.haml
+++ b/app/views/spree/admin/payments/source_forms/_stripe_sca.html.haml
@@ -2,7 +2,7 @@
   %script{:src => "https://js.stripe.com/v3/", :type => "text/javascript"}
   - if Stripe.publishable_key
     :javascript
-      angular.module('admin.payments').value("stripeObject", Stripe("#{Stripe.publishable_key}", { stripeAccount: "#{StripeAccount.find_by_enterprise_id(payment_method.preferred_enterprise_id).andand.stripe_user_id}" }))
+      angular.module('admin.payments').value("stripeObject", Stripe("#{Stripe.publishable_key}"))
 
   .row
     .three.columns

--- a/app/views/spree/admin/payments/source_views/_gateway.html.haml
+++ b/app/views/spree/admin/payments/source_views/_gateway.html.haml
@@ -6,28 +6,28 @@
         %dt
           = Spree.t(:card_number)
           \:
-        %dd= payment.source.display_number
+        %dd= payment.source&.display_number
         %dt
           = Spree.t(:expiration)
           \:
         %dd
-          = payment.source.month
+          = payment.source&.month
           \/
-          = payment.source.year
+          = payment.source&.year
         %dt
           = Spree.t(:card_code)
           \:
-        %dd= payment.source.verification_value
+        %dd= payment.source&.verification_value
     .omega.six.columns
       %dl
         %dt
           = t(:maestro_or_solo_cards)
           \:
-        %dd= payment.source.issue_number
+        %dd= payment.source&.issue_number
         %dt
           = Spree.t(:start_date)
           \:
         %dd
-          = payment.source.start_month
+          = payment.source&.start_month
           \/
-          = payment.source.start_year
+          = payment.source&.start_year

--- a/app/views/spree/admin/payments/source_views/_stripe_sca.html.haml
+++ b/app/views/spree/admin/payments/source_views/_stripe_sca.html.haml
@@ -1,0 +1,1 @@
+= render "spree/admin/payments/source_views/gateway", payment: payment

--- a/app/views/spree/checkout/payment/_stripe_sca.html.haml
+++ b/app/views/spree/checkout/payment/_stripe_sca.html.haml
@@ -1,7 +1,7 @@
 - content_for :injection_data do
   - if Stripe.publishable_key
     :javascript
-      angular.module('Darkswarm').value("stripeObject", Stripe("#{Stripe.publishable_key}", { stripeAccount: "#{StripeAccount.find_by_enterprise_id(payment_method.preferred_enterprise_id).andand.stripe_user_id}" }))
+      angular.module('Darkswarm').value("stripeObject", Stripe("#{Stripe.publishable_key}"))
 
 .row{ "ng-show" => "savedCreditCards.length > 0" }
   .small-12.columns

--- a/lib/stripe/card_cloner.rb
+++ b/lib/stripe/card_cloner.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Here we clone
+# - a card (card_*) stored in a customer in a platform account
+# into
+# - a payment method (pm_*) in a new customer in a connected account
+#
+# This process is used in the migration between using the Stripe Charges API (stripe_connect)
+#   and the Stripe Payment Intents API (stripe_sca)
+#
+# This process can be deleted once all hubs are running on the new stripe_sca method and all cards in the system have been migrated to the new payment_methods
+#   Basically, when all DBs have no card_* values in credit_card.gateway_payment_profile_id
+module Stripe
+  class CardCloner
+    def clone!(credit_card, stripe_account_id)
+      return unless credit_card.gateway_payment_profile_id.starts_with?('card_')
+
+      new_payment_method = clone_payment_method(credit_card, stripe_account_id)
+      new_customer = Stripe::Customer.create({ email: credit_card.user.email },
+                                             stripe_account: stripe_account_id)
+      attach_payment_method_to_customer(new_payment_method.id, new_customer.id, stripe_account_id)
+
+      credit_card.update_attributes gateway_customer_profile_id: new_customer.id,
+                                    gateway_payment_profile_id: new_payment_method.id
+      credit_card
+    end
+
+    private
+
+    def clone_payment_method(credit_card, stripe_account_id)
+      card_id = credit_card.gateway_payment_profile_id
+      customer_id = credit_card.gateway_customer_profile_id
+
+      Stripe::PaymentMethod.create({ customer: customer_id, payment_method: card_id },
+                                   stripe_account: stripe_account_id)
+    end
+
+    def attach_payment_method_to_customer(payment_method_id, customer_id, stripe_account_id)
+      Stripe::PaymentMethod.attach(payment_method_id,
+                                   { customer: customer_id },
+                                   stripe_account: stripe_account_id)
+    end
+  end
+end

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -1,44 +1,49 @@
 # frozen_string_literal: true
 
 # Here we clone
-# - a card (card_*) stored in a customer in a platform account
+#   - a card (card_*) or payment_method (pm_*) stored in a customer in a platform account
 # into
-# - a payment method (pm_*) in a new customer in a connected account
+#   - a payment method (pm_*) in a new customer in a connected account
 #
-# This process is used in the migration between using the Stripe Charges API (stripe_connect)
-#   and the Stripe Payment Intents API (stripe_sca)
+# This is required when using the Stripe Payment Intents API:
+#   - the customer and payment methods are stored in the platform account
+#       so that they can be re-used across multiple sellers
+#   - when a card needs to be charged, we need to create it in the seller's stripe account
 #
-# This process can be deleted once all hubs are running on the new stripe_sca method and all cards in the system have been migrated to the new payment_methods
-#   Basically, when all DBs have no card_* values in credit_card.gateway_payment_profile_id
+# We are doing this process every time the card is charged:
+#   - this means that, if the customer uses the same card on the same seller multiple times,
+#       the card will be created multiple times on the seller's account
+#   - to avoid this, we would have to store the IDs of every card on each seller's stripe account
+#       in our database (this way we only have to store the platform account ID)
 module Stripe
   class CreditCardCloner
-    def clone!(credit_card, stripe_account_id)
-      return unless credit_card.gateway_payment_profile_id.starts_with?('card_')
+    def clone(credit_card, connected_account_id)
+      new_payment_method = clone_payment_method(credit_card, connected_account_id)
 
-      new_payment_method = clone_payment_method(credit_card, stripe_account_id)
       new_customer = Stripe::Customer.create({ email: credit_card.user.email },
-                                             stripe_account: stripe_account_id)
-      attach_payment_method_to_customer(new_payment_method.id, new_customer.id, stripe_account_id)
+                                             stripe_account: connected_account_id)
+      attach_payment_method_to_customer(new_payment_method.id,
+                                        new_customer.id,
+                                        connected_account_id)
 
-      credit_card.update_attributes gateway_customer_profile_id: new_customer.id,
-                                    gateway_payment_profile_id: new_payment_method.id
-      credit_card
+      [new_customer.id, new_payment_method.id]
     end
 
     private
 
-    def clone_payment_method(credit_card, stripe_account_id)
-      card_id = credit_card.gateway_payment_profile_id
+    def clone_payment_method(credit_card, connected_account_id)
+      platform_acct_payment_method_id = credit_card.gateway_payment_profile_id
       customer_id = credit_card.gateway_customer_profile_id
 
-      Stripe::PaymentMethod.create({ customer: customer_id, payment_method: card_id },
-                                   stripe_account: stripe_account_id)
+      Stripe::PaymentMethod.create({ customer: customer_id,
+                                     payment_method: platform_acct_payment_method_id },
+                                   stripe_account: connected_account_id)
     end
 
-    def attach_payment_method_to_customer(payment_method_id, customer_id, stripe_account_id)
+    def attach_payment_method_to_customer(payment_method_id, customer_id, connected_account_id)
       Stripe::PaymentMethod.attach(payment_method_id,
                                    { customer: customer_id },
-                                   stripe_account: stripe_account_id)
+                                   stripe_account: connected_account_id)
     end
   end
 end

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -11,7 +11,7 @@
 # This process can be deleted once all hubs are running on the new stripe_sca method and all cards in the system have been migrated to the new payment_methods
 #   Basically, when all DBs have no card_* values in credit_card.gateway_payment_profile_id
 module Stripe
-  class CardCloner
+  class CreditCardCloner
     def clone!(credit_card, stripe_account_id)
       return unless credit_card.gateway_payment_profile_id.starts_with?('card_')
 

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -18,6 +18,11 @@
 module Stripe
   class CreditCardCloner
     def clone(credit_card, connected_account_id)
+      # No need to clone the card if there's no customer, i.e., it's a card for one time usage
+      if credit_card.gateway_customer_profile_id.blank?
+        return nil, credit_card.gateway_payment_profile_id
+      end
+
       new_payment_method = clone_payment_method(credit_card, connected_account_id)
 
       new_customer = Stripe::Customer.create({ email: credit_card.user.email },

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # Here we clone
-#   - a card (card_*) or payment_method (pm_*) stored in a customer in a platform account
+#   - a card (card_*) or payment_method (pm_*) stored (in a customer) in a platform account
 # into
-#   - a payment method (pm_*) in a new customer in a connected account
+#   - a payment method (pm_*) (in a new customer) in a connected account
 #
 # This is required when using the Stripe Payment Intents API:
 #   - the customer and payment methods are stored in the platform account
@@ -18,12 +18,10 @@
 module Stripe
   class CreditCardCloner
     def clone(credit_card, connected_account_id)
-      # No need to clone the card if there's no customer, i.e., it's a card for one time usage
-      if credit_card.gateway_customer_profile_id.blank?
-        return nil, credit_card.gateway_payment_profile_id
-      end
-
       new_payment_method = clone_payment_method(credit_card, connected_account_id)
+
+      # If no customer is given, it will clone the payment method only
+      return nil, new_payment_method.id if credit_card.gateway_customer_profile_id.blank?
 
       new_customer = Stripe::Customer.create({ email: credit_card.user.email },
                                              stripe_account: connected_account_id)

--- a/lib/stripe/profile_storer.rb
+++ b/lib/stripe/profile_storer.rb
@@ -4,10 +4,9 @@
 
 module Stripe
   class ProfileStorer
-    def initialize(payment, provider, stripe_account_id = nil)
+    def initialize(payment, provider)
       @payment = payment
       @provider = provider
-      @stripe_account_id = stripe_account_id
     end
 
     def create_customer_from_token
@@ -29,13 +28,7 @@ module Stripe
         email: @payment.order.email,
         login: Stripe.api_key,
         address: address_for(@payment)
-      }.merge(stripe_account_option)
-    end
-
-    def stripe_account_option
-      return {} if @stripe_account_id.blank?
-
-      { stripe_account: @stripe_account_id }
+      }
     end
 
     def address_for(payment)

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -172,22 +172,6 @@ describe Spree::CreditCardsController, type: :controller do
             expect(response).to redirect_to spree.account_path(anchor: 'cards')
           end
         end
-
-        context "where the payment method is StripeSCA" do
-          let(:stripe_payment_method) { create(:stripe_sca_payment_method) }
-          let!(:card) { create(:credit_card, gateway_customer_profile_id: 'cus_AZNMJ', payment_method: stripe_payment_method) }
-
-          before do
-            stub_request(:delete, "https://api.stripe.com/v1/customers/cus_AZNMJ").
-              to_return(status: 200, body: JSON.generate(deleted: true, id: "cus_AZNMJ"))
-          end
-
-          it "the request to destroy the Stripe customer includes the stripe_account_id" do
-            expect(Stripe::Customer).to receive(:retrieve).with(card.gateway_customer_profile_id, { stripe_account: "abc123" })
-
-            expect{ delete :destroy, params }.to change(Spree::CreditCard, :count).by(-1)
-          end
-        end
       end
     end
   end

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -10,7 +10,6 @@ feature '
 
   scenario "visiting the payment form" do
     quick_login_as_admin
-
     visit spree.new_admin_order_payment_path order
 
     expect(page).to have_content "New Payment"
@@ -28,7 +27,6 @@ feature '
 
     scenario "visiting the payment form" do
       quick_login_as_admin
-
       visit spree.new_admin_order_payment_path order
 
       expect(page).to have_content "New Payment"
@@ -43,11 +41,24 @@ feature '
 
     it "renders the payment details" do
       quick_login_as_admin
-
       visit spree.admin_order_payments_path order
 
       page.click_link("StripeSCA")
       expect(page).to have_content order.payments.last.source.last_digits
+    end
+
+    context "with a deleted credit card" do
+      before do
+        order.payments.last.update_attribute(:source, nil)
+      end
+
+      it "renders the payment details" do
+        quick_login_as_admin
+        visit spree.admin_order_payments_path order
+
+        page.click_link("StripeSCA")
+        expect(page).to have_content order.payments.last.amount
+      end
     end
   end
 end

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -34,4 +34,20 @@ feature '
       expect(page).to have_content "New Payment"
     end
   end
+
+  context "with a StripeSCA payment method" do
+    before do
+      stripe_payment_method = create(:stripe_sca_payment_method, distributors: [order.distributor])
+      order.payments << create(:payment, payment_method: stripe_payment_method, order: order)
+    end
+
+    it "renders the payment details" do
+      quick_login_as_admin
+
+      visit spree.admin_order_payments_path order
+
+      page.click_link("StripeSCA")
+      expect(page).to have_content order.payments.last.source.last_digits
+    end
+  end
 end

--- a/spec/lib/stripe/credit_card_cloner_spec.rb
+++ b/spec/lib/stripe/credit_card_cloner_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stripe/credit_card_cloner'
+
+module Stripe
+  describe CreditCardCloner do
+    describe "#clone!" do
+      let(:cloner) { Stripe::CreditCardCloner.new }
+
+      let(:customer_id) { "cus_A123" }
+      let(:card_id) { "card_1234" }
+      let(:new_customer_id) { "cus_A456" }
+      let(:new_payment_method_id) { "pm_4567" }
+      let(:stripe_account_id) { "acct_456" }
+      let(:customer_response_mock) { { status: 200, body: customer_response_body } }
+
+      let(:credit_card) { create(:credit_card, user: create(:user)) }
+
+      before do
+        allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+
+        stub_request(:post, "https://api.stripe.com/v1/customers")
+          .with(basic_auth: ["sk_test_12345", ""], body: { email: credit_card.user.email })
+          .to_return(customer_response_mock)
+      end
+
+      context "when called with a credit_card with valid id (card_*)" do
+        let(:customer_response_body) {
+          JSON.generate(id: customer_id, default_card: card_id)
+        }
+
+        it "clones the card successefully" do
+          cloner.clone!(credit_card, stripe_account_id)
+
+          expect(credit_card.gateway_customer_profile_id).to eq new_customer_id
+          expect(credit_card.gateway_payment_profile_id).to eq new_payment_method_id
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/stripe/credit_card_cloner_spec.rb
+++ b/spec/lib/stripe/credit_card_cloner_spec.rb
@@ -9,9 +9,9 @@ module Stripe
       let(:cloner) { Stripe::CreditCardCloner.new }
 
       let(:customer_id) { "cus_A123" }
-      let(:card_id) { "card_1234" }
+      let(:payment_method_id) { "pm_1234" }
       let(:new_customer_id) { "cus_A456" }
-      let(:new_payment_method_id) { "pm_4567" }
+      let(:new_payment_method_id) { "pm_456" }
       let(:stripe_account_id) { "acct_456" }
       let(:customer_response_mock) { { status: 200, body: customer_response_body } }
       let(:payment_method_response_mock) { { status: 200, body: payment_method_response_body } }
@@ -22,27 +22,39 @@ module Stripe
         allow(Stripe).to receive(:api_key) { "sk_test_12345" }
 
         stub_request(:post, "https://api.stripe.com/v1/payment_methods")
-          .with(basic_auth: ["sk_test_12345", ""])
+          .with(body: { customer: customer_id, payment_method: payment_method_id},
+                headers: { 'Stripe-Account' => stripe_account_id })
           .to_return(payment_method_response_mock)
 
         stub_request(:post, "https://api.stripe.com/v1/customers")
-          .with(basic_auth: ["sk_test_12345", ""], body: { email: credit_card.user.email })
+          .with(body: { email: credit_card.user.email },
+                headers: { 'Stripe-Account' => stripe_account_id })
           .to_return(customer_response_mock)
+
+        stub_request(:post, "https://api.stripe.com/v1/payment_methods/#{new_payment_method_id}/attach")
+          .with(body: { customer: new_customer_id },
+                headers: { 'Stripe-Account' => stripe_account_id })
+          .to_return(payment_method_response_mock)
       end
 
       context "when called with a credit_card with valid id (card_*)" do
         let(:payment_method_response_body) {
-          JSON.generate(id: new_payment_method_id, default_card: card_id)
+          JSON.generate(id: new_payment_method_id)
         }
         let(:customer_response_body) {
-          JSON.generate(id: customer_id, default_card: card_id)
+          JSON.generate(id: new_customer_id)
         }
 
-        it "clones the card successefully" do
-          cloner.clone(credit_card, stripe_account_id)
+        before do
+          credit_card.update_attributes gateway_customer_profile_id: customer_id,
+                                        gateway_payment_profile_id: payment_method_id
+        end
 
-          expect(credit_card.gateway_customer_profile_id).to eq new_customer_id
-          expect(credit_card.gateway_payment_profile_id).to eq new_payment_method_id
+        it "clones the card successefully" do
+          customer_id, payment_method_id = cloner.clone(credit_card, stripe_account_id)
+
+          expect(customer_id).to eq new_customer_id
+          expect(payment_method_id).to eq new_payment_method_id
         end
       end
     end

--- a/spec/lib/stripe/credit_card_cloner_spec.rb
+++ b/spec/lib/stripe/credit_card_cloner_spec.rb
@@ -5,7 +5,7 @@ require 'stripe/credit_card_cloner'
 
 module Stripe
   describe CreditCardCloner do
-    describe "#clone!" do
+    describe "#clone" do
       let(:cloner) { Stripe::CreditCardCloner.new }
 
       let(:customer_id) { "cus_A123" }
@@ -14,11 +14,16 @@ module Stripe
       let(:new_payment_method_id) { "pm_4567" }
       let(:stripe_account_id) { "acct_456" }
       let(:customer_response_mock) { { status: 200, body: customer_response_body } }
+      let(:payment_method_response_mock) { { status: 200, body: payment_method_response_body } }
 
       let(:credit_card) { create(:credit_card, user: create(:user)) }
 
       before do
         allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+
+        stub_request(:post, "https://api.stripe.com/v1/payment_methods")
+          .with(basic_auth: ["sk_test_12345", ""])
+          .to_return(payment_method_response_mock)
 
         stub_request(:post, "https://api.stripe.com/v1/customers")
           .with(basic_auth: ["sk_test_12345", ""], body: { email: credit_card.user.email })
@@ -26,12 +31,15 @@ module Stripe
       end
 
       context "when called with a credit_card with valid id (card_*)" do
+        let(:payment_method_response_body) {
+          JSON.generate(id: new_payment_method_id, default_card: card_id)
+        }
         let(:customer_response_body) {
           JSON.generate(id: customer_id, default_card: card_id)
         }
 
         it "clones the card successefully" do
-          cloner.clone!(credit_card, stripe_account_id)
+          cloner.clone(credit_card, stripe_account_id)
 
           expect(credit_card.gateway_customer_profile_id).to eq new_customer_id
           expect(credit_card.gateway_payment_profile_id).to eq new_payment_method_id

--- a/spec/lib/stripe/profile_storer_spec.rb
+++ b/spec/lib/stripe/profile_storer_spec.rb
@@ -7,7 +7,6 @@ module Stripe
     describe "create_customer_from_token" do
       let(:payment) { create(:payment) }
       let(:stripe_payment_method) { create(:stripe_payment_method) }
-      let(:stripe_account_id) { "12312" }
       let(:profile_storer) { Stripe::ProfileStorer.new(payment, stripe_payment_method.provider) }
 
       let(:customer_id) { "cus_A123" }

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -75,50 +75,83 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
     set_order order
   end
 
-  context "when a new card is submitted" do
-    context "and the user doesn't request that the card is saved for later" do
-      before do
-        # Charges the card
-        stub_request(:post, "https://api.stripe.com/v1/payment_intents")
-          .with(basic_auth: ["sk_test_12345", ""], body: /#{stripe_payment_method}.*#{order.number}/)
-          .to_return(payment_intent_response_mock)
-      end
+  context "when the user submits a new card and doesn't request that the card is saved for later" do
+    before do
+      # Charges the card
+      stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+        .with(basic_auth: ["sk_test_12345", ""], body: /#{stripe_payment_method}.*#{order.number}/)
+        .to_return(payment_intent_response_mock)
+    end
 
-      context "and the paymeent intent request is successful" do
-        it "should process the payment without storing card details" do
-          put update_checkout_path, params
+    context "and the paymeent intent request is successful" do
+      it "should process the payment without storing card details" do
+        put update_checkout_path, params
 
-          expect(json_response["path"]).to eq spree.order_path(order)
-          expect(order.payments.completed.count).to be 1
+        expect(json_response["path"]).to eq spree.order_path(order)
+        expect(order.payments.completed.count).to be 1
 
-          card = order.payments.completed.first.source
+        card = order.payments.completed.first.source
 
-          expect(card.gateway_customer_profile_id).to eq nil
-          expect(card.gateway_payment_profile_id).to eq stripe_payment_method
-          expect(card.cc_type).to eq "visa"
-          expect(card.last_digits).to eq "4242"
-          expect(card.first_name).to eq "Jill"
-          expect(card.last_name).to eq "Jeffreys"
-        end
-      end
-
-      context "when the payment intent request returns an error message" do
-        let(:payment_intent_response_mock) do
-          { status: 402, body: JSON.generate(error: { message: "payment-intent-failure" }) }
-        end
-
-        it "should not process the payment" do
-          put update_checkout_path, params
-
-          expect(response.status).to be 400
-
-          expect(json_response["flash"]["error"]).to eq "payment-intent-failure"
-          expect(order.payments.completed.count).to be 0
-        end
+        expect(card.gateway_customer_profile_id).to eq nil
+        expect(card.gateway_payment_profile_id).to eq stripe_payment_method
+        expect(card.cc_type).to eq "visa"
+        expect(card.last_digits).to eq "4242"
+        expect(card.first_name).to eq "Jill"
+        expect(card.last_name).to eq "Jeffreys"
       end
     end
 
-    context "and the customer requests that the card is saved for later" do
+    context "when the payment intent request returns an error message" do
+      let(:payment_intent_response_mock) do
+        { status: 402, body: JSON.generate(error: { message: "payment-intent-failure" }) }
+      end
+
+      it "should not process the payment" do
+        put update_checkout_path, params
+
+        expect(response.status).to be 400
+
+        expect(json_response["flash"]["error"]).to eq "payment-intent-failure"
+        expect(order.payments.completed.count).to be 0
+      end
+    end
+  end
+
+  context "when saving a card or using a stored card is involved" do
+    let(:hubs_customer_response_mock) do
+      {
+        status: 200,
+        body: JSON.generate(id: hubs_customer_id, sources: { data: [{ id: "1" }] })
+      }
+    end
+    let(:hubs_payment_method_response_mock) do
+      {
+        status: 200,
+        body: JSON.generate(id: hubs_stripe_payment_method, customer: hubs_customer_id)
+      }
+    end
+
+     before do
+       # Clones the payment method to the hub's stripe account
+       stub_request(:post, "https://api.stripe.com/v1/payment_methods")
+         .with(body: { customer: customer_id, payment_method: stripe_payment_method },
+               headers: { 'Stripe-Account' => 'abc123' })
+         .to_return(hubs_payment_method_response_mock)
+
+       # Creates a customer on the hub's stripe account to hold the payment meethod
+       stub_request(:post, "https://api.stripe.com/v1/customers")
+         .with(body: { email: order.email },
+               headers: { 'Stripe-Account' => 'abc123' })
+         .to_return(hubs_customer_response_mock)
+
+       # Attaches the payment method to the customer in the hub's stripe account
+       stub_request(:post, "https://api.stripe.com/v1/payment_methods/#{hubs_stripe_payment_method}/attach")
+         .with(body: { customer: hubs_customer_id },
+               headers: { 'Stripe-Account' => 'abc123' })
+         .to_return(hubs_payment_method_response_mock)
+    end
+
+    context "when the user submits a new card and requests that the card is saved for later" do
       let(:payment_method_attach_response_mock) do
         {
           status: 200,
@@ -132,49 +165,20 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
         }
       end
 
-      let(:hubs_customer_response_mock) do
-        {
-          status: 200,
-          body: JSON.generate(id: hubs_customer_id, sources: { data: [{ id: "1" }] })
-        }
-      end
-      let(:hubs_payment_method_response_mock) do
-        {
-          status: 200,
-          body: JSON.generate(id: hubs_stripe_payment_method, customer: hubs_customer_id)
-        }
-      end
-
       before do
         source_attributes = params[:order][:payments_attributes][0][:source_attributes]
         source_attributes[:save_requested_by_customer] = '1'
 
         # Creates a customer
         stub_request(:post, "https://api.stripe.com/v1/customers")
-          .with(body: { email: order.email })
+          .with(body: { email: order.email },
+                headers: hash_excluding('Stripe-Account'))
           .to_return(customer_response_mock)
 
         # Attaches the payment method to the customer
         stub_request(:post, "https://api.stripe.com/v1/payment_methods/#{stripe_payment_method}/attach")
           .with(body: { customer: customer_id })
           .to_return(payment_method_attach_response_mock)
-
-        # Clones the payment method to the hub's stripe account
-        stub_request(:post, "https://api.stripe.com/v1/payment_methods")
-          .with(body: { customer: customer_id, payment_method: stripe_payment_method },
-                headers: { 'Stripe-Account' => 'abc123' })
-          .to_return(hubs_payment_method_response_mock)
-
-        # Creates a customer on the hub's stripe account to hold the payment meethod
-        stub_request(:post, "https://api.stripe.com/v1/customers")
-          .with(body: { email: order.email },
-                headers: { 'Stripe-Account' => 'abc123' })
-          .to_return(hubs_customer_response_mock)
-
-        # Attaches the payment method to the customer in the hub's stripe account
-        stub_request(:post, "https://api.stripe.com/v1/payment_methods/#{hubs_stripe_payment_method}/attach")
-          .with(body: { customer: hubs_customer_id })
-          .to_return(hubs_payment_method_response_mock)
 
         # Charges the card
         stub_request(:post, "https://api.stripe.com/v1/payment_intents")
@@ -248,63 +252,63 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
         end
       end
     end
-  end
 
-  context "when an existing card is submitted" do
-    let(:credit_card) do
-      create(
-        :credit_card,
-        user_id: order.user_id,
-        gateway_payment_profile_id: stripe_payment_method,
-        gateway_customer_profile_id: customer_id,
-        last_digits: "4321",
-        cc_type: "master",
-        first_name: "Sammy",
-        last_name: "Signpost",
-        month: 11, year: 2026
-      )
-    end
-
-    before do
-      params[:order][:existing_card_id] = credit_card.id
-      quick_login_as(order.user)
-
-      # Charges the card
-      stub_request(:post, "https://api.stripe.com/v1/payment_intents")
-        .with(basic_auth: ["sk_test_12345", ""], body: %r{#{customer_id}.*#{stripe_payment_method}})
-        .to_return(payment_intent_response_mock)
-    end
-
-    context "and the payment intent and payment method requests are accepted" do
-      it "should process the payment, and keep the profile ids and other card details" do
-        put update_checkout_path, params
-
-        expect(json_response["path"]).to eq spree.order_path(order)
-        expect(order.payments.completed.count).to be 1
-
-        card = order.payments.completed.first.source
-
-        expect(card.gateway_customer_profile_id).to eq customer_id
-        expect(card.gateway_payment_profile_id).to eq stripe_payment_method
-        expect(card.cc_type).to eq "master"
-        expect(card.last_digits).to eq "4321"
-        expect(card.first_name).to eq "Sammy"
-        expect(card.last_name).to eq "Signpost"
-      end
-    end
-
-    context "when the payment intent request returns an error message" do
-      let(:payment_intent_response_mock) do
-        { status: 402, body: JSON.generate(error: { message: "payment-intent-failure" }) }
+    context "when the user selects an existing card" do
+      let(:credit_card) do
+        create(
+          :credit_card,
+          user_id: order.user_id,
+          gateway_payment_profile_id: stripe_payment_method,
+          gateway_customer_profile_id: customer_id,
+          last_digits: "4321",
+          cc_type: "master",
+          first_name: "Sammy",
+          last_name: "Signpost",
+          month: 11, year: 2026
+        )
       end
 
-      it "should not process the payment" do
-        put update_checkout_path, params
+      before do
+        params[:order][:existing_card_id] = credit_card.id
+        quick_login_as(order.user)
 
-        expect(response.status).to be 400
+        # Charges the card
+        stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+          .with(basic_auth: ["sk_test_12345", ""], body: %r{#{customer_id}.*#{stripe_payment_method}})
+          .to_return(payment_intent_response_mock)
+      end
 
-        expect(json_response["flash"]["error"]).to eq "payment-intent-failure"
-        expect(order.payments.completed.count).to be 0
+      context "and the payment intent and payment method requests are accepted" do
+        it "should process the payment, and keep the profile ids and other card details" do
+          put update_checkout_path, params
+
+          expect(json_response["path"]).to eq spree.order_path(order)
+          expect(order.payments.completed.count).to be 1
+
+          card = order.payments.completed.first.source
+
+          expect(card.gateway_customer_profile_id).to eq customer_id
+          expect(card.gateway_payment_profile_id).to eq stripe_payment_method
+          expect(card.cc_type).to eq "master"
+          expect(card.last_digits).to eq "4321"
+          expect(card.first_name).to eq "Sammy"
+          expect(card.last_name).to eq "Signpost"
+        end
+      end
+
+      context "when the payment intent request returns an error message" do
+        let(:payment_intent_response_mock) do
+          { status: 402, body: JSON.generate(error: { message: "payment-intent-failure" }) }
+        end
+
+        it "should not process the payment" do
+          put update_checkout_path, params
+
+          expect(response.status).to be 400
+
+          expect(json_response["flash"]["error"]).to eq "payment-intent-failure"
+          expect(order.payments.completed.count).to be 0
+        end
       end
     end
   end

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -260,7 +260,7 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
 
         # Charges the card
         stub_request(:post, "https://api.stripe.com/v1/payment_intents")
-          .with(basic_auth: ["sk_test_12345", ""], body: %r{#{customer_id}.*#{stripe_payment_method}})
+          .with(basic_auth: ["sk_test_12345", ""], body: %r{#{customer_id}.*#{hubs_stripe_payment_method}})
           .to_return(payment_intent_response_mock)
       end
 


### PR DESCRIPTION
#### What? Why?

Closes #4685
Here we make all cards stored with StripeSCA go to the platform account (which is what happens with the existing Stripe payment method). To use these cards in the Payment Intents API we need to clone these cards to the hubs stripe accounts (the connected accounts) before we use them. This process of cloning will also work for existing cards saved through the Charges API :+1:
So, this PR makes this payment method complete and compatible with the existing cards in the system.

#### What should we test?
First verify that #4672 is working by following it's test guide.
Afterwards, see acceptance criteria for this PR in #4685.

#### Release notes
Changelog Category: Changed
Made new Stripe SCA payment method compatible with credit cards already stored in Stripe. This payment method is now complete and we can now start to migrate all users to this payment method.