### PR TITLE
Improve Checkout error handling in JS

### DIFF
--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -22,11 +22,14 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
           if response.data.path
             Navigation.go response.data.path
           else
+            throw response unless response.data.errors || response.data.flash
+
             Loading.clear()
             @errors = response.data.errors
             RailsFlashLoader.loadFlash(response.data.flash)
         catch error
-          RailsFlashLoader.loadFlash("Unkown error occurred")
+          RailsFlashLoader.loadFlash(error: t("checkout.failed")) # inform the user about the unexpected error
+          throw error # generate a BugsnagJS alert
 
     # Rails wants our Spree::Address data to be provided with _attributes
     preprocess: ->

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -19,18 +19,23 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
         Navigation.go response.data.path
       .catch (response) =>
         try
-          if response.data.path
-            Navigation.go response.data.path
-          else
-            throw response unless response.data.errors || response.data.flash
-
-            Loading.clear()
-            @errors = response.data.errors
-            RailsFlashLoader.loadFlash(response.data.flash)
+          @handle_checkout_error_response(response)
         catch error
-          Loading.clear()
-          RailsFlashLoader.loadFlash(error: t("checkout.failed")) # inform the user about the unexpected error
+          @loadFlash(error: t("checkout.failed")) # inform the user about the unexpected error
           throw error # generate a BugsnagJS alert
+
+    handle_checkout_error_response: (response) =>
+      if response.data.path
+        Navigation.go response.data.path
+      else
+        throw response unless response.data.errors || response.data.flash
+
+        @errors = response.data.errors
+        @loadFlash(response.data.flash)
+
+    loadFlash: (flash) =>
+      Loading.clear()
+      RailsFlashLoader.loadFlash(flash)
 
     # Rails wants our Spree::Address data to be provided with _attributes
     preprocess: ->

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -28,7 +28,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
       if response.data.path
         Navigation.go response.data.path
       else
-        throw response unless response.data.errors || response.data.flash
+        throw response unless response.data.flash
 
         @errors = response.data.errors
         @loadFlash(response.data.flash)

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -28,6 +28,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
             @errors = response.data.errors
             RailsFlashLoader.loadFlash(response.data.flash)
         catch error
+          Loading.clear()
           RailsFlashLoader.loadFlash(error: t("checkout.failed")) # inform the user about the unexpected error
           throw error # generate a BugsnagJS alert
 

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -14,15 +14,19 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
 
     submit: =>
       Loading.message = t 'submitting_order'
-      $http.put('/checkout.json', {order: @preprocess()}).success (data, status)=>
-        Navigation.go data.path
-      .error (response, status)=>
-        if response.path
-          Navigation.go response.path
-        else
-          Loading.clear()
-          @errors = response.errors
-          RailsFlashLoader.loadFlash(response.flash)
+      $http.put('/checkout.json', {order: @preprocess()})
+      .then (response) =>
+        Navigation.go response.data.path
+      .catch (response) =>
+        try
+          if response.data.path
+            Navigation.go response.data.path
+          else
+            Loading.clear()
+            @errors = response.data.errors
+            RailsFlashLoader.loadFlash(response.data.flash)
+        catch error
+          RailsFlashLoader.loadFlash("Unkown error occurred")
 
     # Rails wants our Spree::Address data to be provided with _attributes
     preprocess: ->

--- a/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
@@ -3,6 +3,7 @@ describe 'Checkout service', ->
   orderData = null
   $httpBackend = null
   Navigation = null
+  navigationSpy = null
   flash = null
   scope = null
   FlashLoaderMock =
@@ -64,7 +65,7 @@ describe 'Checkout service', ->
       scope.Checkout = Checkout
       Navigation = $injector.get("Navigation")
       flash = $injector.get("flash")
-      spyOn(Navigation, "go") # Stubbing out writes to window.location
+      navigationSpy = spyOn(Navigation, "go") # Stubbing out writes to window.location
 
   it "defaults to no shipping method", ->
     expect(Checkout.order.shipping_method_id).toEqual null
@@ -139,8 +140,8 @@ describe 'Checkout service', ->
 
       it "throws an exception and sends a flash message to the flash service when an exception is thrown while handling the error", ->
         spyOn(FlashLoaderMock, "loadFlash") # Stubbing out writes to window.location
-        spyOn(Loading, "clear").and.callFake(-> throw "unexpected error")
-        $httpBackend.expectPUT("/checkout.json").respond 400, {flash: {error: "frogs"}}
+        navigationSpy.and.callFake(-> throw "unexpected error")
+        $httpBackend.expectPUT("/checkout.json").respond 400, {path: 'path'}
         try
           Checkout.submit()
           $httpBackend.flush()

--- a/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
@@ -119,6 +119,7 @@ describe 'Checkout service', ->
       it "puts errors into the scope", ->
         $httpBackend.expectPUT("/checkout.json").respond 400, {errors: {error: "frogs"}}
         Checkout.submit()
+
         $httpBackend.flush()
         expect(Checkout.errors).toEqual {error: "frogs"}
 


### PR DESCRIPTION
- Switch from old success/error to modern then/catch structure: .catch() will get a few more errors then .errors().
- Add try/catch inside catch to detect any errors parsing the response error payload including when the response doesnt include any error or flash information. In these cases log to bugsnag (throw the error again) and inform the user so we dont have silent checkout errors.

#### What? Why?

Related to #5192

#### What should we test?
We need to test checkout error scenarios:
- Redirect to cart page if insufficient stock: go to checkout with variant X in the cart, go to the backoffice and make on_hand zero for variant X, return to checkout page and click "place order", you should be redirected to the cart page with a message insufficient stock
- Try to checkout with invalid email address, for example, "ofn@org"
- Try to pay with an invalid credit card (bogus or stripe payment methods)
- Try to pay with a StripeSCA card where authentication is required for example 4000 0027 6000 3184 and fail the authentication on the stripe test page, you should see an flash error on the checkout page when you are redirected to the checkout page.

#### Release notes
Changelog Category:  Changed
Improved resiliency of the checkout code that handles error scenarios.
