### PR TITLE
Restore ability to load more than 100 products

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/simple_edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/simple_edit.js.coffee
@@ -11,12 +11,36 @@ angular.module('admin.orderCycles').controller "AdminSimpleEditOrderCycleCtrl", 
 
   $scope.init = ->
     $scope.outgoing_exchange = OrderCycle.order_cycle.outgoing_exchanges[0]
-    $scope.loadExchangeProducts()
+    $scope.incoming_exchange = OrderCycle.order_cycle.incoming_exchanges[0]
+    $scope.loadExchangeProducts($scope.incoming_exchange)
 
-  $scope.loadExchangeProducts = ->
-    exchange = OrderCycle.order_cycle.incoming_exchanges[0]
-    ExchangeProduct.index { exchange_id: exchange.id }, (products) ->
-      $scope.enterprises[exchange.enterprise_id].supplied_products = products
+  $scope.loadExchangeProducts = (exchange, page = 1) ->
+    enterprise = $scope.enterprises[exchange.enterprise_id]
+    enterprise.supplied_products ?= []
+
+    return if enterprise.last_page_loaded? && enterprise.last_page_loaded >= page
+    enterprise.last_page_loaded = page
+
+    params = {
+      exchange_id: exchange.id,
+      page: page,
+    }
+    ExchangeProduct.index params, (products, num_of_pages, num_of_products) ->
+      enterprise.num_of_pages = num_of_pages
+      enterprise.num_of_products = num_of_products
+      enterprise.supplied_products.push products...
+
+  $scope.loadMoreExchangeProducts = (exchange) ->
+    $scope.loadExchangeProducts(exchange, $scope.enterprises[exchange.enterprise_id].last_page_loaded + 1)
+
+  $scope.loadAllExchangeProducts = (exchange) ->
+    enterprise = $scope.enterprises[exchange.enterprise_id]
+
+    if enterprise.last_page_loaded < enterprise.num_of_pages
+      for page_to_load in [(enterprise.last_page_loaded + 1)..enterprise.num_of_pages]
+        RequestMonitor.load $scope.loadExchangeProducts(exchange, page_to_load).$promise
+
+    RequestMonitor.loadQueue
 
   $scope.removeDistributionOfVariant = angular.noop
 

--- a/app/views/admin/order_cycles/_simple_form.html.haml
+++ b/app/views/admin/order_cycles/_simple_form.html.haml
@@ -19,6 +19,14 @@
     %tr.products
       %td{ ng: { include: "'admin/panels/exchange_products_simple.html'" } }
 
+    %tr
+      %td
+        .pagination{ 'ng-show' => 'enterprises[exchange.enterprise_id].last_page_loaded < enterprises[exchange.enterprise_id].num_of_pages && !productsLoading()'}
+          .button{ 'ng-click' => 'loadMoreExchangeProducts(exchange)' }
+            {{ 'js.admin.panels.exchange_products.load_more_products' | t }}
+          .button{ 'ng-click' => 'loadAllExchangeProducts(exchange)' }
+            {{ 'js.admin.panels.exchange_products.load_all_products' | t }}
+
 %br/
 = label_tag t('.fees')
 = render 'coordinator_fees', f: f


### PR DESCRIPTION
The simple order cycle form was not updated to use the new pagination.

#### What? Why?

Closes #[the issue number this PR is related to]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

