### PR TITLE
Cache counts used in homepage for 24 hours

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,12 +5,23 @@ class HomeController < BaseController
 
   def index
     if ContentConfig.home_show_stats
-      @num_distributors = Enterprise.is_distributor.activated.visible.count
-      @num_producers = Enterprise.is_primary_producer.activated.visible.count
-      @num_users = Spree::Order.complete.count('DISTINCT user_id')
-      @num_orders = Spree::Order.complete.count
+      @num_distributors = cached_count('distributors', Enterprise.is_distributor.activated.visible)
+      @num_producers = cached_count('producers', Enterprise.is_primary_producer.activated.visible)
+      @num_orders = cached_count('orders', Spree::Order.complete)
+      @num_users = cached_count(
+        'users', Spree::Order.complete.select('DISTINCT spree_orders.user_id')
+      )
     end
   end
 
   def sell; end
+
+  private
+
+  # Cache the value of the query count for 24 hours
+  def cached_count(key, query)
+    Rails.cache.fetch("home_stats_count_#{key}", expires_in: 1.day, race_condition_ttl: 10) do
+      query.count
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5123

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Caches instance-level stats displayed in homepage for 24 hours to avoid constant re-fetching of the same values via expensive queries.

#### What should we test?
<!-- List which features should be tested and how. -->

Stats show on the homepage OK. The queries are triggered once per day.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Cache stats displayed on homepage for 24 hours.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed