### PR TITLE
[Caching] Caching data by class

### DIFF
--- a/app/models/distributor_shipping_method.rb
+++ b/app/models/distributor_shipping_method.rb
@@ -1,5 +1,5 @@
 class DistributorShippingMethod < ActiveRecord::Base
   self.table_name = "distributors_shipping_methods"
-  belongs_to :shipping_method, class_name: Spree::ShippingMethod
+  belongs_to :shipping_method, class_name: Spree::ShippingMethod, touch: true
   belongs_to :distributor, class_name: Enterprise, touch: true
 end

--- a/app/models/spree/classification_decorator.rb
+++ b/app/models/spree/classification_decorator.rb
@@ -1,5 +1,6 @@
 Spree::Classification.class_eval do
   belongs_to :product, class_name: "Spree::Product", touch: true
+  belongs_to :taxon, class_name: "Spree::Taxon", touch: true
 
   before_destroy :dont_destroy_if_primary_taxon
 

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -12,7 +12,7 @@ Spree::Product.class_eval do
   has_many :option_types, through: :product_option_types, dependent: :destroy
 
   belongs_to :supplier, class_name: 'Enterprise', touch: true
-  belongs_to :primary_taxon, class_name: 'Spree::Taxon'
+  belongs_to :primary_taxon, class_name: 'Spree::Taxon', touch: true
 
   delegate_belongs_to :master, :unit_value, :unit_description
   delegate :images_attributes=, :display_as=, to: :master

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -20,4 +20,17 @@ class CacheService
   def self.latest_timestamp_by_class(cached_class)
     cached_class.maximum(:updated_at).to_i
   end
+
+  module FragmentCaching
+    # Rails' caching in views is called "Fragment Caching" and uses some slightly different logic.
+    # Note: supplied keys are actually prepended with "view/" under the hood.
+
+    def self.ams_all_taxons_key
+      "inject-all-taxons-#{CacheService.latest_timestamp_by_class(Spree::Taxon)}"
+    end
+
+    def self.ams_all_properties_key
+      "inject-all-properties-#{CacheService.latest_timestamp_by_class(Spree::Property)}"
+    end
+  end
 end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CacheService
+  def self.cache(cache_key, options = {})
+    Rails.cache.fetch cache_key.to_s, options do
+      yield
+    end
+  end
+
+  # Yields a cached query, expired by the most recently updated record for a given class.
+  # E.g: if *any* Spree::Taxon record is updated, all keys based on Spree::Taxon will auto-expire.
+  def self.cached_data_by_class(cache_key, cached_class)
+    Rails.cache.fetch "#{cache_key}-#{cached_class}-#{latest_timestamp_by_class(cached_class)}" do
+      yield
+    end
+  end
+
+  # Gets the :updated_at value of the most recently updated record for a given class, and returns
+  # it as a timestamp, eg: `1583836069`.
+  def self.latest_timestamp_by_class(cached_class)
+    cached_class.maximum(:updated_at).to_i
+  end
+end

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -48,9 +48,9 @@
     = inject_current_hub
     = inject_current_user
     = inject_rails_flash
-    - cache "inject-all-taxons-#{CacheService.latest_timestamp_by_class(Spree::Taxon)}" do
+    - cache CacheService::FragmentCaching.ams_all_taxons_key do
       = inject_taxons
-    - cache "inject-all-properties-#{CacheService.latest_timestamp_by_class(Spree::Property)}" do
+    - cache CacheService::FragmentCaching.ams_all_properties_key do
       = inject_properties
     = inject_current_order
     = inject_currency_config

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -48,8 +48,10 @@
     = inject_current_hub
     = inject_current_user
     = inject_rails_flash
-    = inject_taxons
-    = inject_properties
+    - cache "inject-all-taxons-#{CacheService.latest_timestamp_by_class(Spree::Taxon)}" do
+      = inject_taxons
+    - cache "inject-all-properties-#{CacheService.latest_timestamp_by_class(Spree::Property)}" do
+      = inject_properties
     = inject_current_order
     = inject_currency_config
     = yield :injection_data

