### PR TITLE
Improve reports performance

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -36,6 +36,10 @@ Spree::LineItem.class_eval do
     end
   }
 
+  scope :in_orders, lambda { |orders|
+    where(order_id: orders)
+  }
+
   # Find line items that are from order sorted by variant name and unit value
   scope :sorted_by_name_and_unit_value, -> {
     joins(variant: :product).

--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -13,8 +13,8 @@ module Permissions
       orders = Spree::Order.
         with_line_items_variants_and_products_outer.
         where(visible_orders_where_values)
-      orders = orders.complete.not_state(:canceled).search(search_params).result if search_orders?
-      orders
+
+      filtered_orders(orders)
     end
 
     # Any orders that the user can edit
@@ -22,8 +22,8 @@ module Permissions
       orders = Spree::Order.
         where(managed_orders_where_values.
           or(coordinated_orders_where_values))
-      orders = orders.complete.not_state(:canceled).search(search_params).result if search_orders?
-      orders
+
+      filtered_orders(orders)
     end
 
     def visible_line_items
@@ -41,7 +41,13 @@ module Permissions
 
     attr_reader :search_params
 
-    def search_orders?
+    def filtered_orders(orders)
+      return orders unless filter_orders?
+
+      orders.complete.not_state(:canceled).search(search_params).result
+    end
+
+    def filter_orders?
       search_params.present?
     end
 

--- a/lib/open_food_network/bulk_coop_report.rb
+++ b/lib/open_food_network/bulk_coop_report.rb
@@ -128,7 +128,7 @@ module OpenFoodNetwork
 
     def order_permissions
       return @order_permissions unless @order_permissions.nil?
-      @order_permissions = ::Permissions::Order.new(@user)
+      @order_permissions = ::Permissions::Order.new(@user, @params[:q])
     end
 
     def report_line_items

--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -5,7 +5,7 @@ module OpenFoodNetwork
       @user = user
       @render_table = render_table
 
-      @permissions = ::Permissions::Order.new(user)
+      @permissions = ::Permissions::Order.new(user, @params[:q])
     end
 
     def header

--- a/lib/open_food_network/orders_and_fulfillments_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report.rb
@@ -83,7 +83,7 @@ module OpenFoodNetwork
 
     def order_permissions
       return @order_permissions unless @order_permissions.nil?
-      @order_permissions = ::Permissions::Order.new(@user)
+      @order_permissions = ::Permissions::Order.new(@user, options[:q])
     end
 
     def report_line_items

--- a/lib/open_food_network/packing_report.rb
+++ b/lib/open_food_network/packing_report.rb
@@ -128,7 +128,7 @@ module OpenFoodNetwork
 
     def order_permissions
       return @order_permissions unless @order_permissions.nil?
-      @order_permissions = ::Permissions::Order.new(@user)
+      @order_permissions = ::Permissions::Order.new(@user, @params[:q])
     end
 
     def is_temperature_controlled?(line_item)

--- a/lib/open_food_network/reports/line_items.rb
+++ b/lib/open_food_network/reports/line_items.rb
@@ -12,9 +12,7 @@ module OpenFoodNetwork
       end
 
       def list(line_item_includes = nil)
-        line_items = @order_permissions.
-          visible_line_items.
-          merge(Spree::LineItem.where(order_id: orders.result))
+        line_items = @order_permissions.visible_line_items.in_orders(orders.result)
 
         if @params[:supplier_id_in].present?
           line_items = line_items.supplied_by_any(@params[:supplier_id_in])

--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -5,14 +5,21 @@ module Permissions
     let(:user) { double(:user) }
     let(:permissions) { Permissions::Order.new(user) }
     let!(:basic_permissions) { OpenFoodNetwork::Permissions.new(user) }
+    let(:distributor) { create(:distributor_enterprise) }
+    let(:coordinator) { create(:distributor_enterprise) }
+    let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator, distributors: [distributor]) }
+    let(:order_completed) { create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor ) }
+    let(:order_cancelled) { create(:order, order_cycle: order_cycle, distributor: distributor, state: 'canceled' ) }
+    let(:order_cart) { create(:order, order_cycle: order_cycle, distributor: distributor, state: 'cart' ) }
+    let(:order_from_last_year) {
+      create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor,
+             completed_at: Time.zone.now - 1.year)
+    }
 
     before { allow(OpenFoodNetwork::Permissions).to receive(:new) { basic_permissions } }
 
     describe "finding orders that are visible in reports" do
