### PR TITLE
5300 Avoid race conditions in Spree::StockItem

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -363,6 +363,13 @@ Rails/UniqueValidationWithoutIndex:
     - 'app/models/customer.rb'
     - 'app/models/exchange.rb'
 
+# Offense count: 2
+# Configuration parameters: Include.
+# Include: app/models/**/*.rb
+Rails/UniqueValidationWithoutIndex:
+  Exclude:
+    - 'app/models/spree/stock_item.rb'
+
 # Offense count: 1
 # Configuration parameters: Environments.
 # Environments: development, test, production

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -1,0 +1,52 @@
+module Spree
+  class StockItem < ActiveRecord::Base
+    belongs_to :stock_location, class_name: 'Spree::StockLocation'
+    belongs_to :variant, class_name: 'Spree::Variant'
+    has_many :stock_movements, dependent: :destroy
+
+    validates_presence_of :stock_location, :variant
+    validates_uniqueness_of :variant_id, scope: :stock_location_id
+
+    attr_accessible :count_on_hand, :variant, :stock_location, :backorderable, :variant_id
+
+    delegate :weight, to: :variant
+
+    def backordered_inventory_units
+      Spree::InventoryUnit.backordered_for_stock_item(self)
+    end
+
+    def variant_name
+      variant.name
+    end
+
+    def adjust_count_on_hand(value)
+      self.with_lock do
+        self.count_on_hand = self.count_on_hand + value
+        process_backorders if in_stock?
+
+        self.save!
+      end
+    end
+
+    def in_stock?
+      self.count_on_hand > 0
+    end
+
+    # Tells whether it's available to be included in a shipment
+    def available?
+      self.in_stock? || self.backorderable?
+    end
+
+    private
+      def count_on_hand=(value)
+        write_attribute(:count_on_hand, value)
+      end
+
+      def process_backorders
+        backordered_inventory_units.each do |unit|
+          return unless in_stock?
+          unit.fill_backorder
+        end
+      end
+  end
+end

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -6,8 +6,8 @@ module Spree
     belongs_to :variant, class_name: 'Spree::Variant'
     has_many :stock_movements, dependent: :destroy
 
-    validates_presence_of :stock_location, :variant
-    validates_uniqueness_of :variant_id, scope: :stock_location_id
+    validates :stock_location, :variant, presence: true
+    validates :variant_id, uniqueness: { scope: :stock_location_id }
 
     attr_accessible :count_on_hand, :variant, :stock_location, :backorderable, :variant_id
 

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -17,9 +17,7 @@ module Spree
       Spree::InventoryUnit.backordered_for_stock_item(self)
     end
 
-    def variant_name
-      variant.name
-    end
+    delegate :name, to: :variant, prefix: true
 
     def adjust_count_on_hand(value)
       with_lock do

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -47,7 +47,7 @@ module Spree
 
     def process_backorders
       backordered_inventory_units.each do |unit|
-        return unless in_stock?
+        break unless in_stock?
 
         unit.fill_backorder
       end

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Spree
   class StockItem < ActiveRecord::Base
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
@@ -39,15 +40,17 @@ module Spree
     end
 
     private
-      def count_on_hand=(value)
-        write_attribute(:count_on_hand, value)
-      end
 
-      def process_backorders
-        backordered_inventory_units.each do |unit|
-          return unless in_stock?
-          unit.fill_backorder
-        end
+    def count_on_hand=(value)
+      write_attribute(:count_on_hand, value)
+    end
+
+    def process_backorders
+      backordered_inventory_units.each do |unit|
+        return unless in_stock?
+
+        unit.fill_backorder
       end
+    end
   end
 end

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -10,6 +10,7 @@ module Spree
     # rubocop:disable Rails/UniqueValidationWithoutIndex
     validates :variant_id, uniqueness: { scope: :stock_location_id }
     # rubocop:enable Rails/UniqueValidationWithoutIndex
+    validates :count_on_hand, numericality: { greater_than_or_equal_to: 0, unless: :backorderable? }
 
     attr_accessible :count_on_hand, :variant, :stock_location, :backorderable, :variant_id
 

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Spree
   class StockItem < ActiveRecord::Base
     belongs_to :stock_location, class_name: 'Spree::StockLocation'

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -42,7 +42,7 @@ module Spree
     private
 
     def count_on_hand=(value)
-      write_attribute(:count_on_hand, value)
+      self[:count_on_hand] = value
     end
 
     def process_backorders

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -20,21 +20,21 @@ module Spree
     end
 
     def adjust_count_on_hand(value)
