### PR TITLE
Create a container to run a DJ worker in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,22 @@ services:
       bash -c "wait-for-it -t 30 db:5432 &&
                rm -f tmp/pids/server.pid &&
                bundle exec rails s -p 3000 -b '0.0.0.0'"
-
+  worker:
+    tty: true
+    stdin_open: true
+    build: .
+    volumes:
+      - .:/usr/src/app
+      - gems:/bundles
+      - ./config/database.yml:/usr/src/app/config/database.yml
+      - ./config/application.yml.example:/usr/src/app/config/application.yml
+    depends_on:
+      - db
+    environment:
+      OFN_DB_HOST: db
+    command: >
+      bash -c "wait-for-it -t 30 db:5432 &&
+               bundle exec rake jobs:work"
 volumes:
   gems:
   postgres:


### PR DESCRIPTION
#### What? Why?

Time has come to run background jobs in development with docker. I need it to work on https://github.com/openfoodfoundation/openfoodnetwork/issues/5294 but I think it's better to separate things and ship things independently.

This, however, doesn't let us run letter opener so you'll see errors like

```
worker_1  | [Worker(host:733aee3327ba pid:1)] 1 jobs processed at 2.9919 j/s, 0 failed
worker_1  | Couldn't find a suitable web browser!
worker_1  | Set the BROWSER environment variable to your desired browser.
worker_1  | Warning: program returned non-zero exit code #1
worker_1  | /usr/bin/xdg-open: 851: /usr/bin/xdg-open: www-browser: not found
worker_1  | /usr/bin/xdg-open: 851: /usr/bin/xdg-open: links2: not found
worker_1  | /usr/bin/xdg-open: 851: /usr/bin/xdg-open: elinks: not found
worker_1  | /usr/bin/xdg-open: 851: /usr/bin/xdg-open: links: not found
worker_1  | /usr/bin/xdg-open: 851: /usr/bin/xdg-open: lynx: not found
worker_1  | /usr/bin/xdg-open: 851: /usr/bin/xdg-open: w3m: not found
worker_1  | xdg-open: no method available for opening 'file:////usr/src/app/tmp/letter_opener/1588260352_4013345_60678af/rich.html'
```

IMO, this is not a big deal as most of the time I just want the job to happen and not so much about the actual mail or other UI. Now, I need subscriptions to be processed and nothing more. We can solve it after this PR.

#### What should we test?

run `docker-compose up` and  then:

```
$ docker-compose exec web bundle exec rails c
irb(main):002:0> Delayed::Job.enqueue SubscriptionPlacementJob.new
```

You should see log lines like

```
worker_1  | [Worker(host:733aee3327ba pid:1)] Job SubscriptionPlacementJob (id=13) RUNNING 
```

from the shell where you boot docker-compose.

#### Release notes

Run delayed jobs in development with docker

Changelog Category: Added
