### PR TITLE
4489 Flaky spec when editing outgoing exchanges in OC

### DIFF
--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -369,7 +369,12 @@ feature '
         find(:css, "tags-input .tags input").set "wholesale\n"
       end
 
-      page.all("table.exchanges tr.distributor td.products").each(&:click)
+      exchange_rows = page.all("table.exchanges tbody")
+      exchange_rows.each do |exchange_row|
+        exchange_row.find("td.products").click
+        # Wait for the products panel to be visible.
+        expect(exchange_row).to have_selector "tr", count: 2
+      end
 
       uncheck "order_cycle_outgoing_exchange_2_variants_#{v1.id}"
       check "order_cycle_outgoing_exchange_2_variants_#{v2.id}"


### PR DESCRIPTION
#### What? Why?

- Closes #4489

The previous code was intermittently failing because of the race condition while clicking to open all panels for outgoing exchange products.

If the open trigger for the third exchange is clicked while the panels for the first and second exchanges are not yet open, the third exchange is pushed down to the bottom of the browser window already when the panels finally open. When this happens, the variant check boxes for the third exchange are no longer considered visible.

#### What should we test?

The test build should be green.

#### Release notes

- Make automated tests more reliable.

Changelog Category: Fixed