### PR TITLE
Revert changes that broke existing usage of this report

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -77,7 +77,7 @@ module OpenFoodNetwork
        ba.phone,
        order.shipping_method.andand.name,
        order.payments.first.andand.payment_method.andand.name,
-       order.payment_total,
+       order.payments.first.amount,
        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance]
     end
 
@@ -92,7 +92,7 @@ module OpenFoodNetwork
        sa.phone,
        order.shipping_method.andand.name,
        order.payments.first.andand.payment_method.andand.name,
-       order.payment_total,
+       order.payments.first.amount,
        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance,
        has_temperature_controlled_items?(order),
        order.special_instructions]


### PR DESCRIPTION
#### What? Why?

Closes #4967 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Reverting a change that broke the use of this report for UK users.
The Amount field must show the value of the payment method for uncaptured payments. Meaning that we can't use payment_total in this use case.


#### What should we test?
<!-- List which features should be tested and how. -->

1. Place an order with a manual method eg Cash. Do not capture this payment
2. Go to the Order Cycle Management reports.
3. Check that the Amount field in both reports populated with the value of the payment placed at checkout.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a bug hiding uncaptured payments from Order Cycle Management reports

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed 

