### PR TITLE
Add DFC Provider engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rails_safe_tasks', '~> 1.0'
 gem "activerecord-import"
 
 gem "catalog", path: "./engines/catalog"
+gem 'dfc_provider', path: './engines/dfc_provider'
 gem "order_management", path: "./engines/order_management"
 gem 'web', path: './engines/web'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,14 +57,16 @@ GIT
       spree_core (>= 1.1)
 
 PATH
-  remote: engines/dfc_provider
-  specs:
-    dfc_provider (0.0.1)
-
-PATH
   remote: engines/catalog
   specs:
     catalog (0.0.1)
+
+PATH
+  remote: engines/dfc_provider
+  specs:
+    dfc_provider (0.0.1)
+      jwt (~> 2.2)
+      rspec (~> 3.9)
 
 PATH
   remote: engines/order_management

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,11 @@ GIT
       spree_core (>= 1.1)
 
 PATH
+  remote: engines/dfc_provider
+  specs:
+    dfc_provider (0.0.1)
+
+PATH
   remote: engines/catalog
   specs:
     catalog (0.0.1)
@@ -710,6 +715,7 @@ DEPENDENCIES
   delayed_job_web
   devise (~> 2.2.5)
   devise-encryptable (= 0.2.0)
+  dfc_provider!
   diffy
   eventmachine (>= 1.2.3)
   factory_bot_rails

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,9 @@ Openfoodnetwork::Application.routes.draw do
 
   get 'sitemap.xml', to: 'sitemap#index', defaults: { format: 'xml' }
 
+  # Mount DFC API endpoints
+  mount DfcProvider::Engine, at: '/'
+
   # Mount Spree's routes
   mount Spree::Core::Engine, :at => '/'
-  mount DfcProvider::Engine, at: '/'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,4 +91,5 @@ Openfoodnetwork::Application.routes.draw do
 
   # Mount Spree's routes
   mount Spree::Core::Engine, :at => '/'
+  mount DfcProvider::Engine, at: '/'
 end

--- a/engines/dfc_provider/README.md
+++ b/engines/dfc_provider/README.md
@@ -1,0 +1,8 @@
+# DfcProvider
+
+This engine is implementing the Data Food Consortium specifications in order to serve semantic data.
+You can find more details about this on https://github.com/datafoodconsortium.
+
+Basically, it allows an OFN user:
+* to retrieve an Access token from DFC Authorization server (using OIDC implemntation)
+* to serve his Products Catalog through a dedicated API using JSON-LD format, structured by the DFC Ontology.

--- a/engines/dfc_provider/README.md
+++ b/engines/dfc_provider/README.md
@@ -3,6 +3,8 @@
 This engine is implementing the Data Food Consortium specifications in order to serve semantic data.
 You can find more details about this on https://github.com/datafoodconsortium.
 
-Basically, it allows an OFN user:
-* to retrieve an Access token from DFC Authorization server (using OIDC implemntation)
-* to serve his Products Catalog through a dedicated API using JSON-LD format, structured by the DFC Ontology.
+Basically, it allows an OFN user linked to an enterprise:
+* to serve his Products Catalog through a dedicated API using JSON-LD format, structured by the DFC Ontology
+* to be authenticated thanks to an Access Token from DFC Authorization server (using an OIDC implementation)
+
+The API endpoint for the catalog is `/api/dfc_provider/enterprise/prodcuts.json` and you need to pass the token inside an authentication header (`Authentication: Bearer 123mytoken456`).

--- a/engines/dfc_provider/app/controllers/api/dfc_provider/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/api/dfc_provider/products_controller.rb
@@ -1,0 +1,26 @@
+module Api::DfcProvider
+  class ProductsController < ActionController::Base
+    before_filter :set_enterprise
+
+    def index
+      products = @enterprise.inventory_variants
+                            .includes(:product, :inventory_items)
+
+      products_json = DfcProvider::ProductSerializer
+                      .new(@enterprise, products, base_url)
+                      .serialized_json
+
+      render json: products_json
+    end
+
+    private
+
+    def set_enterprise
+      @enterprise = ::Enterprise.find(params[:enterprise_id])
+    end
+
+    def base_url
+      "#{root_url}api/dfc_provider"
+    end
+  end
+end

