### PR TITLE
[Spree 2.1] Fix routes in enterprise_fee_summaries controller spec

### DIFF
--- a/spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
 
   describe "#new" do
     it "renders the report form" do
-      get :new
+      get :new, use_route: OrderManagement
 
       expect(response).to be_success
       expect(response).to render_template(new_template_path)
@@ -23,7 +23,8 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
   describe "#create" do
     context "when the parameters are valid" do
       it "sends the generated report in the correct format" do
-        post :create, report: { start_at: "2018-10-09 07:30:00" }, report_format: "csv"
+        post :create, use_route: OrderManagement,
+                      report: { start_at: "2018-10-09 07:30:00" }, report_format: "csv"
 
         expect(response).to be_success
         expect(response.body).not_to be_blank
@@ -33,7 +34,8 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
 
     context "when the parameters are invalid" do
       it "renders the report form with an error" do
-        post :create, report: { start_at: "invalid date" }, report_format: "csv"
+        post :create, use_route: OrderManagement,
+                      report: { start_at: "invalid date" }, report_format: "csv"
 
         expect(flash[:error]).to eq(I18n.t("invalid_filter_parameters", scope: i18n_scope))
         expect(response).to render_template(new_template_path)
@@ -47,7 +49,8 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
       let(:current_user) { distributor.owner }
 
       it "renders the report form with an error" do
-        post :create, report: { distributor_ids: [other_distributor.id] }, report_format: "csv"
+        post :create, use_route: OrderManagement,
+                      report: { distributor_ids: [other_distributor.id] }, report_format: "csv"
 
         expect(flash[:error]).to eq(report_klass::Authorizer.parameter_not_allowed_error_message)
         expect(response).to render_template(new_template_path)
@@ -64,7 +67,8 @@ describe Spree::Admin::Reports::EnterpriseFeeSummariesController, type: :control
       let(:current_user) { distributor.owner }
 
       it "applies permissions to report" do
-        post :create, report: {}, report_format: "csv"
+        post :create, use_route: OrderManagement,
+                      report: {}, report_format: "csv"
 
         expect(assigns(:permissions).allowed_order_cycles.to_a).to eq([order_cycle])
       end


### PR DESCRIPTION
Closes #4877

The app was loading these routes correctly, but the controller test was not. We have an odd situation where we are running a controller test from the main /spec folder, for a controller in the main app, but the routes for it are defined in an engine. 

Apparently rspec has some known issues with cases like this: https://tanzu.vmware.com/content/blog/writing-rails-engine-rspec-controller-tests

Of the three suggested solutions, one worked, one didn't, and the other involved some really messy monkey-patching...

Fixes:
```
  36) Spree::Admin::Reports::EnterpriseFeeSummariesController#new renders the report form
      Failure/Error: get :new
      
      ActionController::UrlGenerationError:
        No route matches {:action=>"new", :controller=>"spree/admin/reports/enterprise_fee_summaries"}
      # ./spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb:16:in `block (3 levels) in <top (required)>'

  37) Spree::Admin::Reports::EnterpriseFeeSummariesController#create when the parameters are valid sends the generated report in the correct format
      Failure/Error: post :create, report: { start_at: "2018-10-09 07:30:00" }, report_format: "csv"
      
      ActionController::UrlGenerationError:
        No route matches {:action=>"create", :controller=>"spree/admin/reports/enterprise_fee_summaries", :report=>{:start_at=>"2018-10-09 07:30:00"}, :report_format=>"csv"}
      # ./spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb:26:in `block (4 levels) in <top (required)>'

  38) Spree::Admin::Reports::EnterpriseFeeSummariesController#create when the parameters are invalid renders the report form with an error
      Failure/Error: post :create, report: { start_at: "invalid date" }, report_format: "csv"
      
      ActionController::UrlGenerationError:
        No route matches {:action=>"create", :controller=>"spree/admin/reports/enterprise_fee_summaries", :report=>{:start_at=>"invalid date"}, :report_format=>"csv"}
      # ./spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb:36:in `block (4 levels) in <top (required)>'

  39) Spree::Admin::Reports::EnterpriseFeeSummariesController#create when some parameters are now allowed renders the report form with an error
      Failure/Error: post :create, report: { distributor_ids: [other_distributor.id] }, report_format: "csv"
      
      ActionController::UrlGenerationError:
        No route matches {:action=>"create", :controller=>"spree/admin/reports/enterprise_fee_summaries", :report=>{:distributor_ids=>["1772"]}, :report_format=>"csv"}
      # ./spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb:50:in `block (4 levels) in <top (required)>'

  40) Spree::Admin::Reports::EnterpriseFeeSummariesController#create filtering results based on permissions applies permissions to report
      Failure/Error: post :create, report: {}, report_format: "csv"
      
      ActionController::UrlGenerationError:
        No route matches {:action=>"create", :controller=>"spree/admin/reports/enterprise_fee_summaries", :report=>{}, :report_format=>"csv"}
      # ./spec/controllers/spree/admin/reports/enterprise_fee_summaries_controller_spec.rb:67:in `block (4 levels) in <top (required)>'
```
