### PR TITLE
remove blue sentence in payment method setting

### DIFF
--- a/app/views/spree/admin/payment_methods/_provider_settings.html.haml
+++ b/app/views/spree/admin/payment_methods/_provider_settings.html.haml
@@ -1,4 +1,3 @@
-= @payment_method
 - case @payment_method
 - when Spree::Gateway::StripeConnect
   = render 'stripe_connect'


### PR DESCRIPTION
#### What? Why?

Closes #5092 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
When you select an item from the list of providers on the payment_method settings, there's an ugly blue sentence showing up below the provider selector. The problem was happening because the `@payment_method` variable was being printed on the view. I removed it, and everything seems fine now.

Before:
![Screen Shot 2020-03-29 at 20 34 32](https://user-images.githubusercontent.com/27960597/77864090-10c17580-71fd-11ea-8af4-fa8eb68f5b97.png)

After:
![Screen Shot 2020-03-29 at 20 26 45](https://user-images.githubusercontent.com/27960597/77864126-46fef500-71fd-11ea-8e4c-565a01be5d61.png)


#### What should we test?
<!-- List which features should be tested and how. -->
The Payment Method settings


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Remove blue sentence under the provider selector on the payment method settings page

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