-      self.with_lock do
-        self.count_on_hand = self.count_on_hand + value
+      with_lock do
+        self.count_on_hand = count_on_hand + value
         process_backorders if in_stock?
 
-        self.save!
+        save!
       end
     end
 
     def in_stock?
-      self.count_on_hand > 0
+      count_on_hand > 0
     end
 
     # Tells whether it's available to be included in a shipment
     def available?
-      self.in_stock? || self.backorderable?
+      in_stock? || backorderable?
     end
 
     private

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -7,9 +7,7 @@ module Spree
     has_many :stock_movements, dependent: :destroy
 
     validates :stock_location, :variant, presence: true
-    # rubocop:disable Rails/UniqueValidationWithoutIndex
     validates :variant_id, uniqueness: { scope: :stock_location_id }
-    # rubocop:enable Rails/UniqueValidationWithoutIndex
     validates :count_on_hand, numericality: { greater_than_or_equal_to: 0, unless: :backorderable? }
 
     attr_accessible :count_on_hand, :variant, :stock_location, :backorderable, :variant_id

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -31,7 +31,7 @@ module Spree
     end
 
     def in_stock?
-      count_on_hand > 0
+      count_on_hand.positive?
     end
 
     # Tells whether it's available to be included in a shipment

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -7,7 +7,9 @@ module Spree
     has_many :stock_movements, dependent: :destroy
 
     validates :stock_location, :variant, presence: true
+    # rubocop:disable Rails/UniqueValidationWithoutIndex
     validates :variant_id, uniqueness: { scope: :stock_location_id }
+    # rubocop:enable Rails/UniqueValidationWithoutIndex
 
     attr_accessible :count_on_hand, :variant, :stock_location, :backorderable, :variant_id
 

--- a/db/migrate/20200512070717_add_lock_version_to_stock_items.rb
+++ b/db/migrate/20200512070717_add_lock_version_to_stock_items.rb
@@ -1,0 +1,5 @@
+class AddLockVersionToStockItems < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_items, :lock_version, :integer, default: 0
+  end
+end

--- a/db/migrate/20200514174526_reset_negative_nonbackorderable_count_on_hand_in_stock_items.rb
+++ b/db/migrate/20200514174526_reset_negative_nonbackorderable_count_on_hand_in_stock_items.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ResetNegativeNonbackorderableCountOnHandInStockItems < ActiveRecord::Migration
+  module Spree
+    class StockItem < ActiveRecord::Base
+      self.table_name = "spree_stock_items"
+    end
+  end
+
+  def up
+    Spree::StockItem.where(backorderable: false)
+      .where("count_on_hand < 0")
+      .update_all(count_on_hand: 0)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -899,6 +899,7 @@ ActiveRecord::Schema.define(version: 20200623140437) do
     t.datetime "updated_at"
     t.boolean  "backorderable",     default: false
     t.datetime "deleted_at"
+    t.integer  "lock_version",      default: 0
   end
 
   add_index "spree_stock_items", ["stock_location_id", "variant_id"], name: "stock_item_by_loc_and_var_id", using: :btree

--- a/spec/controllers/checkout_controller_concurrency_spec.rb
+++ b/spec/controllers/checkout_controller_concurrency_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # This is the first example of testing concurrency in the Open Food Network.
@@ -15,6 +17,20 @@ describe CheckoutController, concurrency: true, type: :controller do
   let(:payment_method) { create(:payment_method, distributors: [distributor]) }
   let(:breakpoint) { Mutex.new }
 
+  let(:address_params) { address.attributes.except("id") }
+  let(:order_params) {
+    {
+      "payments_attributes" => [
+        {
+          "payment_method_id" => payment_method.id,
+          "amount" => order.total
+        }
+      ],
+      "bill_address_attributes" => address_params,
+      "ship_address_attributes" => address_params,
+    }
+  }
+
   before do
     # Create a valid order ready for checkout:
     create(:shipping_method, distributors: [distributor])
@@ -26,7 +42,9 @@ describe CheckoutController, concurrency: true, type: :controller do
     allow(controller).to receive(:spree_current_user).and_return(order.user)
     allow(controller).to receive(:current_distributor).and_return(order.distributor)
     allow(controller).to receive(:current_order_cycle).and_return(order.order_cycle)
+  end
 
+  it "handles two concurrent orders successfully" do
     # New threads start running straight away. The breakpoint is after loading
     # the order and before advancing the order's state and making payments.
     breakpoint.lock
