### PR TITLE
Packing reports include customer first name in alphabetical ordering

### DIFF
--- a/lib/open_food_network/packing_report.rb
+++ b/lib/open_food_network/packing_report.rb
@@ -52,7 +52,9 @@ module OpenFoodNetwork
           { group_by: proc { |line_item| line_item.order.distributor },
             sort_by: proc { |distributor| distributor.name } },
           { group_by: proc { |line_item| line_item.order },
-            sort_by: proc { |order| order.bill_address.lastname },
+            sort_by: proc { |order| order.bill_address.lastname } },
+          { group_by: proc { |line_item| line_item.order },
+            sort_by: proc { |order| order.bill_address.firstname },
             summary_columns: [proc { |_line_items| "" },
                               proc { |_line_items| "" },
                               proc { |_line_items| "" },
@@ -88,7 +90,9 @@ module OpenFoodNetwork
          { group_by: proc { |line_item| line_item.full_name },
            sort_by: proc { |full_name| full_name } },
          { group_by: proc { |line_item| line_item.order },
-           sort_by: proc { |order| order.bill_address.lastname } }]
+           sort_by: proc { |order| order.bill_address.lastname } },
+         { group_by: proc { |line_item| line_item.order },
+           sort_by: proc { |order| order.bill_address.firstname } }]
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #4765

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
The Packing reports (Customer and Supplier) order the orders by customer name. Unfortunately this include last name but not first name.

This recently broke a script I created to merge the data from two reports into a single report for a user. They suddenly had two customers with the same surname. The other report orders by surname and firstname so to make the script run more quickly I used the ordering to match the data. I tried updating the script but google scripts are slow and timeout quickly so I figured it would be better to just fix the bug in the report.


#### What should we test?
<!-- List which features should be tested and how. -->
Create a few orders with the same last name and different first names
Go to the packing reports
Check the ordering of the orders in both reports. The reports should now sort alphabetically by first name too.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Packing reports now include first name in alphabetical ordering.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed 

