### PR TITLE
[Spree 2.1] Add missing permitted param to Column Preferences controller

### DIFF
--- a/app/assets/javascripts/templates/admin/columns_dropdown.html.haml
+++ b/app/assets/javascripts/templates/admin/columns_dropdown.html.haml
@@ -4,7 +4,7 @@
   %div.menu{ 'ng-show' => "expanded" }
     %div.menu_item{ ng: { repeat: "column in columns", click: "toggle(column)", class: "{selected: column.visible}" } }
       %span.check
-      %span.name {{column.name }}
+      %span.name {{ column.name }}
     %hr
     %div.menu_item.text-center
       %input.fullwidth.orange{ type: "button", ng: { value: "saved() ? 'Saved': 'Saving'", show: "saved() || saving", disabled: "saved()" } }

--- a/app/controllers/admin/column_preferences_controller.rb
+++ b/app/controllers/admin/column_preferences_controller.rb
@@ -8,7 +8,6 @@ module Admin
       @cp_set.collection.each { |cp| authorize! :bulk_update, cp }
 
       if @cp_set.save
-        # Return saved VOs with IDs
         render json: @cp_set.collection, each_serializer: Api::Admin::ColumnPreferenceSerializer
       else
         if @cp_set.errors.present?
@@ -22,17 +21,22 @@ module Admin
     private
 
     def permitted_params
-      params.permit(:action_name, column_preferences: [:id, :user_id, :action_name, :column_name, :visible])
+      params.permit(
+        :action_name,
+        column_preferences: [:id, :user_id, :action_name, :column_name, :name, :visible]
+      )
     end
 
     def load_collection
-      collection_hash = Hash[permitted_params[:column_preferences].each_with_index.map { |cp, i| [i, cp] }]
+      collection_hash = Hash[permitted_params[:column_preferences].
+        each_with_index.map { |cp, i| [i, cp] }]
       collection_hash.select!{ |_i, cp| cp[:action_name] == permitted_params[:action_name] }
       @cp_set = ColumnPreferenceSet.new @column_preferences, collection_attributes: collection_hash
     end
 
     def collection
-      ColumnPreference.where(user_id: spree_current_user, action_name: permitted_params[:action_name])
+      ColumnPreference.where(user_id: spree_current_user,
+                             action_name: permitted_params[:action_name])
     end
 
     def collection_actions


### PR DESCRIPTION
#### What? Why?

Closes #5387

This was caused by a missing permitted param in the columns preferences controller.

#### What should we test?
Verify the issue is fixed.
