### PR TITLE
Performance tweaks 2

### DIFF
--- a/app/controllers/producers_controller.rb
+++ b/app/controllers/producers_controller.rb
@@ -8,7 +8,7 @@ class ProducersController < BaseController
       .activated
       .visible
       .is_primary_producer
-      .includes(address: :state)
+      .includes(address: [:state, :country])
       .includes(:properties)
       .includes(supplied_products: :properties)
       .all

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -109,7 +109,10 @@ module Spree
       private
 
       def load_order
-        @order = Order.find_by_number!(params[:id], include: :adjustments) if params[:id]
+        if params[:id]
+          @order = Order.includes(:adjustments, :shipments, line_items: :adjustments).
+            find_by_number!(params[:id])
+        end
         authorize! action, @order
       end
 
@@ -128,7 +131,7 @@ module Spree
       def load_distribution_choices
         @shops = Enterprise.is_distributor.managed_by(spree_current_user).by_name
 
-        ocs = OrderCycle.managed_by(spree_current_user)
+        ocs = OrderCycle.includes(:suppliers, :distributors).managed_by(spree_current_user)
         @order_cycles = ocs.soonest_closing +
                         ocs.soonest_opening +
                         ocs.closed +

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -17,7 +17,10 @@ module InjectionHelper
 
     inject_json_ams(
       "groups",
-      EnterpriseGroup.on_front_page.by_position.select(select_only).includes(address: :state).all,
+      EnterpriseGroup.on_front_page.by_position.select(select_only).
+        includes(enterprises: [:shipping_methods, { address: [:state, :country] }],
+                 address: :state).
+        all,
       Api::GroupListSerializer
     )
   end

--- a/app/models/stock/package.rb
+++ b/app/models/stock/package.rb
@@ -24,8 +24,10 @@ module Stock
     #
     # @return [Array<Spree::ShippingMethod>]
     def shipping_methods
-      super.delete_if do |shipping_method|
-        !ships_with?(order.distributor, shipping_method)
+      available_shipping_methods = super.to_a
+
+      available_shipping_methods.delete_if do |shipping_method|
+        !ships_with?(order.distributor.shipping_methods.to_a, shipping_method)
       end
     end
 
@@ -33,11 +35,11 @@ module Stock
 
     # Checks whether the given distributor provides the specified shipping method
     #
-    # @param distributor [Spree::Enterprise]
+    # @param shipping_methods [Array<Spree::ShippingMethod>]
     # @param shipping_method [Spree::ShippingMethod]
     # @return [Boolean]
-    def ships_with?(distributor, shipping_method)
-      distributor.shipping_methods.include?(shipping_method)
+    def ships_with?(shipping_methods, shipping_method)
+      shipping_methods.include?(shipping_method)
     end
   end
 end

--- a/app/models/stock/package.rb
+++ b/app/models/stock/package.rb
@@ -26,8 +26,8 @@ module Stock
     def shipping_methods
       available_shipping_methods = super.to_a
 
-      available_shipping_methods.delete_if do |shipping_method|
-        !ships_with?(order.distributor.shipping_methods.to_a, shipping_method)
+      available_shipping_methods.keep_if do |shipping_method|
+        ships_with?(order.distributor.shipping_methods.to_a, shipping_method)
       end
     end
 

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -107,7 +107,7 @@ module Api
     end
 
     def active
-      data.active_distributors.andand.include? enterprise
+      data.active_distributor_ids.andand.include? enterprise.id
     end
 
     # Map svg icons.

--- a/app/serializers/api/uncached_enterprise_serializer.rb
+++ b/app/serializers/api/uncached_enterprise_serializer.rb
@@ -9,7 +9,7 @@ module Api
     end
 
     def active
-      options[:data].active_distributors.andand.include? object
+      options[:data].active_distributor_ids.andand.include? object.id
     end
   end
 end

--- a/lib/open_food_network/enterprise_injection_data.rb
+++ b/lib/open_food_network/enterprise_injection_data.rb
@@ -1,7 +1,8 @@
 module OpenFoodNetwork
   class EnterpriseInjectionData
-    def active_distributors
-      @active_distributors ||= Enterprise.distributors_with_active_order_cycles.ready_for_checkout
+    def active_distributor_ids
+      @active_distributor_ids ||=
+        Enterprise.distributors_with_active_order_cycles.ready_for_checkout.pluck(:id)
     end
 
     def earliest_closing_times

--- a/spec/controllers/shops_controller_spec.rb
+++ b/spec/controllers/shops_controller_spec.rb
@@ -7,7 +7,7 @@ describe ShopsController, type: :controller do
   let!(:distributor) { create(:distributor_enterprise) }
 
   before do
-    allow(Enterprise).to receive_message_chain(:distributors_with_active_order_cycles, :ready_for_checkout) { [distributor] }
+    allow(OpenFoodNetwork::EnterpriseInjectionData).to receive(:active_distributor_ids) { [distributor.id] }
   end
 
   it 'renders distributed product properties' do

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -50,7 +50,7 @@ describe Api::CachedEnterpriseSerializer do
 
     context 'when the enterprise is not an active distributor' do
       let(:enterprise_injection_data) do
-        instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributors: [])
+        instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributor_ids: [])
       end
 
       it 'does not duplicate properties' do
@@ -69,7 +69,7 @@ describe Api::CachedEnterpriseSerializer do
 
     context 'when the enterprise is an active distributor' do
       let(:enterprise_injection_data) do
-        instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributors: [shop])
+        instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributor_ids: [shop.id])
       end
 
       it 'does not duplicate properties' do


### PR DESCRIPTION
#### What? Why?

Related to #5049 and #4673 

Removes various N+1 queries from a number of pages. Partly directed by `bullet` reports, and partly by SQL output in `rack-mini-profiler`. Tested locally with Aus production data.

Significantly improves load times on groups and producers pages, and in **admin order edit**, which was especially bad with full production data.

#### What should we test?
<!-- List which features should be tested and how. -->

Sanity check:
- groups
- producers
- admin order edit

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Performance improvements for producers and groups pages, and admin order edit

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

