### PR TITLE
Make JobLogger spec more reliable

### DIFF
--- a/spec/jobs/job_logger_spec.rb
+++ b/spec/jobs/job_logger_spec.rb
@@ -2,17 +2,12 @@ require 'spec_helper'
 
 describe JobLogger do
   describe '.logger' do
-    it 'passes the message to the Logger instance' do
-      job_logger = instance_double(::Logger)
-      allow(job_logger).to receive(:formatter=)
-      allow(job_logger).to receive(:info)
+    it "returns a Ruby's logger instance" do
+      expect(JobLogger.logger).to respond_to(:info)
+    end
 
-      worker_logger = instance_double(::Logger, clone: job_logger)
-      allow(Delayed::Worker).to receive(:logger) { worker_logger }
-
-      JobLogger.logger.info('log message')
-
-      expect(job_logger).to have_received(:info).with('log message')
+    it 'returns custom formatted logger instance' do
+      expect(JobLogger.logger.formatter).to be_instance_of(JobLogger::Formatter)
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #5416 

This will hopefully fix our bild. I believe that the underlying issue is that the logger's test double gets leaked into other examples, as RSpec tells when running `spec/jobs/` specs.

```
5) SubscriptionPlacementJob performing the job when unplaced proxy_orders exist processes placeable proxy_orders
     Failure/Error: JobLogger.logger.info("Placing Order for Proxy Order #{proxy_order.id}")
       #<InstanceDouble(Logger) (anonymous)> was originally created in one example but has leaked into another example and can no longer be used. rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
     # ./app/jobs/subscription_placement_job.rb:31:in `place_order_for'
```
Read more: https://relishapp.com/rspec/rspec-mocks/v/3-4/docs/basics/scope#doubles-cannot-be-reused-in-another-example

For whatever reason, the JobLogger keeps its `.logger` being stubbed after this spec.

#### What should we test?

Nothing. It involves the test suite only.

#### Release notes

Fixed JobLogger test reliability

Changelog Category: Fixed