### PR TITLE
[Spree 2.1] Bypass broken payment rollback callback

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -12,6 +12,13 @@ module Spree
 
     localize_number :amount
 
+    # We bypass this after_rollback callback that is setup in Spree::Payment
+    # The issues the callback fixes are not experienced in OFN:
+    #   if a payment fails on checkout the state "failed" is persisted correctly
+    def persist_invalid
+      return
+    end
+
     def ensure_correct_adjustment
       revoke_adjustment_eligibility if ['failed', 'invalid'].include?(state)
       return if adjustment.try(:finalized?)


### PR DESCRIPTION
#### What? Why?

Closes #4890 and #4898

The cause of the issues: a save statement inside an after_rollback that fails, starts a rollback inside a rollback that tries to save...
I cant figure out why the save inside the rollback is failing BUT anyway, this is just wrong so I suggest we remove this code:

We fix the problem by bypassing [the callback after_rollback](https://github.com/openfoodfoundation/spree/blob/b7ad5b473f9e38c5a1882550b2b4e348f4824f1f/core/app/models/spree/payment.rb#L35). This callback actually saves the payment: yes, a callback that saves the payment after the order transaction is rollbacked. Pretty crazy. I dont understand why fixing this at model level with callbacks was seen as a good idea in Spree. There's an alternative PR in Spree (this is also back in 2013) that fixes this at controller level that is deemed a hack...

This callback was added here:
https://github.com/spree/spree/commit/7772043a1f4e3b675d6daabea798f2a0ec2fddeb
Our build is looking great with this fix and I tested manually locally and the case discribed in the spree PR is not happening in OFN.
