### PR TITLE
[Spree 2.1] Fix Update and Calculate Fees button

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -109,6 +109,8 @@ module Spree
       private
 
       def order_params
+        return params[:order] if params[:order].blank?
+
         params.require(:order).permit(:distributor_id, :order_cycle_id)
       end
 

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -46,6 +46,14 @@ describe Spree::Admin::OrdersController, type: :controller do
     context "complete order" do
       let(:order) { create :completed_order_with_totals }
 
+      it "does not throw an error if no order object is given in params" do
+        params = { id: order }
+
+        spree_put :update, params
+
+        expect(response.status).to eq 302
+      end
+
       it "updates distribution charges and redirects to order details page" do
         expect_any_instance_of(Spree::Order).to receive(:update_distribution_charge!)
 


### PR DESCRIPTION
#### What? Why?

Closes #5362

Problem with strong params where order object is not sent to the server and is not needed. Strong params validation was expecting it.

#### What should we test?
Verify issue is fixed.
I recommend verifying that the bug only happens with completed orders, not orders in cart.

#### Release notes
Changelog Category: Fixed
Fix bug in strong params implementation in admin orders controller.
