### PR TITLE
[Spree 2.1] Update spree revision to a version that doesnt depend on deface

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: b7ad5b473f9e38c5a1882550b2b4e348f4824f1f
+  revision: f9264ebca0d8dd932a7dbee471514a3b85774c8f
   branch: 2-1-0-stable
   specs:
     spree_core (2.1.0)


### PR DESCRIPTION
#### What? Why?

After updating spree 2-1-stable in https://github.com/openfoodfoundation/spree/pull/44 we need to update the spree revision in the 3-0-stable branch. The nokogiri upgrade will flow when we merge master into 3-0-stable

#### What should we test?
green build.
