### PR TITLE
Add optional unicorn-worker-killer configs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,7 @@ gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f5
 
 group :production, :staging do
   gem 'ddtrace'
+  gem 'unicorn-worker-killer'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,6 +411,8 @@ GEM
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     geocoder (1.1.8)
+    get_process_mem (0.2.5)
+      ffi (~> 1.0)
     gmaps4rails (1.5.6)
     haml (4.0.7)
       tilt
@@ -668,6 +670,9 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
     uuidtools (2.1.5)
     warden (1.2.7)
       rack (>= 1.0)
@@ -792,6 +797,7 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   unicorn
   unicorn-rails
+  unicorn-worker-killer
   web!
   webdrivers
   webmock

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,13 @@
 # This file is used by Rack-based servers to start the application.
 
+if ENV.fetch('KILL_UNICORNS', false) && ['production', 'staging'].include?(ENV['RAILS_ENV'])
+  # Gracefully restart individual unicorn workers if they have:
+  # - performed between 25000 and 30000 requests
+  # - grown in memory usage to between 700 and 850 MB
+  require 'unicorn/worker_killer'
+  use Unicorn::WorkerKiller::MaxRequests, 25_000, 30_000
+  use Unicorn::WorkerKiller::Oom, (700 * (1024**2)), (850 * (1024**2))
+end
+
 require ::File.expand_path('../config/environment', __FILE__)
 run Openfoodnetwork::Application

--- a/config.ru
+++ b/config.ru
@@ -5,8 +5,12 @@ if ENV.fetch('KILL_UNICORNS', false) && ['production', 'staging'].include?(ENV['
   # - performed between 25000 and 30000 requests
   # - grown in memory usage to between 700 and 850 MB
   require 'unicorn/worker_killer'
-  use Unicorn::WorkerKiller::MaxRequests, 25_000, 30_000
-  use Unicorn::WorkerKiller::Oom, (700 * (1024**2)), (850 * (1024**2))
+  use Unicorn::WorkerKiller::MaxRequests,
+      ENV.fetch('UWK_REQS_MIN', 25_000).to_i,
+      ENV.fetch('UWK_REQS_MAX', 30_000).to_i
+  use Unicorn::WorkerKiller::Oom,
+      ( ENV.fetch('UWK_MEM_MIN', 700).to_i * (1024**2) ),
+      ( ENV.fetch('UWK_MEM_MAX', 850).to_i * (1024**2) )
 end
 
 require ::File.expand_path('../config/environment', __FILE__)


### PR DESCRIPTION
This is another proposal for an experiment that might help free up memory.

Today I noticed 3 of our unicorn workers were using a normal amount of memory (about 6-9% of total, each) and one worker was using around 60% of total memory (about 5GB) and had been that way for a long time.

![Screenshot from 2020-04-04 20-26-41](https://user-images.githubusercontent.com/9029026/78459279-2e3c8680-76b8-11ea-80c7-40bb5baee4d5.png)

I killed that worker (they restart automatically) and we got 60% of total memory back instantly:

![Screenshot from 2020-04-04 20-28-06](https://user-images.githubusercontent.com/9029026/78459294-42808380-76b8-11ea-94d2-a3b02ecf92e8.png)

There's a very nice gem that will do this gracefully and automatically when a worker has served a set amount of requests or when it get too big in it's memory usage, and I think we should use it!
