### PR TITLE
[Spree 2.1] Add order.email regexp validation

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -29,13 +29,14 @@ Spree::Order.class_eval do
   validate :products_available_from_new_distribution, if: lambda { distributor_id_changed? || order_cycle_id_changed? }
   validate :disallow_guest_order
 
-  # Removes Spree 2.1 additional email validation (currently failing every time)
-  # See: spree/core/validators/email.rb
+  # The EmailValidator introduced in Spree 2.1 is not working
+  # So here we remove it and re-introduce the regexp validation rule from Spree 2.0
   _validate_callbacks.each do |callback|
     if callback.raw_filter.respond_to? :attributes
       callback.raw_filter.attributes.delete :email
     end
   end
+  validates :email, presence: true, format: /\A([\w\.%\+\-']+)@([\w\-]+\.)+([\w]{2,})\z/i, if: :require_email
 
   before_validation :associate_customer, unless: :customer_id?
   before_validation :ensure_customer, unless: :customer_is_valid?

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Order do
 
     it "has errors if email is blank" do
       order.stub(require_email: true)
-      order.update_attributes email: ""
+      order.email = ""
 
       order.valid?
       expect(order.errors[:email]).to eq ["can't be blank", "is invalid"]
@@ -16,7 +16,7 @@ describe Spree::Order do
 
     it "has errors if email is invalid" do
       order.stub(require_email: true)
-      order.update_attributes email: "invalid_email"
+      order.email = "invalid_email"
 
       order.valid?
       expect(order.errors[:email]).to eq ["is invalid"]
@@ -24,7 +24,7 @@ describe Spree::Order do
 
     it "has errors if email has invalid domain" do
       order.stub(require_email: true)
-      order.update_attributes email: "single_letter_tld@domain.z"
+      order.email = "single_letter_tld@domain.z"
 
       order.valid?
       expect(order.errors[:email]).to eq ["is invalid"]
@@ -32,12 +32,11 @@ describe Spree::Order do
 
     it "is valid if email is valid" do
       order.stub(require_email: true)
-      order.update_attributes email: "a@b.ca"
+      order.email = "a@b.ca"
 
       order.valid?
       expect(order.errors[:email]).to eq []
     end
-
   end
 
   describe "setting variant attributes" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -3,6 +3,43 @@ require 'spec_helper'
 describe Spree::Order do
   include OpenFoodNetwork::EmailHelper
 
+  describe "email validation" do
+    let(:order) { build(:order) }
+
+    it "has errors if email is blank" do
+      order.stub(require_email: true)
+      order.update_attributes email: ""
+
+      order.valid?
+      expect(order.errors[:email]).to eq ["can't be blank", "is invalid"]
+    end
+
+    it "has errors if email is invalid" do
+      order.stub(require_email: true)
+      order.update_attributes email: "invalid_email"
+
+      order.valid?
+      expect(order.errors[:email]).to eq ["is invalid"]
+    end
+
+    it "has errors if email has invalid domain" do
+      order.stub(require_email: true)
+      order.update_attributes email: "single_letter_tld@domain.z"
+
+      order.valid?
+      expect(order.errors[:email]).to eq ["is invalid"]
+    end
+
+    it "is valid if email is valid" do
+      order.stub(require_email: true)
+      order.update_attributes email: "a@b.ca"
+
+      order.valid?
+      expect(order.errors[:email]).to eq []
+    end
+
+  end
+
   describe "setting variant attributes" do
     it "sets attributes on line items for variants" do
       d = create(:distributor_enterprise)


### PR DESCRIPTION
#### What? Why?

Closes #4775 
We bring the old regexp order email validator and keep the removal of the spree 2.1 validator that is not working.
This was agreed [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/4775#issuecomment-604015803) as an easy way out of this new broken validator.

#### What should we test?
green build.

