### PR TITLE
Improve order edit page in data inconsistency scenario (follow up from S2 #4186)

### DIFF
--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -1,26 +1,26 @@
 - shipment.manifest.each do |item|
   - line_item = order.find_line_item_by_variant(item.variant)
-  - break if line_item.blank?
 
-  %tr.stock-item{ "data-item-quantity" => "#{item.quantity}" }
-    %td.item-image
-      = mini_image(item.variant)
-    %td.item-name
-      = item.variant.product_and_full_name
-    %td.item-price.align-center
-      = line_item.single_money.to_html
-    %td.item-qty-show.align-center
-      - item.states.each do |state,count|
-        = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
-    - unless shipment.shipped?
-      %td.item-qty-edit.hidden
-        = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5
-    %td.item-total.align-center
-      = line_item_shipment_price(line_item, item.quantity)
+  - if line_item.present?
+    %tr.stock-item{ "data-item-quantity" => "#{item.quantity}" }
+      %td.item-image
+        = mini_image(item.variant)
+      %td.item-name
+        = item.variant.product_and_full_name
+      %td.item-price.align-center
+        = line_item.single_money.to_html
+      %td.item-qty-show.align-center
+        - item.states.each do |state,count|
+          = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
+      - unless shipment.shipped?
+        %td.item-qty-edit.hidden
+          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5
+      %td.item-total.align-center
+        = line_item_shipment_price(line_item, item.quantity)
 
-    %td.cart-item-delete.actions{ "data-hook" => "cart_item_delete" }
-      - if !shipment.shipped? && can?(:update, shipment)
-        = link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => t('actions.save'), :style => 'display: none'
-        = link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('actions.cancel'), :style => 'display: none'
-        = link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('actions.edit')
-        = link_to '', '#', :class => 'delete-item icon-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove', :confirm => t(:are_you_sure)}, :title => t('actions.delete')
+      %td.cart-item-delete.actions{ "data-hook" => "cart_item_delete" }
+        - if !shipment.shipped? && can?(:update, shipment)
+          = link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => t('actions.save'), :style => 'display: none'
+          = link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('actions.cancel'), :style => 'display: none'
+          = link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('actions.edit')
+          = link_to '', '#', :class => 'delete-item icon-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove', :confirm => t(:are_you_sure)}, :title => t('actions.delete')


### PR DESCRIPTION
#### What? Why?
This is a follow up from #5253 that improves the situation for #4186
This is handling a data inconsistency problem that is not critical therefore I am not writing specs for this. The next step is to investigate the root cause, but that's an S3 now so we leave it for later.

In this PR I am simply fixing my code in #5253, break is aborting the cycle through units, if one unit is broken (no line item found) we can still iterate through the other units so that the user sees the remaining items in the order instead of a empty order.
See Filipe's testing comments in #5253 for more details.

#### What should we test?
Have a look at the order from #5253
https://staging.openfoodfrance.org/admin/orders/R656741034/edit
No line items before this PR, one line item after this PR.

And/or repeat tests of #5253 and make sure the remaining line item (not the broken one) is now displayed.

#### Release notes
Changelog Category: Changed
Improved the handling of a data inconsistent scenario in the orders edit page.