### PR TITLE
[Spree 2.1] Fix expectation in helper spec

### DIFF
--- a/spec/helpers/spree/admin/base_helper_spec.rb
+++ b/spec/helpers/spree/admin/base_helper_spec.rb
@@ -9,7 +9,7 @@ describe Spree::BaseHelper, type: :helper do
     subject { helper.link_to_remove_fields(name, form, options) }
 
     it 'returns an `a` tag followed by a hidden `input` tag' do
-      expect(subject).to eq("<a href=\"#\" class=\"remove_fields  icon_link with-tip icon-trash\" data-action=\"remove\" title=\"Remove\"><span class='text'>Hola</span></a>&lt;input type=&quot;hidden&quot; name=&quot;_method&quot; value=&quot;destroy&quot;&gt;")
+      expect(subject).to eq("<a class=\"remove_fields  icon_link with-tip icon-trash\" data-action=\"remove\" href=\"#\" title=\"Remove\"><span class='text'>Hola</span></a>&lt;input type=&quot;hidden&quot; name=&quot;_method&quot; value=&quot;destroy&quot;&gt;")
     end
   end
 end


### PR DESCRIPTION
The output of this link helper has changed slightly. All the attributes are the same as before, but they seem to be in alphabetical order now in Rails 4.

Fixes:
```
  69) Spree::BaseHelper#link_to_remove_fields returns an `a` tag followed by a hidden `input` tag
      Failure/Error: expect(subject).to eq("<a href=\"#\" class=\"remove_fields  icon_link with-tip icon-trash\" data-action=\"remove\" title=\"Remove\"><span class='text'>Hola</span></a>&lt;input type=&quot;hidden&quot; name=&quot;_method&quot; value=&quot;destroy&quot;&gt;")

        expected: "<a href=\"#\" class=\"remove_fields  icon_link with-tip icon-trash\" data-action=\"remove\" title=\"...</span></a>&lt;input type=&quot;hidden&quot; name=&quot;_method&quot; value=&quot;destroy&quot;&gt;"
             got: "<a class=\"remove_fields  icon_link with-tip icon-trash\" data-action=\"remove\" href=\"#\" title=\"...</span></a>&lt;input type=&quot;hidden&quot; name=&quot;_method&quot; value=&quot;destroy&quot;&gt;"

        (compared using ==)
      # ./spec/helpers/spree/admin/base_helper_spec.rb:12:in `block (3 levels) in <top (required)>'
```