### PR TITLE
Fix sample data and custom paper_trail config on order_cycles and schedules on rails 4

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -17,7 +17,7 @@ class OrderCycle < ActiveRecord::Base
   has_many :distributors, source: :receiver, through: :cached_outgoing_exchanges, uniq: true
 
   has_and_belongs_to_many :schedules, join_table: 'order_cycle_schedules'
-  has_paper_trail meta: { custom_data: :schedule_ids }
+  has_paper_trail meta: { custom_data: proc { |order_cycle| order_cycle.schedule_ids.to_s } }
 
   attr_accessor :incoming_exchanges, :outgoing_exchanges
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,6 +1,6 @@
 class Schedule < ActiveRecord::Base
   has_and_belongs_to_many :order_cycles, join_table: 'order_cycle_schedules'
-  has_paper_trail meta: { custom_data: :order_cycle_ids }
+  has_paper_trail meta: { custom_data: proc { |schedule| schedule.order_cycle_ids.to_s } }
 
   has_many :coordinators, uniq: true, through: :order_cycles
 

--- a/lib/tasks/sample_data/group_factory.rb
+++ b/lib/tasks/sample_data/group_factory.rb
@@ -10,19 +10,21 @@ class GroupFactory
     return if EnterpriseGroup.where(name: "Producer group").exists?
 
     create_group(
-      name: "Producer group",
-      owner: enterprises.first.owner,
-      on_front_page: true,
-      description: "The seed producers",
-      address: "6 Rollings Road, Upper Ferntree Gully, 3156"
+      {
+        name: "Producer group",
+        owner: enterprises.first.owner,
+        on_front_page: true,
+        description: "The seed producers"
+      },
+      "6 Rollings Road, Upper Ferntree Gully, 3156"
     )
   end
 
   private
 
-  def create_group(params)
+  def create_group(params, group_address)
     group = EnterpriseGroup.new(params)
-    group.address = address(params[:address])
+    group.address = address(group_address)
     group.enterprises = enterprises
     group.save!
   end


### PR DESCRIPTION
#### What? Why?

Fixes sample data and also adapts paper_trail custom data config.

#### What should we test?
Build green.
Sample data still works in master.
Table versions still has custom_data field with list of ids when creating and editing schedules and order cycles.

#### Release notes
Changelog Category: Changed
Adapt sample data code to rails 4.
Adapt logging in subscriptions related code (schedules) to work with rails 4.
