### PR TITLE
Display shipping and billing address on invoices

### DIFF
--- a/app/views/spree/admin/orders/invoice.html.haml
+++ b/app/views/spree/admin/orders/invoice.html.haml
@@ -17,7 +17,7 @@
       %td{ :align => "right" }
         %h4= @order.order_cycle.andand.name
     %tr{ valign: "top" }
-      %td{ :align => "left" }
+      %td{ align: "left", colspan: 3 }
         %strong= "#{t('.from')}: #{@order.distributor.name}"
         - if @order.distributor.abn.present?
           %br
@@ -26,10 +26,14 @@
         = @order.distributor.address.full_address
         %br
         = @order.distributor.contact.email
-      %td{width: "10%" }
+    %tr{ valign: "top" }
+      %td{ colspan: 3 }
         &nbsp;
-      %td{ :align => "right" }
-        %strong= "#{t('.to')}: #{@order.bill_address.full_name}"
+    %tr{ valign: "top" }
+      %td{ align: "left" }
+        %strong= "#{t('.to')}:"
+        %br
+        = @order.bill_address.full_name
         - if @order.andand.customer.andand.code.present?
           %br
           = "#{t('.code')}: #{@order.customer.code}"
@@ -39,22 +43,25 @@
         - if @order.andand.customer.andand.email.present?
           = "#{@order.customer.email},"
         = "#{@order.bill_address.phone}"
-        %br
+      %td
+        &nbsp;
+      %td{ align: "left", style: "border-left: .1em solid black; padding-left: 1em" }
         %strong= "#{t('.shipping')}: #{@order.shipping_method&.name}"
-        - if @order.shipping_method&.require_ship_address && @order.ship_address != @order.bill_address
+        - if @order.shipping_method&.require_ship_address
+          %br
+          = @order.ship_address.full_name
           %br
           = @order.ship_address.full_address
+          %br
+          = @order.ship_address.phone
+        - if @order.special_instructions.present?
+          %br
+          %br
+            %strong= t :customer_instructions
+          = @order.special_instructions
+
 
 = render 'spree/admin/orders/invoice_table'
-
-- if @order.special_instructions.present?
-  %p.callout
-    %strong
-      = t :customer_instructions
-  %p
-    %em= @order.special_instructions
-  %p
-    &nbsp;
 
 - if @order.distributor.invoice_text.present?
   %p

--- a/app/views/spree/admin/orders/invoice.html.haml
+++ b/app/views/spree/admin/orders/invoice.html.haml
@@ -29,16 +29,21 @@
       %td{width: "10%" }
         &nbsp;
       %td{ :align => "right" }
-        %strong= "#{t('.to')}: #{@order.ship_address.full_name}"
+        %strong= "#{t('.to')}: #{@order.bill_address.full_name}"
         - if @order.andand.customer.andand.code.present?
           %br
           = "#{t('.code')}: #{@order.customer.code}"
         %br
-        = @order.ship_address.full_address
+        = @order.bill_address.full_address
         %br
         - if @order.andand.customer.andand.email.present?
           = "#{@order.customer.email},"
         = "#{@order.bill_address.phone}"
+        %br
+        %strong= "#{t('.shipping')}: #{@order.shipping_method&.name}"
+        - if @order.shipping_method&.require_ship_address && @order.ship_address != @order.bill_address
+          %br
+          = @order.ship_address.full_address
 
 = render 'spree/admin/orders/invoice_table'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3190,6 +3190,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           code: "Code"
           from: "From"
           to: "To"
+          shipping: "Shipping"
         form:
           distribution_fields:
             title: "Distribution"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3189,7 +3189,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           tax_invoice: "TAX INVOICE"
           code: "Code"
           from: "From"
-          to: "To"
+          to: "Bill to"
           shipping: "Shipping"
         form:
           distribution_fields:

