### PR TITLE
Improve BOM

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -23,8 +23,11 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.refreshData = ->
     unless !$scope.orderCycleFilter? || $scope.orderCycleFilter == 0
-      $scope.startDate = moment(OrderCycles.byID[$scope.orderCycleFilter].orders_open_at).format('YYYY-MM-DD')
-      $scope.endDate = moment(OrderCycles.byID[$scope.orderCycleFilter].orders_close_at).startOf('day').format('YYYY-MM-DD')
+      start_date = OrderCycles.byID[$scope.orderCycleFilter].orders_open_at
+      end_date = OrderCycles.byID[$scope.orderCycleFilter].orders_close_at
+      format = "YYYY-MM-DD HH:mm:ss Z"
+      $scope.startDate = moment(start_date, format).format('YYYY-MM-DD')
+      $scope.endDate = moment(end_date, format).startOf('day').format('YYYY-MM-DD')
 
     formatted_start_date = moment($scope.startDate).format()
     formatted_end_date = moment($scope.endDate).add(1,'day').format()

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -1,7 +1,6 @@
 angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout, $http, $q, StatusMessage, Columns, SortOptions, Dereferencer, Orders, LineItems, Enterprises, OrderCycles, VariantUnitManager, RequestMonitor) ->
   $scope.initialized = false
   $scope.RequestMonitor = RequestMonitor
-  $scope.pagination = LineItems.pagination
   $scope.line_items = LineItems.all
   $scope.confirmDelete = true
   $scope.startDate = moment().startOf('day').subtract(7, 'days').format('YYYY-MM-DD')
@@ -12,8 +11,6 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.sharedResource = false
   $scope.columns = Columns.columns
   $scope.sorting = SortOptions
-  $scope.page = 1
-  $scope.per_page = 50
 
   $scope.confirmRefresh = ->
     LineItems.allSaved() || confirm(t("unsaved_changes_warning"))
@@ -23,14 +20,9 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.supplierFilter = ''
     $scope.orderCycleFilter = ''
     $scope.quickSearch = ''
-    $scope.page = 1
 
   $scope.resetSelectFilters = ->
     $scope.resetFilters()
-    $scope.refreshData()
-
-  $scope.changePage = (newPage) ->
-    $scope.page = newPage
     $scope.refreshData()
 
   $scope.refreshData = ->
@@ -75,9 +67,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
       "q[variant_product_supplier_id_eq]": $scope.supplierFilter,
       "q[order_order_cycle_id_eq]": $scope.orderCycleFilter,
       "q[order_completed_at_gteq]": $scope.formattedStartDate,
-      "q[order_completed_at_lt]": $scope.formattedEndDate,
-      page: $scope.page,
-      per_page: $scope.per_page
+      "q[order_completed_at_lt]": $scope.formattedEndDate
     )
 
   $scope.loadAssociatedData = ->

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -12,6 +12,10 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.sharedResource = false
   $scope.columns = Columns.columns
   $scope.sorting = SortOptions
+  $scope.distributorFilter = ''
+  $scope.supplierFilter = ''
+  $scope.orderCycleFilter = ''
+  $scope.quickSearch = ''
   $scope.page = 1
   $scope.per_page = 50
 
@@ -22,7 +26,9 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.distributorFilter = ''
     $scope.supplierFilter = ''
     $scope.orderCycleFilter = ''
-    $scope.quickSearch = ""
+    $scope.quickSearch = ''
+    $scope.page = 1
+    $scope.refreshData()
 
   $scope.changePage = (newPage) ->
     $scope.page = newPage
@@ -76,8 +82,6 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
       StatusMessage.clear()
       unless $scope.initialized
         $scope.initialized = true
-        $timeout ->
-          $scope.resetSelectFilters()
 
   $scope.$watch 'bulk_order_form.$dirty', (newVal, oldVal) ->
     if newVal == true

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -29,6 +29,8 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     formatted_start_date = moment($scope.startDate).format()
     formatted_end_date = moment($scope.endDate).add(1,'day').format()
 
