### PR TITLE
Improve ship methods names on sample data

### DIFF
--- a/lib/tasks/sample_data/shipping_method_factory.rb
+++ b/lib/tasks/sample_data/shipping_method_factory.rb
@@ -26,7 +26,7 @@ class ShippingMethodFactory
   def create_pickup(enterprise)
     create_shipping_method(
       enterprise,
-      name: "Pickup",
+      name: "Pickup #{enterprise.name}",
       description: "pick-up at your awesome hub gathering place",
       require_ship_address: false,
       calculator_type: "Calculator::Weight"
@@ -36,7 +36,7 @@ class ShippingMethodFactory
   def create_delivery(enterprise)
     delivery = create_shipping_method(
       enterprise,
-      name: "Home delivery",
+      name: "Home delivery #{enterprise.name}",
       description: "yummy food delivered at your door",
       require_ship_address: true,
       calculator_type: "Spree::Calculator::FlatRate"


### PR DESCRIPTION
#### What? Why?

Make ship methods in sample data have the name of the enterprise so it's easier to distinguish them 

This how checkout will look like:
![image](https://user-images.githubusercontent.com/1640378/80918336-460d3600-8d5c-11ea-8504-fb59ade9f023.png)

#### What should we test?
I have tested this myself, I think this is unimportant enough to bypass tests here.

#### Release notes
Changelog Category: Changed
Small improvement to sample data used for testing.
