### PR TITLE
[Spree 2.1] Line items destroy route

### DIFF
--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -41,13 +41,6 @@ describe LineItemsController, type: :controller do
 
       before { allow(controller).to receive_messages spree_current_user: item.order.user }
 
-      context "without a line item id" do
-        it "fails and raises an error" do
-          delete :destroy
-          expect(response.status).to eq 404
-        end
-      end
-
       context "with a line item id" do
         let(:params) { { format: :json, id: item } }
 


### PR DESCRIPTION
Closes #4922

Removes a test from line_items_controller_spec.rb

Rails 4 does not recognise requests to destroy routes without ids as valid routes, and raises a routing error instead of a 404.

Fixes:
```
 14) LineItemsController destroying a line item on a completed order without a line item id fails and raises an error
      Failure/Error: delete :destroy

      ActionController::UrlGenerationError:
        No route matches {:action=>"destroy", :controller=>"line_items"}
      # ./spec/controllers/line_items_controller_spec.rb:46:in `block (5 levels) in <top (required)>'
```