### PR TITLE
[StripeSCA] Fix card payments in the Backoffice

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -156,7 +156,6 @@ Layout/LineLength:
   - spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
   - spec/controllers/spree/admin/orders_controller_spec.rb
   - spec/controllers/spree/admin/payment_methods_controller_spec.rb
-  - spec/controllers/spree/admin/payments_controller_spec.rb
   - spec/controllers/spree/admin/products_controller_spec.rb
   - spec/controllers/spree/admin/reports_controller_spec.rb
   - spec/controllers/spree/admin/variants_controller_spec.rb

--- a/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -28,7 +28,9 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
     context "order is complete" do
       let!(:order) do
-        create(:order_with_totals_and_distribution, distributor: shop, state: "complete", completed_at: Time.zone.now)
+        create(:order_with_totals_and_distribution, distributor: shop,
+                                                    state: "complete",
+                                                    completed_at: Time.zone.now)
       end
 
       context "with Check payment (payment.process! does nothing)" do
@@ -42,7 +44,11 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
       context "with Stripe payment where payment.process! errors out" do
         let!(:payment_method) { create(:stripe_payment_method, distributors: [shop]) }
-        before { allow_any_instance_of(Spree::Payment).to receive(:process!).and_raise(Spree::Core::GatewayError.new("Payment Gateway Error")) }
+        before do
+          allow_any_instance_of(Spree::Payment).
+            to receive(:process!).
+            and_raise(Spree::Core::GatewayError.new("Payment Gateway Error"))
+        end
 
         it "redirects to new payment page with flash error" do
           spree_post :create, payment: params, order_id: order.number
@@ -56,7 +62,11 @@ describe Spree::Admin::PaymentsController, type: :controller do
         let!(:payment_method) { create(:stripe_sca_payment_method, distributors: [shop]) }
 
         context "where payment.authorize! raises GatewayError" do
-          before { allow_any_instance_of(Spree::Payment).to receive(:authorize!).and_raise(Spree::Core::GatewayError.new("Stripe Authorization Failure")) }
+          before do
+            allow_any_instance_of(Spree::Payment).
+              to receive(:authorize!).
+              and_raise(Spree::Core::GatewayError.new("Stripe Authorization Failure"))
+          end
 
           it "redirects to new payment page with flash error" do
             spree_post :create, payment: params, order_id: order.number
@@ -126,8 +136,10 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
       context "that was processed by stripe" do
         let!(:payment_method) { create(:stripe_payment_method, distributors: [shop]) }
-        # let!(:credit_card) { create(:credit_card, gateway_customer_profile_id: "cus_1", gateway_payment_profile_id: 'card_2') }
-        let!(:payment) { create(:payment, order: order, state: 'completed', payment_method: payment_method, response_code: 'ch_1a2b3c', amount: order.total) }
+        let!(:payment) do
+          create(:payment, order: order, state: 'completed', payment_method: payment_method,
+                           response_code: 'ch_1a2b3c', amount: order.total)
+        end
 
         before do
           allow(Stripe).to receive(:api_key) { "sk_test_12345" }
@@ -137,7 +149,8 @@ describe Spree::Admin::PaymentsController, type: :controller do
           before do
             stub_request(:post, "https://api.stripe.com/v1/charges/ch_1a2b3c/refunds").
               with(basic_auth: ["sk_test_12345", ""]).
-              to_return(status: 200, body: JSON.generate(id: 're_123', object: 'refund', status: 'succeeded') )
+              to_return(status: 200,
+                        body: JSON.generate(id: 're_123', object: 'refund', status: 'succeeded') )
           end
 
           it "voids the payment" do
@@ -182,7 +195,10 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
       context "that was processed by stripe" do
         let!(:payment_method) { create(:stripe_payment_method, distributors: [shop]) }
-        let!(:payment) { create(:payment, order: order, state: 'completed', payment_method: payment_method, response_code: 'ch_1a2b3c', amount: order.total + 5) }
+        let!(:payment) do
+          create(:payment, order: order, state: 'completed', payment_method: payment_method,
+                           response_code: 'ch_1a2b3c', amount: order.total + 5)
+        end
 
         before do
           allow(Stripe).to receive(:api_key) { "sk_test_12345" }
@@ -192,7 +208,8 @@ describe Spree::Admin::PaymentsController, type: :controller do
           before do
             stub_request(:post, "https://api.stripe.com/v1/charges/ch_1a2b3c/refunds").
               with(basic_auth: ["sk_test_12345", ""]).
-              to_return(status: 200, body: JSON.generate(id: 're_123', object: 'refund', status: 'succeeded') )
+              to_return(status: 200,
+                        body: JSON.generate(id: 're_123', object: 'refund', status: 'succeeded') )
           end
 
           it "partially refunds the payment" do

