### PR TITLE
Fix broken new property button in properties page (regression from removing spree_backend)

### DIFF
--- a/app/views/spree/admin/properties/new.js.erb
+++ b/app/views/spree/admin/properties/new.js.erb
@@ -1,2 +1,2 @@
-$("#new_property").html('<%= escape_javascript(render :template => "spree/admin/properties/new", :formats => [:html], :handlers => [:erb]) %>');
+$("#new_property").html('<%= escape_javascript(render :template => "spree/admin/properties/new", :formats => [:html], :handlers => [:haml]) %>');
 $("#new_property_link").parent().hide();

--- a/spec/features/admin/properties_spec.rb
+++ b/spec/features/admin/properties_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+feature '
+    As an admin
+    I want to manage product properties
+' do
+  include AuthenticationWorkflow
+
+  scenario "creating and editing a property" do
+    login_to_admin_section
+    visit spree.admin_properties_path
+
+    click_link 'New Property'
+    fill_in 'property_name', with: 'New property!'
+    fill_in 'property_presentation', with: 'New property presentation!'
+    click_button 'Create'
+    expect(page).to have_content 'New property!'
+
+    page.find('td.actions a.icon-edit').click
+    expect(page).to have_field 'property_name', with: 'New property!'
+    fill_in 'property_name', with: 'New changed property!'
+    click_button 'Update'
+    expect(page).to have_content 'New changed property!'
+  end
+end


### PR DESCRIPTION
#### What? Why?

I noticed this bug on bugsnag:
https://app.bugsnag.com/yaycode/open-food-network-germany/errors/5e784f7762b590001ac96fc2?event_id=5e784f770058e42e59130000&i=sk&m=nw

It's a very easy fix,, I just did it.

#### What should we test?
There's an auto spec now so no need for manual testing!


#### Release notes
Changelog Category: Fixed
Fixed broken "New property" button in the product properties page.
