### PR TITLE
Future proof form rendering in admin orders

### DIFF
--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -1,5 +1,5 @@
 %div{"data-hook" => "admin_orders_index_search"}
-  = form_tag false, {name: "orders_form", "ng-submit" => "fetchResults()"} do
+  = form_tag nil, {name: "orders_form", "ng-submit" => "fetchResults()"} do
     .field-block.alpha.four.columns
       .date-range-filter.field
         = label_tag nil, t(:date_range)


### PR DESCRIPTION

#### What? Why?

Related to #3706 and #4641. This is a backport of one of @Matt-Yorkley's fixes for Rails 4.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

When switching to Rails 4, we got this error:

> ActionView::Template::Error: Nil location provided. Can't build URI.
>   0) Account and Billing Settings updating as an admin user loads the page
>      Failure/Error: = form_tag false, {name: "orders_form", "ng-submit" => "fetchResults()"} do


#### What should we test?
<!-- List which features should be tested and how. -->

- Go to admin / orders.
- Enter any filter details.
- Filter the orders and make sure it displays some orders.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: The Admin Orders page is now compatible with Rails 4.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

Preparing the next upgrade.