--- a/lib/open_food_network/enterprise_injection_data.rb
+++ b/lib/open_food_network/enterprise_injection_data.rb
@@ -10,11 +10,25 @@ module OpenFoodNetwork
     end
 
     def shipping_method_services
-      @shipping_method_services ||= Spree::ShippingMethod.services
+      @shipping_method_services ||= begin
+        CacheService.cached_data_by_class("shipping_method_services", Spree::ShippingMethod) do
+          # This result relies on a simple join with DistributorShippingMethod.
+          # Updated DistributorShippingMethod records touch their associated Spree::ShippingMethod.
+          Spree::ShippingMethod.services
+        end
+      end
     end
 
     def supplied_taxons
-      @supplied_taxons ||= Spree::Taxon.supplied_taxons
+      @supplied_taxons ||= begin
+        CacheService.cached_data_by_class("supplied_taxons", Spree::Taxon) do
+          # This result relies on a join with associated supplied products, through the
+          # class Classification which maps the relationship. Classification records touch
+          # their associated Spree::Taxon when updated. A Spree::Product's primary_taxon
+          # is also touched when changed.
+          Spree::Taxon.supplied_taxons
+        end
+      end
     end
 
     def all_distributed_taxons

--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -18,6 +18,18 @@ feature "Darkswarm data caching", js: true, caching: true do
 
   describe "caching injected taxons and properties" do
     it "caches taxons and properties" do
+      expect(Spree::Taxon).to receive(:all) { [taxon] }
+      expect(Spree::Property).to receive(:all) { [property] }
+
+      visit shops_path
+
+      expect(Spree::Taxon).to_not receive(:all)
+      expect(Spree::Property).to_not receive(:all)
+
+      visit shops_path
+    end
+
+    it "invalidates caches for taxons and properties" do
       visit shops_path
 
       taxon_timestamp1 = CacheService.latest_timestamp_by_class(Spree::Taxon)

--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-feature "Caching", js: true, caching: true do
+feature "Darkswarm data caching", js: true, caching: true do
   let!(:taxon) { create(:taxon, name: "Cached Taxon") }
   let!(:property) { create(:property, presentation: "Cached Property") }
 

--- a/spec/features/consumer/caching_spec.rb
+++ b/spec/features/consumer/caching_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+feature "Caching", js: true, caching: true do
+  let!(:taxon) { create(:taxon, name: "Cached Taxon") }
+  let!(:property) { create(:property, presentation: "Cached Property") }
+
+  let!(:producer) { create(:supplier_enterprise) }
+  let!(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true, is_primary_producer: true) }
+  let!(:product) { create(:simple_product, supplier: producer, primary_taxon: taxon, taxons: [taxon], properties: [property]) }
+  let!(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], coordinator: distributor) }
+  let(:exchange) { order_cycle.exchanges.outgoing.where(receiver_id: distributor.id).first }
+
+  before do
+    exchange.variants << product.variants.first
+  end
+
+  describe "caching injected taxons and properties" do
+    it "caches taxons and properties" do
+      visit shops_path
+
+      taxon_timestamp1 = CacheService.latest_timestamp_by_class(Spree::Taxon)
+      expect_cached "views/#{CacheService::FragmentCaching.ams_all_taxons_key}"
+
+      property_timestamp1 = CacheService.latest_timestamp_by_class(Spree::Property)
+      expect_cached "views/#{CacheService::FragmentCaching.ams_all_properties_key}"
+
+      toggle_filters
+
+      within "#hubs .filter-row" do
+        expect(page).to have_content taxon.name
+        expect(page).to have_content property.presentation
+      end
+
+      taxon.name = "Changed Taxon"
+      taxon.save
+      property.presentation = "Changed Property"
+      property.save
+
+      visit shops_path
+
+      taxon_timestamp2 = CacheService.latest_timestamp_by_class(Spree::Taxon)
+      expect_cached "views/#{CacheService::FragmentCaching.ams_all_taxons_key}"
+
+      property_timestamp2 = CacheService.latest_timestamp_by_class(Spree::Property)
+      expect_cached "views/#{CacheService::FragmentCaching.ams_all_properties_key}"
+
+      expect(taxon_timestamp1).to_not eq taxon_timestamp2
+      expect(property_timestamp1).to_not eq property_timestamp2
+
+      toggle_filters
+
+      within "#hubs .filter-row" do
+        expect(page).to have_content "Changed Taxon"
+        expect(page).to have_content "Changed Property"
+      end
+    end
+  end
+
+  def expect_cached(key)
+    expect(Rails.cache.exist?(key)).to be true
+  end
+end

