### PR TITLE
Make pagination optional in the ExchangeProductsController

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/services/exchange_product.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/exchange_product.js.coffee
@@ -8,7 +8,7 @@ angular.module('admin.orderCycles').factory('ExchangeProduct', ($resource) ->
 
     index: (params={}, callback=null) ->
       ExchangeProductResource.index params, (data) =>
-        (callback || angular.noop)(data.products, data.pagination.pages, data.pagination.results)
+        (callback || angular.noop)(data.products, data.pagination?.pages, data.pagination?.results)
 
     countVariants: (params={}, callback=null) ->
       ExchangeProductResource.variant_count params, (data) =>

--- a/app/controllers/api/exchange_products_controller.rb
+++ b/app/controllers/api/exchange_products_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 # This controller lists products that can be added to an exchange
+#
+# Pagination is optional and can be required by using param[:page]
 module Api
   class ExchangeProductsController < Api::BaseController
-    DEFAULT_PAGE = 1
     DEFAULT_PER_PAGE = 100
 
     skip_authorization_check only: [:index]
@@ -49,6 +50,8 @@ module Api
     end
 
     def paginated_products
+      return products unless pagination_required?
+
       products.
         page(params[:page] || DEFAULT_PAGE).
         per(params[:per_page] || DEFAULT_PER_PAGE)
@@ -80,19 +83,23 @@ module Api
         order_cycle: @order_cycle
       )
 
-      render text: {
-        products: serializer,
-        pagination: pagination_data(paginated_products)
-      }.to_json
+      result = { products: serializer }
+      result = result.merge(pagination: pagination_data(paginated_products)) if pagination_required?
+
+      render text: result.to_json
     end
 
     def pagination_data(paginated_products)
       {
         results: paginated_products.total_count,
         pages: paginated_products.num_pages,
-        page: (params[:page] || DEFAULT_PAGE).to_i,
+        page: params[:page].to_i,
         per_page: (params[:per_page] || DEFAULT_PER_PAGE).to_i
       }
+    end
+
+    def pagination_required?
+      params[:page].present?
     end
   end
 end

--- a/app/controllers/api/exchange_products_controller.rb
+++ b/app/controllers/api/exchange_products_controller.rb
@@ -53,7 +53,7 @@ module Api
       return products unless pagination_required?
 
       products.
-        page(params[:page] || DEFAULT_PAGE).
+        page(params[:page]).
         per(params[:per_page] || DEFAULT_PER_PAGE)
     end
 

--- a/spec/controllers/api/exchange_products_controller_spec.rb
+++ b/spec/controllers/api/exchange_products_controller_spec.rb
@@ -51,12 +51,27 @@ module Api
         let(:exchange) { order_cycle.exchanges.outgoing.first }
         let(:products_relation) { Spree::Product.includes(:variants).where("spree_variants.id": exchange.variants.map(&:id)) }
 
-        it "paginates results" do
-          spree_get :index, exchange_id: exchange.id, page: 1, per_page: 1
+        before do
+          stub_const("Api::ExchangeProductsController::DEFAULT_PER_PAGE", 1)
+        end
 
-          expect(json_response["products"].size).to eq 1
-          expect(json_response["pagination"]["results"]).to eq 2
-          expect(json_response["pagination"]["pages"]).to eq 2
+        describe "when a specific page is requested" do
+          it "returns the requested page with paginated data" do
+            spree_get :index, exchange_id: exchange.id, page: 1
+
+            expect(json_response["products"].size).to eq 1
+            expect(json_response["pagination"]["results"]).to eq 2
+            expect(json_response["pagination"]["pages"]).to eq 2
+          end
+        end
+
+        describe "when no specific page is requested" do
+          it "returns all results without paginating" do
+            spree_get :index, exchange_id: exchange.id
+
+            expect(json_response["products"].size).to eq 2
+            expect(json_response["pagination"]).to be nil
+          end
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

This is an alternative to https://github.com/openfoodfoundation/openfoodnetwork/pull/4743
Instead of adding pagination to the simple OC edit page it just make pagination optional on the server and so the simple OC page starts to load all products at once.

#### What should we test?
Simple create and edit OC page should work correctly and load more than 100 products if applicable.

#### Release notes
Changelog Category: Fixed
Fix problem in simple OC edit page. It's now loading over 100 products if available.
