### PR TITLE
5400 List each order only once in Orders And Distributors report

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -226,7 +226,6 @@ Layout/LineLength:
   - spec/lib/open_food_network/group_buy_report_spec.rb
   - spec/lib/open_food_network/lettuce_share_report_spec.rb
   - spec/lib/open_food_network/option_value_namer_spec.rb
-  - spec/lib/open_food_network/order_and_distributor_report_spec.rb
   - spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
   - spec/lib/open_food_network/order_cycle_permissions_spec.rb
   - spec/lib/open_food_network/order_grouper_spec.rb

--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -34,7 +34,9 @@ module OpenFoodNetwork
     end
 
     def search
-      @permissions.visible_orders.complete.not_state(:canceled).search(@params[:q])
+      @permissions.visible_orders.select("DISTINCT spree_orders.*").
+        complete.not_state(:canceled).
+        search(@params[:q])
     end
 
     def table

--- a/spec/lib/open_food_network/order_and_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/order_and_distributor_report_spec.rb
@@ -47,6 +47,7 @@ module OpenFoodNetwork
 
           table = subject.table
 
+          expect(table.size).to eq 1
           expect(table[0]).to eq([
                                    order.reload.completed_at.strftime("%F %T"),
                                    order.id,
@@ -69,6 +70,17 @@ module OpenFoodNetwork
                                    shipping_method.name,
                                    shipping_instructions
                                  ])
+        end
+
+        it "prints one row per line item" do
+          pending "Each line item is shown multiple times when there is more than one item in the order"
+
+          create(:line_item_with_shipment, order: order)
+
+          subject = OrderAndDistributorReport.new(create(:admin_user), {}, true)
+
+          table = subject.table
+          expect(table.size).to eq 2 # currently 4
         end
       end
     end

--- a/spec/lib/open_food_network/order_and_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/order_and_distributor_report_spec.rb
@@ -8,11 +8,16 @@ module OpenFoodNetwork
         subject = OrderAndDistributorReport.new nil
 
         header = subject.header
-        expect(header).to eq(['Order date', 'Order Id',
-                              'Customer Name', 'Customer Email', 'Customer Phone', 'Customer City',
-                              'SKU', 'Item name', 'Variant', 'Quantity', 'Max Quantity', 'Cost', 'Shipping Cost',
-                              'Payment Method',
-                              'Distributor', 'Distributor address', 'Distributor city', 'Distributor postcode', 'Shipping Method', 'Shipping instructions'])
+        expect(header).to eq(
+          [
+            'Order date', 'Order Id',
+            'Customer Name', 'Customer Email', 'Customer Phone', 'Customer City',
+            'SKU', 'Item name', 'Variant', 'Quantity', 'Max Quantity', 'Cost', 'Shipping Cost',
+            'Payment Method',
+            'Distributor', 'Distributor address', 'Distributor city', 'Distributor postcode',
+            'Shipping Method', 'Shipping instructions'
+          ]
+        )
       end
 
       context 'with completed order' do
@@ -21,7 +26,12 @@ module OpenFoodNetwork
         let(:product) { create(:product) }
         let(:shipping_method) { create(:shipping_method) }
         let(:shipping_instructions) { 'pick up on thursday please!' }
-        let(:order) { create(:order, state: 'complete', completed_at: Time.zone.now, distributor: distributor, bill_address: bill_address, special_instructions: shipping_instructions) }
+        let(:order) {
+          create(:order,
+                 state: 'complete', completed_at: Time.zone.now,
+                 distributor: distributor, bill_address: bill_address,
+                 special_instructions: shipping_instructions)
+        }
         let(:payment_method) { create(:payment_method, distributors: [distributor]) }
         let(:payment) { create(:payment, payment_method: payment_method, order: order) }
         let(:line_item) { create(:line_item_with_shipment, product: product, order: order) }

--- a/spec/lib/open_food_network/order_and_distributor_report_spec.rb
+++ b/spec/lib/open_food_network/order_and_distributor_report_spec.rb
@@ -73,14 +73,12 @@ module OpenFoodNetwork
         end
 
         it "prints one row per line item" do
-          pending "Each line item is shown multiple times when there is more than one item in the order"
-
           create(:line_item_with_shipment, order: order)
 
           subject = OrderAndDistributorReport.new(create(:admin_user), {}, true)
 
           table = subject.table
-          expect(table.size).to eq 2 # currently 4
+          expect(table.size).to eq 2
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #5400

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

In January, an SQL optimisation lead to listing orders multiple times in the Orders And Distributors report. I now de-duplicated the entries.

13633e8 replaced a `where id in (?)` query with `outer join ... where`. The join lead to multiple rows per order. This was okay in most reports because they use that query only to further query line items. But the Orders And Distributors report was iterating over those duplicated orders. A `select distinct` clause corrects this here.

I quickly checked all other uses of the affected `visible_orders` method and it appears that all other usages are fine.

Many reports would benefit from refactoring to reduce the complexity. The code has grown over time and became difficult to maintain.


#### What should we test?
<!-- List which features should be tested and how. -->


- User - Place an order with more than one item
- Admin - Check the report and observe that the number of lines in the table relate to the number of items in the order.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Removed duplicate rows in the Orders And Distributors report.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

