### PR TITLE
Make display_on attribute available for managers to change in shipping and payment methods

### DIFF
--- a/app/views/spree/admin/payment_methods/_form.html.haml
+++ b/app/views/spree/admin/payment_methods/_form.html.haml
@@ -17,11 +17,11 @@
         = label_tag nil, t(:environment)
       .omega.eight.columns
         = collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {id: 'gtwy-env', class: 'select2 fullwidth'})
-    .row
-      .alpha.three.columns
-        = label_tag nil, t(:display)
-      .omega.eight.columns
-        = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
+  .row
+    .alpha.three.columns
+      = label_tag nil, t(:display)
+    .omega.eight.columns
+      = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t(display), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
   .row
     .alpha.three.columns
       = label_tag nil, t(:active)

--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -15,13 +15,12 @@
     .omega.eight.columns
       = f.text_area :description, class: 'fullwidth', rows: 2, placeholder: t(:spree_admin_eg_collect_your_order)
       = error_message_on :shipping_method, :description
-  - if spree_current_user.admin?
-    .row
-      .alpha.three.columns
-        = f.label :display_on, t(:display)
-      .omega.eight.columns
-        = select(:shipping_method, :display_on, [[t(".both"), nil], [t(".back_end"), "back_end"]], {}, {class: 'select2 fullwidth'})
-        = error_message_on :shipping_method, :display_on
+  .row
+    .alpha.three.columns
+      = f.label :display_on, t(:display)
+    .omega.eight.columns
+      = select(:shipping_method, :display_on, [[t(".both"), nil], [t(".back_end"), "back_end"]], {}, {class: 'select2 fullwidth'})
+      = error_message_on :shipping_method, :display_on
 
   .row
     .alpha.three.columns

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -158,6 +158,8 @@ feature '
     it "creates payment methods" do
       visit spree.new_admin_payment_method_path
       fill_in 'payment_method_name', with: 'Cheque payment method'
+      expect(page).to have_field 'payment_method_description'
+      expect(page).to have_select 'payment_method_display_on'
 
       check "payment_method_distributor_ids_#{distributor1.id}"
       find(:css, "tags-input .tags input").set "local\n"

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -108,7 +108,7 @@ feature 'shipping methods' do
       # Show the correct fields
       expect(page).to have_field 'shipping_method_name'
       expect(page).to have_field 'shipping_method_description'
-      expect(page).not_to have_select 'shipping_method_display_on'
+      expect(page).to have_select 'shipping_method_display_on'
       expect(page).to have_css 'div#shipping_method_zones_field'
       expect(page).to have_field 'shipping_method_require_ship_address_true', checked: true
 


### PR DESCRIPTION
#### What? Why?

Fixes a problem introduced in #5392 where a message is shown to managers but the option was only available to admins. This PR makes the option available to all users of this page.

#### What should we test?
We dont need to test #5392 again, I think we just need to validate the option shows up for managers as well as admins now.

#### Release notes
Changelog Category: Added
Make shipping and payment methods option display_on available to managers.