--- a/engines/dfc_provider/app/controllers/api/dfc_provider/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/api/dfc_provider/products_controller.rb
@@ -1,26 +1,32 @@
-module Api::DfcProvider
-  class ProductsController < ActionController::Base
-    before_filter :set_enterprise
+# frozen_string_literal: true
 
-    def index
-      products = @enterprise.inventory_variants
-                            .includes(:product, :inventory_items)
+# Controller used to provide the API products for the DFC application
+module Api
+  module DfcProvider
+    class ProductsController < Api::BaseController
+      before_filter :set_enterprise
 
-      products_json = DfcProvider::ProductSerializer
-                      .new(@enterprise, products, base_url)
-                      .serialized_json
+      def index
+        products = @enterprise.
+          inventory_variants.
+          includes(:product, :inventory_items)
 
-      render json: products_json
-    end
+        products_json = ::DfcProvider::ProductSerializer.
+          new(@enterprise, products, base_url).
+          serialized_json
 
-    private
+        render json: products_json
+      end
 
-    def set_enterprise
-      @enterprise = ::Enterprise.find(params[:enterprise_id])
-    end
+      private
 
-    def base_url
-      "#{root_url}api/dfc_provider"
+      def set_enterprise
+        @enterprise = ::Enterprise.find(params[:enterprise_id])
+      end
+
+      def base_url
+        "#{root_url}api/dfc_provider"
+      end
     end
   end
 end

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
@@ -28,7 +28,12 @@ module DfcProvider
       private
 
       def check_enterprise
-        @enterprise = @user.enterprises.first
+        @enterprise =
+          if params[:enterprise_id] == 'default'
+            @user.enterprises.first
+          else
+            @user.enterprises.where(id: params[:enterprise_id]).first
+          end
 
         return if @enterprise.present?
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 # Controller used to provide the API products for the DFC application
-module Api
-  module DfcProvider
-    class ProductsController < Api::BaseController
+module DfcProvider
+  module Api
+    class ProductsController < ::Api::BaseController
+      skip_before_filter :authenticate_user
       before_filter :set_enterprise
+      before_filter :authenticate_user
+      skip_authorization_check
 
       def index
         products = @enterprise.
@@ -19,6 +22,10 @@ module Api
       end
 
       private
+
+      def authenticate_user
+        @current_api_user = @enterprise.owner
+      end
 
       def set_enterprise
         @enterprise = ::Enterprise.find(params[:enterprise_id])

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
@@ -4,13 +4,8 @@
 module DfcProvider
   module Api
     class ProductsController < ::ActionController::Metal
-      include ActionController::Head
-      include AbstractController::Rendering
-      include ActionController::Rendering
-      include ActionController::Renderers::All
-      include ActionController::MimeResponds
-      include ActionController::ImplicitRender
-      include AbstractController::Callbacks
+      include Spree::Api::ControllerSetup
+
       # To access 'base_url' helper
       include ActionController::UrlFor
       include Rails.application.routes.url_helpers
@@ -19,8 +14,6 @@ module DfcProvider
                     :check_enterprise,
                     :check_user,
                     :check_accessibility
-
-      respond_to :json
 
       def index
         products = @enterprise.

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
@@ -16,9 +16,8 @@ module DfcProvider
       include Rails.application.routes.url_helpers
 
       before_filter :check_authorization,
-                    :check_enterprise,
                     :check_user,
-                    :check_accessibility
+                    :check_enterprise
 
       respond_to :json
 
@@ -28,7 +27,7 @@ module DfcProvider
           includes(:product, :inventory_items)
 
         products_json = ::DfcProvider::ProductSerializer.
