### PR TITLE
[Spree 2.1] Product Import - Add variant_unit_name to the list of fields to be ignored when creating a variant

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -64,7 +64,8 @@ module ProductImport
     def mark_as_new_variant(entry, product_id)
       new_variant = Spree::Variant.new(
         entry.assignable_attributes.except('id', 'product_id', 'on_hand', 'on_demand',
-                                           'variant_unit', 'variant_unit_scale', 'primary_taxon_id')
+                                           'variant_unit', 'variant_unit_name',
+                                           'variant_unit_scale', 'primary_taxon_id')
       )
       new_variant.save
       new_variant.on_demand = entry.attributes['on_demand'] if entry.attributes['on_demand'].present?
@@ -311,7 +312,8 @@ module ProductImport
 
     def mark_as_existing_variant(entry, existing_variant)
       existing_variant.assign_attributes(
-        entry.assignable_attributes.except('id', 'product_id', 'variant_unit', 'variant_unit_scale', 'primary_taxon_id')
+        entry.assignable_attributes.except('id', 'product_id', 'variant_unit', 'variant_unit_name',
+                                           'variant_unit_scale', 'primary_taxon_id')
       )
       check_on_hand_nil(entry, existing_variant)
 


### PR DESCRIPTION
#### What? Why?

Closes #5363

This field was breaking the creation of variants. And, for unknown reason also breaking the permalink generation process :man_shrugging: we may need to come back to this later if the problem occurs again.

#### What should we test?
Verify product import works with variant_unit_name set and with products with names that would give equal permalinks.
