### PR TITLE
[Spree 2.1] Fix embedded response headers

### DIFF
--- a/app/services/embedded_page_service.rb
+++ b/app/services/embedded_page_service.rb
@@ -49,7 +49,8 @@ class EmbeddedPageService
   end
 
   def set_response_headers
-    @response.headers.delete 'X-Frame-Options'
+    @response.headers.except! 'X-Frame-Options'
+    @response.default_headers.except! 'X-Frame-Options'
     @response.headers['Content-Security-Policy'] = "frame-ancestors 'self' #{@embedding_domain}"
   end
 


### PR DESCRIPTION
Rails 4 adds an extra layer of "default" headers that override any that are missing (or deleted). This was breaking embedded shopfront responses.

Fixes:
```
  74) setting response headers for embedded shopfronts with embedded shopfronts enabled with a valid whitelist allows iframes on certain pages when enabled in configuration
      Failure/Error: expect(response.headers['X-Frame-Options']).to be_nil

        expected: nil
             got: "SAMEORIGIN"
      # ./spec/requests/embedded_shopfronts_headers_spec.rb:54:in `block (4 levels) in <top (required)>'

  75) setting response headers for embedded shopfronts with embedded shopfronts enabled with www prefix matches the URL structure in the header
      Failure/Error: expect(response.headers['X-Frame-Options']).to be_nil

        expected: nil
             got: "SAMEORIGIN"
      # ./spec/requests/embedded_shopfronts_headers_spec.rb:75:in `block (4 levels) in <top (required)>'
```