### PR TITLE
[Mobile] Make search box font size be 16px so that no zoom happens on iphone

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-inputs.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.css.scss
@@ -9,6 +9,9 @@
 
   input#search {
     @include medium-input(rgba(0, 0, 0, 0.3), #777, $clr-brick);
+
+    // avoid zoom on iphone, see issue #4535
+    font-size: 1rem;
   }
 
   // ordering


### PR DESCRIPTION
#### What? Why?

Closes #4535

#### What should we test?
See issue for details.
I tested this on staging ES with my iphone 4, it works (the fix works, I am not sure about my iphone 4 :rofl:)

#### Release notes
Changelog Category: Changed
Make font size bigger on product search to improve UX on iphone
