### PR TITLE
Add warning to enterprise Shipping Method list and to Shipping method edit page

### DIFF
--- a/app/views/admin/enterprises/form/_shipping_methods.html.haml
+++ b/app/views/admin/enterprises/form/_shipping_methods.html.haml
@@ -1,4 +1,6 @@
 - if @shipping_methods.count > 0
+  .row
+    = t 'spree.admin.shipping_methods.form.deactivation_warning'
   %table
     %thead
       %tr

--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -1,4 +1,4 @@
-=admin_inject_shipping_method
+= admin_inject_shipping_method
 .alpha.eleven.columns{ "ng-app" => "admin.shippingMethods",
   "ng-controller" => "shippingMethodCtrl" }
   .row
@@ -46,26 +46,26 @@
     .alpha.eleven.columns
       = render partial: 'spree/admin/shared/calculator_fields', locals: { f: f }
 
-.alpha.six.columns
-  .alpha.six.columns
-    %fieldset.categories.no-border-bottom
-      %legend{align: "center"}= t('.categories')
-      = f.field_container :categories do
-        - Spree::ShippingCategory.all.each do |category|
-          = label_tag do
-            = check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category))
-            = category.name
-            %br/
-        = error_message_on :shipping_method, :shipping_category_id
+  .row
+    .alpha.eleven.columns
+      %fieldset.categories.no-border-bottom
+        %legend{align: "center"}= t('.categories')
+        = f.field_container :categories do
+          - Spree::ShippingCategory.all.each do |category|
+            = label_tag do
+              = check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category))
+              = category.name
+              %br/
+          = error_message_on :shipping_method, :shipping_category_id
 
-  .alpha.six.columns
-    %fieldset.no-border-bottom
-      %legend{align: "center"}= t('.zones')
-      = f.field_container :zones do
-        - shipping_method_zones = @shipping_method.zones.to_a
-        - Spree::Zone.all.each do |zone|
-          = label_tag do
-            = check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone))
-            = zone.name
-          %br/
-        = error_message_on :shipping_method, :zone_id
+    .alpha.eleven.columns
+      %fieldset.no-border-bottom
+        %legend{align: "center"}= t('.zones')
+        = f.field_container :zones do
+          - shipping_method_zones = @shipping_method.zones.to_a
+          - Spree::Zone.all.each do |zone|
+            = label_tag do
+              = check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone))
+              = zone.name
+            %br/
+          = error_message_on :shipping_method, :zone_id

--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -2,6 +2,8 @@
 .alpha.eleven.columns{ "ng-app" => "admin.shippingMethods",
   "ng-controller" => "shippingMethodCtrl" }
   .row
+    = t '.deactivation_warning'
+  .row
     .alpha.three.columns
       = f.label :name, t(:name)
     .omega.eight.columns

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -12,7 +12,8 @@
     %fieldset.no-border-top
       = render partial: 'form', locals: { f: f }
       .one.column &nbsp;
-      = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :shipping_method }
+      .alpha.four.columns
+        = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :shipping_method }
       .clear
-      %div
+      .row
         = render partial: 'spree/admin/shared/edit_resource_links'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,12 +741,12 @@ en:
           ofn_uid: OFN UID
           ofn_uid_tip: The unique id used to identify the enterprise on Open Food Network.
         shipping_methods:
-          name: Name
-          applies: Applies?
-          manage: Manage Shipping Methods
-          create_button: Create New Shipping Method
-          create_one_button: Create One Now
-          no_method_yet: You don't have any shipping methods yet.
+          name: "Name"
+          applies: "Active?"
+          manage: "Manage Shipping Methods"
+          create_button: "Create New Shipping Method"
+          create_one_button: "Create One Now"
+          no_method_yet: "You don't have any shipping methods yet."
         shop_preferences:
           shopfront_requires_login: "Publicly visible shopfront?"
           shopfront_requires_login_tip: "Choose whether customers must login to view the shopfront or if it's visible to everybody."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3246,6 +3246,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           zones: "Zones"
           both: "Both Checkout and Back office"
           back_end: "Back office only"
+          deactivation_warning: "De-activating a shipping method can make the shipping method disappear from your list. Alternatively, you can hide a shipping method from the checkout page by setting the option 'Display' to 'back office only'."
       payment_methods:
         new:
           new_payment_method: "New Payment Method"


### PR DESCRIPTION
#### What? Why?

Closes #5399
See issue for screenshots.

Note: the alternative offered in the warning message is still broken in master but will be working after PR #5392. This Pr can only be merged after #5392 is merged.

Here I also change the translation in the enterprise ship method list from "Applies?" to "Active?"
![image](https://user-images.githubusercontent.com/1640378/81826264-83797c80-952f-11ea-861d-55be91a1b55d.png)

I also move the hubs selector up to the right side of the page where it was original in OFN v1:
![image](https://user-images.githubusercontent.com/1640378/81826328-94c28900-952f-11ea-89bf-3156afad52c7.png)


#### What should we test?
Verify the warning message is clearly displayed on both pages.


#### Release notes
Changelog Category: Added
Add warning message to shipping methods list and edit page so that user is aware of the problems of de-activating a shipping methods and knows what is the alternative.
