### PR TITLE
Fix closed shop message not displaying full-width

### DIFF
--- a/app/views/shop/messages/_closed_shop.html.haml
+++ b/app/views/shop/messages/_closed_shop.html.haml
@@ -1,15 +1,16 @@
-.row.closed-shop-header
-  .small-12.columns
-    .content{ "darker-background" => true }
-      %h4
-        .warning-sign
-          .rectangle
-          %strong !
-        .message
-          = t :shopping_oc_closed
-      %p
-        = render partial: "shopping_shared/next_order_cycle"
-        = render partial: "shopping_shared/last_order_cycle"
+.closed-shop-header
+  .row
+    .small-12.columns
+      .content{ "darker-background" => true }
+        %h4
+          .warning-sign
+            .rectangle
+            %strong !
+          .message
+            = t :shopping_oc_closed
+        %p
+          = render partial: "shopping_shared/next_order_cycle"
+          = render partial: "shopping_shared/last_order_cycle"
 
 .row
   .small-12.columns


### PR DESCRIPTION
#### What? Why?

This came up in a design sweep, tracked here: https://github.com/openfoodfoundation/openfoodnetwork/issues/4572#issuecomment-626374074

Fixes layout for orders closed message. It now looks like this:

![Screenshot from 2020-05-12 18-26-35](https://user-images.githubusercontent.com/9029026/81720477-c29bc500-947e-11ea-9577-5cebc775448c.png)

Previously the dark grey background was cropped to the inner content width instead of expanding to the full page width.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Orders closed messages are fullwidth as intended.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Adjusted layout for display of orders closed message in shopfront.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
