### PR TITLE
Fix translation missing in order cycles outgoing page (closed #4937)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -914,6 +914,12 @@ en:
         cancel: "Cancel"
         back_to_list: "Back To List"
       outgoing:
+        outgoing: "Outgoing"
+        distributor: "Distributor"
+        products: "Products"
+        tags: "Tags"
+        delivery_details: "Delivery Details"
+        fees: "Fees"
         previous: "Previous"
         save: "Save"
         save_and_back_to_list: "Save and Back to List"


### PR DESCRIPTION
#### What? Why?

Closes #4937 

In fr, fr_BE, and fr_CA locale, words mentioned in #4937 in order cycles outgoing page are still in English, but French is needed.

#### What should we test?

1. Change locale: change config/application.yml as below and restart rails server

```
[..snip..]

TIMEZONE: Paris
DEFAULT_COUNTRY_CODE: FR
LOCALE: fr
AVAILABLE_LOCALES: fr,fr_BE,fr_CA
CHECKOUT_ZONE: France
CURRENCY: EUR

[..snip..]
```

2. Log in as a manager for a hub or a mutli-producer shop
3. Go to /admin/order_cycles
4. Create an order cycle
5. Go to /admin/order_cycles/:order_cycle_id/outgoing
6. Check words mentioned in #4937 are in French.

#### Release notes
Fixed translation missing in order cycles outgoing page
Changelog Category: Fixed
