### PR TITLE
[Spree 2.1] Fix OrderCycle.earliest_closing_times spec

### DIFF
--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -413,11 +413,11 @@ describe OrderCycle do
     let!(:oc3) { create(:simple_order_cycle, orders_close_at: time3, distributors: [e2]) }
 
     it "returns the closing time, indexed by enterprise id" do
-      expect(OrderCycle.earliest_closing_times[e1.id]).to eq(time1)
+      expect(OrderCycle.earliest_closing_times[e1.id].round).to eq(time1.round)
     end
 
     it "returns the earliest closing time" do
-      expect(OrderCycle.earliest_closing_times[e2.id]).to eq(time2)
+      expect(OrderCycle.earliest_closing_times[e2.id].round).to eq(time2.round)
     end
   end
 


### PR DESCRIPTION
#### What? Why?
There was a problem in OrderCycle.earliest_closing_times spec

This was the current error:
```ruby
  11) OrderCycle finding the earliest closing times for each distributor returns the closing time, indexed by enterprise id
      Failure/Error: expect(OrderCycle.earliest_closing_times[e1.id]).to eq(time1)     
        expected: 2020-03-06 06:35:29.175033239 +1100
             got: 2020-03-06 06:35:29.175033000 +1100
        (compared using ==)
        Diff:
        @@ -1,2 +1,2 @@
        -Fri, 06 Mar 2020 06:35:29 AEDT +11:00
        +2020-03-06 06:35:29 +1100
```

OrderCycle.earliest_closing_times is returning a time that is a few miliseconds off the defined time...
I couldnt find a better solution then just round the times in the spec.
I think this is acceptable but we could find the root cause...