### PR TITLE
Order Cycle design sweep

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -76,13 +76,14 @@ ordercycle {
       color: $white;
       background-color: transparent;
       border: 0;
+      border-radius: 0 $radius-small $radius-small 0;
       margin-bottom: 0;
       font-size: 1em;
       line-height: 1.3em;
       padding: 0.5em 1.25em 0.5em 0.75em;
       height: 2.35em;
-      background-size: 30px auto;
-      border-radius: 0 $radius-small $radius-small 0;
+      background-position-x: 102%;
+      background-size: 30px auto;      
       min-width: 13em;
 
       @include breakpoint(mobile) {

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -168,7 +168,7 @@ shop ordercycle {
 
     @include breakpoint(tablet) {
       float: none;
-      padding: 0 0 10px;
+      padding: 0;
     }
   }
 

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -111,6 +111,7 @@ ordercycle {
 
     @include breakpoint(mobile) {
       display: flex;
+      margin-right: 0;
     }
   }
 

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -63,6 +63,8 @@ ordercycle {
 
     select {
       background-image: url('/assets/white-caret.svg');
+      background-size: 30px auto;
+      background-position-x: 102%;
     }
 
     p {
@@ -71,20 +73,18 @@ ordercycle {
 
     select,
     p {
-      width: 200px;
       display: inline-block;
       color: $white;
       background-color: transparent;
       border: 0;
       border-radius: 0 $radius-small $radius-small 0;
       margin-bottom: 0;
+      padding: 0.5em 1.25em 0.5em 0.75em;
       font-size: 1em;
       line-height: 1.3em;
-      padding: 0.5em 1.25em 0.5em 0.75em;
       height: 2.35em;
-      background-position-x: 102%;
-      background-size: 30px auto;      
       min-width: 13em;
+      width: 200px;
 
       @include breakpoint(mobile) {
         width: 100%;

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -71,7 +71,7 @@ ordercycle {
 
     select,
     p {
-      width: inherit;
+      width: 200px;
       display: inline-block;
       color: $white;
       background-color: transparent;
@@ -88,6 +88,10 @@ ordercycle {
       @include breakpoint(mobile) {
         width: 100%;
         min-width: 0;
+      }
+
+      @media all and (min-width: 640px) and (max-width: 1024px), (min-width: 1200px) {
+        width: 250px;
       }
     }
 

--- a/app/assets/stylesheets/darkswarm/distributor_header.css.scss
+++ b/app/assets/stylesheets/darkswarm/distributor_header.css.scss
@@ -20,10 +20,6 @@ section {
     padding: 30px 0 0;
     position: relative;
 
-    select {
-      width: 200px;
-    }
-
     img {
       display: block;
       height: 100px;

--- a/app/assets/stylesheets/darkswarm/shop.css.scss
+++ b/app/assets/stylesheets/darkswarm/shop.css.scss
@@ -234,6 +234,7 @@ $sidebar-footer-height: 5em;
   .warning-sign {
     margin: 0 10px 0 5px;
     display: inline-block;
+    line-height: 1.9rem;
 
     strong {
       color: $grey-650;


### PR DESCRIPTION
#### What? Why?

This PR addresses most points in #4572

OC Selector

- [x] Increase width of OC selector dropdown so more characters can fit in [desktop & tablet]
               - the width is currently 200px, in this PR we make it 250px for screens between 640px and 1024px and screens larger than 1200px

- [x] Widen OC selector dropdown on RIGHT SIDE so it has equal margins on left and right sides [mobile]
- [x] Add padding to the left of the dropdown caret/arrow so it’s not positioned directly next to the text [all breakpoints]

Both points above:
![image](https://user-images.githubusercontent.com/1640378/81692000-aafc1680-9455-11ea-9c83-04ec1a5fe93d.png)

No open OC

- [x] Exclamation point ‘!’ and ‘Orders are closed’ text is not vertically centred with the shape [mobile]
![image](https://user-images.githubusercontent.com/1640378/81691941-9029a200-9455-11ea-8547-13c7f36db14f.png)

#### What should we test?
Verify points described above.

#### Release notes
Changelog Category: Changed
Improved design details according to Order Cycle design sweep.
