### PR TITLE
Memoize ScopeProductToHub in product list

### DIFF
--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -40,7 +40,7 @@ class ProductsRenderer
   end
 
   def product_scoper
-    OpenFoodNetwork::ScopeProductToHub.new(distributor)
+    @product_scoper ||= OpenFoodNetwork::ScopeProductToHub.new(distributor)
   end
 
   def enterprise_fee_calculator


### PR DESCRIPTION
#### What? Why?

Memoizing this scoper means we avoid fetching all of the hub's variant overrides every time we scope a product (which happens in it's initializer). This happens for every product loaded when displaying a shops's product list, which is currently one of our **top 3 pain points** in Datadog :fire:.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

#### What should we test?
<!-- List which features should be tested and how. -->

A quick check to make sure product lists are loading in the shop page should be enough :+1:

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance on product list endpoint

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
