### PR TITLE
Upgrade jquery-ui-rails to v4.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ gem "foundation-rails"
 
 gem 'jquery-migrate-rails'
 gem 'jquery-rails', '3.1.5'
-gem 'jquery-ui-rails', '~> 4.1.2'
+gem 'jquery-ui-rails', '~> 4.2'
 gem 'select2-rails', '~> 3.4.7'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', ref: '60da2ae4c44cbb4c8d602f59fb5fff8d0f21db3c'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,8 +425,8 @@ GEM
     jquery-rails (3.1.5)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (4.1.2)
-      railties (>= 3.1.0)
+    jquery-ui-rails (4.2.1)
+      railties (>= 3.2.16)
     json (1.8.6)
     json_spec (1.1.5)
       multi_json (~> 1.0)
@@ -734,7 +734,7 @@ DEPENDENCIES
   immigrant
   jquery-migrate-rails
   jquery-rails (= 3.1.5)
-  jquery-ui-rails (~> 4.1.2)
+  jquery-ui-rails (~> 4.2)
   json_spec (~> 1.1.4)
   jwt (~> 2.2)
   kaminari (~> 0.14.1)


### PR DESCRIPTION
#### What? Why?

Follow up from #5380
I tried upgrading to 5.0.5 but it didnt work. But we can upgrade from 4.1 to 4.2 :+1:


#### What should we test?
We can try and see if this time #5201 is fixed. 

We should also do a sanity check on admin datepickers and dropdowns with search fields.

#### Release notes
Changelog Category: Changed

Bump jquery-ui-rails to 4.2.1

