### PR TITLE
Fix 2 broken buttons in the product variants list page

### DIFF
--- a/app/controllers/spree/admin/variants_controller.rb
+++ b/app/controllers/spree/admin/variants_controller.rb
@@ -59,7 +59,7 @@ module Spree
         @collection ||= if @deleted.blank?
                           super
                         else
-                          Variant.where(product_id: parent.id).deleted
+                          Variant.unscoped.where(product_id: parent.id).deleted
                         end
         @collection
       end

--- a/app/views/spree/admin/variants/index.html.haml
+++ b/app/views/spree/admin/variants/index.html.haml
@@ -49,6 +49,6 @@
   - content_for :page_actions do
     %ul.inline-menu
       %li#new_var_link
-        = link_to_with_icon('icon-plus', t('.new_variant'), new_admin_product_variant_url(@product), remote: true, 'data-update' => 'new_variant', class: 'button')
+        = link_to_with_icon('icon-plus', t('.new_variant'), new_admin_product_variant_url(@product), class: 'button')
 
       %li= link_to_with_icon('icon-filter', @deleted.blank? ? t('.show_deleted') : t('.show_active'), admin_product_variants_url(@product, deleted: @deleted.blank? ? "on" : "off"), class: 'button')

--- a/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -5,7 +5,28 @@ module Spree
     describe VariantsController, type: :controller do
       before { login_as_admin }
 
-      describe "search action" do
+      describe "#index" do
+        describe "deleted variants" do
+          let(:product) { create(:product, name: 'Product A') }
+          let(:deleted_variant) do
+            deleted_variant = product.variants.create(unit_value: "2")
+            deleted_variant.delete
+            deleted_variant
+          end
+
+          it "lists only non-deleted variants with params[:deleted] == off" do
+            spree_get :index, product_id: product.permalink, deleted: "off"
+            expect(assigns(:variants)).to eq(product.variants)
+          end
+
+          it "lists only deleted variants with params[:deleted] == on" do
+            spree_get :index, product_id: product.permalink, deleted: "on"
+            expect(assigns(:variants)).to eq([deleted_variant])
+          end
+        end
+      end
+
+      describe "#search" do
         let!(:p1) { create(:simple_product, name: 'Product 1') }
         let!(:p2) { create(:simple_product, name: 'Product 2') }
         let!(:v1) { p1.variants.first }


### PR DESCRIPTION
#### What? Why?

Closes #4961 and #4962

Very simple fixes to two issues. I think #4961 was a regression from removing spree_backend but I think 4962 has been there for longer...

I added a test to cover #4962 
There is already a test covering #4961 I dont understand how does it passes without this fix... I managed to replicate the problem manually and solve it with the fix...

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->


#### What should we test?
Very both issues are fixed.



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
Fix variants list page by making both "new variant" and "show deleted" buttons work again
