### PR TITLE
Fix reloading issue in dev environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 require 'open_food_network/referer_parser'
-require 'spree/authentication_helpers'
+require_dependency 'spree/authentication_helpers'
 
 class ApplicationController < ActionController::Base
   protect_from_forgery


### PR DESCRIPTION
I constantly get `NameError: uninitialized constant Spree::AuthenticationHelpers` when touching local files and then reloading a page, and have to restart my rails server every time (in development). I read the other day that this is the best way to fix the issue, and it seems to work well... basically it will automatically reload the required class if and when it needs to.