### PR TITLE
Fix script for syncing public/ in AWS bucket to local

### DIFF
--- a/script/mirror_db.sh
+++ b/script/mirror_db.sh
@@ -54,7 +54,7 @@ $RAILS_RUN script/prepare_imported_db.rb
 if [ -n "$BUCKET" ]; then
   if hash aws 2>/dev/null; then
     echo "Mirroring images..."
-    aws s3 sync "s3://$BUCKET/public public/"
+    aws s3 sync "s3://$BUCKET/public" public/
   else
     echo "Please install the AWS CLI tools so that I can copy the images from $BUCKET for you."
     echo "eg. sudo easy_install awscli"


### PR DESCRIPTION
#### What? Why?

The current code fails with the following error:

```
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: the following arguments are required: paths
```

I think this was not an `awscli` change but just a typo introduced in [this commit](https://github.com/openfoodfoundation/openfoodnetwork/commit/76d77ceb51).

#### What should we test?

Run the script locally with the bucket argument:

```
./script/mirror_db.sh <your-local-ofn-server> <your-bucket-name>
```

#### Release notes

Fixed developer tool for syncing local public/ directory with files in bucket.

Changelog Category: Fixed