### PR TITLE
Add extra social media to order confirmation email

### DIFF
--- a/app/assets/stylesheets/mail/email.css.scss
+++ b/app/assets/stylesheets/mail/email.css.scss
@@ -138,6 +138,10 @@ a {
   &.ms {
     background-color: #000 !important;
   }
+
+  &.ig {
+    background-color: #fb3958 !important;
+  }
 }
 
 .sidebar .soc-btn {

--- a/app/models/content_configuration.rb
+++ b/app/models/content_configuration.rb
@@ -57,8 +57,8 @@ class ContentConfiguration < Spree::Preferences::FileConfiguration
   # Other
   preference :footer_facebook_url, :string, default: "https://www.facebook.com/OpenFoodNet"
   preference :footer_twitter_url, :string, default: "https://twitter.com/OpenFoodNet"
-  preference :footer_instagram_url, :string, default: ""
-  preference :footer_linkedin_url, :string, default: "http://www.linkedin.com/groups/Open-Food-Foundation-4743336"
+  preference :footer_instagram_url, :string, default: "https://www.instagram.com/openfoodnetworkuk/"
+  preference :footer_linkedin_url, :string, default: "https://www.linkedin.com/company/openfoodnetwork/"
   preference :footer_googleplus_url, :string, default: ""
   preference :footer_pinterest_url, :string, default: ""
   preference :footer_email, :string, default: "hello@openfoodnetwork.org"

--- a/app/views/shared/mailers/_social_and_contact.html.haml
+++ b/app/views/shared/mailers/_social_and_contact.html.haml
@@ -18,7 +18,7 @@
                 %a.soc-btn.li{href: ContentConfig.footer_linkedin_url}
                   LinkedIn
               -if ContentConfig.footer_instagram_url.present?
-                %a.soc-btn.tw{href: ContentConfig.footer_instagram_url}
+                %a.soc-btn.ig{href: ContentConfig.footer_instagram_url}
                   Instagram
       %table.column{:align => "left"}
         %tr

--- a/app/views/spree/order_mailer/confirm_email_for_customer.html.haml
+++ b/app/views/spree/order_mailer/confirm_email_for_customer.html.haml
@@ -25,3 +25,4 @@
 = render 'shipping'
 = render 'special_instructions'
 = render 'signoff'
+= render 'shared/mailers/social_and_contact'


### PR DESCRIPTION
#### What? Why?

Closes #3509 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
It's a feature to show to the customers our social media links

Here's a screenshot example:
![image](https://user-images.githubusercontent.com/30028621/79639032-4e138600-815f-11ea-9bb0-55284d042b5b.png)



#### What should we test?
<!-- List which features should be tested and how. -->
Place an order and see the order confirmation for the customer


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

