### PR TITLE
[Spree 2.1] Fix headers in api/base_controller spec

### DIFF
--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -35,7 +35,7 @@ describe Api::BaseController do
 
   context "cannot make a request to the API" do
     it "with an invalid API key" do
-      request.env["X-Spree-Token"] = "fake_key"
+      request.headers["X-Spree-Token"] = "fake_key"
       get :index, {}
       expect(json_response).to eq( "error" => "Invalid API key (fake_key) specified." )
       expect(response.status).to eq(401)


### PR DESCRIPTION
The headers in the request were not being populated correctly in the test, so the #api_key method was not functioning as intended, as `request.headers["X-Spree-Token"]` was `nil` from the controller's perspective (instead of `"fake_key"` as expected).

Fixes:
```
  48) Api::BaseController cannot make a request to the API with an invalid API key
      Failure/Error: expect(json_response).to eq( "error" => "Invalid API key (fake_key) specified." )

        expected: {"error"=>"Invalid API key (fake_key) specified."}
             got: {"products"=>[]}

        (compared using ==)

        Diff:
        @@ -1,2 +1,2 @@
        -"error" => "Invalid API key (fake_key) specified.",
        +"products" => [],

      # ./spec/controllers/api/base_controller_spec.rb:40:in `block (3 levels) in <top (required)>'
```