### PR TITLE
[Spree 2.1] Fix ShippingMethod.services query

### DIFF
--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -41,7 +41,7 @@ Spree::ShippingMethod.class_eval do
         select("distributor_id").
         select("BOOL_OR(spree_shipping_methods.require_ship_address = 'f') AS pickup").
         select("BOOL_OR(spree_shipping_methods.require_ship_address = 't') AS delivery").
-        map { |sm| [sm.distributor_id.to_i, { pickup: sm.pickup == 't', delivery: sm.delivery == 't' }] }
+        map { |sm| [sm.distributor_id.to_i, { pickup: sm.pickup, delivery: sm.delivery }] }
     ]
   end
 

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -36,7 +36,7 @@ feature 'shipping methods' do
       expect(page).to have_no_button I18n.t("actions.create")
 
       # Then the shipping method should have its distributor set
-      message = "Shipping method \"Carrier Pidgeon\" has been successfully created!"
+      message = "Shipping Method \"Carrier Pidgeon\" has been successfully created!"
       expect(page).to have_flash_message message
 
       sm = Spree::ShippingMethod.last
@@ -49,7 +49,7 @@ feature 'shipping methods' do
     scenario "deleting a shipping method" do
       visit_delete spree.admin_shipping_method_path(@shipping_method)
 
-      expect(page).to have_content "Shipping method \"#{@shipping_method.name}\" has been successfully removed!"
+      expect(page).to have_content "Shipping Method \"#{@shipping_method.name}\" has been successfully removed!"
       expect(Spree::ShippingMethod.where(id: @shipping_method.id)).to be_empty
     end
 
@@ -126,7 +126,7 @@ feature 'shipping methods' do
       click_button I18n.t("actions.create")
 
       expect(page).to have_content I18n.t('spree.admin.shipping_methods.edit.editing_shipping_method')
-      expect(flash_message).to eq I18n.t('successfully_created', resource: 'Shipping method "Teleport"')
+      expect(flash_message).to eq I18n.t('successfully_created', resource: 'Shipping Method "Teleport"')
 
       expect(first('tags-input .tag-list ti-tag-item')).to have_content "local"
 


### PR DESCRIPTION
#### What? Why?

Fixes shipping method specs related to the services method:
```
 31) Spree::ShippingMethod finding services offered by all distributors reports when the services are available
      Failure/Error: expect(ShippingMethod.services[d1.id]).to eq(pickup: true, delivery: true)
      
        expected: {:delivery=>true, :pickup=>true}
             got: {:delivery=>false, :pickup=>false}
      
        (compared using ==)
      
        Diff:
        @@ -1,3 +1,3 @@
        -:delivery => true,
        -:pickup => true,
        +:delivery => false,
        +:pickup => false,
        
      # ./spec/models/spree/shipping_method_spec.rb:68:in `block (3 levels) in <module:Spree>'

```

We make the query work in rails 4 here.


Also included in this PR is the second commit with a little fix that makes spec/features/admin/shipping_methods_spec.rb green!

#### What should we test?
green spec.