### PR TITLE
[Spree 2.1] Fix #create_enterprise_user

### DIFF
--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -29,6 +29,11 @@ module AuthenticationWorkflow
     new_user = build(:user, attrs)
     new_user.spree_roles = [Spree::Role.find_or_create_by!(name: 'user')]
     new_user.save
+    if attrs.has_key? :enterprises
+      attrs[:enterprises].each do |enterprise|
+        enterprise.users << new_user
+      end
+    end
     new_user
   end
 


### PR DESCRIPTION
Closes #4842 

Closely related to #4821 

User was not being associated to enterprises passed in attributes in `#create_enterprise_user`.

Fixes various specs throughout the build, including:

```
44) 
    As an administrator
    I want numbers, all the numbers!
 Permissions for different reports As an enterprise user does not show super admin only report
      Failure/Error: click_link "Reports"
      
      Capybara::ElementNotFound:
        Unable to find visible link "Reports"
      # ./spec/features/admin/reports_spec.rb:19:in `block (4 levels) in <top (required)>'

```
