### PR TITLE
Fix javascript logic that parses server errors in the bulk product edit page

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -1,4 +1,4 @@
-angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout, $filter, $http, $window, BulkProducts, DisplayProperties, DirtyProducts, VariantUnitManager, StatusMessage, producers, Taxons, Columns, tax_categories, RequestMonitor, SortOptions) ->
+angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout, $filter, $http, $window, BulkProducts, DisplayProperties, DirtyProducts, VariantUnitManager, StatusMessage, producers, Taxons, Columns, tax_categories, RequestMonitor, SortOptions, ErrorsParser) ->
   $scope.StatusMessage = StatusMessage
 
   $scope.columns = Columns.columns
@@ -230,10 +230,9 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
       BulkProducts.updateVariantLists(data.products || [])
       $timeout -> $scope.displaySuccess()
     ).error (data, status) ->
-      if status == 400 && data.errors? && data.errors.length > 0
-        errors = error + "\n" for error in data.errors
-        alert t("products_update_error") + "\n" + errors
-        $scope.displayFailure t("products_update_error")
+      if status == 400 && data.errors?
+        errorsString = ErrorsParser.toString(data.errors, status)
+        $scope.displayFailure t("products_update_error") + "\n" + errorsString
       else
         $scope.displayFailure t("products_update_error_data") + status
 
@@ -284,7 +283,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
 
 
   $scope.displayFailure = (failMessage) ->
-    StatusMessage.display  'failure', t("products_update_error_msg") + "#{failMessage}"
+    StatusMessage.display  'failure', t("products_update_error_msg") + " #{failMessage}"
 
 
   $scope.displayDirtyProducts = ->

--- a/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
@@ -7,7 +7,7 @@ angular.module("admin.utils").factory "ErrorsParser", ->
       errorsString = ""
       if errors.length > 0
         # it is an array of errors
-        errorsString = errors.join("\n")
+        errorsString = errors.join("\n") + "\n"
       else
         # it is a hash of errors
         keys = Object.keys(errors)

--- a/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
@@ -2,16 +2,25 @@
 angular.module("admin.utils").factory "ErrorsParser", ->
   new class ErrorsParser
     toString: (errors, defaultContent = "") =>
+      return defaultContent unless errors?
+
+      errorsString = ""
       if errors.length > 0
         # it is an array of errors
-        errorsString = error + "\n" for error in errors
+        errorsString = this.arrayToString(errors)
       else
         # it is a hash of errors
         keys = Object.keys(errors)
-        errorsString = ""
         for key in keys
-          errorsString += error for error in errors[key]
+          errorsString += this.arrayToString(errors[key])
 
-        errorsString = defaultContent if errorsString == ""
+      this.defaultIfEmpty(errorsString, defaultContent)
 
-      errorsString
+    arrayToString: (array) =>
+      string = ""
+      string += entry + "\n" for entry in array
+      string
+
+    defaultIfEmpty: (content, defaultContent) =>
+      return defaultContent if content == ""
+      content

--- a/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
@@ -7,19 +7,14 @@ angular.module("admin.utils").factory "ErrorsParser", ->
       errorsString = ""
       if errors.length > 0
         # it is an array of errors
-        errorsString = this.arrayToString(errors)
+        errorsString = errors.join("\n")
       else
         # it is a hash of errors
         keys = Object.keys(errors)
         for key in keys
-          errorsString += this.arrayToString(errors[key])
+          errorsString += errors[key].join("\n") + "\n"
 
       this.defaultIfEmpty(errorsString, defaultContent)
-
-    arrayToString: (array) =>
-      string = ""
-      string += entry + "\n" for entry in array
-      string
 
     defaultIfEmpty: (content, defaultContent) =>
       return defaultContent if content == ""

--- a/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/errors_parser.js.coffee
@@ -1,0 +1,17 @@
+# Parses a structure of errors that came from the server
+angular.module("admin.utils").factory "ErrorsParser", ->
+  new class ErrorsParser
+    toString: (errors, defaultContent = "") =>
+      if errors.length > 0
+        # it is an array of errors
+        errorsString = error + "\n" for error in errors
+      else
+        # it is a hash of errors
+        keys = Object.keys(errors)
+        errorsString = ""
+        for key in keys
+          errorsString += error for error in errors[key]
+
+        errorsString = defaultContent if errorsString == ""
+
+      errorsString

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -725,7 +725,7 @@ describe "AdminProductEditCtrl", ->
           $httpBackend.expectPOST("/admin/products/bulk_update").respond 400, { "errors": { "base": ["a basic error"] } }
           $scope.updateProducts "updated list of products"
           $httpBackend.flush()
