### PR TITLE
Include deleted products in OC mailer

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -377,7 +377,6 @@ Metrics/AbcSize:
   - app/helpers/spree/admin/base_helper.rb
   - app/helpers/spree/admin/zones_helper.rb
   - app/helpers/spree/orders_helper.rb
-  - app/mailers/producer_mailer.rb
   - app/models/calculator/flat_percent_per_item.rb
   - app/models/column_preference.rb
   - app/models/enterprise.rb
@@ -574,7 +573,6 @@ Metrics/MethodLength:
   - app/helpers/spree/admin/navigation_helper.rb
   - app/helpers/spree/admin/base_helper.rb
   - app/jobs/subscription_placement_job.rb
-  - app/mailers/producer_mailer.rb
   - app/models/column_preference.rb
   - app/models/enterprise.rb
   - app/models/enterprise_relationship.rb

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -173,7 +173,6 @@ Naming/MethodParameterName:
 Naming/PredicateName:
   Exclude:
     - 'spec/**/*'
-    - 'app/mailers/producer_mailer.rb'
     - 'app/models/enterprise.rb'
     - 'app/models/enterprise_relationship.rb'
     - 'app/models/order_cycle.rb'
@@ -630,7 +629,6 @@ Style/FrozenStringLiteralComment:
     - 'app/jobs/subscription_placement_job.rb'
     - 'app/jobs/welcome_enterprise_job.rb'
     - 'app/mailers/enterprise_mailer.rb'
-    - 'app/mailers/producer_mailer.rb'
     - 'app/mailers/spree/base_mailer_decorator.rb'
     - 'app/mailers/spree/order_mailer_decorator.rb'
     - 'app/mailers/spree/user_mailer.rb'

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -2,28 +2,31 @@ class ProducerMailer < Spree::BaseMailer
   include I18nHelper
 
   def order_cycle_report(producer, order_cycle)
-    @producer = producer
-    @coordinator = order_cycle.coordinator
-    @order_cycle = order_cycle
-    line_items = line_items_from(@order_cycle, @producer)
-    @grouped_line_items = line_items.group_by(&:product_and_full_name)
-    @receival_instructions = @order_cycle.receival_instructions_for @producer
-    @total = total_from_line_items(line_items)
-    @tax_total = tax_total_from_line_items(line_items)
+    unscoping do
+      @producer = producer
+      @coordinator = order_cycle.coordinator
+      @order_cycle = order_cycle
 
-    I18n.with_locale valid_locale(@producer.owner) do
-      order_cycle_subject = I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)
-      subject = "[#{Spree::Config.site_name}] #{order_cycle_subject}"
+      line_items = line_items_from(@order_cycle, @producer)
+      @grouped_line_items = line_items.group_by(&:product_and_full_name)
+      @receival_instructions = @order_cycle.receival_instructions_for @producer
+      @total = total_from_line_items(line_items)
+      @tax_total = tax_total_from_line_items(line_items)
 
-      return unless has_orders?(order_cycle, producer)
+      I18n.with_locale valid_locale(@producer.owner) do
+        order_cycle_subject = I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)
+        subject = "[#{Spree::Config.site_name}] #{order_cycle_subject}"
 
-      mail(
-        to: @producer.contact.email,
-        from: from_address,
-        subject: subject,
-        reply_to: @coordinator.contact.email,
-        cc: @coordinator.contact.email
-      )
+        return unless has_orders?(order_cycle, producer)
+
+        mail(
+          to: @producer.contact.email,
+          from: from_address,
+          subject: subject,
+          reply_to: @coordinator.contact.email,
+          cc: @coordinator.contact.email
+        )
+      end
     end
   end
 
@@ -35,7 +38,7 @@ class ProducerMailer < Spree::BaseMailer
 
   def line_items_from(order_cycle, producer)
     Spree::LineItem.
-      includes(variant: { option_values: :option_type }).
+      includes(variant: [:product, { option_values: :option_type }]).
       from_order_cycle(order_cycle).
       sorted_by_name_and_unit_value.
       merge(Spree::Product.in_supplier(producer)).
@@ -48,5 +51,23 @@ class ProducerMailer < Spree::BaseMailer
 
   def tax_total_from_line_items(line_items)
     Spree::Money.new line_items.sum(&:included_tax)
+  end
+
+  # This hack makes ActiveRecord skip the default_scope (deleted_at IS NULL)
+  # when eager loading associations. Further details:
+  # https://github.com/rails/rails/issues/11036
+  def unscoping
+    variant_default_scopes = Spree::Variant.default_scopes
+    product_default_scopes = Spree::Product.default_scopes
+
+    Spree::Variant.default_scopes = []
+    Spree::Product.default_scopes = []
+
+    return_value = yield
+
+    Spree::Variant.default_scopes = variant_default_scopes
+    Spree::Product.default_scopes = product_default_scopes
+
+    return_value
   end
 end

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -1,22 +1,16 @@
+# frozen_string_literal: true
+
 class ProducerMailer < Spree::BaseMailer
   include I18nHelper
 
   def order_cycle_report(producer, order_cycle)
