### PR TITLE
[Spree 2.1] Add 'pt' to list of available locales in test suite

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,7 @@ Openfoodnetwork::Application.configure do
 
   # Tests assume English text on the site.
   config.i18n.default_locale = "en"
-  config.i18n.available_locales = ['en', 'es']
+  config.i18n.available_locales = ['en', 'es', 'pt']
   config.i18n.fallbacks = [:en]
   I18n.locale = config.i18n.locale = config.i18n.default_locale
 

--- a/spec/features/admin/multilingual_spec.rb
+++ b/spec/features/admin/multilingual_spec.rb
@@ -12,10 +12,10 @@ feature 'Multilingual', js: true do
     visit spree.admin_dashboard_path
   end
 
-  it 'has two locales available' do
+  it 'has three locales available' do
     expect(Rails.application.config.i18n[:default_locale]).to eq 'en'
     expect(Rails.application.config.i18n[:locale]).to eq 'en'
-    expect(Rails.application.config.i18n[:available_locales]).to eq ['en', 'es']
+    expect(Rails.application.config.i18n[:available_locales]).to eq ['en', 'es', 'pt']
   end
 
   it 'can switch language by params' do

--- a/spec/features/admin/order_cycles_spec.rb
+++ b/spec/features/admin/order_cycles_spec.rb
@@ -117,10 +117,10 @@ feature '
   end
 
   describe 'listing order cycles with other locales' do
-    let!(:oc_de) { create(:simple_order_cycle, name: 'oc', orders_open_at: '2012-01-01 00:00') }
+    let!(:oc_pt) { create(:simple_order_cycle, name: 'oc', orders_open_at: '2012-01-01 00:00') }
 
     around(:each) do |spec|
-      I18n.locale = :de
+      I18n.locale = :pt
       spec.run
       I18n.locale = :en
     end
@@ -130,7 +130,7 @@ feature '
         quick_login_as_admin
         visit admin_order_cycles_path
 
-        within("tr.order-cycle-#{oc_de.id}") do
+        within("tr.order-cycle-#{oc_pt.id}") do
           expect(find('input.datetimepicker', match: :first).value).to start_with '2012-01-01 00:00'
           find('img.ui-datepicker-trigger', match: :first).click
         end
@@ -142,7 +142,7 @@ feature '
           find('button.ui-datepicker-close', match: :first).click
         end
 
-        within("tr.order-cycle-#{oc_de.id}") do
+        within("tr.order-cycle-#{oc_pt.id}") do
           expect(find('input.datetimepicker', match: :first).value).to eq '2012-01-30 00:00'
         end
       end

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -7,10 +7,10 @@ feature 'Multilingual', js: true do
   include UIComponentHelper
   include CookieHelper
 
-  it 'has two locales available' do
+  it 'has three locales available' do
     expect(Rails.application.config.i18n[:default_locale]).to eq 'en'
     expect(Rails.application.config.i18n[:locale]).to eq 'en'
-    expect(Rails.application.config.i18n[:available_locales]).to eq ['en', 'es']
+    expect(Rails.application.config.i18n[:available_locales]).to eq ['en', 'es', 'pt']
   end
 
   it '18n-js fallsback to default language' do # in backend it doesn't until we change enforce_available_locales to `true`


### PR DESCRIPTION
Closes #4835 

Fixes several errors such as:

```
104) UserRegistrationsController via ajax sets user.locale from cookie on create
       Failure/Error: I18n.locale = spree_current_user.andand.locale || cookies[:locale] || I18n.default_locale

       I18n::InvalidLocale:
         "pt" is not a valid locale
       # ./app/helpers/i18n_helper.rb:14:in `set_locale'
       # ./spec/controllers/user_registrations_controller_spec.rb:56:in `block (3 levels) in <top (required)>'
```