### PR TITLE
Add NavigationCheck to order cycles edit form

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -29,7 +29,7 @@ angular.module("admin.enterprises")
     # from a directive "nav-check" in the page - if we pass it here it will be called in the test suite,
     # and on all new uses of this contoller, and we might not want that.
     enterpriseNavCallback = ->
-      if $scope.enterprise_form != undefined && $scope.enterprise_form.$dirty
+      if $scope.enterprise_form?.$dirty
         t('admin.unsaved_confirm_leave')
 
     # Register the NavigationCheck callback

--- a/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/edit.js.coffee
@@ -1,5 +1,5 @@
 angular.module('admin.orderCycles')
-  .controller 'AdminEditOrderCycleCtrl', ($scope, $controller, $filter, $location, $window, OrderCycle, Enterprise, EnterpriseFee, StatusMessage, Schedules, RequestMonitor, ocInstance) ->
+  .controller 'AdminEditOrderCycleCtrl', ($scope, $controller, $filter, $location, $window, OrderCycle, Enterprise, EnterpriseFee, StatusMessage, Schedules, RequestMonitor, NavigationCheck, ocInstance) ->
     $controller('AdminOrderCycleBasicCtrl', {$scope: $scope, ocInstance: ocInstance})
 
     order_cycle_id = $location.absUrl().match(/\/admin\/order_cycles\/(\d+)/)[1]
@@ -18,5 +18,12 @@ angular.module('admin.orderCycles')
 
     $scope.submit = ($event, destination) ->
       $event.preventDefault()
+      NavigationCheck.clear()
       StatusMessage.display 'progress', t('js.saving')
       OrderCycle.update(destination, $scope.order_cycle_form)
+
+    warnAboutUnsavedChanges = ->
+      if $scope.order_cycle_form?.$dirty
+        t('admin.unsaved_confirm_leave')
+
+    NavigationCheck.register(warnAboutUnsavedChanges)

--- a/spec/features/admin/order_cycles_complex_nav_check_spec.rb
+++ b/spec/features/admin/order_cycles_complex_nav_check_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+feature '
+    As an administrator
+    I want to be alerted when I navigate away from a dirty order cycle form
+', js: true do
+  include AuthenticationWorkflow
+
+  scenario "alert when navigating away from dirty form" do
+    # Given a 'complex' order cycle form
+    oc = create(:order_cycle)
+
+    # When I edit the form
+    quick_login_as_admin
+    visit edit_admin_order_cycle_path(oc)
+
+    wait_for_edit_form_to_load_order_cycle(oc)
+   
+    expect(page).to have_selector '.wizard-progress .current a', text: '1. GENERAL SETTINGS'
+    expect(page.find('#order_cycle_name').value).to eq(oc.name)
+    expect(page).to have_button("Save", disabled: true)
+    fill_in 'order_cycle_name', with: 'Plums & Avos'
+
+    # Then the form is dirty and an alert warns about navigating away from the form
+    expect(page).to have_button("Save", disabled: false)
+    expect(page).to have_selector '.wizard-progress a', text: '2. INCOMING PRODUCTS'
+    accept_alert do
+      click_link '2. Incoming Products'
+    end
+  end
+
+  private
+
+  def wait_for_edit_form_to_load_order_cycle(order_cycle)
+    expect(page).to have_field "order_cycle_name", with: order_cycle.name
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #5108

This adds a similar navigation check that is used on the enterprises form to the order_cycles edit form. This check pops up a javascript alert for the user when any attempt to change the window.location (or page refresh) occurs.

#### What should we test?
This can be manually tested by:
- Editing an order cycle for a hub (an enterprise that 'sells any').
- Make any change that triggers the activation of the save buttons, and the disabling of the next button
- Click any button that navigates to a new page (eg a nav item or the wizard links)
- An alert will display asking you to confirm that you want to leave the 'site' (as chrome calls it)
<img width="954" alt="Screen Shot 2020-05-04 at 10 58 14 pm" src="https://user-images.githubusercontent.com/2467577/80968174-d9c52c00-8e5a-11ea-89c0-6dd76d57b951.png">

I've also attempted to modify the spec for this form, `spec/features/admin/order_cycles_spec.rb` but am getting odd behavior that I haven't figured out yet (hence why this PR is WIP). I'm getting a selenium timeout on the ["editing an order cycle"](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/spec/features/admin/order_cycles_spec.rb#L428) scenario which makes modifying the test to handle these alerts difficult. I'm curious to see how CI fares.

#### Release notes
Alert administrators when an order cycle form is unsaved

Changelog Category: Fixed 

