### PR TITLE
Fix tab-buttons element overlapping order cycle selector

### DIFF
--- a/app/assets/stylesheets/darkswarm/shop_tabs.css.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.css.scss
@@ -9,7 +9,6 @@
     color: $dark-grey;
     box-shadow: $distributor-header-shadow;
     position: relative;
-    z-index: 10;
 
     .columns {
       display: flex;


### PR DESCRIPTION
#### What? Why?

Same as #5451 but on 2.9.9 patch.

This is a quick fix to a release blocking issue #5433

#### What should we test?
Verify the issue from 5433 is fixed.

#### Release notes
Changelog Category: Fixed
Fix issue with clickable area on the Order Cycle selector.