### PR TITLE
Add warning to payment method edit page

### DIFF
--- a/app/views/spree/admin/payment_methods/_form.html.haml
+++ b/app/views/spree/admin/payment_methods/_form.html.haml
@@ -1,6 +1,8 @@
 = admin_inject_payment_method
 = admin_inject_json_ams_array "admin.paymentMethods", "shops", @hubs, Api::Admin::BasicEnterpriseSerializer
-%div.alpha.eleven.columns{ "ng-app" => "admin.paymentMethods", "ng-controller" => "paymentMethodCtrl" }
+.alpha.eleven.columns{ "ng-app" => "admin.paymentMethods", "ng-controller" => "paymentMethodCtrl" }
+  .row
+    = t '.deactivation_warning'
   .row
     .alpha.three.columns
       = label_tag nil, t(:name)

--- a/app/views/spree/admin/payment_methods/_form.html.haml
+++ b/app/views/spree/admin/payment_methods/_form.html.haml
@@ -5,40 +5,40 @@
     = t '.deactivation_warning'
   .row
     .alpha.three.columns
-      = label_tag nil, t(:name)
+      = label_tag nil, t('.name')
     .omega.eight.columns
       = text_field :payment_method, :name, class: 'fullwidth'
   .row
     .alpha.three.columns
-      = label_tag nil, t(:description)
+      = label_tag nil, t('.description')
     .omega.eight.columns
       = text_area :payment_method, :description, {cols: 60, rows: 6, class: 'fullwidth'}
   - if spree_current_user.admin?
     .row
       .alpha.three.columns
-        = label_tag nil, t(:environment)
+        = label_tag nil, t('.environment')
       .omega.eight.columns
         = collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {id: 'gtwy-env', class: 'select2 fullwidth'})
   .row
     .alpha.three.columns
-      = label_tag nil, t(:display)
+      = label_tag nil, t('.display')
     .omega.eight.columns
       = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t('.' + display.to_s), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
   .row
     .alpha.three.columns
-      = label_tag nil, t(:active)
+      = label_tag nil, t('.active')
     .two.columns
       = radio_button :payment_method, :active, true
       &nbsp;
-      = label_tag nil, t(:say_yes)
+      = label_tag nil, t('.active_yes')
     .omega.six.columns
       = radio_button :payment_method, :active, false
       &nbsp;
-      = label_tag nil, t(:say_no)
+      = label_tag nil, t('.active_no')
 
   .row
     .alpha.three.columns
-      = label(:payment_method, :tags, t(:tags))
+      = label(:payment_method, :tags, t('.tags'))
     .omega.eight.columns
       = hidden_field(:payment_method, :tag_list, "ng-value" => "paymentMethod.tag_list")
       %tags-with-translation#something{ object: "paymentMethod" }

--- a/app/views/spree/admin/payment_methods/_form.html.haml
+++ b/app/views/spree/admin/payment_methods/_form.html.haml
@@ -21,7 +21,7 @@
     .alpha.three.columns
       = label_tag nil, t(:display)
     .omega.eight.columns
-      = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
+      = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t('.' + display.to_s), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
   .row
     .alpha.three.columns
       = label_tag nil, t(:active)

--- a/app/views/spree/admin/payment_methods/_providers.html.haml
+++ b/app/views/spree/admin/payment_methods/_providers.html.haml
@@ -1,7 +1,7 @@
 #provider-settings{ ng: { controller: "ProvidersCtrl" } }
   .row
     .alpha.three.columns
-      = label :payment_method, :type, t(:provider)
+      = label :payment_method, :type, t('.provider')
     .omega.eight.columns
       = collection_select(:payment_method, :type, @providers, :to_s, :clean_name, (!@object.persisted? ? { :selected => "Spree::PaymentMethod::Check"} : {}), { class: 'select2 fullwidth', 'provider-prefs-for' => "#{@object.id}"})
 

--- a/app/views/spree/admin/payment_methods/edit.html.haml
+++ b/app/views/spree/admin/payment_methods/edit.html.haml
@@ -4,7 +4,7 @@
   = @payment_method.name
 - content_for :page_actions do
   %li
-    = button_link_to t(:new), spree.new_admin_payment_method_path, icon: 'icon-plus'
+    = button_link_to t('.new'), spree.new_admin_payment_method_path, icon: 'icon-plus'
   %li
     = button_link_to t('.back_to_payment_methods_list'), spree.admin_payment_methods_path, icon: 'icon-arrow-left'
 = render partial: 'spree/shared/error_messages', locals: { target: @payment_method }

--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -34,7 +34,7 @@
               %br/
           %td= method.type
           %td.align-center= method.environment.to_s.titleize
-          %td.align-center= method.display_on.blank? ? Spree.t(:both) : Spree.t(method.display_on)
+          %td.align-center= method.display_on.blank? ? t('.both') : t('.' + method.display_on.to_s)
           %td.align-center= method.active ? Spree.t(:say_yes) : Spree.t(:say_no)
           %td.actions
             = link_to_edit method, no_text: true

--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -1,9 +1,9 @@
 - content_for :page_title do
-  = Spree.t(:payment_methods)
+  = t('.payment_methods')
 
 - content_for :page_actions do
   %li
