### PR TITLE
[Spree 2.1] Add actionpack-action_caching gem to make action caching work again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'sass-rails'
 gem 'truncate_html'
 gem 'unicorn'
 
+gem 'actionpack-action_caching'
 # AMS is pinned to 0.8.4 because 0.9.x is a complete re-write, as is 0.10.x
 # Once Rails is updated to 5.x we should bump directly to 0.10.x
 gem "active_model_serializers", "0.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
+    actionpack-action_caching (1.2.1)
+      actionpack (>= 4.0.0)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
     activemerchant (1.78.0)
@@ -687,6 +689,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   active_model_serializers (= 0.8.4)
   activemerchant (~> 1.78.0)
   activerecord-import


### PR DESCRIPTION
#### What? Why?

Closes #5463

Add required gem to keep action caching work.

#### What should we test?
spec in issue should be green. I tested locally and it is :+1: 
