### PR TITLE
[Spree 2.1] Add strong params to admin/column_preferences_controller.rb

### DIFF
--- a/app/controllers/admin/column_preferences_controller.rb
+++ b/app/controllers/admin/column_preferences_controller.rb
@@ -21,14 +21,18 @@ module Admin
 
     private
 
+    def permitted_params
+      params.permit(:action_name, column_preferences: [:id, :user_id, :action_name, :column_name, :visible])
+    end
+
     def load_collection
-      collection_hash = Hash[params[:column_preferences].each_with_index.map { |cp, i| [i, cp] }]
-      collection_hash.select!{ |_i, cp| cp[:action_name] == params[:action_name] }
+      collection_hash = Hash[permitted_params[:column_preferences].each_with_index.map { |cp, i| [i, cp] }]
+      collection_hash.select!{ |_i, cp| cp[:action_name] == permitted_params[:action_name] }
       @cp_set = ColumnPreferenceSet.new @column_preferences, collection_attributes: collection_hash
     end
 
     def collection
-      ColumnPreference.where(user_id: spree_current_user, action_name: params[:action_name])
+      ColumnPreference.where(user_id: spree_current_user, action_name: permitted_params[:action_name])
     end
 
     def collection_actions


### PR DESCRIPTION
Part of: #4644 

Fixes failures such as:

```
  119) Admin::ColumnPreferencesController bulk_update json where I don't own the preferences submitted prevents me from updating the column preferences
       Failure/Error: raise ActiveModel::ForbiddenAttributesError, params.to_s

       ActiveModel::ForbiddenAttributesError:
         {"action_name"=>"enterprises_index", "column_preferences"=>[{"id"=>1, "user_id"=>2716, "action_name"=>"enterprises_index", "column_name"=>"name", "visible"=>false}, {"id"=>nil, "user_id"=>2716, "action_name"=>"enterprises_index", "column_name"=>"producer", "visible"=>true}, {"id"=>nil, "user_id"=>2716, "action_name"=>"enterprises_index", "column_name"=>"status", "visible"=>true}], "format"=>"json", "controller"=>"admin/column_preferences", "action"=>"bulk_update"}
       # ./app/controllers/application_controller.rb:16:in `print_params'
       # ./spec/controllers/admin/column_preferences_controller_spec.rb:28:in `block (5 levels) in <top (required)>'
       # ------------------
       # --- Caused by: ---
       # ActiveModel::ForbiddenAttributesError:
       #   ActiveModel::ForbiddenAttributesError
       #   ./app/models/model_set.rb:24:in `block in collection_attributes='

```