### PR TITLE
4534 phone enterkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ coverage
 /reports/
 !/reports/README.md
 bin/
+.vscode/

--- a/app/views/shared/components/_enterprise_search.html.haml
+++ b/app/views/shared/components/_enterprise_search.html.haml
@@ -1,7 +1,8 @@
 #active-table-search.row
   .small-12.columns
-    %input{type: :text,
+    %input{inputmode: "search",
+    type: "search",
     "ng-model" => "query",
-    placeholder: t('search_by_name'),
+    placeholder: t(:search_by_name),
     "ng-debounce" => "500",
     "ofn-disable-enter" => true}


### PR DESCRIPTION
#### What? Why?

Closes #4534 

Mobile UX issue regarding the dynamic keyboards on mobile devices. When a user is in a search field in a shop while using a mobile device, the button on the keyboard that says 'return' or 'done' should say 'search' to reflect the action the user is taking. 

#### What should we test?
When on the Shop page, the 'return' or 'enter' button on the keyboard will change to reflect the user is on a search field. Therefore, multiple devices and mobile browsers need to be tested. See note below regarding varying results. 

#### Release notes
Within the Enterprise(shop) search, `input inputmode='search'` was added to the search field in order to enable the 'Go' (iOS) or magnifying glass (Android) on the mobile keyboard. `input type='search'` was left in the code as it did not change the outcome and could potentially affect older devices which support that syntax. In testing on Browserstack, this syntax is highly browser and device dependent, so results vary widely across devices. 

Changelog Category: Changed