### PR TITLE
[Spree 2.1] Staging and Production configs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,13 +38,8 @@ Openfoodnetwork::Application.configure do
   # Note: This config no longer works with our new logging strategy
   # config.log_level = :debug
 
-  # Configure logging for Rails 3.2:
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(Rails.root.join("log", "#{Rails.env}.log")))
-  config.logger.level = Logger::INFO
-  config.logger.formatter = Logger::Formatter.new
-  config.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
-  # Once we get to Rails 4.0, we can replace the above with:
-  #config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
+  # Configure logging:
+  config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
 
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 Openfoodnetwork::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
-  config.eager_load = false
+  config.eager_load = true
 
   # Code is not reloaded between requests
   config.cache_classes = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,8 +35,8 @@ Openfoodnetwork::Application.configure do
   # Use https in email links
   config.action_mailer.default_url_options = { protocol: 'https' }
 
-  # Note: This config no longer works with our new logging strategy
-  # config.log_level = :debug
+  # Set log level (default is :debug in Rails 4)
+  config.log_level = :info
 
   # Configure logging:
   config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,13 +38,8 @@ Openfoodnetwork::Application.configure do
   # Note: This config no longer works with our new logging strategy
   # config.log_level = :debug
 
-  # Configure logging for Rails 3.2:
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(Rails.root.join("log", "#{Rails.env}.log")))
-  config.logger.level = Logger::INFO
-  config.logger.formatter = Logger::Formatter.new
-  config.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
-  # Once we get to Rails 4.0, we can replace the above with:
-  #config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
+  # Configure logging:
+  config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }
 
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,7 +1,7 @@
 Openfoodnetwork::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
-  config.eager_load = false
+  config.eager_load = true
 
   # Code is not reloaded between requests
   config.cache_classes = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -35,8 +35,8 @@ Openfoodnetwork::Application.configure do
   # Use https in email links
   config.action_mailer.default_url_options = { protocol: 'https' }
 
-  # Note: This config no longer works with our new logging strategy
-  # config.log_level = :debug
+  # Set log level (default is :debug in Rails 4)
+  config.log_level = :info
 
   # Configure logging:
   config.log_formatter = Logger::Formatter.new.tap { |f| f.datetime_format = "%Y-%m-%d %H:%M:%S" }


### PR DESCRIPTION
Closes #4900 

Uses recommended eager_load settings for staging and production. From Rails itself:
```
Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true
```

Also fixes logging configs for Rails 4 in staging and production.

Already staged and tested; it works :tada:

