### PR TITLE
[Spree 2.1] acts_as_gmappable

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -17,8 +17,6 @@ class Enterprise < ActiveRecord::Base
 
   self.inheritance_column = nil
 
-  # acts_as_gmappable process_geocoding: false
-
   has_many :relationships_as_parent, class_name: 'EnterpriseRelationship',
                                      foreign_key: 'parent_id',
                                      dependent: :destroy

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,6 +1,7 @@
 # Google requires an API key with a billing account to use their API.
 # The key is stored in config/application.yml.
 Geocoder.configure(
+  lookup: :google,
   use_https: true,
   api_key: ENV.fetch('GOOGLE_MAPS_API_KEY', nil)
 )


### PR DESCRIPTION
Part of #4777

Fixes maps in Rails 4 :tada:

In the new `2.x.x` version of the `gmaps4rails` gem (for Rails 4+), `acts_as_gmappable` doesn't exist any more, the gem has been overhauled and a lot of the other functionality has shifted to the `geocoding` gem.

It looks like we already use the `geocoding` gem correctly in `Spree::Address` decorator. It needed a slight config tweak, but now it works. The `gmaps4rails` gem seems to display the maps fine (I tested both locally using the UK maps API key).