### PR TITLE
[Spree 2.1] Make private method #total_units public

### DIFF
--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -45,6 +45,17 @@ module OpenFoodNetwork
       proc { |line_items| line_items.first.variant.product.name }
     end
 
+    def total_units(line_items)
+      return " " if not_all_have_unit?(line_items)
+
+      total_units = line_items.sum do |li|
+        product = li.variant.product
+        li.quantity * li.unit_value / scale_factor(product)
+      end
+
+      total_units.round(3)
+    end
+
     private
 
     def report
@@ -60,17 +71,6 @@ module OpenFoodNetwork
       else
         DefaultReport
       end
-    end
-
-    def total_units(line_items)
-      return " " if not_all_have_unit?(line_items)
-
-      total_units = line_items.sum do |li|
-        product = li.variant.product
-        li.quantity * li.unit_value / scale_factor(product)
-      end
-
-      total_units.round(3)
     end
 
     def not_all_have_unit?(line_items)


### PR DESCRIPTION
Apparently this method was being called by another class as if it was public.

Fixes 2 instances of this error:
```
  90) OpenFoodNetwork::OrdersAndFulfillmentsReport::SupplierTotalsReport generates the report
      Failure/Error: delegate :supplier_name, :product_name, :line_items_name, :total_units, to: :context

      NoMethodError:
        private method `total_units' called for #<OpenFoodNetwork::OrdersAndFulfillmentsReport:0x00007f8db5d67168>
      # ./lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb:8:in `total_units'
      # ./lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb:48:in `block in columns'
      # ./lib/open_food_network/order_grouper.rb:41:in `block in build_table'
      # ./lib/open_food_network/order_grouper.rb:41:in `map'
      # ./lib/open_food_network/order_grouper.rb:41:in `build_table'
      # ./lib/open_food_network/order_grouper.rb:47:in `block in build_table'
      # ./lib/open_food_network/order_grouper.rb:43:in `each'
      # ./lib/open_food_network/order_grouper.rb:43:in `build_table'
      # ./lib/open_food_network/order_grouper.rb:47:in `block in build_table'
      # ./lib/open_food_network/order_grouper.rb:43:in `each'
      # ./lib/open_food_network/order_grouper.rb:43:in `build_table'
      # ./lib/open_food_network/order_grouper.rb:47:in `block in build_table'
      # ./lib/open_food_network/order_grouper.rb:43:in `each'
      # ./lib/open_food_network/order_grouper.rb:43:in `build_table'
      # ./lib/open_food_network/order_grouper.rb:56:in `table'
      # ./spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report_spec.rb:19:in `block (2 levels) in <top (required)>'
      # ./spec/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report_spec.rb:23:in `block (2 levels) in <top (required)>'
```