### PR TITLE
Show outstanding balance on orders page

### DIFF
--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -19,7 +19,7 @@ class Api::Admin::OrderSerializer < ActiveModel::Serializer
   def display_outstanding_balance
     return "" unless ["balance_due", "credit_owed"].include?(object.payment_state)
 
-    "(#{object.display_outstanding_balance.to_html})"
+    object.display_outstanding_balance.to_s
   end
 
   def edit_path

--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -3,7 +3,7 @@ class Api::Admin::OrderSerializer < ActiveModel::Serializer
              :edit_path, :state, :payment_state, :shipment_state,
              :payments_path, :ready_to_ship, :ready_to_capture, :created_at,
              :distributor_name, :special_instructions,
-             :item_total, :adjustment_total, :payment_total, :total
+             :item_total, :adjustment_total, :payment_total, :total, :display_outstanding_balance
 
   has_one :distributor, serializer: Api::Admin::IdSerializer
   has_one :order_cycle, serializer: Api::Admin::IdSerializer
@@ -14,6 +14,12 @@ class Api::Admin::OrderSerializer < ActiveModel::Serializer
 
   def distributor_name
     object.distributor.andand.name
+  end
+
+  def display_outstanding_balance
+    return "" unless ["balance_due", "credit_owed"].include?(object.payment_state)
+
+    "(#{object.display_outstanding_balance.to_html})"
   end
 
   def edit_path

--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -17,7 +17,7 @@ class Api::Admin::OrderSerializer < ActiveModel::Serializer
   end
 
   def display_outstanding_balance
-    return "" unless ["balance_due", "credit_owed"].include?(object.payment_state)
+    return "" if object.outstanding_balance.zero?
 
     object.display_outstanding_balance.to_s
   end

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -68,7 +68,7 @@
         %span.state{'ng-class' => 'order.payment_state', 'ng-if' => 'order.payment_state'}
           %a{'ng-href' => '{{order.payments_path}}' }
             {{'js.admin.orders.payment_states.' + order.payment_state | t}}
-            %span{'ng-if' =>'order.display_outstanding_balance'}
+            %span{'ng-if' => 'order.display_outstanding_balance'}
               ({{order.display_outstanding_balance}})
       %td.align-center
         %span.state{'ng-class' => 'order.shipment_state', 'ng-if' => 'order.shipment_state'}

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -68,6 +68,7 @@
         %span.state{'ng-class' => 'order.payment_state', 'ng-if' => 'order.payment_state'}
           %a{'ng-href' => '{{order.payments_path}}' }
             {{'js.admin.orders.payment_states.' + order.payment_state | t}}
+            {{order.display_outstanding_balance}}
       %td.align-center
         %span.state{'ng-class' => 'order.shipment_state', 'ng-if' => 'order.shipment_state'}
           {{'js.admin.orders.shipment_states.' + order.shipment_state | t}}

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -68,7 +68,8 @@
         %span.state{'ng-class' => 'order.payment_state', 'ng-if' => 'order.payment_state'}
           %a{'ng-href' => '{{order.payments_path}}' }
             {{'js.admin.orders.payment_states.' + order.payment_state | t}}
-            {{order.display_outstanding_balance}}
+            %span{'ng-if' =>'order.display_outstanding_balance'}
+              ({{order.display_outstanding_balance}})
       %td.align-center
         %span.state{'ng-class' => 'order.shipment_state', 'ng-if' => 'order.shipment_state'}
           {{'js.admin.orders.shipment_states.' + order.shipment_state | t}}

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -46,8 +46,12 @@ FactoryBot.define do
     distributor { create(:distributor_enterprise) }
     order_cycle { create(:simple_order_cycle) }
 
-    after(:create) do |order|
-      create(:payment, amount: order.total + 10_000, order: order, state: "completed")
+    transient do
+      credit_amount { 10_000 }
+    end
+
+    after(:create) do |order, evaluator|
+      create(:payment, amount: order.total + evaluator.credit_amount, order: order, state: "completed")
       order.reload
     end
   end
@@ -56,8 +60,12 @@ FactoryBot.define do
     distributor { create(:distributor_enterprise) }
     order_cycle { create(:simple_order_cycle) }
 
-    after(:create) do |order|
-      create(:payment, amount: order.total - 1, order: order, state: "completed")
+    transient do
+      unpaid_amount { 1 }
+    end
+
+    after(:create) do |order, evaluator|
+      create(:payment, amount: order.total - evaluator.unpaid_amount, order: order, state: "completed")
       order.reload
     end
   end

--- a/spec/serializers/api/admin/order_serializer_spec.rb
+++ b/spec/serializers/api/admin/order_serializer_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Api::Admin::OrderSerializer do
+  let(:serializer) { described_class.new order }
+
+  describe "#display_outstanding_balance" do
+    let(:order) { create(:order) }
+
+    it "returns empty string" do
+      expect(serializer.display_outstanding_balance).to eql("")
+    end
+
+    context "with outstanding payments" do
+      let(:order) { create(:order_without_full_payment, unpaid_amount: 10) }
+
+      it "generates the outstanding balance" do
+        expect(serializer.display_outstanding_balance).to eql("($10.00)")
+      end
+    end
+
+    context "with credit owed" do
+      let(:order) { create(:order_with_credit_payment, credit_amount: 20) }
+
+      it "generates the outstanding balance" do
+        expect(serializer.display_outstanding_balance).to eql("($-20.00)")
+      end
+    end
+  end
+end

--- a/spec/serializers/api/admin/order_serializer_spec.rb
+++ b/spec/serializers/api/admin/order_serializer_spec.rb
@@ -14,7 +14,7 @@ describe Api::Admin::OrderSerializer do
       let(:order) { create(:order_without_full_payment, unpaid_amount: 10) }
 
       it "generates the outstanding balance" do
-        expect(serializer.display_outstanding_balance).to eql("($10.00)")
+        expect(serializer.display_outstanding_balance).to eql("$10.00")
       end
     end
 
@@ -22,7 +22,7 @@ describe Api::Admin::OrderSerializer do
       let(:order) { create(:order_with_credit_payment, credit_amount: 20) }
 
       it "generates the outstanding balance" do
-        expect(serializer.display_outstanding_balance).to eql("($-20.00)")
+        expect(serializer.display_outstanding_balance).to eql("$-20.00")
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes [#5173]

Prior to this change, there was no way of knowing how much was owed (or
in need of refunding) at a glance for each order on the orders index page,
this information was only available by clicking through to an order
payment page

This change adds the outstanding balance for each order.

There was some discussion about whether a refund should be a -ve number or not, I chose to keep it as a -ve number to keep it consistent with the information displayed on the payments page.

#### What should we test?

- Make an order with shipping at a shop as a cash payment
- Navigate to the order tab in the admin portal, you should see the balance outstanding for that order underneath the payment state. 
- Now capture the payment for that order 
- Change the order to pick up instead of delivery, the order should now display the amount required for a refund.

![Screen Shot 2020-05-01 at 9 50 18 pm](https://user-images.githubusercontent.com/1100707/80803812-c154d780-8bf6-11ea-905a-1edfab81b27a.png)

#### Release notes
Show outstanding balance for each order on orders index page.


Changelog Category: Added 

