### PR TITLE
[Spree 2.1] Use latest version of spree which includes PR openfoodfoundation/spree#39

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 95d3ccb32f2e4016d0fc73f39446d1739da56c50
+  revision: b7ad5b473f9e38c5a1882550b2b4e348f4824f1f
   branch: 2-1-0-stable
   specs:
     spree_core (2.1.0)

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -118,4 +118,8 @@ FactoryBot.modify do
       end
     end
   end
+
+  factory :completed_order_with_totals do
+    distributor { create(:distributor_enterprise) }
+  end
 end


### PR DESCRIPTION
#### What? Why?

The branch spree 2-1-0-stable was built from scratch from the oficial spree 2.1-0 version. Our custom commits were cherry-picked one by one on top of it.

I found that when doing this I missed the commits in openfoodfoundation/spree#39.
I have added these 2 commits to the 2-1-0-stable version now and this PR makes the OFN 3-0-stable use that version.

As we move into this code we have to adapt spree factory completed_order_with_totals so that it contains a distributor.

This fixes a few specs on the upgrade build :muscle: 

#### What should we test?
green spec/features/admin/orders_spec.rb:306