--- a/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe "spree/admin/orders/invoice.html.haml" do
+  let(:shop) { create(:distributor_enterprise) }
+  let(:order) { create(:completed_order_with_totals, distributor: shop) }
+  let(:adas_address) do
+    Spree::Address.new(
+      firstname: "Ada",
+      lastname: "Lovelace",
+      phone: "0404 123 456",
+      address1: "2 Mahome St",
+      city: "Thornbury",
+      zipcode: "3071",
+      state_id: 1,
+      state_name: "Victoria",
+    )
+  end
+  let(:adas_address_display) { "2 Mahome St, Thornbury, 3071, Victoria" }
+
+  before do
+    assign(:order, order)
+  end
+
+  it "displays the customer code" do
+    order.customer = Customer.create!(
+      user: order.user,
+      email: order.user.email,
+      enterprise: order.distributor,
+      code: "Money Penny",
+    )
+    render
+    expect(rendered).to have_content "Code: Money Penny"
+  end
+
+  it "displays the billing and shipping address" do
+    order.bill_address = adas_address
+    render
+    expect(rendered).to have_content "To: Ada Lovelace"
+    expect(rendered).to have_content adas_address.phone
+    expect(rendered).to have_content adas_address_display
+  end
+
+  it "displays shipping info" do
+    order.shipping_method.update_attributes!(
+      name: "Home delivery",
+      require_ship_address: true,
+    )
+    order.ship_address = adas_address
+
+    render
+    expect(rendered).to have_content "Shipping: Home delivery"
+    expect(rendered).to have_content adas_address_display
+  end
+
+  it "prints address once if billing and shipping address are the same" do
+    order.bill_address = adas_address
+    order.ship_address = Spree::Address.new(order.bill_address.attributes)
+    order.shipping_method.update_attributes!(
+      name: "Home delivery",
+      require_ship_address: true,
+    )
+
+    render
+    expect(rendered).to have_content "Shipping: Home delivery"
+    expect(rendered.scan(/2 Mahome St, Thornbury, 3071/).count).to eq 1
+  end
+end

--- a/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/invoice.html.haml_spec.rb
@@ -32,10 +32,10 @@ describe "spree/admin/orders/invoice.html.haml" do
     expect(rendered).to have_content "Code: Money Penny"
   end
 
-  it "displays the billing and shipping address" do
+  it "displays the billing address" do
     order.bill_address = adas_address
     render
-    expect(rendered).to have_content "To: Ada Lovelace"
+    expect(rendered).to have_content "Ada Lovelace"
     expect(rendered).to have_content adas_address.phone
     expect(rendered).to have_content adas_address_display
   end
@@ -49,19 +49,26 @@ describe "spree/admin/orders/invoice.html.haml" do
 
     render
     expect(rendered).to have_content "Shipping: Home delivery"
+    expect(rendered).to have_content adas_address.phone
     expect(rendered).to have_content adas_address_display
   end
 
-  it "prints address once if billing and shipping address are the same" do
-    order.bill_address = adas_address
-    order.ship_address = Spree::Address.new(order.bill_address.attributes)
+  it "displays special instructions" do
+    order.special_instructions = "The combination is 12345."
+
+    render
+    expect(rendered).to have_content "The combination is 12345."
+  end
+
+  it "hides billing address for pickups" do
+    order.ship_address = adas_address
     order.shipping_method.update_attributes!(
-      name: "Home delivery",
-      require_ship_address: true,
+      name: "Pickup",
+      require_ship_address: false,
     )
 
     render
-    expect(rendered).to have_content "Shipping: Home delivery"
-    expect(rendered.scan(/2 Mahome St, Thornbury, 3071/).count).to eq 1
+    expect(rendered).to have_content "Shipping: Pickup"
+    expect(rendered).to_not have_content adas_address_display
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5019

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We have two invoice templates. Each instance can decide which template to use. Australia uses the default template and France uses the alternative template for legal compliance.

Both templates used to display the customer's shipping address and the invoice was also used as packing sheet and for delivery. The French template displays the customer's billing address since #4560 for legal compliance.

If orders are not delivered but picked up at a hub, the shipping address is set to the hub's address. In that case the Australian template was confusing because it displayed the hub's address as the customer's address. In case of home delivery, we still want the shipping address though.

We decided to display both, the customer's billing address and the shipping address in case of delivery to a different address. The hub's address is always displayed on the left side under "From". To make it more clear, we changed the layout a bit and moved special delivery instructions to the top. That should be easier to see during delivery.

New layout with customer code:
![Screenshot from 2020-03-20 15-27-10](https://user-images.githubusercontent.com/3524483/77136949-d438a000-6abf-11ea-96d1-e8742c575875.png)

Different addresses:
![Screenshot from 2020-03-20 15-34-46](https://user-images.githubusercontent.com/3524483/77137058-63de4e80-6ac0-11ea-85b7-5dfffaf71a05.png)

With instructions:
![Screenshot from 2020-03-20 15-27-45](https://user-images.githubusercontent.com/3524483/77136956-dac71780-6abf-11ea-9385-06311d2840d9.png)

Pickup with proper layout as PDF:
![Screenshot from 2020-03-20 15-54-16](https://user-images.githubusercontent.com/3524483/77137725-27f8b880-6ac3-11ea-98b5-5b79e043caa9.png)



#### What should we test?
<!-- List which features should be tested and how. -->

* Log in as super-admin and check under Configuration that the invoice template is the default template, not the alternative one.
* Set up an order cycle with two shipping methods: one delivery and one pickup
* Verify three cases:
  - Pickup: The user's billing address shows on the left.
  - Delivery to separate address: Billing and delivery address show.
  - Special instructions: They show at the top and not at the bottom of the invoice.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

The default invoice template (used by some instances) now displays the billing address and shipping details in the header.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

