### PR TITLE
Cart populate performance

### DIFF
--- a/app/services/variants_stock_levels.rb
+++ b/app/services/variants_stock_levels.rb
@@ -8,7 +8,8 @@ class VariantsStockLevels
     variant_stock_levels = variant_stock_levels(order.line_items)
 
     order_variant_ids = variant_stock_levels.keys
-    missing_variants = Spree::Variant.where(id: (requested_variant_ids - order_variant_ids))
+    missing_variants = Spree::Variant.includes(:stock_items).
+      where(id: (requested_variant_ids - order_variant_ids))
 
     missing_variants.each do |missing_variant|
       variant = scoped_variant(order.distributor, missing_variant)

--- a/app/services/variants_stock_levels.rb
+++ b/app/services/variants_stock_levels.rb
@@ -8,10 +8,12 @@ class VariantsStockLevels
     variant_stock_levels = variant_stock_levels(order.line_items)
 
     order_variant_ids = variant_stock_levels.keys
-    missing_variant_ids = requested_variant_ids - order_variant_ids
-    missing_variant_ids.each do |variant_id|
-      variant = scoped_variant(order.distributor, Spree::Variant.find(variant_id))
-      variant_stock_levels[variant_id] = { quantity: 0, max_quantity: 0, on_hand: variant.on_hand, on_demand: variant.on_demand }
+    missing_variants = Spree::Variant.where(id: (requested_variant_ids - order_variant_ids))
+
+    missing_variants.each do |missing_variant|
+      variant = scoped_variant(order.distributor, missing_variant)
+      variant_stock_levels[variant.id] =
+        { quantity: 0, max_quantity: 0, on_hand: variant.on_hand, on_demand: variant.on_demand }
     end
 
     variant_stock_levels


### PR DESCRIPTION
#### What? Why?

Adds some quick improvements to `CartController#populate`, which currently seems to perform very well in some conditions and very badly in others. It _think_ this difference is probably just when the number of items in the cart is very large. This endpoint is in our **top 3 pain points** in Datadog.

Removes a couple of N+1 queries.

#### What should we test?
<!-- List which features should be tested and how. -->

Adding and removing items in the cart works. Loading (when adding a new item to the cart) should be faster if the number of items already in the cart is large.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance on CartController#populate for large carts

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

