### PR TITLE
[Spree 2.1] Touch on new records

### DIFF
--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -78,6 +78,8 @@ Spree::ShippingMethod.class_eval do
   private
 
   def touch_distributors
-    distributors.each(&:touch)
+    distributors.each do |distributor|
+      distributor.touch if distributor.persisted?
+    end
   end
 end


### PR DESCRIPTION
Rails 4 now throws a fatal error if calling #touch on an object that hasn't been saved yet: https://github.com/rails/rails/blob/c63cfc8722292ec39def505861fbc20bd9774f4c/activerecord/lib/active_record/persistence.rb#L957

This checks #persisted? before calling #touch.

Fixes:
```
  41) Stock::Package#shipping_methods does not return shipping methods not used by the package's order distributor
      Failure/Error: distributors.each(&:touch)

      ActiveRecord::ActiveRecordError:
        can not touch on a new record object
      # ./app/models/spree/shipping_method_decorator.rb:81:in `touch_distributors'
      # ./spec/models/stock/package_spec.rb:39:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:17:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:32:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:7:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:44:in `block (3 levels) in <module:Stock>'

  42) Stock::Package#shipping_categories returns shipping categories that are not shipping categories of the order's products
      Failure/Error: distributors.each(&:touch)

      ActiveRecord::ActiveRecordError:
        can not touch on a new record object
      # ./app/models/spree/shipping_method_decorator.rb:81:in `touch_distributors'
      # ./spec/models/stock/package_spec.rb:39:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:17:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:32:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:7:in `block (2 levels) in <module:Stock>'
      # ./spec/models/stock/package_spec.rb:50:in `block (3 levels) in <module:Stock>'
```
