### PR TITLE
Cart variant scoping

### DIFF
--- a/app/services/variants_stock_levels.rb
+++ b/app/services/variants_stock_levels.rb
@@ -14,22 +14,10 @@ class VariantsStockLevels
       variant_stock_levels[variant_id] = { quantity: 0, max_quantity: 0, on_hand: variant.on_hand, on_demand: variant.on_demand }
     end
 
-    # The code above is most probably dead code, this bugsnag notification will confirm it
-    notify_bugsnag(order, requested_variant_ids, order_variant_ids) if missing_variant_ids.present?
-
     variant_stock_levels
   end
 
   private
-
-  def notify_bugsnag(order, requested_variant_ids, order_variant_ids)
-    error_msg = "VariantsStockLevels.call with variants in the request that are not in the order"
-    Bugsnag.notify(RuntimeError.new(error_msg),
-                   requested_variant_ids: requested_variant_ids.as_json,
-                   order_variant_ids: order_variant_ids.as_json,
-                   order: order.as_json,
-                   line_items: order.line_items.as_json)
-  end
 
   def variant_stock_levels(line_items)
     Hash[

--- a/app/services/variants_stock_levels.rb
+++ b/app/services/variants_stock_levels.rb
@@ -48,7 +48,11 @@ class VariantsStockLevels
   def scoped_variant(distributor, variant)
     return variant if distributor.blank?
 
-    OpenFoodNetwork::ScopeVariantToHub.new(distributor).scope(variant)
+    scoper(distributor).scope(variant)
     variant
+  end
+
+  def scoper(distributor)
+    @scoper ||= OpenFoodNetwork::ScopeVariantToHub.new(distributor)
   end
 end

--- a/app/services/variants_stock_levels.rb
+++ b/app/services/variants_stock_levels.rb
@@ -7,8 +7,6 @@ class VariantsStockLevels
   def call(order, requested_variant_ids)
     variant_stock_levels = variant_stock_levels(order.line_items)
 
-    # Variants are not scoped here and so the stock levels reported are incorrect
-    # See cart_controller_spec for more details and #3222
     order_variant_ids = variant_stock_levels.keys
     missing_variant_ids = requested_variant_ids - order_variant_ids
     missing_variant_ids.each do |variant_id|

--- a/spec/services/variants_stock_levels_spec.rb
+++ b/spec/services/variants_stock_levels_spec.rb
@@ -59,7 +59,7 @@ describe VariantsStockLevels do
     let!(:variant_override) {
       create(:variant_override, hub: distributor,
                                 variant: variant_in_the_order,
-                                count_on_hand: 404)
+                                count_on_hand: 200)
     }
 
     before do
@@ -68,9 +68,9 @@ describe VariantsStockLevels do
       order.save
     end
 
-    xit "returns the on_hand value of the override" do
+    it "returns the on_hand value of the override" do
       expect(variant_stock_levels.call(order, [variant_in_the_order.id])).to eq(
-        variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 404, on_demand: false }
+        variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false }
       )
     end
   end

--- a/spec/services/variants_stock_levels_spec.rb
+++ b/spec/services/variants_stock_levels_spec.rb
@@ -48,4 +48,30 @@ describe VariantsStockLevels do
       )
     end
   end
+
+  describe "when the variant has an override" do
+    let!(:distributor) { create(:distributor_enterprise) }
+    let(:supplier) { variant_in_the_order.product.supplier }
+    let!(:order_cycle) {
+      create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor],
+                                  variants: [variant_in_the_order])
+    }
+    let!(:variant_override) {
+      create(:variant_override, hub: distributor,
+                                variant: variant_in_the_order,
+                                count_on_hand: 404)
+    }
+
+    before do
+      order.order_cycle = order_cycle
+      order.distributor = distributor
+      order.save
+    end
+
+    xit "returns the on_hand value of the override" do
+      expect(variant_stock_levels.call(order, [variant_in_the_order.id])).to eq(
+        variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 404, on_demand: false }
+      )
+    end
+  end
 end

