### PR TITLE
[Spree 2.1] PG::ProtocolViolation: ERROR: bind message supplies 0 parameters...

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -63,7 +63,7 @@ class OrderCycle < ActiveRecord::Base
     if user.has_spree_role?('admin')
       where(nil)
     else
-      where(coordinator_id: user.enterprises)
+      where(coordinator_id: user.enterprises.to_a)
     end
   }
 


### PR DESCRIPTION
It looks like there are some issues with prepared statements here, where the resulting SQL contains something like: `WHERE "enterprise_roles"."user_id" = $1`. The "$1" part is being lost somehow and isn't present if it's used in nested subqueries. Adding `#to_sql` on the fragment fixes the issue.

Discussion here: https://github.com/rails/rails/issues/20077

Example fixed spec (there are lots like this one):
```
  59) Spree::Admin::ReportsController Supplier Bulk Coop where I have granted P-OC to the distributor only shows product line items that I am supplying
      Failure/Error: produced_line_items.select("spree_line_items.id"))

      ActiveRecord::StatementInvalid:
        PG::ProtocolViolation: ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 1
        : SELECT id FROM "spree_line_items"  WHERE "spree_line_items"."order_id" IN (SELECT id FROM "spree_orders"  WHERE (("spree_orders"."distributor_id" IN (SELECT enterprises.id FROM "enterprises" INNER JOIN "enterprise_roles" ON "enterprise_roles"."enterprise_id" = "enterprises"."id" WHERE (enterprise_roles.user_id = 947)) OR "spree_orders"."order_cycle_id" IN (SELECT id FROM "order_cycles"  WHERE "order_cycles"."coordinator_id" IN (SELECT "enterprises"."id" FROM "enterprises" INNER JOIN "enterprise_roles" ON "enterprises"."id" = "enterprise_roles"."enterprise_id" WHERE "enterprise_roles"."user_id" = $1)))))
      # ./app/services/permissions/order.rb:28:in `visible_line_items'
      # ./lib/open_food_network/reports/line_items.rb:16:in `list'
      # ./lib/open_food_network/bulk_coop_report.rb:54:in `table_items'
      # ./app/controllers/spree/admin/reports_controller.rb:264:in `order_grouper_table'
      # ./app/controllers/spree/admin/reports_controller.rb:101:in `bulk_coop'
      # ./spec/controllers/spree/admin/reports_controller_spec.rb:168:in `block (5 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # PG::ProtocolViolation:
      #   ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 1
      #   ./app/services/permissions/order.rb:28:in `visible_line_items'
```