### PR TITLE
redirect to shops list when an enterprise is not found

### DIFF
--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -63,8 +63,6 @@ class EnterprisesController < BaseController
   end
 
   def reset_order
-    distributor = Enterprise.is_distributor.find_by_permalink(params[:id]) ||
-                  Enterprise.is_distributor.find(params[:id])
     order = current_order(true)
 
     reset_distributor(order, distributor)
@@ -74,6 +72,14 @@ class EnterprisesController < BaseController
     reset_order_cycle(order, distributor)
 
     order.save!
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = I18n.t(:enterprise_shop_show_error)
+    redirect_to shops_path
+  end
+
+  def distributor
+    @distributor ||= Enterprise.is_distributor.find_by_permalink(params[:id]) ||
+                     Enterprise.is_distributor.find(params[:id])
   end
 
   def reset_distributor(order, distributor)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2412,6 +2412,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   enterprise_register_success_notice: "Congratulations! Registration for %{enterprise} is complete!"
   enterprise_bulk_update_success_notice: "Enterprises updated successfully"
   enterprise_bulk_update_error: 'Update failed'
+  enterprise_shop_show_error: "The shop you are looking for doesn't exist or is inactive on OFN. Please check other shops."
   order_cycles_create_notice: 'Your order cycle has been created.'
   order_cycles_update_notice: 'Your order cycle has been updated.'
   order_cycles_bulk_update_notice: 'Order cycles have been updated.'

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -139,4 +139,18 @@ describe EnterprisesController, type: :controller do
       expect(response.status).to be 409
     end
   end
+
+  context "checking access on nonexistent enterprise" do
+    before do
+      spree_get :shop, id: "some_nonexistent_enterprise"
+    end
+
+    it "redirects to shops_path" do
+      expect(response).to redirect_to shops_path
+    end
+
+    it "shows a flash message with the error" do
+      expect(request.flash[:error]).to eq(I18n.t(:enterprise_shop_show_error))
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

This PR closes #4727. I'm just rescuing the exception when the enterprise is not found and redirecting to the shops_path with a flash message.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how. -->
If the user is redirected to the shops_path with a flash message when the enterprise not exists or is unavailable.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Redirect to list of shops when an enterprise is not found or is unavailable.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->
#2247 