### PR TITLE
Revert 5332 "Add timestamps to OC schedule join table" in the rails 4 branch

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -16,8 +16,7 @@ class OrderCycle < ActiveRecord::Base
   has_many :suppliers, -> { uniq }, source: :sender, through: :cached_incoming_exchanges
   has_many :distributors, -> { uniq }, source: :receiver, through: :cached_outgoing_exchanges
 
-  has_many :schedules, through: :order_cycle_schedules
-  has_many :order_cycle_schedules
+  has_and_belongs_to_many :schedules, join_table: 'order_cycle_schedules'
   has_paper_trail meta: { custom_data: proc { |order_cycle| order_cycle.schedule_ids.to_s } }
 
   attr_accessor :incoming_exchanges, :outgoing_exchanges

--- a/app/models/order_cycle_schedule.rb
+++ b/app/models/order_cycle_schedule.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class OrderCycleSchedule < ActiveRecord::Base
-  belongs_to :schedule
-  belongs_to :order_cycle
-end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,8 +1,7 @@
 class Schedule < ActiveRecord::Base
+  has_and_belongs_to_many :order_cycles, join_table: 'order_cycle_schedules'
   has_paper_trail meta: { custom_data: proc { |schedule| schedule.order_cycle_ids.to_s } }
 
-  has_many :order_cycles, through: :order_cycle_schedules
-  has_many :order_cycle_schedules, dependent: :destroy
   has_many :coordinators, -> { uniq }, through: :order_cycles
 
   validates :order_cycles, presence: true

--- a/db/migrate/20200430105459_add_timestamps_to_order_cycle_schedules.rb
+++ b/db/migrate/20200430105459_add_timestamps_to_order_cycle_schedules.rb
@@ -1,7 +1,0 @@
-class AddTimestampsToOrderCycleSchedules < ActiveRecord::Migration
-  def change
-    change_table :order_cycle_schedules do |t|
-      t.timestamps
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -275,8 +275,6 @@ ActiveRecord::Schema.define(version: 20200430105459) do
   create_table "order_cycle_schedules", force: true do |t|
     t.integer "order_cycle_id", null: false
     t.integer "schedule_id",    null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
   add_index "order_cycle_schedules", ["order_cycle_id"], name: "index_order_cycle_schedules_on_order_cycle_id", using: :btree


### PR DESCRIPTION
#### What? Why?
This reverts commit 1903134e139e495442b1f630d1a3d8ff083a7435 the single commit in PR #5332
This resolves the problem in #5459 but 5459 goal still needs to be addressed in the rails 4 branch.

#### What should we test?
A better build than before!
