### PR TITLE
[Spree 2.1] Fix timezone mix up in a spec

### DIFF
--- a/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/parameters_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/parameters_spec.rb
@@ -39,7 +39,7 @@ describe OrderManagement::Reports::EnterpriseFeeSummary::Parameters do
       end
 
       describe "requiring start_at to be before end_at" do
-        let(:now) { Time.zone.now }
+        let(:now) { Time.zone.now.utc }
 
         it "adds error when start_at is after end_at" do
           allow(subject).to receive(:start_at) { now.to_s }


### PR DESCRIPTION
#### What? Why?
Fixes rspec ./engines/order_management/spec/services/order_management/reports/enterprise_fee_summary/parameters_spec.rb:53 in the upgrade branch: job 1 [here](https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/branches/pull-request-4825/builds/18)

Converting times with timezones to string was ignoring the timezone and thus making the start date be before the end date in this spec.

From slack #random
Converting Time to string will ignore timezone by default :man-shrugging: we had this problem in a spec:
2.3.7 :009 > Time.zone.now
=> Sun, 05 Apr 2020 02:41:04 AEDT +11:00
2.3.7 :010 > Time.zone.now + 1.hour
=> Sun, 05 Apr 2020 02:41:06 AEST +10:00
2.3.7 :011 > (Time.zone.now + 1.hour).to_s
=> "2020-04-05 02:41:11 +1000" <<< NO TIMEZONE
2.3.7 :012 > Time.zone.now.to_s > (Time.zone.now + 1.hour).to_s
=> true  (edited) 


