### PR TITLE
[Spree 2.1] Allow to create order_cycle_schedules

### DIFF
--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -30,20 +30,20 @@ module Admin
 
     def create
       if params[:order_cycle_ids].blank?
-        return respond_with(@object)
+        return respond_with(@schedule)
       end
 
-      @object.attributes = permitted_resource_params
-      @object.save!
+      @schedule.attributes = permitted_resource_params
+      @schedule.save!
 
-      @object.order_cycle_ids = params[:order_cycle_ids]
-      if @object.save
+      @schedule.order_cycle_ids = params[:order_cycle_ids]
+      if @schedule.save
         sync_subscriptions_create
 
-        flash[:success] = flash_message_for(@object, :successfully_created)
-        respond_with(@object)
+        flash[:success] = flash_message_for(@schedule, :successfully_created)
+        respond_with(@schedule)
       else
-        respond_with(@object)
+        respond_with(@schedule)
       end
     end
 
@@ -96,7 +96,7 @@ module Admin
       result = editable_order_cycles(requested)
 
       params[:schedule][:order_cycle_ids] = result
-      @object.order_cycle_ids = result
+      @schedule.order_cycle_ids = result
     end
 
     def editable_order_cycles(requested)

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -7,7 +7,7 @@ module Admin
     before_filter :check_editable_order_cycle_ids_create, only: [:create]
     before_filter :check_editable_order_cycle_ids_update, only: [:update]
     before_filter :check_dependent_subscriptions, only: [:destroy]
-    update.after :sync_subscriptions
+    update.after :sync_subscriptions_update
 
     respond_to :json
 
@@ -125,21 +125,19 @@ module Admin
       @permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
     end
 
-    def sync_subscriptions
+    def sync_subscriptions_update
       return unless params[:schedule][:order_cycle_ids]
 
-      removed_ids = @existing_order_cycle_ids - @schedule.order_cycle_ids
-      new_ids = @schedule.order_cycle_ids - @existing_order_cycle_ids
-      return unless removed_ids.any? || new_ids.any?
-
-      subscriptions = Subscription.where(schedule_id: @schedule)
-      syncer = OrderManagement::Subscriptions::ProxyOrderSyncer.new(subscriptions)
-      syncer.sync!
+      sync_subscriptions
     end
 
     def sync_subscriptions_create
       return unless params[:order_cycle_ids]
 
+      sync_subscriptions
+    end
+
+    def sync_subscriptions
       removed_ids = @existing_order_cycle_ids - @schedule.order_cycle_ids
       new_ids = @schedule.order_cycle_ids - @existing_order_cycle_ids
       return unless removed_ids.any? || new_ids.any?

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -34,10 +34,11 @@ module Admin
       end
 
       @schedule.attributes = permitted_resource_params
-      @schedule.save!
 
-      @schedule.order_cycle_ids = params[:order_cycle_ids]
       if @schedule.save
+        @schedule.order_cycle_ids = params[:order_cycle_ids]
+        @schedule.save!
+
         sync_subscriptions_create
 
         flash[:success] = flash_message_for(@schedule, :successfully_created)

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -29,10 +29,7 @@ module Admin
     end
 
     def create
-      invoke_callbacks(:create, :before)
-
       if params[:order_cycle_ids].blank?
-        invoke_callbacks(:create, :fails)
         return respond_with(@object)
       end
 
@@ -49,7 +46,6 @@ module Admin
           format.js   { render layout: false }
         end
       else
-        invoke_callbacks(:create, :fails)
         respond_with(@object)
       end
     end

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -41,10 +41,7 @@ module Admin
         sync_subscriptions_create
 
         flash[:success] = flash_message_for(@object, :successfully_created)
-        respond_with(@object) do |format|
-          format.html { redirect_to location_after_save }
-          format.js   { render layout: false }
-        end
+        respond_with(@object)
       else
         respond_with(@object)
       end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -3,9 +3,8 @@ class Schedule < ActiveRecord::Base
 
   has_many :order_cycles, through: :order_cycle_schedules
   has_many :order_cycle_schedules, dependent: :destroy
-  has_many :coordinators, -> { uniq }, through: :order_cycles
 
