### PR TITLE
[Spree 2.1] Uncomment Enterprise#relate_to_owners_enterprises

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -433,21 +433,21 @@ class Enterprise < ActiveRecord::Base
     # We grant permissions to all pre-existing hubs
     hub_permissions = [:add_to_order_cycle]
     hub_permissions << :create_variant_overrides if is_primary_producer
-    #enterprises.is_hub.each do |enterprise|
-    #  EnterpriseRelationship.create!(parent: self,
-    #                                 child: enterprise,
-    #                                 permissions_list: hub_permissions)
-    #end
+    enterprises.is_hub.each do |enterprise|
+      EnterpriseRelationship.create!(parent: self,
+                                     child: enterprise,
+                                     permissions_list: hub_permissions)
+    end
 
     # All pre-existing producers grant permission to new hubs
-    #if is_hub
-    #  enterprises.is_primary_producer.each do |enterprise|
-    #    EnterpriseRelationship.create!(parent: enterprise,
-    #                                   child: self,
-    #                                   permissions_list: [:add_to_order_cycle,
-    #                                                      :create_variant_overrides])
-    #  end
-    #end
+    if is_hub
+      enterprises.is_primary_producer.each do |enterprise|
+        EnterpriseRelationship.create!(parent: enterprise,
+                                       child: self,
+                                       permissions_list: [:add_to_order_cycle,
+                                                          :create_variant_overrides])
+      end
+    end
   end
 
   def shopfront_taxons


### PR DESCRIPTION
#### What? Why?

Closes #4894

Reintroducing code that was commented earlier on in the upgrade process. It makes this spec go green.

#### What should we test?
Green model/enterprise_spec

