### PR TITLE
Clear filters on admin/products page

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -105,6 +105,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     $scope.producerFilter = "0"
     $scope.categoryFilter = "0"
     $scope.importDateFilter = "0"
+    $scope.fetchProducts()
 
   $scope.$watch 'sortOptions', (sort) ->
     return unless sort && sort.predicate != ""

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -903,8 +903,8 @@ describe "AdminProductEditCtrl", ->
         $scope.categoryFilter = "6"
         $scope.resetSelectFilters()
         expect($scope.query).toBe ""
-        expect($scope.producerFilter).toBe "0"
-        expect($scope.categoryFilter).toBe "0"
+        expect($scope.producerFilter).toBeUndefined
+        expect($scope.categoryFilter).toBeUndefined
 
 
 describe "converting arrays of objects with ids to an object with ids as keys", ->


### PR DESCRIPTION
#### What? Why?

Closes #5096 

Displays the admin/products items shown on first page load instead of the previously displayed "No products yet. Why don't you add some?".

#### What should we test?

- When searching for a product not found, verify that result is first "Sorry, no results match [search]", then upon clicking clear filters, changes back to displaying all products.
- When searching for a product that is found, verify that result is still correct with and without applied filters, and when clicking clear filters, changes back to displaying all products as before.


#### Release notes
Fixed Clear Filters button function when no results are found in searching the products.

Changelog Category: Fixed