### PR TITLE
Remove some dead JS code related to admin sub menus

### DIFF
--- a/app/assets/javascripts/admin/side_menu/services/side_menu.js.coffee
+++ b/app/assets/javascripts/admin/side_menu/services/side_menu.js.coffee
@@ -4,7 +4,6 @@ angular.module("admin.side_menu")
       items: []
       selected: null
 
-
       # Checks for path and uses it to set the view
       # If no path, loads first view
       init: =>
@@ -31,11 +30,3 @@ angular.module("admin.side_menu")
         for item in @items when item.name is name
           return item
         null
-
-      hide_item_by_name: (name) =>
-        item = @find_by_name(name)
-        item.visible = false if item
-
-      show_item_by_name: (name) =>
-        item = @find_by_name(name)
-        item.visible = true if item

--- a/spec/javascripts/unit/admin/side_menu/services/side_menu.js.coffee
+++ b/spec/javascripts/unit/admin/side_menu/services/side_menu.js.coffee
@@ -69,25 +69,3 @@ describe "SideMenu service", ->
     it "returns null if no items are found", ->
       SideMenu.items = [ { name: "Name 1"}, { name: "Name 2"} ]
       expect(SideMenu.find_by_name("Name 3")).toBe null
-
-  describe "hiding an item by name", ->
-    it "sets visible to false on the response from find_by_name", ->
-      mockItem = { visible: true }
-      spyOn(SideMenu, 'find_by_name').and.returnValue mockItem
-      SideMenu.hide_item_by_name()
-      expect(mockItem.visible).toBe false
-
-    it "doesn't crash if null is returned from find_by_name", ->
-      spyOn(SideMenu, 'find_by_name').and.returnValue null
-      SideMenu.hide_item_by_name()
-
-  describe "showing an item by name", ->
-    it "sets visible to false on the response from find_by_name", ->
-      mockItem = { visible: false }
-      spyOn(SideMenu, 'find_by_name').and.returnValue mockItem
-      SideMenu.show_item_by_name()
-      expect(mockItem.visible).toBe true
-
-    it "doesn't crash if null is returned from find_by_name", ->
-      spyOn(SideMenu, 'find_by_name').and.returnValue null
-      SideMenu.show_item_by_name()


### PR DESCRIPTION
#### What? Why?

These functions are not used.

#### What should we test?
Verify the Admin Enterprise submenu (Primary Detaits, Contact, Address, Social, etc) works while editing the details of an enterprise.
Same verification for Enterprise Groups


#### Release notes
Changelog Category: Removed
Remove some dead JS code related to admin enterprise sub menus
