### PR TITLE
Add link to docker tips wiki page to Docker.md

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -52,3 +52,5 @@ The default admin user is 'ofn@example.com' with 'ofn123' password.
 Check the app in the browser at `http://localhost:3000`.
 
 You will then get the trace of the containers in the terminal. You can stop the containers using Ctrl-C in the terminal.
+
+You can find some useful tips and commands [here](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Docker:-useful-tips-and-commands).


### PR DESCRIPTION
This wiki page will be useful and we can expand it with docker troubleshooting info.