### PR TITLE
[Spree 2.1] Add strong params implementation to properties controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,6 @@ gem 'uglifier', '>= 1.0.3'
 gem 'angular-rails-templates', '~> 0.3.0'
 gem 'foundation-icons-sass-rails'
 gem 'momentjs-rails'
-# gem 'turbo-sprockets-rails3'
 
 gem 'foundation-rails', '= 5.5.2.1'
 

--- a/app/controllers/spree/admin/properties_controller.rb
+++ b/app/controllers/spree/admin/properties_controller.rb
@@ -1,6 +1,9 @@
 module Spree
   module Admin
     class PropertiesController < ResourceController
+      def permitted_resource_params
+        params.require(:property).permit(:name, :presentation)
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Adds permit to the properties controller that was recently added from Spree.

I added an additional unrelated little thing to this PR:
- remove commented gem 'turbo-sprockets-rails3', this gem is not needed in rails 4, see [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/4995#issuecomment-598699149)

#### What should we test?
green build.

