### PR TITLE
Fix Grumpy Cat on shop page (cart with items from a closed OC)

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -40,7 +40,7 @@ class CheckoutController < Spree::StoreController
     # This is only required because of spree_paypal_express. If we implement
     # a version of paypal that uses this controller, and more specifically
     # the #update_failed method, then we can remove this call
-    RestartCheckout.new(@order).call
+    OrderCheckoutRestart.new(@order).call
   end
 
   def update

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -97,7 +97,14 @@ class EnterprisesController < BaseController
 
   def reset_order_cycle(order, distributor)
     order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
-    order.order_cycle = order_cycles.first if order_cycles.size == 1
+
+    select_first_order_cycle(order, order_cycles)
+  end
+
+  def select_first_order_cycle(order, order_cycles)
+    return unless order_cycles.size == 1
+
+    order.order_cycle = order_cycles.first
   end
 
   def shop_order_cycles

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -98,6 +98,11 @@ class EnterprisesController < BaseController
   def reset_order_cycle(order, distributor)
     order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
 
+    if order.order_cycle.present? && !order_cycles.include?(order.order_cycle)
+      order.order_cycle = nil
+      order.empty!
+    end
+
     select_default_order_cycle(order, order_cycles)
   end
 

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -98,11 +98,11 @@ class EnterprisesController < BaseController
   def reset_order_cycle(order, distributor)
     order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
 
-    select_first_order_cycle(order, order_cycles)
+    select_default_order_cycle(order, order_cycles)
   end
 
-  def select_first_order_cycle(order, order_cycles)
-    return unless order_cycles.size == 1
+  def select_default_order_cycle(order, order_cycles)
+    return unless order.order_cycle.blank? && order_cycles.size == 1
 
     order.order_cycle = order_cycles.first
   end

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -112,14 +112,6 @@ class EnterprisesController < BaseController
     order.order_cycle = order_cycles.first
   end
 
-  def shop_order_cycles
-    if current_order_cycle
-      [current_order_cycle]
-    else
-      OrderCycle.not_closed.with_distributor(current_distributor)
-    end
-  end
-
   def set_noindex_meta_tag
     @noindex_meta_tag = true unless current_distributor.visible?
   end

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -65,51 +65,10 @@ class EnterprisesController < BaseController
   def reset_order
     order = current_order(true)
 
-    reset_distributor(order, distributor)
-
-    reset_user_and_customer(order) if try_spree_current_user
-
-    reset_order_cycle(order, distributor)
-
-    order.save!
+    OrderCartReset.new(order, params[:id], try_spree_current_user, current_customer).call
   rescue ActiveRecord::RecordNotFound
     flash[:error] = I18n.t(:enterprise_shop_show_error)
     redirect_to shops_path
-  end
-
-  def distributor
-    @distributor ||= Enterprise.is_distributor.find_by_permalink(params[:id]) ||
-                     Enterprise.is_distributor.find(params[:id])
-  end
-
-  def reset_distributor(order, distributor)
-    if order.distributor && order.distributor != distributor
-      order.empty!
-      order.set_order_cycle! nil
-    end
-    order.distributor = distributor
-  end
-
-  def reset_user_and_customer(order)
-    order.associate_user!(spree_current_user) if order.user.blank? || order.email.blank?
-    order.__send__(:associate_customer) if order.customer.nil? # Only associates existing customers
-  end
-
-  def reset_order_cycle(order, distributor)
-    order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
-
-    if order.order_cycle.present? && !order_cycles.include?(order.order_cycle)
-      order.order_cycle = nil
-      order.empty!
-    end
-
-    select_default_order_cycle(order, order_cycles)
-  end
-
-  def select_default_order_cycle(order, order_cycles)
-    return unless order.order_cycle.blank? && order_cycles.size == 1
-
-    order.order_cycle = order_cycles.first
   end
 
   def set_noindex_meta_tag

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -22,7 +22,7 @@ Spree::PaypalController.class_eval do
     if current_order.complete?
       flash[:notice] = t(:order_processed_successfully)
 
