### PR TITLE
[Spree 2.1] Change Shipment#manifest to include deleted variants (again, this time in rails 4)

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -15,6 +15,14 @@ module Spree
       end
     end
 
+    def manifest
+      inventory_units.joins(:variant).includes(:variant).group_by(&:variant).map do |variant, units|
+        states = {}
+        units.group_by(&:state).each { |state, iu| states[state] = iu.count }
+        OpenStruct.new(variant: variant, quantity: units.length, states: states)
+      end
+    end
+
     # The shipment manifest is built by loading inventory units and variants from the DB
     # These variants come unscoped
     # So, we need to scope the variants just after the manifest is built

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -19,17 +19,10 @@ module Spree
       inventory_units.group_by(&:variant).map do |variant, units|
         states = {}
         units.group_by(&:state).each { |state, iu| states[state] = iu.count }
+        scoper.scope(variant)
         OpenStruct.new(variant: variant, quantity: units.length, states: states)
       end
     end
-
-    # The shipment manifest is built by loading inventory units and variants from the DB
-    # These variants come unscoped
-    # So, we need to scope the variants just after the manifest is built
-    def manifest_with_scoping
-      manifest_without_scoping.each { |item| scoper.scope(item.variant) }
-    end
-    alias_method_chain :manifest, :scoping
 
     def scoper
       @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -16,7 +16,7 @@ module Spree
     end
 
     def manifest
-      inventory_units.joins(:variant).includes(:variant).group_by(&:variant).map do |variant, units|
+      inventory_units.group_by(&:variant).map do |variant, units|
         states = {}
         units.group_by(&:state).each { |state, iu| states[state] = iu.count }
         OpenStruct.new(variant: variant, quantity: units.length, states: states)


### PR DESCRIPTION
#### What? Why?

Closes #4885
For some reason this is not working in rails 4: https://github.com/openfoodfoundation/spree/pull/41/files
So here we bring manifest method into OFN and, by removing the joins and includes part of the statement, we make it use the default inventory_units.variant scope  which includes deleted variants as introduced in PR 41 above. This way deleted variants are now seen in inventory_units and the spec in 4885 is green.

#### What should we test?
Green models/spree/payment_spec.
