### PR TITLE
[Spree 2.1] Fix order index search form

### DIFF
--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -1,5 +1,5 @@
 %div{"data-hook" => "admin_orders_index_search"}
-  = form_tag nil, {name: "orders_form", "ng-submit" => "fetchResults()"} do
+  = form_tag :orders, {name: "orders_form", "ng-submit" => "fetchResults()"} do
     .field-block.alpha.four.columns
       .date-range-filter.field
         = label_tag nil, t(:date_range)


### PR DESCRIPTION
Closes #4942 

Fixes:
```
  2) spree/admin/orders/index.html.haml print invoices button displays button when invoices are enabled
     Failure/Error: = form_tag nil, {name: "orders_form", "ng-submit" => "fetchResults()"} do

     ActionView::Template::Error:
       No route matches {:action=>"index", :controller=>"spree/admin/orders"}
     # ./app/views/spree/admin/orders/_filters.html.haml:2:in `_a1b716152f19bf3f4772a98e56adf411'
     # ./app/views/spree/admin/orders/index.html.haml:20:in `block in _d04c5552f7a480bf5f02e5fad0c10de6'
     # ./app/views/spree/admin/orders/index.html.haml:19:in `_d04c5552f7a480bf5f02e5fad0c10de6'
     # ./spec/views/spree/admin/orders/index.html.haml_spec.rb:26:in `block (3 levels) in <top (required)>'
     # ./spec/views/spree/admin/orders/index.html.haml_spec.rb:8:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ActionController::UrlGenerationError:
     #   No route matches {:action=>"index", :controller=>"spree/admin/orders"}
     #   ./app/views/spree/admin/orders/_filters.html.haml:2:in `_a1b716152f19bf3f4772a98e56adf411'

  3) spree/admin/orders/index.html.haml print invoices button does not display button when invoices are disabled
     Failure/Error: = form_tag nil, {name: "orders_form", "ng-submit" => "fetchResults()"} do

     ActionView::Template::Error:
       No route matches {:action=>"index", :controller=>"spree/admin/orders"}
     # ./app/views/spree/admin/orders/_filters.html.haml:2:in `_a1b716152f19bf3f4772a98e56adf411'
     # ./app/views/spree/admin/orders/index.html.haml:20:in `block in _d04c5552f7a480bf5f02e5fad0c10de6'
     # ./app/views/spree/admin/orders/index.html.haml:19:in `_d04c5552f7a480bf5f02e5fad0c10de6'
     # ./spec/views/spree/admin/orders/index.html.haml_spec.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/views/spree/admin/orders/index.html.haml_spec.rb:8:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ActionController::UrlGenerationError:
     #   No route matches {:action=>"index", :controller=>"spree/admin/orders"}
     #   ./app/views/spree/admin/orders/_filters.html.haml:2:in `_a1b716152f19bf3f4772a98e56adf411'
```