-      ResetOrderService.new(self, current_order).call
+      OrderCompletionReset.new(self, current_order).call
       session[:access_token] = current_order.token
     end
   end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -109,12 +109,12 @@ Spree::Order.class_eval do
   alias_method_chain :empty!, :clear_shipping_and_payments
 
   def set_order_cycle!(order_cycle)
-    unless self.order_cycle == order_cycle
-      self.order_cycle = order_cycle
-      self.distributor = nil unless order_cycle.nil? || order_cycle.has_distributor?(distributor)
-      empty!
-      save!
-    end
+    return if self.order_cycle == order_cycle
+
+    self.order_cycle = order_cycle
+    self.distributor = nil unless order_cycle.nil? || order_cycle.has_distributor?(distributor)
+    empty!
+    save!
   end
 
   # "Checkout" is the initial state and, for card payments, "pending" is the state after authorization

--- a/app/services/checkout/post_checkout_actions.rb
+++ b/app/services/checkout/post_checkout_actions.rb
@@ -9,7 +9,7 @@ module Checkout
 
     def success(controller, params, current_user)
       save_order_addresses_as_user_default(params, current_user)
-      ResetOrderService.new(controller, @order).call
+      OrderCompletionReset.new(controller, @order).call
     end
 
     def failure

--- a/app/services/checkout/post_checkout_actions.rb
+++ b/app/services/checkout/post_checkout_actions.rb
@@ -14,7 +14,7 @@ module Checkout
 
     def failure
       @order.updater.shipping_address_from_distributor
-      RestartCheckout.new(@order).call
+      OrderCheckoutRestart.new(@order).call
     end
 
     private

--- a/app/services/order_cart_reset.rb
+++ b/app/services/order_cart_reset.rb
@@ -35,19 +35,24 @@ class OrderCartReset
   end
 
   def reset_order_cycle
-    order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
+    listed_order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
 
-    if order.order_cycle.present? && !order_cycles.include?(order.order_cycle)
+    if order_cycle_not_listed?(order.order_cycle, listed_order_cycles)
       order.order_cycle = nil
       order.empty!
     end
 
-    select_default_order_cycle(order, order_cycles)
+    select_default_order_cycle(order, listed_order_cycles)
   end
 
-  def select_default_order_cycle(order, order_cycles)
-    return unless order.order_cycle.blank? && order_cycles.size == 1
+  def order_cycle_not_listed?(order_cycle, listed_order_cycles)
+    order_cycle.present? && !listed_order_cycles.include?(order_cycle)
+  end
 
-    order.order_cycle = order_cycles.first
+  # If no OC is selected and there is only one in the list of OCs, selects it
+  def select_default_order_cycle(order, listed_order_cycles)
+    return unless order.order_cycle.blank? && listed_order_cycles.size == 1
+
+    order.order_cycle = listed_order_cycles.first
   end
 end

--- a/app/services/order_checkout_restart.rb
+++ b/app/services/order_checkout_restart.rb
@@ -1,5 +1,5 @@
 # Resets the passed order to cart state while clearing associated payments and shipments
-class RestartCheckout
+class OrderCheckoutRestart
   def initialize(order)
     @order = order
   end

--- a/app/services/order_completion_reset.rb
+++ b/app/services/order_completion_reset.rb
@@ -1,6 +1,8 @@
-# Builds a new order based on the one specified. This implements the "continue
-# shopping" feature once an order is completed.
-class ResetOrderService
+# frozen_string_literal: false
+
+# Resets a completed order by building a new order based on the one specified.
+# This implements the "continue shopping" feature once an order is completed.
+class OrderCompletionReset
   # Constructor
   #
   # @param controller [#expire_current_order, #current_order]

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -299,11 +299,11 @@ describe CheckoutController, type: :controller do
   end
 
   describe "#update_failed" do
