### PR TITLE
Remove Rails Foundation Helper and improve error display and logging in checkout controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,6 @@ gem 'momentjs-rails'
 gem 'turbo-sprockets-rails3'
 
 gem "foundation-rails"
-gem 'foundation_rails_helper', github: 'willrjmarshall/foundation_rails_helper', branch: "rails3"
 
 gem 'jquery-migrate-rails'
 gem 'jquery-rails', '3.1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,16 +65,6 @@ GIT
       rails-i18n
       spree_core (>= 1.1)
 
-GIT
-  remote: https://github.com/willrjmarshall/foundation_rails_helper.git
-  revision: 4d5d53fdc4b1fb71e66524d298c5c635de82cfbb
-  branch: rails3
-  specs:
-    foundation_rails_helper (0.4)
-      actionpack (>= 3.0)
-      activemodel (>= 3.0)
-      railties (>= 3.0)
-
 PATH
   remote: engines/catalog
   specs:
@@ -740,7 +730,6 @@ DEPENDENCIES
   foreigner
   foundation-icons-sass-rails
   foundation-rails
-  foundation_rails_helper!
   fuubar (~> 2.5.0)
   geocoder
   gmaps4rails

--- a/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
@@ -15,6 +15,7 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
         if(response.error)
           Loading.clear()
           RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
+          @triggerAngularDigest()
         else
           secrets.token = response.token.id
           secrets.cc_type = @mapCC(response.token.card.brand)
@@ -32,11 +33,16 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
         if(response.error)
           Loading.clear()
           RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
+          @triggerAngularDigest()
         else
           secrets.token = response.paymentMethod.id
           secrets.cc_type = response.paymentMethod.card.brand
           secrets.card = response.paymentMethod.card
           submit()
+
+    triggerAngularDigest: ->
+      # $evalAsync is improved way of triggering a digest without calling $apply
+      $rootScope.$evalAsync()
 
     # Maps the brand returned by Stripe to that required by activemerchant
     mapCC: (ccType) ->

--- a/app/assets/stylesheets/darkswarm/checkout.css.scss
+++ b/app/assets/stylesheets/darkswarm/checkout.css.scss
@@ -109,9 +109,4 @@ checkout {
       }
     }
   }
-
-  .error {
-    color: #c82020;
-  }
 }
-

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -165,7 +165,7 @@ class CheckoutController < Spree::StoreController
       checkout_succeeded
       redirect_to(order_path(@order)) && return
     else
-      flash[:error] = order_workflow_error
+      flash[:error] = order_error
       checkout_failed
     end
   end
@@ -179,8 +179,6 @@ class CheckoutController < Spree::StoreController
       @order.select_shipping_method(shipping_method_id) if @order.state == "delivery"
 
       next if advance_order_state(@order)
-
-      flash[:error] = order_workflow_error
       return update_failed
     end
 
@@ -205,7 +203,7 @@ class CheckoutController < Spree::StoreController
     false
   end
 
-  def order_workflow_error
+  def order_error
     if @order.errors.present?
       @order.errors.full_messages.to_sentence
     else
@@ -245,6 +243,7 @@ class CheckoutController < Spree::StoreController
   end
 
   def update_failed
+    flash[:error] = order_error if flash.empty?
     checkout_failed
     update_failed_response
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,4 @@
 module ApplicationHelper
-  include FoundationRailsHelper::FlashHelper
-
   def feature?(feature)
     OpenFoodNetwork::FeatureToggle.enabled? feature
   end

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -3,7 +3,7 @@
   = inject_available_payment_methods
   = inject_saved_credit_cards
 
