### PR TITLE
Sort invoices in bulk invoice with completed_at desc order

### DIFF
--- a/app/services/bulk_invoice_service.rb
+++ b/app/services/bulk_invoice_service.rb
@@ -7,9 +7,8 @@ class BulkInvoiceService
 
   def start_pdf_job(order_ids)
     pdf = CombinePDF.new
-    orders = Spree::Order.where(id: order_ids)
 
-    orders.each do |order|
+    orders_from(order_ids).each do |order|
       invoice = renderer.render_to_string(order)
 
       pdf << CombinePDF.parse(invoice)
@@ -28,6 +27,10 @@ class BulkInvoiceService
   end
 
   private
+
+  def orders_from(order_ids)
+    Spree::Order.where(id: order_ids).order("completed_at DESC")
+  end
 
   def new_invoice_id
     Time.zone.now.to_i.to_s

--- a/app/services/bulk_invoice_service.rb
+++ b/app/services/bulk_invoice_service.rb
@@ -8,7 +8,7 @@ class BulkInvoiceService
   def start_pdf_job(order_ids)
     pdf = CombinePDF.new
 
-    orders_from(order_ids).each do |order|
+    orders_from(order_ids).find_each do |order|
       invoice = renderer.render_to_string(order)
 
       pdf << CombinePDF.parse(invoice)

--- a/app/services/bulk_invoice_service.rb
+++ b/app/services/bulk_invoice_service.rb
@@ -8,7 +8,7 @@ class BulkInvoiceService
   def start_pdf_job(order_ids)
     pdf = CombinePDF.new
 
-    orders_from(order_ids).find_each do |order|
+    orders_from(order_ids).each do |order|
       invoice = renderer.render_to_string(order)
 
       pdf << CombinePDF.parse(invoice)

--- a/spec/services/bulk_invoice_service_spec.rb
+++ b/spec/services/bulk_invoice_service_spec.rb
@@ -47,4 +47,11 @@ describe BulkInvoiceService do
       expect(filepath).to eq 'tmp/invoices/1234567.pdf'
     end
   end
+
+  describe "#orders_from" do
+    it "orders with completed desc" do
+      expect(service.send(:orders_from, [1, 2]).to_sql)
+        .to include('ORDER BY completed_at DESC')
+    end
+  end
 end

--- a/spec/services/bulk_invoice_service_spec.rb
+++ b/spec/services/bulk_invoice_service_spec.rb
@@ -50,8 +50,11 @@ describe BulkInvoiceService do
 
   describe "#orders_from" do
     it "orders with completed desc" do
-      expect(service.send(:orders_from, [1, 2]).to_sql)
-        .to include('ORDER BY completed_at DESC')
+      order_old = create(:order_with_distributor, :completed, completed_at: 2.minutes.ago)
+      order_older = create(:order_with_distributor, :completed, completed_at: 3.minutes.ago)
+
+      expect(service.send(:orders_from, [order_older.id, order_old.id]).pluck(:id))
+        .to eq([order_old.id, order_older.id])
     end
   end
 end

--- a/spec/services/bulk_invoice_service_spec.rb
+++ b/spec/services/bulk_invoice_service_spec.rb
@@ -60,11 +60,9 @@ describe BulkInvoiceService do
       order_oldest = create(:order_with_distributor, :completed, completed_at: 4.minutes.ago)
       order_older = create(:order_with_distributor, :completed, completed_at: 3.minutes.ago)
 
-      # This is the creation order provided `find_each` which invalidates
-      # our intended sorting by `completed_at`:
       expect(renderer).to receive(:render_to_string).with(order_old).ordered.and_return("")
-      expect(renderer).to receive(:render_to_string).with(order_oldest).ordered.and_return("")
       expect(renderer).to receive(:render_to_string).with(order_older).ordered.and_return("")
+      expect(renderer).to receive(:render_to_string).with(order_oldest).ordered.and_return("")
 
       order_ids = [order_oldest, order_old, order_older].map(&:id)
       service.start_pdf_job_without_delay(order_ids)


### PR DESCRIPTION
#### What? Why?

Closes #5321 

We need to find a way to pass the order of the list to the Print Invoice action. But first on this ticket, we will just focus on ordering with completed_at desc order.


#### What should we test?
On `/admin/orders`, when by clicking on `Print Invoices`, we need to control that the PDF generated is ordering the order following completed_at desc order.


#### Release notes
- Sort orders with completed_at desc order while using Print Invoices action


Changelog Category:  Changed