-  validates :order_cycles, presence: true
+  has_many :coordinators, -> { uniq }, through: :order_cycles
 
   scope :with_coordinator, lambda { |enterprise| joins(:order_cycles).where('coordinator_id = ?', enterprise.id).select('DISTINCT schedules.*') }
 

--- a/app/services/order_cycle_form.rb
+++ b/app/services/order_cycle_form.rb
@@ -8,14 +8,17 @@ class OrderCycleForm
     @order_cycle_params = order_cycle_params
     @user = user
     @permissions = OpenFoodNetwork::Permissions.new(user)
+    @schedule_ids = order_cycle_params.delete(:schedule_ids)
   end
 
   def save
-    build_schedule_ids
+    schedule_ids = build_schedule_ids
     order_cycle.assign_attributes(order_cycle_params)
     return false unless order_cycle.valid?
 
     order_cycle.transaction do
+      order_cycle.save!
+      order_cycle.schedule_ids = schedule_ids
       order_cycle.save!
       apply_exchange_changes
       sync_subscriptions
@@ -42,7 +45,7 @@ class OrderCycleForm
   end
 
   def schedule_ids?
-    order_cycle_params[:schedule_ids].present?
+    @schedule_ids.present?
   end
 
   def build_schedule_ids
@@ -51,7 +54,7 @@ class OrderCycleForm
     result = existing_schedule_ids
     result |= (requested_schedule_ids & permitted_schedule_ids) # Add permitted and requested
     result -= ((result & permitted_schedule_ids) - requested_schedule_ids) # Remove permitted but not requested
-    order_cycle_params[:schedule_ids] = result
+    result
   end
 
   def sync_subscriptions
@@ -70,7 +73,7 @@ class OrderCycleForm
   end
 
   def requested_schedule_ids
-    order_cycle_params[:schedule_ids].map(&:to_i)
+    @schedule_ids.map(&:to_i)
   end
 
   def permitted_schedule_ids

--- a/engines/order_management/spec/services/order_management/subscriptions/count_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/count_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 module OrderManagement
   module Subscriptions
     describe Count do

--- a/engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/estimator_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 module OrderManagement
   module Subscriptions
     describe Estimator do

--- a/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
@@ -18,59 +18,51 @@ module OrderManagement
 
       describe "#sync!" do
         let(:now) { Time.zone.now }
