### PR TITLE
Bring Spree::Variant#active from Spree so that we can improve it

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -89,7 +89,6 @@ Layout/LineLength:
   - app/models/spree/tax_rate_decorator.rb
   - app/models/spree/taxon_decorator.rb
   - app/models/spree/user.rb
-  - app/models/spree/variant_decorator.rb
   - app/models/subscription.rb
   - app/models/variant_override.rb
   - app/models/variant_override_set.rb

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -88,11 +88,12 @@ Spree::Variant.class_eval do
   def self.active(currency = nil)
     # "where(id:" is necessary so that the returned relation has no includes
     # The relation without includes will not be readonly and allow updates on it
-    where(id: joins(:prices).
-                where(deleted_at: nil).
-                where('spree_prices.currency' => currency || Spree::Config[:currency]).
-                where('spree_prices.amount IS NOT NULL').
-                select("spree_variants.id"))
+    where("spree_variants.id in (?)", joins(:prices).
+                                        where(deleted_at: nil).
+                                        where('spree_prices.currency' =>
+                                          currency || Spree::Config[:currency]).
+                                        where('spree_prices.amount IS NOT NULL').
+                                        select("spree_variants.id"))
   end
 
   # We override in_stock? to avoid depending on the non-overridable method Spree::Stock::Quantifier.can_supply?

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -85,6 +85,10 @@ Spree::Variant.class_eval do
     ]
   end
 
+  def self.active(currency = nil)
+    where(id: joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL').select("spree_variants.id"))
+  end
+
   # We override in_stock? to avoid depending on the non-overridable method Spree::Stock::Quantifier.can_supply?
   #   VariantStock implements can_supply? itself which depends on overridable methods
   def in_stock?(quantity = 1)

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -86,7 +86,13 @@ Spree::Variant.class_eval do
   end
 
   def self.active(currency = nil)
-    where(id: joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL').select("spree_variants.id"))
+    # "where(id:" is necessary so that the returned relation has no includes
+    # The relation without includes will not be readonly and allow updates on it
+    where(id: joins(:prices).
+                where(deleted_at: nil).
+                where('spree_prices.currency' => currency || Spree::Config[:currency]).
+                where('spree_prices.amount IS NOT NULL').
+                select("spree_variants.id"))
   end
 
   # We override in_stock? to avoid depending on the non-overridable method Spree::Stock::Quantifier.can_supply?

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -16,7 +16,8 @@ Spree::Variant.class_eval do
   has_many :variant_overrides
   has_many :inventory_items
 
-  attr_accessible :unit_value, :unit_description, :images_attributes, :display_as, :display_name, :import_date
+  attr_accessible :unit_value, :unit_description, :images_attributes,
+                  :display_as, :display_name, :import_date
   accepts_nested_attributes_for :images
 
   validates :unit_value, presence: true, if: ->(variant) {
@@ -53,13 +54,23 @@ Spree::Variant.class_eval do
   }
 
   scope :visible_for, lambda { |enterprise|
-    joins(:inventory_items).where('inventory_items.enterprise_id = (?) AND inventory_items.visible = (?)', enterprise, true)
+    joins(:inventory_items).
+      where(
+        'inventory_items.enterprise_id = (?) AND inventory_items.visible = (?)',
+        enterprise,
+        true
+      )
   }
 
   scope :not_hidden_for, lambda { |enterprise|
     return where("1=0") if enterprise.blank?
 
-    joins("LEFT OUTER JOIN (SELECT * from inventory_items WHERE enterprise_id = #{sanitize enterprise.andand.id}) AS o_inventory_items ON o_inventory_items.variant_id = spree_variants.id")
+    joins("
+      LEFT OUTER JOIN (SELECT *
+                         FROM inventory_items
+                         WHERE enterprise_id = #{sanitize enterprise.andand.id})
+        AS o_inventory_items
+        ON o_inventory_items.variant_id = spree_variants.id")
       .where("o_inventory_items.id IS NULL OR o_inventory_items.visible = (?)", true)
   }
 
@@ -68,7 +79,8 @@ Spree::Variant.class_eval do
   scope :stockable_by, lambda { |enterprise|
     return where("1=0") if enterprise.blank?
 
-    joins(:product).where(spree_products: { id: Spree::Product.stockable_by(enterprise).pluck(:id) })
+    joins(:product).
+      where(spree_products: { id: Spree::Product.stockable_by(enterprise).pluck(:id) })
   }
 
   # Define sope as class method to allow chaining with other scopes filtering id.
@@ -96,7 +108,8 @@ Spree::Variant.class_eval do
                                         select("spree_variants.id"))
   end
 
-  # We override in_stock? to avoid depending on the non-overridable method Spree::Stock::Quantifier.can_supply?
+  # We override in_stock? to avoid depending
+  #   on the non-overridable method Spree::Stock::Quantifier.can_supply?
   #   VariantStock implements can_supply? itself which depends on overridable methods
   def in_stock?(quantity = 1)
     can_supply?(quantity)


### PR DESCRIPTION
#### What? Why?

Fixes spec/controllers/api/variants_controller_spec.rb:94, the variants returned by #scope are not readonly anymore in the rails 4 branch. 
Original code in spree: https://github.com/openfoodfoundation/spree/blob/8a8585a43cd04d1a50dc65227f337a91b18d66d5/core/app/models/spree/variant.rb#L49
See commit message.

### What should we test?
Edit and delete variants in both the bulk_product_update page and the variants list and edit pages.

#### Release notes
Changelog Category: Changed
Adapted variants code to work in rails 4.
