### PR TITLE
Enable Ruby Runtime Metrics in Datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -4,5 +4,6 @@ if ENV['DATADOG_RAILS_APM']
     c.use :delayed_job, service_name: 'delayed_job'
     c.use :dalli, service_name: 'memcached'
     c.analytics_enabled = true
+    c.runtime_metrics_enabled = true
   end
 end


### PR DESCRIPTION
#### What? Why?

Sibling of https://github.com/openfoodfoundation/openfoodnetwork/pull/5162

This automatically collects a bunch of Ruby's GC-related metrics that will come in handy while we tune the Unicorn workers. Some of these are:

* runtime.ruby.class_count
* runtime.ruby.gc.malloc_increase_bytes
* runtime.ruby.gc.total_allocated_objects
* runtime.ruby.gc.total_freed_objects
* runtime.ruby.gc.heap_marked_slots
* runtime.ruby.gc.heap_available_slots
* runtime.ruby.gc.heap_free_slots
* runtime.ruby.thread_count

Check https://docs.datadoghq.com/tracing/runtime_metrics/ruby/#data-collected for the complete list.

The cool thing is that

> Runtime metrics can be viewed in correlation with your Ruby services

This will give us the information needed to tweak the app server's GC settings if we need to.

#### What should we test?

Nothing. This only affects Datadog.

#### Release notes
Enable Ruby runtime metrics monitoring in Datadog
Changelog Category: Added