### PR TITLE
[Spree 2.1] Fix spec setup in api/orders_controller_spec

### DIFF
--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -165,7 +165,7 @@ module Api
         before { allow(controller).to receive(:spree_current_user) { admin_user } }
 
         it "when no order number is given" do
-          get :show, id: nil
+          get :show, id: ""
           expect(response).to have_http_status(:not_found)
         end
 


### PR DESCRIPTION
`ActionController` doesn't accept `nil` values for `:id` as a valid route request in Rails 4, so this
test was receiving a routing error instead of the expected 404 / not found response.

Fixes:
```
  2) Api::OrdersController#show Resource not found when no order number is given
     Failure/Error: get :show, id: nil

     ActionController::UrlGenerationError:
       No route matches {:action=>"show", :controller=>"api/orders", :id=>nil}
     # ./spec/controllers/api/orders_controller_spec.rb:168:in `block (4 levels) in <module:Api>'
```