### PR TITLE
[Spree 2.1] Add missing :cc_type attribute to default :credit_card factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -164,6 +164,10 @@ FactoryBot.modify do
     country { Spree::Country.find_by name: 'Australia' || Spree::Country.first }
   end
 
+  factory :credit_card do
+    cc_type 'visa'
+  end
+
   factory :payment do
     transient do
       distributor {


### PR DESCRIPTION
Closes #4895 

Adds default attribute cc_type for credit cards in tests.

Fixes 5 specs, including:
```
  11) Spree::CreditCardsController#update when the specified credit card is found and the card is owned by the user when the update completes successfully renders a serialized copy of the updated card
      Failure/Error: object.cc_type.capitalize

      NoMethodError:
        undefined method `capitalize' for nil:NilClass
      # ./app/serializers/api/credit_card_serializer.rb:6:in `brand'
      # (eval):4:in `_fast_attributes'
      # ./app/controllers/spree/credit_cards_controller.rb:26:in `update'
      # ./spec/controllers/spree/credit_cards_controller_spec.rb:100:in `block (7 levels) in <top (required)>'
      # ./spec/controllers/spree/credit_cards_controller_spec.rb:100:in `block (6 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # NoMethodError:
      #   undefined method `capitalize' for nil:NilClass
      #   ./app/serializers/api/credit_card_serializer.rb:6:in `brand'
```