### PR TITLE
Cart add error handling

### DIFF
--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -50,7 +50,6 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
         @popQueue() if @update_enqueued
 
       .error (response, status)=>
-        @scheduleRetry(status)
         @update_running = false
 
     compareAndNotifyStockLevels: (stockLevels) =>
@@ -86,13 +85,6 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
           quantity: li.quantity
           max_quantity: li.max_quantity
       {variants: variants}
-
-    scheduleRetry: (status) =>
-      console.log "Error updating cart: #{status}. Retrying in 3 seconds..."
-      $timeout =>
-        console.log "Retrying cart update"
-        @orderChanged()
-      , 3000
 
     saved: =>
       @dirty = false

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $rootScope, $resource, localStorageService) ->
+Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $rootScope, $resource, localStorageService, RailsFlashLoader) ->
   # Handles syncing of current cart/order state to server
   new class Cart
     dirty: false
@@ -50,6 +50,7 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
         @popQueue() if @update_enqueued
 
       .error (response, status)=>
+        RailsFlashLoader.loadFlash({error: t('js.cart.add_to_cart_failed')})
         @update_running = false
 
     compareAndNotifyStockLevels: (stockLevels) =>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2438,6 +2438,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     resolve_errors: Please resolve the following errors
     more_items: "+ %{count} More"
     default_card_updated: Default Card Updated
+    cart:
+      add_to_cart_failed: >
+        There was a problem adding this product to the cart.
+        Perhaps it has become unavailable or the shop is closing.
     admin:
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
       modals:

--- a/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
@@ -3,6 +3,7 @@ describe 'Products service', ->
   Products = null
   OrderCycle = {}
   Shopfront = null
+  RailsFlashLoader = null
   Variants = null
   Cart = null
   shopfront = null
@@ -43,6 +44,8 @@ describe 'Products service', ->
     OrderCycle =
       order_cycle:
         order_cycle_id: 1
+    RailsFlashLoader =
+      loadFlash: (arg) ->
 
     module 'Darkswarm'
     module ($provide)->
@@ -52,12 +55,14 @@ describe 'Products service', ->
       $provide.value "properties", properties
       $provide.value "Geo", Geo
       $provide.value "OrderCycle", OrderCycle
+      $provide.value "railsFlash", null
       null
 
-    inject ($injector, _$httpBackend_)->
+    inject ($injector, _$httpBackend_, _RailsFlashLoader_)->
       Products = $injector.get("Products")
       Shopfront = $injector.get("Shopfront")
       Properties = $injector.get("Properties")
+      RailsFlashLoader = _RailsFlashLoader_
       Variants = $injector.get("Variants")
       Cart = $injector.get("Cart")
       $httpBackend = _$httpBackend_


### PR DESCRIPTION
#### What? Why?

Second part of #5358 

Now that the other part of the issue is fixed in #5361 we shouldn't see this case arise at all. In the rare event that an edge case pops up we will now:

- at least show the user some feedback letting them know something has gone wrong, instead of the cart breaking and nothing happening
- _not_ keep continuously re-posting the data to the endpoint if the endpoint is fatally failing to process it anyway (which kills the server)

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how. -->

If #5361 hasn't been merged yet, we can probably reproduce a cart error with the test steps from that PR:

> Load a shop page, then delete a variant that's already shown on the page, then add that variant to the cart.

I can't figure out how to actually get the cart to throw an error any other way.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved fatal error handling on `CartController#populate` endpoint

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
