### PR TITLE
[Spree 2.1] Adapt EnterpriseFeeSummary report code to slightly different rails 4 sql data conversion

### DIFF
--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/data_representations/coordinator_fee.rb
@@ -19,7 +19,7 @@ module OrderManagement
           end
 
           def inherits_tax_category?
-            data["enterprise_fee_inherits_tax_category"] == "t"
+            data["enterprise_fee_inherits_tax_category"]
           end
         end
       end

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
@@ -364,7 +364,7 @@ module OrderManagement
           chain_to_scope do
             select(
               <<-JOIN_STRING.strip_heredoc
-                SUM(spree_adjustments.amount) AS total_amount,
+                SUM(spree_adjustments.amount)::TEXT AS total_amount,
                   spree_payment_methods.name AS payment_method_name,
                   spree_shipping_methods.name AS shipping_method_name,
                   hubs.name AS hub_name,


### PR DESCRIPTION
#### What? Why?

Fixed 5 specs in engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/report_service_spec.rb

#### What should we test?
Green specs.
