### PR TITLE
[Spree 2.1] ofn-qz

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ gem 'jquery-rails', '3.0.4'
 gem 'jquery-ui-rails', '~> 4.0.0'
 gem 'select2-rails', '~> 3.4.7'
 
-# gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c'
+gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', branch: 'ofn-rails-4'
 
 group :production, :staging do
   gem 'ddtrace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,13 @@ GIT
       spree_core (~> 2.1.0)
 
 GIT
+  remote: https://github.com/openfoodfoundation/ofn-qz.git
+  revision: 467f6ea1c44529c7c91cac4c8211bbd863588c0b
+  branch: ofn-rails-4
+  specs:
+    ofn-qz (0.1.0)
+
+GIT
   remote: https://github.com/openfoodfoundation/spree.git
   revision: 95d3ccb32f2e4016d0fc73f39446d1739da56c50
   branch: 2-1-0-stable
@@ -737,6 +744,7 @@ DEPENDENCIES
   momentjs-rails
   nokogiri (~> 1.6.8.1)
   oauth2 (~> 1.4.4)
+  ofn-qz!
   oj
   order_management!
   paper_trail (~> 5.2.3)


### PR DESCRIPTION
Part of #4777

Uses new modified branch of `ofn-qz` gem that allows it to be installed with Rails 4.

New gem branch: https://github.com/openfoodfoundation/ofn-qz/tree/ofn-rails-4 

Fixes:
```
 6) 
    As an administrator
    I want to manage orders
 as an enterprise manager viewing the edit page can print an order's ticket
     Got 0 failures and 2 other errors:

     6.1) Failure/Error:
            accept_alert do
              print_data = page.evaluate_script('printData');
              elements_in_print_data =
                [
                  order.distributor.name,
                  order.distributor.address.address_part1,
                  order.distributor.address.address_part2,
                  order.distributor.contact.email,
                  order.number,
                  order.line_items.map { |line_item|
          
          Capybara::ModalNotFound:
            Unable to find modal dialog
          # ./spec/features/admin/orders_spec.rb:338:in `block (5 levels) in <top (required)>'
          # ./spec/features/admin/orders_spec.rb:337:in `block (4 levels) in <top (required)>'
          # ------------------
          # --- Caused by: ---
          # Selenium::WebDriver::Error::TimeoutError:
          #   timed out after 30 seconds (no such alert
          #     (Session info: headless chrome=72.0.3626.96)
          #     (Driver info: chromedriver=72.0.3626.69 (3c16f8a135abc0d4da2dff33804db79b849a7c38),platform=Linux 4.4.0-116-generic x86_64))
          #   ./spec/features/admin/orders_spec.rb:338:in `block (5 levels) in <top (required)>'

     6.2) Failure/Error: @app.call(env)
          
          ActionController::RoutingError:
            No route matches [GET] "/javascripts/qz/ticket-popup.js"
          # ./lib/open_food_network/rack_request_blocker.rb:36:in `call'
          # ------------------
          # --- Caused by: ---
          # Capybara::CapybaraError:
          #   Your application server raised an error - It has been raised in your test code because Capybara.raise_server_errors == true
          #   ./spec/spec_helper.rb:115:in `block (2 levels) in <top (required)>'

``` 