+    return unless moment(formatted_start_date).isValid() and moment(formatted_start_date).isValid()
+
     RequestMonitor.load $scope.orders = Orders.index(
       "q[state_not_eq]": "canceled",
       "q[completed_at_not_null]": "true",

--- a/app/assets/javascripts/admin/resources/resources/line_item_resource.js.coffee
+++ b/app/assets/javascripts/admin/resources/resources/line_item_resource.js.coffee
@@ -2,7 +2,6 @@ angular.module("admin.resources").factory 'LineItemResource', ($resource) ->
   $resource('/admin/bulk_line_items/:id.json', {}, {
     'index':
       method: 'GET'
-      isArray: true
     'update':
       method: 'PUT'
       transformRequest: (data, headersGetter) =>

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -31,17 +31,17 @@
       %label{ :for => 'supplier_filter' }
         = t("admin.producer")
       %br
-      %input#supplier_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'suppliers', blank: "{ id: '', name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'supplierFilter', change: 'refreshData()' } }
+      %input#supplier_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'suppliers', placeholder: "#{t(:all)}", blank: "{ id: '', name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'supplierFilter', change: 'refreshData()' } }
     .filter_select{ :class => "three columns" }
       %label{ :for => 'distributor_filter' }
         = t("admin.shop")
       %br
-      %input#distributor_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'distributors', blank: "{ id: '', name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'distributorFilter', change: 'refreshData()' } }
+      %input#distributor_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'distributors', placeholder: "#{t(:all)}", blank: "{ id: '', name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'distributorFilter', change: 'refreshData()' } }
     .filter_select{ :class => "three columns" }
       %label{ :for => 'order_cycle_filter' }
         = t("admin.order_cycle")
       %br
-      %input#order_cycle_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'orderCycles', blank: "{ id: 0, name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'orderCycleFilter', change: 'refreshData()' } }
+      %input#order_cycle_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'orderCycles', placeholder: "#{t(:all)}", blank: "{ id: '', name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'orderCycleFilter', change: 'refreshData()' } }
     .filter_clear{ :class => "two columns omega" }
       %label{ :for => 'clear_all_filters' }
       %br

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -184,6 +184,3 @@
             %a{ ng: { href: "/admin/orders/{{line_item.order.number}}/edit" }, :class => "edit-order icon-edit no-text", 'confirm-link-click' => 'confirmRefresh()' }
           %td.actions
             %a{ 'ng-click' => "deleteLineItem(line_item)", :class => "delete-line-item icon-trash no-text" }
-
-    .row
-      = render partial: 'admin/shared/angular_pagination'

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -175,7 +175,7 @@
             %span.error{ ng: { bind: 'line_item.errors.quantity' } }
           %td.max{ 'ng-show' => 'columns.max.visible' } {{ line_item.max_quantity }}
           %td.final_weight_volume{ 'ng-show' => 'columns.final_weight_volume.visible' }
-            %input.show-dirty{ :type => 'number', :name => 'final_weight_volume', :id => 'final_weight_volume', ng: { model: "line_item.final_weight_volume", readonly: "unitValueLessThanZero(line_item)", change: "weightAdjustedPrice(line_item)", required: "true", class: '{"update-error": line_item.errors.final_weight_volume}' }, min: 0, 'ng-pattern' => '/[1-9]+/' }
+            %input.show-dirty{ type: 'number', step: 'any', :name => 'final_weight_volume', :id => 'final_weight_volume', ng: { model: "line_item.final_weight_volume", readonly: "unitValueLessThanZero(line_item)", change: "weightAdjustedPrice(line_item)", required: "true", class: '{"update-error": line_item.errors.final_weight_volume}' }, min: 0, 'ng-pattern' => '/[0-9]*[.]?[0-9]+/' }
             %span.error{ ng: { bind: 'line_item.errors.final_weight_volume' } }
           %td.price{ 'ng-show' => 'columns.price.visible' }
             %input.show-dirty{ :type => 'text', :name => 'price', :id => 'price', :ng => { value: 'line_item.price * line_item.quantity | currency:""', readonly: "true", class: '{"update-error": line_item.errors.price}' } }

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -20,12 +20,12 @@
       %label{ :for => 'start_date_filter' }
         = t("admin.start_date")
       %br
-      %input{ :class => "two columns alpha", :type => "text", :id => 'start_date_filter', 'ng-model' => 'startDate', 'datepicker' => "startDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()' }
+      %input{ :class => "two columns alpha", :type => "text", :id => 'start_date_filter', 'ng-model' => 'startDate', 'datepicker' => "startDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()', 'ng-model-options' => '{ debounce: 1000 }' }
     .date_filter{ :class => "two columns" }
       %label{ :for => 'end_date_filter' }
         = t("admin.end_date")
       %br
-      %input{ :class => "two columns alpha", :type => "text", :id => 'end_date_filter', 'ng-model' => 'endDate', 'datepicker' => "endDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()' }
+      %input{ :class => "two columns alpha", :type => "text", :id => 'end_date_filter', 'ng-model' => 'endDate', 'datepicker' => "endDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()', 'ng-model-options' => '{ debounce: 1000 }' }
     .one.column &nbsp;
     .filter_select{ :class => "three columns" }
       %label{ :for => 'supplier_filter' }

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -31,12 +31,12 @@
       %label{ :for => 'supplier_filter' }
         = t("admin.producer")
       %br
-      %input#supplier_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'suppliers', blank: "{ id: 0, name: '#{t(:all)}' }", ng: { model: 'supplierFilter' } }
+      %input#supplier_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'suppliers', blank: "{ id: '', name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'supplierFilter', change: 'refreshData()' } }
     .filter_select{ :class => "three columns" }
       %label{ :for => 'distributor_filter' }
         = t("admin.shop")
       %br
-      %input#distributor_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'distributors', blank: "{ id: 0, name: '#{t(:all)}' }", ng: { model: 'distributorFilter' } }
+      %input#distributor_filter.ofn-select2.fullwidth{ type: 'number', 'min-search' => 5, data: 'distributors', blank: "{ id: '', name: '#{t(:all)}' }", on: { selecting: "confirmRefresh" }, ng: { model: 'distributorFilter', change: 'refreshData()' } }
     .filter_select{ :class => "three columns" }
       %label{ :for => 'order_cycle_filter' }
         = t("admin.order_cycle")
@@ -94,7 +94,7 @@
 
   %hr.divider.sixteen.columns.alpha.omega
 
-  .controls.sixteen.columns.alpha.omega{ ng: { hide: 'RequestMonitor.loading || lineItems.length == 0' } }
+  .controls.sixteen.columns.alpha.omega{ ng: { hide: 'RequestMonitor.loading || line_items.length == 0' } }
     %div.three.columns.alpha
       %input.fullwidth{ :type => "text", :id => 'quick_search', 'ng-model' => 'quickSearch', :placeholder => 'Quick Search' }
     = render 'admin/shared/bulk_actions_dropdown'
@@ -157,7 +157,7 @@
               = t("admin.orders.bulk_management.ask")
               %input{ :type => 'checkbox', 'ng-model' => "confirmDelete" }
 
-        %tr.line_item{ ng: { repeat: "line_item in filteredLineItems = ( lineItems | filter:quickSearch | selectFilter:supplierFilter:distributorFilter:orderCycleFilter | variantFilter:selectedUnitsProduct:selectedUnitsVariant:sharedResource | orderBy:sorting.predicate:sorting.reverse )", 'class-even' => "'even'", 'class-odd' => "'odd'", attr: { id: "li_{{line_item.id}}" } } }
+        %tr.line_item{ ng: { repeat: "line_item in filteredLineItems = ( line_items | filter:quickSearch | variantFilter:selectedUnitsProduct:selectedUnitsVariant:sharedResource | orderBy:sorting.predicate:sorting.reverse )", 'class-even' => "'even'", 'class-odd' => "'odd'", attr: { id: "li_{{line_item.id}}" } } }
           %td.bulk
             %input{ :type => "checkbox", :name => 'bulk', 'ng-model' => 'line_item.checked', 'ignore-dirty' => true }
           %td.order_no{ 'ng-show' => 'columns.order_no.visible' } {{ line_item.order.number }}
@@ -184,3 +184,6 @@
             %a{ ng: { href: "/admin/orders/{{line_item.order.number}}/edit" }, :class => "edit-order icon-edit no-text", 'confirm-link-click' => 'confirmRefresh()' }
           %td.actions
             %a{ 'ng-click' => "deleteLineItem(line_item)", :class => "delete-line-item icon-trash no-text" }
+
+    .row
+      = render partial: 'admin/shared/angular_pagination'

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -36,22 +36,22 @@ describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "retrieves a list of line_items with appropriate attributes, including line items with appropriate attributes" do
-          keys = json_response.first.keys.map(&:to_sym)
+          keys = json_response['line_items'].first.keys.map(&:to_sym)
           expect(line_item_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
 
         it "sorts line_items in ascending id line_item" do
-          ids = json_response.map{ |line_item| line_item['id'] }
+          ids = json_response['line_items'].map{ |line_item| line_item['id'] }
           expect(ids[0]).to be < ids[1]
           expect(ids[1]).to be < ids[2]
         end
 
         it "formats final_weight_volume as a float" do
-          expect(json_response.map{ |line_item| line_item['final_weight_volume'] }.all?{ |fwv| fwv.is_a?(Float) }).to eq(true)
+          expect(json_response['line_items'].map{ |line_item| line_item['final_weight_volume'] }.all?{ |fwv| fwv.is_a?(Float) }).to eq(true)
         end
 
         it "returns distributor object with id key" do
-          expect(json_response.map{ |line_item| line_item['supplier'] }.all?{ |d| d.key?('id') }).to eq(true)
+          expect(json_response['line_items'].map{ |line_item| line_item['supplier'] }.all?{ |d| d.key?('id') }).to eq(true)
         end
       end
 
@@ -61,7 +61,7 @@ describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "retrives a list of line items which match the criteria" do
-          expect(json_response.map{ |line_item| line_item['id'] }).to eq [line_item2.id, line_item3.id]
+          expect(json_response['line_items'].map{ |line_item| line_item['id'] }).to eq [line_item2.id, line_item3.id]
         end
       end
 
@@ -71,7 +71,7 @@ describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "retrives a list of line items whose orders match the criteria" do
-          expect(json_response.map{ |line_item| line_item['id'] }).to eq [line_item2.id, line_item3.id, line_item4.id]
+          expect(json_response['line_items'].map{ |line_item| line_item['id'] }).to eq [line_item2.id, line_item3.id, line_item4.id]
         end
       end
     end
@@ -106,7 +106,7 @@ describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "retrieves a list of line_items" do
-          keys = json_response.first.keys.map(&:to_sym)
+          keys = json_response['line_items'].first.keys.map(&:to_sym)
           expect(line_item_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end
@@ -118,7 +118,7 @@ describe Admin::BulkLineItemsController, type: :controller do
         end
 
         it "retrieves a list of line_items" do
-          keys = json_response.first.keys.map(&:to_sym)
+          keys = json_response['line_items'].first.keys.map(&:to_sym)
           expect(line_item_attributes.all?{ |attr| keys.include? attr }).to eq(true)
         end
       end

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -494,7 +494,7 @@ feature '
 
         it "shows a dialog and ignores changes when confirm dialog is accepted" do
           page.driver.accept_modal :confirm, text: "Unsaved changes exist and will be lost if you continue." do
-            fill_in "start_date_filter", with: (Date.current - 9).strftime("%F %T")
+            fill_in "start_date_filter", with: (Date.current - 9).strftime('%Y-%m-%d')
           end
           expect(page).to have_no_selector "#save-bar"
           within("tr#li_#{li2.id} td.quantity") do
@@ -577,6 +577,7 @@ feature '
           find("div#bulk-actions-dropdown").click
           find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
           expect(page).to have_no_selector "tr#li_#{li1.id}"
+          expect(page).to have_selector "#quick_search"
           fill_in "quick_search", with: ''
           wait_until { request_monitor_finished 'LineItemsCtrl' }
           expect(page).to have_selector "tr#li_#{li2.id}"


### PR DESCRIPTION
#### What? Why?

Closes #5098

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

- Adds optional pagination to LineItemsController (currently unused by BOM)
- Adjusts some problematic issues with the datepickers that were triggering huge superfluous queries (with date restraints removed!)
- Fixes a bug where selecting an order cycle with the dropdown filter was totally breaking the datepickers by filling them with the string "Invalid date" and making the page unusable
- Fixes a bug that completely stops all line items being saved if any of the line items in the page has a `final_weight_volume` which is a decimal (this case is very common in production data)

#### What should we test?
<!-- List which features should be tested and how. -->

BOM functionality works in general, and the above-mentioned bugs are fixed.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Various improvements to Bulk Order Management page

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
