### PR TITLE
Add order number and date/time to order cycles customer report

### DIFF
--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -36,7 +36,9 @@ module OpenFoodNetwork
          I18n.t(:report_header_customer_code), I18n.t(:report_header_tags),
          I18n.t(:report_header_billing_street), I18n.t(:report_header_billing_street_2),
          I18n.t(:report_header_billing_city), I18n.t(:report_header_billing_postcode),
-         I18n.t(:report_header_billing_state)]
+         I18n.t(:report_header_billing_state),
+         I18n.t(:report_header_order_number),
+         I18n.t(:report_header_date)]
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
@@ -92,7 +94,9 @@ module OpenFoodNetwork
               proc { |_line_items| "" },
               proc { |_line_items| "" },
               proc { |_line_items| "" },
-              proc { |_line_items| "" }
+              proc { |_line_items| "" },
+              proc { |line_items| line_items.first.order.number },
+              proc { |line_items| line_items.first.order.completed_at.strftime("%F %T") },
             ]
           },
           {
@@ -187,7 +191,9 @@ module OpenFoodNetwork
           proc { |line_items| line_items.first.order.bill_address.andand.address2 },
           proc { |line_items| line_items.first.order.bill_address.andand.city },
           proc { |line_items| line_items.first.order.bill_address.andand.zipcode },
-          proc { |line_items| line_items.first.order.bill_address.andand.state }
+          proc { |line_items| line_items.first.order.bill_address.andand.state },
+          proc { |line_items| line_items.first.order.number },
+          proc { |line_items| line_items.first.order.completed_at.strftime("%F %T") },
         ]
       end
       # rubocop:enable Metrics/AbcSize

--- a/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe OpenFoodNetwork::OrdersAndFulfillmentsReport::CustomerTotalsRepor
       total_field = report_table.last[5]
       expect(total_field).to eq I18n.t("admin.reports.total")
     end
+
+    it 'includes the order number and date in item rows' do
+      order_number_and_date_fields = report_table.first[33..34]
+      expect(order_number_and_date_fields).to eq([
+        order.number,
+        order.completed_at.strftime("%F %T"),
+      ])
+    end
+
+    it 'includes the order number and date in total rows' do
+      order_number_and_date_fields = report_table.last[33..34]
+      expect(order_number_and_date_fields).to eq([
+        order.number,
+        order.completed_at.strftime("%F %T"),
+      ])
+    end
   end
 
   context "loading shipping methods" do


### PR DESCRIPTION
#### What? Why?

Closes #5214 

Adds the order `number` and `completed_at` date to the far right hand side of the order cycles customer totals report. This is so as to maintain the existing position of other columns in case users have developed tools that depend on the order of the columns.

#### What should we test?
(From issue):
1. Run the Order Cycle - Customer Totals report
2. See the Order Number and date/time of order completion on each row of the table, at the far right (last two columns)

#### Release notes
- Order number and date/time of completion are now displayed at the far right hand side of the order cycle customer totals report. 

Changelog Category: Added
