### PR TITLE
Hide broken product taxons field, remove last rabl template and rabl itself

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -861,7 +861,6 @@ Style/FrozenStringLiteralComment:
     - 'app/validators/date_time_string_validator.rb'
     - 'app/validators/distributors_validator.rb'
     - 'app/validators/integer_array_validator.rb'
-    - 'app/views/spree/admin/taxons/search.rabl'
     - 'config.ru'
     - 'engines/order_management/app/controllers/order_management/application_controller.rb'
     - 'engines/order_management/app/services/order_management/reports/enterprise_fee_summary/authorizer.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'aws-sdk'
 gem 'bugsnag'
 gem 'db2fog'
 gem 'haml'
-gem 'rabl'
 gem 'redcarpet'
 gem 'sass', "~> 3.3"
 gem 'sass-rails', '~> 3.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,8 +518,6 @@ GEM
       byebug (>= 9.0, < 9.1)
       pry (~> 0.10)
     public_suffix (4.0.3)
-    rabl (0.8.4)
-      activesupport (>= 2.3.14)
     rack (1.4.7)
     rack-cache (1.11.0)
       rack (>= 0.4)
@@ -767,7 +765,6 @@ DEPENDENCIES
   paperclip (~> 3.4.1)
   pg (~> 0.21.0)
   pry-byebug (>= 3.4.3)
-  rabl
   rack-mini-profiler (< 3.0.0)
   rack-rewrite
   rack-ssl

--- a/app/assets/javascripts/darkswarm/services/order_cycle.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/order_cycle.js.coffee
@@ -1,6 +1,6 @@
 Darkswarm.factory 'OrderCycle', ($resource, orderCycleData) ->
   class OrderCycle
-    @order_cycle = orderCycleData # Object or {} due to RABL 
+    @order_cycle = orderCycleData # Object or {}
     @push_order_cycle: (callback) ->
       new $resource("/shop/order_cycle").save {order_cycle_id: @order_cycle.order_cycle_id}, (order_data)->
         OrderCycle.order_cycle.orders_close_at = order_data.orders_close_at

--- a/app/controllers/spree/admin/taxons_controller.rb
+++ b/app/controllers/spree/admin/taxons_controller.rb
@@ -3,14 +3,6 @@ module Spree
     class TaxonsController < Spree::Admin::BaseController
       respond_to :html, :json, :js
 
-      def search
-        @taxons = if params[:ids]
-                    Spree::Taxon.where(id: params[:ids].split(','))
-                  else
-                    Spree::Taxon.limit(20).search(name_cont: params[:q]).result
-                  end
-      end
-
       def create
         @taxonomy = Taxonomy.find(params[:taxonomy_id])
         @taxon = @taxonomy.taxons.build(params[:taxon])

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -16,11 +16,6 @@
         = sanitize(@product.description)
       = f.error_message_on :description
 
-    = f.field_container :taxons do
-      = f.label :taxon_ids, t(:taxons)
-      %br
-      = f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',')
-
   .right.four.columns.omega
     .variant_units_form{ 'ng-app' => 'admin.products', 'ng-controller' => 'editUnitsCtrl' }
 

--- a/app/views/spree/admin/taxons/search.rabl
+++ b/app/views/spree/admin/taxons/search.rabl
@@ -1,4 +1,0 @@
-object false
-child(@taxons => :taxons) do
-  attributes :name, :pretty_name, :id
-end

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -154,12 +154,6 @@ Spree::Core::Engine.routes.draw do
       resources :taxons
     end
 
-    resources :taxons, :only => [] do
-      collection do
-        get :search
-      end
-    end
-
     resources :tax_rates
     resource  :tax_settings
     resources :tax_categories


### PR DESCRIPTION
#### What? Why?

Closes #4060

The taxons list on the product edit page is not working properly in production (2.7.5), values are not saved. This same field in master (will be in 2.7.7) is not showing up, just the label is showing (this last problem was introduced by #4621).
This PR contains a quick fix which is to simply hide this field. This is acceptable because this field is not used anywhere in the app, this info is useless so far.

I think it's ok to leave the product.taxons code there because 1. it is used to store the product category as the product.primary_taxon and 2. it will also be useful when/if we want to have a product in multiple categories (a very common feature in any ecommerce solution).

Additionally this PR removes last rabl template taxons/search which is not used afterall...
This enables us to say goodbye to rabl and close 4060.

#### What should we test?
We need to test everything related to taxons. Product categories, the taxonomies admin pages, the enterprise shop preferences taxons and the product categories on the bulk product page.

#### Release notes
Changelog Category: Removed
Removed rabl, we no longer use this dependency.
Hide product traxons field, this field is not related to anything else in the app.
