### PR TITLE
Don't render twice

### DIFF
--- a/app/controllers/api/order_cycles_controller.rb
+++ b/app/controllers/api/order_cycles_controller.rb
@@ -7,7 +7,7 @@ module Api
     skip_before_filter :authenticate_user, :ensure_api_key, only: [:taxons, :properties]
 
     def products
-      render_no_products unless order_cycle.open?
+      return render_no_products unless order_cycle.open?
 
       products = ProductsRenderer.new(
         distributor,


### PR DESCRIPTION
#### What? Why?

Closes #5369 

Not much more to say here that isn't already in the title.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

I'm not sure we can test this one easily. The products list endpoint that displays products should not return an error when the shopfront is closed, but actually viewing a closed shopfront is quite difficult, and the product list shouldn't actually load successfully in this case anyway...

Edit: I've had another look, and I think we can do this to verify it's fixed:
- go to an open shop with an open order cycle
- look in the browser dev console in the network tab and find the request for the product list
- copy the full URL of the request, it'll have `/api/order_cycles` and `/products` in it, and `?distributor=` and some other bits
- close the order cycle
- paste that URL into the browser
- you shouldn't see the snail
- you shouldn't see much of anything else either, it'll be a blank json response

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed double-rendering of products in unusual closed shopfront edge case

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
