### PR TITLE
Ensure perform_deliveries is correctly set in user email spec

### DIFF
--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -76,9 +76,11 @@ describe Spree.user_class do
     it "should send a confirmation email" do
       setup_email
 
-      expect do
-        create(:user, email: 'new_user@example.com', confirmation_sent_at: nil, confirmed_at: nil)
-      end.to send_confirmation_instructions
+      performing_deliveries do
+        expect do
+          create(:user, email: 'new_user@example.com', confirmation_sent_at: nil, confirmed_at: nil)
+        end.to send_confirmation_instructions
+      end
 
       sent_mail = ActionMailer::Base.deliveries.last
       expect(sent_mail.to).to eq ['new_user@example.com']


### PR DESCRIPTION
Closes #5040

Wraps sending of test email in a `performing_deliveries` block, to make sure it actually sends. The problem was that `ActionMailer.Base.perfom_deliveries` was false at this point.

Also checked confirmation emails are sending correctly in dev environment (with `letter_opener`).

Note: this issue was originally discovered in the Spree upgrade but it also affects `master`, depending on the environment and order that tests are run (in parallel).

#### Release Notes

Fixed an email issue in the test suite

Category: Fixed