### PR TITLE
[Spree 2.1] Fix creation of enterprises/users in specs

### DIFF
--- a/app/controllers/api/enterprise_attachment_controller.rb
+++ b/app/controllers/api/enterprise_attachment_controller.rb
@@ -1,3 +1,5 @@
+require 'api/admin/enterprise_serializer'
+
 module Api
   class EnterpriseAttachmentController < BaseController
     class MissingImplementationError < StandardError; end

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -93,9 +93,9 @@ class Enterprise < ActiveRecord::Base
   validate :enforce_ownership_limit, if: lambda { owner_id_changed? && !owner_id.nil? }
 
   before_validation :initialize_permalink, if: lambda { permalink.nil? }
-  before_validation :ensure_owner_is_manager, if: lambda { owner_id_changed? && !owner_id.nil? }
   before_validation :set_unused_address_fields
   after_validation :geocode_address
+  after_validation :ensure_owner_is_manager, if: lambda { owner_id_changed? && !owner_id.nil? }
 
   after_touch :touch_distributors
   after_create :set_default_contact
@@ -410,7 +410,7 @@ class Enterprise < ActiveRecord::Base
   end
 
   def ensure_owner_is_manager
-    #users << owner unless users.include?(owner)
+    users << owner unless users.include?(owner)
   end
 
   def enforce_ownership_limit

--- a/spec/factories/enterprise_factory.rb
+++ b/spec/factories/enterprise_factory.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :enterprise, class: Enterprise do
     transient do
       users []
+      logo {}
+      promo_image {}
     end
 
     owner { FactoryBot.create :user }
@@ -15,6 +17,7 @@ FactoryBot.define do
       proxy.users.each do |user|
         enterprise.users << user unless enterprise.users.include?(user)
       end
+      enterprise.update_attributes logo: proxy.logo, promo_image: proxy.promo_image
     end
   end
 

--- a/spec/factories/enterprise_factory.rb
+++ b/spec/factories/enterprise_factory.rb
@@ -1,11 +1,21 @@
 FactoryBot.define do
   factory :enterprise, class: Enterprise do
+    transient do
+      users []
+    end
+
     owner { FactoryBot.create :user }
     sequence(:name) { |n| "Enterprise #{n}" }
     sells 'any'
     description 'enterprise'
     long_description '<p>Hello, world!</p><p>This is a paragraph.</p>'
     address { FactoryBot.create(:address) }
+
+    after(:create) do |enterprise, proxy|
+      proxy.users.each do |user|
+        enterprise.users << user unless enterprise.users.include?(user)
+      end
+    end
   end
 
   factory :supplier_enterprise, parent: :enterprise do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.modify do
   factory :user do
+    transient do
+      enterprises []
+    end
+
     confirmation_sent_at '1970-01-01 00:00:00'
     confirmed_at '1970-01-01 00:00:01'
 
@@ -13,8 +17,10 @@ FactoryBot.modify do
       end
     end
 
-    after(:create) do |user|
+    after(:create) do |user, proxy|
       user.spree_roles.clear # Remove admin role
+
+      user.enterprises << proxy.enterprises
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #4646

We have to move the definition of the association to after creation in the factory.

#### What should we test?
The error "Enterprise roles is invalid" is gone from the build.

#### Release notes
No release notes for upgrade isssues.

