### PR TITLE
Added placeholders in variant edit page

### DIFF
--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -1,10 +1,10 @@
 .label-block.left.six.columns.alpha{'ng-app' => 'admin.products'}
   .field
     = f.label :display_name, t('.display_name')
-    = f.text_field :display_name, class: "fullwidth", placeholder: t('admin.products.display_name_placeholder')
+    = f.text_field :display_name, class: "fullwidth", placeholder: t('.display_name_placeholder')
   .field
     = f.label :display_as, t('.display_as')
-    = f.text_field :display_as, class: "fullwidth", placeholder: t('admin.products.display_as_placeholder')
+    = f.text_field :display_as, class: "fullwidth", placeholder: t('.display_as_placeholder')
 
   - if product_has_variant_unit_option_type?(@product)
     - if @product.variant_unit != 'items'

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -1,10 +1,10 @@
 .label-block.left.six.columns.alpha{'ng-app' => 'admin.products'}
   .field
     = f.label :display_name, t('.display_name')
-    = f.text_field :display_name, class: "fullwidth"
+    = f.text_field :display_name, class: "fullwidth", placeholder: t('admin.products.display_name_placeholder')
   .field
     = f.label :display_as, t('.display_as')
-    = f.text_field :display_as, class: "fullwidth"
+    = f.text_field :display_as, class: "fullwidth", placeholder: t('admin.products.display_as_placeholder')
 
   - if product_has_variant_unit_option_type?(@product)
     - if @product.variant_unit != 'items'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,8 +476,6 @@ en:
 
     products:
       unit_name_placeholder: 'eg. bunches'
-      display_as_placeholder: 'eg. 2 kg'
-      display_name_placeholder: 'eg. Tomatoes'
       index:
         unit: Unit
         display_as: Display As
@@ -3382,6 +3380,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           price: "Price"
           display_as: "Display As"
           display_name: "Display Name"
+          display_as_placeholder: 'eg. 2 kg'
+          display_name_placeholder: 'eg. Tomatoes'
         autocomplete:
           producer_name: "Producer"
           unit: "Unit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,6 +476,8 @@ en:
 
     products:
       unit_name_placeholder: 'eg. bunches'
+      display_as_placeholder: 'eg. 2 kg'
+      display_name_placeholder: 'eg. Tomatoes'
       index:
         unit: Unit
         display_as: Display As


### PR DESCRIPTION
#### What? Why?

Closes #3793 

Added requested placeholders for Display Name and Display As to variant edit page as "eg Tomatoes" and "eg 2 kg" respectively. Can be easily changed to any other message of interest in en.yml.


#### What should we test?
Variant edit page has these placeholders that disappear once user enters input to text field.



#### Release notes
Added placeholders to variant edit page for clarification when user is inputting data.

Changelog Category: Added

#### How is this related to the Spree upgrade?
Changed Form file is located under the Spree subfolder in views directory.