### PR TITLE
1760-Instagram-Link-Validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -813,4 +813,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -813,4 +813,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   2.1.4
+   1.17.2

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -25,8 +25,7 @@ class Enterprise < ActiveRecord::Base
   has_many :relationships_as_child, class_name: 'EnterpriseRelationship',
                                     foreign_key: 'child_id',
                                     dependent: :destroy
-  has_and_belongs_to_many :groups, join_table: 'enterprise_groups_enterprises',
-                                   class_name: 'EnterpriseGroup'
+  has_and_belongs_to_many :groups, class_name: 'EnterpriseGroup'
   has_many :producer_properties, foreign_key: 'producer_id'
   has_many :properties, through: :producer_properties
   has_many :supplied_products, class_name: 'Spree::Product',
@@ -97,6 +96,8 @@ class Enterprise < ActiveRecord::Base
   before_validation :set_unused_address_fields
   after_validation :geocode_address
 
+  validates :instagram, format: /\A[a-zA-Z0-9._]{1,30}\z/, allow_blank: true
+
   after_touch :touch_distributors
   after_create :set_default_contact
   after_create :relate_to_owners_enterprises
@@ -116,10 +117,7 @@ class Enterprise < ActiveRecord::Base
   scope :not_ready_for_checkout, lambda {
     # When ready_for_checkout is empty, return all rows when there are no enterprises ready for
     # checkout.
-    ready_enterprises = Enterprise.ready_for_checkout.
-      except(:select).
-      select('DISTINCT enterprises.id')
-
+    ready_enterprises = Enterprise.ready_for_checkout.select('enterprises.id')
     if ready_enterprises.present?
       where("enterprises.id NOT IN (?)", ready_enterprises)
     else
@@ -321,7 +319,7 @@ class Enterprise < ActiveRecord::Base
   def distributed_taxons
     Spree::Taxon.
       joins(:products).
-      where('spree_products.id IN (?)', Spree::Product.in_distributor(self).select(&:id)).
+      where('spree_products.id IN (?)', Spree::Product.in_distributor(self)).
       select('DISTINCT spree_taxons.*')
   end
 
@@ -337,7 +335,7 @@ class Enterprise < ActiveRecord::Base
   def supplied_taxons
     Spree::Taxon.
       joins(:products).
-      where('spree_products.id IN (?)', Spree::Product.in_supplier(self).select(&:id)).
+      where('spree_products.id IN (?)', Spree::Product.in_supplier(self)).
       select('DISTINCT spree_taxons.*')
   end
 
@@ -370,6 +368,10 @@ class Enterprise < ActiveRecord::Base
     abn.present?
   end
 
+  def instagram=(value)
+    self[:instagram] = ((value.downcase).try(:gsub, instagram_regex, '\1')).gsub('@','')
+  end
+
   protected
 
   def devise_mailer
@@ -377,6 +379,10 @@ class Enterprise < ActiveRecord::Base
   end
 
   private
+
+  def instagram_regex
+    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@]{1,30})/?\z}
+  end
 
   def current_exchange_variants
     ExchangeVariant.joins(exchange: :order_cycle)

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -97,7 +97,7 @@ class Enterprise < ActiveRecord::Base
   before_validation :set_unused_address_fields
   after_validation :geocode_address
 
-  validates :instagram, format: /\A[a-zA-Z0-9._]{1,30}\z/, allow_blank: true
+  validates :instagram, format: /\A[a-zA-Z0-9._-]{1,30}\z/, allow_blank: true
 
   after_touch :touch_distributors
   after_create :set_default_contact
@@ -385,7 +385,7 @@ class Enterprise < ActiveRecord::Base
   private
 
   def instagram_regex
-    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@]{1,30})/?\z}
+    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
   end
 
   def current_exchange_variants

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -373,7 +373,7 @@ class Enterprise < ActiveRecord::Base
   end
 
   def instagram=(value)
-    self[:instagram] = value.downcase.try(:gsub, instagram_regex, '\1').gsub('@','')
+    self[:instagram] = value.downcase.try(:gsub, instagram_regex, '\1').gsub('@', '')
   end
 
   protected

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -120,7 +120,7 @@ feature "Registration", js: true do
       expect(e.facebook).to eq "FaCeBoOk"
       expect(e.linkedin).to eq "LiNkEdIn"
       expect(e.twitter).to eq "@TwItTeR"
