### PR TITLE
Move PROFILE debug assets flag to another ENV var

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,7 +50,7 @@ Openfoodnetwork::Application.configure do
   # You can remove them by simply running:
   #
   #   $ bundle exec rake assets:clean
-  config.assets.debug = !ENV["PROFILE"]
+  config.assets.debug = !!ENV["DEBUG_ASSETS"]
 
   # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
   # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
#### What? Why?
This improves the situation from #5146 where we would need to either have cached assets and classes OR debug assets.
This PR enables us to have both profile and debug assets disabled by default.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
After this PR the default behaviour is the same as before #5146 

#### Release notes
Changelog Category: Added
Added DEBUG_ASSETS env var to enable asset debugging through a env var.
