### PR TITLE
Make explicit the namespace of the BaseController for api controllers

### DIFF
--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class CustomersController < BaseController
+  class CustomersController < Api::BaseController
     skip_authorization_check only: :index
 
     def index

--- a/app/controllers/api/enterprise_attachment_controller.rb
+++ b/app/controllers/api/enterprise_attachment_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class EnterpriseAttachmentController < BaseController
+  class EnterpriseAttachmentController < Api::BaseController
     class MissingImplementationError < StandardError; end
     class UnknownEnterpriseAuthorizationActionError < StandardError; end
 

--- a/app/controllers/api/enterprise_fees_controller.rb
+++ b/app/controllers/api/enterprise_fees_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class EnterpriseFeesController < BaseController
+  class EnterpriseFeesController < Api::BaseController
     respond_to :json
 
     def destroy

--- a/app/controllers/api/logos_controller.rb
+++ b/app/controllers/api/logos_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class LogosController < EnterpriseAttachmentController
+  class LogosController < Api::EnterpriseAttachmentController
     private
 
     def attachment_name

--- a/app/controllers/api/order_cycles_controller.rb
+++ b/app/controllers/api/order_cycles_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class OrderCyclesController < BaseController
+  class OrderCyclesController < Api::BaseController
     include EnterprisesHelper
     respond_to :json
 

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class OrdersController < BaseController
+  class OrdersController < Api::BaseController
     def show
       authorize! :read, order
       render json: order, serializer: Api::OrderDetailedSerializer, current_order: order

--- a/app/controllers/api/product_images_controller.rb
+++ b/app/controllers/api/product_images_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class ProductImagesController < BaseController
+  class ProductImagesController < Api::BaseController
     respond_to :json
 
     def update_product_image

--- a/app/controllers/api/promo_images_controller.rb
+++ b/app/controllers/api/promo_images_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class PromoImagesController < EnterpriseAttachmentController
+  class PromoImagesController < Api::EnterpriseAttachmentController
     private
 
     def attachment_name


### PR DESCRIPTION
#### What? Why?

This fixes a few errors in the rails upgrade branch as in some cases ::BaseController was being picked up and current_api_user was not available in the controller.

#### What should we test?
Green build.

#### Release notes
Changelog Category: Changed
Adapt code to work with rails 4.
