### PR TITLE
[Spree 2.1] Fix authentication spec by adapting code to devise 3

### DIFF
--- a/app/assets/javascripts/templates/signup.html.haml
+++ b/app/assets/javascripts/templates/signup.html.haml
@@ -37,6 +37,8 @@
           autocomplete: "off",
           tabindex: 2,
           "ng-model" => "spree_user.password_confirmation"}
+        %span.error{"ng-show" => "errors.password_confirmation != null"}
+          {{ errors.password_confirmation.join(' ') }}
     .row
       .large-12.columns
         %input.button.primary{name: "commit",


### PR DESCRIPTION
#### What? Why?

Closes #4947

OFN master is on devise 2.8.8 and in rails 4 we are on devise 3.0.4.

Devise 2 reports the mismatch between password and password_confirmation on user.errors[:password] while devise 3 reports it on user.errors[:password_confirmation].
This PR adds the html template to also show user.errors[:password_confirmation].
This fixes the spec in #4947 because the error is now shown (below the password confirmation field instead of below the password field).

#### What should we test?
green spec
