### PR TITLE
Make "backoffice only" ship methods work and remove option "frontoffice only"

### DIFF
--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -14,7 +14,7 @@ module EnterprisesHelper
   def available_shipping_methods
     return [] if current_distributor.blank?
 
-    shipping_methods = current_distributor.shipping_methods
+    shipping_methods = current_distributor.shipping_methods.display_on_checkout.to_a
 
     applicator = OpenFoodNetwork::TagRuleApplicator.new(current_distributor, "FilterShippingMethods", current_customer.andand.tag_list)
     applicator.filter!(shipping_methods)

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -30,6 +30,7 @@ Spree::ShippingMethod.class_eval do
   }
 
   scope :by_name, -> { order('spree_shipping_methods.name ASC') }
+  scope :display_on_checkout, -> { where("display_on is null OR display_on = ''") }
 
   # Return the services (pickup, delivery) that different distributors provide, in the format:
   # {distributor_id => {pickup: true, delivery: false}, ...}

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -30,7 +30,7 @@ Spree::ShippingMethod.class_eval do
   }
 
   scope :by_name, -> { order('spree_shipping_methods.name ASC') }
-  scope :display_on_checkout, -> { where("display_on is null OR display_on = ''") }
+  scope :display_on_checkout, -> { where("spree_shipping_methods.display_on is null OR spree_shipping_methods.display_on = ''") }
 
   # Return the services (pickup, delivery) that different distributors provide, in the format:
   # {distributor_id => {pickup: true, delivery: false}, ...}

--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -18,7 +18,7 @@
       .alpha.three.columns
         = f.label :display_on, t(:display)
       .omega.eight.columns
-        = select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [t(".#{display}"), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
+        = select(:shipping_method, :display_on, [[t(".both"), nil], [t(".back_end"), "back_end"]], {}, {class: 'select2 fullwidth'})
         = error_message_on :shipping_method, :display_on
 
   .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3221,9 +3221,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           zone: "Zone"
           calculator: "Calculator"
           display: "Display"
-          both: "Both"
-          front_end: "Front End"
-          back_end: "Back End"
+          both: "Both Checkout and Back office"
+          back_end: "Back office only"
           no_shipping_methods_found: "No shipping methods found"
         new:
           new_shipping_method: "New Shipping Method"
@@ -3235,9 +3234,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         form:
           categories: "Categories"
           zones: "Zones"
-          both: "Both"
-          front_end: "Front End"
-          back_end: "Back End"
+          both: "Both Checkout and Back office"
+          back_end: "Back office only"
       payment_methods:
         new:
           new_payment_method: "New Payment Method"

--- a/db/migrate/20200508101630_convert_frontend_shipping_method_to_both.rb
+++ b/db/migrate/20200508101630_convert_frontend_shipping_method_to_both.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ConvertFrontendShippingMethodToBoth < ActiveRecord::Migration
+  def up
+    # The display_on value front_end is not working
+    #   (it's not being used in the back office to ignore shipping methods marked as front_end)
+    # So, here we are converting all entries to the more generic "both" option
+    #   both is represented as nil in the database
+    # # This enables us to remove the front_end option from the code
+    execute("UPDATE spree_shipping_methods SET display_on = null WHERE display_on = 'front_end'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200430105459) do
+ActiveRecord::Schema.define(:version => 20200508101630) do
 
   create_table "adjustment_metadata", :force => true do |t|
     t.integer "adjustment_id"

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -229,6 +229,15 @@ feature "As a consumer I want to check out my cart", js: true do
         end
       end
 
+      it "filters out 'Back office only' shipping methods" do
+        expect(page).to have_content shipping_with_fee.name
+        shipping_with_fee.update_attribute :display_on, 'back_end' # Back office only
+
+        visit checkout_path
+        checkout_as_guest
+        expect(page).not_to have_content shipping_with_fee.name
+      end
+
       context "using FilterShippingMethods" do
         let(:user) { create(:user) }
         let(:customer) { create(:customer, user: user, enterprise: distributor) }

--- a/spec/helpers/enterprises_helper_spec.rb
+++ b/spec/helpers/enterprises_helper_spec.rb
@@ -8,8 +8,8 @@ describe EnterprisesHelper, type: :helper do
   before { allow(helper).to receive(:spree_current_user) { user } }
 
   describe "loading available shipping methods" do
-    let!(:sm1) { create(:shipping_method, require_ship_address: false, distributors: [distributor]) }
-    let!(:sm2) { create(:shipping_method, require_ship_address: false, distributors: [some_other_distributor]) }
+    let!(:distributor_shipping_method) { create(:shipping_method, require_ship_address: false, distributors: [distributor]) }
+    let!(:other_distributor_shipping_method) { create(:shipping_method, require_ship_address: false, distributors: [some_other_distributor]) }
 
     context "when the order has no current_distributor" do
       before do
@@ -25,8 +25,8 @@ describe EnterprisesHelper, type: :helper do
       before { allow(helper).to receive(:current_distributor) { distributor } }
 
       it "finds the shipping methods for the current distributor" do
-        expect(helper.available_shipping_methods).to_not include sm2
-        expect(helper.available_shipping_methods).to include sm1
+        expect(helper.available_shipping_methods).to_not include other_distributor_shipping_method
+        expect(helper.available_shipping_methods).to include distributor_shipping_method
       end
     end
 
@@ -44,8 +44,8 @@ describe EnterprisesHelper, type: :helper do
                is_default: true,
                preferred_shipping_method_tags: "local-delivery")
       }
-      let!(:tagged_sm) { sm1 }
-      let!(:untagged_sm) { sm2 }
+      let!(:tagged_sm) { distributor_shipping_method }
+      let!(:untagged_sm) { other_distributor_shipping_method }
 
       before do
         tagged_sm.update_attribute(:tag_list, 'local-delivery')

--- a/spec/helpers/enterprises_helper_spec.rb
+++ b/spec/helpers/enterprises_helper_spec.rb
@@ -28,6 +28,14 @@ describe EnterprisesHelper, type: :helper do
         expect(helper.available_shipping_methods).to_not include other_distributor_shipping_method
         expect(helper.available_shipping_methods).to include distributor_shipping_method
       end
+
+      it "does not return 'back office only' shipping method" do
+        backoffice_only_shipping_method = create(:shipping_method, require_ship_address: false, distributors: [distributor], display_on: 'back_end')
+
+        expect(helper.available_shipping_methods).to_not include backoffice_only_shipping_method
+        expect(helper.available_shipping_methods).to_not include other_distributor_shipping_method
+        expect(helper.available_shipping_methods).to include distributor_shipping_method
+      end
     end
 
     context "when FilterShippingMethods tag rules are in effect" do


### PR DESCRIPTION
#### What? Why?
This doesnt fix the root cause of #5367 but I think it's a good workaround. And it makes something that was broken work.

The "display on" field of shipping methods was basically ignored everywhere before this PR.
After this PR:
- the "back office only" ship methods will not show up on checkout :tada:
- we will not see the "frontoffice only" option: making shipping methods only available in checkout (this would not be straight forward to fix because we would need to make the backoffice ignore these shipping methods...).

So, re #5367, managers instead of unlinking the ship methods from their enterprise, they can just set them as "backoffice only" so that it's not available on checkout.

#### What should we test?
We need to verify ship methods tagged with this "back office only" tag do not show up in the checkout. We need to verify these methods will still be available in admin when editing an order.

#### Release notes
Changelog Category: Fixed
Shipping methods can now be marked "Backoffice only" and that will work: the shipping method will not be available for users in the checkout process but will be available in the backoffice when editing an order.
