### PR TITLE
[Caching] Timed caching on shops data

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,10 +19,8 @@ class HomeController < BaseController
   private
 
   # Cache the value of the query count
-  def cached_count(key, query)
-    CacheService.cache("home_stats_count_#{key}",
-                       expires_in: CacheService::HOME_STATS_EXPIRY,
-                       race_condition_ttl: 10) do
+  def cached_count(statistic, query)
+    CacheService.home_stats(statistic) do
       query.count
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -18,9 +18,11 @@ class HomeController < BaseController
 
   private
 
-  # Cache the value of the query count for 24 hours
+  # Cache the value of the query count
   def cached_count(key, query)
-    Rails.cache.fetch("home_stats_count_#{key}", expires_in: 1.day, race_condition_ttl: 10) do
+    CacheService.cache("home_stats_count_#{key}",
+                       expires_in: CacheService::HOME_STATS_EXPIRY,
+                       race_condition_ttl: 10) do
       query.count
     end
   end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CacheService
+  HOME_STATS_EXPIRY = 1.day.freeze
   FILTERS_EXPIRY = 30.seconds.freeze
 
   def self.cache(cache_key, options = {})

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -36,5 +36,19 @@ class CacheService
     def self.ams_all_properties_key
       "inject-all-properties-#{CacheService.latest_timestamp_by_class(Spree::Property)}"
     end
+
+    def self.ams_shops
+      [
+        "shops/index/inject_enterprises",
+        { expires_in: SHOPS_EXPIRY }
+      ]
+    end
+
+    def self.ams_shop(enterprise)
+      [
+        "enterprises/shop/inject_enterprise_shopfront-#{enterprise.id}",
+        { expires_in: SHOPS_EXPIRY }
+      ]
+    end
   end
 end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -3,6 +3,7 @@
 class CacheService
   HOME_STATS_EXPIRY = 1.day.freeze
   FILTERS_EXPIRY = 30.seconds.freeze
+  SHOPS_EXPIRY = 15.seconds.freeze
 
   def self.cache(cache_key, options = {})
     Rails.cache.fetch cache_key.to_s, options do

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -25,6 +25,14 @@ class CacheService
     cached_class.maximum(:updated_at).to_i
   end
 
+  def self.home_stats(statistic)
+    Rails.cache.fetch("home_stats_count_#{statistic}",
+                      expires_in: HOME_STATS_EXPIRY,
+                      race_condition_ttl: 10) do
+      yield
+    end
+  end
+
   module FragmentCaching
     # Rails' caching in views is called "Fragment Caching" and uses some slightly different logic.
     # Note: supplied keys are actually prepended with "view/" under the hood.

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -35,7 +35,7 @@ class CacheService
 
   module FragmentCaching
     # Rails' caching in views is called "Fragment Caching" and uses some slightly different logic.
-    # Note: supplied keys are actually prepended with "view/" under the hood.
+    # Note: keys supplied here are actually prepended with "views/" under the hood.
 
     def self.ams_all_taxons_key
       "inject-all-taxons-#{CacheService.latest_timestamp_by_class(Spree::Taxon)}"

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -6,7 +6,8 @@
   = current_distributor.logo.url
 
 - content_for :injection_data do
-  = inject_enterprise_shopfront(@enterprise)
+  - cache "enterprises/shop/inject_enterprise_shopfront-#{@enterprise.id}", expires_in: CacheService::SHOPS_EXPIRY do
+    = inject_enterprise_shopfront(@enterprise)
 
 %shop.darkswarm
   - if @shopfront_layout == 'embedded'

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -6,7 +6,7 @@
   = current_distributor.logo.url
 
 - content_for :injection_data do
-  - cache "enterprises/shop/inject_enterprise_shopfront-#{@enterprise.id}", expires_in: CacheService::SHOPS_EXPIRY do
+  - cache(*CacheService::FragmentCaching.ams_shop(@enterprise)) do
     = inject_enterprise_shopfront(@enterprise)
 
 %shop.darkswarm

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -2,7 +2,7 @@
   = t :shops_title
 
 - content_for :injection_data do
-  - cache "shops/index/inject_enterprises", expires_in: CacheService::SHOPS_EXPIRY do
+  - cache(*CacheService::FragmentCaching.ams_shops) do
     = inject_enterprises(@enterprises)
 
 #panes

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -2,7 +2,8 @@
   = t :shops_title
 
 - content_for :injection_data do
