### PR TITLE
Move TaxRate#match to OFN to avoid having to adapt to the spree 2.1 version

### DIFF
--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -1,6 +1,13 @@
 module Spree
   TaxRate.class_eval do
     class << self
+      def match(order)
+        return [] unless order.tax_zone
+        all.select do |rate|
+          rate.zone == order.tax_zone || rate.zone.contains?(order.tax_zone) || rate.zone.default_tax
+        end
+      end
+
       def match_with_sales_tax_registration(order)
         return [] if order.distributor && !order.distributor.charges_sales_tax
 

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -2,18 +2,13 @@ module Spree
   TaxRate.class_eval do
     class << self
       def match(order)
+        return [] if order.distributor && !order.distributor.charges_sales_tax
         return [] unless order.tax_zone
+
         all.select do |rate|
           rate.zone == order.tax_zone || rate.zone.contains?(order.tax_zone) || rate.zone.default_tax
         end
       end
-
-      def match_with_sales_tax_registration(order)
-        return [] if order.distributor && !order.distributor.charges_sales_tax
-
-        match_without_sales_tax_registration(order)
-      end
-      alias_method_chain :match, :sales_tax_registration
     end
 
     def adjust_with_included_tax(order)

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module Spree
   describe TaxRate do
     describe "selecting tax rates to apply to an order" do


### PR DESCRIPTION
#### What? Why?

This fixes at least 9 specs in the upgrade branch and closes #4875 and #4893 

The change in spree 2.1 fixes a bug in spree but I am pretty sure we can save a lot of time by ignoring it and fix the bug in our codebase if it ever gets into our priorities (I dont think we will be fixing bugs on refunds with VAT tax adjustments soon).
Btw, we are also avoiding some low quality spree code with this: https://github.com/spree/spree/pull/3699/commits/efa67e0de9b18e1852e99531a2664e46dceb8194

#### What should we test?
Green build should be enough as this is just copying the code around.

#### Release notes
Changelog Category: Changed
Bring some spree code to OFN to avoid having to adapt to new spree code.

