### PR TITLE
Fixing incorrect payment and balance calculation

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -77,7 +77,7 @@ module OpenFoodNetwork
        ba.phone,
        order.shipping_method.andand.name,
        order.payments.first.andand.payment_method.andand.name,
-       order.payments.first.amount,
+       order.payment_total,
        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance]
     end
 
@@ -92,7 +92,7 @@ module OpenFoodNetwork
        sa.phone,
        order.shipping_method.andand.name,
        order.payments.first.andand.payment_method.andand.name,
-       order.payments.first.amount,
+       order.payment_total,
        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance,
        has_temperature_controlled_items?(order),
        order.special_instructions]

--- a/lib/open_food_network/user_balance_calculator.rb
+++ b/lib/open_food_network/user_balance_calculator.rb
@@ -6,25 +6,13 @@ module OpenFoodNetwork
     end
 
     def balance
-      payment_total - completed_order_total
+      -completed_orders.sum(&:outstanding_balance)
     end
 
     private
 
-    def completed_order_total
-      completed_orders.sum(&:total)
-    end
-
-    def payment_total
-      payments.sum(&:amount)
-    end
-
     def completed_orders
       Spree::Order.where(distributor_id: @distributor, email: @email).complete.not_state(:canceled)
-    end
-
-    def payments
-      Spree::Payment.where(order_id: completed_orders, state: "completed")
     end
   end
 end

--- a/spec/lib/open_food_network/user_balance_calculator_spec.rb
+++ b/spec/lib/open_food_network/user_balance_calculator_spec.rb
@@ -69,7 +69,7 @@ module OpenFoodNetwork
           create(:order_with_totals_and_distribution,
                  user: user1, distributor: hub1,
                  completed_at: 1.day.ago, state: "canceled")
-        } # total=10
+        } # total=13 (10 + 3 shipping fee)
         let!(:p4) {
           create(:payment, order: o4, amount: 20.00,
                            state: "completed")
@@ -77,6 +77,62 @@ module OpenFoodNetwork
 
         it "does not include canceled orders in the balance" do
           expect(UserBalanceCalculator.new(o4.email, hub1).balance).to eq(-9) # = 15 + 2 - 13 - 13
+        end
+      end
+
+      context "with void payments" do
+        let!(:o4) {
+          create(:order_with_totals_and_distribution,
+                 user: user1, distributor: hub1,
+                 completed_at: 1.day.ago)
+        } # total=13 (10 + 3 shipping fee)
+        let!(:p4) {
+          create(:payment, order: o4, amount: 20.00,
+                           state: "void")
+        }
+
+        it "does not include void in the balance" do
+          expect(UserBalanceCalculator.new(o4.email, hub1).balance).to eq(-22) # = 15 + 2 - 13 - 13 - 10
+        end
+      end
+
+      context "with invalid payments" do
+        let!(:o4) {
+          create(:order_with_totals_and_distribution,
+                 user: user1, distributor: hub1,
+                 completed_at: 1.day.ago)
+        } # total=13 (10 + 3 shipping fee)
+        let!(:p4) {
+          create(:payment, order: o4, amount: 20.00,
+                           state: "invalid")
+        }
+
+        it "does not include invalid payments in the balance" do
+          expect(UserBalanceCalculator.new(o4.email, hub1).balance).to eq(-22) # = 15 + 2 - 13 - 13 - 10
+        end
+      end
+
+      context "with multiple payments on single order" do
+        let!(:o4) {
+          create(:order_with_totals_and_distribution,
+                 user: user1, distributor: hub1,
+                 completed_at: 1.day.ago)
+        } # total=13 (10 + 3 shipping fee)
+        let!(:p4) {
+          create(:payment, order: o4, amount: 4.00,
+                           state: "completed")
+        }
+        let!(:p5) {
+          create(:payment, order: o4, amount: 5.00,
+                           state: "completed")
+        }
+        let!(:p6) {
+          create(:payment, order: o4, amount: 6.00,
+                           state: "completed")
+        }
+
+        it "includes orders with multiple payments in the balance" do
+          expect(UserBalanceCalculator.new(o4.email, hub1).balance).to eq(-7) # = 15 + 2 + 4 + 5 + 6 - 13 - 13 - 10
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #4732

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

OFN has a very very basic ability to manage customer balances.

Shoppers can see their balance in Accounts -> Transactions.

Hub Managers can see customer balances in Reports -> Order Cycle Management -> Payment Methods reports.

The two places use different calculations to come to a customer balance. Shoppers see a sum or order balances while hub managers see a sum of order totals minus payments.

These two calculations should match. In the code the most common method used is the version the shoppers see. The Reports should use that method too.
#### What should we test?
<!-- List which features should be tested and how. -->
To test:

1. With a shopper account create some orders and payments.
2. As Hub manager make adjustments to the orders and payments. Including voiding payments and orders. Add multiple payments to an order and include addition payments so that the orders also have more payments than the order amount.
3. As you make the changes in step 2 check the Shopper balance in Accounts -> Transactions. Compare this to the Balance and Payment Totals shown in Reports -> Order Cycle Management Reports -> Payment Methods Report.

The figures should match with all the changes you make.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Hub Managers can accurately monitor Shopper balances using Payment Methods report

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->

First step in 
https://community.openfoodnetwork.org/t/2-enable-customers-to-pay-partially-or-fully-with-their-credits/1211/31

#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

We'll update the documentation after scoping the minimal acceptance criteria for Enabling Customers to pay with credits. 