### PR TITLE
Add Fragment Caching on shops and producers pages

### DIFF
--- a/app/views/producers/index.html.haml
+++ b/app/views/producers/index.html.haml
@@ -1,32 +1,32 @@
-- cache 'cached_producers_page_content', expires_in: 30.minutes do
-  - content_for(:title) do
-    = t :producers_title
+- content_for(:title) do
+  = t :producers_title
 
-  - content_for :injection_data do
+- content_for :injection_data do
+  - cache 'cached_producers_page_content', expires_in: 5.minutes do
     = inject_enterprises(@enterprises)
 
-  .producers{"ng-controller" => "EnterprisesCtrl", "ng-cloak" => true}
-    .row
-      .small-12.columns.pad-top
-        %h1
-          = t :producers_headline
+.producers{"ng-controller" => "EnterprisesCtrl", "ng-cloak" => true}
+  .row
+    .small-12.columns.pad-top
+      %h1
+        = t :producers_headline
 
-    = render partial: "shared/components/enterprise_search"
-    = render partial: "producers/filters"
+  = render partial: "shared/components/enterprise_search"
+  = render partial: "producers/filters"
 
-    .row
-      .small-12.columns
-        .active_table
-          %producer.active_table_node.row.animate-repeat{id: "{{producer.path}}",
-          "ng-repeat" => "producer in filteredEnterprises = (Enterprises.producers | searchEnterprises:query | taxons:activeTaxons | properties:activeProperties:'supplied_properties')",
-          "ng-controller" => "ProducerNodeCtrl",
-          "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !producer.active}",
-          id: "{{producer.hash}}"}
+  .row
+    .small-12.columns
+      .active_table
+        %producer.active_table_node.row.animate-repeat{id: "{{producer.path}}",
+        "ng-repeat" => "producer in filteredEnterprises = (Enterprises.producers | searchEnterprises:query | taxons:activeTaxons | properties:activeProperties:'supplied_properties')",
+        "ng-controller" => "ProducerNodeCtrl",
+        "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !producer.active}",
+        id: "{{producer.hash}}"}
 
-            .small-12.columns
-              = render partial: 'producers/skinny'
-              = render partial: 'producers/fat'
+          .small-12.columns
+            = render partial: 'producers/skinny'
+            = render partial: 'producers/fat'
 
-          = render partial: 'shared/components/enterprise_no_results'
+        = render partial: 'shared/components/enterprise_no_results'
 
-  = render partial: "shared/footer"
+= render partial: "shared/footer"

--- a/app/views/producers/index.html.haml
+++ b/app/views/producers/index.html.haml
@@ -1,31 +1,32 @@
-- content_for(:title) do
-  = t :producers_title
+- cache 'cached_producers_page_content', expires_in: 30.minutes do
+  - content_for(:title) do
+    = t :producers_title
 
-- content_for :injection_data do
-  = inject_enterprises(@enterprises)
+  - content_for :injection_data do
+    = inject_enterprises(@enterprises)
 
-.producers{"ng-controller" => "EnterprisesCtrl", "ng-cloak" => true}
-  .row
-    .small-12.columns.pad-top
-      %h1
-        = t :producers_headline
+  .producers{"ng-controller" => "EnterprisesCtrl", "ng-cloak" => true}
+    .row
+      .small-12.columns.pad-top
+        %h1
+          = t :producers_headline
 
-  = render partial: "shared/components/enterprise_search"
-  = render partial: "producers/filters"
+    = render partial: "shared/components/enterprise_search"
+    = render partial: "producers/filters"
 
-  .row
-    .small-12.columns
-      .active_table
-        %producer.active_table_node.row.animate-repeat{id: "{{producer.path}}",
-        "ng-repeat" => "producer in filteredEnterprises = (Enterprises.producers | searchEnterprises:query | taxons:activeTaxons | properties:activeProperties:'supplied_properties')",
-        "ng-controller" => "ProducerNodeCtrl",
-        "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !producer.active}",
-        id: "{{producer.hash}}"}
+    .row
+      .small-12.columns
+        .active_table
+          %producer.active_table_node.row.animate-repeat{id: "{{producer.path}}",
+          "ng-repeat" => "producer in filteredEnterprises = (Enterprises.producers | searchEnterprises:query | taxons:activeTaxons | properties:activeProperties:'supplied_properties')",
+          "ng-controller" => "ProducerNodeCtrl",
+          "ng-class" => "{'closed' : !open(), 'open' : open(), 'inactive' : !producer.active}",
+          id: "{{producer.hash}}"}
 
-          .small-12.columns
-            = render partial: 'producers/skinny'
-            = render partial: 'producers/fat'
+            .small-12.columns
+              = render partial: 'producers/skinny'
+              = render partial: 'producers/fat'
 
-        = render partial: 'shared/components/enterprise_no_results'
+          = render partial: 'shared/components/enterprise_no_results'
 
-= render partial: "shared/footer"
+  = render partial: "shared/footer"

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -1,17 +1,18 @@
-- content_for(:title) do
-  = t :shops_title
+- cache 'cached_shops_page_content', expires_in: 30.minutes do
+  - content_for(:title) do
+    = t :shops_title
 
-- content_for :injection_data do
-  = inject_enterprises(@enterprises)
+  - content_for :injection_data do
+    = inject_enterprises(@enterprises)
 
-#panes
-  #shops.pane
-    .row
-      .small-12.medium-6.medium-offset-3.columns.text-center
-        %h2
-          = t :shops_headline
-        %p.text-big
-          = t :shops_text
+  #panes
+    #shops.pane
+      .row
+        .small-12.medium-6.medium-offset-3.columns.text-center
+          %h2
+            = t :shops_headline
+          %p.text-big
+            = t :shops_text
 
-= render "hubs"
-= render "shared/footer"
+  = render "hubs"
+  = render "shared/footer"

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -1,18 +1,18 @@
-- cache 'cached_shops_page_content', expires_in: 30.minutes do
-  - content_for(:title) do
-    = t :shops_title
+- content_for(:title) do
+  = t :shops_title
 
-  - content_for :injection_data do
+- content_for :injection_data do
+  - cache 'cached_shops_page_content', expires_in: 5.minutes do
     = inject_enterprises(@enterprises)
 
-  #panes
-    #shops.pane
-      .row
-        .small-12.medium-6.medium-offset-3.columns.text-center
-          %h2
-            = t :shops_headline
-          %p.text-big
-            = t :shops_text
+#panes
+  #shops.pane
+    .row
+      .small-12.medium-6.medium-offset-3.columns.text-center
+        %h2
+          = t :shops_headline
+        %p.text-big
+          = t :shops_text
 
-  = render "hubs"
-  = render "shared/footer"
+= render "hubs"
+= render "shared/footer"


### PR DESCRIPTION
#### What? Why?

Let's add some Fragment Caching on these 2 pages as they are very long to be generated.

Related to #5143 

From DataDog, we can see that Postgres requests are taking sometimes:
![Screenshot from 2020-04-07 14-51-34](https://user-images.githubusercontent.com/27745/78671653-d8e2be00-78df-11ea-962a-2556674759c3.png)

I am not seeing any dynamic code on the fragment I am caching, most of the logic is done on front end side with Angular.
Let's consider this as a patch in order to give some air to our servers.

#### What should we test?
We should test that /producers and /shops pages are working as expected, for logged user and for unlogged user.


Changelog Category: Changed


