### PR TITLE
[Spree 2.1] Customer details

### DIFF
--- a/app/views/spree/admin/orders/customer_details/edit.html.haml
+++ b/app/views/spree/admin/orders/customer_details/edit.html.haml
@@ -9,7 +9,7 @@
 - content_for :page_actions do
   %li= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
-- if @order.cart?
+- if @order.cart? || @order.address?
   #select-customer{"data-hook" => ""}
     %fieldset.no-border-bottom
       %legend{:align => "center"}= Spree.t(:customer_search)

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -169,6 +169,9 @@ feature '
 
     expect(page).to have_selector 'h1.page-title', text: "Customer Details"
 
+    # The customer selection partial should be visible
+    expect(page).to have_selector '#select-customer'
+
     # And I select that customer's email address and save the order
     targetted_select2_search @customer.email, from: '#customer_search_override', dropdown_css: '.select2-drop'
     click_button 'Update'


### PR DESCRIPTION
For some reason the order is in `address` state here instead of `cart` state when adding customer details. There's a conditional in the address view which loads the customer selection dropdown that was not being triggered, so a customer could not be selected (and their existing address was not being filled out in the form).

Fixes:
```
  1)
    As an administrator
    I want to manage orders
 filling customer details
     Failure/Error: expect(order.ship_address.lastname).to eq @customer.ship_address.lastname

     NoMethodError:
       undefined method `lastname' for nil:NilClass
     # ./spec/features/admin/orders_spec.rb:179:in `block (2 levels) in <top (required)>'
```