--- a/spec/features/consumer/producers_spec.rb
+++ b/spec/features/consumer/producers_spec.rb
@@ -16,8 +16,8 @@ feature '
   let(:taxon_fruit) { create(:taxon, name: 'Fruit') }
   let(:taxon_veg) { create(:taxon, name: 'Vegetables') }
 
-  let!(:product1) { create(:simple_product, supplier: producer1, taxons: [taxon_fruit]) }
-  let!(:product2) { create(:simple_product, supplier: producer2, taxons: [taxon_veg]) }
+  let!(:product1) { create(:simple_product, supplier: producer1, primary_taxon: taxon_fruit, taxons: [taxon_fruit]) }
+  let!(:product2) { create(:simple_product, supplier: producer2, primary_taxon: taxon_veg, taxons: [taxon_veg]) }
 
   let(:shop) { create(:distributor_enterprise) }
   let!(:er) { create(:enterprise_relationship, parent: shop, child: producer1) }

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -110,13 +110,13 @@ feature 'Shops', js: true do
 
   describe "taxon badges" do
     let!(:closed_oc) { create(:closed_order_cycle, distributors: [shop], variants: [p_closed.variants.first]) }
-    let!(:p_closed) { create(:simple_product, taxons: [taxon_closed]) }
+    let!(:p_closed) { create(:simple_product, primary_taxon: taxon_closed, taxons: [taxon_closed]) }
     let(:shop) { create(:distributor_enterprise, with_payment_and_shipping: true) }
     let(:taxon_closed) { create(:taxon, name: 'Closed') }
 
     describe "open shops" do
       let!(:open_oc) { create(:open_order_cycle, distributors: [shop], variants: [p_open.variants.first]) }
-      let!(:p_open) { create(:simple_product, taxons: [taxon_open]) }
+      let!(:p_open) { create(:simple_product, primary_taxon: taxon_open, taxons: [taxon_open]) }
       let(:taxon_open) { create(:taxon, name: 'Open') }
 
       it "shows taxons for open order cycles only" do

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -109,5 +109,15 @@ module Spree
         expect(shipping_method.include?(address)).to be true
       end
     end
+
+    describe "touches" do
+      let!(:distributor) { create(:distributor_enterprise) }
+      let!(:shipping_method) { create(:shipping_method) }
+      let(:add_distributor) { shipping_method.distributors << distributor }
+
+      it "is touched when applied to a distributor" do
+        expect{ add_distributor }.to change { shipping_method.reload.updated_at}
+      end
+    end
   end
 end

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -30,11 +30,20 @@ module Spree
     end
 
     describe "touches" do
-      let!(:taxon) { create(:taxon) }
-      let!(:product) { create(:simple_product) }
+      let!(:taxon1) { create(:taxon) }
+      let!(:taxon2) { create(:taxon) }
+      let!(:taxon3) { create(:taxon) }
+      let!(:product) { create(:simple_product, primary_taxon: taxon1, taxons: [taxon1, taxon2]) }
 
-      it "is touched when applied to a product" do
-        expect{ product.taxons << taxon }.to change { taxon.reload.updated_at }
+      it "is touched when a taxon is applied to a product" do
+        expect{ product.taxons << taxon3 }.to change { taxon3.reload.updated_at }
+      end
+
+      it "is touched when assignment of primary_taxon on a product changes" do
+        expect do
+          product.primary_taxon = taxon2
+          product.save
+        end.to change { taxon2.reload.updated_at }
       end
     end
   end

