### PR TITLE
Fix cart fields sharing same scope

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/on_hand.js.coffee
@@ -1,6 +1,7 @@
 Darkswarm.directive "ofnOnHand", ->
   restrict: 'A'
   require: "ngModel"
+  scope: true
 
   link: (scope, elem, attr, ngModel) ->
     # In cases where this field gets its value from the HTML element rather than the model,

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -176,7 +176,7 @@ feature "full-page cart", js: true do
       end
 
       describe "with insufficient stock available" do
-        xit "prevents user from entering invalid values" do
+        it "prevents user from entering invalid values" do
           add_product_to_cart order, product_with_fee
 
           variant.update_attributes!(on_hand: 2, on_demand: false)

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -159,6 +159,7 @@ feature "full-page cart", js: true do
     describe "updating quantities" do
       let(:li) { order.line_items(true).last }
       let(:variant) { product_with_tax.variants.first }
+      let(:variant2) { product_with_fee.variants.first }
 
       before do
         add_product_to_cart order, product_with_tax
@@ -175,15 +176,26 @@ feature "full-page cart", js: true do
       end
 
       describe "with insufficient stock available" do
-        it "prevents user from entering an invalid value" do
-          # Given we have 2 on hand, and we've loaded the page after that fact
+        xit "prevents user from entering invalid values" do
+          add_product_to_cart order, product_with_fee
+
           variant.update_attributes!(on_hand: 2, on_demand: false)
+          variant2.update_attributes!(on_hand: 3, on_demand: false)
           visit main_app.cart_path
 
           accept_alert 'Insufficient stock available, only 2 remaining' do
-            fill_in "order_line_items_attributes_0_quantity", with: '4'
+            within "tr.variant-#{variant.id}" do
+              fill_in "order_line_items_attributes_0_quantity", with: '4'
+            end
           end
           expect(page).to have_field "order_line_items_attributes_0_quantity", with: '2'
+
+          accept_alert 'Insufficient stock available, only 3 remaining' do
+            within "tr.variant-#{variant2.id}" do
+              fill_in "order_line_items_attributes_1_quantity", with: '4'
+            end
+          end
+          expect(page).to have_field "order_line_items_attributes_1_quantity", with: '3'
         end
 
         it "shows the quantities saved, not those submitted" do


### PR DESCRIPTION
#### What? Why?

Closes #5455

All cart page quantity fields were displaying a single max quantity instead of a different value for each one, because the directive for capping stock on the fields didn't have individual scopes on each one.


#### What should we test?
<!-- List which features should be tested and how. -->

Maximum quantities on cart page should be accurate and not weirdly duplicated with the same repeated value. So if there are three products in the cart with stock levels of 2, 3 and 4, the maximum stock values should be 2, 3, and 4 and not 2, 2, 2 or 4, 4, 4 for example.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed maximum quantity issue on cart page.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
