### PR TITLE
Added inputmode attribute to show appropriate mobile keyboard for sel…

### DIFF
--- a/app/assets/javascripts/templates/forgot.html.haml
+++ b/app/assets/javascripts/templates/forgot.html.haml
@@ -28,3 +28,4 @@
           tabindex: "3",
           type: "submit",
           value: "{{'reset_password' | t}}"}
+

--- a/app/assets/javascripts/templates/forgot.html.haml
+++ b/app/assets/javascripts/templates/forgot.html.haml
@@ -20,6 +20,7 @@
           type: "email",
           id: "email",
           tabindex: 1,
+          inputmode: "email",
           "ng-model" => "spree_user.email"}
     .row
       .large-12.columns

--- a/app/assets/javascripts/templates/login.html.haml
+++ b/app/assets/javascripts/templates/login.html.haml
@@ -41,3 +41,4 @@
           tabindex: "3",
           type: "submit",
           value: "{{'label_login' | t}}"}
+

--- a/app/assets/javascripts/templates/login.html.haml
+++ b/app/assets/javascripts/templates/login.html.haml
@@ -15,6 +15,7 @@
           type: "email",
           id: "email",
           tabindex: 1,
+          inputmode: "email",
           "ng-model" => "spree_user.email"}
     .row
       .large-12.columns
@@ -24,6 +25,7 @@
           id: "password",
           autocomplete: "off",
           tabindex: 2,
+          inputmode: "password",
           "ng-model" => "spree_user.password"}
     .row
       .large-12.columns

--- a/app/assets/javascripts/templates/signup.html.haml
+++ b/app/assets/javascripts/templates/signup.html.haml
@@ -46,3 +46,4 @@
           tabindex: "3",
           type: "submit",
           value: "{{'action_signup' | t}}"}
+

--- a/app/assets/javascripts/templates/signup.html.haml
+++ b/app/assets/javascripts/templates/signup.html.haml
@@ -14,6 +14,7 @@
           type: "email",
           id: "email",
           tabindex: 1,
+          inputmode: "email",
           "ng-model" => "spree_user.email"}
         %span.error{"ng-show" => "errors.email != null"}
           {{ errors.email.join(' ') }}
@@ -25,6 +26,7 @@
           id: "password",
           autocomplete: "off",
           tabindex: 2,
+          inputmode: "password",
           "ng-model" => "spree_user.password"}
         %span.error{"ng-show" => "errors.password != null"}
           {{ errors.password.join(' ') }}
@@ -36,6 +38,7 @@
           id: "password_confirmation",
           autocomplete: "off",
           tabindex: 2,
+          inputmode: "password",
           "ng-model" => "spree_user.password_confirmation"}
     .row
       .large-12.columns

--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -21,10 +21,10 @@
 
       .row
         .small-6.columns
-          = validated_input t(:email), 'order.email', type: :email, "ofn-focus" => "accordion['details']"
+          = validated_input t(:email), 'order.email', type: "email", inputmode: "email", "ofn-focus" => "accordion['details']"
 
         .small-6.columns
-          = validated_input t(:phone), 'order.bill_address.phone'
+          = validated_input t(:phone), 'order.bill_address.phone', inputmode: "tel"
 
       .row
         .small-12.columns.text-right

--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -30,3 +30,4 @@
         .small-12.columns.text-right
           %button.primary{"ng-disabled" => "details.$invalid", "ng-click" => "login_or_next($event)"}
             = t :next
+


### PR DESCRIPTION
Closes #5104

Mobile UX issue regarding the dynamic keyboards on mobile devices. When a user is in a form field, the mobile keyboard should respond appropriately, primarily for email, passwords, and numbers (credit cards).

What should we test?
On mobile devices:

sign_up form, login_in form, and forgotten password form - all at https://openfoodnetwork.org.au/#/login
details on checkout (email and credit card details field). Credit card detail field should display number keypad - https://openfoodnetwork.org.au/checkout
user account settings (credit cards) Credit card detail field should display number keypad - https://openfoodnetwork.org.au/account#/cards
user account settings (account settings) Email and password fields should display correct mobile keyboard - user account settings (credit cards) Credit card detail field should display number keypad - https://openfoodnetwork.org.au/account#/settings
Release notes
Files changed:

app/assets/javascripts/templates/forgot.html.haml --> added inputmode: "email" attribute

app/assets/javascripts/templates/login.html.haml --> added inputmode: "email" and inputmode: "password" attributes

app/assets/javascripts/templates/signup.html.haml --> added inputmode: "email" and inputmode: "password" (x2) attributes

app/views/checkout/_details.html.haml --> added inputmode: "email" and inputmode: "tel" attributes.

input type= was left in the code as it did not change the outcome and could potentially affect older devices which support that syntax. In testing on Browserstack, this syntax is highly browser and device dependent, so results vary widely across devices.

Changelog Category: Changed