-          new(@enterprise, products, base_url).
+          new(products, base_url).
           serialized_json
 
         render json: products_json
@@ -37,7 +36,7 @@ module DfcProvider
       private
 
       def check_enterprise
-        @enterprise = ::Enterprise.where(id: params[:enterprise_id]).first
+        @enterprise = @user.enterprises.first
 
         return if @enterprise.present?
 
@@ -47,7 +46,7 @@ module DfcProvider
       def check_authorization
         return if access_token.present?
 
-        head :unauthorized
+        head :unprocessable_entity
       end
 
       def check_user
@@ -55,13 +54,7 @@ module DfcProvider
 
         return if @user.present?
 
-        head :unprocessable_entity
-      end
-
-      def check_accessibility
-        return if @enterprise.owner == @user
-
-        head :forbidden
+        head :unauthorized
       end
 
       def base_url

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
@@ -3,16 +3,8 @@
 # Controller used to provide the API products for the DFC application
 module DfcProvider
   module Api
-    class ProductsController < ::ActionController::Metal
-      include ActionController::Head
-      include AbstractController::Rendering
-      include ActionController::Rendering
-      include ActionController::Renderers::All
-      include ActionController::MimeResponds
-      include ActionController::ImplicitRender
-      include AbstractController::Callbacks
+    class ProductsController < ::ActionController::Base
       # To access 'base_url' helper
-      include ActionController::UrlFor
       include Rails.application.routes.url_helpers
 
       before_filter :check_authorization,

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
@@ -18,11 +18,11 @@ module DfcProvider
           inventory_variants.
           includes(:product, :inventory_items)
 
-        products_json = ::DfcProvider::ProductSerializer.
+        serialized_data = ::DfcProvider::ProductSerializer.
           new(products, base_url).
-          serialized_json
+          serialized_data
 
-        render json: products_json
+        render json: serialized_data
       end
 
       private

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/products_controller.rb
@@ -4,8 +4,13 @@
 module DfcProvider
   module Api
     class ProductsController < ::ActionController::Metal
-      include Spree::Api::ControllerSetup
-
+      include ActionController::Head
+      include AbstractController::Rendering
+      include ActionController::Rendering
+      include ActionController::Renderers::All
+      include ActionController::MimeResponds
+      include ActionController::ImplicitRender
+      include AbstractController::Callbacks
       # To access 'base_url' helper
       include ActionController::UrlFor
       include Rails.application.routes.url_helpers
@@ -14,6 +19,8 @@ module DfcProvider
                     :check_enterprise,
                     :check_user,
                     :check_accessibility
+
+      respond_to :json
 
       def index
         products = @enterprise.

--- a/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# Serializer used to render the products passed
+# into JSON-LD format based on DFC ontology
 module DfcProvider
   class ProductSerializer
     def initialize(enterprise, products, base_url)
@@ -9,20 +13,26 @@ module DfcProvider
     def serialized_json
       {
         "@context" =>
-          {
-            "DFC" => "http://datafoodconsortium.org/ontologies/DFC_FullModel.owl#",
-            "@base" => @base_url
-          },
-         "@id" => "/enterprises/#{@enterprise.id}/products",
-         "DFC:supplies" => @products.map do |variant|
-            {
-              "DFC:description" => variant.name,
-              "DFC:quantity" => variant.total_on_hand,
-              "@id" => variant.id,
-              "DFC:hasUnit" => {"@id" => "/unit/#{variant.unit_description.presence || 'piece' }"}
-            }
-          end
-        }.to_json
+        {
+          "DFC" => "http://datafoodconsortium.org/ontologies/DFC_FullModel.owl#",
+          "@base" => @base_url
+        },
+        "@id" => "/enterprises/#{@enterprise.id}/products",
+        "DFC:supplies" => serialized_products
+      }.to_json
+    end
+
+    private
+
+    def serialized_products
+      @products.map do |variant|
+        {
+          "DFC:description" => variant.name,
+          "DFC:quantity" => variant.total_on_hand,
+          "@id" => variant.id,
+          "DFC:hasUnit" => { "@id" => "/unit/#{variant.unit_description.presence || 'piece'}" }
+        }
+      end
     end
   end
 end

