### PR TITLE
Fix translation keys in en.yml file from previous conflicting PRs

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3360,6 +3360,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           unit: "Unit"
       shared:
         sortable_header:
+          name: "Name"
           number: "Number"
           state: "State"
           payment_state: "Payment State"
@@ -3367,9 +3368,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           email: "Email"
           total: "Total"
       general_settings:
-      shared:
-        sortable_header:
-          name: "Name"
         edit:
           legal_settings: "Legal Settings"
           cookies_consent_banner_toggle: "Display cookies consent banner"


### PR DESCRIPTION
#### What? Why?
Resolves conflict between #5286 and #4966.

Updated en.yml to reflect changes made previously in two separate PRs. A conflict between the two created errors within the en.yml file

#### What should we test?
Is translation present on the orders list (number, state, payment_state, shipment_state, email, and total fields) at /admin/orders?q[s]=completed_at+desc
Is translation present on the name field within the admin Products List at /admin/products?

#### Release notes
Resolves conflict in en.yml file which was breaking the general settings translation keys

Changelog Category: Fixed