### PR TITLE
[Spree 2.1] Fix enterprise package selection submit button

### DIFF
--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -27,7 +27,7 @@ Openfoodnetwork::Application.routes.draw do
 
       member do
         get :welcome
-        put :register
+        patch :register
       end
 
       resources :producer_properties do

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -124,6 +124,10 @@ feature "Registration", js: true do
 
       click_link "Go to Enterprise Dashboard"
       expect(page).to have_content "CHOOSE YOUR PACKAGE"
+
+      page.find('.full_hub h3').click
+      click_button "Select and Continue"
+      expect(page).to have_content "Your profile live"
     end
 
     context "when the user has no more remaining enterprises" do


### PR DESCRIPTION
#### What? Why?

Closes #5360

The target route needs to be patch in rails 4, put wont work. I extended the registration process spec to cover this step.

#### What should we test?
Verify the issue is solved.

#### Release notes
Changelog Category: Fixed
Fixed enterprise package selection submit button
