### PR TITLE
Added missing translation to column dropdown

### DIFF
--- a/app/assets/javascripts/templates/admin/columns_dropdown.html.haml
+++ b/app/assets/javascripts/templates/admin/columns_dropdown.html.haml
@@ -8,4 +8,4 @@
     %hr
     %div.menu_item.text-center
       %input.fullwidth.orange{ type: "button", ng: { value: "saved() ? 'Saved': 'Saving'", show: "saved() || saving", disabled: "saved()" } }
-      %input.fullwidth.red{ type: "button", value: 'Save As Default', ng: { show: "!saved() && !saving", click: "saveColumnPreferences(action)"} }
+      %input.fullwidth.red{ type: "button", :value => t('admin.column_save_as_default').html_safe, ng: { show: "!saved() && !saving", click: "saveColumnPreferences(action)"} }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,6 +362,7 @@ en:
     choose: "Choose..."
     please_select: Please select...
 
+    column_save_as_default: Save As Default
     columns: Columns
     actions: Actions
     viewing: "Viewing: %{current_view_name}"


### PR DESCRIPTION
#### What? Why?

Closes #5245

Adds translation to the "Save as Default" drop down option when options are selected and/or deselected in the admin/inventory or admin/products pages.


#### What should we test?
Translations taking place on these pages when column options are being clicked.



#### Release notes
Added translation to drop down menu save as default option.

Changelog Category: Added
