### PR TITLE
4966 missing translation admin prod list

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3387,6 +3387,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           producer_name: "Producer"
           unit: "Unit"
       general_settings:
+      shared:
+        sortable_header:
+          name: "Name"
         edit:
           legal_settings: "Legal Settings"
           cookies_consent_banner_toggle: "Display cookies consent banner"


### PR DESCRIPTION
#### What? Why?

Closes #4966 

Translation keys were missing on the name field of the admin Products list. This fix (adding the appropriate keys to the config/locales/en.yml file resolved the missing translation keys issue. 

#### What should we test?
Is translation present on the name field within the admin Products List at /admin/products?

#### Release notes
Translation now working on the admin Products List

Changelog Category:  Fixed

#### Dependencies
Not dependent, but is related (in the resolution) to #5246 

#### Documentation updates
No updates required

