### PR TITLE
Add product translations to admin order creation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2910,6 +2910,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     location: "Location"
     count_on_hand: "Count On Hand"
     quantity: "Quantity"
+    on_demand: "On Demand"
+    on_hand: "On Hand"
     package_from: "package from"
     item_description: "Item Description"
     price: "Price"


### PR DESCRIPTION
#### What? Why?

Closes #4965 

Add the previously missing translations for "On Hand" and "On Demand" for spree translations on the admin order creation page.


#### What should we test?
Translations for these two fields in other locales.



#### Release notes
Addressed the missing spree translations on admin order creation page, where previously created html labelled as "Translation missing: ..."

Changelog Category: Added

#### How is this related to the Spree upgrade?
Had to add translations to Spree subheader in en.yml document.