### PR TITLE
Show order edit link on mobile instead of the cancel link

### DIFF
--- a/app/views/spree/users/_open_orders.html.haml
+++ b/app/views/spree/users/_open_orders.html.haml
@@ -7,8 +7,8 @@
         %th.order3.show-for-large-up= t('.changes_allowed_until')
         %th.order4.show-for-large-up= t('.items')
         %th.order5.text-right= t('.total')
-        %th.order6.text-right.show-for-large-up= t('.edit')
-        %th.order7.text-right= t('.cancel')
+        %th.order6.text-right= t('.edit')
+        %th.order7.show-for-large-up.text-right= t('.cancel')
       %tbody.transaction-group{"ng-repeat" => "order in Orders.changeable", "ng-class-odd"=>"'odd'", "ng-class-even"=>"'even'"}
         %tr.order-row
           %td.order1
@@ -18,7 +18,7 @@
           %td.order3.show-for-large-up{"ng-bind" => "::order.changes_allowed_until"}
           %td.order4.show-for-large-up{"ng-bind" => "::order.item_count"}
           %td.order5.text-right{"ng-class" => "{'credit' : order.total < 0, 'debit' : order.total > 0, 'paid' : order.total == 0}","ng-bind" => "::order.total | localizeCurrency"}
-          %td.order6.text-right.show-for-large-up.brick
+          %td.order6.text-right.brick
             %a{"ng-href" => "{{::order.path}}" }= t('.edit')
-          %td.order7.text-right
+          %td.order7.show-for-large-up.text-right
             = link_to t('.cancel'), "", method: :put, "ng-href" => "{{::order.cancel_path}}", "confirm-link-click" => t('orders_confirm_cancel')


### PR DESCRIPTION
#### What? Why?

Closes #4973

Switch cancel button with edit button on mobile view. Screenshots [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/4973#issuecomment-625851421).

#### What should we test?
Verify the large screen page and also the mobile view and make sure the edit link is visible and that it fits the screen.

#### Release notes
Changelog Category: Changed
On the account orders list, on mobile, show edit order link instead of cancel order link.
