### PR TITLE
[Mobile] Hide OC selector if shop requires login/customer

### DIFF
--- a/app/views/shopping_shared/_order_cycles.html.haml
+++ b/app/views/shopping_shared/_order_cycles.html.haml
@@ -1,7 +1,7 @@
 - content_for :injection_data do
   = inject_current_order_cycle
 
-- unless no_open_order_cycles?
+- unless no_open_order_cycles? || require_customer?
   %ordercycle{"ng-controller" => "OrderCycleCtrl", "ng-cloak" => true,
     "ng-class" => "{'requires-selection': !OrderCycle.selected()}"}
     %form.custom

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -466,6 +466,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
           expect(page).to have_content "Only approved customers can access this shop."
           expect(page).to have_content "login or signup"
           expect(page).to have_no_content product.name
+          expect(page).not_to have_selector "ordercycle"
         end
       end
 
@@ -483,6 +484,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
             expect(page).to have_content "Only approved customers can access this shop."
             expect(page).to have_content "please contact #{distributor.name}"
             expect(page).to have_no_content product.name
+            expect(page).not_to have_selector "ordercycle"
           end
         end
 


### PR DESCRIPTION
#### What? Why?

Closes #4529

#### What should we test?
Make the shop private and verify the require login or require customer messages appear correctly and, when those messages appear, the OC selector does not appear.

#### Release notes
Changelog Category: Changed
Hide OC selector is users needs to login or if user is not a customer of the shop.
