### PR TITLE
Update jquery-ui-rails version to 4.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem "foundation-rails"
 
 gem 'jquery-migrate-rails'
 gem 'jquery-rails', '3.1.5'
-gem 'jquery-ui-rails', '~> 4.0.0'
+gem 'jquery-ui-rails', '~> 4.1.1'
 gem 'select2-rails', '~> 3.4.7'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c'

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem "foundation-rails"
 
 gem 'jquery-migrate-rails'
 gem 'jquery-rails', '3.1.5'
-gem 'jquery-ui-rails', '~> 4.1.1'
+gem 'jquery-ui-rails', '~> 4.1.2'
 gem 'select2-rails', '~> 3.4.7'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,7 @@ GEM
     jquery-rails (3.1.5)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (4.0.5)
+    jquery-ui-rails (4.1.2)
       railties (>= 3.1.0)
     json (1.8.6)
     json_spec (1.1.5)
@@ -726,7 +726,7 @@ DEPENDENCIES
   immigrant
   jquery-migrate-rails
   jquery-rails (= 3.1.5)
-  jquery-ui-rails (~> 4.0.0)
+  jquery-ui-rails (~> 4.1.1)
   json_spec (~> 1.1.4)
   jwt (~> 2.2)
   kaminari (~> 0.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -726,7 +726,7 @@ DEPENDENCIES
   immigrant
   jquery-migrate-rails
   jquery-rails (= 3.1.5)
-  jquery-ui-rails (~> 4.1.1)
+  jquery-ui-rails (~> 4.1.2)
   json_spec (~> 1.1.4)
   jwt (~> 2.2)
   kaminari (~> 0.14.1)


### PR DESCRIPTION
#### What? Why?
There are some noise about assets not found related to jquery-ui-rails gem.

Relates to #5201 but doesn't solve it.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

~~This change will solve the noise for unable to find `ui-bg_flat_75_ffffff_40x100.png`. This is a bug in the gem itself and they introduce a `depend_on` as mentioned in https://github.com/jquery-ui-rails/jquery-ui-rails/pull/59 and https://github.com/jquery-ui-rails/jquery-ui-rails/pull/60.~~

So we only just need to update jquery-ui-rails to version 4.1.1

#### What should we test?
<!-- List which features should be tested and how. -->

Steps to reproduce the bug here: https://github.com/openfoodfoundation/openfoodnetwork/pull/5380#issuecomment-625021684

We should also do a sanity check on admin datepickers and dropdowns with search fields.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Update jquery-ui-rails version to 4.1.1 to introduce some depend_on assets in the gem as there are currently some assets errors in the application.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed


