### PR TITLE
Cart with soft-deletion

### DIFF
--- a/app/models/spree/stock/quantifier.rb
+++ b/app/models/spree/stock/quantifier.rb
@@ -11,6 +11,8 @@ module Spree
       end
 
       def total_on_hand
+        return 0 if @variant.deleted?
+
         stock_items.sum(&:count_on_hand)
       end
 

--- a/app/models/spree/stock/quantifier.rb
+++ b/app/models/spree/stock/quantifier.rb
@@ -11,6 +11,8 @@ module Spree
       end
 
       def total_on_hand
+        # Associated stock_items no longer exist if the variant has been soft-deleted. A variant
+        # may still be in an active cart after it's deleted, so this will mark it as out of stock.
         return 0 if @variant.deleted?
 
         stock_items.sum(&:count_on_hand)

--- a/app/services/variants_stock_levels.rb
+++ b/app/services/variants_stock_levels.rb
@@ -8,7 +8,7 @@ class VariantsStockLevels
     variant_stock_levels = variant_stock_levels(order.line_items.includes(variant: :stock_items))
 
     order_variant_ids = variant_stock_levels.keys
-    missing_variants = Spree::Variant.includes(:stock_items).
+    missing_variants = Spree::Variant.with_deleted.includes(:stock_items).
       where(id: (requested_variant_ids - order_variant_ids))
 
     missing_variants.each do |missing_variant|

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -227,6 +227,14 @@ describe OrderCycle do
           expect(oc.variants_distributed_by(d2)).not_to include p1_v_hidden, p1_v_deleted
           expect(oc.variants_distributed_by(d1)).to include p2_v
         end
+
+        context "with soft-deleted variants" do
+          it "does not consider soft-deleted variants to be currently distributed in the oc" do
+            p2_v.delete
+
+            expect(oc.variants_distributed_by(d1)).to_not include p2_v
+          end
+        end
       end
 
       context "when hub prefers product selection from inventory only" do

--- a/spec/models/spree/stock/quantifier_spec.rb
+++ b/spec/models/spree/stock/quantifier_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  module Stock
+    describe Quantifier do
+      let(:quantifier) { Spree::Stock::Quantifier.new(variant) }
+      let(:variant) { create(:variant, on_hand: 99) }
+
+      describe "#total_on_hand" do
+        context "with a soft-deleted variant" do
+          before do
+            variant.delete
+          end
+
+          it "returns zero stock for the variant" do
+            expect(quantifier.total_on_hand).to eq 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -32,6 +32,11 @@ describe VariantOverride do
         expect(VariantOverride.indexed(hub1)).to eq( variant => vo1 )
         expect(VariantOverride.indexed(hub2)).to eq( variant => vo2 )
       end
+
+      it "does not include overrides for soft-deleted variants" do
+        variant.delete
+        expect(VariantOverride.indexed(hub1)).to eq( nil => vo1 )
+      end
     end
   end
 

--- a/spec/services/cart_service_spec.rb
+++ b/spec/services/cart_service_spec.rb
@@ -60,7 +60,7 @@ describe CartService do
         let(:relevant_line_item) { order.reload.find_line_item_by_variant(variant) }
 
         describe "when the soft-deleted variant is not in the cart yet" do
-          xit "doesn't fail, and does not add the deleted variant to the cart" do
+          it "does not add the deleted variant to the cart" do
             variant.delete
 
             cart_service.populate({ variants: { variant.id.to_s => { quantity: '2' } } }, true)
@@ -70,17 +70,17 @@ describe CartService do
           end
         end
 
-        describe "when the soft-deleted variant already has a line_item in the cart" do
+        describe "when the soft-deleted variant is already in the cart" do
           let!(:existing_line_item) {
             create(:line_item, variant: variant, quantity: 2, order: order)
           }
 
-          xit "doesn't fail, and removes the line_item from the cart" do
+          it "removes the line_item from the cart" do
             variant.delete
 
-            cart_service.populate({ variants: { variant.id.to_s => { quantity: '2' } } }, true)
+            cart_service.populate({ variants: { variant.id.to_s => { quantity: '3' } } }, true)
 
-            expect(relevant_line_item).to be_nil
+            expect(Spree::LineItem.where(id: relevant_line_item).first).to be_nil
             expect(cart_service.errors.count).to be 0
           end
         end


### PR DESCRIPTION
#### What? Why?

Closes #5358 

Adds various missing specs for variant soft-deletion issues and adjusts `CartService` logic so that if a variant is soft-deleted whilst it's in an active cart or is added to a cart, the user gets useful feedback (and no fatal error problems), the item is removed and acts as if it has gone out of stock.

#### What should we test?
<!-- List which features should be tested and how. -->

Load a shop page, then delete a variant that's already shown on the page, then add that variant to the cart. It should show an out-of-stock modal and remove it from the cart.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed issues around adding deleted variants to cart.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
