### PR TITLE
Change date displayed on sales_tax reports

### DIFF
--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -92,7 +92,7 @@ module OpenFoodNetwork
     # @return [Array]
     def row_for(line_item, order)
       [
-        order.created_at,
+        order.completed_at.strftime("%F %T"),
         order.id,
         order.bill_address.full_name,
         order.email,

--- a/lib/open_food_network/sales_tax_report.rb
+++ b/lib/open_food_network/sales_tax_report.rb
@@ -57,7 +57,7 @@ module OpenFoodNetwork
           totals = totals_of order.line_items
           shipping_cost = shipping_cost_for order
 
-          [order.number, order.created_at, totals[:items], totals[:items_total],
+          [order.number, order.completed_at.strftime("%F %T"), totals[:items], totals[:items_total],
            totals[:taxable_total], totals[:sales_tax], shipping_cost, order.shipping_tax, order.enterprise_fee_tax, order.total_tax,
            order.bill_address.full_name, order.distributor.andand.name]
         end

--- a/spec/lib/open_food_network/order_and_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/order_and_distributor_report_spec.rb
@@ -38,7 +38,7 @@ module OpenFoodNetwork
           table = subject.table
 
           expect(table[0]).to eq([
-                                   order.reload.created_at,
+                                   order.reload.completed_at.strftime("%F %T"),
                                    order.id,
                                    bill_address.full_name,
                                    order.email,


### PR DESCRIPTION
#### What? Why?
Closes #5306 

I just change the date called on the report generation, from `created_at` value to `completed_at` value, on Sales Tax reports and Order And Distributor reports.
The format is more consistent with codebase, hiding the part related to time zone.

#### What should we test?
On Sales Tax reports (accessible on `/admin/reports/sales_tax`) and Order And Distributor reports (accessible on `/admin/reports/order_and_distributors`), you need to check that the `completed_at` value is displayed on the `Date` column. ANd with a readable format, like `2020-05-02 01:51:49`.


#### Release notes
- Put completed_at date on Sales Tax reports and on Order And Distributor reports


Changelog Category: Changed
