### PR TITLE
Fix sorting of orders list

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -67,7 +67,7 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, $timeout, Reque
     return unless sort && sort.predicate != ""
 
     $scope.sorting = sort.getSortingExpr()
-    $scope.fetchProducts()
+    $scope.fetchResults()
   , true
 
   $scope.capturePayment = (order) ->

--- a/spec/javascripts/unit/admin/customers/controllers/customers_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/customers/controllers/customers_controller_spec.js.coffee
@@ -20,7 +20,6 @@ describe "CustomersCtrl", ->
       {id: 109, name: "Australia", states: [{id: 55, name: "ACT", abbr: "ACT"}]}
     ]
 
-
     inject ($controller, $rootScope, _CustomerResource_, $httpBackend) ->
       scope = $rootScope
       http = $httpBackend

--- a/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
@@ -36,9 +36,18 @@ describe "ordersCtrl", ->
         'q[s]': 'completed_at desc'
       }))
 
-
   describe "using pagination", ->
     it "changes the page", ->
       $scope.changePage(2)
       expect($scope.page).toEqual 2
       expect(Orders.index).toHaveBeenCalled()
+
+  describe "sorting products", ->
+    it "sorts orders", ->
+      spyOn $scope, "fetchResults"
+
+      $scope.sortOptions.toggle('number')
+      $scope.$apply()
+
+      expect($scope.sorting).toEqual 'number asc'
+      expect($scope.fetchResults).toHaveBeenCalled()


### PR DESCRIPTION
Fix column sorting for admin/orders. Now when you click a column header, it refreshes the filtered results with the correct sorting (like for Products).

#### What? Why?

Closes #5190 

When you are in the Orders page of backend (e.g. https://openfoodnetwork.org.au/admin/orders ) each column header is hyperlinked, but clicking on them doesn't trigger any action.

There was a wrong copied function call in the coffeescript. Oops.


#### What should we test?


When you click a column header it should sort by that column. When you click again it should sort in the reverse order. e.g. clicking Shipment State should sort all 'Pending' to the top, clicking again should sort all 'Completed' to the top.

Repeat this test with at least 16 orders so that there is more than one page of orders. The sorting should happen across pages.


#### Release notes

Fix column sorting for admin/orders

Changelog Category:  Fixed

