### PR TITLE
Translate credit card brand so that active merchand code handles the payment correctly

### DIFF
--- a/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
@@ -14,6 +14,7 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
       @stripe.createToken(@card, cardData).then (response) =>
         if(response.error)
           StatusMessage.display 'error', response.error.message
+          console.log(JSON.stringify(response.error))
         else
           secrets.token = response.token.id
           secrets.cc_type = @mapCC(response.token.card.brand)
@@ -29,9 +30,10 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
       @stripe.createPaymentMethod({ type: 'card', card: @card }, @card, cardData).then (response) =>
         if(response.error)
           StatusMessage.display 'error', response.error.message
+          console.log(JSON.stringify(response.error))
         else
           secrets.token = response.paymentMethod.id
-          secrets.cc_type = response.paymentMethod.card.brand
+          secrets.cc_type = @mapCC(response.paymentMethod.card.brand)
           secrets.card = response.paymentMethod.card
           submit()
 

--- a/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
@@ -14,10 +14,10 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
       @stripe.createToken(@card, cardData).then (response) =>
         if(response.error)
           StatusMessage.display 'error', response.error.message
-          console.log(JSON.stringify(response.error))
+          console.error(JSON.stringify(response.error))
         else
           secrets.token = response.token.id
-          secrets.cc_type = @mapCC(response.token.card.brand)
+          secrets.cc_type = @mapTokenApiCardBrand(response.token.card.brand)
           secrets.card = response.token.card
           submit()
 
@@ -30,22 +30,30 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
       @stripe.createPaymentMethod({ type: 'card', card: @card }, @card, cardData).then (response) =>
         if(response.error)
           StatusMessage.display 'error', response.error.message
-          console.log(JSON.stringify(response.error))
+          console.error(JSON.stringify(response.error))
         else
           secrets.token = response.paymentMethod.id
-          secrets.cc_type = @mapCC(response.paymentMethod.card.brand)
+          secrets.cc_type = @mapPaymentMethodsApiCardBrand(response.paymentMethod.card.brand)
           secrets.card = response.paymentMethod.card
           submit()
 
-    # Maps the brand returned by Stripe to that required by activemerchant
-    mapCC: (ccType) ->
-      switch ccType
+    # Maps the brand returned by Stripe's tokenAPI to that required by activemerchant
+    mapTokenApiCardBrand: (cardBrand) ->
+      switch cardBrand
         when 'MasterCard' then return 'master'
         when 'Visa' then return 'visa'
         when 'American Express' then return 'american_express'
         when 'Discover' then return 'discover'
         when 'JCB' then return 'jcb'
         when 'Diners Club' then return 'diners_club'
+
+    # Maps the brand returned by Stripe's paymentMethodsAPI to that required by activemerchant
+    mapPaymentMethodsApiCardBrand: (cardBrand) ->
+      switch cardBrand
+        when 'mastercard' then return 'master'
+        when 'amex' then return 'american_express'
+        when 'diners' then return 'diners_club'
+        else return cardBrand # a few brands are equal, for example, visa
 
     # It doesn't matter if any of these are nil, all are optional.
     makeCardData: (secrets) ->

--- a/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
@@ -16,6 +16,7 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
           Loading.clear()
           RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
           @triggerAngularDigest()
+          console.log(JSON.stringify(response.error))
         else
           secrets.token = response.token.id
           secrets.cc_type = @mapCC(response.token.card.brand)
@@ -34,9 +35,10 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
           Loading.clear()
           RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
           @triggerAngularDigest()
+          console.log(JSON.stringify(response.error))
         else
           secrets.token = response.paymentMethod.id
-          secrets.cc_type = response.paymentMethod.card.brand
+          secrets.cc_type = @mapCC(response.paymentMethod.card.brand)
           secrets.card = response.paymentMethod.card
           submit()
 

--- a/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
@@ -16,10 +16,10 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
           Loading.clear()
           RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
           @triggerAngularDigest()
-          console.log(JSON.stringify(response.error))
+          console.error(JSON.stringify(response.error))
         else
           secrets.token = response.token.id
-          secrets.cc_type = @mapCC(response.token.card.brand)
+          secrets.cc_type = @mapTokenApiCardBrand(response.token.card.brand)
           secrets.card = response.token.card
           submit()
 
@@ -35,10 +35,10 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
           Loading.clear()
           RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
           @triggerAngularDigest()
-          console.log(JSON.stringify(response.error))
+          console.error(JSON.stringify(response.error))
         else
           secrets.token = response.paymentMethod.id
