### PR TITLE
Remove the assets group from the gemfile (taken from spree upgrade branch)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'haml'
 gem 'rabl'
 gem 'redcarpet'
 gem 'sass', "~> 3.3"
-gem 'sass-rails', '~> 3.2.3', groups: [:default, :assets]
+gem 'sass-rails', '~> 3.2.3'
 gem 'truncate_html'
 gem 'unicorn'
 
@@ -99,21 +99,17 @@ gem 'whenever', require: false
 
 gem 'test-unit', '~> 3.3'
 
-# Gems used only for assets and not required
-# in production environments by default.
-group :assets do
-  gem 'coffee-rails', '~> 3.2.1'
-  gem 'compass-rails'
+gem 'coffee-rails', '~> 3.2.1'
+gem 'compass-rails'
 
-  gem 'mini_racer', '0.2.9'
+gem 'mini_racer', '0.2.9'
 
-  gem 'uglifier', '>= 1.0.3'
+gem 'uglifier', '>= 1.0.3'
 
-  gem 'angular-rails-templates', '~> 0.3.0'
-  gem 'foundation-icons-sass-rails'
-  gem 'momentjs-rails'
-  gem 'turbo-sprockets-rails3'
-end
+gem 'angular-rails-templates', '~> 0.3.0'
+gem 'foundation-icons-sass-rails'
+gem 'momentjs-rails'
+gem 'turbo-sprockets-rails3'
 
 gem "foundation-rails"
 gem 'foundation_rails_helper', github: 'willrjmarshall/foundation_rails_helper', branch: "rails3"


### PR DESCRIPTION
#### What? Why?

The assets group disappears in rails 4, we can do it now.

#### What should we test?
I am not sure but probably just deploy and load some pages in the frontoffice and the backoffice. 

#### Release notes
Changelog Category: Changed
Prepare gemfile  for rails 4 upgrade.
