### PR TITLE
Fix search bar in /shops and /groups

### DIFF
--- a/app/assets/stylesheets/darkswarm/active_table_search.css.scss
+++ b/app/assets/stylesheets/darkswarm/active_table_search.css.scss
@@ -158,7 +158,7 @@ products .filter-box {
 
   @include placeholder(rgba(0, 0, 0, 0.4), #777);
 
-  input[type="text"] {
+  input[type="text"], input[type="search"] {
     @include big-input(rgba(0, 0, 0, 0.3), #777, $clr-brick);
   }
 }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -15,10 +15,9 @@
     .small-12.columns
       %p
         %input{type: "search",
-        "ng-model" => "search",
+        "ng-model" => "query",
         placeholder: t(:groups_search),
         inputmode: "search",
-        name: "search",
         "ng-debounce" => "150",
         "ofn-disable-enter" => true}
 

--- a/app/views/shared/components/_enterprise_search.html.haml
+++ b/app/views/shared/components/_enterprise_search.html.haml
@@ -1,9 +1,8 @@
 #active-table-search.row
   .small-12.columns
     %input{type: "search",
-    "ng-model" => "search",
+    "ng-model" => "query",
     placeholder: t('search_by_name'),
     inputmode: "search",
-    name: "name",
     "ng-debounce" => "500",
     "ofn-disable-enter" => true}


### PR DESCRIPTION
#### What? Why?

Fixes bugs in the /shops and /groups search bars introduced recently. The styling was removed, and the search functionality was broken.

GIF from @filipefurtad0:

![search](https://user-images.githubusercontent.com/9029026/82324695-579c4200-99da-11ea-810c-572955b07789.gif)


#### What should we test?
<!-- List which features should be tested and how. -->

Search is working correctly in /shops and /groups

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed issue with search bars in /shops and /groups

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
