### PR TITLE
4779 payment method display

### DIFF
--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,10 @@
+module OrdersHelper
+  def order_paid_via(order)
+    # `sort_by` avoids additional database queries when payments are loaded
+    # already. There is usually only one payment and this shouldn't cause
+    # any overhead compared to `order(:updated_at)`.
+    #
+    # Using `last` without sort is not deterministic.
+    order.payments.sort_by(&:updated_at).last.andand.payment_method
+  end
+end

--- a/app/services/order_payment_finder.rb
+++ b/app/services/order_payment_finder.rb
@@ -2,11 +2,13 @@
 
 module OrderPaymentFinder
   def self.last_payment_method(order)
-    # `sort_by` avoids additional database queries when payments are loaded
+    # `max_by` avoids additional database queries when payments are loaded
     # already. There is usually only one payment and this shouldn't cause
-    # any overhead compared to `order(:updated_at)`.
+    # any overhead compared to `order(:created_at).last`. Using `last`
+    # without order is not deterministic.
     #
-    # Using `last` without sort is not deterministic.
-    order.payments.max_by(&:updated_at)&.payment_method
+    # We are not using `updated_at` because all payments are touched when the
+    # order is updated and then all payments have the same `updated_at` value.
+    order.payments.max_by(&:created_at)&.payment_method
   end
 end

--- a/app/services/order_payment_finder.rb
+++ b/app/services/order_payment_finder.rb
@@ -7,6 +7,6 @@ module OrderPaymentFinder
     # any overhead compared to `order(:updated_at)`.
     #
     # Using `last` without sort is not deterministic.
-    order.payments.sort_by(&:updated_at).last&.payment_method
+    order.payments.max_by(&:updated_at)&.payment_method
   end
 end

--- a/app/services/order_payment_finder.rb
+++ b/app/services/order_payment_finder.rb
@@ -1,5 +1,7 @@
-module OrdersHelper
-  def order_paid_via(order)
+# frozen_string_literal: true
+
+module OrderPaymentFinder
+  def self.last_payment_method(order)
     # `sort_by` avoids additional database queries when payments are loaded
     # already. There is usually only one payment and this shouldn't cause
     # any overhead compared to `order(:updated_at)`.

--- a/app/services/order_payment_finder.rb
+++ b/app/services/order_payment_finder.rb
@@ -7,6 +7,6 @@ module OrderPaymentFinder
     # any overhead compared to `order(:updated_at)`.
     #
     # Using `last` without sort is not deterministic.
-    order.payments.sort_by(&:updated_at).last.andand.payment_method
+    order.payments.sort_by(&:updated_at).last&.payment_method
   end
 end

--- a/app/views/spree/order_mailer/_payment.html.haml
+++ b/app/views/spree/order_mailer/_payment.html.haml
@@ -8,7 +8,7 @@
     = t :email_payment_summary
 %h4
   = t :email_payment_method
-  %strong=  @order.payments.first.andand.payment_method.andand.name.andand.html_safe
+  %strong=  OrderPaymentFinder.last_payment_method(@order)&.name
 %p
-  %em= @order.payments.first.andand.payment_method.andand.description.andand.html_safe
+  %em= OrderPaymentFinder.last_payment_method(@order)&.description
 %p &nbsp;

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -13,9 +13,9 @@
     .pad
       .text-big
         = t :order_payment
-        %strong=  OrderPaymentFinder.last_payment_method(order).andand.name
+        %strong=  OrderPaymentFinder.last_payment_method(order)&.name
       %p.text-small.text-skinny.pre-line
-        %em= OrderPaymentFinder.last_payment_method(order).andand.description
+        %em= OrderPaymentFinder.last_payment_method(order)&.description
 
     .order-summary.text-small
       %strong

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -13,9 +13,9 @@
     .pad
       .text-big
         = t :order_payment
-        %strong=  order_paid_via(order).andand.name
+        %strong=  OrderPaymentFinder.last_payment_method(order).andand.name
       %p.text-small.text-skinny.pre-line
-        %em= order_paid_via(order).andand.description
+        %em= OrderPaymentFinder.last_payment_method(order).andand.description
 
     .order-summary.text-small
       %strong

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -13,9 +13,9 @@
     .pad
       .text-big
         = t :order_payment
-        %strong=  order.payments.first.andand.payment_method.andand.name
+        %strong=  order_paid_via(order).andand.name
       %p.text-small.text-skinny.pre-line
