### PR TITLE
Allow data archiving using the :truncate_data task

### DIFF
--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -28,8 +28,7 @@ namespace :ofn do
     task :truncate, [:months_to_keep] => :environment do |_task, args|
       warn_with_confirmation
 
-      months_to_keep = args.months_to_keep.to_i
-      TruncateData.new(months_to_keep).call
+      TruncateData.new(args.months_to_keep).call
     end
 
     def warn_with_confirmation

--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -9,10 +9,11 @@ require 'tasks/data/truncate_data'
 namespace :ofn do
   namespace :data do
     desc 'Truncate data'
-    task truncate: :environment do
+    task :truncate, [:months_to_keep] => :environment do |_task, args|
       guard_and_warn
 
-      TruncateData.new.call
+      months_to_keep = args.months_to_keep.to_i
+      TruncateData.new(months_to_keep).call
     end
 
     def guard_and_warn

--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -40,7 +40,7 @@ namespace :ofn do
       Are you sure you want to proceed? (y/N)
       MSG
 
-      exit unless HighLine.new.agree(message) { |q| q.default = "N" }
+      exit unless HighLine.new.agree(message) { |question| question.default = "N" }
     end
   end
 end

--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -6,6 +6,22 @@ require 'tasks/data/truncate_data'
 # This task can be used to significantly reduce the size of a database
 #   This is used for example when loading live data into a staging server
 #   This way the staging server is not overloaded with too much data
+#
+# This is also aimed at implementing data archiving. We assume data older than
+# 2 years can be safely removed and restored from a backup. This gives room for
+# hubs to do their tax declaration.
+#
+# It's a must to perform a backup right before executing this. Then, to allow
+# for a later data recovery we need to keep track of the exact moment this rake
+# task was executed.
+#
+# Execute this in production only when the instance users are sleeping to avoid any trouble.
+#
+# Example:
+#
+# $ bundle exec rake "ofn:data:truncate[24]"
+#
+# This will remove data older than 2 years (24 months).
 namespace :ofn do
   namespace :data do
     desc 'Truncate data'

--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -10,20 +10,18 @@ namespace :ofn do
   namespace :data do
     desc 'Truncate data'
     task :truncate, [:months_to_keep] => :environment do |_task, args|
-      guard_and_warn
+      warn_with_confirmation
 
       months_to_keep = args.months_to_keep.to_i
       TruncateData.new(months_to_keep).call
     end
 
-    def guard_and_warn
-      if Rails.env.production?
-        Rails.logger.info("This task cannot be executed in production")
-        exit
-      end
-
-      message = "\n <%= color('This will permanently change DB contents', :yellow) %>,
-                are you sure you want to proceed? (y/N)"
+    def warn_with_confirmation
+      message = <<-MSG.strip_heredoc
+      \n
+      <%= color('This will permanently change DB contents. Please, make a backup first.', :yellow) %>
+      Are you sure you want to proceed? (y/N)
+      MSG
       exit unless HighLine.new.agree(message) { |q| q.default = "n" }
     end
   end

--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -34,7 +34,7 @@ namespace :ofn do
     def warn_with_confirmation
       message = <<-MSG.strip_heredoc
       \n
-      <% highlighted_message = "This will permanently change DB contents. Please, make a backup first." %>
+      <% highlighted_message = "This will permanently change DB contents. This is not meant to be run in production as it needs more thorough testing." %>
       <%= color(highlighted_message, :blink, :on_red) %>
       Are you sure you want to proceed? (y/N)
       MSG

--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -35,10 +35,12 @@ namespace :ofn do
     def warn_with_confirmation
       message = <<-MSG.strip_heredoc
       \n
-      <%= color('This will permanently change DB contents. Please, make a backup first.', :yellow) %>
+      <% highlighted_message = "This will permanently change DB contents. Please, make a backup first." %>
+      <%= color(highlighted_message, :blink, :on_red) %>
       Are you sure you want to proceed? (y/N)
       MSG
