### PR TITLE
Direct new enterprise users to their dashboard

### DIFF
--- a/app/views/registration/steps/_finished.html.haml
+++ b/app/views/registration/steps/_finished.html.haml
@@ -9,4 +9,4 @@
             %p= t(".login")
     .row
       .small-12.columns.text-center
-        %a.button.primary{ type: "button", href: "/" }= "#{t(".action")} >"
+        %a.button.primary{ type: "button", href: spree.admin_dashboard_path }= t(".action")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1987,7 +1987,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         headline: "Finished!"
         thanks: "Thanks for filling out the details for %{enterprise}."
         login: "You can change or update your enterprise at any stage by logging into Open Food Network and going to Admin."
-        action: "Open Food Network home"
+        action: "Go to Enterprise Dashboard"
 
   back: "Back"
   continue: "Continue"

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -121,6 +121,9 @@ feature "Registration", js: true do
       expect(e.linkedin).to eq "LiNkEdIn"
       expect(e.twitter).to eq "@TwItTeR"
       expect(e.instagram).to eq "@InStAgRaM"
+
+      click_link "Go to Enterprise Dashboard"
+      expect(page).to have_content "CHOOSE YOUR PACKAGE"
     end
 
     context "when the user has no more remaining enterprises" do


### PR DESCRIPTION
#### What? Why?

Closes #4277

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

People were directed to the home page and had to do several more clicks
to continue with their enterprise setup. Now the button at the end of the registration is going straight to the dashboard which guides through the next setup steps.



#### What should we test?
<!-- List which features should be tested and how. -->

This needs to be tested with working email setup.

- Go to the home page as guest (not logged in).
- Find the register link and create your account.
- Confirm your email address and follow the enterprise creation steps.
- As shown in #4277, the last step should display a button to the dashboard.
- Click the button and make sure that you land at the package selection.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

The registration workflow directs you straight to the admin dashboard to finish the enterprise setup now. It used to have a detour to the home page.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed


#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

The user guide contains these two places mentioning the process. They need updating:

- https://guide.openfoodnetwork.org/basic-features/register-and-create-your-profile
- https://guide.openfoodnetwork.org/basic-features/enterprise-profile/package-types
