### PR TITLE
4771 Back to shop button

### DIFF
--- a/app/helpers/shared_helper.rb
+++ b/app/helpers/shared_helper.rb
@@ -16,4 +16,8 @@ module SharedHelper
   def admin_user?
     spree_current_user.andand.has_spree_role? 'admin'
   end
+
+  def current_shop_products_path
+    "#{main_app.enterprise_shop_path(current_distributor)}#/shop"
+  end
 end

--- a/app/views/spree/orders/edit.html.haml
+++ b/app/views/spree/orders/edit.html.haml
@@ -22,7 +22,7 @@
     - if @order.line_items.empty?
       %div.row{"data-hook" => "empty_cart"}
         %p= t(:your_cart_is_empty)
-        %p= link_to t(:continue_shopping), main_app.shop_path, :class => 'button continue'
+        %p= link_to t(:continue_shopping), current_shop_products_path, :class => 'button continue'
 
     - else
       %div{"data-hook" => "outside_cart_form"}

--- a/app/views/spree/orders/form/_cart_links.html.haml
+++ b/app/views/spree/orders/form/_cart_links.html.haml
@@ -1,6 +1,6 @@
 .row.links{'data-hook' => "cart_buttons"}
   .columns.large-8{"data-hook" => ""}
-    %a.button.large.secondary{href: main_app.shop_path}
+    %a.button.large.secondary{href: current_shop_products_path}
       %i.ofn-i_008-caret-left
       = t :orders_edit_continue
   .columns.large-4.text-right

--- a/app/views/spree/orders/form/_update_buttons.html.haml
+++ b/app/views/spree/orders/form/_update_buttons.html.haml
@@ -6,7 +6,7 @@
           %i.ofn-i_008-caret-left
           = t(:order_back_to_cart)
       - else
-        = link_to main_app.shop_path, :class => "button expand" do
+        = link_to current_shop_products_path, :class => "button expand" do
           %i.ofn-i_008-caret-left
           = t(:order_back_to_store)
     - else

--- a/app/views/spree/orders/form/_update_buttons.html.haml
+++ b/app/views/spree/orders/form/_update_buttons.html.haml
@@ -1,12 +1,12 @@
 .row
   .columns.small-12.medium-3
-    - if current_order.andand.distributor == @order.distributor
-      - if current_order.line_items.present?
+    - if current_order.nil? || current_order.distributor.nil? || current_order.distributor == @order.distributor
+      - if current_order&.line_items.present?
         = link_to main_app.cart_path, :class => "button expand" do
           %i.ofn-i_008-caret-left
           = t(:order_back_to_cart)
       - else
-        = link_to current_shop_products_path, :class => "button expand" do
+        = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop", class: "button expand" do
           %i.ofn-i_008-caret-left
           = t(:order_back_to_store)
     - else

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -20,6 +20,26 @@ feature "full-page cart", js: true do
       set_order order
     end
 
+    describe "continue shopping" do
+      it "shows a button leading back to the shop" do
+        # Set up a shopfront message to test that we are not going to the
+        # home tab.
+        # PENDING: this passes only without home tab!
+        #distributor.preferred_shopfront_message = "Test driven farming"
+
+        add_product_to_cart order, product_with_fee, quantity: 2
+        visit main_app.cart_path
+
+        expect(page).to have_link "Continue shopping"
+
+        click_link "Continue shopping"
+
+        expect(page).to have_no_link "Continue shopping"
+        expect(page).to have_button "Edit your cart"
+        #expect(page).to have_no_content distributor.preferred_shopfront_message
+      end
+    end
+
     describe "product description" do
       it "does not link to the product page" do
         add_product_to_cart order, product_with_fee, quantity: 2

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -24,8 +24,7 @@ feature "full-page cart", js: true do
       it "shows a button leading back to the shop" do
         # Set up a shopfront message to test that we are not going to the
         # home tab.
-        # PENDING: this passes only without home tab!
-        #distributor.preferred_shopfront_message = "Test driven farming"
+        distributor.preferred_shopfront_message = "Test driven farming"
 
         add_product_to_cart order, product_with_fee, quantity: 2
         visit main_app.cart_path
@@ -36,7 +35,7 @@ feature "full-page cart", js: true do
 
         expect(page).to have_no_link "Continue shopping"
         expect(page).to have_button "Edit your cart"
-        #expect(page).to have_no_content distributor.preferred_shopfront_message
+        expect(page).to have_no_content distributor.preferred_shopfront_message
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #4771

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Since the default shop page is now showing the shopfront message instead of the products, the "Continue shopping" buttons were leading there. It would make more sense though to go straight to the products in two cases:

- On the cart page.
- On the edit order page.

#### What should we test?
<!-- List which features should be tested and how. -->

- Add a shopfront message to a shop.
- Change the shops settings to allow for editing orders.
- Go to the shop and verify that you are landing on the home tab.
- Add products to the cart.
- Go to the cart and click "Continue shopping".
- You should end up on the products page (not home tab).
- Checkout out and edit the order.
- Click on "Continue shopping" and you should get to the products again.
- Clicking on the "Shopping@..." button in the main navigation menu should take you to the home tab though.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed: The "Continue shopping" button takes you back to the products again even if the shop has a home tab.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