@@ -36,21 +54,6 @@ describe CheckoutController, concurrency: true, type: :controller do
       # I did not find out how to call the original code otherwise.
       ActiveSupport::Notifications.instrument("spree.checkout.update")
     end
-  end
-
-  it "waits for concurrent checkouts" do
-    # Basic data the user submits during checkout:
-    address_params = address.attributes.except("id")
-    order_params = {
-      "payments_attributes" => [
-        {
-          "payment_method_id" => payment_method.id,
-          "amount" => order.total
-        }
-      ],
-      "bill_address_attributes" => address_params,
-      "ship_address_attributes" => address_params,
-    }
 
     # Starting two checkout threads. The controller code will determine if
     # these two threads are synchronised correctly or run into a race condition.

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -97,7 +97,7 @@ module Spree
       end
 
       it "caps at zero when stock is negative" do
-        v.update! on_hand: -2
+        v.__send__(:stock_item).update_column(:count_on_hand, -2)
         li.cap_quantity_at_stock!
         expect(li.reload.quantity).to eq 0
       end
@@ -123,7 +123,7 @@ module Spree
           before { vo.update(count_on_hand: -3) }
 
           it "caps at zero" do
-            v.update(on_hand: -2)
+            v.__send__(:stock_item).update_column(:count_on_hand, -2)
             li.cap_quantity_at_stock!
             expect(li.reload.quantity).to eq 0
           end

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Spree::StockItem do
+  let(:stock_location) { create(:stock_location_with_items) }
+
+  subject { stock_location.stock_items.order(:id).first }
+
+  it 'maintains the count on hand for a variant' do
+    subject.count_on_hand.should eq 10
+  end
+
+  it "can return the stock item's variant's name" do
+    subject.variant_name.should == subject.variant.name
+  end
+
+  context "available to be included in shipment" do
+    context "has stock" do
+      it { subject.should be_available }
+    end
+
+    context "backorderable" do
+      before { subject.backorderable = true }
+      it { subject.should be_available }
+    end
+
+    context "no stock and not backorderable" do
+      before do
+        subject.backorderable = false
+        subject.stub(count_on_hand: 0)
+      end
+
+      it { subject.should_not be_available }
+    end
+  end
+
+  context "adjust count_on_hand" do
+    let!(:current_on_hand) { subject.count_on_hand }
+
+    it 'is updated pessimistically' do
+      copy = Spree::StockItem.find(subject.id)
+
+      subject.adjust_count_on_hand(5)
+      subject.count_on_hand.should eq(current_on_hand + 5)
+
+      copy.count_on_hand.should eq(current_on_hand)
+      copy.adjust_count_on_hand(5)
+      copy.count_on_hand.should eq(current_on_hand + 10)
+    end
+
+    context "item out of stock (by two items)" do
+      let(:inventory_unit) { double('InventoryUnit') }
+      let(:inventory_unit_2) { double('InventoryUnit2') }
+
+      before { subject.adjust_count_on_hand(- (current_on_hand + 2)) }
+
+      it "doesn't process backorders" do
+        subject.should_not_receive(:backordered_inventory_units)
+        subject.adjust_count_on_hand(1)
+      end
+
+      context "adds new items" do
+        before { subject.stub(:backordered_inventory_units => [inventory_unit, inventory_unit_2]) }
+
+        it "fills existing backorders" do
+          inventory_unit.should_receive(:fill_backorder)
+          inventory_unit_2.should_receive(:fill_backorder)
+
+          subject.adjust_count_on_hand(3)
+          subject.count_on_hand.should == 1
+        end
+      end
+    end
+  end
+end

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -8,30 +8,30 @@ RSpec.describe Spree::StockItem do
   subject { stock_location.stock_items.order(:id).first }
 
   it 'maintains the count on hand for a variant' do
-    subject.count_on_hand.should eq 10
+    expect(subject.count_on_hand).to eq 10
   end
 
   it "can return the stock item's variant's name" do
-    subject.variant_name.should == subject.variant.name
+    expect(subject.variant_name).to eq(subject.variant.name)
   end
 
   context "available to be included in shipment" do
     context "has stock" do
-      it { subject.should be_available }
+      it { expect(subject).to be_available }
     end
 
     context "backorderable" do
       before { subject.backorderable = true }
-      it { subject.should be_available }
+      it { expect(subject).to be_available }
     end
 
     context "no stock and not backorderable" do
       before do
         subject.backorderable = false
-        subject.stub(count_on_hand: 0)
+        allow(subject).to receive_messages(count_on_hand: 0)
       end
 
