### PR TITLE
Don't load distributed properties on inactive distributors

### DIFF
--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -73,12 +73,16 @@ module Api
 
     # This results in 3 queries per enterprise
     def distributed_properties
+      return [] unless active
+
       (distributed_product_properties + distributed_producer_properties).uniq do |property_object|
         property_object.property.presentation
       end
     end
 
     def distributed_product_properties
+      return [] unless active
+
       properties = Spree::Property
         .joins(products: { variants: { exchanges: :order_cycle } })
         .merge(Exchange.outgoing)
@@ -91,6 +95,8 @@ module Api
     end
 
     def distributed_producer_properties
+      return [] unless active
+
       properties = Spree::Property
         .joins(
           producer_properties: {

--- a/spec/features/consumer/groups_spec.rb
+++ b/spec/features/consumer/groups_spec.rb
@@ -60,8 +60,8 @@ feature 'Groups', js: true do
       let!(:group) { create(:enterprise_group, enterprises: [d1, d2], on_front_page: true) }
       let!(:order_cycle) { create(:simple_order_cycle, distributors: [d1, d2], coordinator: create(:distributor_enterprise)) }
       let(:producer) { create(:supplier_enterprise) }
-      let(:d1) { create(:distributor_enterprise) }
-      let(:d2) { create(:distributor_enterprise) }
+      let(:d1) { create(:distributor_enterprise, with_payment_and_shipping: true) }
+      let(:d2) { create(:distributor_enterprise, with_payment_and_shipping: true) }
       let(:p1) { create(:simple_product, supplier: producer) }
       let(:p2) { create(:simple_product, supplier: create(:supplier_enterprise)) }
       let(:ex_d1) { order_cycle.exchanges.outgoing.where(receiver_id: d1).first }

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -53,17 +53,9 @@ describe Api::CachedEnterpriseSerializer do
         instance_double(OpenFoodNetwork::EnterpriseInjectionData, active_distributor_ids: [])
       end
 
-      it 'does not duplicate properties' do
+      it 'does not serialize distributed properties' do
         properties = cached_enterprise_serializer.distributed_properties
-        expect(properties.map(&:presentation)).to eq([property.presentation])
-      end
-
-      it 'fetches producer properties' do
-        distributed_producer_properties = cached_enterprise_serializer
-          .distributed_producer_properties
-
-        expect(distributed_producer_properties.map(&:presentation))
-          .to eq(producer.producer_properties.map(&:property).map(&:presentation))
+        expect(properties).to eq []
       end
     end
 


### PR DESCRIPTION
Part of #5143 

#### What? Why?

We don't need to query **distributed properties** and **distributed product properties** on enterprises that aren't active distributors, because they don't have products in active order cycles.

Tested locally with production data loaded; this change cuts page load on `/shops` by ~75% and removes ~300 very expensive and completely superfluous queries.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how. -->

This needs a server with a good amount of data, probably Aus Staging...

- `/shops` page is working ok in general
- all shops can be filtered by "**Type**" and "**Delivery**" as before
- open shops can be filtered by their product properties as before
- when filtering by product "**Properties**" with open and closed shops, only open shops are shown in the results

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance on `/shops` page.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