-    let(:restart_checkout) { instance_double(RestartCheckout, call: true) }
+    let(:restart_checkout) { instance_double(OrderCheckoutRestart, call: true) }
 
     before do
       controller.instance_variable_set(:@order, order)
-      allow(RestartCheckout).to receive(:new) { restart_checkout }
+      allow(OrderCheckoutRestart).to receive(:new) { restart_checkout }
       allow(controller).to receive(:current_order) { order }
     end
 

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -4,7 +4,7 @@ describe CheckoutController, type: :controller do
   let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let(:order_cycle) { create(:simple_order_cycle) }
   let(:order) { create(:order) }
-  let(:reset_order_service) { double(ResetOrderService) }
+  let(:reset_order_service) { double(OrderCompletionReset) }
 
   before do
     allow(order).to receive(:checkout_allowed?).and_return true
@@ -117,8 +117,8 @@ describe CheckoutController, type: :controller do
       let(:test_shipping_method_id) { "111" }
 
       before do
-        # stub order and resetorderservice
-        allow(ResetOrderService).to receive(:new).with(controller, order) { reset_order_service }
+        # stub order and OrderCompletionReset
+        allow(OrderCompletionReset).to receive(:new).with(controller, order) { reset_order_service }
         allow(reset_order_service).to receive(:call)
         allow(order).to receive(:update_attributes).and_return true
         allow(controller).to receive(:current_order).and_return order
@@ -211,7 +211,7 @@ describe CheckoutController, type: :controller do
     end
 
     it "returns order confirmation url on success" do
-      allow(ResetOrderService).to receive(:new).with(controller, order) { reset_order_service }
+      allow(OrderCompletionReset).to receive(:new).with(controller, order) { reset_order_service }
       expect(reset_order_service).to receive(:call)
 
       allow(order).to receive(:update_attributes).and_return true
@@ -232,7 +232,7 @@ describe CheckoutController, type: :controller do
 
     describe "stale object handling" do
       it "retries when a stale object error is encountered" do
-        allow(ResetOrderService).to receive(:new).with(controller, order) { reset_order_service }
+        allow(OrderCompletionReset).to receive(:new).with(controller, order) { reset_order_service }
         expect(reset_order_service).to receive(:call)
 
         allow(order).to receive(:update_attributes).and_return true

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -95,7 +95,7 @@ describe EnterprisesController, type: :controller do
     describe "when an out of stock item is in the cart" do
       let(:variant) { create(:variant, on_demand: false, on_hand: 10) }
       let(:line_item) { create(:line_item, variant: variant) }
-      let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: [variant]) }
+      let(:order_cycle) { create(:simple_order_cycle, distributors: [current_distributor], variants: [variant]) }
 
       before do
         order.set_distribution! current_distributor, order_cycle

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -3,14 +3,15 @@ require 'spec_helper'
 describe EnterprisesController, type: :controller do
   describe "shopping for a distributor" do
     let(:order) { controller.current_order(true) }