-      it { subject.should_not be_available }
+      it { expect(subject).not_to be_available }
     end
   end
 
@@ -42,11 +42,11 @@ RSpec.describe Spree::StockItem do
       copy = Spree::StockItem.find(subject.id)
 
       subject.adjust_count_on_hand(5)
-      subject.count_on_hand.should eq(current_on_hand + 5)
+      expect(subject.count_on_hand).to eq(current_on_hand + 5)
 
-      copy.count_on_hand.should eq(current_on_hand)
+      expect(copy.count_on_hand).to eq(current_on_hand)
       copy.adjust_count_on_hand(5)
-      copy.count_on_hand.should eq(current_on_hand + 10)
+      expect(copy.count_on_hand).to eq(current_on_hand + 10)
     end
 
     context "item out of stock (by two items)" do
@@ -56,19 +56,19 @@ RSpec.describe Spree::StockItem do
       before { subject.adjust_count_on_hand(- (current_on_hand + 2)) }
 
       it "doesn't process backorders" do
-        subject.should_not_receive(:backordered_inventory_units)
+        expect(subject).not_to receive(:backordered_inventory_units)
         subject.adjust_count_on_hand(1)
       end
 
       context "adds new items" do
-        before { subject.stub(backordered_inventory_units: [inventory_unit, inventory_unit_2]) }
+        before { allow(subject).to receive_messages(backordered_inventory_units: [inventory_unit, inventory_unit_2]) }
 
         it "fills existing backorders" do
-          inventory_unit.should_receive(:fill_backorder)
-          inventory_unit_2.should_receive(:fill_backorder)
+          expect(inventory_unit).to receive(:fill_backorder)
+          expect(inventory_unit_2).to receive(:fill_backorder)
 
           subject.adjust_count_on_hand(3)
-          subject.count_on_hand.should == 1
+          expect(subject.count_on_hand).to eq(1)
         end
       end
     end

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::StockItem do
+RSpec.describe Spree::StockItem do
   let(:stock_location) { create(:stock_location_with_items) }
 
   subject { stock_location.stock_items.order(:id).first }

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe Spree::StockItem do
@@ -59,7 +60,7 @@ RSpec.describe Spree::StockItem do
       end
 
       context "adds new items" do
-        before { subject.stub(:backordered_inventory_units => [inventory_unit, inventory_unit_2]) }
+        before { subject.stub(backordered_inventory_units: [inventory_unit, inventory_unit_2]) }
 
         it "fills existing backorders" do
           inventory_unit.should_receive(:fill_backorder)

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spree::StockItem do
   subject { stock_location.stock_items.order(:id).first }
 
   it 'maintains the count on hand for a variant' do
-    expect(subject.count_on_hand).to eq 10
+    expect(subject.count_on_hand).to eq 15
   end
 
   it "can return the stock item's variant's name" do

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Spree::StockItem do


### PR DESCRIPTION
#### What? Why?

- References #5300

I've looked into #5300, exploring if the negative inventory levels could be related to a missing callback for guest checkout, subscriptions, and the now removed backorders, but this doesn't seem to be the case.

The issue seems to be that stock levels in `Spree::StockItem`, which we check for stock levels before completing an order, could be updated by another order before the stock level is updated by the current order.

This PR introduces two changes:

* Optimistic locking for `Spree::StockItem` via `lock_version`.
* Require `count_on_hand` in `Spree::StockItem` to be positive if not backorderable.

#### What should we test?

Scenario 1: Stock restrictions for customer checking out should still work. Open two browser sessions, one logged in as admin (Session A), another logged in as customer (Session B).

1. **Session A:** Set the stock level of a product to limited stock with e.g. 4.
2. **Session B:** Add less than total stock left to cart, e.g. 3.
3. **Session A:** Update the stock level of the product to be less than the quantity in cart, e.g. 2.
4. **Session B:** Attempt to check out. This should warn of insufficient stock.
5. **Session B:** Reduce quantity in cart, e.g. 2.
6. **Session B:** Checkout should succeed.

Scenario 2: Stock restrictions for admin setting up an order should still work. Open two browser sessions, both logged in as admin.

1. **Session A:** Set the stock level of a product to limited stock with e.g. 4.
2. **Session B:** Create an order, Add less than total stock left to cart, e.g. 3.
3. **Session A:** Update the stock level of the product to be less than the quantity in cart, e.g. 2.
4. **Session B:** Attempt to complete the order. This should succeed but reduce the quantity in the order to the max available.

#### Release notes

Address race condition resulting in orders exceeding available stock.

Changelog Category: Fixed