### PR TITLE
Fix problem with misssing params in schedules controller

### DIFF
--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -3,6 +3,7 @@ require 'open_food_network/proxy_order_syncer'
 
 module Admin
   class SchedulesController < ResourceController
+    before_filter :adapt_params, only: [:create, :update]
     before_filter :check_editable_order_cycle_ids, only: [:create, :update]
     before_filter :check_dependent_subscriptions, only: [:destroy]
     create.after :sync_subscriptions
@@ -46,6 +47,14 @@ module Admin
 
     def collection_actions
       [:index]
+    end
+
+    # In this controller, params like params[:name] are moved into params[:schedule] becoming params[:schedule][:name]
+    # For some reason in rails 4, this is not happening for params[:order_cycle_ids]
+    #   We do it manually in this filter
+    def adapt_params
+      params[:schedule] = {} if params[:schedule].blank?
+      params[:schedule][:order_cycle_ids] = params[:order_cycle_ids]
     end
 
     def check_editable_order_cycle_ids

--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -93,7 +93,7 @@ describe Admin::SchedulesController, type: :controller do
 
         it "allows me to add/remove only order cycles I coordinate to/from the schedule" do
           order_cycle_ids = [coordinated_order_cycle2.id, uncoordinated_order_cycle2.id, uncoordinated_order_cycle3.id]
-          spree_put :update, format: :json, id: coordinated_schedule.id, schedule: { order_cycle_ids: order_cycle_ids }
+          spree_put :update, format: :json, id: coordinated_schedule.id, order_cycle_ids: order_cycle_ids
           expect(assigns(:schedule)).to eq coordinated_schedule
           # coordinated_order_cycle2 is added, uncoordinated_order_cycle is NOT removed
           expect(coordinated_schedule.reload.order_cycles).to include coordinated_order_cycle2, uncoordinated_order_cycle, uncoordinated_order_cycle3
@@ -106,9 +106,9 @@ describe Admin::SchedulesController, type: :controller do
           allow(OpenFoodNetwork::ProxyOrderSyncer).to receive(:new) { syncer_mock }
           expect(syncer_mock).to receive(:sync!).exactly(2).times
 
-          spree_put :update, format: :json, id: coordinated_schedule.id, schedule: { order_cycle_ids: [coordinated_order_cycle.id, coordinated_order_cycle2.id] }
-          spree_put :update, format: :json, id: coordinated_schedule.id, schedule: { order_cycle_ids: [coordinated_order_cycle.id] }
-          spree_put :update, format: :json, id: coordinated_schedule.id, schedule: { order_cycle_ids: [coordinated_order_cycle.id] }
+          spree_put :update, format: :json, id: coordinated_schedule.id, order_cycle_ids: [coordinated_order_cycle.id, coordinated_order_cycle2.id]
+          spree_put :update, format: :json, id: coordinated_schedule.id, order_cycle_ids: [coordinated_order_cycle.id]
+          spree_put :update, format: :json, id: coordinated_schedule.id, order_cycle_ids: [coordinated_order_cycle.id]
         end
       end
 
@@ -151,7 +151,7 @@ describe Admin::SchedulesController, type: :controller do
 
         context "where I manage at least one of the order cycles to be added to the schedules" do
           before do
-            params[:schedule].merge!( order_cycle_ids: [coordinated_order_cycle.id, uncoordinated_order_cycle.id] )
+            params.merge!( order_cycle_ids: [coordinated_order_cycle.id, uncoordinated_order_cycle.id] )
           end
 
           it "allows me to create the schedule, adding only order cycles that I manage" do
@@ -172,7 +172,7 @@ describe Admin::SchedulesController, type: :controller do
 
         context "where I don't manage any of the order cycles to be added to the schedules" do
           before do
-            params[:schedule].merge!( order_cycle_ids: [uncoordinated_order_cycle.id] )
+            params.merge!( order_cycle_ids: [uncoordinated_order_cycle.id] )
           end
 
           it "prevents me from creating the schedule" do
@@ -184,7 +184,7 @@ describe Admin::SchedulesController, type: :controller do
       context 'as an admin user' do
         before do
           allow(controller).to receive(:spree_current_user) { create(:admin_user) }
-          params[:schedule].merge!( order_cycle_ids: [coordinated_order_cycle.id, uncoordinated_order_cycle.id] )
+          params.merge!( order_cycle_ids: [coordinated_order_cycle.id, uncoordinated_order_cycle.id] )
         end
 
         it "allows me to create a schedule" do


### PR DESCRIPTION
#### What? Why?

Closes #4943

This is hack to fix the problem described in #4943
I dont know the existing mechanism (working in master) that copies params like params[:name] into params[:schedule] becoming params[:schedule][:name]
My best hypothesis is that this mechanism is not working for order_cycle_ids because it is an HABTM association in Schedule and not a basic attribute or a has_many association.

#### What should we test?
green specs in 4943