--- a/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
@@ -9,7 +9,7 @@ module DfcProvider
       @base_url = base_url
     end
 
-    def serialized_json
+    def serialized_data
       {
         "@context" =>
         {
@@ -18,7 +18,7 @@ module DfcProvider
         },
         "@id" => "/enterprise/products",
         "DFC:supplies" => serialized_products
-      }.to_json
+      }
     end
 
     private

--- a/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
@@ -1,0 +1,28 @@
+module DfcProvider
+  class ProductSerializer
+    def initialize(enterprise, products, base_url)
+      @enterprise = enterprise
+      @products = products
+      @base_url = base_url
+    end
+
+    def serialized_json
+      {
+        "@context" =>
+          {
+            "DFC" => "http://datafoodconsortium.org/ontologies/DFC_FullModel.owl#",
+            "@base" => @base_url
+          },
+         "@id" => "/enterprises/#{@enterprise.id}/products",
+         "DFC:supplies" => @products.map do |variant|
+            {
+              "DFC:description" => variant.name,
+              "DFC:quantity" => variant.total_on_hand,
+              "@id" => variant.id,
+              "DFC:hasUnit" => {"@id" => "/unit/#{variant.unit_description.presence || 'piece' }"}
+            }
+          end
+        }.to_json
+    end
+  end
+end

--- a/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/product_serializer.rb
@@ -4,8 +4,7 @@
 # into JSON-LD format based on DFC ontology
 module DfcProvider
   class ProductSerializer
-    def initialize(enterprise, products, base_url)
-      @enterprise = enterprise
+    def initialize(products, base_url)
       @products = products
       @base_url = base_url
     end
@@ -17,7 +16,7 @@ module DfcProvider
           "DFC" => "http://datafoodconsortium.org/ontologies/DFC_FullModel.owl#",
           "@base" => @base_url
         },
-        "@id" => "/enterprises/#{@enterprise.id}/products",
+        "@id" => "/enterprise/products",
         "DFC:supplies" => serialized_products
       }.to_json
     end

--- a/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
+++ b/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Service used to authorize the user on DCF Provider API
+# It controls an OICD Access token and an enterprise.
+module DfcProvider
+  class AuthorizationControl
+    def initialize(access_token)
+      @access_token = access_token
+    end
+
+    def process
+      decode_token
+      find_ofn_user
+    end
+
+    def decode_token
+      data = JWT.decode(
+        @access_token,
+        nil,
+        false
+      )
+
+      @header = data.last
+      @payload = data.first
+    end
+
+    def find_ofn_user
+      Spree::User.where(email: @payload['email']).first
+    end
+  end
+end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -2,7 +2,7 @@
 
 DfcProvider::Engine.routes.draw do
   namespace :api do
-    namespace :dfc_provider do
+    scope :dfc_provider, as: :dfc_provider, path: '/dfc_provider' do
       resources :enterprises, only: :none do
         resources :products, only: %i[index]
       end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -3,7 +3,7 @@
 DfcProvider::Engine.routes.draw do
   namespace :api do
     scope :dfc_provider, as: :dfc_provider, path: '/dfc_provider' do
-      resources :enterprises, only: :none do
+      resource :enterprise, only: :none do
         resources :products, only: %i[index]
       end
     end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 DfcProvider::Engine.routes.draw do
   namespace :api do
     namespace :dfc_provider do

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -3,8 +3,8 @@
 DfcProvider::Engine.routes.draw do
   namespace :api do
     scope :dfc_provider, as: :dfc_provider, path: '/dfc_provider' do