-          secrets.cc_type = @mapCC(response.paymentMethod.card.brand)
+          secrets.cc_type = @mapPaymentMethodsApiCardBrand(response.paymentMethod.card.brand)
           secrets.card = response.paymentMethod.card
           submit()
 
@@ -46,15 +46,23 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
       # $evalAsync is improved way of triggering a digest without calling $apply
       $rootScope.$evalAsync()
 
-    # Maps the brand returned by Stripe to that required by activemerchant
-    mapCC: (ccType) ->
-      switch ccType
+    # Maps the brand returned by Stripe's tokenAPI to that required by activemerchant
+    mapTokenApiCardBrand: (cardBrand) ->
+      switch cardBrand
         when 'MasterCard' then return 'master'
         when 'Visa' then return 'visa'
         when 'American Express' then return 'american_express'
         when 'Discover' then return 'discover'
         when 'JCB' then return 'jcb'
         when 'Diners Club' then return 'diners_club'
+
+    # Maps the brand returned by Stripe's paymentMethodsAPI to that required by activemerchant
+    mapPaymentMethodsApiCardBrand: (cardBrand) ->
+      switch cardBrand
+        when 'mastercard' then return 'master'
+        when 'amex' then return 'american_express'
+        when 'diners' then return 'diners_club'
+        else return cardBrand # a few brands are equal, for example, visa
 
     # It doesn't matter if any of these are nil, all are optional.
     makeCardData: (secrets) ->

--- a/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
@@ -51,11 +51,18 @@ describe 'StripeElements Service', ->
           expect(Loading.clear).toHaveBeenCalled()
           expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: "Error: There was a problem"})
 
-  describe 'mapCC', ->
-    it "maps the brand returned by Stripe to that required by activemerchant", ->
-      expect(StripeElements.mapCC('MasterCard')).toEqual "master"
-      expect(StripeElements.mapCC('Visa')).toEqual "visa"
-      expect(StripeElements.mapCC('American Express')).toEqual "american_express"
-      expect(StripeElements.mapCC('Discover')).toEqual "discover"
-      expect(StripeElements.mapCC('JCB')).toEqual "jcb"
-      expect(StripeElements.mapCC('Diners Club')).toEqual "diners_club"
+  describe 'mapTokenApiCardBrand', ->
+    it "maps the brand returned by Stripe's tokenAPI to that required by activemerchant", ->
+      expect(StripeElements.mapTokenApiCardBrand('MasterCard')).toEqual "master"
+      expect(StripeElements.mapTokenApiCardBrand('Visa')).toEqual "visa"
+      expect(StripeElements.mapTokenApiCardBrand('American Express')).toEqual "american_express"
+      expect(StripeElements.mapTokenApiCardBrand('Discover')).toEqual "discover"
+      expect(StripeElements.mapTokenApiCardBrand('JCB')).toEqual "jcb"
+      expect(StripeElements.mapTokenApiCardBrand('Diners Club')).toEqual "diners_club"
+
+  describe 'mapPaymentMethodsApiCardBrand', ->
+    it "maps the brand returned by Stripe's paymentMethodsAPI to that required by activemerchant", ->
+      expect(StripeElements.mapPaymentMethodsApiCardBrand('mastercard')).toEqual "master"
+      expect(StripeElements.mapPaymentMethodsApiCardBrand('amex')).toEqual "american_express"
+      expect(StripeElements.mapPaymentMethodsApiCardBrand('diners')).toEqual "diners_club"
+      expect(StripeElements.mapPaymentMethodsApiCardBrand('visa')).toEqual "visa"


### PR DESCRIPTION
#### What? Why?

I _believe_ it closes #5068

We convert card types so that active merchant handles the payment correctly. For some reason I didnt copy this logic from the old stripe payment method. We need this.
This is done in checkout and backend payments collection.

Additionally, I added a simple console.log statement to LOG errors on JS calls to Stripe. We will have the console log in the browser available to see what went wrong. This was discussed here: https://github.com/openfoodfoundation/openfoodnetwork/issues/5003#issuecomment-600246636
This is how it will look like in the user browser console:
![image](https://user-images.githubusercontent.com/1640378/77537743-80023700-6e96-11ea-8ae6-cd957a6dbdcd.png)

#### What should we test?
Verify stripeSCA payments are working as before.
We can test the logging by checking out with a test stripe card but inserting a invalid expiry date. It shows a red message but you can click checkout anyway and check the console log.
#### Release notes
Changelog Category: Fixed
Fix a problem in stripeSCA for some card types like mastercard.
