### PR TITLE
Make the payment methods filter handle misconfigured stripe payment methods

### DIFF
--- a/lib/open_food_network/available_payment_method_filter.rb
+++ b/lib/open_food_network/available_payment_method_filter.rb
@@ -15,9 +15,9 @@ module OpenFoodNetwork
     end
 
     def stripe_configuration_incomplete?(payment_method)
-      return true if payment_method.preferred_enterprise_id.zero?
-
-      payment_method.stripe_account_id.blank?
+      payment_method.preferred_enterprise_id.nil? ||
+        payment_method.preferred_enterprise_id.zero? ||
+        payment_method.stripe_account_id.blank?
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

I bumped into this one while doing the Stripe SCA work.

Closes #4044
This also makes #4713 much better (maybe closes it?): there will be no 500 error on checkout, the mis-configured payment method will just not show up on the checkout page.

#### What should we test?
Configure a Check payment method and make sure it can be used on checkout.
Configure a Stripe payment method and do not add a enterprise or connect to stripe. Make sure it does not appear on checkout but checkout works.
Configure a Stripe payment method and define the enterprise but do not connect to stripe. Make sure it does not appear on checkout but checkout works.
Configure a Stripe payment method and define the enterprise and connect to stripe. Make sure it *does* appear on checkout and you can checkout using it.

No error 500 on checkout :-)

#### Release notes
Changelog Category: Fixed
Fixed bug on checkout when a stripe payment method was misconfigured.