-        let(:schedule) { create(:schedule) }
-        let(:closed_oc) { # Closed
-          create(:simple_order_cycle, schedules: [schedule],
-                                      orders_open_at: now - 1.minute,
-                                      orders_close_at: now)
+        let(:schedule) { create(:schedule, order_cycles: [oc]) }
+
+        let(:closed_oc) {
+          create(:simple_order_cycle, orders_open_at: now - 1.minute, orders_close_at: now)
         }
         let(:open_oc_closes_before_begins_at_oc) { # Open, but closes before begins at
-          create(:simple_order_cycle, schedules: [schedule],
-                                      orders_open_at: now - 1.minute,
-                                      orders_close_at: now + 59.seconds)
+          create(:simple_order_cycle, orders_open_at: now - 1.minute, orders_close_at: now + 59.seconds)
         }
         let(:open_oc) { # Open & closes between begins at and ends at
-          create(:simple_order_cycle, schedules: [schedule],
-                                      orders_open_at: now - 1.minute,
-                                      orders_close_at: now + 90.seconds)
+          create(:simple_order_cycle, orders_open_at: now - 1.minute, orders_close_at: now + 90.seconds)
         }
         let(:upcoming_closes_before_begins_at_oc) { # Upcoming, but closes before begins at
-          create(:simple_order_cycle, schedules: [schedule],
-                                      orders_open_at: now + 30.seconds,
-                                      orders_close_at: now + 59.seconds)
+          create(:simple_order_cycle, orders_open_at: now + 30.seconds, orders_close_at: now + 59.seconds)
         }
         let(:upcoming_closes_on_begins_at_oc) { # Upcoming & closes on begins at
-          create(:simple_order_cycle, schedules: [schedule],
-                                      orders_open_at: now + 30.seconds,
-                                      orders_close_at: now + 1.minute)
+          create(:simple_order_cycle, orders_open_at: now + 30.seconds, orders_close_at: now + 1.minute)
         }
         let(:upcoming_closes_on_ends_at_oc) { # Upcoming & closes on ends at
-          create(:simple_order_cycle, schedules: [schedule],
-                                      orders_open_at: now + 30.seconds,
-                                      orders_close_at: now + 2.minutes)
+          create(:simple_order_cycle, orders_open_at: now + 30.seconds, orders_close_at: now + 2.minutes)
         }
         let(:upcoming_closes_after_ends_at_oc) { # Upcoming & closes after ends at
-          create(:simple_order_cycle, schedules: [schedule],
-                                      orders_open_at: now + 30.seconds,
-                                      orders_close_at: now + 121.seconds)
+          create(:simple_order_cycle, orders_open_at: now + 30.seconds, orders_close_at: now + 121.seconds)
         }
+
         let(:subscription) {
-          build(:subscription, schedule: schedule,
-                               begins_at: now + 1.minute,
-                               ends_at: now + 2.minutes)
+          build(:subscription, begins_at: now + 1.minute, ends_at: now + 2.minutes)
         }
         let(:proxy_orders) { subscription.reload.proxy_orders }
         let(:order_cycles) { proxy_orders.map(&:order_cycle) }
         let(:syncer) { ProxyOrderSyncer.new(subscription) }
 
         context "when the subscription is not persisted" do
-          before do
-            oc # Ensure oc is created before we attempt to sync
-            expect{ syncer.sync! }.to_not change(ProxyOrder, :count).from(0)
+          let(:schedule) { create(:schedule, order_cycles: [oc]) }
+          let(:subscription) do
+            build(
+              :subscription,
+              begins_at: now + 1.minute,
+              ends_at: now + 2.minutes,
+              schedule: schedule
+            )
           end
 
           context "and the schedule includes a closed oc (ie. closed before opens_at)" do
-            let(:oc) { closed_oc }
+            let!(:oc) { closed_oc }
+
             it "does not create a new proxy order for that oc" do
               expect{ subscription.save! }.to_not change(ProxyOrder, :count).from(0)
               expect(order_cycles).to_not include oc
@@ -78,7 +70,8 @@ module OrderManagement
           end
 
           context "and the schedule includes an open oc that closes before begins_at" do
-            let(:oc) { open_oc_closes_before_begins_at_oc }
+            let!(:oc) { open_oc_closes_before_begins_at_oc }
+
             it "does not create a new proxy order for that oc" do
               expect{ subscription.save! }.to_not change(ProxyOrder, :count).from(0)
               expect(order_cycles).to_not include oc
@@ -86,15 +79,19 @@ module OrderManagement
           end
 
           context "and the schedule has an open OC that closes between begins_at and ends_at" do
-            let(:oc) { open_oc }
+            let!(:oc) { open_oc }
+
             it "creates a new proxy order for that oc" do
+              syncer.sync!
+
               expect{ subscription.save! }.to change(ProxyOrder, :count).from(0).to(1)
-              expect(order_cycles).to include oc
+              expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
             end
           end
 
           context "and the schedule includes upcoming oc that closes before begins_at" do
-            let(:oc) { upcoming_closes_before_begins_at_oc }
+            let!(:oc) { upcoming_closes_before_begins_at_oc }
+
             it "does not create a new proxy order for that oc" do
               expect{ subscription.save! }.to_not change(ProxyOrder, :count).from(0)
               expect(order_cycles).to_not include oc
@@ -102,23 +99,50 @@ module OrderManagement
           end
 
           context "and the schedule includes upcoming oc that closes on begins_at" do
-            let(:oc) { upcoming_closes_on_begins_at_oc }
+            let!(:oc) { upcoming_closes_on_begins_at_oc }
+
+            let(:schedule) { create(:schedule, order_cycles: [oc]) }
+            let(:subscription) do
+              build(
+                :subscription,
+                begins_at: now + 1.minute,
+                ends_at: now + 2.minutes,
+                schedule: schedule
+              )
+            end
+            let(:syncer) { ProxyOrderSyncer.new(subscription) }
+
             it "creates a new proxy order for that oc" do
+              syncer.sync!
+
               expect{ subscription.save! }.to change(ProxyOrder, :count).from(0).to(1)
-              expect(order_cycles).to include oc
+              expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
             end
           end
 
           context "and the schedule includes upcoming oc that closes after ends_at" do
-            let(:oc) { upcoming_closes_on_ends_at_oc }
+            let!(:oc) { upcoming_closes_on_ends_at_oc }
+
             it "creates a new proxy order for that oc" do
+              schedule = create(:schedule, order_cycles: [oc])
+              subscription = build(
+                :subscription,
+                begins_at: now + 1.minute,
+                ends_at: now + 2.minutes,
+                schedule: schedule
+              )
+
+              syncer = ProxyOrderSyncer.new(subscription)
+              syncer.sync!
+
               expect{ subscription.save! }.to change(ProxyOrder, :count).from(0).to(1)
-              expect(order_cycles).to include oc
+              expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
             end
           end
 
           context "and the schedule includes upcoming oc that closes after ends_at" do
-            let(:oc) { upcoming_closes_after_ends_at_oc }
+            let!(:oc) { upcoming_closes_after_ends_at_oc }
+
             it "does not create a new proxy order for that oc" do
               expect{ subscription.save! }.to_not change(ProxyOrder, :count).from(0)
               expect(order_cycles).to_not include oc
@@ -212,7 +236,19 @@ module OrderManagement
 
                 context "and the oc is open and closes between begins_at and ends_at" do
                   let(:oc) { open_oc }
+
                   it "keeps the proxy order" do
+                    schedule = create(:schedule, order_cycles: [oc])
+                    subscription = build(
+                      :subscription,
+                      begins_at: now + 1.minute,
+                      ends_at: now + 2.minutes,
+                      schedule: schedule
+                    )
+
+                    syncer = ProxyOrderSyncer.new(subscription)
+                    syncer.sync!
+
                     expect{ syncer.sync! }.to_not change(ProxyOrder, :count).from(1)
                     expect(proxy_orders).to include proxy_order
                   end
@@ -228,7 +264,19 @@ module OrderManagement
 
                 context "and the oc is upcoming and closes on begins_at" do
                   let(:oc) { upcoming_closes_on_begins_at_oc }
+
                   it "keeps the proxy order" do
+                    schedule = create(:schedule, order_cycles: [oc])
+                    subscription = build(
+                      :subscription,
+                      begins_at: now + 1.minute,
+                      ends_at: now + 2.minutes,
+                      schedule: schedule
+                    )
+
+                    syncer = ProxyOrderSyncer.new(subscription)
+                    syncer.sync!
+
                     expect{ syncer.sync! }.to_not change(ProxyOrder, :count).from(1)
                     expect(proxy_orders).to include proxy_order
                   end
@@ -236,7 +284,19 @@ module OrderManagement
 
                 context "and the oc is upcoming and closes on ends_at" do
                   let(:oc) { upcoming_closes_on_ends_at_oc }
+
                   it "keeps the proxy order" do
+                    schedule = create(:schedule, order_cycles: [oc])
+                    subscription = build(
+                      :subscription,
+                      begins_at: now + 1.minute,
+                      ends_at: now + 2.minutes,
+                      schedule: schedule
+                    )
+
+                    syncer = ProxyOrderSyncer.new(subscription)
+                    syncer.sync!
+
                     expect{ syncer.sync! }.to_not change(ProxyOrder, :count).from(1)
                     expect(proxy_orders).to include proxy_order
                   end
@@ -376,8 +436,20 @@ module OrderManagement
           end
 
           context "when a proxy order does not exist" do
+            let(:schedule) { create(:schedule, order_cycles: [oc]) }
+            let(:subscription) do
+              create(
+                :subscription,
+                begins_at: now + 1.minute,
+                ends_at: now + 2.minutes,
+                schedule: schedule
+              )
+            end
+            let(:syncer) { ProxyOrderSyncer.new(subscription) }
+
             context "and the schedule includes a closed oc (ie. closed before opens_at)" do
               let!(:oc) { closed_oc }
+
               it "does not create a new proxy order for that oc" do
                 expect{ syncer.sync! }.to_not change(ProxyOrder, :count).from(0)
                 expect(order_cycles).to_not include oc
@@ -386,6 +458,7 @@ module OrderManagement
 
             context "and the schedule includes an open oc that closes before begins_at" do
               let(:oc) { open_oc_closes_before_begins_at_oc }
+
               it "does not create a new proxy order for that oc" do
                 expect{ subscription.save! }.to_not change(ProxyOrder, :count).from(0)
                 expect(order_cycles).to_not include oc
@@ -394,14 +467,16 @@ module OrderManagement
 
             context "and the schedule has an open oc that closes between begins_at and ends_at" do
               let!(:oc) { open_oc }
+
               it "creates a new proxy order for that oc" do
                 expect{ syncer.sync! }.to change(ProxyOrder, :count).from(0).to(1)
-                expect(order_cycles).to include oc
+                expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
               end
             end
 
             context "and the schedule includes upcoming oc that closes before begins_at" do
               let!(:oc) { upcoming_closes_before_begins_at_oc }
+
               it "does not create a new proxy order for that oc" do
                 expect{ syncer.sync! }.to_not change(ProxyOrder, :count).from(0)
                 expect(order_cycles).to_not include oc
@@ -410,22 +485,25 @@ module OrderManagement
 
             context "and the schedule includes upcoming oc that closes on begins_at" do
               let!(:oc) { upcoming_closes_on_begins_at_oc }
+
               it "creates a new proxy order for that oc" do
                 expect{ syncer.sync! }.to change(ProxyOrder, :count).from(0).to(1)
-                expect(order_cycles).to include oc
+                expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
               end
             end
 
             context "and the schedule includes upcoming oc that closes on ends_at" do
               let!(:oc) { upcoming_closes_on_ends_at_oc }
+
               it "creates a new proxy order for that oc" do
                 expect{ syncer.sync! }.to change(ProxyOrder, :count).from(0).to(1)
-                expect(order_cycles).to include oc
+                expect(subscription.reload.proxy_orders.map(&:order_cycle)).to include oc
               end
             end
 
             context "and the schedule includes upcoming oc that closes after ends_at" do
               let!(:oc) { upcoming_closes_after_ends_at_oc }
+
               it "does not create a new proxy order for that oc" do
                 expect{ syncer.sync! }.to_not change(ProxyOrder, :count).from(0)
                 expect(order_cycles).to_not include oc

--- a/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
@@ -102,14 +102,6 @@ module OrderManagement
             let!(:oc) { upcoming_closes_on_begins_at_oc }
 
             let(:schedule) { create(:schedule, order_cycles: [oc]) }
-            let(:subscription) do
-              build(
-                :subscription,
-                begins_at: now + 1.minute,
-                ends_at: now + 2.minutes,
-                schedule: schedule
-              )
-            end
             let(:syncer) { ProxyOrderSyncer.new(subscription) }
 
             it "creates a new proxy order for that oc" do

--- a/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/proxy_order_syncer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 module OrderManagement
   module Subscriptions
     describe ProxyOrderSyncer do

--- a/engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/summary_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 module OrderManagement
   module Subscriptions
     describe Summary do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,7 +28,16 @@ FactoryBot.define do
 
   factory :schedule, class: Schedule do
     sequence(:name) { |n| "Schedule #{n}" }
-    order_cycles { [OrderCycle.first || FactoryBot.create(:simple_order_cycle)] }
+
+    transient do
+      order_cycles { [OrderCycle.first || create(:simple_order_cycle)] }
+    end
+
+    before(:create) do |schedule, evaluator|
+      evaluator.order_cycles.each do |order_cycle|
+        order_cycle.schedules << schedule
+      end
+    end
   end
 
   factory :proxy_order, class: ProxyOrder do

--- a/spec/features/admin/schedules_spec.rb
+++ b/spec/features/admin/schedules_spec.rb
@@ -129,10 +129,10 @@ feature 'Schedules', js: true do
         end
 
         expect(Schedule.find_by(id: weekly_schedule.id)).to be_nil
-        expect(oc1.schedules).to eq []
-        expect(oc2.schedules).to eq []
-        expect(oc3.schedules).to eq []
-        expect(oc4.schedules).to eq []
+        expect(oc1.reload.schedules).to eq []
+        expect(oc2.reload.schedules).to eq []
+        expect(oc3.reload.schedules).to eq []
+        expect(oc4.reload.schedules).to eq []
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #5459

There's no way we can create an order_cycle_schedules if the schedule doesn't have an id, which we can't get if to persist it we need an OC first, which in turn, will create an order_cycle_schedules.

#### What should we test?

Nothing. Tests related to this issue should pass