-      resource :enterprise, only: :none do
-        resources :products, only: %i[index]
+      resources :enterprises, only: :none do
+        resources :products, only: [:index]
       end
     end
   end

--- a/engines/dfc_provider/config/routes.rb
+++ b/engines/dfc_provider/config/routes.rb
@@ -1,0 +1,9 @@
+DfcProvider::Engine.routes.draw do
+  namespace :api do
+    namespace :dfc_provider do
+      resources :enterprises, only: :none do
+        resources :products, only: %i[index]
+      end
+    end
+  end
+end

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -1,4 +1,6 @@
-$:.push File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
 require "dfc_provider/version"
@@ -9,7 +11,7 @@ Gem::Specification.new do |s|
   s.version     = DfcProvider::VERSION
   s.authors     = ['Admin OFF']
   s.email       = ['admin@openfoodfrance.org']
-  s.summary     = 'Provdes an API stack implementing DFC semantic specifications'
+  s.summary     = 'Provides an API stack implementing DFC semantic specifications'
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ['MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -9,8 +9,7 @@ require "dfc_provider/version"
 Gem::Specification.new do |spec|
   spec.name        = 'dfc_provider'
   spec.version     = DfcProvider::VERSION
-  spec.authors     = ['Admin OFF']
-  spec.email       = ['admin@openfoodfrance.org']
+  spec.authors     = ["developers@ofn"]
   spec.summary     = 'Provides an API stack implementing DFC semantic ' \
                   'specifications'
 

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.email       = ['admin@openfoodfrance.org']
   s.summary     = 'Provides an API stack implementing DFC semantic specifications'
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ['MIT-LICENSE', 'Rakefile', 'README.rdoc']
+  s.files = Dir["{app,config,db,lib}/**/*"] + ['README.rdoc']
   s.test_files = Dir['test/**/*']
 end

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -1,0 +1,16 @@
+$:.push File.expand_path("../lib", __FILE__)
+
+# Maintain your gem's version:
+require "dfc_provider/version"
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = 'dfc_provider'
+  s.version     = DfcProvider::VERSION
+  s.authors     = ['Admin OFF']
+  s.email       = ['admin@openfoodfrance.org']
+  s.summary     = 'Provdes an API stack implementing DFC semantic specifications'
+
+  s.files = Dir["{app,config,db,lib}/**/*"] + ['MIT-LICENSE', 'Rakefile', 'README.rdoc']
+  s.test_files = Dir['test/**/*']
+end

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -6,13 +6,17 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 require "dfc_provider/version"
 
 # Describe your gem and declare its dependencies:
-Gem::Specification.new do |s|
-  s.name        = 'dfc_provider'
-  s.version     = DfcProvider::VERSION
-  s.authors     = ['Admin OFF']
-  s.email       = ['admin@openfoodfrance.org']
-  s.summary     = 'Provides an API stack implementing DFC semantic specifications'
+Gem::Specification.new do |spec|
+  spec.name        = 'dfc_provider'
+  spec.version     = DfcProvider::VERSION
+  spec.authors     = ['Admin OFF']
+  spec.email       = ['admin@openfoodfrance.org']
+  spec.summary     = 'Provides an API stack implementing DFC semantic ' \
+                  'specifications'
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ['README.rdoc']
-  s.test_files = Dir['test/**/*']
+  spec.files = Dir["{app,config,lib}/**/*"] + ['README.md']
+  spec.test_files = Dir['spec/**/*']
+
+  spec.add_dependency 'jwt', '~> 2.2'
+  spec.add_dependency 'rspec', '~> 3.9'
 end

--- a/engines/dfc_provider/dfc_provider.gemspec
+++ b/engines/dfc_provider/dfc_provider.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.version     = DfcProvider::VERSION
   spec.authors     = ["developers@ofn"]
   spec.summary     = 'Provides an API stack implementing DFC semantic ' \
-                  'specifications'
+                     'specifications'
 
   spec.files = Dir["{app,config,lib}/**/*"] + ['README.md']
   spec.test_files = Dir['spec/**/*']

--- a/engines/dfc_provider/lib/dfc_provider.rb
+++ b/engines/dfc_provider/lib/dfc_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dfc_provider/engine"
 
 module DfcProvider

--- a/engines/dfc_provider/lib/dfc_provider.rb
+++ b/engines/dfc_provider/lib/dfc_provider.rb
@@ -1,0 +1,4 @@
+require "dfc_provider/engine"
+
+module DfcProvider
+end

--- a/engines/dfc_provider/lib/dfc_provider/engine.rb
+++ b/engines/dfc_provider/lib/dfc_provider/engine.rb
@@ -1,0 +1,5 @@
+module DfcProvider
+  class Engine < ::Rails::Engine
+    isolate_namespace DfcProvider
+  end
+end

--- a/engines/dfc_provider/lib/dfc_provider/engine.rb
+++ b/engines/dfc_provider/lib/dfc_provider/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DfcProvider
   class Engine < ::Rails::Engine
     isolate_namespace DfcProvider

--- a/engines/dfc_provider/lib/dfc_provider/version.rb
+++ b/engines/dfc_provider/lib/dfc_provider/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DfcProvider
-  VERSION = "0.0.1"
+  VERSION = '0.0.1'
 end

--- a/engines/dfc_provider/lib/dfc_provider/version.rb
+++ b/engines/dfc_provider/lib/dfc_provider/version.rb
@@ -1,0 +1,3 @@
+module DfcProvider
+  VERSION = "0.0.1"
+end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/products_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/products_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe DfcProvider::Api::ProductsController, type: :controller do
+  render_views
+
+  let(:enterprise) { create(:distributor_enterprise) }
+  let(:product) do
+    create(:simple_product, supplier: enterprise )
+  end
+  let!(:visible_inventory_item) do
+    create(:inventory_item,
+           enterprise: enterprise,
+           variant: product.variants.first,
+           visible: true)
+  end
+
+  describe('.index') do
+    before do
+      allow(controller)
+        .to receive(:spree_current_user) { enterprise.owner }
+
+      get :index, enterprise_id: enterprise.id
+    end
+
+    it 'is successful' do
+      expect(response.status).to eq 200
+    end
+
+    it 'renders the related product' do
+      expect(response.body)
+        .to include("\"DFC:description\":\"#{product.variants.first.name}\"")
+    end
+  end
+end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/products_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/products_controller_spec.rb
@@ -31,7 +31,7 @@ describe DfcProvider::Api::ProductsController, type: :controller do
         context 'with an enterprise' do
           context 'given with an id' do
             context 'related to the user' do
-              before { get :index, enterprise_id: enterprise.id }
+              before { get :index, enterprise_id: 'default' }
 
               it 'is successful' do
                 expect(response.status).to eq 200
@@ -46,9 +46,8 @@ describe DfcProvider::Api::ProductsController, type: :controller do
             context 'not related to the user' do
               let(:enterprise) { create(:enterprise) }
 
-              before { get :index, enterprise_id: enterprise.id }
-
               it 'returns not_found head' do
+                get :index, enterprise_id: enterprise.id
                 expect(response.status).to eq 404
               end
             end
@@ -71,33 +70,28 @@ describe DfcProvider::Api::ProductsController, type: :controller do
         context 'without a recorded enterprise' do
           let(:enterprise) { create(:enterprise) }
 
-          before { get :index, enterprise_id: 'default' }
-
           it 'returns not_found head' do
+            get :index, enterprise_id: 'default'
             expect(response.status).to eq 404
           end
         end
       end
 
       context 'without an authenticated user' do
-        before do
+        it 'returns unauthorized head' do
           allow_any_instance_of(DfcProvider::AuthorizationControl)
             .to receive(:process)
             .and_return(nil)
-        end
 
-        before { get :index, enterprise_id: 'default' }
-
-        it 'returns unauthorized head' do
+          get :index, enterprise_id: 'default'
           expect(response.status).to eq 401
         end
       end
     end
 
     context 'without an authorization token' do
-      before { get :index, enterprise_id: enterprise.id }
-
       it 'returns unprocessable_entity head' do
+        get :index, enterprise_id: enterprise.id
         expect(response.status).to eq 422
       end
     end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/products_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/products_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe DfcProvider::Api::ProductsController, type: :controller do
@@ -13,22 +15,82 @@ describe DfcProvider::Api::ProductsController, type: :controller do
            variant: product.variants.first,
            visible: true)
   end