-    unscoping do
-      @producer = producer
-      @coordinator = order_cycle.coordinator
-      @order_cycle = order_cycle
+    @producer = producer
+    @order_cycle = order_cycle
 
-      line_items = line_items_from(@order_cycle, @producer)
-      @grouped_line_items = line_items.group_by(&:product_and_full_name)
-      @receival_instructions = @order_cycle.receival_instructions_for @producer
-      @total = total_from_line_items(line_items)
-      @tax_total = tax_total_from_line_items(line_items)
+    with_unscoped_products_and_variants do
+      load_data
 
-      I18n.with_locale valid_locale(@producer.owner) do
-        order_cycle_subject = I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)
-        subject = "[#{Spree::Config.site_name}] #{order_cycle_subject}"
-
+      I18n.with_locale(owner_locale) do
         return unless orders?(order_cycle, producer)
 
         mail(
@@ -31,6 +25,26 @@ class ProducerMailer < Spree::BaseMailer
   end
 
   private
+
+  def owner_locale
+    valid_locale(@producer.owner)
+  end
+
+  def load_data
+    @coordinator = @order_cycle.coordinator
+
+    line_items = line_items_from(@order_cycle, @producer)
+
+    @grouped_line_items = line_items.group_by(&:product_and_full_name)
+    @receival_instructions = @order_cycle.receival_instructions_for(@producer)
+    @total = total_from_line_items(line_items)
+    @tax_total = tax_total_from_line_items(line_items)
+  end
+
+  def subject
+    order_cycle_subject = I18n.t('producer_mailer.order_cycle.subject', producer: @producer.name)
+    "[#{Spree::Config.site_name}] #{order_cycle_subject}"
+  end
 
   def orders?(order_cycle, producer)
     line_items_from(order_cycle, producer).any?
@@ -56,7 +70,7 @@ class ProducerMailer < Spree::BaseMailer
   # This hack makes ActiveRecord skip the default_scope (deleted_at IS NULL)
   # when eager loading associations. Further details:
   # https://github.com/rails/rails/issues/11036
-  def unscoping
+  def with_unscoped_products_and_variants
     variant_default_scopes = Spree::Variant.default_scopes
     product_default_scopes = Spree::Product.default_scopes
 

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -17,7 +17,7 @@ class ProducerMailer < Spree::BaseMailer
         order_cycle_subject = I18n.t('producer_mailer.order_cycle.subject', producer: producer.name)
         subject = "[#{Spree::Config.site_name}] #{order_cycle_subject}"
 
-        return unless has_orders?(order_cycle, producer)
+        return unless orders?(order_cycle, producer)
 
         mail(
           to: @producer.contact.email,
@@ -32,7 +32,7 @@ class ProducerMailer < Spree::BaseMailer
 
   private
 
-  def has_orders?(order_cycle, producer)
+  def orders?(order_cycle, producer)
     line_items_from(order_cycle, producer).any?
   end
 

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -51,7 +51,7 @@ class ProducerMailer < Spree::BaseMailer
   end
 
   def line_items_from(order_cycle, producer)
-    Spree::LineItem.
+    @line_items ||= Spree::LineItem.
       includes(variant: [:product, { option_values: :option_type }]).
       from_order_cycle(order_cycle).
       sorted_by_name_and_unit_value.

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -52,7 +52,7 @@ class ProducerMailer < Spree::BaseMailer
 
   def line_items_from(order_cycle, producer)
     @line_items ||= Spree::LineItem.
-      includes(variant: [:product, { option_values: :option_type }]).
+      includes(:option_values, variant: [:product, { option_values: :option_type }]).
       from_order_cycle(order_cycle).
       sorted_by_name_and_unit_value.
       merge(Spree::Product.in_supplier(producer)).

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -101,6 +101,19 @@ describe ProducerMailer, type: :mailer do
     end.to change(ActionMailer::Base.deliveries, :count).by(0)
   end
 
+  it "shows a deleted variant's full name" do
+    variant = p1.variants.first
+    full_name = variant.full_name
+    variant.delete
+
+    expect(mail.body.encoded).to include(full_name)
+  end
+
+  it 'shows deleted products' do
+    p1.delete
+    expect(mail.body.encoded).to include(p1.name)
+  end
+
   private
 
   def body_lines_including(mail, s)


### PR DESCRIPTION
#### What? Why?

Closes #5242

This includes products and variants that have been soft-deleted so we show them in the OC supplier email notification even if they got deleted after the user purchase.

The root cause is a known Rails bug. See 63d04eace1a697447fb2e71bc2a340acd33e2fa2 for details.

Both in FR and AU the root cause of the last error was a deleted variant  (I haven't checked each of the occurrences of this error).

#### What should we test?

We need to check that we can notify suppliers of an order cycle where at least a variant got deleted after the order was placed. For that, place the orders, delete one of the purchased variants and then, click on "Notify producers" from the OC edit page. Then, try out the same but deleting a product instead.

In both cases, we shouldn't see any error related to it in either Bugsnag or in `/admin/delayed_job/failed`.

#### Release notes

Fix order cycle producer notification failing when a product or variant got deleted after the order was placed.

Changelog Category: Fixed
