### PR TITLE
Activate Foundation's dropdowns after tab switch

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
@@ -29,11 +29,17 @@ Darkswarm.controller "ProductsCtrl", ($scope, $filter, $rootScope, Products, Ord
       data.map( (taxon) ->
         $scope.supplied_taxons[taxon.id] = Taxons.taxons_by_id[taxon.id]
       )
+      # Some taxons may be displayed in a dropdown.
+      # Foundation needs initialising again to add dropdown actions.
+      Foundation.init()
     OrderCycleResource.properties params, (data)=>
       $scope.supplied_properties = {}
       data.map( (property) ->
         $scope.supplied_properties[property.id] = Properties.properties_by_id[property.id]
       )
+      # Some properties may be displayed in a dropdown.
+      # Foundation needs initialising again to add dropdown actions.
+      Foundation.init()
 
   $scope.loadMore = ->
     if ($scope.page * $scope.per_page) <= Products.products.length


### PR DESCRIPTION

#### What? Why?

Closes #4729

If the dropdown doesn't exist during page load, Foundation misses it. We
need to initialise it again.



#### What should we test?
<!-- List which features should be tested and how. -->

- Load a shop with many taxons and many properties.
- The window size needs to be small enough to show the `+x More` button.
- Click on the button and make sure it shows the dropdown.
- Switch to another tab and reload the page.
- Switch back to the shop tab and check the filter buttons again.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed the "+1 More" drop-down menu for product filters in shop fronts.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

