### PR TITLE
[Spree 2.1] Fix variant overrides specs and shops spec

### DIFF
--- a/app/controllers/admin/variant_overrides_controller.rb
+++ b/app/controllers/admin/variant_overrides_controller.rb
@@ -5,7 +5,7 @@ module Admin
     include OpenFoodNetwork::SpreeApiKeyLoader
     include EnterprisesHelper
 
-    before_filter :load_data
+    prepend_before_filter :load_data
     before_filter :load_collection, only: [:bulk_update]
     before_filter :load_spree_api_key, only: :index
 

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -118,7 +118,7 @@ class Enterprise < ActiveRecord::Base
       except(:select).
       select('DISTINCT enterprises.id')
 
-    if ready_enterprises.present?
+    if ready_enterprises.any?
       where("enterprises.id NOT IN (?)", ready_enterprises)
     else
       where(nil)


### PR DESCRIPTION
#### What? Why?

Two last commits to make the 3-0-stable build green.
The first commit fixes a problem in the variant_overrides_controller by making load_data run before load_resource (in resource_controller).
The second commit fixes a problem in the Enterprise scope that is breaking the closed shop controller spec:  .present? calls .length that breaks with ActiveModel::MissingAttributeError Exception: missing attribute: address_id (probably trying to load the collection from the db?). Calling any? works well.

#### What should we test?
Together with #5316 I think this makes the 3-0-stable build green.