-      let(:distributor) { create(:distributor_enterprise) }
-      let(:coordinator) { create(:distributor_enterprise) }
       let(:random_enterprise) { create(:distributor_enterprise) }
-      let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator, distributors: [distributor]) }
       let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor ) }
       let!(:line_item) { create(:line_item, order: order) }
       let!(:producer) { create(:supplier_enterprise) }
@@ -64,6 +71,18 @@ module Permissions
             expect(permissions.visible_orders).to_not include order
           end
         end
+
+        context "with search params" do
+          let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
+          let(:permissions) { Permissions::Order.new(user, search_params) }
+
+          it "only returns completed, non-cancelled orders within search filter range" do
+            expect(permissions.visible_orders).to include order_completed
+            expect(permissions.visible_orders).to_not include order_cancelled
+            expect(permissions.visible_orders).to_not include order_cart
+            expect(permissions.visible_orders).to_not include order_from_last_year
+          end
+        end
       end
 
       context "as an enterprise that is a distributor in the order cycle, but not the distributor of the order" do
@@ -78,10 +97,7 @@ module Permissions
     end
 
     describe "finding line items that are visible in reports" do
-      let(:distributor) { create(:distributor_enterprise) }
-      let(:coordinator) { create(:distributor_enterprise) }
       let(:random_enterprise) { create(:distributor_enterprise) }
-      let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator, distributors: [distributor]) }
       let(:order) { create(:order, order_cycle: order_cycle, distributor: distributor ) }
       let!(:line_item1) { create(:line_item, order: order) }
       let!(:line_item2) { create(:line_item, order: order) }
@@ -135,6 +151,27 @@ module Permissions
 
         it "should not let me see the line_items" do
           expect(permissions.visible_line_items).to_not include line_item1, line_item2
+        end
+      end
+
+      context "with search params" do
+        let!(:line_item3) { create(:line_item, order: order_completed) }
+        let!(:line_item4) { create(:line_item, order: order_cancelled) }
+        let!(:line_item5) { create(:line_item, order: order_cart) }
+        let!(:line_item6) { create(:line_item, order: order_from_last_year) }
+
+        let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
+        let(:permissions) { Permissions::Order.new(user, search_params) }
+
+        before do
+          allow(user).to receive(:has_spree_role?) { "admin" }
+        end
+
+        it "only returns line items from completed, non-cancelled orders within search filter range" do
+          expect(permissions.visible_line_items).to include order_completed.line_items.first
+          expect(permissions.visible_line_items).to_not include order_cancelled.line_items.first
+          expect(permissions.visible_line_items).to_not include order_cart.line_items.first
+          expect(permissions.visible_line_items).to_not include order_from_last_year.line_items.first
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Related to #5029 and #4782

I started playing with Aus production data locally, and had a look at reports again.

From my initial idea in Slack:

> I'm sure we're missing something. It's a problem of combining different sets, right? We build these sets like "editable_orders", "editable_line_items" and then combine them in a huge query but I think we can reduce the scope of those sets before building them...

> when we search reports we have filters that limit the results to a date range, set of distributors, etc.

> but it seems like we're applying that only after doing lots of big query building that includes things like "all the line items a user can edit, ever", which could be 50,000+

**TLDR;** if we add the scoping from the search filters into the logic of building sets like `editable_line_items` _before_ combining them into the query, it reduces page loads in various reports by **50-90%**, and the horrifying amount of `line_item` ids added to the `IN` clause is reduced to a reasonable amount.


#### What should we test?
<!-- List which features should be tested and how. -->

- Reports are all working in general. 
- Should be loading significantly faster than before (on a server with lots of data).

This PR affects:
- **bulk_coop** reports
- **order_and_distributor** reports
- **orders_and_fulfillments** reports
- **packing** reports

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improve reports performance

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

