### PR TITLE
Fix Permissions::Order spec in rails 4

### DIFF
--- a/spec/services/permissions/order_spec.rb
+++ b/spec/services/permissions/order_spec.rb
@@ -47,6 +47,18 @@ module Permissions
         it "should let me see the order" do
           expect(permissions.visible_orders).to include order
         end
+
+        context "with search params" do
+          let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
+          let(:permissions) { Permissions::Order.new(user, search_params) }
+
+          it "only returns completed, non-cancelled orders within search filter range" do
+            expect(permissions.visible_orders).to include order_completed
+            expect(permissions.visible_orders).to_not include order_cancelled
+            expect(permissions.visible_orders).to_not include order_cart
+            expect(permissions.visible_orders).to_not include order_from_last_year
+          end
+        end
       end
 
       context "as a producer which has granted P-OC to the distributor of an order" do
@@ -69,18 +81,6 @@ module Permissions
         context "which does not contain my products" do
           it "should not let me see the order" do
             expect(permissions.visible_orders).to_not include order
-          end
-        end
-
-        context "with search params" do
-          let(:search_params) { { completed_at_gt: Time.zone.now.yesterday.strftime('%Y-%m-%d') } }
-          let(:permissions) { Permissions::Order.new(user, search_params) }
-
-          it "only returns completed, non-cancelled orders within search filter range" do
-            expect(permissions.visible_orders).to include order_completed
-            expect(permissions.visible_orders).to_not include order_cancelled
-            expect(permissions.visible_orders).to_not include order_cart
-            expect(permissions.visible_orders).to_not include order_from_last_year
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

Fixes permissions::order service spec in the rails 4 branch.

The problem was introduced here by relying on order (from factories) that have products by the same producer required in the test:
https://github.com/openfoodfoundation/openfoodnetwork/pull/5030/files#diff-610e1eeeabb29a85e6d4a271d2bd7f56R75
In rails 4 the products in these orders dont have the same producer as required and so the test breaks.
We move the test to a simpler context above. It's still valid and it just validates what it is meant to validate.
See commit messages for more details.

#### What should we test?
green build

#### Release notes
Changelog Category: Changed
Adapted test code to rails 4 related to order permissions.
