### PR TITLE
[Spree 2.1] Fix ProductSet spec (1 broken spec)

### DIFF
--- a/app/models/spree/product_set.rb
+++ b/app/models/spree/product_set.rb
@@ -1,6 +1,6 @@
 class Spree::ProductSet < ModelSet
   def initialize(attributes = {})
-    super(Spree::Product, [], attributes, proc { |attrs| attrs[:product_id].blank? })
+    super(Spree::Product, [], attributes)
   end
 
   def save
@@ -34,11 +34,9 @@ class Spree::ProductSet < ModelSet
     split_taxon_ids!(attributes)
 
     product = find_model(@collection, attributes[:id])
-    if product.nil?
-      @klass.new(attributes).save unless @reject_if.andand.call(attributes)
-    else
-      update_product(product, attributes)
-    end
+    return if product.nil?
+
+    update_product(product, attributes)
   end
 
   def split_taxon_ids!(attributes)

--- a/spec/models/spree/product_set_spec.rb
+++ b/spec/models/spree/product_set_spec.rb
@@ -12,7 +12,6 @@ describe Spree::ProductSet do
         let(:collection_hash) do
           {
             0 => {
-              product_id: 11,
               name: 'a product',
               price: 2.0,
               supplier_id: create(:enterprise).id,
@@ -25,11 +24,10 @@ describe Spree::ProductSet do
           }
         end
 
-        it 'creates it with the specified attributes' do
+        it 'does not create a new product' do
           product_set.save
 
-          expect(Spree::Product.last.attributes)
-            .to include('name' => 'a product')
+          expect(Spree::Product.last).to be nil
         end
       end
 


### PR DESCRIPTION
#### What? Why?

Remove dead code that creates products in product_set.
This will fix a broken spec in the upgrade build because in rails 4 the product_id attribute causes the update to break.

This code product_set is never used to create products, only update and so this code is never used. 

#### What should we test?
Create product and bulk update products and variants.
Make sure the attributes like on_hand, display_name, variant_unit_name are saved correctly.

#### Release notes
Changelog Category: Removed
Delete some dead code that will ease the rails upgrade.