### PR TITLE
[Spree 2.1] Fix tag rule applicator in enterprises_helper

### DIFF
--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -14,7 +14,7 @@ module EnterprisesHelper
   def available_shipping_methods
     return [] if current_distributor.blank?
 
-    shipping_methods = current_distributor.shipping_methods
+    shipping_methods = current_distributor.shipping_methods.to_a
 
     applicator = OpenFoodNetwork::TagRuleApplicator.new(current_distributor, "FilterShippingMethods", current_customer.andand.tag_list)
     applicator.filter!(shipping_methods)


### PR DESCRIPTION
#### What? Why?

Fixes enterprises_helper_spec. 
shipping_methods is fetched as an association in current_distributor and the changes done on the applicator on that object will not stick. Converting it to an array fixes the problem.
Note: for the payment_methods just below, if only payment_methods were used we would have the same problem of having an ActiveRecord::Associations::CollectionProxy. But in this case, in the end of the fetching we call .all which converts the collection to an array already.

#### What should we test?
Green spec.