-        %em= order.payments.first.andand.payment_method.andand.description
+        %em= order_paid_via(order).andand.description
 
     .order-summary.text-small
       %strong

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -13,9 +13,9 @@
     .pad
       .text-big
         = t :order_payment
-        %strong=  order.payments.first.andand.payment_method.andand.name.andand.html_safe
+        %strong=  order.payments.first.andand.payment_method.andand.name
       %p.text-small.text-skinny.pre-line
-        %em= order.payments.first.andand.payment_method.andand.description.andand.html_safe
+        %em= order.payments.first.andand.payment_method.andand.description
 
     .order-summary.text-small
       %strong

--- a/spec/views/spree/shared/_order_details.html.haml_spec.rb
+++ b/spec/views/spree/shared/_order_details.html.haml_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "spree/shared/_order_details.html.haml" do
+  include AuthenticationWorkflow
+  helper Spree::BaseHelper
+
+  let(:order) { create(:completed_order_with_fees) }
+
+  before do
+    assign(:order, order)
+    allow(view).to receive_messages(
+      order: order,
+      current_order: order,
+    )
+  end
+
+  it "shows how the order is paid for" do
+    order.payments.first.payment_method.name = "Bartering"
+
+    render
+
+    expect(rendered).to have_content("Paying via: Bartering")
+  end
+end

--- a/spec/views/spree/shared/_order_details.html.haml_spec.rb
+++ b/spec/views/spree/shared/_order_details.html.haml_spec.rb
@@ -21,4 +21,12 @@ describe "spree/shared/_order_details.html.haml" do
 
     expect(rendered).to have_content("Paying via: Bartering")
   end
+
+  it "displays payment methods safely" do
+    order.payments.first.payment_method.name = "Bar<script>evil</script>ter&rarr;ing"
+
+    render
+
+    expect(rendered).to have_content("Paying via: Bar<script>evil</script>ter&rarr;ing")
+  end
 end

--- a/spec/views/spree/shared/_order_details.html.haml_spec.rb
+++ b/spec/views/spree/shared/_order_details.html.haml_spec.rb
@@ -29,4 +29,26 @@ describe "spree/shared/_order_details.html.haml" do
 
     expect(rendered).to have_content("Paying via: Bar<script>evil</script>ter&rarr;ing")
   end
+
+  it "shows the last used payment method" do
+    first_payment = order.payments.first
+    second_payment = create(
+      :payment,
+      order: order,
+      payment_method: create(:payment_method, name: "Cash")
+    )
+    third_payment = create(
+      :payment,
+      order: order,
+      payment_method: create(:payment_method, name: "Credit")
+    )
+    first_payment.update_column(:updated_at, 3.days.ago)
+    second_payment.update_column(:updated_at, 2.days.ago)
+    third_payment.update_column(:updated_at, 1.day.ago)
+    order.payments.reload
+
+    render
+
+    expect(rendered).to have_content("Paying via: Credit")
+  end
 end

--- a/spec/views/spree/shared/_order_details.html.haml_spec.rb
+++ b/spec/views/spree/shared/_order_details.html.haml_spec.rb
@@ -42,9 +42,9 @@ describe "spree/shared/_order_details.html.haml" do
       order: order,
       payment_method: create(:payment_method, name: "Credit")
     )
-    first_payment.update_column(:updated_at, 3.days.ago)
-    second_payment.update_column(:updated_at, 2.days.ago)
-    third_payment.update_column(:updated_at, 1.day.ago)
+    first_payment.update_column(:created_at, 3.days.ago)
+    second_payment.update_column(:created_at, 2.days.ago)
+    third_payment.update_column(:created_at, 1.day.ago)
     order.payments.reload
 
     render


### PR DESCRIPTION
#### What? Why?

Closes #4779

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

If we had multiple failed payments and then a successful payment, the
order confirmation was displaying the payment method of the first failed
payment. That was confusing and is now changed to the last payment
method.

#### What should we test?
<!-- List which features should be tested and how. -->

Sanity check:

- Check out normally.
- Confirm the "Paid via" display in the order confirmation page.
- Confirm the "Paid via" display in the order confirmation emails (customer and enterprise).

New behaviour:

- Check out with a failing payment. I think there are certain credit card numbers for Stripe that generate a failure.
- Then check out with a cash payment method.
- Confirm the "Paid via" display in the order confirmation page.
- Confirm the "Paid via" display in the order confirmation emails (customer and enterprise).

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: Order confirmations now display the last used payment method instead of the first.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

