### PR TITLE
fix ampersand problem using ng-bind-html

### DIFF
--- a/app/views/admin/order_cycles/_row.html.haml
+++ b/app/views/admin/order_cycles/_row.html.haml
@@ -19,8 +19,7 @@
         {{ orderCycle.producers.length }}
         = t('.suppliers')
       %span{ ng: { hide: 'orderCycle.producers.length > 3', bind: 'orderCycle.producerNames' } }
-    %td.coordinator{ ng: { show: 'columns.coordinator.visible' } }
-      {{ orderCycle.coordinator.name }}
+    %td.coordinator{ ng: { show: 'columns.coordinator.visible', bind: { html: 'orderCycle.coordinator.name'} } }
     %td.shops{ ng: { show: 'columns.shops.visible' } }
       %span{'ofn-with-tip' => '{{ orderCycle.shopNames }}', ng: { show: 'orderCycle.shops.length > 3' } }
         {{ orderCycle.shops.length }}

--- a/app/views/admin/variant_overrides/_new_products.html.haml
+++ b/app/views/admin/variant_overrides/_new_products.html.haml
@@ -13,7 +13,7 @@
       %th.hide=t('admin.variant_overrides.index.hide')
   %tbody{ ng: { repeat: 'product in filteredProducts | limitTo:productLimit' } }
     %tr{ id: "v_{{variant.id}}", ng: { repeat: 'variant in product.variants | inventoryVariants:hub_id:views' } }
-      %td.producer{ ng: { bind: '::producersByID[product.producer_id].name'} }
+      %td.producer{ ng: { bind: { html: '::producersByID[product.producer_id].name'} } }
       %td.product{ ng: { bind: '::product.name'} }
       %td.variant
         %span{ ng: { bind: '::variant.display_name || ""'} }

--- a/app/views/admin/variant_overrides/_products_product.html.haml
+++ b/app/views/admin/variant_overrides/_products_product.html.haml
@@ -1,5 +1,5 @@
 %tr.product.even
-  %td.producer{ ng: { show: 'columns.producer.visible', bind: '::producersByID[product.producer_id].name'} }
+  %td.producer{ ng: { show: 'columns.producer.visible', bind: { html: '::producersByID[product.producer_id].name'} } }
   %td.product{ ng: { show: 'columns.product.visible', bind: '::product.name'} }
   %td.sku{ ng: { show: 'columns.sku.visible' } }
   %td.price{ ng: { show: 'columns.price.visible' } }


### PR DESCRIPTION
#### What? Why?

Closes #4830 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

When an enterprise name contains `&`, it was being escaped making the view to show `&amp;`. Using ng-bind-html, it inserts the resulting HTML into the element in a secure way and shows the name correctly.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Use ng-bind-html in the inventory list and order cycles to show correctly producer's name containing an ampersand.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

![Screen Shot 2020-03-01 at 17 40 27](https://user-images.githubusercontent.com/27960597/75633698-01dba900-5be6-11ea-8222-16fd77911cd5.png)
![Screen Shot 2020-03-01 at 17 40 39](https://user-images.githubusercontent.com/27960597/75633701-03a56c80-5be6-11ea-897a-ac6aa8c9ae24.png)
![Screen Shot 2020-03-01 at 17 54 03](https://user-images.githubusercontent.com/27960597/75633702-043e0300-5be6-11ea-9e05-02effe0f8009.png)
