### PR TITLE
Logageddon Hotfix

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Openfoodnetwork::Application.configure do
   # Use https in email links
   config.action_mailer.default_url_options = { protocol: 'https' }
 
-  # See everything in the log (default is :info)
+  # Note: This config no longer works with our new logging strategy
   # config.log_level = :debug
 
   # Configure logging for Rails 3.2:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,6 +38,7 @@ Openfoodnetwork::Application.configure do
 
   # Configure logging for Rails 3.2:
   config.logger = ActiveSupport::TaggedLogging.new(Logger.new(Rails.root.join("log", "#{Rails.env}.log")))
+  config.logger.level = Logger::INFO
   config.logger.formatter = Logger::Formatter.new
   config.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
   # Once we get to Rails 4.0, we can replace the above with:

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -33,7 +33,7 @@ Openfoodnetwork::Application.configure do
   # Use https in email links
   config.action_mailer.default_url_options = { protocol: 'https' }
 
-  # See everything in the log (default is :info)
+  # Note: This config no longer works with our new logging strategy
   # config.log_level = :debug
 
   # Configure logging for Rails 3.2:

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,6 +38,7 @@ Openfoodnetwork::Application.configure do
 
   # Configure logging for Rails 3.2:
   config.logger = ActiveSupport::TaggedLogging.new(Logger.new(Rails.root.join("log", "#{Rails.env}.log")))
+  config.logger.level = Logger::INFO
   config.logger.formatter = Logger::Formatter.new
   config.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
   # Once we get to Rails 4.0, we can replace the above with:


### PR DESCRIPTION
Hotfix for logging issues related to unexpectedly high log output after recent changes made in https://github.com/openfoodfoundation/openfoodnetwork/pull/4542

Apparently using a custom logger meant that the default log_level of `:info` was not being applied as expected. As a result, we were logging at `:debug` level what means we were logging everything: even all the SQL queries, and the file was growing very fast reaching 5.1Gb. This and the backups that include the file filled up the disk.