### PR TITLE
[Spree 2.1] Fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,7 +482,6 @@ GEM
     polyamorous (0.6.4)
       activerecord (>= 3.0)
     polyglot (0.3.5)
-    power_assert (1.1.5)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -623,8 +622,7 @@ GEM
     state_machine (1.2.0)
     stringex (1.5.1)
     stripe (5.15.0)
-    test-unit (3.3.5)
-      power_assert
+    temple (0.8.2)
     test-unit (3.3.5)
     thor (0.20.3)
     thread_safe (0.3.6)


### PR DESCRIPTION
Looks like it was messed up during a conflict merge. This is the new output of `bundle install` on the branch.

:+1: 