-
+    let(:line_item) { create(:line_item) }
     let!(:current_distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
     let!(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
-    let!(:order_cycle1) { create(:simple_order_cycle, distributors: [distributor], orders_open_at: 2.days.ago, orders_close_at: 3.days.from_now ) }
+    let!(:order_cycle1) { create(:simple_order_cycle, distributors: [distributor], orders_open_at: 2.days.ago, orders_close_at: 3.days.from_now, variants: [line_item.variant] ) }
     let!(:order_cycle2) { create(:simple_order_cycle, distributors: [distributor], orders_open_at: 3.days.ago, orders_close_at: 4.days.from_now ) }
 
     before do
       order.set_distributor! current_distributor
+      order.line_items << line_item
     end
 
     it "sets the shop as the distributor on the order when shopping for the distributor" do
@@ -81,15 +82,10 @@ describe EnterprisesController, type: :controller do
     end
 
     it "should not empty an order if returning to the same distributor" do
-      product = create(:product)
-      create(:simple_order_cycle, distributors: [current_distributor], variants: [product.variants.first])
-      line_item = create(:line_item, variant: product.variants.first)
-      controller.current_order.line_items << line_item
-
       spree_get :shop, id: current_distributor
 
       expect(controller.current_order.distributor).to eq current_distributor
-      expect(controller.current_order.line_items.first.variant).to eq product.variants.first
+      expect(controller.current_order.line_items.first.variant).to eq line_item.variant
     end
 
     describe "when an out of stock item is in the cart" do
@@ -110,6 +106,19 @@ describe EnterprisesController, type: :controller do
 
         expect(response).to redirect_to cart_path
       end
+    end
+
+    it "resets order if the order cycle of the current order is no longer open or visible" do
+      order.distributor = distributor
+      order.order_cycle = order_cycle1
+      order.save
+      order_cycle1.update_attribute :orders_close_at, Time.zone.now
+
+      spree_get :shop, id: distributor
+
+      expect(controller.current_order.distributor).to eq(distributor)
+      expect(controller.current_order.order_cycle).to eq(order_cycle2)
+      expect(controller.current_order.line_items).to be_empty
     end
 
     it "sets order cycle if only one is available at the chosen distributor" do

--- a/spec/services/checkout/post_checkout_actions_spec.rb
+++ b/spec/services/checkout/post_checkout_actions_spec.rb
@@ -11,10 +11,10 @@ describe Checkout::PostCheckoutActions do
     let(:params) { { order: {} } }
     let(:current_user) { order.distributor.owner }
 
-    let(:reset_order_service) { instance_double(ResetOrderService) }
+    let(:reset_order_service) { instance_double(OrderCompletionReset) }
 
     before do
-      expect(ResetOrderService).to receive(:new).
+      expect(OrderCompletionReset).to receive(:new).
         with(controller, order).and_return(reset_order_service)
       expect(reset_order_service).to receive(:call)
     end

--- a/spec/services/checkout/post_checkout_actions_spec.rb
+++ b/spec/services/checkout/post_checkout_actions_spec.rb
@@ -48,10 +48,10 @@ describe Checkout::PostCheckoutActions do
   end
 
   describe "#failure" do
-    let(:restart_checkout_service) { instance_double(RestartCheckout) }
+    let(:restart_checkout_service) { instance_double(OrderCheckoutRestart) }
 
     it "restarts the checkout process" do
-      expect(RestartCheckout).to receive(:new).with(order).and_return(restart_checkout_service)
+      expect(OrderCheckoutRestart).to receive(:new).with(order).and_return(restart_checkout_service)
       expect(restart_checkout_service).to receive(:call)
 
       postCheckoutActions.failure

--- a/spec/services/order_cart_reset_spec.rb
+++ b/spec/services/order_cart_reset_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OrderCartReset do
+  let(:distributor) { create(:distributor_enterprise) }
+  let(:order) { create(:order, :with_line_item, distributor: distributor) }
+
+  context "if order distributor is not the requested distributor" do
+    let(:new_distributor) { create(:distributor_enterprise) }
+
+    it "empties order" do
+      OrderCartReset.new(order, new_distributor.id.to_s, nil, nil).call
+
+      expect(order.line_items).to be_empty
+    end
+  end
+
+  context "if the order's order cycle is not in the list of visible order cycles" do
+    let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor]) }
+    let(:order_cycle_list) { instance_double(Shop::OrderCyclesList) }
+
+    before do
+      expect(Shop::OrderCyclesList).to receive(:new).and_return(order_cycle_list)
+      order.update_attribute :order_cycle, order_cycle
+    end
+
+    it "empties order and makes order cycle nil" do
+      expect(order_cycle_list).to receive(:call).and_return([])
+
+      OrderCartReset.new(order, distributor.id.to_s, nil, nil).call
+
+      expect(order.line_items).to be_empty
+      expect(order.order_cycle).to be_nil
+    end
+
+    it "selects default Order Cycle if there's one" do
+      other_order_cycle = create(:simple_order_cycle, distributors: [distributor])
+      expect(order_cycle_list).to receive(:call).and_return([other_order_cycle])
+
+      OrderCartReset.new(order, distributor.id.to_s, nil, nil).call
+
+      expect(order.order_cycle).to eq other_order_cycle
+    end
+  end
+end

