### PR TITLE
Temporarily hide OC selector in checkout page

### DIFF
--- a/app/views/checkout/edit.html.haml
+++ b/app/views/checkout/edit.html.haml
@@ -15,7 +15,7 @@
       %strong
         = pickup_time current_order_cycle
 
-  = render partial: "shopping_shared/header"
+  = render partial: "shopping_shared/header", locals: { hide_oc_selector: true }
 
   %accordion{"close-others" => "false"}
     %checkout.row{"ng-controller" => "CheckoutCtrl"}

--- a/app/views/shopping_shared/_header.html.haml
+++ b/app/views/shopping_shared/_header.html.haml
@@ -10,5 +10,6 @@
           = distributor.name
         %location= distributor.address.city
 
-    .show-for-large-up.large-4.columns
-      = render partial: "shopping_shared/order_cycles"
+    - unless defined? hide_oc_selector
+      .show-for-large-up.large-4.columns
+        = render partial: "shopping_shared/order_cycles"

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -53,7 +53,7 @@ feature "Using embedded shopfront functionality", js: true do
         expect(page).to have_text 'Your shopping cart'
         find('a#checkout-link').click
 
-        expect(page).to have_text 'Checkout now'
+        expect(page).to have_text 'Ok, ready to checkout?'
 
         click_button 'Login'
         login_with_modal


### PR DESCRIPTION
#### What? Why?

Hides the OC selector on checkout page as a quick fix for a checkout display issue. This will be reassessed and improved by next week's release.

#### What should we test?
<!-- List which features should be tested and how. -->

OC selector is removed from checkout page:

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

Fixed a CSS display bug on checkout