### PR TITLE
Fix new order translation

### DIFF
--- a/app/views/spree/admin/orders/new.html.haml
+++ b/app/views/spree/admin/orders/new.html.haml
@@ -1,13 +1,10 @@
-- content_for :page_title do
-  = t(:new)
-
 - content_for :page_actions do
   %li= button_link_to t(:back_to_orders_list), spree.admin_orders_path, :icon => 'icon-arrow-left'
 
 = admin_inject_shops(module: 'admin.orders')
 = admin_inject_order_cycles
 
-= render 'spree/admin/shared/order_tabs', :current => 'Order Details'
+= render 'spree/admin/shared/order_tabs', :current => 'Order Details', :new_order => true
 
 = csrf_meta_tags
 

--- a/app/views/spree/admin/orders/set_distribution.html.haml
+++ b/app/views/spree/admin/orders/set_distribution.html.haml
@@ -1,13 +1,10 @@
-- content_for :page_title do
-  = t(:new)
-
 - content_for :page_actions do
   %li= button_link_to t(:back_to_orders_list), spree.admin_orders_path, :icon => 'icon-arrow-left'
 
 = admin_inject_shops(module: 'admin.orders')
 = admin_inject_order_cycles
 
-= render 'spree/admin/shared/order_tabs', :current => 'Order Details'
+= render 'spree/admin/shared/order_tabs', :current => 'Order Details', :new_order => true
 
 = csrf_meta_tags
 

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -1,7 +1,13 @@
+- if defined?(new_order) && (new_order)
+  - order_prefix = t(:new_order)
+- else
+  - order_prefix = t(:order)
+
 - content_for :page_title do
-  = t(:order)
+  = order_prefix
   \#
   = @order.number
+
 
 - if @order.bill_address.present?
   = @order.bill_address.firstname


### PR DESCRIPTION
#### What? Why?

Closes #5094
"New Order" was mis-translated because "new" was being appended to "order" instead of using the "new order" key. Added logic to use "new order" key on a new order.



#### What should we test?
Load the new order page.



#### Release notes
Fix for new order translation.



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

