### PR TITLE
Make test not depend on response's order

### DIFF
--- a/spec/controllers/api/shops_controller_spec.rb
+++ b/spec/controllers/api/shops_controller_spec.rb
@@ -37,8 +37,9 @@ module Api
           spree_get :closed_shops, nil
 
           expect(json_response).not_to match hub.name
-          expect(json_response[0]['id']).to eq closed_hub1.id
-          expect(json_response[1]['id']).to eq closed_hub2.id
+
+          response_ids = json_response.map { |shop| shop['id'] }
+          expect(response_ids).to contain_exactly(closed_hub1.id, closed_hub2.id)
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

I'm assuming this is failing in CI due to the order in which the closed shops are returned.

This is blocking the release's build.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes

Make test not rely on the order of the returned records.

Changelog Category: Fixed