### PR TITLE
[Spree 2.1] Re-add spring and newrelic_rpm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,12 +154,12 @@ end
 group :development do
   gem 'byebug', '~> 9.0.0' # 9.1 requires ruby 2.2
   gem 'debugger-linecache'
-  #gem "newrelic_rpm", "~> 3.0"
+  gem "newrelic_rpm", "~> 3.0"
   gem 'pry-byebug', '>= 3.4.3'
   gem 'rubocop'
   gem 'rubocop-rails'
-  #gem 'spring'
-  #gem 'spring-commands-rspec'
+  gem 'spring'
+  gem 'spring-commands-rspec'
 
   # 1.0.9 fixed openssl issues on macOS https://github.com/eventmachine/eventmachine/issues/602
   # While we don't require this gem directly, no dependents forced the upgrade to a version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ GEM
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    newrelic_rpm (3.18.1.330)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     oauth2 (1.4.4)
@@ -631,6 +632,9 @@ GEM
       tilt (>= 1.3, < 3)
     spinjs-rails (1.4)
       rails (>= 3.1)
+    spring (1.7.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -742,6 +746,7 @@ DEPENDENCIES
   letter_opener (>= 1.4.1)
   mini_racer (= 0.2.9)
   momentjs-rails
+  newrelic_rpm (~> 3.0)
   nokogiri (~> 1.6.8.1)
   oauth2 (~> 1.4.4)
   ofn-qz!
@@ -775,6 +780,8 @@ DEPENDENCIES
   spree_core!
   spree_i18n!
   spree_paypal_express!
+  spring
+  spring-commands-rspec
   stripe
   test-unit (~> 3.3)
   timecop


### PR DESCRIPTION
#### What? Why?

From #4777 
We un-comment spring and newrelix_rpm from the gemfile, they are not causing trouble any more.
Spring is working really well actually!

#### What should we test?
green build

