### PR TITLE
Allow changing the connection pool size

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   adapter: postgresql
   encoding: unicode
-  pool: 5
+  pool: <%= ENV.fetch('OFN_DB_POOL', 5) %>
   host: <%= ENV.fetch('OFN_DB_HOST', 'localhost') %>
   username: <%= ENV.fetch('OFN_DB_USERNAME', 'ofn') %>
   password: <%= ENV.fetch('OFN_DB_PASSWORD', 'f00d') %>


### PR DESCRIPTION
#### What? Why?

This allows us to tune the pool size for UK. The hypothesis from @kristinalim is:

> From what I understand, it can result to Rails processes waiting for each other to complete, while the DB server can take more simultaneous connections.

#### What should we test?
We'll do it in production.

#### Release notes

Allow specifying the size of the database connection pool from an env var
Changelog Category: Added
