### PR TITLE
5299 Impossible to filter orders with several tags

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -36,7 +36,6 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, $timeout, Reque
       'q[completed_at_not_null]': $scope['q']['completed_at_not_null'] || null,
       'q[distributor_id_in]': $scope['q']['distributor_id_in'],
       'q[order_cycle_id_in]': $scope['q']['order_cycle_id_in'],
-      'q[order_cycle_id_in]': $scope['q']['order_cycle_id_in'],
       'q[s]': $scope.sorting || 'completed_at desc',
       per_page: $scope.per_page,
       page: page

--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -34,8 +34,8 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, $timeout, Reque
       'q[bill_address_lastname_start]': $scope['q']['bill_address_lastname_start'],
       # Set default checkbox values to null. See: https://github.com/openfoodfoundation/openfoodnetwork/pull/3076#issuecomment-440010498
       'q[completed_at_not_null]': $scope['q']['completed_at_not_null'] || null,
-      'q[distributor_id_in]': $scope['q']['distributor_id_in'],
-      'q[order_cycle_id_in]': $scope['q']['order_cycle_id_in'],
+      'q[distributor_id_in][]': $scope['q']['distributor_id_in'],
+      'q[order_cycle_id_in][]': $scope['q']['order_cycle_id_in'],
       'q[s]': $scope.sorting || 'completed_at desc',
       per_page: $scope.per_page,
       page: page

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -39,7 +39,6 @@ feature '
     end
 
     scenario "filter by multiple order cycles" do
-      # Set up 3 orders and 3 order cycles
       order_cycle_2 = create(:simple_order_cycle, name: 'Two')
       order_cycle_3 = create(:simple_order_cycle, name: 'Three')
       order_cycle_4 = create(:simple_order_cycle, name: 'Four')
@@ -54,11 +53,9 @@ feature '
       quick_login_as_admin
       visit 'admin/orders'
 
-      # Select order cycle 2 and 3
       multi_select2_select 'Two', from: 'q_order_cycle_id_in'
       multi_select2_select 'Three', from: 'q_order_cycle_id_in'
 
-      # click link "Filter Results"
       page.find('.filter-actions .button.icon-search').click
 
       # Order 2 and 3 should show, but not 4

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -38,6 +38,36 @@ feature '
                   visible: :all)[:innerHTML]).to have_content(/.*Four.*Three.*Two/m)
     end
 
+    scenario "filter by multiple order cycles" do
+      # Set up 3 orders and 3 order cycles
+      order_cycle_2 = create(:simple_order_cycle, name: 'Two')
+      order_cycle_3 = create(:simple_order_cycle, name: 'Three')
+      order_cycle_4 = create(:simple_order_cycle, name: 'Four')
+
+      order_2 = create(:order_with_credit_payment, user: user, distributor: distributor,
+                                                  order_cycle: order_cycle_2)
+      order_3 = create(:order_with_credit_payment, user: user, distributor: distributor,
+                                                  order_cycle: order_cycle_3)
+      order_4 = create(:order_with_credit_payment, user: user, distributor: distributor,
+                                                  order_cycle: order_cycle_4)
+
+      quick_login_as_admin
+      visit 'admin/orders'
+
+      # Select order cycle 2 and 3
+      multi_select2_select 'Two', from: 'q_order_cycle_id_in'
+      multi_select2_select 'Three', from: 'q_order_cycle_id_in'
+
+      # click link "Filter Results"
+      page.find('.filter-actions .button.icon-search').click
+
+      # Order 2 and 3 should show, but not 4
+      expect(page).to have_content order_2.number
+      expect(page).to have_content order_3.number
+      expect(page).to_not have_content order_4.number
+
+    end
+
     context "with a capturable order" do
       before do
         order.finalize! # ensure order has a payment to capture

--- a/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
@@ -5,6 +5,7 @@ describe "ordersCtrl", ->
   orders = [
     { id: 8, order_cycle: { id: 4 }, distributor: { id: 5 }, number: "R123456" }
     { id: 9, order_cycle: { id: 5 }, distributor: { id: 7 }, number: "R213776" }
+    { id: 10, order_cycle: { id: 6 }, distributor: { id: 8 }, number: "R213777" }
   ]
   form = {
     q: {
@@ -42,7 +43,7 @@ describe "ordersCtrl", ->
       expect($scope.page).toEqual 2
       expect(Orders.index).toHaveBeenCalled()
 
-  describe "sorting products", ->
+  describe "sorting orders", ->
     it "sorts orders", ->
       spyOn $scope, "fetchResults"
 
@@ -51,3 +52,15 @@ describe "ordersCtrl", ->
 
       expect($scope.sorting).toEqual 'number asc'
       expect($scope.fetchResults).toHaveBeenCalled()
+
+  describe "filtering orders", ->
+    it "filters orders by all selected order cycles", ->
+
+      $scope['q']['order_cycle_id_in'] = ['4', '5']
+
+      $scope.fetchResults()
+
+      # Fetched with correct square brackets in field name for array value
+      expect(Orders.index).toHaveBeenCalledWith(jasmine.objectContaining({
+        'q[order_cycle_id_in][]': ['4', '5']
+      }))

--- a/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
@@ -55,7 +55,6 @@ describe "ordersCtrl", ->
 
   describe "filtering orders", ->
     it "filters orders by all selected order cycles", ->
-
       $scope['q']['order_cycle_id_in'] = ['4', '5']
 
       $scope.fetchResults()


### PR DESCRIPTION
#### What? Why?

Closes #5299

On the Admin Orders page (`/admin/orders`), there are two tag options in the filter:

 * Distributors
 * Order Cycles

When multiple tags for either of these are selected, the filter only uses the last tag, all others are ignored.

This fix ensures that all selected tags are used in the filter. It also removes a redundant duplicate line.

#### What should we test?
Test filtering with zero, one and multiple tags for both Distributors and Order Cycles



#### Release notes
Fix filtering by multiple tags on the Admin Orders page.

Changelog Category: Fixed 


