### PR TITLE
[Spree 2.1] Add missing strong params to less important controllers missed by specs

### DIFF
--- a/app/controllers/spree/admin/countries_controller.rb
+++ b/app/controllers/spree/admin/countries_controller.rb
@@ -1,6 +1,9 @@
 module Spree
   module Admin
     class CountriesController < ResourceController
+
+      protected
+
       def permitted_resource_params
         params.require(:country).
           permit(:name, :iso_name, :states_required)

--- a/app/controllers/spree/admin/countries_controller.rb
+++ b/app/controllers/spree/admin/countries_controller.rb
@@ -1,6 +1,11 @@
 module Spree
   module Admin
     class CountriesController < ResourceController
+      def permitted_resource_params
+        params.require(:country).
+          permit(:name, :iso_name, :states_required)
+      end
+
       def collection
         super.order(:name)
       end

--- a/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -19,6 +19,11 @@ module Spree
           @return_authorization.add_variant(variant_id.to_i, qty.to_i)
         end
       end
+
+      def permitted_resource_params
+        params.require(:return_authorization).
+          permit(:amount, :reason, :stock_location_id)
+      end
     end
   end
 end

--- a/app/controllers/spree/admin/shipping_categories_controller.rb
+++ b/app/controllers/spree/admin/shipping_categories_controller.rb
@@ -1,6 +1,9 @@
 module Spree
   module Admin
     class ShippingCategoriesController < ResourceController
+
+      protected
+
       def permitted_resource_params
         params.require(:shipping_category).
           permit(:name, :temperature_controlled)

--- a/app/controllers/spree/admin/shipping_categories_controller.rb
+++ b/app/controllers/spree/admin/shipping_categories_controller.rb
@@ -1,6 +1,10 @@
 module Spree
   module Admin
     class ShippingCategoriesController < ResourceController
+      def permitted_resource_params
+        params.require(:shipping_category).
+          permit(:name, :temperature_controlled)
+      end
     end
   end
 end

--- a/spec/controllers/spree/admin/countries_controller_spec.rb
+++ b/spec/controllers/spree/admin/countries_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe CountriesController, type: :controller do
+      include AuthenticationWorkflow
+
+      describe "#update" do
+        before { login_as_admin }
+
+        it "updates the name of an existing country" do
+          country = create(:country)
+          spree_put :update, id: country.id,
+                             country: { name: "Kyrgyzstan" }
+
+          expect(response).to redirect_to spree.admin_countries_url
+          expect(country.reload.name).to eq "Kyrgyzstan"
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe ReturnAuthorizationsController, type: :controller do
+      include AuthenticationWorkflow
+
+      let(:order) do
+        create(:order, :with_line_item, :completed,
+               distributor: create(:distributor_enterprise) )
+      end
+
+      before do
+        login_as_admin
+
+        # Pay the order
+        order.payments.first.complete
+        order.updater.update_payment_state
+
+        # Ship the order
+        order.reload.shipment.ship!
+      end
+
+      it "creates and updates a return authorization" do
+        # Create return authorization
+        spree_post :create, order_id: order.number,
+                            return_authorization: { amount: "20.2", reason: "broken" }
+
+        expect(response).to redirect_to spree.admin_order_return_authorizations_url(order.number)
+        return_authorization = order.return_authorizations.first
+        expect(return_authorization.amount.to_s).to eq "20.2"
+        expect(return_authorization.reason.to_s).to eq "broken"
+
+        # Update return authorization
+        spree_put :update, id: return_authorization.id,
+                           return_authorization: { amount: "10.2", reason: "half broken" }
+
+        expect(response).to redirect_to spree.admin_order_return_authorizations_url(order.number)
+        return_authorization.reload
+        expect(return_authorization.amount.to_s).to eq "10.2"
+        expect(return_authorization.reason.to_s).to eq "half broken"
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe ShippingCategoriesController, type: :controller do
+      include AuthenticationWorkflow
+
+      describe "#create and #update" do
+        before { login_as_admin }
+
+        it "creates a shipping shipping category" do
+          expect {
+            spree_post :create, shipping_category: { name: "Frozen" }
+          }.to change(Spree::ShippingCategory.all, :count).by(1)
+
+          expect(response).to redirect_to spree.admin_shipping_categories_url
+        end
+
+        it "updates an existing shipping category" do
+          shipping_category = create(:shipping_category)
+          spree_put :update, id: shipping_category.id,
+                             shipping_category: { name: "Super Frozen" }
+
+          expect(response).to redirect_to spree.admin_shipping_categories_url
+          expect(shipping_category.reload.name).to eq "Super Frozen"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Fixes a few minor problems in the rails 4 branch:
- cannot edit country name
- cannot add shipping category
- cannot add/edit return authorization to shipped orders

These cases were not covered by specs. I found them by searching for controllers that inherit from resource controller but do not define required params.
I added specs for them now.

#### What should we test?
Verify that you can
- edit country name
- add new shipping category
- add/edit return authorization to shipped orders
