### PR TITLE
Add PROFILE var to set production-like settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ public/system
 public/stylesheets
 public/images
 public/spree
+public/assets
 config/abr.yml
 config/initializers/feature_toggle.rb
 NERD_tree*

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Openfoodnetwork::Application.configure do
   config.cache_classes = !!ENV["PROFILE"]
 
   # :file_store is used by default when no cache store is specifically configured.
-  # config.cache_store = :file_store
+  config.cache_store = :memory_store if !!ENV["PROFILE"]
 
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,10 +1,14 @@
 Openfoodnetwork::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
+  #
+  # PROFILE switches several settings to a more "production-like" value
+  # for profiling and benchmarking the application locally. All changes you
+  # make to the app will require restart.
 
   # In the development environment your application's code is reloaded on
   # every request.  This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = !!ENV["PROFILE"]
 
   # :file_store is used by default when no cache store is specifically configured.
   # config.cache_store = :file_store
@@ -14,7 +18,7 @@ Openfoodnetwork::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = !!ENV["PROFILE"]
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
@@ -28,8 +32,25 @@ Openfoodnetwork::Application.configure do
   # Do not compress assets
   config.assets.compress = false
 
+  # Generate digests for assets URLs.
+  #
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = !!ENV["PROFILE"]
+
   # Expands the lines which load the assets
-  config.assets.debug = false
+  #
+  # Setting this to false makes Rails bundle assets into all.js and all.css.
+  #
+  # Disabling asset debugging still requires that assets be compiled for each
+  # request. You can avoid that by precompiling the assets as in production:
+  #
+  #   $ bundle exec rake assets:precompile:primary assets:precompile:nondigest
+  #
+  # You can remove them by simply running:
+  #
+  #   $ bundle exec rake assets:clean
+  config.assets.debug = !ENV["PROFILE"]
 
   # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
   # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
#### What? Why?

Related to #5131 

I took this from a recent newsletter I got (from the guy behind http://www.speedshop.co/). Sometimes replicating performance issues locally is actually slower than production due to dev mode settings (code reloading, etc.), heavy dev-only gems and the asset pipeline.

The PROFILE env var switches these settings all at the same time, giving us an environment closer to production, essential for reliable profiling. Then, rack-mini-profiler is going to be more accurate.

Apparently it's something [RubyGems](https://github.com/rubygems/rubygems.org/blob/b026df86ae9df0e4d4c7dae2f220fe2219d52350/config/environments/development.rb#L72-L92) and [CodeTriage](https://github.com/codetriage/CodeTriage/commit/a3c957647dc039d73036c565620643cf216e30c7) both use.

I provided useful to investigate cache issues with some assets.

#### What should we test?

Development only

#### Release notes

Added PROFILE env var for production-like performance profiling.

Changelog Category: Added
