### PR TITLE
Make package spec work in rails 4

### DIFF
--- a/spec/models/stock/package_spec.rb
+++ b/spec/models/stock/package_spec.rb
@@ -6,8 +6,8 @@ module Stock
 
     subject(:package) { Package.new(stock_location, order, contents) }
 
-    let(:enterprise) { build(:enterprise) }
-    let(:other_enterprise) { build(:enterprise) }
+    let(:enterprise) { create(:enterprise) }
+    let(:other_enterprise) { create(:enterprise) }
 
     let(:order) { build(:order, distributor: enterprise) }
 


### PR DESCRIPTION
#### What? Why?

Fixes the models/package_spec in the upgrade branch.

#### What should we test?
Green build.

#### Release notes
Changelog Category: Changed
Adapt some test code to rails 4 and spree 2.1.
