### PR TITLE
Fix line_items_controller_spec in the rails 4 branch

### DIFF
--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -59,7 +59,10 @@ describe LineItemsController, type: :controller do
         end
 
         context "where the item's order is associated with the current user" do
-          before { order.update_attributes!(user_id: user.id) }
+          before do
+            order.update_attributes!(user_id: user.id)
+            allow(controller).to receive_messages spree_current_user: item.order.user
+          end
 
           context "without an order cycle or distributor" do
             it "denies deletion" do


### PR DESCRIPTION

#### What? Why?

This fixes spec/controllers/line_items_controller_spec.rb:86 in the rails 4 branch.

#### What should we test?
Green build is enough.

#### Release notes
Changelog Category: Changed
Adapted cart management test code to rails 4.