+  let(:user) { enterprise.owner }
 
   describe('.index') do
-    before do
-      allow(controller)
-        .to receive(:spree_current_user) { enterprise.owner }
+    context 'with authorization token' do
+      before do
+        request.env['Authorization'] = 'Bearer 123456.abcdef.123456'
+      end
 
-      get :index, enterprise_id: enterprise.id
+      context 'with an enterprise' do
+        context 'with a linked user' do
+          before do
+            allow_any_instance_of(DfcProvider::AuthorizationControl)
+              .to receive(:process)
+              .and_return(user)
+          end
+
+          context 'with valid accessibility' do
+            before do
+              get :index, enterprise_id: enterprise.id
+            end
+
+            it 'is successful' do
+              expect(response.status).to eq 200
+            end
+
+            it 'renders the related product' do
+              expect(response.body)
+                .to include("\"DFC:description\":\"#{product.variants.first.name}\"")
+            end
+          end
+
+          context 'without valid accessibility' do
+            before do
+              get :index, enterprise_id: create(:enterprise).id
+            end
+
+            it 'returns unauthorized head' do
+              expect(response.status).to eq 403
+            end
+          end
+        end
+
+        context 'without a linked user' do
+          before do
+            allow_any_instance_of(DfcProvider::AuthorizationControl)
+              .to receive(:process)
+              .and_return(nil)
+          end
+
+          before do
+            get :index, enterprise_id: enterprise.id
+          end
+
+          it 'returns unprocessable_entity head' do
+            expect(response.status).to eq 422
+          end
+        end
+      end
+
+      context 'without a recorded enterprise' do
+        before do
+          get :index, enterprise_id: '123456'
+        end
+
+        it 'returns not_found head' do
+          expect(response.status).to eq 404
+        end
+      end
     end
 
