### PR TITLE
[Spree 2.1] Fix duplicate validations in payment methods and shipping methods

### DIFF
--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -10,7 +10,7 @@ Spree::PaymentMethod.class_eval do
 
   after_initialize :init
 
-  validates_with DistributorsValidator
+  validate :distributor_validation
 
   # -- Scopes
   scope :managed_by, lambda { |user|
@@ -72,5 +72,11 @@ Spree::PaymentMethod.class_eval do
       i = name.rindex('::') + 2
       name[i..-1]
     end
+  end
+
+  private
+
+  def distributor_validation
+    validates_with DistributorsValidator
   end
 end

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -6,7 +6,7 @@ Spree::ShippingMethod.class_eval do
 
   after_save :touch_distributors
 
-  validates_with DistributorsValidator
+  validate :distributor_validation
 
   scope :managed_by, lambda { |user|
     if user.has_spree_role?('admin')
@@ -79,5 +79,9 @@ Spree::ShippingMethod.class_eval do
 
   def touch_distributors
     distributors.each(&:touch)
+  end
+
+  def distributor_validation
+    validates_with DistributorsValidator
   end
 end


### PR DESCRIPTION
Closes #4831

Updates some syntax to follow the recommended usage in the code comments of the ActiveModel #validates_with method. The validation was being called twice every time the object was saved, instead of once.

Fixes:
```
  12) Spree::PaymentMethod raises errors when required fields are missing
      Failure/Error: expect(pm.errors.to_a).to eq(["Name can't be blank", "At least one hub must be selected"])

        expected: ["Name can't be blank", "At least one hub must be selected"]
             got: ["Name can't be blank", "At least one hub must be selected", "At least one hub must be selected"]

        (compared using ==)
      # ./spec/models/spree/payment_method_spec.rb:16:in `block (2 levels) in <module:Spree>'
```