### PR TITLE
[Spree 2.1] Product import specs

### DIFF
--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -162,7 +162,7 @@ module ProductImport
       end
 
       product = Spree::Product.new
-      product.assign_attributes(entry.attributes.except('id', 'on_hand', 'on_demand'))
+      product.assign_attributes(entry.assignable_attributes.except('id', 'on_hand', 'on_demand', 'display_name'))
       product.supplier_id = entry.producer_id
       assign_defaults(product, entry)
 

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -62,7 +62,10 @@ module ProductImport
     end
 
     def mark_as_new_variant(entry, product_id)
-      new_variant = Spree::Variant.new(entry.attributes.except('id', 'product_id', 'on_hand', 'on_demand'))
+      new_variant = Spree::Variant.new(
+        entry.assignable_attributes.except('id', 'product_id', 'on_hand', 'on_demand',
+                                           'variant_unit', 'variant_unit_scale', 'primary_taxon_id')
+      )
       new_variant.save
       new_variant.on_demand = entry.attributes['on_demand'] if entry.attributes['on_demand'].present?
       new_variant.on_hand = entry.attributes['on_hand'] if entry.attributes['on_hand'].present?
@@ -295,7 +298,7 @@ module ProductImport
 
     def mark_as_new_product(entry)
       new_product = Spree::Product.new
-      new_product.assign_attributes(entry.attributes.except('id'))
+      new_product.assign_attributes(entry.assignable_attributes.except('id', 'on_hand', 'on_demand', 'display_name'))
       new_product.supplier_id = entry.producer_id
       entry.on_hand = 0 if entry.on_hand.nil?
 
@@ -307,7 +310,9 @@ module ProductImport
     end
 
     def mark_as_existing_variant(entry, existing_variant)
-      existing_variant.assign_attributes(entry.attributes.except('id', 'product_id'))
+      existing_variant.assign_attributes(
+        entry.assignable_attributes.except('id', 'product_id', 'variant_unit', 'variant_unit_scale', 'primary_taxon_id')
+      )
       check_on_hand_nil(entry, existing_variant)
 
       if existing_variant.valid?

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -46,6 +46,10 @@ module ProductImport
       attrs.except(*non_product_attributes)
     end
 
+    def assignable_attributes
+      attributes.except(*non_assignable_attributes)
+    end
+
     def displayable_attributes
       # Modified attributes list for displaying in user feedback
       attrs = {}
@@ -91,6 +95,11 @@ module ProductImport
       ['line_number', 'valid', 'errors', 'product_object',
        'product_validations', 'inventory_validations', 'validates_as',
        'save_type', 'on_hand_nil', 'has_overrides']
+    end
+
+    def non_assignable_attributes
+      ['producer', 'producer_id', 'category', 'shipping_category', 'tax_category',
+       'units', 'unscaled_units', 'unit_type', 'enterprise', 'enterprise_id']
     end
   end
 end

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -20,6 +20,20 @@ module ProductImport
                   :tax_category_id, :shipping_category_id, :description,
                   :import_date, :enterprise, :enterprise_id
 
+    NON_DISPLAY_ATTRIBUTES = ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise',
+                              'enterprise_id', 'producer_id', 'distributor_id', 'primary_taxon',
+                              'primary_taxon_id', 'category_id', 'shipping_category_id',
+                              'tax_category_id', 'variant_unit_scale', 'variant_unit',
+                              'unit_value'].freeze
+
+    NON_PRODUCT_ATTRIBUTES = ['line_number', 'valid', 'errors', 'product_object',
+                              'product_validations', 'inventory_validations', 'validates_as',
+                              'save_type', 'on_hand_nil', 'has_overrides'].freeze
+
+    NON_ASSIGNABLE_ATTRIBUTES = ['producer', 'producer_id', 'category', 'shipping_category',
+                                 'tax_category', 'units', 'unscaled_units', 'unit_type',
+                                 'enterprise', 'enterprise_id'].freeze
+
     def initialize(attrs)
       @validates_as = ''
       remove_empty_skus attrs
@@ -43,11 +57,11 @@ module ProductImport
       instance_variables.each do |var|
         attrs[var.to_s.delete("@")] = instance_variable_get(var)
       end
-      attrs.except(*non_product_attributes)
+      attrs.except(*NON_PRODUCT_ATTRIBUTES)
     end
 
     def assignable_attributes
-      attributes.except(*non_assignable_attributes)
+      attributes.except(*NON_ASSIGNABLE_ATTRIBUTES)
     end
 
     def displayable_attributes
@@ -56,7 +70,7 @@ module ProductImport
       instance_variables.each do |var|
         attrs[var.to_s.delete("@")] = instance_variable_get(var)
       end
-      attrs.except(*non_product_attributes, *non_display_attributes)
+      attrs.except(*NON_PRODUCT_ATTRIBUTES, *NON_DISPLAY_ATTRIBUTES)
     end
 
     def invalid_attributes
@@ -65,7 +79,7 @@ module ProductImport
       errors.each do |attr, message|
         invalid_attrs[attr.to_s] = "#{attr.to_s.capitalize} #{message.first}"
       end
-      invalid_attrs.except(*non_product_attributes, *non_display_attributes)
+      invalid_attrs.except(* NON_PRODUCT_ATTRIBUTES, *NON_DISPLAY_ATTRIBUTES)
     end
 
     private
@@ -79,27 +93,9 @@ module ProductImport
 
       units.converted_attributes.each do |attr, value|
         if respond_to?("#{attr}=")
-          public_send("#{attr}=", value) unless non_product_attributes.include?(attr)
+          public_send("#{attr}=", value) unless NON_PRODUCT_ATTRIBUTES.include?(attr)
         end
       end
-    end
-
-    def non_display_attributes
-      ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise',
-       'enterprise_id', 'producer_id', 'distributor_id', 'primary_taxon',
-       'primary_taxon_id', 'category_id', 'shipping_category_id',
-       'tax_category_id', 'variant_unit_scale', 'variant_unit', 'unit_value']
-    end
-
-    def non_product_attributes
-      ['line_number', 'valid', 'errors', 'product_object',
-       'product_validations', 'inventory_validations', 'validates_as',
-       'save_type', 'on_hand_nil', 'has_overrides']
-    end
-
-    def non_assignable_attributes
-      ['producer', 'producer_id', 'category', 'shipping_category', 'tax_category',
-       'units', 'unscaled_units', 'unit_type', 'enterprise', 'enterprise_id']
     end
   end
 end


### PR DESCRIPTION
For some reason some of the superfluous attributes being assigned here have started throwing fatal errors in Rails 4 instead of being silently ignored...

Example error: 
```
ActiveRecord::AssociationTypeMismatch:
       Spree::ShippingCategory(#47179900444260) expected, got String(#47179814002740)
```

This isn't pretty, but it seems to fix all 56 of the broken product import tests (when run on top of `luisramos0/3-0-latest`).