-          expect($scope.displayFailure).toHaveBeenCalledWith("Saving failed with the following error(s):\na basic error")
+          expect($scope.displayFailure).toHaveBeenCalledWith("Saving failed with the following error(s):\na basic error\n")
 
 
   describe "adding variants", ->

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -710,13 +710,22 @@ describe "AdminProductEditCtrl", ->
         $httpBackend.flush()
         expect($scope.displayFailure).toHaveBeenCalled()
 
-      it "shows an alert with error information when post returns 400 with an errors array", ->
-        spyOn(window, "alert")
-        $scope.products = "updated list of products"
-        $httpBackend.expectPOST("/admin/products/bulk_update").respond 400, { "errors": ["an error"] }
-        $scope.updateProducts "updated list of products"
-        $httpBackend.flush()
-        expect(window.alert).toHaveBeenCalledWith("Saving failed with the following error(s):\nan error\n")
+      describe "displaying the error information when post returns 400", ->
+        beforeEach ->
+          spyOn $scope, "displayFailure"
+          $scope.products = "updated list of products"
+
+        it "displays errors in an array", ->
+          $httpBackend.expectPOST("/admin/products/bulk_update").respond 400, { "errors": ["an error"] }
+          $scope.updateProducts "updated list of products"
+          $httpBackend.flush()
+          expect($scope.displayFailure).toHaveBeenCalledWith("Saving failed with the following error(s):\nan error\n")
+
+        it "displays errors in a hash", ->
+          $httpBackend.expectPOST("/admin/products/bulk_update").respond 400, { "errors": { "base": ["a basic error"] } }
+          $scope.updateProducts "updated list of products"
+          $httpBackend.flush()
+          expect($scope.displayFailure).toHaveBeenCalledWith("Saving failed with the following error(s):\na basic error")
 
 
   describe "adding variants", ->

--- a/spec/javascripts/unit/admin/utils/services/errors_parser_spec.js.coffee
+++ b/spec/javascripts/unit/admin/utils/services/errors_parser_spec.js.coffee
@@ -1,0 +1,20 @@
+describe "ErrorsParser service", ->
+  errorsParser = null
+
+  beforeEach ->
+    module('admin.utils')
+    inject (ErrorsParser) ->
+      errorsParser = ErrorsParser
+
+  describe "toString", ->
+    it "returns empty string for nil errors", ->
+      expect(errorsParser.toString(null)).toEqual ""
+
+    it "returns the elements in the array if an array is provided", ->
+      expect(errorsParser.toString(["1", "2"])).toEqual "1\n2\n"
+
+    it "returns the elements in the hash if a hash is provided", ->
+      expect(errorsParser.toString({ "keyname": ["1", "2"] })).toEqual "1\n2\n"
+
+    it "returns all elements in all hash keys provided", ->
+      expect(errorsParser.toString({ "keyname1": ["1", "2"], "keyname2": ["3", "4"] })).toEqual "1\n2\n3\n4\n"


### PR DESCRIPTION
#### What? Why?

Closes #3120 
This PR fixes the error message handling in bulk product update page, the errors structure coming from the server was not being parsed correctly by the javascript code.
The JS code and the server code were introduced in the [same commit](https://github.com/openfoodfoundation/openfoodnetwork/commit/5fea15e8a93e1ad29d6610b5fd14b6fc4497093a
) but the original server "errors" object could have been an array and now it's a structure with keys. I decided to leave the code that parses errors as an array in case that happens in some situations.

#### What should we test?
Verify the bulk product update page still works as normal (basic tests) and make sure you get appropriate error messages for the errors you manage to generate in the page (I am not sure what these could be, maybe we will find there's more we can do here). Most importantly if you leave variant unit name empty you should see this now:
![image](https://user-images.githubusercontent.com/1640378/74155748-00cde200-4c0d-11ea-8d55-21c2e7fb423c.png)

#### Release notes
Changelog Category: Changed
Improved error messages on the bulk product edit page.
