### PR TITLE
[Spree 2.1] Remove assignment of invalid attribute in test setup

### DIFF
--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -24,13 +24,9 @@ feature "Order Management", js: true do
     before do
       # For some reason, both bill_address and ship_address are not set
       # automatically.
-      #
-      # Also, assigning the shipping_method to a ShippingMethod instance results
-      # in a SystemStackError.
       order.update_attributes!(
         bill_address: bill_address,
-        ship_address: ship_address,
-        shipping_method_id: shipping_method.id
+        ship_address: ship_address
       )
     end
 


### PR DESCRIPTION
`:shipping_method_id` hasn't been a valid attribute of `Spree::Order` since last September.

Related to #4884

Fixes:
```
  11) Order Management viewing a completed order when checking out as an anonymous guest allows the user to see the details
      Failure/Error:
        order.update_attributes!(
          bill_address: bill_address,
          ship_address: ship_address,
          shipping_method_id: shipping_method.id
        )

      ActiveRecord::UnknownAttributeError:
        unknown attribute: shipping_method_id
      # ./spec/features/consumer/shopping/orders_spec.rb:30:in `block (3 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # NoMethodError:
      #   undefined method `shipping_method_id=' for #<Spree::Order:0x00007f5e82a94d80>
      #   ./spec/features/consumer/shopping/orders_spec.rb:30:in `block (3 levels) in <top (required)>'

  12) Order Management viewing a completed order when logged in as the customer allows the user to see order details
      Failure/Error:
        order.update_attributes!(
          bill_address: bill_address,
          ship_address: ship_address,
          shipping_method_id: shipping_method.id
        )

      ActiveRecord::UnknownAttributeError:
        unknown attribute: shipping_method_id
      # ./spec/features/consumer/shopping/orders_spec.rb:30:in `block (3 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # NoMethodError:
      #   undefined method `shipping_method_id=' for #<Spree::Order:0x00007f5e83382708>
      #   ./spec/features/consumer/shopping/orders_spec.rb:30:in `block (3 levels) in <top (required)>'

  13) Order Management viewing a completed order when not logged in allows the user to see order details after login
      Failure/Error:
        order.update_attributes!(
          bill_address: bill_address,
          ship_address: ship_address,
          shipping_method_id: shipping_method.id
        )

      ActiveRecord::UnknownAttributeError:
        unknown attribute: shipping_method_id
      # ./spec/features/consumer/shopping/orders_spec.rb:30:in `block (3 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # NoMethodError:
      #   undefined method `shipping_method_id=' for #<Spree::Order:0x00007f5e8bafe6f0>
      #   ./spec/features/consumer/shopping/orders_spec.rb:30:in `block (3 levels) in <top (required)>'
```