### PR TITLE
[Spree 2.1] Fix shipments admin/enterprises and api/enterprises controller specs

### DIFF
--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -449,8 +449,8 @@ module Admin
       before do
         # As a user with permission
         allow(controller).to receive_messages spree_current_user: user
-        allow(OrderCycle).to receive_messages find_by_id: "existing OrderCycle"
-        allow(Enterprise).to receive_messages find_by_id: "existing Enterprise"
+        allow(OrderCycle).to receive_messages find_by: "existing OrderCycle"
+        allow(Enterprise).to receive_messages find_by: "existing Enterprise"
         allow(OrderCycle).to receive_messages new: "new OrderCycle"
 
         allow(OpenFoodNetwork::OrderCyclePermissions).to receive(:new) { permission_mock }

--- a/spec/controllers/api/enterprises_controller_spec.rb
+++ b/spec/controllers/api/enterprises_controller_spec.rb
@@ -52,7 +52,7 @@ module Api
       describe "submitting a valid image" do
         before do
           allow(Enterprise)
-            .to receive(:find_by_permalink).with(enterprise.id.to_s) { enterprise }
+            .to receive(:find_by).with({ permalink: enterprise.id.to_s }) { enterprise }
           allow(enterprise).to receive(:update_attributes).and_return(true)
         end
 
@@ -68,7 +68,7 @@ module Api
 
       before do
         allow(Enterprise)
-          .to receive(:find_by_permalink).with(enterprise.id.to_s) { enterprise }
+          .to receive(:find_by).with({ permalink: enterprise.id.to_s }) { enterprise }
         allow(controller).to receive(:spree_current_user) { non_managing_user }
       end
 

--- a/spec/controllers/api/shipments_controller_spec.rb
+++ b/spec/controllers/api/shipments_controller_spec.rb
@@ -214,7 +214,7 @@ describe Api::ShipmentsController, type: :controller do
     end
 
     def make_order_contents_fail
-      expect(Spree::Order).to receive(:find_by_number!) { order }
+      expect(Spree::Order).to receive(:find_by!).with({ number: order.number }) { order }
       expect(order).to receive(:contents) { raise error_message }
     end
 


### PR DESCRIPTION
#### What? Why?

After the finders were adapted to rails 4 in PR #4675 these specs needed this change as well.
Fixes shipment_controller_spec in rails 4 branch as well as 3 specs in admin/enterprises_controller_spec and 1 in api/enterprises_controller_spec