-      expect(e.instagram).to eq "@InStAgRaM"
+      expect(e.instagram).to eq "InStAgRaM"
 
       click_link "Go to Enterprise Dashboard"
       expect(page).to have_content "CHOOSE YOUR PACKAGE"

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -120,7 +120,7 @@ feature "Registration", js: true do
       expect(e.facebook).to eq "FaCeBoOk"
       expect(e.linkedin).to eq "LiNkEdIn"
       expect(e.twitter).to eq "@TwItTeR"
-      expect(e.instagram).to eq "InStAgRaM"
+      expect(e.instagram).to eq "instagram"
 
       click_link "Go to Enterprise Dashboard"
       expect(page).to have_content "CHOOSE YOUR PACKAGE"

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -147,7 +147,6 @@ describe Enterprise do
       end
 
       context "prevent an wrong instagram link pattern" do
-
         it "expects to be invalid the instagram attribute https://facebook.com/user" do
           e = build(:enterprise, instagram: 'https://facebook.com/user')
           expect(e).to_not be_valid

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -165,7 +165,7 @@ describe Enterprise do
 
       context "accepted pattern" do
         it "validates empty instagram attribute" do
-          e = build(:enterprise)
+          e = build(:enterprise, instagram: '')
           expect(e).to be_valid
           expect(e.instagram).to eq ""
         end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -220,7 +220,6 @@ describe Enterprise do
           expect(e).to be_valid
         end
 
-
         it "renders the expected pattern" do
           e = build(:enterprise, instagram: 'instagram.com/user')
           expect(e.instagram).to eq('user')

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -146,82 +146,93 @@ describe Enterprise do
         expect(enterprise.contact).to eq enterprise.owner
       end
 
-      context "prevent an wrong instagram link pattern" do
-        it "expects to be invalid the instagram attribute https://facebook.com/user" do
+      context "prevent a wrong instagram link pattern" do
+        it "invalidates the instagram attribute https://facebook.com/user" do
           e = build(:enterprise, instagram: 'https://facebook.com/user')
           expect(e).to_not be_valid
         end
 
-        it "expects to be invalid the instagram attribute tagram.com/user" do
+        it "invalidates the instagram attribute tagram.com/user" do
           e = build(:enterprise, instagram: 'tagram.com/user')
           expect(e).to_not be_valid
         end
 
-        it "expects to be invalid the instagram attribute https://instagram.com/user/preferences" do
+        it "invalidates the instagram attribute https://instagram.com/user/preferences" do
           e = build(:enterprise, instagram: 'https://instagram.com/user/preferences')
           expect(e).to_not be_valid
         end
       end
 
       context "accepted pattern" do
-        it "expects to be valid empty instagram attribute" do
+        it "validates empty instagram attribute" do
           e = build(:enterprise)
           expect(e).to be_valid
+          expect(e.instagram).to eq ""
         end
 
-        it "expects to be valid the instagram attribute @my-user" do
+        it "validates the instagram attribute @my-user" do
           e = build(:enterprise, instagram: '@my-user')
           expect(e).to be_valid
+          expect(e.instagram).to eq "my-user"
         end
 
-        it "expects be valid the instagram attribute user" do
+        it "validates the instagram attribute user" do
           e = build(:enterprise, instagram: 'user')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
 
-        it "expects be valid the instagram attribute my_www5.example" do
+        it "validates the instagram attribute my_www5.example" do
           e = build(:enterprise, instagram: 'my_www5.example')
           expect(e).to be_valid
+          expect(e.instagram).to eq "my_www5.example"
         end
 
-        it "expects be valid the instagram attribute http://instagram.com/user" do
+        it "validates the instagram attribute http://instagram.com/user" do
           e = build(:enterprise, instagram: 'http://instagram.com/user')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
 
-        it "expects be valid the instagram attribute https://instagram.com/user/" do
+        it "validates the instagram attribute https://instagram.com/user/" do
           e = build(:enterprise, instagram: 'https://instagram.com/user/')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
 
-        it "expects be valid the instagram attribute https://www.instagram.com/user" do
+        it "validates the instagram attribute https://www.instagram.com/user" do
           e = build(:enterprise, instagram: 'https://www.instagram.com/user')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
 
