### PR TITLE
Temporally disable OC notification retries

### DIFF
--- a/app/jobs/order_cycle_notification_job.rb
+++ b/app/jobs/order_cycle_notification_job.rb
@@ -6,4 +6,9 @@ OrderCycleNotificationJob = Struct.new(:order_cycle_id) do
       ProducerMailer.order_cycle_report(supplier, order_cycle).deliver
     end
   end
+
+  # Temporally disable DJ's retries until we fix https://github.com/openfoodfoundation/openfoodnetwork/issues/5242.
+  def max_attempts
+    1
+  end
 end


### PR DESCRIPTION
#### What? Why?

This stops DJ from retrying this job when failed. I suspect this is the root cause of https://github.com/openfoodfoundation/openfoodnetwork/issues/5242.

This changes the logs **for this job** from

```
2020-04-16T14:40:59+0000: [Worker(delayed_job host:staging.katuma.org pid:4446)] Job OrderCycleNotificationJob (id=236046) RUNNING                                                             
2020-04-16T14:40:59+0000: [Worker(delayed_job host:staging.katuma.org pid:4446)] Job OrderCycleNotificationJob (id=236046) FAILED (2 prior attempts) with RuntimeError: Pau debugging 
```
to
```
2020-04-16T14:42:33+0000: [Worker(delayed_job host:staging.katuma.org pid:4853)] Job OrderCycleNotificationJob (id=236047) RUNNING
2020-04-16T14:42:33+0000: [Worker(delayed_job host:staging.katuma.org pid:4853)] Job OrderCycleNotificationJob (id=236047) FAILED (0 prior attempts) with RuntimeError: Pau debugging
2020-04-16T14:42:33+0000: [Worker(delayed_job host:staging.katuma.org pid:4853)] Job OrderCycleNotificationJob (id=236047) FAILED permanently because of 1 consecutive failures
```

#### What should we test?

This should be deployed ASAP.