### PR TITLE
5246 missing translation orders list

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3386,6 +3386,14 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         autocomplete:
           producer_name: "Producer"
           unit: "Unit"
+      shared:
+        sortable_header:
+          number: "Number"
+          state: "State"
+          payment_state: "Payment State"
+          shipment_state: "Shipment State"
+          email: "Email"
+          total: "Total"
       general_settings:
         edit:
           legal_settings: "Legal Settings"


### PR DESCRIPTION
#### What? Why?

Closes #5246

Translation keys were missing on multiple fields in the Orders List. This fix (adding the appropriate keys to the config/locales/en.yml file resolved the missing translation keys issue. 

#### What should we test?
Is translation present on the orders list (number, state, payment_state, shipment_state, email, and total fields) at /admin/orders?q[s]=completed_at+desc

#### Release notes
Translation now working on the Orders List

Changelog Category:  Fixed

#### Dependencies
Not dependent, but is related (in the resolution) to #4966 

#### Documentation updates
No updates required

