### PR TITLE
Fix weight calculator

### DIFF
--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -54,6 +54,8 @@ module Calculator
     #    Customer ends up getting 350mL (line_item.final_weight_volume) of wine
     #      that represent 2.8 (quantity_implied_in_final_weight_volume) glasses of wine
     def quantity_implied_in_final_weight_volume(line_item)
+      return line_item.quantity if line_item.variant.unit_value.zero?
+
       (1.0 * line_item.final_weight_volume / line_item.variant.unit_value).round(3)
     end
 

--- a/app/models/calculator/weight.rb
+++ b/app/models/calculator/weight.rb
@@ -54,7 +54,7 @@ module Calculator
     #    Customer ends up getting 350mL (line_item.final_weight_volume) of wine
     #      that represent 2.8 (quantity_implied_in_final_weight_volume) glasses of wine
     def quantity_implied_in_final_weight_volume(line_item)
-      return line_item.quantity if line_item.variant.unit_value.zero?
+      return line_item.quantity if line_item.variant.unit_value.to_f.zero?
 
       (1.0 * line_item.final_weight_volume / line_item.variant.unit_value).round(3)
     end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -156,19 +156,24 @@ describe Calculator::Weight do
     let(:product) {
       create(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: "bunch")
     }
-    let(:variant1) { create(:variant, product: product, unit_value: 0, weight: nil) }
-    let(:variant2) { create(:variant, product: product, unit_value: 0, weight: 10.0) }
-    let(:line_item1) { create(:line_item, variant: variant1, quantity: 1) }
-    let(:line_item2) { create(:line_item, variant: variant2, quantity: 1) }
+    let(:line_item) { create(:line_item, variant: variant, quantity: 1) }
 
     before { subject.set_preference(:per_kg, 5) }
 
-    it "uses zero weight if variant.weight is not present" do
-      expect(subject.compute(line_item1)).to eq 0
+    context "when variant.weight is present" do
+      let(:variant) { create(:variant, product: product, unit_value: 0, weight: 10.0) }
+
+      it "uses the variant weight" do
+        expect(subject.compute(line_item)).to eq 50.0
+      end
     end
 
-    it "uses the variant weight if variant.weight is present" do
-      expect(subject.compute(line_item2)).to eq 50.0
+    context "when variant.weight is nil" do
+      let(:variant) { create(:variant, product: product, unit_value: 0, weight: nil) }
+
+      it "uses zero weight" do
+        expect(subject.compute(line_item)).to eq 0
+      end
     end
   end
 end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -141,7 +141,7 @@ describe Calculator::Weight do
     end
 
     context "when the product uses item unit" do
-      let!(:product_attributes) { { variant_unit: "items", variant_unit_scale: nil, variant_unit: "pc", display_as: "pc" } }
+      let!(:product_attributes) { { variant_unit: "items", variant_unit_scale: nil, variant_unit_name: "pc", display_as: "pc" } }
       let!(:variant_attributes) { { unit_value: 3.0, weight: 2.5, display_as: "pc" } }
 
       it "is correct" do

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -163,19 +163,11 @@ describe Calculator::Weight do
 
     before { subject.set_preference(:per_kg, 5) }
 
-    it "returns NaN if variant.weight is not present" do
-      expect(subject.compute(line_item1).nan?).to be_truthy
-    end
-
-    xit "uses zero weight if variant.weight is not present" do
+    it "uses zero weight if variant.weight is not present" do
       expect(subject.compute(line_item1)).to eq 0
     end
 
-    it "returns NaN if variant.weight is present" do
-      expect(subject.compute(line_item2).nan?).to be_truthy
-    end
-
-    xit "uses the variant weight if variant.weight is present" do
+    it "uses the variant weight if variant.weight is present" do
       expect(subject.compute(line_item2)).to eq 50.0
     end
   end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -19,8 +19,8 @@ describe Calculator::Weight do
   end
 
   describe "line item with variant_unit weight and variant unit_value" do
-    let(:variant) { build(:variant, unit_value: 10_000) }
-    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+    let(:variant) { create(:variant, unit_value: 10_000) }
+    let(:line_item) { create(:line_item, variant: variant, quantity: 2) }
 
     before { subject.set_preference(:per_kg, 5) }
 
@@ -46,11 +46,11 @@ describe Calculator::Weight do
   end
 
   it "computes shipping cost for an object with an order" do
