### PR TITLE
Fix bug in subscriptions logging by making versions.custom_data a longer field

### DIFF
--- a/db/migrate/20200327105910_change_versions_custom_data_to_text.rb
+++ b/db/migrate/20200327105910_change_versions_custom_data_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeVersionsCustomDataToText < ActiveRecord::Migration
+  def up
+    change_column :versions, :custom_data, :text
+  end
+
+  def down
+    change_column :versions, :custom_data, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200209163549) do
+ActiveRecord::Schema.define(:version => 20200327105910) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -1202,7 +1202,7 @@ ActiveRecord::Schema.define(:version => 20200209163549) do
     t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"
-    t.string   "custom_data"
+    t.text     "custom_data"
   end
 
   add_index "versions", ["item_type", "item_id"], :name => "index_versions_on_item_type_and_item_id"


### PR DESCRIPTION
#### What? Why?

Closes #5086

Make custom_data longer so a long list of schedules and order_cycles can be stored in the versions table.

Even if we cant replicate #5086 this is a valid change we should put in. That's why I prepared this PR immediately because it will avoid any other occurrences of the bugsnag error:
https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/5e7dd4c615afa70017451d6c?event_id=5e7dd4c60059500d25370000&i=sk&m=nw

#### What should we test?
We need to add a schedule to many order cycles (40 was the number that broken it in uk live) and make sure the UI still works without any snail.

#### Release notes
Changelog Category: Fixed
Improved subscription logging system by making it more resilient to larger sets of data.
