### PR TITLE
Replace select box with text when only one OC is available for selection

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -67,7 +67,8 @@ ordercycle {
       text-align: left;
     }
 
-    select, p {
+    select,
+    p {
       width: inherit;
       display: inline-block;
       color: $white;

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -49,7 +49,7 @@ ordercycle {
       border-radius: 0.25em 0 0 0.25em;
       float: left;
       font-size: 1em;
-      line-height: 1.5em;
+      line-height: 1.3em;
       padding: 0.5em 0.75em;
       height: 2.35em;
 
@@ -75,7 +75,7 @@ ordercycle {
       border: 0;
       margin-bottom: 0;
       font-size: 1em;
-      line-height: 1.5em;
+      line-height: 1.3em;
       padding: 0.5em 1.25em 0.5em 0.75em;
       height: 2.35em;
       background-size: 30px auto;

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -60,6 +60,14 @@ ordercycle {
     }
 
     select {
+      background-image: url('/assets/white-caret.svg');
+    }
+
+    p {
+      text-align: left;
+    }
+
+    select, p {
       width: inherit;
       display: inline-block;
       color: $white;
@@ -70,7 +78,6 @@ ordercycle {
       line-height: 1.5em;
       padding: 0.5em 1.25em 0.5em 0.75em;
       height: 2.35em;
-      background-image: url('/assets/white-caret.svg');
       background-size: 30px auto;
       border-radius: 0 0.25em 0.25em 0;
       min-width: 13em;

--- a/app/views/enterprises/_change_order_cycle.html.haml
+++ b/app/views/enterprises/_change_order_cycle.html.haml
@@ -1,0 +1,24 @@
+%div{"ng-controller" => "OrderCycleChangeCtrl", "ng-cloak" => true}
+  %closing
+    %div{"ng-if" => "OrderCycle.selected()"}
+      = t :enterprises_next_closing
+      %strong {{ OrderCycle.orders_close_at() | date_in_words }}
+    %div{"ng-if" => "!OrderCycle.selected()"}
+      = t :enterprises_choose
+
+  .order-cycle-select
+    .select-label
+      %span= t :enterprises_ready_for
+
+    - if oc_select_options.count == 1
+      %p
+        = oc_select_options.first[:time]
+
+    - else
+      %select.select2.avenir#order_cycle_id{"ng-model" => "order_cycle.order_cycle_id",
+        "ofn-change-order-cycle" => true,
+        "disabled" => require_customer?,
+        "ng-options" => "oc.id as oc.time for oc in #{oc_select_options.to_json}"}
+
+        - if oc_select_options.count > 1
+          %option{value: "", disabled: "", selected: ""}= t :shopping_oc_select

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -30,13 +30,18 @@
         .select-label
           %span= t :enterprises_ready_for
 
-        %select.select2.avenir#order_cycle_id{"ng-model" => "order_cycle.order_cycle_id",
-          "ofn-change-order-cycle" => true,
-          "disabled" => require_customer?,
-          "ng-options" => "oc.id as oc.time for oc in #{oc_select_options.to_json}"}
+        - if oc_select_options.count == 1
+          %p
+            = oc_select_options.first[:time]
 
-          - if oc_select_options.count > 1
-            %option{value: "", disabled: "", selected: ""}= t :shopping_oc_select
+        - else
+          %select.select2.avenir#order_cycle_id{"ng-model" => "order_cycle.order_cycle_id",
+            "ofn-change-order-cycle" => true,
+            "disabled" => require_customer?,
+            "ng-options" => "oc.id as oc.time for oc in #{oc_select_options.to_json}"}
+
+            - if oc_select_options.count > 1
+              %option{value: "", disabled: "", selected: ""}= t :shopping_oc_select
 
   - content_for :ordercycle_sidebar do
     .show-for-large-up.large-4.columns

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -17,31 +17,7 @@
     %a.close{ ng: { click: "alert.close()" } } &times;
 
   - content_for :order_cycle_form do
-
-    %div{"ng-controller" => "OrderCycleChangeCtrl", "ng-cloak" => true}
-      %closing
-        %div{"ng-if" => "OrderCycle.selected()"}
-          = t :enterprises_next_closing
-          %strong {{ OrderCycle.orders_close_at() | date_in_words }}
-        %div{"ng-if" => "!OrderCycle.selected()"}
-          = t :enterprises_choose
-
-      .order-cycle-select
-        .select-label
-          %span= t :enterprises_ready_for
-
-        - if oc_select_options.count == 1
-          %p
-            = oc_select_options.first[:time]
-
-        - else
-          %select.select2.avenir#order_cycle_id{"ng-model" => "order_cycle.order_cycle_id",
-            "ofn-change-order-cycle" => true,
-            "disabled" => require_customer?,
-            "ng-options" => "oc.id as oc.time for oc in #{oc_select_options.to_json}"}
-
-            - if oc_select_options.count > 1
-              %option{value: "", disabled: "", selected: ""}= t :shopping_oc_select
+    = render partial: "change_order_cycle"
 
   - content_for :ordercycle_sidebar do
     .show-for-large-up.large-4.columns

--- a/spec/features/consumer/shopping/products_spec.rb
+++ b/spec/features/consumer/shopping/products_spec.rb
@@ -30,8 +30,6 @@ feature "As a consumer I want to view products", js: true do
         product.save!
 
         visit shop_path
-        select "monday", from: "order_cycle_id"
-
         expect(page).to have_content product.name
         click_link product.name
 
@@ -48,8 +46,6 @@ feature "As a consumer I want to view products", js: true do
         product.save!
 
         visit shop_path
-        select "monday", from: "order_cycle_id"
-
         expect(page).to have_content product.name
         click_link product.name
 

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -50,7 +50,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
       it "selects an order cycle if only one is open" do
         exchange1.update_attribute :pickup_time, "turtles"
         visit shop_path
-        expect(page).to have_selector "option[selected]", text: 'turtles'
+        expect(page).to have_selector "p", text: 'turtles'
       end
 
       describe "with multiple order cycles" do

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -209,8 +209,6 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       it "filters search results properly" do
         visit shop_path
-        select "frogs", from: "order_cycle_id"
-
         fill_in "search", with: "74576345634XXXXXX"
         expect(page).to have_content "Sorry, no results found"
         expect(page).not_to have_content product2.name
@@ -222,8 +220,6 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
       it "returns search results for products where the search term matches one of the product's variant names" do
         visit shop_path
-        select "frogs", from: "order_cycle_id"
-
         fill_in "search", with: "Badg"           # For variant with display_name "Badgers"
 
         within('div.pad-top') do


### PR DESCRIPTION
#### What? Why?

Closes #4573 
This RP ticks the last check on 4573:
- [X] When there is only 1 OC available remove the drop down arrow

Replace the select with text when there's only one OC. I just re-used most of the select style.

1 OC available, before:
![Peek 2020-05-02 18-48](https://user-images.githubusercontent.com/1640378/80871691-9ecdc780-8ca5-11ea-88e0-0e2a45a10ded.gif)

1 OC available, after:
![image](https://user-images.githubusercontent.com/1640378/80871689-9b3a4080-8ca5-11ea-8582-2ac895808432.png)

#### What should we test?
We need to test this will work with tagged OCs that the user will not see.
Open two OCs and check the dropdown appears.
Tag one of the OCs so that the user will not have access to it. The dropdown should not appear with only one OC.

#### Release notes
Changelog Category: Changed
Replace dropdown with text in Order cycle selector when there's only one Order cycle available for the user.
