### PR TITLE
Fix disappearing tags issue

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -102,9 +102,11 @@ module Admin
                   context: 'tags' })
 
       customer_tags.each_with_object({}) do |tag, indexed_hash|
-        customer_id = tag.taggings.first.taggable_id
-        indexed_hash[customer_id] ||= []
-        indexed_hash[customer_id] << tag.name
+        tag.taggings.each do |tagging|
+          customer_id = tagging.taggable_id
+          indexed_hash[customer_id] ||= []
+          indexed_hash[customer_id] << tag.name
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #5282 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Tags in admin customers page are working properly.

Go to admin, customers and select an enterprise. You will need multiple customers with multiple tags. Some of those tags should be on multiple customers. Then save and reload the page.

On the old version (production) you can observe that a tag that has been used for multiple customers will appear only on one customer. So each tag is displayed only once. But with this fix, you should see the tag on all customers it was assigned to.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed problem with disappearing tags on admin customers page.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

