### PR TITLE
Increase max characters for locale in spree_users

### DIFF
--- a/db/migrate/20200406085833_increase_characters_of_locale_in_spree_users.rb
+++ b/db/migrate/20200406085833_increase_characters_of_locale_in_spree_users.rb
@@ -1,0 +1,9 @@
+class IncreaseCharactersOfLocaleInSpreeUsers < ActiveRecord::Migration
+  def up
+    change_column :spree_users, :locale, :string, limit: 6
+  end
+
+  def down
+    change_column :spree_users, :locale, :string, limit: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200327105910) do
+ActiveRecord::Schema.define(:version => 20200406085833) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
@@ -1045,7 +1045,7 @@ ActiveRecord::Schema.define(:version => 20200327105910) do
     t.datetime "reset_password_sent_at"
     t.string   "api_key",                :limit => 40
     t.integer  "enterprise_limit",                     :default => 5, :null => false
-    t.string   "locale",                 :limit => 5
+    t.string   "locale",                 :limit => 6
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"


### PR DESCRIPTION
#### What? Why?

- Closes #5170 

There are many locales that have six (6) characters.

Locales such as `fil_PH` cannot be used because locale in the spree_users table can only store up to 5 characters. There is an error when I switch to `fil_PH` as a logged in user.

As explained in the issue #5170, there are actually a lot of locales with 6 characters.

#### What should we test?

1. Add the locale and translations for a 6-character locale (such as `fil_PH`) to the instance. (This needs to be done by a dev.)
2. Log in as a user.
3. Switch to the 6-character locale.

#### Release notes

Add support for 6-character locales.

Changelog Category: Added