### PR TITLE
Fixes spec/services/order_syncer_spec in rails 4

### DIFF
--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -15,6 +15,7 @@ describe OrderSyncer do
       before do
         # Create shipping rates for available shipping methods.
         order.shipments.each(&:refresh_rates)
+        order.select_shipping_method(shipping_method)
       end
 
       it "updates the shipping_method on the order and on shipments" do


### PR DESCRIPTION
#### What? Why?

We make this spec more reliable. We shouldnt rely on refresh_shipping_rates to select the ship method we want. We should select it ourselves. This was breaking the spec in rails 4 branch.

#### What should we test?
green build.

#### Release notes
Changelog Category: Changed
Adapt test code to work in rails 4.