-      exit unless HighLine.new.agree(message) { |q| q.default = "n" }
+
+      exit unless HighLine.new.agree(message) { |q| q.default = "N" }
     end
   end
 end

--- a/lib/tasks/data/truncate_data.rake
+++ b/lib/tasks/data/truncate_data.rake
@@ -1,3 +1,8 @@
+# frozen_string_literal: true
+
+require 'highline'
+require 'tasks/data/truncate_data'
+
 # This task can be used to significantly reduce the size of a database
 #   This is used for example when loading live data into a staging server
 #   This way the staging server is not overloaded with too much data
@@ -7,75 +12,18 @@ namespace :ofn do
     task truncate: :environment do
       guard_and_warn
 
-      sql_delete_from "
-        spree_inventory_units #{where_order_id_in_orders_to_delete}"
-      sql_delete_from "
-        spree_inventory_units
-        where shipment_id in (select id from spree_shipments #{where_order_id_in_orders_to_delete})"
-
-      truncate_adjustments
-
-      sql_delete_from "spree_line_items #{where_order_id_in_orders_to_delete}"
-      sql_delete_from "spree_payments #{where_order_id_in_orders_to_delete}"
-      sql_delete_from "spree_shipments #{where_order_id_in_orders_to_delete}"
-      Spree::ReturnAuthorization.delete_all
-
-      truncate_order_cycle_data
-
-      sql_delete_from "proxy_orders #{where_oc_id_in_ocs_to_delete}"
-
-      sql_delete_from "spree_orders #{where_oc_id_in_ocs_to_delete}"
-      sql_delete_from "order_cycle_schedules #{where_oc_id_in_ocs_to_delete}"
-      sql_delete_from "order_cycles #{where_ocs_to_delete}"
-
-      Spree::TokenizedPermission.where("created_at < '#{date}'").delete_all
-      Spree::StateChange.delete_all
-      Spree::LogEntry.delete_all
-      sql_delete_from "sessions"
+      TruncateData.new.call
     end
 
-    def sql_delete_from(sql)
-      ActiveRecord::Base.connection.execute("delete from #{sql}")
-    end
+    def guard_and_warn
+      if Rails.env.production?
+        Rails.logger.info("This task cannot be executed in production")
+        exit
+      end
 
-    private
-
-    def date
-      3.months.ago
-    end
-
-    def where_ocs_to_delete
-      "where orders_close_at < '#{date}'"
-    end
-
-    def where_oc_id_in_ocs_to_delete
-      "where order_cycle_id in (select id from order_cycles #{where_ocs_to_delete} )"
-    end
-
-    def where_order_id_in_orders_to_delete
-      "where order_id in (select id from spree_orders #{where_oc_id_in_ocs_to_delete})"
-    end
-
-    def truncate_adjustments
-      sql_delete_from "spree_adjustments where source_type = 'Spree::Order'
-        and source_id in (select id from spree_orders #{where_oc_id_in_ocs_to_delete})"
-      sql_delete_from "spree_adjustments where source_type = 'Spree::Shipment'
-        and source_id in (select id from spree_shipments #{where_order_id_in_orders_to_delete})"
-      sql_delete_from "spree_adjustments where source_type = 'Spree::Payment'
-        and source_id in (select id from spree_payments #{where_order_id_in_orders_to_delete})"
-      sql_delete_from "spree_adjustments where source_type = 'Spree::LineItem'
-        and source_id in (select id from spree_line_items #{where_order_id_in_orders_to_delete})"
-    end
-
-    def truncate_order_cycle_data
-      sql_delete_from "coordinator_fees #{where_oc_id_in_ocs_to_delete}"
-      sql_delete_from "
-        exchange_variants where exchange_id
-        in (select id from exchanges #{where_oc_id_in_ocs_to_delete})"
-      sql_delete_from "
-        exchange_fees where exchange_id
-        in (select id from exchanges #{where_oc_id_in_ocs_to_delete})"
-      sql_delete_from "exchanges #{where_oc_id_in_ocs_to_delete}"
+      message = "\n <%= color('This will permanently change DB contents', :yellow) %>,
+                are you sure you want to proceed? (y/N)"
+      exit unless HighLine.new.agree(message) { |q| q.default = "n" }
     end
   end
 end

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -36,10 +36,10 @@ class TruncateData
     sql_delete_from "spree_line_items #{where_order_id_in_orders_to_delete}"
     sql_delete_from "spree_payments #{where_order_id_in_orders_to_delete}"
     sql_delete_from "spree_shipments #{where_order_id_in_orders_to_delete}"
+    sql_delete_from "spree_return_authorizations #{where_order_id_in_orders_to_delete}"
   end
 
   def remove_transient_data
-    Spree::ReturnAuthorization.delete_all
     Spree::StateChange.delete_all("created_at < '#{1.month.ago.to_date}'")
     Spree::LogEntry.delete_all("created_at < '#{1.month.ago.to_date}'")
     Session.delete_all("created_at < '#{2.weeks.ago.to_date}'")

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -70,13 +70,16 @@ class TruncateData
 
   def truncate_adjustments
     sql_delete_from "spree_adjustments where source_type = 'Spree::Order'
-    and source_id in (select id from spree_orders #{where_oc_id_in_ocs_to_delete})"
+      and source_id in (select id from spree_orders #{where_oc_id_in_ocs_to_delete})"
+
     sql_delete_from "spree_adjustments where source_type = 'Spree::Shipment'
-                      and source_id in (select id from spree_shipments #{where_order_id_in_orders_to_delete})"
+      and source_id in (select id from spree_shipments #{where_order_id_in_orders_to_delete})"
+
     sql_delete_from "spree_adjustments where source_type = 'Spree::Payment'
-                                        and source_id in (select id from spree_payments #{where_order_id_in_orders_to_delete})"
+      and source_id in (select id from spree_payments #{where_order_id_in_orders_to_delete})"
+
     sql_delete_from "spree_adjustments where source_type = 'Spree::LineItem'
-                                                          and source_id in (select id from spree_line_items #{where_order_id_in_orders_to_delete})"
+      and source_id in (select id from spree_line_items #{where_order_id_in_orders_to_delete})"
   end
 
   def truncate_order_cycle_data

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -34,7 +34,7 @@ class TruncateData
 
   def remove_transient_data
     Spree::ReturnAuthorization.delete_all
-    Spree::StateChange.delete_all
+    Spree::StateChange.delete_all("created_at < '#{1.month.ago.to_date}'")
     Spree::LogEntry.delete_all
     sql_delete_from "sessions"
   end

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -53,7 +53,7 @@ class TruncateData
   end
 
   def sql_delete_from(sql)
-    ActiveRecord::Base.connection.execute("delete from #{sql}")
+    ActiveRecord::Base.connection.execute("DELETE FROM #{sql}")
   end
 
   def where_order_id_in_orders_to_delete

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -12,25 +12,33 @@ class TruncateData
   end
 
   def call
-    truncate_inventory
-    truncate_adjustments
-    truncate_order_associations
-    truncate_order_cycle_data
+    logging do
+      truncate_inventory
+      truncate_adjustments
+      truncate_order_associations
+      truncate_order_cycle_data
 
-    sql_delete_from "spree_orders #{where_oc_id_in_ocs_to_delete}"
+      sql_delete_from "spree_orders #{where_oc_id_in_ocs_to_delete}"
 
-    truncate_subscriptions
+      truncate_subscriptions
 
-    sql_delete_from "order_cycles #{where_ocs_to_delete}"
+      sql_delete_from "order_cycles #{where_ocs_to_delete}"
 
-    Spree::TokenizedPermission.where("created_at < '#{date}'").delete_all
+      Spree::TokenizedPermission.where("created_at < '#{date}'").delete_all
 
-    remove_transient_data
+      remove_transient_data
+    end
   end
 
   private
 
   attr_reader :date
+
+  def logging
+    Rails.logger.info("TruncateData started with truncation date #{date}")
+    yield
+    Rails.logger.info("TruncateData finished")
+  end
 
   def truncate_order_associations
     sql_delete_from "spree_line_items #{where_order_id_in_orders_to_delete}"

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -35,7 +35,7 @@ class TruncateData
   def remove_transient_data
     Spree::ReturnAuthorization.delete_all
     Spree::StateChange.delete_all("created_at < '#{1.month.ago.to_date}'")
-    Spree::LogEntry.delete_all
+    Spree::LogEntry.delete_all("created_at < '#{1.month.ago.to_date}'")
     sql_delete_from "sessions"
   end
 

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TruncateData
-  def initialize(months_to_keep: nil)
+  def initialize(months_to_keep = nil)
     @date = (months_to_keep || 3).months.ago
   end
 

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class TruncateData
+  def initialize(months_to_keep: nil)
+    @date = (months_to_keep || 3).months.ago
+  end
+
+  def call
+    sql_delete_from "
+        spree_inventory_units #{where_order_id_in_orders_to_delete}"
+    sql_delete_from "
+        spree_inventory_units
+        where shipment_id in (select id from spree_shipments #{where_order_id_in_orders_to_delete})"
+
+    truncate_adjustments
+
+    sql_delete_from "spree_line_items #{where_order_id_in_orders_to_delete}"
+    sql_delete_from "spree_payments #{where_order_id_in_orders_to_delete}"
+    sql_delete_from "spree_shipments #{where_order_id_in_orders_to_delete}"
+    Spree::ReturnAuthorization.delete_all
+
+    truncate_order_cycle_data
+
+    sql_delete_from "proxy_orders #{where_oc_id_in_ocs_to_delete}"
+
+    sql_delete_from "spree_orders #{where_oc_id_in_ocs_to_delete}"
+    sql_delete_from "order_cycle_schedules #{where_oc_id_in_ocs_to_delete}"
+    sql_delete_from "order_cycles #{where_ocs_to_delete}"
+
+    Spree::TokenizedPermission.where("created_at < '#{date}'").delete_all
+    Spree::StateChange.delete_all
+    Spree::LogEntry.delete_all
+    sql_delete_from "sessions"
+  end
+
+  private
+
+  attr_reader :date
+
+  def sql_delete_from(sql)
+    ActiveRecord::Base.connection.execute("delete from #{sql}")
+  end
+
+  def where_order_id_in_orders_to_delete
+    "where order_id in (select id from spree_orders #{where_oc_id_in_ocs_to_delete})"
+  end
+
+  def where_oc_id_in_ocs_to_delete
+    "where order_cycle_id in (select id from order_cycles #{where_ocs_to_delete} )"
+  end
+
+  def where_ocs_to_delete
+    "where orders_close_at < '#{date}'"
+  end
+
+  def truncate_adjustments
+    sql_delete_from "spree_adjustments where source_type = 'Spree::Order'
+    and source_id in (select id from spree_orders #{where_oc_id_in_ocs_to_delete})"
+    sql_delete_from "spree_adjustments where source_type = 'Spree::Shipment'
+                      and source_id in (select id from spree_shipments #{where_order_id_in_orders_to_delete})"
+    sql_delete_from "spree_adjustments where source_type = 'Spree::Payment'
+                                        and source_id in (select id from spree_payments #{where_order_id_in_orders_to_delete})"
+    sql_delete_from "spree_adjustments where source_type = 'Spree::LineItem'
+                                                          and source_id in (select id from spree_line_items #{where_order_id_in_orders_to_delete})"
+  end
+
+  def truncate_order_cycle_data
+    sql_delete_from "coordinator_fees #{where_oc_id_in_ocs_to_delete}"
+    sql_delete_from "
+    exchange_variants where exchange_id
+    in (select id from exchanges #{where_oc_id_in_ocs_to_delete})"
+    sql_delete_from "
+        exchange_fees where exchange_id
+        in (select id from exchanges #{where_oc_id_in_ocs_to_delete})"
+    sql_delete_from "exchanges #{where_oc_id_in_ocs_to_delete}"
+  end
+end

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -8,7 +8,7 @@ class TruncateData
   end
 
   def initialize(months_to_keep = nil)
-    @date = (months_to_keep || 3).months.ago
+    @date = (months_to_keep || 3).to_i.months.ago
   end
 
   def call

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -8,7 +8,7 @@ class TruncateData
   end
 
   def initialize(months_to_keep = nil)
-    @date = (months_to_keep || 3).to_i.months.ago
+    @date = (months_to_keep || 24).to_i.months.ago
   end
 
   def call

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class TruncateData
+  # This model lets us operate on the sessions DB table using ActiveRecord's
+  # methods within the scope of this service. This relies on the AR's
+  # convention where a Session model maps to a sessions table.
+  class Session < ActiveRecord::Base
+  end
+
   def initialize(months_to_keep = nil)
     @date = (months_to_keep || 3).months.ago
   end
@@ -36,7 +42,7 @@ class TruncateData
     Spree::ReturnAuthorization.delete_all
     Spree::StateChange.delete_all("created_at < '#{1.month.ago.to_date}'")
     Spree::LogEntry.delete_all("created_at < '#{1.month.ago.to_date}'")
-    sql_delete_from "sessions"
+    Session.delete_all("created_at < '#{2.weeks.ago.to_date}'")
   end
 
   def truncate_subscriptions

--- a/spec/lib/tasks/data/truncate_data_rake_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_rake_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'truncate_data.rake' do
+  describe ':truncate' do
+    context 'when months_to_keep is specified' do
+      it 'truncates order cycles closed earlier than months_to_keep months ago' do
+        Rake.application.rake_require 'tasks/data/truncate_data'
+        Rake::Task.define_task(:environment)
+
+        highline = instance_double(HighLine, agree: true)
+        allow(HighLine).to receive(:new).and_return(highline)
+
+        old_order_cycle = create(
+          :order_cycle,
+          orders_open_at: 7.months.ago,
+          orders_close_at: 7.months.ago + 1.day,
+        )
+        create(:order, order_cycle: old_order_cycle)
+        recent_order_cycle = create(
+          :order_cycle,
+          orders_open_at: 1.months.ago,
+          orders_close_at: 1.months.ago + 1.day,
+        )
+        create(:order, order_cycle: recent_order_cycle)
+
+        months_to_keep = 6
+        Rake.application.invoke_task "ofn:data:truncate[#{months_to_keep}]"
+
+        expect(OrderCycle.all).to contain_exactly(recent_order_cycle)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'tasks/data/truncate_data'
+
+describe TruncateData do
+  describe '#call' do
+    before do
+      allow(Spree::ReturnAuthorization).to receive(:delete_all)
+      allow(Spree::StateChange).to receive(:delete_all)
+      allow(Spree::LogEntry).to receive(:delete_all)
+    end
+
+    context 'when months_to_keep is not specified' do
+      it 'truncates order cycles closed earlier than 3 months ago' do
+        order_cycle = create(
+          :order_cycle, orders_open_at: 4.months.ago, orders_close_at: 4.months.ago + 1.day
+        )
+        create(:order, order_cycle: order_cycle)
+
+        TruncateData.new.call
+
+        expect(OrderCycle.all).to be_empty
+      end
+    end
+
+    context 'when months_to_keep is nil' do
+      it 'truncates order cycles closed earlier than 3 months ago' do
+        order_cycle = create(
+          :order_cycle, orders_open_at: 4.months.ago, orders_close_at: 4.months.ago + 1.day
+        )
+        create(:order, order_cycle: order_cycle)
+
+        TruncateData.new(months_to_keep: nil).call
+
+        expect(OrderCycle.all).to be_empty
+      end
+    end
+
+    context 'when months_to_keep is specified' do
+      it 'truncates order cycles closed earlier than months_to_keep months ago' do
+        old_order_cycle = create(
+          :order_cycle, orders_open_at: 7.months.ago, orders_close_at: 7.months.ago + 1.day
+        )
+        create(:order, order_cycle: old_order_cycle)
+        recent_order_cycle = create(
+          :order_cycle, orders_open_at: 1.months.ago, orders_close_at: 1.months.ago + 1.day
+        )
+        create(:order, order_cycle: recent_order_cycle)
+
+        TruncateData.new(months_to_keep: 6).call
+
+        expect(OrderCycle.all).to contain_exactly(recent_order_cycle)
+      end
+    end
+  end
+end
+

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -29,7 +29,7 @@ describe TruncateData do
         )
         create(:order, order_cycle: order_cycle)
 
-        TruncateData.new(months_to_keep: nil).call
+        TruncateData.new(nil).call
 
         expect(OrderCycle.all).to be_empty
       end
@@ -46,7 +46,7 @@ describe TruncateData do
         )
         create(:order, order_cycle: recent_order_cycle)
 
-        TruncateData.new(months_to_keep: 6).call
+        TruncateData.new(6).call
 
         expect(OrderCycle.all).to contain_exactly(recent_order_cycle)
       end

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -7,6 +7,7 @@ describe TruncateData do
       allow(Spree::ReturnAuthorization).to receive(:delete_all)
       allow(Spree::StateChange).to receive(:delete_all)
       allow(Spree::LogEntry).to receive(:delete_all)
+      allow(TruncateData::Session).to receive(:delete_all)
     end
 
     context 'when months_to_keep is not specified' do
@@ -36,6 +37,14 @@ describe TruncateData do
           .to have_received(:delete_all)
           .with("created_at < '#{1.month.ago.to_date}'")
       end
+
+      it 'deletes sessions older than two weeks' do
+        TruncateData.new.call
+
+        expect(TruncateData::Session)
+          .to have_received(:delete_all)
+          .with("created_at < '#{2.weeks.ago.to_date}'")
+      end
     end
 
     context 'when months_to_keep is nil' do
@@ -64,6 +73,14 @@ describe TruncateData do
         expect(Spree::LogEntry)
           .to have_received(:delete_all)
           .with("created_at < '#{1.month.ago.to_date}'")
+      end
+
+      it 'deletes sessions older than two weeks' do
+        TruncateData.new.call
+
+        expect(TruncateData::Session)
+          .to have_received(:delete_all)
+          .with("created_at < '#{2.weeks.ago.to_date}'")
       end
     end
 
@@ -97,6 +114,14 @@ describe TruncateData do
         expect(Spree::LogEntry)
           .to have_received(:delete_all)
           .with("created_at < '#{1.month.ago.to_date}'")
+      end
+
+      it 'deletes sessions older than two weeks' do
+        TruncateData.new.call
+
+        expect(TruncateData::Session)
+          .to have_received(:delete_all)
+          .with("created_at < '#{2.weeks.ago.to_date}'")
       end
     end
   end

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -28,6 +28,14 @@ describe TruncateData do
           .to have_received(:delete_all)
           .with("created_at < '#{1.month.ago.to_date}'")
       end
+
+      it 'deletes log entries older than a month' do
+        TruncateData.new.call
+
+        expect(Spree::LogEntry)
+          .to have_received(:delete_all)
+          .with("created_at < '#{1.month.ago.to_date}'")
+      end
     end
 
     context 'when months_to_keep is nil' do
@@ -46,6 +54,14 @@ describe TruncateData do
         TruncateData.new.call
 
         expect(Spree::StateChange)
+          .to have_received(:delete_all)
+          .with("created_at < '#{1.month.ago.to_date}'")
+      end
+
+      it 'deletes log entries older than a month' do
+        TruncateData.new.call
+
+        expect(Spree::LogEntry)
           .to have_received(:delete_all)
           .with("created_at < '#{1.month.ago.to_date}'")
       end
@@ -71,6 +87,14 @@ describe TruncateData do
         TruncateData.new.call
 
         expect(Spree::StateChange)
+          .to have_received(:delete_all)
+          .with("created_at < '#{1.month.ago.to_date}'")
+      end
+
+      it 'deletes log entries older than a month' do
+        TruncateData.new.call
+
+        expect(Spree::LogEntry)
           .to have_received(:delete_all)
           .with("created_at < '#{1.month.ago.to_date}'")
       end

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -8,6 +8,7 @@ describe TruncateData do
       allow(Spree::StateChange).to receive(:delete_all)
       allow(Spree::LogEntry).to receive(:delete_all)
       allow(TruncateData::Session).to receive(:delete_all)
+      allow(Rails.logger).to receive(:info)
     end
 
     context 'when months_to_keep is not specified' do

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -12,9 +12,9 @@ describe TruncateData do
     end
 
     context 'when months_to_keep is not specified' do
-      it 'truncates order cycles closed earlier than 3 months ago' do
+      it 'truncates order cycles closed earlier than 2 years ago' do
         order_cycle = create(
-          :order_cycle, orders_open_at: 4.months.ago, orders_close_at: 4.months.ago + 1.day
+          :order_cycle, orders_open_at: 25.months.ago, orders_close_at: 25.months.ago + 1.day
         )
         create(:order, order_cycle: order_cycle)
 
@@ -49,9 +49,9 @@ describe TruncateData do
     end
 
     context 'when months_to_keep is nil' do
-      it 'truncates order cycles closed earlier than 3 months ago' do
+      it 'truncates order cycles closed earlier than 2 years ago' do
         order_cycle = create(
-          :order_cycle, orders_open_at: 4.months.ago, orders_close_at: 4.months.ago + 1.day
+          :order_cycle, orders_open_at: 25.months.ago, orders_close_at: 25.months.ago + 1.day
         )
         create(:order, order_cycle: order_cycle)
 

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -20,6 +20,14 @@ describe TruncateData do
 
         expect(OrderCycle.all).to be_empty
       end
+
+      it 'deletes state changes older than a month' do
+        TruncateData.new.call
+
+        expect(Spree::StateChange)
+          .to have_received(:delete_all)
+          .with("created_at < '#{1.month.ago.to_date}'")
+      end
     end
 
     context 'when months_to_keep is nil' do
@@ -32,6 +40,14 @@ describe TruncateData do
         TruncateData.new(nil).call
 
         expect(OrderCycle.all).to be_empty
+      end
+
+      it 'deletes state changes older than a month' do
+        TruncateData.new.call
+
+        expect(Spree::StateChange)
+          .to have_received(:delete_all)
+          .with("created_at < '#{1.month.ago.to_date}'")
       end
     end
 
@@ -49,6 +65,14 @@ describe TruncateData do
         TruncateData.new(6).call
 
         expect(OrderCycle.all).to contain_exactly(recent_order_cycle)
+      end
+
+      it 'deletes state changes older than a month' do
+        TruncateData.new.call
+
+        expect(Spree::StateChange)
+          .to have_received(:delete_all)
+          .with("created_at < '#{1.month.ago.to_date}'")
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #4782 (I hope)

This refactors the `:truncate_data` rake task to allow for the removal of old data from an OFN instance as a mean for data archiving. Older data can still be recovered from an older backup. We just need to know when the data archiving was performed and go find the backup we made right
before.

It extracts the `TruncateData` service to make it possible to test without the annoyance of rake task testing. It's not a straightforward thing as you can see in https://thoughtbot.com/blog/test-rake-tasks-like-a-boss. It's a headache we can avoid if we conform to the testing pyramid.

This also gives us room to iterate on our data archiving strategy as we move along.

All credit goes to @lin-d-hop for insisting on the idea of data archiving.

##### Heads-up
:warning: to truncate data in staging as we used to you'll need to run 

```
$ bundle exec rake "ofn:data:truncate[3]"
```
That's because we switched the default 3 months to 24.

#### What should we test?

Test that loading production data in staging and then truncating it keeps working as expected. There should be no data integrity issues.

#### Release notes

Refactored truncate data rake task and default to 24 months instead of 3.
Changelog Category: Changed