### PR TITLE
Add link to Docker.md from GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -2,6 +2,8 @@
 
 This is a general guide to setting up an Open Food Network development environment on your local machine.
 
+The fastest way to make it work locally is to use Docker, see the [Docker setup guide](DOCKER.md).
+
 The following guides are located in the wiki and provide more OS-specific step-by-step instructions:
 
 - [Ubuntu Setup Guide][ubuntu]


### PR DESCRIPTION
Docker is working pretty well now, a link on the getting_started guide will make it more visible and more tested. I create a PR as I am not sure everyone will agree.