-  = inject_enterprises(@enterprises)
+  - cache "shops/index/inject_enterprises", expires_in: CacheService::SHOPS_EXPIRY do
+    = inject_enterprises(@enterprises)
 
 #panes
   #shops.pane

--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -50,6 +50,9 @@ feature "Darkswarm data caching", js: true, caching: true do
       property.presentation = "Changed Property"
       property.save
 
+      # Clear timed shops cache so we can test uncached supplied properties
+      clear_shops_cache
+
       visit shops_path
 
       taxon_timestamp2 = CacheService.latest_timestamp_by_class(Spree::Taxon)
@@ -72,5 +75,10 @@ feature "Darkswarm data caching", js: true, caching: true do
 
   def expect_cached(key)
     expect(Rails.cache.exist?(key)).to be true
+  end
+
+  def clear_shops_cache
+    cache_key = "views/#{CacheService::FragmentCaching.ams_shops[0]}"
+    Rails.cache.delete cache_key
   end
 end

--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -45,10 +45,8 @@ feature "Darkswarm data caching", js: true, caching: true do
         expect(page).to have_content property.presentation
       end
 
-      taxon.name = "Changed Taxon"
-      taxon.save
-      property.presentation = "Changed Property"
-      property.save
+      taxon.update_attributes!(name: "Changed Taxon")
+      property.update_attributes!(presentation: "Changed Property")
 
       # Clear timed shops cache so we can test uncached supplied properties
       clear_shops_cache

--- a/spec/features/consumer/caching/shops_caching_spec.rb
+++ b/spec/features/consumer/caching/shops_caching_spec.rb
@@ -18,6 +18,7 @@ feature "Shops caching", js: true, caching: true do
     end
 
     it "keeps data cached for a short time on subsequent requests" do
+      # Ensure sufficient time for requests to load and timed caches to expire
       Timecop.travel(10.minutes.ago) do
         visit shops_path
 
@@ -65,6 +66,7 @@ feature "Shops caching", js: true, caching: true do
     end
 
     it "keeps data cached for a short time on subsequent requests" do
+      # Ensure sufficient time for requests to load and timed caches to expire
       Timecop.travel(10.minutes.ago) do
         visit enterprise_shop_path(distributor)
 

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -22,7 +22,7 @@ describe CacheService do
 
     before do
       rails_cache.stub(:fetch)
-      CacheService.stub(:latest_timestamp_by_class) { timestamp }
+      allow(Enterprise).to receive(:maximum).with(:updated_at).and_return(timestamp)
     end
 
     it "caches data by timestamp for last record of that class" do
@@ -30,7 +30,6 @@ describe CacheService do
         "TEST"
       end
 
-      expect(CacheService).to have_received(:latest_timestamp_by_class).with(Enterprise)
       expect(rails_cache).to have_received(:fetch).with("test-cache-key-Enterprise-#{timestamp}")
     end
   end

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -5,7 +5,7 @@ describe CacheService do
 
   describe "#cache" do
     before do
-      rails_cache.stub(:fetch)
+      allow(rails_cache).to receive(:fetch)
     end
 
     it "provides a wrapper for basic #fetch calls to Rails.cache" do
@@ -21,7 +21,7 @@ describe CacheService do
     let(:timestamp) { Time.now.to_i }
 
     before do
-      rails_cache.stub(:fetch)
+      allow(rails_cache).to receive(:fetch)
       allow(Enterprise).to receive(:maximum).with(:updated_at).and_return(timestamp)
     end
 


### PR DESCRIPTION
#### What? Why?

Related to #5273 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds some short time-based caching on AMS data in `/shops` (index) and `/shop` (show), after it is fetched, serialized, and rendered.

**Note:** this data includes things like shop `name,` `description`, `twitter_handle`, `supplied_taxons`, and is cached for **up to 15 seconds**. It applies to some of the enterprise data displayed in both `/shops` and `/shop` pages.

#### What should we test?
<!-- List which features should be tested and how. -->

Enterprise data in both `/shops` and `/shop` pages takes _up to_ 15 seconds (from the last time the page was loaded) to update, after it's changed in the backoffice. This should include things like enterprise name, description, and if the shop is open or closed.

Dev test: caching this data is working correctly. You can see clear messages in the logs with `log_level = :debug`, and see the queries are not being re-run. 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added 15-second caching on enterprise data in /shops and /shop pages

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->