### PR TITLE
StripeSCA - reuse better method to fetch last payment of an order to avoid nasty bugs in the future

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -153,10 +153,12 @@ class CheckoutController < Spree::StoreController
   end
 
   def valid_payment_intent_provided?
-    params["payment_intent"]&.starts_with?("pi_") &&
-      @order.state == "payment" &&
-      @order.payments.last.state == "pending" &&
-      @order.payments.last.response_code == params["payment_intent"]
+    return false unless params["payment_intent"]&.starts_with?("pi_")
+
+    last_payment = OrderPaymentFinder.new(@order).last_payment
+    @order.state == "payment" &&
+      last_payment&.state == "pending" &&
+      last_payment&.response_code == params["payment_intent"]
   end
 
   def handle_redirect_from_stripe

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -9,9 +9,5 @@ module Admin
         adjustment.originator_type == "Spree::ShippingMethod"
       end
     end
-
-    def last_payment_method(order)
-      OrderPaymentFinder.new(order).last_payment&.payment_method
-    end
   end
 end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -9,5 +9,9 @@ module Admin
         adjustment.originator_type == "Spree::ShippingMethod"
       end
     end
+
+    def last_payment_method(order)
+      OrderPaymentFinder.new(order).last_payment&.payment_method
+    end
   end
 end

--- a/app/helpers/order_helper.rb
+++ b/app/helpers/order_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module OrderHelper
+  def last_payment_method(order)
+    OrderPaymentFinder.new(order).last_payment&.payment_method
+  end
+end

--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -2,6 +2,7 @@ Spree::OrderMailer.class_eval do
   helper HtmlHelper
   helper CheckoutHelper
   helper SpreeCurrencyHelper
+  helper OrderHelper
   include I18nHelper
 
   def cancel_email(order_or_order_id, resend = false)

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,6 +1,7 @@
 class SubscriptionMailer < Spree::BaseMailer
   helper CheckoutHelper
   helper ShopMailHelper
+  helper OrderHelper
   include I18nHelper
 
   def confirmation_email(order)

--- a/app/services/order_payment_finder.rb
+++ b/app/services/order_payment_finder.rb
@@ -6,13 +6,23 @@ class OrderPaymentFinder
   end
 
   def last_payment
-    # `max_by` avoids additional database queries when payments are loaded
-    # already. There is usually only one payment and this shouldn't cause
-    # any overhead compared to `order(:created_at).last`. Using `last`
-    # without order is not deterministic.
-    #
-    # We are not using `updated_at` because all payments are touched when the
-    # order is updated and then all payments have the same `updated_at` value.
-    @order.payments.max_by(&:created_at)
+    last(@order.payments)
+  end
+
+  def last_pending_payment
+    last(@order.pending_payments)
+  end
+
+  private
+
+  # `max_by` avoids additional database queries when payments are loaded
+  # already. There is usually only one payment and this shouldn't cause
+  # any overhead compared to `order(:created_at).last`. Using `last`
+  # without order is not deterministic.
+  #
+  # We are not using `updated_at` because all payments are touched when the
+  # order is updated and then all payments have the same `updated_at` value.
+  def last(payments)
+    payments.max_by(&:created_at)
   end
 end

--- a/app/services/order_payment_finder.rb
+++ b/app/services/order_payment_finder.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-module OrderPaymentFinder
-  def self.last_payment_method(order)
+class OrderPaymentFinder
+  def initialize(order)
+    @order = order
+  end
+
+  def last_payment
     # `max_by` avoids additional database queries when payments are loaded
     # already. There is usually only one payment and this shouldn't cause
     # any overhead compared to `order(:created_at).last`. Using `last`
@@ -9,6 +13,6 @@ module OrderPaymentFinder
     #
     # We are not using `updated_at` because all payments are touched when the
     # order is updated and then all payments have the same `updated_at` value.
-    order.payments.max_by(&:created_at)&.payment_method
+    @order.payments.max_by(&:created_at)
   end
 end

