### PR TITLE
Add optional OOBGC support to Unicorn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,7 @@ gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f5
 
 group :production, :staging do
   gem 'ddtrace'
+  gem 'gctools'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,6 +410,7 @@ GEM
     fuubar (2.5.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
+    gctools (0.2.4)
     geocoder (1.1.8)
     gmaps4rails (1.5.6)
     haml (4.0.7)
@@ -731,6 +732,7 @@ DEPENDENCIES
   foundation-icons-sass-rails
   foundation-rails
   fuubar (~> 2.5.0)
+  gctools
   geocoder
   gmaps4rails
   haml

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,12 @@
 # This file is used by Rack-based servers to start the application.
 
+# Use Out-Of-Bounds Garbage Collection to improve memory cleanup
+# See: http://tmm1.net/ruby21-oobgc/ for details
+if ENV.fetch("USE_OOBGC", false) && (Rails.env.production? || Rails.env.staging?)
+  require 'gctools/oobgc'
+
+  use GC::OOB::UnicornMiddleware
+end
+
 require ::File.expand_path('../config/environment', __FILE__)
 run Openfoodnetwork::Application


### PR DESCRIPTION
This is a proposal for an experiment that might help clear up memory in a more ordered fashion by doing small bits of garbage collection between requests...

More info here: http://tmm1.net/ruby21-oobgc/

