### PR TITLE
Bump Code Climate's Rubocop version to their latest

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ version: "2"
 plugins:
   rubocop:
     enabled: true
-    channel: "rubocop-0-57"
+    channel: "rubocop-0-76"
     config:
       file: ".rubocop_styleguide.yml"
   scss-lint:


### PR DESCRIPTION

#### What? Why?

I noticed that Code Climate is using an older version of Rubocop. That explains why we see different results locally. In this PR I chose the most recent version supported by Code Climate which is closer to our used version.

Code Climate seems to be a bit behind which clashes with our Dependabot updates. Maybe we should not follow Dependabot here and always update rubocop manually. It needs manual intervention anyway. Let's see.

#### What should we test?
<!-- List which features should be tested and how. -->

No test needed.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fine-tuned the configuration of our automated code quality control.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

