### PR TITLE
Add new cops (disabled) to rubocop config

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -117,6 +117,15 @@ Style/FormatString:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styleformatstring
 
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false
+
 Style/IfUnlessModifier:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styleifunlessmodifier


### PR DESCRIPTION
#### What? Why?

The new version of rubocop comes with new cops we need to add to config and disable for now. We can add them later if we want, right now, I dont think we should spend time here.

#### What should we test?
No tests needed.

#### Release notes
Changelog Category: Changed
Updated rubocop config.