-= f_form_for current_order,
+= form_for current_order,
   html: {name: "checkout",
     id: "checkout_form",
     novalidate: true,

--- a/app/views/checkout/_shipping.html.haml
+++ b/app/views/checkout/_shipping.html.haml
@@ -52,7 +52,8 @@
 
       .row
         .small-12.columns
-          = f.text_area :special_instructions, label: t(:checkout_instructions), size: "60x4", "ng-model" => "order.special_instructions"
+          %label{ for: 'order_special_instructions'}= t(:checkout_instructions)
+          = f.text_area :special_instructions, size: "60x4", "ng-model" => "order.special_instructions"
 
       .row
         .small-12.columns.text-right

--- a/app/views/user_passwords/edit.html.haml
+++ b/app/views/user_passwords/edit.html.haml
@@ -1,4 +1,4 @@
-= f_form_for @spree_user, :as => :spree_user, :url => spree.spree_user_password_path, :method => :put do |f|
+= form_for @spree_user, :as => :spree_user, :url => spree.spree_user_password_path, :method => :put do |f|
   = render :partial => 'spree/shared/error_messages', :locals => { :target => @spree_user }
   %fieldset
     .row
@@ -6,9 +6,11 @@
         %legend= t(:change_my_password)
     .row
       .small-12.medium-6.large-4.columns.medium-centered.large-centered
+        %label{ for: 'spree_user_password'}= t(:password)
         = f.password_field :password
     .row
       .small-12.medium-6.large-4.columns.medium-centered.large-centered
+        %label{ for: 'spree_user_password_confirmation'}= t(:password_confirmation)
         = f.password_field :password_confirmation
     = f.hidden_field :reset_password_token
     .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
         shipping_category_id: "Shipping Category"
         variant_unit: "Variant Unit"
         variant_unit_name: "Variant Unit Name"
+      spree/credit_card:
+        base: "Credit Card"
       order_cycle:
         orders_close_at: Close date
     errors:
@@ -50,6 +52,10 @@ en:
               taken: "There's already an account for this email. Please login or reset your password."
         spree/order:
           no_card: There are no authorised credit cards available to charge
+        spree/credit_card:
+          attributes:
+            base:
+              card_expired: "has expired"
         order_cycle:
           attributes:
             orders_close_at:

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -197,13 +197,13 @@ describe CheckoutController, type: :controller do
       allow(controller).to receive(:current_order).and_return(order)
     end
 
-    it "returns errors" do
+    it "returns errors and flash if order.update_attributes fails" do
       spree_post :update, format: :json, order: {}
       expect(response.status).to eq(400)
-      expect(response.body).to eq({ errors: assigns[:order].errors, flash: {} }.to_json)
+      expect(response.body).to eq({ errors: assigns[:order].errors, flash: { error: order.errors.full_messages.to_sentence } }.to_json)
     end
 
-    it "returns flash" do
+    it "returns errors and flash if order.next fails" do
       allow(order).to receive(:update_attributes).and_return true
       allow(order).to receive(:next).and_return false
       spree_post :update, format: :json, order: {}

--- a/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
@@ -46,11 +46,10 @@ describe 'StripeElements Service', ->
       it "doesn't submit the form, shows an error message instead", inject (Loading, RailsFlashLoader) ->
         spyOn(Loading, "clear")
         spyOn(RailsFlashLoader, "loadFlash")
-        StripeElements.requestToken(secrets, submit)
-        $rootScope.$digest() # required for #then to by called
-        expect(submit).not.toHaveBeenCalled()
-        expect(Loading.clear).toHaveBeenCalled()
-        expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: "Error: There was a problem"})
+        StripeElements.requestToken(secrets, submit).then (data) ->
+          expect(submit).not.toHaveBeenCalled()
+          expect(Loading.clear).toHaveBeenCalled()
+          expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: "Error: There was a problem"})
 
   describe 'mapCC', ->
     it "maps the brand returned by Stripe to that required by activemerchant", ->


### PR DESCRIPTION
#### What? Why?
Closes #5046 and #5075

There are 5 changes in this PR:
**5046** - we remove rails_foundation_helper (removed code can be seen [here](https://github.com/willrjmarshall/foundation_rails_helper/tree/master/lib/foundation_rails_helper)):
- flash_helper - I have tested a few flash messages and they are all showing up as before
- form_helper (f_form_for) - I cant find any differences in the checkout form with and without this

**5075** - errors on calls to stripe now show as flash messages to the user (like an invalid card number not detected by the credit card form)

**Additionally but related to 5075**, in this PR I am improving the checkout controller so that if there is an error in some part of the server side checkout process, the flash message to the user will always show the errors present on the order object.
**And additionally but also related to 5075**, in this PR I am generating a bugsnag error every time the checkout process fails. I think this will be very useful to debug of the mysteries of failed checkouts. Because it's such a critical part of the app I think we should have these alerts. For an example of a case, see #5075

Improve **color of field specific error messages** in checkout page.
Before:
https://files.slack.com/files-pri/T02G54U79-F010MTLHMFD/image.png
![image](https://user-images.githubusercontent.com/1640378/77952478-a1628900-72c3-11ea-9c11-47ff8fc90bfe.png)
After:
![image](https://user-images.githubusercontent.com/1640378/77952495-a9bac400-72c3-11ea-803b-9bd6f522c873.png)

#### What should we test?
rails_foundation_helper:
- verify that error flash messages on top of the page show up in checkout and in the admin forms (for example the warning when enterprises dont have payment methods defined)
- make sure the checkout form looks visually equal to what it was before

Errors in stripe calls: see 5075 for a simple way to simulate this.

Improving checkout controller: this change is a safe guard, I am not sure when this will happen or how to test it but imo it makes sense to add this code.

Verify the field specific error messages in the checkout page have white text now and are easier to read.

#### Release notes
Changelog Category: Fixed
Fixed silent checkout when calls to stripe were failing. User will now see an error message.
Removed rails_foundation_helper, an old dependency no longer needed.
Improved checkout controller to provide user with an error message in more error scenarios.
