### PR TITLE
[Spree 2.1] Fix expectations in order_shipment_spec

### DIFF
--- a/spec/models/concerns/order_shipment_spec.rb
+++ b/spec/models/concerns/order_shipment_spec.rb
@@ -41,7 +41,7 @@ describe OrderShipment do
 
         it "returns nil for empty shipping_method_id" do
           empty_shipping_method_id = ' '
-          expect(shipment.shipping_rates).to_not receive(:find_by_shipping_method_id).with(empty_shipping_method_id)
+          expect(shipment.shipping_rates).to_not receive(:find_by).with(shipping_method_id: empty_shipping_method_id)
 
           expect(order.select_shipping_method(empty_shipping_method_id)).to be_nil
         end
@@ -50,7 +50,7 @@ describe OrderShipment do
       context "when shipping_method_id is not valid for the order" do
         it "returns nil" do
           invalid_shipping_method_id = order.shipment.shipping_method.id + 1000
-          expect(shipment.shipping_rates).to receive(:find_by_shipping_method_id).with(invalid_shipping_method_id) { nil }
+          expect(shipment.shipping_rates).to receive(:find_by).with(shipping_method_id: invalid_shipping_method_id) { nil }
 
           expect(order.select_shipping_method(invalid_shipping_method_id)).to be_nil
         end


### PR DESCRIPTION
Some deprecated calls to `#find_by_*` had previously been updated/fixed, but this spec was still checking if an object received the `#find_by_shipping_method_id` message.

Example fixed spec:
```
  85) OrderShipment#select_shipping_method when order has a shipment when shipping_method_id is not valid for the order returns nil
      Failure/Error: expect(shipment.shipping_rates).to receive(:find_by_shipping_method_id).with(invalid_shipping_method_id) { nil }

        (#<ActiveRecord::Associations::CollectionProxy []>).find_by_shipping_method_id(1312)
            expected: 1 time with arguments: (1312)
            received: 0 times
      # ./spec/models/concerns/order_shipment_spec.rb:53:in `block (5 levels) in <top (required)>'
```