### PR TITLE
[Spree 2.1] Remove new attr_accessible entries

### DIFF
--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -12,8 +12,6 @@ module Spree
 
       validate :ensure_enterprise_selected
 
-      attr_accessible :preferred_enterprise_id
-
       def method_type
         'stripe_sca'
       end

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,7 +1,1 @@
 PaperTrail.config.track_associations = false
-
-module PaperTrail
-  class Version < ActiveRecord::Base
-    attr_accessible :custom_data
-  end
-end


### PR DESCRIPTION
#### What? Why?

Fixes the build initial db setup after these entries were added to 3-0-stable from master.

#### What should we test?
We need to verify that paper_trail is still working for OCs and schedules with the custom data field.
