### PR TITLE
If there's only one OC available to the customer because there are tag rules hidding other OCs, select that OC by default

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -37,9 +37,17 @@ class BaseController < ApplicationController
                                                         current_customer.andand.tag_list)
     applicator.filter!(@order_cycles)
 
-    # And default to the only order cycle if there's only the one
-    if @order_cycles.count == 1
-      current_order(true).set_order_cycle! @order_cycles.first
-    end
+    reset_order_cycle
+  end
+
+  # Default to the only order cycle if there's only one
+  #
+  # Here we need to use @order_cycles.size not @order_cycles.count
+  #   because TagRuleApplicator changes ActiveRecord::Relation @order_cycles
+  #     and these changes are not seen if the relation is reloaded with count
+  def reset_order_cycle
+    return if @order_cycles.size != 1
+
+    current_order(true).set_order_cycle! @order_cycles.first
   end
 end

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -37,8 +37,8 @@ class BaseController < ApplicationController
   # Default to the only order cycle if there's only one
   #
   # Here we need to use @order_cycles.size not @order_cycles.count
-  #   because TagRuleApplicator changes ActiveRecord::Relation @order_cycles
-  #     and these changes are not seen if the relation is reloaded with count
+  #   because OrderCyclesList returns a modified ActiveRecord::Relation
+  #     and these modifications are not seen if it is reloaded with count
   def set_order_cycle
     return if @order_cycles.size != 1
 

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -29,21 +29,9 @@ class BaseController < ApplicationController
       return
     end
 
-    fetch_order_cycles(@distributor)
+    @order_cycles = Shop::OrderCyclesList.new(@distributor, current_customer).call
 
     set_order_cycle
-  end
-
-  def fetch_order_cycles(distributor)
-    return if @order_cycles.present?
-
-    @order_cycles = OrderCycle.with_distributor(distributor).active
-      .order(distributor.preferred_shopfront_order_cycle_order)
-
-    applicator = OpenFoodNetwork::TagRuleApplicator.new(distributor,
-                                                        "FilterOrderCycles",
-                                                        current_customer.andand.tag_list)
-    applicator.filter!(@order_cycles)
   end
 
   # Default to the only order cycle if there's only one

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -96,8 +96,8 @@ class EnterprisesController < BaseController
   end
 
   def reset_order_cycle(order, distributor)
-    fetch_order_cycles(distributor)
-    order.order_cycle = @order_cycles.first if @order_cycles.size == 1
+    order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
+    order.order_cycle = order_cycles.first if order_cycles.size == 1
   end
 
   def shop_order_cycles

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -96,8 +96,8 @@ class EnterprisesController < BaseController
   end
 
   def reset_order_cycle(order, distributor)
-    order_cycle_options = OrderCycle.active.with_distributor(distributor)
-    order.order_cycle = order_cycle_options.first if order_cycle_options.count == 1
+    fetch_order_cycles(distributor)
+    order.order_cycle = @order_cycles.first if @order_cycles.size == 1
   end
 
   def shop_order_cycles

--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -47,17 +47,6 @@ module OrderCyclesHelper
     end
   end
 
-  def order_cycle_options
-    @order_cycles.
-      with_distributor(current_distributor).
-      map { |oc| [order_cycle_close_to_s(oc.orders_close_at), oc.id] }
-  end
-
-  def order_cycle_close_to_s(orders_close_at)
-    "%s (%s)" % [orders_close_at.strftime("#{orders_close_at.day.ordinalize} %b"),
-                 distance_of_time_in_words_to_now(orders_close_at)]
-  end
-
   def active_order_cycle_for_distributor?(_distributor)
     OrderCycle.active.with_distributor(@distributor).present?
   end

--- a/app/services/shop/order_cycles_list.rb
+++ b/app/services/shop/order_cycles_list.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Lists available order cycles for a given customer in a given distributor
+
+class OrderCyclesList
+  def initialize(distributor, customer)
+    @distributor = distributor
+    @customer = customer
+  end
+
+  def call
+    order_cycles = OrderCycle.with_distributor(@distributor).active
+      .order(@distributor.preferred_shopfront_order_cycle_order)
+
+    applicator = OpenFoodNetwork::TagRuleApplicator.new(@distributor,
+                                                        "FilterOrderCycles",
+                                                        @customer.andand.tag_list)
+    applicator.filter!(order_cycles)
+
+    order_cycles
+  end
+end

--- a/app/services/shop/order_cycles_list.rb
+++ b/app/services/shop/order_cycles_list.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
 # Lists available order cycles for a given customer in a given distributor
+module Shop
+  class OrderCyclesList
+    def initialize(distributor, customer)
+      @distributor = distributor
+      @customer = customer
+    end
 
-class OrderCyclesList
-  def initialize(distributor, customer)
-    @distributor = distributor
-    @customer = customer
-  end
+    def call
+      order_cycles = OrderCycle.with_distributor(@distributor).active
+        .order(@distributor.preferred_shopfront_order_cycle_order)
 
-  def call
-    order_cycles = OrderCycle.with_distributor(@distributor).active
-      .order(@distributor.preferred_shopfront_order_cycle_order)
+      applicator = OpenFoodNetwork::TagRuleApplicator.new(@distributor,
+                                                          "FilterOrderCycles",
+                                                          @customer.andand.tag_list)
+      applicator.filter!(order_cycles)
 
-    applicator = OpenFoodNetwork::TagRuleApplicator.new(@distributor,
-                                                        "FilterOrderCycles",
-                                                        @customer.andand.tag_list)
-    applicator.filter!(order_cycles)
-
-    order_cycles
+      order_cycles
+    end
   end
 end

--- a/app/services/shop/order_cycles_list.rb
+++ b/app/services/shop/order_cycles_list.rb
@@ -12,6 +12,14 @@ module Shop
       order_cycles = OrderCycle.with_distributor(@distributor).active
         .order(@distributor.preferred_shopfront_order_cycle_order)
 
+      apply_tag_rules!(order_cycles)
+    end
+
+    private
+
+    # order_cycles is a ActiveRecord::Relation that is modified with reject in the TagRuleApplicator
+    # If this relation is reloaded (for example by calling count on it), the modifications are lost
+    def apply_tag_rules!(order_cycles)
       applicator = OpenFoodNetwork::TagRuleApplicator.new(@distributor,
                                                           "FilterOrderCycles",
                                                           @customer.andand.tag_list)


### PR DESCRIPTION
#### What? Why?

Closes #3170 
This is a quick fix to the issue.
Several tech debt problems in the code were left for later:
- TagRuleApplicator changing a relation with reject! and making #size return a different value from #count :see_no_evil:  I added comments to make it more explicit.
- a big and unnecessary filter mess in EnterrpisesController and BaseController with filters resetting the order and then the set_order_cycles filter... this could be a simple list of actions performed by code in extracted services.

#### What should we test?
We need to verify the issue is fixed and that OC selection is correct when we jump between shops in the frontoffice.

#### Release notes
Changelog Category: Fixed
Fixed problem in shopfront where users had to select the only available OC (no default selections) if in the system there was one or more OCs the user couldn't see.
