### PR TITLE
Fix proxy orders controller in rails 4 by removing the use of responders

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -33,7 +33,6 @@ Layout/LineLength:
   - app/controllers/admin/inventory_items_controller.rb
   - app/controllers/admin/manager_invitations_controller.rb
   - app/controllers/admin/product_import_controller.rb
-  - app/controllers/admin/proxy_orders_controller.rb
   - app/controllers/admin/schedules_controller.rb
   - app/controllers/admin/subscriptions_controller.rb
   - app/controllers/admin/variant_overrides_controller.rb

--- a/app/controllers/admin/proxy_orders_controller.rb
+++ b/app/controllers/admin/proxy_orders_controller.rb
@@ -9,9 +9,7 @@ module Admin
 
     def cancel
       if @proxy_order.cancel
-        respond_with(@proxy_order) do |format|
-          format.json { render_as_json @proxy_order }
-        end
+        render_as_json @proxy_order
       else
         respond_with(@proxy_order) do |format|
           format.json { render json: { errors: [t('admin.proxy_orders.cancel.could_not_cancel_the_order')] }, status: :unprocessable_entity }
@@ -21,13 +19,9 @@ module Admin
 
     def resume
       if @proxy_order.resume
-        respond_with(@proxy_order) do |format|
-          format.json { render_as_json @proxy_order }
-        end
+        render_as_json @proxy_order
       else
-        respond_with(@proxy_order) do |format|
-          format.json { render json: { errors: [t('admin.proxy_orders.resume.could_not_resume_the_order')] }, status: :unprocessable_entity }
-        end
+        render json: { errors: [t('admin.proxy_orders.resume.could_not_resume_the_order')] }, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/admin/proxy_orders_controller.rb
+++ b/app/controllers/admin/proxy_orders_controller.rb
@@ -11,9 +11,8 @@ module Admin
       if @proxy_order.cancel
         render_as_json @proxy_order
       else
-        respond_with(@proxy_order) do |format|
-          format.json { render json: { errors: [t('admin.proxy_orders.cancel.could_not_cancel_the_order')] }, status: :unprocessable_entity }
-        end
+        render json: { errors: [t('admin.proxy_orders.cancel.could_not_cancel_the_order')] },
+               status: :unprocessable_entity
       end
     end
 
@@ -21,7 +20,8 @@ module Admin
       if @proxy_order.resume
         render_as_json @proxy_order
       else
-        render json: { errors: [t('admin.proxy_orders.resume.could_not_resume_the_order')] }, status: :unprocessable_entity
+        render json: { errors: [t('admin.proxy_orders.resume.could_not_resume_the_order')] },
+               status: :unprocessable_entity
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #4951 by fixing the first spec.

We bypass using the responder that was looking for a template and just render the json. Looks like it works like this :+1:

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
We should test pausing and resuming a subscription as well as cancelling the subscription. We should verify these actions are still working.
I'd be very happpy to teach a tester how to use this:
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Testing-Subscriptions


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
Adapt code to the rails 4 upgrade.
