### PR TITLE
make shop name a link on /account

### DIFF
--- a/app/views/spree/users/_open_orders.html.haml
+++ b/app/views/spree/users/_open_orders.html.haml
@@ -13,7 +13,8 @@
         %tr.order-row
           %td.order1
             %a{"ng-href" => "{{::order.path}}", "ng-bind" => "::order.number"}
-          %td.order2{"ng-bind" => "::Orders.shopsByID[order.shop_id].name"}
+          %td.order2
+            %a{"ng-href" => "{{::Orders.shopsByID[order.shop_id].hash}}#{main_app.shop_path}", "ng-bind" => "::Orders.shopsByID[order.shop_id].name"}
           %td.order3.show-for-large-up{"ng-bind" => "::order.changes_allowed_until"}
           %td.order4.show-for-large-up{"ng-bind" => "::order.item_count"}
           %td.order5.text-right{"ng-class" => "{'credit' : order.total < 0, 'debit' : order.total > 0, 'paid' : order.total == 0}","ng-bind" => "::order.total | localizeCurrency"}

--- a/app/views/spree/users/_past_orders.html.haml
+++ b/app/views/spree/users/_past_orders.html.haml
@@ -13,7 +13,8 @@
         %tr.order-row
           %td.order1
             %a{"ng-href" => "{{::order.path}}", "ng-bind" => "::order.number"}
-          %td.order2{"ng-bind" => "::Orders.shopsByID[order.shop_id].name"}
+          %td.order2
+            %a{"ng-href" => "{{::Orders.shopsByID[order.shop_id].hash}}#{main_app.shop_path}", "ng-bind" => "::Orders.shopsByID[order.shop_id].name"}
           %td.order3.show-for-large-up{"ng-bind" => "::order.completed_at"}
           %td.order4.show-for-large-up{"ng-bind" => "::order.item_count"}
           %td.order5.text-right{"ng-class" => "{'debit': order.payment_state != 'paid', 'credit': order.payment_state == 'paid'}","ng-bind" => "::order.total | localizeCurrency"}

--- a/spec/features/consumer/account_spec.rb
+++ b/spec/features/consumer/account_spec.rb
@@ -42,8 +42,14 @@ feature '
         # Lists all other orders
         expect(page).to have_content d1o1.number.to_s
         expect(page).to have_content d1o2.number.to_s
+        expect(page).to have_link(distributor1.name,
+                                  href: "#{distributor1.permalink}/shop", count: 2)
         expect(page).to have_content d2o1.number.to_s
+        expect(page).to have_link(distributor2.name,
+                                  href: "#{distributor2.permalink}/shop", count: 1)
         expect(page).to have_content credit_order.number.to_s
+        expect(page).to have_link(distributor_credit.name,
+                                  href: "#{distributor_credit.permalink}/shop", count: 1)
 
         # Viewing transaction history
         click_link I18n.t('spree.users.show.tabs.transactions')
@@ -75,6 +81,8 @@ feature '
 
           expect(page).to have_link d1o1.number, href: spree.order_path(d1o1)
           expect(page).to have_link d1o2.number, href: spree.order_path(d1o2)
+          expect(page).to have_link(distributor1.name,
+                                  href: "#{distributor1.permalink}/shop", count: 2)
           expect(page).to have_link I18n.t('spree.users.open_orders.cancel'), href: spree.cancel_order_path(d1o1)
           expect(page).to have_link I18n.t('spree.users.open_orders.cancel'), href: spree.cancel_order_path(d1o2)
         end


### PR DESCRIPTION
#### What? Why?

Closes #5102 

Under /account all the past and open orders are listed with their respective Shops. This PR makes the shop name a link to the shop page. I just changed the shop name element to have a href with /shop_permalink/shop.

#### What should we test?
On /account, we should test if a click on the shop name, inside the past/open orders table, redirects us to the shop page.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Make the shop name a link to the shop page on the account page.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed