### PR TITLE
Remove dead spec in SchedulesController

### DIFF
--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -10,19 +10,6 @@ describe Admin::SchedulesController, type: :controller do
     let!(:coordinated_schedule) { create(:schedule, order_cycles: [coordinated_order_cycle] ) }
     let!(:uncoordinated_schedule) { create(:schedule, order_cycles: [other_order_cycle] ) }
 
-    context "html" do
-      context "where I manage an order cycle coordinator" do
-        before do
-          allow(controller).to receive_messages spree_current_user: managed_coordinator.owner
-        end
-
-        it "returns an empty @collection" do
-          spree_get :index, format: :html
-          expect(assigns(:collection)).to eq []
-        end
-      end
-    end
-
     context "json" do
       context "where I manage an order cycle coordinator" do
         before do


### PR DESCRIPTION
#### What? Why?
Removed dead spec...
This spec is broken in rails 4 and looking at the commit where it was introduced and making an overview of the schedules code, my conclusion is that we never need an HTML list of schedules, why would we test that it renders an empty collection!?

#### What should we test?
green build and test that schedules setup works: we need to test that we can create and assign schedules to order cycles in the order cycle list page as well as in the order cycles edit pages.

#### Release notes
Changelog Category: Removed
Remove unnecessary test.
