### PR TITLE
[mobile ux] Fix misplaced paragraph in shop tab

### DIFF
--- a/app/views/shop/messages/_select_oc.html.haml
+++ b/app/views/shop/messages/_select_oc.html.haml
@@ -1,3 +1,5 @@
 .content.footer-pad{ "darker-background" => true, "ng-controller" => "ProductsCtrl", "ng-show" => "order_cycle.order_cycle_id == null" }
-  .select-oc-message
-    = t '.select_oc_html'
+  .row
+    .small-12.columns
+      .select-oc-message
+        = t '.select_oc_html'


### PR DESCRIPTION
#### What? Why?

Fixes this :point_down: 

![Screenshot from 2020-05-15 14-10-58](https://user-images.githubusercontent.com/762088/82049017-f280dd80-96b5-11ea-83df-d74ff9569626.png)


replacing it with :point_down: 

![Screenshot from 2020-05-15 14-11-11](https://user-images.githubusercontent.com/762088/82049025-f57bce00-96b5-11ea-9863-772b5da0c1f1.png)


#### What should we test?

When the OC is not yet selected, the message should properly positioned as shown in the screenshot above.

#### Release notes

Fix misplaced paragraph in shop tab

Changelog Category: Fixed

