### PR TITLE
change shop name to be link to shop on transactions page

### DIFF
--- a/app/views/spree/users/_skinny.html.haml
+++ b/app/views/spree/users/_skinny.html.haml
@@ -2,7 +2,8 @@
   .columns.small-2
     %img.margin-top.account-logo{"logo-fallback" => true, "ng-src" => "{{shop.logo}}"}
   .columns.small-5
-    %h3.margin-top{"ng-bind" => "::shop.name"}
+    %h3.margin-top
+      %a{"ng-href" => "{{::shop.hash}}#{main_app.shop_path}", "ng-bind" => "::shop.name"}
   .columns.small-4.text-right
     %h3.margin-top.distributor-balance{"ng-bind" => "::shop.balance | formatBalance", "ng-class" => "{'credit' : shop.balance < 0, 'debit' : shop.balance > 0, 'paid' : shop.balance == 0}" }
   .columns.small-1.text-right

--- a/spec/features/consumer/account_spec.rb
+++ b/spec/features/consumer/account_spec.rb
@@ -56,7 +56,11 @@ feature '
 
         # It shows all hubs that have been ordered from with balance or credit
         expect(page).to have_content distributor1.name
+        expect(page).to have_link(distributor1.name,
+                                  href: "#{distributor1.permalink}/shop", count: 1)
         expect(page).to have_content distributor2.name
+        expect(page).to have_link(distributor2.name,
+                                  href: "#{distributor2.permalink}/shop", count: 1)
         expect(page).not_to have_content distributor_without_orders.name
 
         expect(page).to have_content distributor1.name + " " + "Balance due"


### PR DESCRIPTION
#### What? Why?

(TBC)
Closes #[the issue number this PR is related to]

I changed the shop name on the Transactions page to be a link to the shop page.

Before
![Screen Shot 2020-05-04 at 07 10 48](https://user-images.githubusercontent.com/27960597/80955859-6974c700-8dd6-11ea-9db3-b4cc4bc325d4.png)

After
![Screen Shot 2020-05-04 at 07 05 38](https://user-images.githubusercontent.com/27960597/80955591-ece1e880-8dd5-11ea-99fb-86bdbd704622.png)


#### What should we test?
When you click on the shop name on the transactions page, you should be taken to the shop page.

#### Release notes
Change shop name on Transactions Page to be a link to the shop page.

Changelog Category: Changed

