### PR TITLE
[Spree 2.1] Re-introduce Paypal gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'
 # Our branch contains two changes
 # - Pass customer email and phone number to PayPal (merged to upstream master)
 # - Change type of password from string to password to hide it in the form
-# gem 'spree_paypal_express', github: "openfoodfoundation/better_spree_paypal_express", branch: "2-0-stable"
+gem 'spree_paypal_express', github: 'openfoodfoundation/better_spree_paypal_express', branch: '2-1-0-stable'
 gem 'stripe'
 
 # We need at least this version to have Digicert's root certificate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,15 @@ GIT
     custom_error_message (1.1.1)
 
 GIT
+  remote: https://github.com/openfoodfoundation/better_spree_paypal_express.git
+  revision: e28e4a8c5cedba504eea9cdad4be440d277d7e68
+  branch: 2-1-0-stable
+  specs:
+    spree_paypal_express (2.0.3)
+      paypal-sdk-merchant (= 1.106.1)
+      spree_core (~> 2.1.0)
+
+GIT
   remote: https://github.com/openfoodfoundation/spree.git
   revision: 95d3ccb32f2e4016d0fc73f39446d1739da56c50
   branch: 2-1-0-stable
@@ -478,6 +487,11 @@ GEM
       activerecord (>= 4.0, < 6.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
+    paypal-sdk-core (0.2.10)
+      multi_json (~> 1.0)
+      xml-simple
+    paypal-sdk-merchant (1.106.1)
+      paypal-sdk-core (~> 0.2.3)
     pg (0.21.0)
     polyamorous (0.6.4)
       activerecord (>= 3.0)
@@ -752,6 +766,7 @@ DEPENDENCIES
   spinjs-rails
   spree_core!
   spree_i18n!
+  spree_paypal_express!
   stripe
   test-unit (~> 3.3)
   timecop

--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -35,8 +35,7 @@
 //= require equalize
 //= require css_browser_selector_dev
 //= require responsive-tables
-//  needs to be readded:
-//  require admin/spree_paypal_express
+//= require admin/spree_paypal_express
 //= require admin/handlebar_extensions
 
 // OFN specific

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -1,0 +1,45 @@
+Spree::PaypalController.class_eval do
+  before_filter :enable_embedded_shopfront
+  before_filter :destroy_orphaned_paypal_payments, only: :confirm
+  after_filter :reset_order_when_complete, only: :confirm
+
+  def cancel
+    flash[:notice] = Spree.t('flash.cancel', scope: 'paypal')
+    redirect_to main_app.checkout_path
+  end
+
+  # Clears the cached order. Required for #current_order to return a new order
+  # to serve as cart. See https://github.com/spree/spree/blob/1-3-stable/core/lib/spree/core/controller_helpers/order.rb#L14
+  # for details.
+  def expire_current_order
+    session[:order_id] = nil
+    @current_order = nil
+  end
+
+  private
+
+  def reset_order_when_complete
+    if current_order.complete?
+      flash[:notice] = t(:order_processed_successfully)
+
+      ResetOrderService.new(self, current_order).call
+      session[:access_token] = current_order.token
+    end
+  end
+
+  # See #1074 and #1837 for more detail on why we need this
+  # An 'orphaned' Spree::Payment is created for every call to CheckoutController#update
+  # for orders that are processed using a Spree::Gateway::PayPalExpress payment method
+  # These payments are 'orphaned' because they are never used by the spree_paypal_express gem
+  # which creates a brand new Spree::Payment from scratch in PayPalController#confirm
+  # However, the 'orphaned' payments are useful when applying a transaction fee, because the fees
+  # need to be calculated before the order details are sent to PayPal for confirmation
+  # This is our best hook for removing the orphaned payments at an appropriate time. ie. after
+  # the payment details have been confirmed, but before any payments have been processed
+  def destroy_orphaned_paypal_payments
+    return unless payment_method.is_a?(Spree::Gateway::PayPalExpress)
+
+    orphaned_payments = current_order.payments.where(payment_method_id: payment_method.id, source_id: nil)
+    orphaned_payments.each(&:destroy)
+  end
+end

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -2,6 +2,7 @@ Spree::PaypalController.class_eval do
   before_filter :enable_embedded_shopfront
   before_filter :destroy_orphaned_paypal_payments, only: :confirm
   after_filter :reset_order_when_complete, only: :confirm
+  before_filter :permit_parameters!
 
   def cancel
     flash[:notice] = Spree.t('flash.cancel', scope: 'paypal')
@@ -17,6 +18,10 @@ Spree::PaypalController.class_eval do
   end
 
   private
+
+  def permit_parameters!
+    params.permit(:token, :payment_method_id, :PayerID)
+  end
 
   def reset_order_when_complete
     if current_order.complete?

--- a/app/services/checkout/payment_redirect.rb
+++ b/app/services/checkout/payment_redirect.rb
@@ -21,7 +21,7 @@ module Checkout
     private
 
     def spree_routes_helper
-      Spree::Core::Engine.routes_url_helpers
+      Spree::Core::Engine.routes.url_helpers
     end
   end
 end

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -47,7 +47,7 @@ Spree::Core::Engine.routes.draw do
 
   match '/admin', to: 'admin/overview#index', as: :admin_dashboard, via: :get
 
-  #resources :credit_cards
+  resources :credit_cards
 
   namespace :admin do
     get '/search/known_users' => "search#known_users", :as => :search_known_users

--- a/spec/controllers/spree/paypal_controller_spec.rb
+++ b/spec/controllers/spree/paypal_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Spree
+  describe PaypalController, type: :controller do
+    context 'when cancelling' do
+      it 'redirects back to checkout' do
+        expect(spree_get(:cancel)).to redirect_to checkout_path
+      end
+    end
+
+    context 'when confirming' do
+      let(:previous_order) { controller.current_order(true) }
+      let(:payment_method) { create(:payment_method) }
+
+      before do
+        allow(previous_order).to receive(:complete?).and_return(true)
+      end
+
+      it 'resets the order' do
+        spree_post :confirm, payment_method_id: payment_method.id
+        expect(controller.current_order).not_to eq(previous_order)
+      end
+
+      it 'sets the access token of the session' do
+        spree_post :confirm, payment_method_id: payment_method.id
+        expect(session[:access_token]).to eq(controller.current_order.token)
+      end
+    end
+
+    describe '#expire_current_order' do
+      it 'empties the order_id of the session' do
+        expect(session).to receive(:[]=).with(:order_id, nil)
+        controller.expire_current_order
+      end
+
+      it 'resets the @current_order ivar' do
+        controller.expire_current_order
+        expect(controller.instance_variable_get(:@current_order)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/spree/gateway_tagging_spec.rb
+++ b/spec/models/spree/gateway_tagging_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+# We extended Spree::PaymentMethod to be taggable. Unfortunately, an inheritance
+# bug prevented the taggable code to be passed on to the descendants of
+# PaymentMethod. We fixed that in config/initializers/spree.rb.
+#
+# This spec tests several descendants for their taggability. The tests are in
+# a separate file, because they cover one aspect of several classes.
+shared_examples "taggable" do |expected_taggable_type|
+  it "provides a tag list" do
+    expect(subject.tag_list).to eq []
+  end
+
+  it "stores tags for the root taggable type" do
+    subject.tag_list.add("one")
+    subject.save!
+
+    expect(subject.taggings.last.taggable_type).to eq expected_taggable_type
+  end
+end
+
+module Spree
+  describe "PaymentMethod and descendants" do
+    let(:shop) { create(:enterprise) }
+    let(:valid_subject) do
+      # Supply required parameters so that it can be saved to attach taggings.
+      described_class.new(
+        name: "Some payment method",
+        distributor_ids: [shop.id]
+      )
+    end
+    subject { valid_subject }
+
+    describe PaymentMethod do
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
+
+    describe Gateway do
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
+
+    describe Gateway::PayPalExpress do
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
+
+    describe Gateway::StripeConnect do
+      subject do
+        # StripeConnect needs an owner to be valid.
+        valid_subject.tap { |m| m.preferred_enterprise_id = shop.id }
+      end
+
+      it_behaves_like "taggable", "Spree::PaymentMethod"
+    end
+  end
+end


### PR DESCRIPTION
Closes #4645 

This uses the (newly added) `2-1-0-stable` branch of the paypal gem. It's the upstream `2-1-stable` branch plus a couple of old OFN modifications (from our version of `2-0-stable`), plus a minor modification to the gemspec to allow it to be used with spree_core `2.1.0`.

The branch is here: https://github.com/openfoodfoundation/better_spree_paypal_express/tree/2-1-0-stable

Also re-adds temporarily removed paypal bits in the codebase and fixes a small spree routes_helper issue.

