### PR TITLE
[Rails 4.1] Rename order_cycle.accessible_by to remove name clash with active record

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -145,7 +145,7 @@ module Admin
         preload(:schedules).
         ransack(params[:q]).
         result.
-        accessible_by(spree_current_user)
+        visible_by(spree_current_user)
     end
 
     def load_data_for_index

--- a/app/controllers/spree/admin/reports_controller.rb
+++ b/app/controllers/spree/admin/reports_controller.rb
@@ -255,7 +255,7 @@ module Spree
       def my_order_cycles
         OrderCycle.
           active_or_complete.
-          accessible_by(spree_current_user).
+          visible_by(spree_current_user).
           order('orders_close_at DESC')
       end
 

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -70,7 +70,7 @@ class OrderCycle < ActiveRecord::Base
   }
 
   # Return order cycles that user coordinates, sends to or receives from
-  scope :accessible_by, lambda { |user|
+  scope :visible_by, lambda { |user|
     if user.has_spree_role?('admin')
       scoped
     else

--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -39,7 +39,7 @@ class AbilityDecorator
   # OR if they manage a producer which is included in any order cycles
   def can_manage_order_cycles?(user)
     can_manage_orders?(user) ||
-      OrderCycle.accessible_by(user).any?
+      OrderCycle.visible_by(user).any?
   end
 
   # Users can manage orders if they have a sells own/any enterprise.
@@ -193,7 +193,7 @@ class AbilityDecorator
 
   def add_order_cycle_management_abilities(user)
     can [:admin, :index, :read, :edit, :update, :incoming, :outgoing], OrderCycle do |order_cycle|
-      OrderCycle.accessible_by(user).include? order_cycle
+      OrderCycle.visible_by(user).include? order_cycle
     end
     can [:admin, :index, :create], Schedule
     can [:admin, :update, :destroy], Schedule do |schedule|

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/permissions.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/permissions.rb
@@ -3,7 +3,7 @@ module OrderManagement
     module EnterpriseFeeSummary
       class Permissions < ::Reports::Permissions
         def allowed_order_cycles
-          @allowed_order_cycles ||= OrderCycle.accessible_by(user)
+          @allowed_order_cycles ||= OrderCycle.visible_by(user)
         end
 
         def allowed_distributors

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -65,8 +65,8 @@ describe OrderCycle do
     oc_received = create(:simple_order_cycle, distributors: [e2])
     oc_not_accessible = create(:simple_order_cycle, coordinator: e1)
 
-    expect(OrderCycle.accessible_by(user)).to include(oc_coordinated, oc_sent, oc_received)
-    expect(OrderCycle.accessible_by(user)).not_to include(oc_not_accessible)
+    expect(OrderCycle.visible_by(user)).to include(oc_coordinated, oc_sent, oc_received)
+    expect(OrderCycle.visible_by(user)).not_to include(oc_not_accessible)
   end
 
   it "finds the most recently closed order cycles" do


### PR DESCRIPTION
#### What? Why?

I have created the rails-4-1 branch based off the 3-0-stable branch to give it a try and I have found some little improvements that will support the upgrade later on. This resolution of a name clash is one of them.

Error:
```
An error occurred while loading ./spec/features/admin/orders_spec.rb.
Failure/Error:
  scope :accessible_by, lambda { |user|
    if user.has_spree_role?('admin')
      where(nil)
    else
      with_exchanging_enterprises_outer.
        where('order_cycles.coordinator_id IN (?) OR enterprises.id IN (?)',
              user.enterprises.map(&:id),
              user.enterprises.map(&:id)).
        select('DISTINCT order_cycles.*')
    end

ArgumentError:
  You tried to define a scope named "accessible_by" on the model "OrderCycle", but Active Record already defined a class method with the same name.
# ./app/models/order_cycle.rb:72:in `<class:OrderCycle>'
# ./app/models/order_cycle.rb:3:in `<top (required)>'
# ./spec/factories/order_cycle_factory.rb:70:in `block in <top (required)>'
# ./spec/factories/order_cycle_factory.rb:1:in `<top (required)>'
# ./spec/spec_helper.rb:169:in `block in <top (required)>'
# ./spec/spec_helper.rb:74:in `<top (required)>'
# ./spec/features/admin/orders_spec.rb:3:in `require'
# ./spec/features/admin/orders_spec.rb:3:in `<top (required)>'
```

#### What should we test?
Green build should be enough here.



#### Release notes
Changelog Category: Changed
First PR that adapts OFN code to rails 4.1