--- a/spec/services/variants_stock_levels_spec.rb
+++ b/spec/services/variants_stock_levels_spec.rb
@@ -64,7 +64,7 @@ describe VariantsStockLevels do
     let!(:variant_override_not_in_order) {
       create(:variant_override, hub: distributor,
                                 variant: variant_not_in_the_order,
-                                count_on_hand: 404)
+                                count_on_hand: 201)
     }
 
     before do
@@ -76,17 +76,23 @@ describe VariantsStockLevels do
     context "when the variant is in the order" do
       it "returns the on_hand value of the override" do
         expect(variant_stock_levels.call(order, [variant_in_the_order.id])).to eq(
-          variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false }
+          variant_in_the_order.id => {
+            quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false
+          }
         )
       end
     end
 
     context "with variants that are not in the order" do
-      xit "returns the on_hand value of the override" do
+      it "returns the on_hand value of the override" do
         variant_ids = [variant_in_the_order.id, variant_not_in_the_order.id]
         expect(variant_stock_levels.call(order, variant_ids)).to eq(
-          variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false },
-          variant_not_in_the_order.id => { quantity: 0, max_quantity: 0, on_hand: 404, on_demand: false }
+          variant_in_the_order.id => {
+            quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false
+          },
+          variant_not_in_the_order.id => {
+            quantity: 0, max_quantity: 0, on_hand: 201, on_demand: false
+          }
         )
       end
     end

--- a/spec/services/variants_stock_levels_spec.rb
+++ b/spec/services/variants_stock_levels_spec.rb
@@ -54,12 +54,17 @@ describe VariantsStockLevels do
     let(:supplier) { variant_in_the_order.product.supplier }
     let!(:order_cycle) {
       create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor],
-                                  variants: [variant_in_the_order])
+                                  variants: [variant_in_the_order, variant_not_in_the_order])
     }
-    let!(:variant_override) {
+    let!(:variant_override_in_order) {
       create(:variant_override, hub: distributor,
                                 variant: variant_in_the_order,
                                 count_on_hand: 200)
+    }
+    let!(:variant_override_not_in_order) {
+      create(:variant_override, hub: distributor,
+                                variant: variant_not_in_the_order,
+                                count_on_hand: 404)
     }
 
     before do
@@ -68,10 +73,22 @@ describe VariantsStockLevels do
       order.save
     end
 
-    it "returns the on_hand value of the override" do
-      expect(variant_stock_levels.call(order, [variant_in_the_order.id])).to eq(
-        variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false }
-      )
+    context "when the variant is in the order" do
+      it "returns the on_hand value of the override" do
+        expect(variant_stock_levels.call(order, [variant_in_the_order.id])).to eq(
+          variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false }
+        )
+      end
+    end
+
+    context "with variants that are not in the order" do
+      xit "returns the on_hand value of the override" do
+        variant_ids = [variant_in_the_order.id, variant_not_in_the_order.id]
+        expect(variant_stock_levels.call(order, variant_ids)).to eq(
+          variant_in_the_order.id => { quantity: 2, max_quantity: 3, on_hand: 200, on_demand: false },
+          variant_not_in_the_order.id => { quantity: 0, max_quantity: 0, on_hand: 404, on_demand: false }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #3222 
Possibly cause of S2: #5069

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The code in the original issue has been moved around and refactored several times since it was opened, but the issue was still there.

Adds two tests for cases where `VariantsStockLevels` was used when populating the cart but no scoping was being done to the variants, and fixes both cases so the correct stock values are returned.

#### What should we test?
<!-- List which features should be tested and how. -->

Adding/removing variants with variant overrides in the cart, should give correct feedback based on the override's stock, not the variant's stock.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Updated cart stock logic to include variant overrides

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed