### PR TITLE
[Spree 2.1] Packing report deleted variants

### DIFF
--- a/app/controllers/spree/admin/reports_controller.rb
+++ b/app/controllers/spree/admin/reports_controller.rb
@@ -247,7 +247,7 @@ module Spree
       end
 
       def suppliers_of_products_distributed_by(distributors)
-        distributors.map { |d| Spree::Product.in_distributor(d).includes(:supplier).all }.
+        distributors.map { |d| Spree::Product.in_distributor(d).includes(:supplier).to_a }.
           flatten.map(&:supplier).uniq
       end
 

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -71,8 +71,10 @@ Spree::LineItem.class_eval do
       where('spree_adjustments.id IS NULL')
   }
 
+  # Overridden so that LineItems always have access to soft-deleted Variant attributes
+  # In some situations, unscoped super will be nil, in these cases we fetch the variant using the variant_id
+  # See isssue #4946 for more details
   def variant
-    # Overridden so that LineItems always have access to soft-deleted Variant attributes
     Spree::Variant.unscoped { super } || Spree::Variant.unscoped.find(self.variant_id)
   end
 

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -73,7 +73,7 @@ Spree::LineItem.class_eval do
 
   def variant
     # Overridden so that LineItems always have access to soft-deleted Variant attributes
-    Spree::Variant.unscoped { super }
+    Spree::Variant.unscoped { super } || Spree::Variant.unscoped.find(self.variant_id)
   end
 
   def cap_quantity_at_stock!

--- a/lib/open_food_network/reports/line_items.rb
+++ b/lib/open_food_network/reports/line_items.rb
@@ -21,7 +21,7 @@ module OpenFoodNetwork
         end
 
         if line_item_includes.present?
-          line_items = line_items.includes(*line_item_includes)
+          line_items = line_items.includes(*line_item_includes).references(:line_items)
         end
 
         editable_line_items = editable_line_items(line_items)


### PR DESCRIPTION
Closes #4946

Adds a couple of fixes for noisy deprecation warnings, and ensures that line_item.variant can always be found when the variant is soft-deleted.

Fixed spec:
```
  0) Packing Reports viewing a report when an associated variant has been soft-deleted shows line items
     Failure/Error: if user.has_spree_role?('admin')

     RuntimeError:
       Spree::LineItem#product delegated to variant.product, but variant is nil: #<Spree::LineItem id: 339, order_id: 320, variant_id: 3254, quantity: 1, price: #<BigDecimal:556b33fe1700,'0.1E2',9(18)>, created_at: "2020-03-12 18:18:48", updated_at: "2020-03-12 18:18:48", max_quantity: nil, currency: "GBP", distribution_fee: nil, final_weight_volume: #<BigDecimal:556b33fe0788,'0.1E1',9(18)>, cost_price: #<BigDecimal:556b33fe0698,'0.17E2',9(18)>, tax_category_id: 362>
     # ./app/models/spree/line_item_decorator.rb:24:in `rescue in product'
     # ./app/models/spree/line_item_decorator.rb:18:in `product'
     # ./lib/open_food_network/packing_report.rb:65:in `block in rules'
     # ./lib/open_food_network/order_grouper.rb:20:in `block in group_and_sort'
     # ./lib/open_food_network/order_grouper.rb:20:in `each'
     # ./lib/open_food_network/order_grouper.rb:20:in `group_by'
     # ./lib/open_food_network/order_grouper.rb:20:in `group_and_sort'
     # ./lib/open_food_network/order_grouper.rb:12:in `build_tree'
     # ./lib/open_food_network/order_grouper.rb:25:in `block in group_and_sort'
     # ./lib/open_food_network/order_grouper.rb:24:in `each'
     # ./lib/open_food_network/order_grouper.rb:24:in `group_and_sort'
     # ./lib/open_food_network/order_grouper.rb:12:in `build_tree'
     # ./lib/open_food_network/order_grouper.rb:25:in `block in group_and_sort'
     # ./lib/open_food_network/order_grouper.rb:24:in `each'
     # ./lib/open_food_network/order_grouper.rb:24:in `group_and_sort'
     # ./lib/open_food_network/order_grouper.rb:12:in `build_tree'
     # ./lib/open_food_network/order_grouper.rb:55:in `table'
     # ./app/controllers/spree/admin/reports_controller.rb:264:in `order_grouper_table'
     # ./app/controllers/spree/admin/reports_controller.rb:73:in `packing'
     # ./lib/open_food_network/rack_request_blocker.rb:36:in `call'
     # ------------------
     # --- Caused by: ---
     # NoMethodError:
     #   undefined method `product' for nil:NilClass
     #   ./app/models/spree/line_item_decorator.rb:20:in `product'
```

Fixed deprecation warnings:
```
DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you can call #load (e.g. `Post.where(published: true).load`). If you want to get an array of records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`). (called from block in suppliers_of_products_distributed_by at /home/user/Github/openfoodnetwork/app/controllers/spree/admin/reports_controller.rb:250)
```
```
DEPRECATION WARNING: It looks like you are eager loading table(s) (one of: spree_line_items, spree_orders, spree_variants, spree_products, enterprises, enterprise_relationship_permissions, enterprise_relationships) that are referenced in a string SQL snippet. For example: 

    Post.includes(:comments).where("comments.title = 'foo'")

Currently, Active Record recognizes the table in the string, and knows to JOIN the comments table to the query, rather than loading comments in a separate query. However, doing this without writing a full-blown SQL parser is inherently flawed. Since we don't want to write an SQL parser, we are removing this functionality. From now on, you must explicitly tell Active Record when you are referencing a table from a string:

    Post.includes(:comments).where("comments.title = 'foo'").references(:comments)

If you don't rely on implicit join references you can disable the feature entirely by setting `config.active_record.disable_implicit_join_references = true`. (called from editable_line_items at /home/user/Github/openfoodnetwork/lib/open_food_network/reports/line_items.rb:63)

```
