### PR TITLE
Do not reset the dev env when booting docker

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -35,13 +35,20 @@ Download the Docker images and build the containers:
 $ docker-compose build
 ```
 
-Run the app with all the required containers:
+Setup the database and seed it with sample data:
+```sh
+$ docker-compose run web bundle exec rake db:reset
+$ docker-compose run web bundle exec rake db:test:prepare
+$ docker-compose run web bundle exec rake ofn:sample_data
+```
+
+Finally, run the app with all the required containers:
 
 ```sh
 $ docker-compose up
 ```
 
-This command will setup the database and seed it with sample data. The default admin user is 'ofn@example.com' with 'ofn123' password.
+The default admin user is 'ofn@example.com' with 'ofn123' password.
 Check the app in the browser at `http://localhost:3000`.
 
 You will then get the trace of the containers in the terminal. You can stop the containers using Ctrl-C in the terminal.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV BUNDLE_PATH /bundles
 WORKDIR /usr/src/app
 COPY .ruby-version .
 
-# Rbenv & Ruby part
+# Install Rbenv & Ruby
 RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
     git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build && \
     ${RBENV_ROOT}/plugins/ruby-build/install.sh && \
@@ -21,7 +21,7 @@ RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
     rbenv global $(cat .ruby-version) && \
     gem install bundler --version=1.17.2
 
-# Postgres
+# Install Postgres
 RUN sh -c "echo 'deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' > /etc/apt/sources.list.d/pgdg.list" && \
     wget --quiet -O - https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
@@ -38,4 +38,6 @@ RUN wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.z
     unzip chromedriver_linux64.zip -d /usr/bin && \
     chmod u+x /usr/bin/chromedriver
 
+# Copy code and install app dependencies
 COPY . /usr/src/app/
+RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,7 @@ services:
       ADMIN_PASSWORD: ofn123
       OFN_DB_HOST: db
     command: >
-      bash -c "(bundle check || bundle install) &&
-               wait-for-it -t 30 db:5432 &&
-               bundle exec rake db:reset &&
-               bundle exec rake db:test:prepare ofn:sample_data || true &&
+      bash -c "wait-for-it -t 30 db:5432 &&
                rm -f tmp/pids/server.pid &&
                bundle exec rails s -p 3000 -b '0.0.0.0'"
 


### PR DESCRIPTION
#### What? Why?

The current web container's command destroys anything you might have in your local DB from a previous session, assuming you always want to start from a clean environment. This is hardly the case and makes `docker-compose up` take quite long. What if you just stopped containers temporally while developing? All the sample orders you created are gone :see_no_evil: 

This changes the approach to not assume anything. If you need to install a new gem or reset your DB just run the commands you would without docker. You can run anything you want with `docker-compose run web bundle exec <rails/rake command>` anyway.

For someone setting things for the first time, the `Dockerfile` process still installs all dependencies.

#### What should we test?

Nothing. I know it works because I always comment out these lines.

#### Release notes

Do not reset the development environment when starting docker
Changelog Category: Changed