### PR TITLE
Fix spec/controllers/admin/bulk_line_items_controller_spec in rails 4

### DIFF
--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::BulkLineItemsController, type: :controller do
 
     context "as an administrator" do
       before do
-        allow(controller).to receive_messages spree_current_user: quick_login_as_admin
+        allow(controller).to receive_messages spree_current_user: create(:admin_user)
       end
 
       context "when no ransack params are passed in" do


### PR DESCRIPTION
#### What? Why?

It makes the specs green in rails 4 branch.

#### What should we test?
A green build is enough.

#### Release notes
Changelog Category: Changed
Adapt test code to work with rails 4.