--- a/spec/models/spree/taxon_spec.rb
+++ b/spec/models/spree/taxon_spec.rb
@@ -28,5 +28,14 @@ module Spree
         expect(Taxon.distributed_taxons(:current)).to eq(e.id => Set.new([t1.id]))
       end
     end
+
+    describe "touches" do
+      let!(:taxon) { create(:taxon) }
+      let!(:product) { create(:simple_product) }
+
+      it "is touched when applied to a product" do
+        expect{ product.taxons << taxon }.to change { taxon.reload.updated_at }
+      end
+    end
   end
 end

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe CacheService do
+  let(:rails_cache) { Rails.cache }
+
+  describe "#cache" do
+    before do
+      rails_cache.stub(:fetch)
+    end
+
+    it "provides a wrapper for basic #fetch calls to Rails.cache" do
+      CacheService.cache("test-cache-key", expires_in: 10.seconds) do
+        "TEST"
+      end
+
+      expect(rails_cache).to have_received(:fetch).with("test-cache-key", expires_in: 10.seconds)
+    end
+  end
+
+  describe "#cached_data_by_class" do
+    let(:timestamp) { Time.now.to_i }
+
+    before do
+      rails_cache.stub(:fetch)
+      CacheService.stub(:latest_timestamp_by_class) { timestamp }
+    end
+
+    it "caches data by timestamp for last record of that class" do
+      CacheService.cached_data_by_class("test-cache-key", Enterprise) do
+        "TEST"
+      end
+
+      expect(CacheService).to have_received(:latest_timestamp_by_class).with(Enterprise)
+      expect(rails_cache).to have_received(:fetch).with("test-cache-key-Enterprise-#{timestamp}")
+    end
+  end
+
+  describe "#latest_timestamp_by_class" do
+    let!(:taxon1) { create(:taxon) }
+    let!(:taxon2) { create(:taxon) }
+
+    it "gets the :updated_at value of the last record for a given class and returns a timestamp" do
+      taxon1.touch
+      expect(CacheService.latest_timestamp_by_class(Spree::Taxon)).to eq taxon1.updated_at.to_i
+
+      taxon2.touch
+      expect(CacheService.latest_timestamp_by_class(Spree::Taxon)).to eq taxon2.updated_at.to_i
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,15 @@ RSpec.configure do |config|
       .each { |s| s.driver.reset! }
   end
 
+  # Enable caching in any specs tagged with `caching: true`. Usage is exactly the same as the
+  # well-known `js: true` tag used to enable javascript in feature specs.
+  config.around(:each, :caching) do |example|
+    caching = ActionController::Base.perform_caching
+    ActionController::Base.perform_caching = example.metadata[:caching]
+    example.run
+    ActionController::Base.perform_caching = caching
+  end
+
   config.before(:all) { restart_phantomjs }
 
   # Geocoding


### PR DESCRIPTION
#### What? Why?

Related to #5273 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

- Adds some caching to queries and AMS arrays, where the results are a big array of objects from a single class. The expiration of the cache entries is based on the last time a record for that class was changed. 
- Adds some related `touch` calls for these cases.

Detailed explanation here: https://github.com/openfoodfoundation/openfoodnetwork/pull/5273#discussion_r413779989

#### What should we test?
<!-- List which features should be tested and how. -->

Here we are caching some data related to taxons, properties (enterprise and product), and shipping_methods. It's not applied to a specific page, but should effect any non-admin pages. 

When:
- a taxon, property, or shipping_method are changed
- a shipping_method is added to an enterprise's list of shipping_methods
- a taxon is applied to a product (assigned as primary_taxon)

...then these changes should be reflected correctly in the frontend _without_ any delay, when the page is refreshed.

Dev test: caching this data is working correctly. You can see clear messages in the logs with `log_level = :debug`, and see the queries are not being re-run.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added class-based caching for large arrays of simple objects

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