-    variant1 = build(:variant, unit_value: 10_000)
-    variant2 = build(:variant, unit_value: 20_000)
+    variant1 = create(:variant, unit_value: 10_000)
+    variant2 = create(:variant, unit_value: 20_000)
 
-    line_item1 = build(:line_item, variant: variant1, quantity: 1)
-    line_item2 = build(:line_item, variant: variant2, quantity: 2)
+    line_item1 = create(:line_item, variant: variant1, quantity: 1)
+    line_item2 = create(:line_item, variant: variant2, quantity: 2)
 
     order = double(:order, line_items: [line_item1, line_item2])
     object_with_order = double(:object_with_order, order: order)
@@ -65,7 +65,7 @@ describe Calculator::Weight do
 
     let(:calculator) { described_class.new(preferred_per_kg: 6) }
     let(:line_item) do
-      build(:line_item, variant: variant, quantity: 2).tap do |object|
+      create(:line_item, variant: variant, quantity: 2).tap do |object|
         object.send(:calculate_final_weight_volume)
       end
     end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -152,7 +152,7 @@ describe Calculator::Weight do
     end
   end
 
-  context "when variant_unit is 'items' and unit_value is zero" do
+  context "when variant_unit is 'items'" do
     let(:product) {
       create(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: "bunch")
     }
@@ -160,7 +160,7 @@ describe Calculator::Weight do
 
     before { subject.set_preference(:per_kg, 5) }
 
-    context "when variant.weight is present" do
+    context "when unit_value is zero variant.weight is present" do
       let(:variant) { create(:variant, product: product, unit_value: 0, weight: 10.0) }
 
       it "uses the variant weight" do
@@ -168,10 +168,34 @@ describe Calculator::Weight do
       end
     end
 
-    context "when variant.weight is nil" do
+    context "when unit_value is zero variant.weight is nil" do
       let(:variant) { create(:variant, product: product, unit_value: 0, weight: nil) }
 
       it "uses zero weight" do
+        expect(subject.compute(line_item)).to eq 0
+      end
+    end
+
+    context "when unit_value is nil and variant.weight is present" do
+      let(:variant) {
+        create(:variant, product: product, unit_description: "bunches", unit_value: nil, weight: 10.0)
+      }
+
+      it "uses the variant weight" do
+        line_item.final_weight_volume = 1
+
+        expect(subject.compute(line_item)).to eq 50.0
+      end
+    end
+
+    context "when unit_value is nil and variant.weight is nil" do
+      let(:variant) {
+        create(:variant, product: product, unit_description: "bunches", unit_value: nil, weight: nil)
+      }
+
+      it "uses zero weight" do
+        line_item.final_weight_volume = 1
+
         expect(subject.compute(line_item)).to eq 0
       end
     end

--- a/spec/models/calculator/weight_spec.rb
+++ b/spec/models/calculator/weight_spec.rb
@@ -151,4 +151,32 @@ describe Calculator::Weight do
       end
     end
   end
+
+  context "when variant_unit is 'items' and unit_value is zero" do
+    let(:product) {
+      create(:product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: "bunch")
+    }
+    let(:variant1) { create(:variant, product: product, unit_value: 0, weight: nil) }
+    let(:variant2) { create(:variant, product: product, unit_value: 0, weight: 10.0) }
+    let(:line_item1) { create(:line_item, variant: variant1, quantity: 1) }
+    let(:line_item2) { create(:line_item, variant: variant2, quantity: 1) }
+
+    before { subject.set_preference(:per_kg, 5) }
+
+    it "returns NaN if variant.weight is not present" do
+      expect(subject.compute(line_item1).nan?).to be_truthy
+    end
+
+    xit "uses zero weight if variant.weight is not present" do
+      expect(subject.compute(line_item1)).to eq 0
+    end
+
+    it "returns NaN if variant.weight is present" do
+      expect(subject.compute(line_item2).nan?).to be_truthy
+    end
+
+    xit "uses the variant weight if variant.weight is present" do
+      expect(subject.compute(line_item2)).to eq 50.0
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #4695

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Fixes issue where weight calculator was causing fatal errors by returning `BigDecimal::NaN` in some cases.

In the case where `variant.product.unit_type` was `items`, and `variant.unit_value` was set to `0`, and `variant.weight` was not set; we were **dividing by zero** in one of the calculations.

#### What should we test?
<!-- List which features should be tested and how. -->

Checkout should work when: 
- one of the products in the order uses "items" as the type and has unit_value "0".
- the shipping method uses the weight calculator

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed problematic edge case for shipping methods using weight calculator

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed