### PR TITLE
Changed report_header fields for amount and quantity to reflect corre…

### DIFF
--- a/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/customer_totals_report.rb
@@ -20,7 +20,7 @@ module OpenFoodNetwork
         [I18n.t(:report_header_hub), I18n.t(:report_header_customer), I18n.t(:report_header_email),
          I18n.t(:report_header_phone), I18n.t(:report_header_producer),
          I18n.t(:report_header_product), I18n.t(:report_header_variant),
-         I18n.t(:report_header_amount),
+         I18n.t(:report_header_quantity),
          I18n.t(:report_header_item_price, currency: currency_symbol),
          I18n.t(:report_header_item_fees_price, currency: currency_symbol),
          I18n.t(:report_header_admin_handling_fees, currency: currency_symbol),

--- a/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/default_report.rb
@@ -12,7 +12,7 @@ module OpenFoodNetwork
           I18n.t(:report_header_producer),
           I18n.t(:report_header_product),
           I18n.t(:report_header_variant),
-          I18n.t(:report_header_amount),
+          I18n.t(:report_header_quantity),
           I18n.t(:report_header_curr_cost_per_unit),
           I18n.t(:report_header_total_cost),
           I18n.t(:report_header_status),

--- a/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
@@ -12,7 +12,7 @@ module OpenFoodNetwork
       def header
         [I18n.t(:report_header_hub), I18n.t(:report_header_producer),
          I18n.t(:report_header_product), I18n.t(:report_header_variant),
-         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit),
+         I18n.t(:report_header_quantity), I18n.t(:report_header_curr_cost_per_unit),
          I18n.t(:report_header_total_cost), I18n.t(:report_header_total_shipping_cost),
          I18n.t(:report_header_shipping_method)]
       end

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
@@ -14,7 +14,7 @@ module OpenFoodNetwork
       def header
         [I18n.t(:report_header_producer), I18n.t(:report_header_product),
          I18n.t(:report_header_variant), I18n.t(:report_header_to_hub),
-         I18n.t(:report_header_amount), I18n.t(:report_header_curr_cost_per_unit),
+         I18n.t(:report_header_quantity), I18n.t(:report_header_curr_cost_per_unit),
          I18n.t(:report_header_total_cost), I18n.t(:report_header_shipping_method)]
       end
 

--- a/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
+++ b/lib/open_food_network/orders_and_fulfillments_report/supplier_totals_report.rb
@@ -13,7 +13,7 @@ module OpenFoodNetwork
 
       def header
         [I18n.t(:report_header_producer), I18n.t(:report_header_product),
-         I18n.t(:report_header_variant), I18n.t(:report_header_amount),
+         I18n.t(:report_header_variant), I18n.t(:report_header_quantity),
          I18n.t(:report_header_total_units), I18n.t(:report_header_curr_cost_per_unit),
          I18n.t(:report_header_total_cost), I18n.t(:report_header_status),
          I18n.t(:report_header_incoming_transport)]


### PR DESCRIPTION
…ct translation to French

#### What? Why?

Closes #5095 
In French report column headings should translate to "quantité" when describing a number of products, but translate to "montant" if you are looking for an amount in euros.
Within several reports, columns related to quantity are labelled as 'Amount' (and vice-versa) which creates a confusing translation to French. 

#### What should we test?
The following reports should show the correct French translation on the column header in reference to number (quantity) or cost (amount)
orders_and_fulfillments_report/customer_totals_report.rb
orders_and_fulfillments_report/default_report.rb
orders_and_fulfillments_report/distributor_totals_by_supplier_report.rb
orders_and_fulfillments_report/supplier_totals_by_distributor_report.rb
orders_and_fulfillments_report/supplier_totals_report.rb

#### Release notes
Where applicable, changed report_header to reflect number (quantity) or cost/currency (amount) to achieve correct translation to French. 
Quantity (number) --> Quantité
Amount (cost/currency) --> Montant

Changelog Category: Changed