-        it "expects be valid the instagram attribute https://www.instagram.com/@user" do
+        it "validates the instagram attribute https://www.instagram.com/@user" do
           e = build(:enterprise, instagram: 'https://www.instagram.com/@user')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
 
-        it "expects be valid the instagram attribute instagram.com/@user" do
+        it "validates the instagram attribute instagram.com/@user" do
           e = build(:enterprise, instagram: 'instagram.com/@user')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
         
-        it "expects be valid the instagram attribute Https://www.Instagram.com/@User" do
+        it "validates the instagram attribute Https://www.Instagram.com/@User" do
           e = build(:enterprise, instagram: 'Https://www.Instagram.com/@User')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
 
-        it "expects be valid the instagram attribute instagram.com/user" do
+        it "validates the instagram attribute instagram.com/user" do
           e = build(:enterprise, instagram: 'instagram.com/user')
           expect(e).to be_valid
+          expect(e.instagram).to eq "user"
         end
 
         it "renders the expected pattern" do
           e = build(:enterprise, instagram: 'instagram.com/user')
-          expect(e.instagram).to eq('user')
+          expect(e.instagram).to eq "user"
         end
       end
 

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -145,6 +145,88 @@ describe Enterprise do
       it "sets the enterprise contact to the owner by default" do
         expect(enterprise.contact).to eq enterprise.owner
       end
+
+      context "prevent an wrong instagram link pattern" do
+
+        it "expects to be invalid the instagram attribute https://facebook.com/user" do
+          e = build(:enterprise, instagram: 'https://facebook.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "expects to be invalid the instagram attribute tagram.com/user" do
+          e = build(:enterprise, instagram: 'tagram.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "expects to be invalid the instagram attribute https://instagram.com/user/preferences" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/preferences')
+          expect(e).to_not be_valid
+        end
+      end
+
+      context "accepted pattern" do
+        it "expects to be valid empty instagram attribute" do
+          e = build(:enterprise)
+          expect(e).to be_valid
+        end
+
+        it "expects to be valid the instagram attribute @my-user" do
+          e = build(:enterprise, instagram: '@my-user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute user" do
+          e = build(:enterprise, instagram: 'user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute my_www5.example" do
+          e = build(:enterprise, instagram: 'my_www5.example')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute http://instagram.com/user" do
+          e = build(:enterprise, instagram: 'http://instagram.com/user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute https://instagram.com/user/" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute https://www.instagram.com/user" do
+          e = build(:enterprise, instagram: 'https://www.instagram.com/user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute https://www.instagram.com/@user" do
+          e = build(:enterprise, instagram: 'https://www.instagram.com/@user')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute instagram.com/@user" do
+          e = build(:enterprise, instagram: 'instagram.com/@user')
+          expect(e).to be_valid
+        end
+        
+        it "expects be valid the instagram attribute Https://www.Instagram.com/@User" do
+          e = build(:enterprise, instagram: 'Https://www.Instagram.com/@User')
+          expect(e).to be_valid
+        end
+
+        it "expects be valid the instagram attribute instagram.com/user" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e).to be_valid
+        end
+
+
+        it "renders the expected pattern" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e.instagram).to eq('user')
+        end
+      end
+
     end
 
     describe "preferred_shopfront_taxon_order" do


### PR DESCRIPTION
#### What? Why?

Closes #1760

This PR returns Instagram validation to the enterprise social tab. It also accounts for the new potential input conditions:

- @instagram_handle
- https://instagram.com/@instagram_handle

These are both common (and, in the case of the second, incorrect) ways Instagram users enter in their handles on social tabs. 

This new validation also ignores case for both the Instagram handle (as these are always lowercase), and for the link, as a single erroneous capitalized character will cause it to validate as incorrect. (ie. a mistype of the link) 


#### What should we test?
Within the enterprise_spec.rb test suite, I've reincorporated the old validation tests as well as a few more to account for the new conditions specified above. This should test multiple variations of correct formats (ie with or without the entire link, the use of '@', etc), as well as incorrect formats and invalid links. 


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Added Instagram handle validation for the enterprise social tab. This allows for less confusion when the user enters their Instagram handle, even in different ways. 


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added 


#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->
https://github.com/openfoodfoundation/openfoodnetwork/issues/1760
https://github.com/openfoodfoundation/openfoodnetwork/pull/3238