--- a/app/views/spree/order_mailer/_payment.html.haml
+++ b/app/views/spree/order_mailer/_payment.html.haml
@@ -8,7 +8,7 @@
     = t :email_payment_summary
 %h4
   = t :email_payment_method
-  %strong=  OrderPaymentFinder.last_payment_method(@order)&.name
+  %strong=  last_payment_method(@order)&.name
 %p
-  %em= OrderPaymentFinder.last_payment_method(@order)&.description
+  %em= last_payment_method(@order)&.description
 %p &nbsp;

--- a/app/views/spree/shared/_order_details.html.haml
+++ b/app/views/spree/shared/_order_details.html.haml
@@ -13,9 +13,9 @@
     .pad
       .text-big
         = t :order_payment
-        %strong=  OrderPaymentFinder.last_payment_method(order)&.name
+        %strong=  last_payment_method(order)&.name
       %p.text-small.text-skinny.pre-line
-        %em= OrderPaymentFinder.last_payment_method(order)&.description
+        %em= last_payment_method(order)&.description
 
     .order-summary.text-small
       %strong

--- a/engines/order_management/app/services/order_management/subscriptions/payment_setup.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/payment_setup.rb
@@ -18,7 +18,7 @@ module OrderManagement
       private
 
       def create_payment
-        payment = @order.pending_payments.last
+        payment = OrderPaymentFinder.new(@order).last_pending_payment
         return payment if payment.present?
 
         @order.payments.create(

--- a/engines/order_management/app/services/order_management/subscriptions/stripe_payment_setup.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/stripe_payment_setup.rb
@@ -5,7 +5,7 @@ module OrderManagement
     class StripePaymentSetup
       def initialize(order)
         @order = order
-        @payment = @order.pending_payments.last
+        @payment = OrderPaymentFinder.new(@order).last_pending_payment
       end
 
       def call!

--- a/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
@@ -5,7 +5,7 @@ module OrderManagement
     class StripeScaPaymentAuthorize
       def initialize(order)
         @order = order
-        @payment = @order.pending_payments.last
+        @payment = OrderPaymentFinder.new(@order).last_pending_payment
       end
 
       def call!

--- a/spec/services/order_payment_finder_spec.rb
+++ b/spec/services/order_payment_finder_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OrderPaymentFinder do
+  let(:order) { create(:order_with_distributor) }
+  let(:finder) { OrderPaymentFinder.new(order) }
+
+  context "when order has several non pending payments" do
+    let!(:failed_payment) { create(:payment, order: order, state: 'failed') }
+    let!(:complete_payment) { create(:payment, order: order, state: 'completed') }
+
+    it "#last_payment returns the last payment" do
+      expect(finder.last_payment).to eq complete_payment
+    end
+
+    it "#last_pending_payment returns nil" do
+      expect(finder.last_pending_payment).to be nil
+    end
+  end
+
+  context "when order has a pending payment and a non pending payment" do
+    let!(:processing_payment) { create(:payment, order: order, state: 'processing') }
+    let!(:failed_payment) { create(:payment, order: order, state: 'failed') }
+
+    it "#last_payment returns the last payment" do
+      expect(finder.last_payment).to eq failed_payment
+    end
+
+    it "#last_pending_payment returns the pending payment" do
+      # a payment in the processing state is a pending payment
+      expect(finder.last_pending_payment).to eq processing_payment
+    end
+
+    context "and an extra last pending payment" do
+      let!(:pending_payment) { create(:payment, order: order, state: 'pending') }
+
+      it "#last_payment returns the last payment" do
+        expect(finder.last_payment).to eq pending_payment
+      end
+
+      it "#last_pending_payment returns the pending payment" do
+        expect(finder.last_pending_payment).to eq pending_payment
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

In StripeSCA context, reuse better method to fetch last payment introduced in #4790 by @mkllnk 

#### What should we test?
We should repeat the test in #4790 and then:
 verify StripeSCA checkout still works for normal cards and cards that require extra SCA auth, for example, 4242... and 4000 0027 6000 3184.


#### Release notes
Changelog Category: Changed
Improved how stripeSCA handles orders with multiple payments. This will avoid hard to track bugs in the future.