### PR TITLE
[Spree 2.1] Fix unknown attribute passed to Spree::Product.new

### DIFF
--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -35,7 +35,8 @@ class Spree::ProductSet < ModelSet
 
     product = find_model(@collection, attributes[:id])
     if product.nil?
-      @klass.new(attributes).save unless @reject_if.andand.call(attributes)
+      return if @reject_if.andand.call(attributes)
+      @klass.new(attributes.except!(:product_id)).save
     else
       update_product(product, attributes)
     end


### PR DESCRIPTION
Similar to issues with `assign_attributes` in Product Import...

`:product_id` is not a valid attribute for a new `Spree::Product` object , but was being passed to it here and is used as part of `product_set`. This was being silently ignored in Rails 3, but now throws a fatal error in Rails 4. 

Fixes:
```
  10) Spree::ProductSet#save when passing :collection_attributes when the product does not exist yet creates it with the specified attributes
      Failure/Error: @klass.new(attributes).save unless @reject_if.andand.call(attributes)

      ActiveRecord::UnknownAttributeError:
        unknown attribute: product_id
      # ./app/models/spree/product_set.rb:38:in `update_attributes'
      # ./app/models/spree/product_set.rb:8:in `block in save'
      # ./app/models/spree/product_set.rb:7:in `each_value'
      # ./app/models/spree/product_set.rb:7:in `each'
      # ./app/models/spree/product_set.rb:7:in `all?'
      # ./app/models/spree/product_set.rb:7:in `save'
      # ./spec/models/spree/product_set_spec.rb:29:in `block (5 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # NoMethodError:
      #   undefined method `product_id=' for #<Spree::Product:0x00007fd3ca0cd730>
      #   ./app/models/spree/product_set.rb:38:in `update_attributes'
```