### PR TITLE
[Spree 2.1] Fix cart page update

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Openfoodnetwork::Application.routes.draw do
   get "/learn", to: redirect("https://openfoodnetwork.org/#{ENV['DEFAULT_COUNTRY_CODE'].andand.downcase}/learn/")
 
   get "/cart", :to => "spree/orders#edit", :as => :cart
-  put "/cart", :to => "spree/orders#update", :as => :update_cart
+  patch "/cart", :to => "spree/orders#update", :as => :update_cart
   put "/cart/empty", :to => 'spree/orders#empty', :as => :empty_cart
   get '/orders/:id/token/:token' => 'spree/orders#show', :as => :token_order
 


### PR DESCRIPTION
Closes #4950

Rails 4 now defaults to using PATCH for updates from forms.

Fixes:
```
  2) full-page cart viewing the cart updating quantities with insufficient stock available shows the quantities saved, not those submitted
     Failure/Error: @app.call(env)

     AbstractController::ActionNotFound:
       The action 'update' could not be found for CartController
     # ./lib/open_food_network/rack_request_blocker.rb:36:in `call'
     # ------------------
     # --- Caused by: ---
     # Capybara::ExpectationNotMet:
     #   expected to find text "Insufficient stock available, only 2 remaining" in "Internal Server Error The action 'update' could not be found for CartController WEBrick/1.3.1 (Ruby/2.3.7/2018-03-28) at 127.0.0.1:38614"
     #   ./spec/features/consumer/shopping/cart_spec.rb:182:in `block (5 levels) in <top (required)>'
```