-    = button_link_to Spree.t(:new_payment_method), new_object_url, icon: 'icon-plus', id: 'admin_new_payment_methods_link'
+    = button_link_to t('.new_payment_method'), new_object_url, icon: 'icon-plus', id: 'admin_new_payment_methods_link'
 
 - if @payment_methods.any?
   %table#listing_payment_methods.index
@@ -17,12 +17,12 @@
       %col{style: "width: 11%"}
     %thead
       %tr
-        %th= Spree.t(:name)
-        %th= t(:products_distributor)
-        %th= Spree.t(:provider)
-        %th= Spree.t(:environment)
-        %th= Spree.t(:display)
-        %th= Spree.t(:active)
+        %th= t('.name')
+        %th= t('.products_distributor')
+        %th= t('.provider')
+        %th= t('.environment')
+        %th= t('.display')
+        %th= t('.active')
         %th.actions
     %tbody
       - @payment_methods.each do |method|
@@ -35,9 +35,9 @@
           %td= method.type
           %td.align-center= method.environment.to_s.titleize
           %td.align-center= method.display_on.blank? ? t('.both') : t('.' + method.display_on.to_s)
-          %td.align-center= method.active ? Spree.t(:say_yes) : Spree.t(:say_no)
+          %td.align-center= method.active ? t('.active_yes') : t('.active_no')
           %td.actions
             = link_to_edit method, no_text: true
             = link_to_delete method, no_text: true
 - else
-  .alpha.twelve.columns.no-objects-found= Spree.t(:no_payment_methods_found)
+  .alpha.twelve.columns.no-objects-found= t('.no_payment_methods_found')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3025,8 +3025,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     new_state: "New State"
 
     payment_methods: "Payment Methods"
-    new_payment_method: "New Payment Method"
-    provider: "Provider"
 
     taxonomies: "Taxonomies"
     new_taxonomy: "New Taxonomy"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3249,13 +3249,25 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           deactivation_warning: "De-activating a shipping method can make the shipping method disappear from your list. Alternatively, you can hide a shipping method from the checkout page by setting the option 'Display' to 'back office only'."
       payment_methods:
         index:
+          payment_methods: "Payment Methods"
+          new_payment_method: "New Payment Method"
+          name: "Name"
+          products_distributor: "Distributor"
+          provider: "Provider"
+          environment: "Environment"
+          display: "Display"
+          active: "Active"
           both: "Both"
           front_end: "Checkout only"
           back_end: "Back office only"
+          active_yes: "Yes"
+          active_no: "No"
+          no_payment_methods_found: "No payment methods found"
         new:
           new_payment_method: "New Payment Method"
           back_to_payment_methods_list: "Back To Payment Methods List"
         edit:
+          new: "New"
           editing_payment_method: "Editing Payment Method"
           back_to_payment_methods_list: "Back To Payment Methods List"
         stripe_connect:
@@ -3272,10 +3284,20 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           business_name: Business Name
           charges_enabled: Charges Enabled
         form:
+          name: "Name"
+          description: "Description"
+          environment: "Environment"
+          display: "Display"
+          active: "Active"
+          active_yes: "Yes"
+          active_no: "No"
           both: "Both Checkout and Back office"
           front_end: "Checkout only"
           back_end: "Back office only"
+          tags: "Tags"
           deactivation_warning: "De-activating a payment method can make the payment method disappear from your list. Alternatively, you can hide a payment method from the checkout page by setting the option 'Display' to 'back office only'."
+        providers:
+          provider: "Provider"
       payments:
         source_forms:
           stripe:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3248,6 +3248,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           back_end: "Back office only"
           deactivation_warning: "De-activating a shipping method can make the shipping method disappear from your list. Alternatively, you can hide a shipping method from the checkout page by setting the option 'Display' to 'back office only'."
       payment_methods:
+        index:
+          both: "Both"
+          front_end: "Checkout only"
+          back_end: "Back office only"
         new:
           new_payment_method: "New Payment Method"
           back_to_payment_methods_list: "Back To Payment Methods List"
@@ -3267,6 +3271,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           account_id: Account ID
           business_name: Business Name
           charges_enabled: Charges Enabled
+        form:
+          both: "Both Checkout and Back office"
+          front_end: "Checkout only"
+          back_end: "Back office only"
       payments:
         source_forms:
           stripe:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3275,6 +3275,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           both: "Both Checkout and Back office"
           front_end: "Checkout only"
           back_end: "Back office only"
+          deactivation_warning: "De-activating a payment method can make the payment method disappear from your list. Alternatively, you can hide a payment method from the checkout page by setting the option 'Display' to 'back office only'."
       payments:
         source_forms:
           stripe:


### PR DESCRIPTION
#### What? Why?

Following #5424 (shipping methods), in this PR we add a warning message to payment methods edit page as well.

![image](https://user-images.githubusercontent.com/1640378/81833128-3c8f8500-9537-11ea-90f2-cb4989ce289f.png)

As part of this PR I tested that the display field is working for both "Checkout only" and "Backoffice only". This PR makes these option values translatable!

Also, we bring quite a few translations that were only in spree in the payments list, new and edit page. Looking at FR production I can see the form labels Tags and Active in the edit page will now be translatable.

#### What should we test?
Verify the new warning and check translations are not broken.
Verify the "display" field appears for both managers and super admins.

#### Release notes
Changelog Category: Added
Add warning message to payment methods edit page so that user is aware of the problems of de-activating a payment method and knows what is the alternative.