--- a/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -12,16 +12,104 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
   context "#create" do
     let!(:payment_method) { create(:payment_method, distributors: [shop]) }
-    let!(:order) do
-      create(:order_with_totals_and_distribution, distributor: shop, state: "payment")
-    end
-
     let(:params) { { amount: order.total, payment_method_id: payment_method.id } }
 
-    it "advances the order state" do
-      expect {
-        spree_post :create, payment: params, order_id: order.number
-      }.to change { order.reload.state }.from("payment").to("complete")
+    context "order is not complete" do
+      let!(:order) do
+        create(:order_with_totals_and_distribution, distributor: shop, state: "payment")
+      end
+
+      it "advances the order state" do
+        expect {
+          spree_post :create, payment: params, order_id: order.number
+        }.to change { order.reload.state }.from("payment").to("complete")
+      end
+    end
+
+    context "order is complete" do
+      let!(:order) do
+        create(:order_with_totals_and_distribution, distributor: shop, state: "complete", completed_at: Time.zone.now)
+      end
+
+      context "with Check payment (payment.process! does nothing)" do
+        it "redirects to list of payments with success flash" do
+          spree_post :create, payment: params, order_id: order.number
+
+          redirects_to_list_of_payments_with_success_flash
+          expect(order.reload.payments.last.state).to eq "checkout"
+        end
+      end
+
+      context "with Stripe payment where payment.process! errors out" do
+        let!(:payment_method) { create(:stripe_payment_method, distributors: [shop]) }
+        before { allow_any_instance_of(Spree::Payment).to receive(:process!).and_raise(Spree::Core::GatewayError.new("Payment Gateway Error")) }
+
+        it "redirects to new payment page with flash error" do
+          spree_post :create, payment: params, order_id: order.number
+
+          redirects_to_new_payment_page_with_flash_error("Payment Gateway Error")
+          expect(order.reload.payments.last.state).to eq "checkout"
+        end
+      end
+
+      context "with StripeSCA payment" do
+        let!(:payment_method) { create(:stripe_sca_payment_method, distributors: [shop]) }
+
+        context "where payment.authorize! raises GatewayError" do
+          before { allow_any_instance_of(Spree::Payment).to receive(:authorize!).and_raise(Spree::Core::GatewayError.new("Stripe Authorization Failure")) }
+
+          it "redirects to new payment page with flash error" do
+            spree_post :create, payment: params, order_id: order.number
+
+            redirects_to_new_payment_page_with_flash_error("Stripe Authorization Failure")
+            expect(order.reload.payments.last.state).to eq "checkout"
+          end
+        end
+
+        context "where payment.authorize! does not move payment to pending state" do
+          before do
+            allow_any_instance_of(Spree::Payment).to receive(:authorize!).and_return(true)
+          end
+
+          it "redirects to new payment page with flash error" do
+            spree_post :create, payment: params, order_id: order.number
+
+            redirects_to_new_payment_page_with_flash_error("Authorization Failure")
+            expect(order.reload.payments.last.state).to eq "checkout"
+          end
+        end
+
+        context "where both payment.process! and payment.authorize! work" do
+          before do
+            allow_any_instance_of(Spree::Payment).to receive(:authorize!) do |payment|
+              payment.update_attribute :state, "pending"
+            end
+            allow_any_instance_of(Spree::Payment).to receive(:process!).and_return(true)
+          end
+
+          it "redirects to list of payments with success flash" do
+            spree_post :create, payment: params, order_id: order.number
+
+            redirects_to_list_of_payments_with_success_flash
+            expect(order.reload.payments.last.state).to eq "pending"
+          end
+        end
+      end
+
+      def redirects_to_list_of_payments_with_success_flash
+        expect_redirect_to spree.admin_order_payments_url(order)
+        expect(flash[:success]).to eq "Payment has been successfully created!"
+      end
+
+      def redirects_to_new_payment_page_with_flash_error(flash_error)
+        expect_redirect_to spree.new_admin_order_payment_url(order)
+        expect(flash[:error]).to eq flash_error
+      end
+
+      def expect_redirect_to(path)
+        expect(response.status).to eq 302
+        expect(response.location).to eq path
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #5212

Make backoffice payments call authorize (before calling process) if payment method is stripe_sca.
Improved a little the test coverage, it is still low...

#### What should we test?
Take payments in the Backoffice with stripe and stripeSCA and make sure they both work.
Try different test cards.
This page is not handling SCA redirects (like checkout is) so a card that requires SCA auth will not work.

#### Release notes
Changelog Category: Fixed
Fixed taking card payments in the Backoffice with StripeSCA payment method.
