### PR TITLE
[Mobile UX] Style updates on buttons

### DIFF
--- a/app/assets/stylesheets/darkswarm/branding.css.scss
+++ b/app/assets/stylesheets/darkswarm/branding.css.scss
@@ -54,6 +54,7 @@ $teal-400: #4cb5c5;
 $teal-500: #0096ad;
 
 $orange-400: #ff9466;
+$orange-450: #f4704c;
 $orange-500: #f27052;
 $orange-600: #d7583a;
 

--- a/app/assets/stylesheets/darkswarm/shopping-cart.css.scss
+++ b/app/assets/stylesheets/darkswarm/shopping-cart.css.scss
@@ -115,3 +115,14 @@
     height: 36px;
   }
 }
+
+.links {
+  .button {
+    padding: 1.125rem 0 1.1875rem;
+    width: 210px;
+
+    @media all and (max-width: 480px) {
+      width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/darkswarm/ui.css.scss
+++ b/app/assets/stylesheets/darkswarm/ui.css.scss
@@ -64,13 +64,13 @@
 
 .button.primary, button.primary {
   font-family: $body-font;
-  background: $clr-brick;
+  background: $orange-450;
   color: white;
 }
 
 .button.primary:hover, .button.primary:active, .button.primary:focus, button.primary:hover, button.primary:active, button.primary:focus {
-  background: $clr-brick-bright;
-  text-shadow: 0 1px 0 $clr-brick;
+  background: $orange-400;
+  text-shadow: 0 1px 0 $orange-450;
 }
 
 button.success, .button.success {

--- a/app/views/checkout/_summary.html.haml
+++ b/app/views/checkout/_summary.html.haml
@@ -31,5 +31,4 @@
 
       //= f.submit "Purchase", class: "button", "ofn-focus" => "accordion['payment']"
       %a.button.secondary{href: main_app.cart_url}
-        %i.ofn-i_008-caret-left
         = t :checkout_back_to_cart

--- a/app/views/spree/orders/form/_cart_links.html.haml
+++ b/app/views/spree/orders/form/_cart_links.html.haml
@@ -1,7 +1,5 @@
 .row.links{'data-hook' => "cart_buttons"}
-  .columns.large-8{"data-hook" => ""}
-    %a.button.large.secondary{href: current_shop_products_path}
-      = t :orders_edit_continue
-  .columns.large-4.text-right
-    %a#checkout-link.button.large.primary{href: main_app.checkout_path}
-      = t :orders_edit_checkout
+  %a.button.large.secondary{href: current_shop_products_path}
+    = t :orders_edit_continue
+  %a#checkout-link.button.large.primary.right{href: main_app.checkout_path}
+    = t :orders_edit_checkout

--- a/app/views/spree/orders/form/_cart_links.html.haml
+++ b/app/views/spree/orders/form/_cart_links.html.haml
@@ -1,9 +1,7 @@
 .row.links{'data-hook' => "cart_buttons"}
   .columns.large-8{"data-hook" => ""}
     %a.button.large.secondary{href: current_shop_products_path}
-      %i.ofn-i_008-caret-left
       = t :orders_edit_continue
   .columns.large-4.text-right
     %a#checkout-link.button.large.primary{href: main_app.checkout_path}
       = t :orders_edit_checkout
-      %i.ofn-i_007-caret-right

--- a/app/views/spree/orders/form/_update_buttons.html.haml
+++ b/app/views/spree/orders/form/_update_buttons.html.haml
@@ -3,11 +3,9 @@
     - if current_order.nil? || current_order.distributor.nil? || current_order.distributor == @order.distributor
       - if current_order&.line_items.present?
         = link_to main_app.cart_path, :class => "button expand" do
-          %i.ofn-i_008-caret-left
           = t(:order_back_to_cart)
       - else
         = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop", class: "button expand" do
-          %i.ofn-i_008-caret-left
           = t(:order_back_to_store)
     - else
       &nbsp;


### PR DESCRIPTION
#### What? Why?

Part of #4773 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adjusts styling and alignment on cart and checkout buttons.

#### What should we test?
<!-- List which features should be tested and how. -->

- Remove the left/right arrows in buttons -- they're taking up precious space in mobile
- Correct the positioning of the buttons in mobile so they fit in one single row
- Correct the positioning of the buttons in desktop so they're left / right aligned with the table
- Update the button colour to orange (because red indicates error)

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Updated styling on cart and checkout pages

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

