### PR TITLE
Dont populate empty cart

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
@@ -5,5 +5,9 @@ Darkswarm.directive "shopVariant", ->
   scope:
     variant: '='
   controller: ($scope, Cart) ->
-    $scope.$watchGroup ['variant.line_item.quantity', 'variant.line_item.max_quantity'], ->
+    $scope.$watchGroup [
+      'variant.line_item.quantity',
+      'variant.line_item.max_quantity'
+    ], (new_value, old_value) ->
+      return if old_value[0] == null && new_value[0] == null
       Cart.adjust($scope.variant.line_item)

--- a/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
@@ -45,6 +45,13 @@ describe 'Cart service', ->
     Cart.adjust(order.line_items[0])
     expect(Cart.line_items.length).toEqual 0
 
+  it "does not add an item in the cart without quantity", ->
+    Cart.line_items = []
+
+    spyOn(Cart, 'orderChanged')
+    order.line_items[0].max_quantity = 0
+    expect(Cart.orderChanged).not.toHaveBeenCalled()
+
   it "sums the quantity of each line item for cart total", ->
     order.line_items[0].quantity = 2
     expect(Cart.total_item_count()).toEqual 2


### PR DESCRIPTION
#### What? Why?

I noticed in development that the server received a POST /cart/populate even though my cart was empty and the page was just loading. I couldn't add any items yet.

When loading the page $watchGroup calls the listener function for every listed line item but with a set variant and null quantity and max_quantity. There's no point on computing an order change when there was none.

This saves an empty request on the second most used endpoint of the app, especially busy when users are placing orders.

#### What should we test?

We should check we still can add and remove items from the cart and come back and forth from the /shops page without any browser alert. We should then check we can place the order as usual.

#### Release notes

Do not send populate the cart on page load with no user request.
Changelog Category: Changed

