### PR TITLE
[Spree 2.1] Move all spree_core dependencies to OFN so we can upgrade them later

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,20 @@ gem 'pg', '~> 0.21.0'
 # for details.
 gem 'spree_core', github: 'openfoodfoundation/spree', branch: '2-1-0-stable'
 
+### Dependencies brought from spree core
+gem 'acts_as_list', '= 0.2.0'
+gem 'awesome_nested_set', '~> 3.0.0.rc.1'
+gem 'cancan', '~> 1.6.10'
+gem 'ffaker', '~> 1.16'
+gem 'highline', '= 1.6.18' # Necessary for the install generator
+gem 'httparty', '~> 0.11' # For checking alerts.
+gem 'json', '>= 1.7.7'
+gem 'money', '5.1.1'
+gem 'paranoia', '~> 2.0'
+gem 'ransack', '1.0.0'
+gem 'state_machine', '1.2.0'
+gem 'stringex', '~> 1.5.1'
+
 gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'
 
 # Our branch contains two changes
@@ -50,14 +64,14 @@ gem 'kaminari', '~> 0.14.1'
 
 gem 'andand'
 gem 'angularjs-rails', '1.5.5'
-gem 'aws-sdk'
+gem 'aws-sdk', '1.11.1' # temporarily locked down due to https://github.com/aws/aws-sdk-ruby/issues/273
 gem 'bugsnag'
 gem 'db2fog'
 gem 'haml'
 gem 'redcarpet'
 gem 'sass'
 gem 'sass-rails'
-gem 'truncate_html'
+gem 'truncate_html', '0.9.2'
 gem 'unicorn'
 
 gem 'actionpack-action_caching'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -696,16 +696,19 @@ DEPENDENCIES
   activerecord-postgresql-adapter
   activerecord-session_store
   acts-as-taggable-on (~> 3.4)
+  acts_as_list (= 0.2.0)
   andand
   angular-rails-templates (~> 0.3.0)
   angularjs-file-upload-rails (~> 2.4.1)
   angularjs-rails (= 1.5.5)
   atomic
+  awesome_nested_set (~> 3.0.0.rc.1)
   awesome_print
-  aws-sdk
+  aws-sdk (= 1.11.1)
   blockenspiel
   bugsnag
   byebug (~> 11.0)
+  cancan (~> 1.6.10)
   capybara (>= 2.18.0)
   catalog!
   coffee-rails (~> 4.0.0)
@@ -726,6 +729,7 @@ DEPENDENCIES
   diffy
   eventmachine (>= 1.2.3)
   factory_bot_rails (= 4.10.0)
+  ffaker (~> 1.16)
   figaro
   foreigner
   foundation-icons-sass-rails
@@ -734,12 +738,15 @@ DEPENDENCIES
   geocoder
   gmaps4rails
   haml
+  highline (= 1.6.18)
+  httparty (~> 0.11)
   i18n (~> 0.6.11)
   i18n-js (~> 3.6.0)
   immigrant
   jquery-migrate-rails
   jquery-rails (= 3.1.5)
   jquery-ui-rails (~> 4.2)
+  json (>= 1.7.7)
   json_spec (~> 1.1.4)
   jwt (~> 2.2)
   kaminari (~> 0.14.1)
@@ -747,6 +754,7 @@ DEPENDENCIES
   letter_opener (>= 1.4.1)
   mini_racer (= 0.2.14)
   momentjs-rails
+  money (= 5.1.1)
   newrelic_rpm (~> 3.0)
   oauth2 (~> 1.4.4)
   ofn-qz!
@@ -754,6 +762,7 @@ DEPENDENCIES
   order_management!
   paper_trail (~> 5.2.3)
   paperclip (~> 3.4.1)
+  paranoia (~> 2.0)
   pg (~> 0.21.0)
   pry (~> 0.12.0)
   pry-byebug (~> 3.7)
@@ -763,6 +772,7 @@ DEPENDENCIES
   rails (~> 4.0.13)
   rails-i18n (~> 4.0)
   rails_safe_tasks (~> 1.0)
+  ransack (= 1.0.0)
   redcarpet
   roadie-rails (~> 1.3.0)
   roo (~> 2.8.3)
@@ -782,10 +792,12 @@ DEPENDENCIES
   spree_paypal_express!
   spring
   spring-commands-rspec
+  state_machine (= 1.2.0)
+  stringex (~> 1.5.1)
   stripe
   test-unit (~> 3.3)
   timecop
-  truncate_html
+  truncate_html (= 0.9.2)
   uglifier (>= 1.0.3)
   unicorn
   unicorn-rails


### PR DESCRIPTION
#### What? Why?

I did this trick to remove deface from spree_core and get nokogiri upgraded on our side.
I thought that now that we are basically settled on the ideia that spree 2-1-0 will be the last spree version ofn uses (anyone has second thoughts about this? maybe it is a good time to discuss) we could do it for all dependencies of spree core. I relaxed them a bit in spree here (to allow rails 4.1 upgrade soon) https://github.com/openfoodfoundation/spree/pull/45 and added them to OFN in this PR.

This will enable us to upgrade some of these immediately after this PR.

#### What should we test?
There are no actual version changes in this PR, just the requirements were moved around so a green build and a simple sanity check will be enough.
