### PR TITLE
Add timestamps to OC schedule join table

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -16,7 +16,8 @@ class OrderCycle < ActiveRecord::Base
   has_many :suppliers, source: :sender, through: :cached_incoming_exchanges, uniq: true
   has_many :distributors, source: :receiver, through: :cached_outgoing_exchanges, uniq: true
 
-  has_and_belongs_to_many :schedules, join_table: 'order_cycle_schedules'
+  has_many :schedules, through: :order_cycle_schedules
+  has_many :order_cycle_schedules
   has_paper_trail meta: { custom_data: proc { |order_cycle| order_cycle.schedule_ids.to_s } }
 
   attr_accessor :incoming_exchanges, :outgoing_exchanges

--- a/app/models/order_cycle_schedule.rb
+++ b/app/models/order_cycle_schedule.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class OrderCycleSchedule < ActiveRecord::Base
+  belongs_to :schedule
+  belongs_to :order_cycle
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,7 +1,8 @@
 class Schedule < ActiveRecord::Base
-  has_and_belongs_to_many :order_cycles, join_table: 'order_cycle_schedules'
   has_paper_trail meta: { custom_data: proc { |schedule| schedule.order_cycle_ids.to_s } }
 
+  has_many :order_cycles, through: :order_cycle_schedules
+  has_many :order_cycle_schedules, dependent: :destroy
   has_many :coordinators, uniq: true, through: :order_cycles
 
   attr_accessible :name, :order_cycle_ids

--- a/db/migrate/20200430105459_add_timestamps_to_order_cycle_schedules.rb
+++ b/db/migrate/20200430105459_add_timestamps_to_order_cycle_schedules.rb
@@ -1,0 +1,7 @@
+class AddTimestampsToOrderCycleSchedules < ActiveRecord::Migration
+  def change
+    change_table :order_cycle_schedules do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200429122446) do
+ActiveRecord::Schema.define(:version => 20200430105459) do
+
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"
     t.integer "enterprise_id"
@@ -269,8 +270,10 @@ ActiveRecord::Schema.define(:version => 20200429122446) do
   add_index "inventory_items", ["enterprise_id", "variant_id"], :name => "index_inventory_items_on_enterprise_id_and_variant_id", :unique => true
 
   create_table "order_cycle_schedules", :force => true do |t|
-    t.integer "order_cycle_id", :null => false
-    t.integer "schedule_id",    :null => false
+    t.integer  "order_cycle_id", :null => false
+    t.integer  "schedule_id",    :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "order_cycle_schedules", ["order_cycle_id"], :name => "index_order_cycle_schedules_on_order_cycle_id"


### PR DESCRIPTION
#### What? Why?

Closes #4462

This is critical to debugging bugs related to subscriptions.

Essentially, `has_and_belongs_to_many` doesn't give us the option for any other column that the foreign keys themselves:

> A has_and_belongs_to_many association creates a direct many-to-many connection with another model, with no intervening model.

Source: https://guides.rubyonrails.org/v3.2/association_basics.html#the-has_and_belongs_to_many-association

Note, however, that there's no way to update an order_cycle_schedule, that I can think of but `updated_at` doesn't do any harm.

#### What should we test?

We need to ensure that a subscription can be created and modified as usual.

#### Release notes

The `order_cycle_schedules` join table has `created_at` and `updated_at` columns.

Changelog Category: Added