-    it 'is successful' do
-      expect(response.status).to eq 200
-    end
+    context 'without an authorization token' do
+      before { get :index, enterprise_id: enterprise.id }
 
-    it 'renders the related product' do
-      expect(response.body)
-        .to include("\"DFC:description\":\"#{product.variants.first.name}\"")
+      it 'returns unauthorized head' do
+        expect(response.status).to eq 401
+      end
     end
   end
 end

--- a/engines/dfc_provider/spec/spec_helper.rb
+++ b/engines/dfc_provider/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "../../spec/spec_helper.rb"
 
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }

--- a/engines/dfc_provider/spec/spec_helper.rb
+++ b/engines/dfc_provider/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require "../../spec/spec_helper.rb"
+
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
#### What? Why?
We need to provide an API to help DFC application to synchronize our catalog.

Closes #5217
Closes #5218 

This engine will provide an isolated stack for this API. It will help to serve the catalog with the proper format. And also to authenticate the user.

#### What should we test?
You can test that the API is returning the proper catalog in JSON-LD format. An example of an endpoint will be `/api/dfc_provider/enterprises/1/products`. It will also support `/api/dfc_provider/enterprises/default/products`, fetching the first enterprise of the user for this.

Example:
```
curl -v -X GET -H "Authorization: Bearer "OIDC_token"" -H "Content-Type: application/json" http://localhost:3000/api/dfc_provider/enterprises/default/products.json
```

#### Release notes
- Add DFC Provider engine to implement the Products Catalog of an user with DFC compliance


Changelog Category: Added 
