### PR TITLE
Performance tweaks

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -33,7 +33,8 @@ module Admin
     end
 
     def edit
-      @object = Enterprise.where(permalink: params[:id]).includes(users: [:ship_address, :bill_address]).first
+      @object = Enterprise.where(permalink: params[:id]).
+        includes(users: [:ship_address, :bill_address]).first
       super
     end
 

--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -32,6 +32,11 @@ module Admin
       end
     end
 
+    def edit
+      @object = Enterprise.where(permalink: params[:id]).includes(users: [:ship_address, :bill_address]).first
+      super
+    end
+
     def welcome
       render layout: "spree/layouts/bare_admin"
     end
@@ -172,12 +177,14 @@ module Admin
     end
 
     def load_methods_and_fees
+      enterprise_payment_methods = @enterprise.payment_methods.to_a
+      enterprise_shipping_methods = @enterprise.shipping_methods.to_a
       # rubocop:disable Style/TernaryParentheses
       @payment_methods = Spree::PaymentMethod.managed_by(spree_current_user).sort_by! do |pm|
-        [(@enterprise.payment_methods.include? pm) ? 0 : 1, pm.name]
+        [(enterprise_payment_methods.include? pm) ? 0 : 1, pm.name]
       end
       @shipping_methods = Spree::ShippingMethod.managed_by(spree_current_user).sort_by! do |sm|
-        [(@enterprise.shipping_methods.include? sm) ? 0 : 1, sm.name]
+        [(enterprise_shipping_methods.include? sm) ? 0 : 1, sm.name]
       end
       # rubocop:enable Style/TernaryParentheses
 

--- a/app/controllers/producers_controller.rb
+++ b/app/controllers/producers_controller.rb
@@ -8,7 +8,7 @@ class ProducersController < BaseController
       .activated
       .visible
       .is_primary_producer
-      .includes(address: :state)
+      .includes(address: [:state, :country])
       .includes(:properties)
       .includes(supplied_products: :properties)
       .all

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -8,7 +8,7 @@ class ShopsController < BaseController
       .activated
       .visible
       .is_distributor
-      .includes(address: :state)
+      .includes(address: [:state, :country])
       .includes(:properties)
       .includes(supplied_products: :properties)
       .all

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -3,7 +3,7 @@ require 'open_food_network/enterprise_injection_data'
 module InjectionHelper
   include SerializerHelper
 
-  def inject_enterprises(enterprises = Enterprise.activated.includes(address: :state).all)
+  def inject_enterprises(enterprises = Enterprise.activated.includes(address: [:state, :country]).all)
     inject_json_ams(
       "enterprises",
       enterprises,
@@ -35,13 +35,15 @@ module InjectionHelper
 
     inject_json_ams(
       "enterprises",
-      Enterprise.activated.visible.select(select_only).includes(address: :state).all,
+      Enterprise.activated.visible.select(select_only).includes(address: [:state, :country]).all,
       Api::EnterpriseShopfrontListSerializer
     )
   end
 
   def inject_enterprise_and_relatives
-    inject_json_ams "enterprises", current_distributor.relatives_including_self.activated.includes(address: :state).all, Api::EnterpriseSerializer, enterprise_injection_data
+    inject_json_ams "enterprises",
+                    current_distributor.relatives_including_self.activated.includes(address: [:state, :country]).all,
+                    Api::EnterpriseSerializer, enterprise_injection_data
   end
 
   def inject_group_enterprises

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -3,10 +3,10 @@ require 'open_food_network/enterprise_injection_data'
 module InjectionHelper
   include SerializerHelper
 
-  def inject_enterprises(enterprises = Enterprise.activated.includes(address: [:state, :country]).all)
+  def inject_enterprises(enterprises = nil)
     inject_json_ams(
       "enterprises",
-      enterprises,
+      enterprises || default_enterprise_query,
       Api::EnterpriseSerializer,
       enterprise_injection_data
     )
@@ -41,8 +41,14 @@ module InjectionHelper
   end
 
   def inject_enterprise_and_relatives
+    enterprises_and_relatives = current_distributor.
+      relatives_including_self.
+      activated.
+      includes(address: [:state, :country]).
+      all
+
     inject_json_ams "enterprises",
-                    current_distributor.relatives_including_self.activated.includes(address: [:state, :country]).all,
+                    enterprises_and_relatives,
                     Api::EnterpriseSerializer, enterprise_injection_data
   end
 
@@ -139,6 +145,10 @@ module InjectionHelper
   end
 
   private
+
+  def default_enterprise_query
+    Enterprise.activated.includes(address: [:state, :country]).all
+  end
 
   def enterprise_injection_data
     @enterprise_injection_data ||= OpenFoodNetwork::EnterpriseInjectionData.new

--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -5,5 +5,21 @@ module Spree
     def variant_options(v, _options = {})
       v.options_text
     end
+
+    # Overriden to eager-load :states
+    def available_countries
+      checkout_zone = Zone.find_by_name(Spree::Config[:checkout_zone])
+
+      if checkout_zone && checkout_zone.kind == 'country'
+        countries = checkout_zone.country_list
+      else
+        countries = Country.includes(:states).all
+      end
+
+      countries.collect do |country|
+        country.name = Spree.t(country.iso, scope: 'country_names', default: country.name)
+        country
+      end.sort { |a, b| a.name <=> b.name }
+    end
   end
 end

--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -10,11 +10,11 @@ module Spree
     def available_countries
       checkout_zone = Zone.find_by_name(Spree::Config[:checkout_zone])
 
-      if checkout_zone && checkout_zone.kind == 'country'
-        countries = checkout_zone.country_list
-      else
-        countries = Country.includes(:states).all
-      end
+      countries = if checkout_zone && checkout_zone.kind == 'country'
+                    checkout_zone.country_list
+                  else
+                    Country.includes(:states).all
+                  end
 
       countries.collect do |country|
         country.name = Spree.t(country.iso, scope: 'country_names', default: country.name)


### PR DESCRIPTION
#### What? Why?

Removes some very common N+1s found with the bullet gem, and makes enterprises edit usable as superadmin.

Tested locally with full Aus production data.

#### What should we test?

A quick sanity check to make sure shipping methods and payment methods load correctly in enterprise edit page would be good (as superadmin and non-superadmin).

#### Release notes

Improved performance in some enterprise queries and for enterprise edit as superadmin

Changelog Category: Changed