### PR TITLE
Enterprise serializer optimisations

### DIFF
--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -113,7 +113,7 @@ module Api
     end
 
     def active
-      data.active_distributor_ids.andand.include? enterprise.id
+      @active ||= data.active_distributor_ids.andand.include? enterprise.id
     end
 
     # Map svg icons.

--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -62,10 +62,14 @@ module Api
     end
 
     def supplied_taxons
+      return [] unless enterprise.is_primary_producer
+
       ids_to_objs data.supplied_taxons[enterprise.id]
     end
 
     def supplied_properties
+      return [] unless enterprise.is_primary_producer
+
       (product_properties + producer_properties).uniq do |property_object|
         property_object.property.presentation
       end

--- a/app/serializers/api/enterprise_shopfront_serializer.rb
+++ b/app/serializers/api/enterprise_shopfront_serializer.rb
@@ -74,12 +74,16 @@ module Api
     end
 
     def supplied_taxons
+      return [] unless enterprise.is_primary_producer
+
       ActiveModel::ArraySerializer.new(
         enterprise.supplied_taxons, each_serializer: Api::TaxonSerializer
       )
     end
 
     def supplied_properties
+      return [] unless enterprise.is_primary_producer
+
       (product_properties + producer_properties).uniq do |property_object|
         property_object.property.presentation
       end

--- a/app/serializers/api/enterprise_shopfront_serializer.rb
+++ b/app/serializers/api/enterprise_shopfront_serializer.rb
@@ -18,7 +18,8 @@ module Api
     end
 
     def active
-      enterprise.ready_for_checkout? && OrderCycle.active.with_distributor(enterprise).exists?
+      @active ||=
+        enterprise.ready_for_checkout? && OrderCycle.active.with_distributor(enterprise).exists?
     end
 
     def pickup

--- a/app/serializers/api/enterprise_shopfront_serializer.rb
+++ b/app/serializers/api/enterprise_shopfront_serializer.rb
@@ -119,7 +119,7 @@ module Api
     private
 
     def product_properties
-      enterprise.supplied_products.flat_map(&:properties)
+      enterprise.supplied_products.includes(:properties).flat_map(&:properties)
     end
 
     def producer_properties

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -9,18 +9,35 @@ describe Api::CachedEnterpriseSerializer do
     let(:duplicate_property) { create(:property, presentation: 'One') }
     let(:different_property) { create(:property, presentation: 'Two') }
 
-    let(:enterprise) do
-      create(:enterprise, properties: [duplicate_property, different_property])
-    end
-
     before do
       product = create(:product, properties: [property])
       enterprise.supplied_products << product
     end
 
-    it "removes duplicate product and producer properties" do
-      properties = cached_enterprise_serializer.supplied_properties
-      expect(properties).to eq([property, different_property])
+    context "when the enterprise is a producer" do
+      let(:enterprise) do
+        create(:enterprise,
+               is_primary_producer: true,
+               properties: [duplicate_property, different_property])
+      end
+
+      it "serializes combined product and producer properties without duplicates" do
+        properties = cached_enterprise_serializer.supplied_properties
+        expect(properties).to eq([property, different_property])
+      end
+    end
+
+    context "when the enterprise is not a producer" do
+      let(:enterprise) do
+        create(:enterprise,
+               is_primary_producer: false,
+               properties: [duplicate_property, different_property])
+      end
+
+      it "does not serialize supplied properties" do
+        properties = cached_enterprise_serializer.supplied_properties
+        expect(properties).to eq([])
+      end
     end
   end
 

--- a/spec/serializers/api/enterprise_serializer_spec.rb
+++ b/spec/serializers/api/enterprise_serializer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Api::EnterpriseSerializer do
   let(:serializer) { Api::EnterpriseSerializer.new enterprise, data: data }
-  let(:enterprise) { create(:distributor_enterprise) }
+  let(:enterprise) { create(:distributor_enterprise, is_primary_producer: true) }
   let(:taxon) { create(:taxon) }
   let(:data) {
     OpenStruct.new(earliest_closing_times: {},


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds some simple optimisations to serialization of enterprise data:

- A bit of needed memoizing and eager-loading
- Avoids querying **supplied_taxons** and **supplied_properties** for enterprises that are **not suppliers**

#### What should we test?
<!-- List which features should be tested and how. -->

I'm not quite sure about the best way to test this. A sanity check on displaying product properties and taxons? 

Basically if an enterprise is marked as not being a producer, we now won't try to find the taxons and properties of their own products. I think it's not even possible to add products as a non-producer?

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved performance of enterprise serialization

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