--- a/spec/services/order_checkout_restart_spec.rb
+++ b/spec/services/order_checkout_restart_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe RestartCheckout do
+describe OrderCheckoutRestart do
   let(:order) { create(:order_with_distributor) }
 
   describe "#call" do
     context "when the order is already in the 'cart' state" do
       it "does nothing" do
         expect(order).to_not receive(:restart_checkout!)
-        RestartCheckout.new(order).call
+        OrderCheckoutRestart.new(order).call
       end
     end
 
@@ -25,7 +25,7 @@ describe RestartCheckout do
         before { order.ship_address = nil }
 
         it "resets the order state, and clears incomplete shipments and payments" do
-          RestartCheckout.new(order).call
+          OrderCheckoutRestart.new(order).call
 
           expect_cart_state_and_reset_adjustments
         end
@@ -35,7 +35,7 @@ describe RestartCheckout do
         before { order.ship_address = order.address_from_distributor }
 
         it "resets the order state, and clears incomplete shipments and payments" do
-          RestartCheckout.new(order).call
+          OrderCheckoutRestart.new(order).call
 
           expect_cart_state_and_reset_adjustments
         end
@@ -46,7 +46,7 @@ describe RestartCheckout do
 
         it "does not reset the order state nor clears incomplete shipments and payments" do
           expect do
-            RestartCheckout.new(order).call
+            OrderCheckoutRestart.new(order).call
           end.to raise_error(StateMachine::InvalidTransition)
 
           expect(order.state).to eq 'payment'

--- a/spec/services/order_completion_reset_spec.rb
+++ b/spec/services/order_completion_reset_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ResetOrderService do
+describe OrderCompletionReset do
   let(:current_token) { double(:current_token) }
   let(:current_distributor) { double(:distributor) }
   let(:current_order) do


### PR DESCRIPTION
#### What? Why?

Closes #5340

This issue was caused by landing on a shop page with some variants in the cart from an Order Cycle that was no longer visible to the user (either closed or some new tag rules). The code is now smart enough to verify the order_cycle is not visible and will empty the order.

Thsi was a simple if statement on the enterprise_controller but sometimes we have to make the world a better place, I mean OFN, so I went on an afternoon of refactoring by extracting new OrderCartRest service (and add some unit tests) and renaming 2 other services according to service naming conventions so now we have related services together:
- OrderCheckoutRestart (restart order workflow)
- OrderCompletionReset (reset order after completion)
- OrderCartReset (reset order on shop page).

It's when we extract these services (and see how complex they are) that we see how obviously overloaded our controllers are!!! We need more of this in OFN.

#### What should we test?
Verify the issue is fixed. When OC is closed and there are items in the cart, the cart will be cleared up and the normal redirection rules will apply:
1- no other OCs: flash message and redirect to shops page
2- if there is only one more OC, that one will be selected and displayed
3- if there are two or more OCs, the red Oc selector will show up.

We should also try to break it by changing things in the Backoffice and load different shops pages #variation #exploratorytesting

Note: now I realize I havent tested with 3 OCs.
#### Release notes
Changelog Category: Fixed
Fixed grumpy cat page (422 http error) when Order Cycle was closed while user was shopping (the broken case was only when there other Order Cycles open for the same shop)
