### PR TITLE
Make OC selector options color explicitly gray and not white

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -75,6 +75,10 @@ ordercycle {
       border-radius: 0 0.25em 0.25em 0;
       min-width: 13em;
 
+      option {
+        color: $grey-700;
+      }
+
       @media all and (max-width: 480px) {
         width: 100%;
       }

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -75,13 +75,13 @@ ordercycle {
       border-radius: 0 0.25em 0.25em 0;
       min-width: 13em;
 
-      option {
-        color: $grey-700;
-      }
-
       @media all and (max-width: 480px) {
         width: 100%;
       }
+    }
+
+    option {
+      color: $grey-700;
     }
 
     @media all and (max-width: 1024px) {


### PR DESCRIPTION
#### What? Why?

Closes #5077
See issue, we get options rendered white on white on some browsers, namely chrome on windows 10.

#### What should we test?
Use browser stack to replicate chrome 79 on windows 10 and then verify the PR fixes the problem.

#### Release notes
Changelog Category: Fixed
Fixed a rendering problem in the shopfront Order cycle selector.
