### PR TITLE
Fix enterprise_caching_spec in rails 4

### DIFF
--- a/spec/models/enterprise_caching_spec.rb
+++ b/spec/models/enterprise_caching_spec.rb
@@ -33,7 +33,7 @@ describe Enterprise do
         it "touches enterprise when the supplier of a product changes" do
           expect {
             product.update_attributes!(supplier: supplier2)
-          }.to change { enterprise.updated_at }
+          }.to change { enterprise.reload.updated_at }
         end
       end
 


### PR DESCRIPTION
#### What? Why?

Closes #4891

#### What should we test?
Green build is enough.

#### Release notes
Changelog Category:  Changed
Adapt a spec to work with rails 4.
