### PR TITLE
Added missing translations to enterprise_relationship page

### DIFF
--- a/app/views/admin/enterprise_relationships/_enterprise_relationship.html.haml
+++ b/app/views/admin/enterprise_relationships/_enterprise_relationship.html.haml
@@ -6,6 +6,7 @@
   %td
     %ul
       %li{"ng-repeat" => "permission in enterprise_relationship.permissions"}
-        to {{ EnterpriseRelationships.permission_presentation(permission.name) }}
+        = t 'admin_enterprise_relationships_to'
+        {{ EnterpriseRelationships.permission_presentation(permission) }}
   %td.actions
     %a.delete-enterprise-relationship.icon-trash.no-text{'ng-click' => 'delete(enterprise_relationship)'}

--- a/app/views/admin/enterprise_relationships/_enterprise_relationship.html.haml
+++ b/app/views/admin/enterprise_relationships/_enterprise_relationship.html.haml
@@ -7,6 +7,6 @@
     %ul
       %li{"ng-repeat" => "permission in enterprise_relationship.permissions"}
         = t 'admin_enterprise_relationships_to'
-        {{ EnterpriseRelationships.permission_presentation(permission) }}
+        {{ EnterpriseRelationships.permission_presentation(permission.name) }}
   %td.actions
     %a.delete-enterprise-relationship.icon-trash.no-text{'ng-click' => 'delete(enterprise_relationship)'}

--- a/app/views/admin/enterprise_relationships/_form.html.haml
+++ b/app/views/admin/enterprise_relationships/_form.html.haml
@@ -13,7 +13,8 @@
     %div{"ng-repeat" => "permission in EnterpriseRelationships.all_permissions"}
       %label
         %input{type: "checkbox", "ng-model" => "permissions[permission]"}
-        to {{ EnterpriseRelationships.permission_presentation(permission) }}
+        = t 'admin_enterprise_relationships_to'
+        {{ EnterpriseRelationships.permission_presentation(permission) }}
   %td.actions
     %input{type: "button", value: t(:admin_enterprise_relationships_button_create), "ng-click" => "create()"}
     .errors {{ EnterpriseRelationships.create_errors }}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2053,6 +2053,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   admin_enterprise_relationships_permits: "permits"
   admin_enterprise_relationships_seach_placeholder: "Search"
   admin_enterprise_relationships_button_create: "Create"
+  admin_enterprise_relationships_to: "to"
   admin_enterprise_groups: "Enterprise Groups"
   admin_enterprise_groups_name: "Name"
   admin_enterprise_groups_owner: "Owner"


### PR DESCRIPTION
#### What? Why?

Closes #5000

"To" was not being translated on page for the checkboxes at the top of the page nor the labels for each enterprise.

#### What should we test?
Check to see that translations occur using the new input to en.yml file.


#### Release notes
Added "to" to en.yml and corresponding translations to enterprise_relationships page.

Changelog Category: Fixed