### PR TITLE
Changed translation syntax to normal t() call and lazy lookup.

### DIFF
--- a/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -57,7 +57,7 @@
                 <button class="add_variant no-text icon-plus icon_link with-tip" data-stock-location-id="{{variant.stock_location_id}}" title="Add" data-action="add"></button>
               </td>
             {{else}}
-              <td><%= Spree.t(:out_of_stock) %></td>
+              <td><%= t('admin.subscriptions.stock.out_of_stock') %></td>
               <td>0</td>
             {{/if}}
           </tr>


### PR DESCRIPTION
#### What? Why?

Closes #5281 
On the Admin order creation screen, when a product is out of stock, the 'Out of Stock' label is not being translated to French.

#### What should we test?
Go to /admin/orders?q[s]=completed_at+desc
Click on "New order"
Try to add a product with no stock
Verify the 'Out of Stock' string is translated when viewing in French

#### Release notes
Updated translations syntax from a Spree.t wrapper to a normal t() wrapper and lazy lookup. This added the appropriate translation key so 'Out of Stock' is now being translated to French.

Changelog Category: Changed


