### PR TITLE
created partial for order page title to resolve French translation of…

### DIFF
--- a/app/views/spree/admin/adjustments/edit.html.haml
+++ b/app/views/spree/admin/adjustments/edit.html.haml
@@ -1,4 +1,5 @@
-= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' }
+= render :partial => 'spree/admin/shared/order_page_title'
+= render :partial => 'spree/admin/shared/order_tabs', locals: { current: 'Adjustments' }
 
 - content_for :page_title do
   %i.icon-arrow-right

--- a/app/views/spree/admin/adjustments/index.html.haml
+++ b/app/views/spree/admin/adjustments/index.html.haml
@@ -1,4 +1,5 @@
-= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' }
+= render partial: 'spree/admin/shared/order_page_title'
+= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Adjustments' }
 
 - content_for :page_title do
   %i.icon-arrow-right

--- a/app/views/spree/admin/adjustments/new.html.haml
+++ b/app/views/spree/admin/adjustments/new.html.haml
@@ -1,4 +1,5 @@
-= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' }
+= render partial: 'spree/admin/shared/order_page_title'
+= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Adjustments' }
 
 - content_for :page_title do
   %i.icon-arrow-right

--- a/app/views/spree/admin/orders/customer_details/edit.html.haml
+++ b/app/views/spree/admin/orders/customer_details/edit.html.haml
@@ -1,4 +1,5 @@
-= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Details' }
+= render partial: 'spree/admin/shared/order_page_title'
+= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Customer Details' }
 
 = csrf_meta_tags
 

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -8,7 +8,8 @@
   - if can?(:admin, Spree::Order)
     %li= button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
-= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Order Details' }
+= render partial: "spree/admin/shared/order_page_title"
+= render partial: "spree/admin/shared/order_tabs", locals: { current: 'Order Details' }
 
 %div{"data-hook" => "admin_order_edit_header"}
   -# Suppress errors when manually creating a new order - needs to proceed to edit page

--- a/app/views/spree/admin/orders/new.html.haml
+++ b/app/views/spree/admin/orders/new.html.haml
@@ -1,5 +1,7 @@
 - content_for :page_title do
-  = t(:new)
+  = t(:new_order)
+  \#
+  = @order.number
 
 - content_for :page_actions do
   %li= button_link_to t(:back_to_orders_list), spree.admin_orders_path, :icon => 'icon-arrow-left'

--- a/app/views/spree/admin/orders/set_distribution.html.haml
+++ b/app/views/spree/admin/orders/set_distribution.html.haml
@@ -1,11 +1,13 @@
-- content_for :page_title do
-  = t(:new)
-
 - content_for :page_actions do
   %li= button_link_to t(:back_to_orders_list), spree.admin_orders_path, :icon => 'icon-arrow-left'
 
 = admin_inject_shops(module: 'admin.orders')
 = admin_inject_order_cycles
+
+- content_for :page_title do
+  = t(:new_order)
+  \#
+  = @order.number
 
 = render 'spree/admin/shared/order_tabs', :current => 'Order Details'
 

--- a/app/views/spree/admin/payments/index.html.haml
+++ b/app/views/spree/admin/payments/index.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'spree/admin/shared/order_page_title'
 = render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Payments' }
 
 - content_for :page_actions do

--- a/app/views/spree/admin/payments/new.html.haml
+++ b/app/views/spree/admin/payments/new.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'spree/admin/shared/order_page_title'
 = render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Payments' }
 
 - content_for :page_title do

--- a/app/views/spree/admin/payments/show.html.haml
+++ b/app/views/spree/admin/payments/show.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'spree/admin/shared/order_page_title'
 = render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Payments' }
 
 - content_for :page_title do

--- a/app/views/spree/admin/return_authorizations/edit.html.haml
+++ b/app/views/spree/admin/return_authorizations/edit.html.haml
@@ -6,6 +6,7 @@
     - if @return_authorization.can_cancel?
       = button_link_to t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: t('.are_you_sure') }, icon: 'icon-remove'
 
+= render partial: 'spree/admin/shared/order_page_title'
 = render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Return Authorizations' }
 
 - content_for :page_title do

--- a/app/views/spree/admin/return_authorizations/index.html.haml
+++ b/app/views/spree/admin/return_authorizations/index.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'spree/admin/shared/order_page_title'
 = render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Return Authorizations' }
 
 - content_for :page_actions do

--- a/app/views/spree/admin/return_authorizations/new.html.haml
+++ b/app/views/spree/admin/return_authorizations/new.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'spree/admin/shared/order_page_title'
 = render partial: 'spree/admin/shared/order_tabs', locals: { current: 'Return Authorizations' }
 
 - content_for :page_title do

--- a/app/views/spree/admin/shared/_order_page_title.html.haml
+++ b/app/views/spree/admin/shared/_order_page_title.html.haml
@@ -1,0 +1,4 @@
+- content_for :page_title do
+  = t(:order)
+  \#
+  = @order.number

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -1,8 +1,3 @@
-- content_for :page_title do
-  = t(:order)
-  \#
-  = @order.number
-
 - if @order.bill_address.present?
   = @order.bill_address.firstname
   = @order.bill_address.lastname


### PR DESCRIPTION
… new order

#### What? Why?

Closes #5094

When creating a new order as an admin, the translation key is not correct in French on the page heading. 

#### What should we test?
<!-- List which features should be tested and how. -->
Go to /admin/orders/new and check that the translation key for the title is the correct verbiage in French. The page header title is now in a shared partial, so other pages that were updated need to be tested for correct verbiage. 
        modified:   app/views/spree/admin/adjustments/edit.html.haml
        modified:   app/views/spree/admin/adjustments/index.html.haml
        modified:   app/views/spree/admin/adjustments/new.html.haml
        modified:   app/views/spree/admin/orders/customer_details/edit.html.haml
        modified:   app/views/spree/admin/orders/edit.html.haml
        modified:   app/views/spree/admin/orders/new.html.haml
        modified:   app/views/spree/admin/orders/set_distribution.html.haml
        modified:   app/views/spree/admin/payments/index.html.haml
        modified:   app/views/spree/admin/payments/new.html.haml
        modified:   app/views/spree/admin/payments/show.html.haml
        modified:   app/views/spree/admin/return_authorizations/edit.html.haml
        modified:   app/views/spree/admin/return_authorizations/index.html.haml
        modified:   app/views/spree/admin/return_authorizations/new.html.haml
        modified:   app/views/spree/admin/shared/_order_tabs.html.haml

#### Release notes
The code to generate the page header for order number was extracted to a new partial. Within the new and set_distribution files, the partial to render the page title was not updated in order to generate the correct title. Other files using the _order_tabs partial were updated to render the new _order_page_title partial. 

Changelog Category: Changed