### PR TITLE
Change minimal amount in price sack calculator to float

### DIFF
--- a/app/models/spree/calculator/price_sack_decorator.rb
+++ b/app/models/spree/calculator/price_sack_decorator.rb
@@ -13,7 +13,7 @@ module Spree
     end
 
     def compute(object)
-      min = preferred_minimal_amount.to_i
+      min = preferred_minimal_amount.to_f
       order_amount = line_items_for(object).map { |x| x.price * x.quantity }.sum
 
       if order_amount < min

--- a/spec/models/spree/calculator/price_sack_spec.rb
+++ b/spec/models/spree/calculator/price_sack_spec.rb
@@ -49,6 +49,32 @@ describe Spree::Calculator::PriceSack do
     end
   end
 
+  context "minimal amount is float" do
+    before do
+      calculator.preferred_minimal_amount = 16.5
+      calculator.preferred_normal_amount = 5
+      calculator.preferred_discount_amount = 1
+      line_item.quantity = 2
+    end
+
+    context "with price bellow minimal amount" do
+      let(:price) { 8 }
+
+      it "returns the correct value of cost" do
+        expect(calculator.compute(line_item)).to eq(5)
+      end
+    end
+
+    context "with price above minimal amount" do
+      let(:price) { 8.5 }
+
+      it "returns the correct value of cost" do
+        expect(calculator.compute(line_item)).to eq(1)
+      end
+    end
+
+  end
+
   context "extends LocalizedNumber" do
     it_behaves_like "a model using the LocalizedNumber module", [:preferred_minimal_amount, :preferred_normal_amount, :preferred_discount_amount]
   end


### PR DESCRIPTION
#### What? Why?

Closes #5303 

Change the minimal amount of price sack from integer to float
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Create a price sack with float minimal amount


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

