### PR TITLE
[Spree 2.1] Make Spree::OrderUpdater update all adjustments, not just promotions and shipment adjustments

### DIFF
--- a/app/models/spree/order_updater_decorator.rb
+++ b/app/models/spree/order_updater_decorator.rb
@@ -1,0 +1,6 @@
+Spree::OrderUpdater.class_eval do
+  # Override spree method to make it update all adjustments as in Spree v2.0.4
+  def update_shipping_adjustments
+    order.adjustments.reload.each { |adjustment| adjustment.update! }
+  end
+end


### PR DESCRIPTION
#### What? Why?

This fixes #4915 
This spree commit is the obvious cause of the problem:
https://github.com/openfoodfoundation/spree/commit/39f9b3e9fed24f3ce8cacf3ec38b808d143550dd
it is changing from updating all adjustments to updating only shipment and promotions adjustments.
Payment adjustments are left behind and that's exactly what's failing in #4915

In terms of the solution: I dont understand why adding the method to OFN's OrderUpdater doesnt work, only adding it to the decorator works...

This updater code is a mess! Spree::OrderUpdater itself is a disaster. We have a delegator on top of it to do our own stuff. But the worse thing is that in Spree 2.2 there are massive changes to this class.... I wonder what can we do to improve this mess now or later...

#### What should we test?
Green spec.

