### PR TITLE
Fix group maps

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/group_page_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/group_page_controller.js.coffee
@@ -1,6 +1,3 @@
-Darkswarm.controller "GroupPageCtrl", ($scope, enterprises, Enterprises, MapConfiguration, OfnMap) ->
+Darkswarm.controller "GroupPageCtrl", ($scope, enterprises, Enterprises) ->
   $scope.Enterprises = Enterprises
-
-  $scope.map = angular.copy MapConfiguration.options
-  $scope.mapMarkers = OfnMap.enterprise_markers enterprises
   $scope.embedded_layout = window.location.search.indexOf("embedded_shopfront=true") != -1

--- a/app/assets/stylesheets/darkswarm/map.css.scss
+++ b/app/assets/stylesheets/darkswarm/map.css.scss
@@ -63,3 +63,8 @@
     left: 0px;
   }
 }
+
+.tabs-content .map-footer {
+  position: relative;
+  bottom: 30px;
+}

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -32,13 +32,8 @@
             %tab{heading: t(:label_map),
                 active: "tabs.map.active",
                 select: "select(\'map\')"}
-              .map-container
-                %map{"ng-controller" => "MapCtrl", "ng-if" => "(isActive(\'/map\') && (mapShowed = true)) || mapShowed"}
-                  %ui-gmap-google-map{options: "map.additional_options", center: "map.center", zoom: "map.zoom", styles: "map.styles", draggable: "true"}
-                    %map-osm-tiles
-                    %map-search
-                    %ui-gmap-markers{models: "OfnMap.enterprises", fit: "true",
-                    coords: "'self'", icon: "'icon'", click: "'reveal'"}
+              %div{"ng-if" => "(isActive(\'/map\') && (mapShowed = true)) || mapShowed"}
+                = render partial: "shared/map"
 
             %tab{heading: t(:groups_about),
                 active: "tabs.about.active",

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -33,11 +33,11 @@
                 active: "tabs.map.active",
                 select: "select(\'map\')"}
               .map-container
-                %map{"ng-if" => "(isActive(\'/map\') && (mapShowed = true)) || mapShowed"}
+                %map{"ng-controller" => "MapCtrl", "ng-if" => "(isActive(\'/map\') && (mapShowed = true)) || mapShowed"}
                   %ui-gmap-google-map{options: "map.additional_options", center: "map.center", zoom: "map.zoom", styles: "map.styles", draggable: "true"}
                     %map-osm-tiles
                     %map-search
-                    %ui-gmap-markers{models: "mapMarkers", fit: "true",
+                    %ui-gmap-markers{models: "OfnMap.enterprises", fit: "true",
                     coords: "'self'", icon: "'icon'", click: "'reveal'"}
 
             %tab{heading: t(:groups_about),

--- a/app/views/map/index.html.haml
+++ b/app/views/map/index.html.haml
@@ -5,6 +5,3 @@
   = inject_enterprise_shopfront_list
 
 = render partial: "shared/map"
-
-.map-footer
-  %a{:href => "http://www.openstreetmap.org/copyright"} &copy; OpenStreetMap contributors

--- a/app/views/map/index.html.haml
+++ b/app/views/map/index.html.haml
@@ -4,13 +4,7 @@
 - content_for :injection_data do
   = inject_enterprise_shopfront_list
 
-.map-container{"fill-vertical" => true}
-  %map{"ng-controller" => "MapCtrl"}
-    %ui-gmap-google-map{options: "map.additional_options", center: "map.center", zoom: "map.zoom", styles: "map.styles", draggable: "true"}
-      %map-osm-tiles
-      %map-search
-      %ui-gmap-markers{models: "OfnMap.enterprises", fit: "true",
-      coords: "'self'", icon: "'icon'", click: "'reveal'"}
+= render partial: "shared/map"
 
 .map-footer
   %a{:href => "http://www.openstreetmap.org/copyright"} &copy; OpenStreetMap contributors

--- a/app/views/shared/_map.html.haml
+++ b/app/views/shared/_map.html.haml
@@ -1,0 +1,8 @@
+.map-container
+  %map{"ng-controller" => "MapCtrl"}
+    %ui-gmap-google-map{options: "map.additional_options", center: "map.center", zoom: "map.zoom",
+                        styles: "map.styles", draggable: "true"}
+      %map-osm-tiles
+      %map-search
+      %ui-gmap-markers{models: "OfnMap.enterprises", fit: "true",
+                       coords: "'self'", icon: "'icon'", click: "'reveal'"}

--- a/app/views/shared/_map.html.haml
+++ b/app/views/shared/_map.html.haml
@@ -6,3 +6,6 @@
       %map-search
       %ui-gmap-markers{models: "OfnMap.enterprises", fit: "true",
                        coords: "'self'", icon: "'icon'", click: "'reveal'"}
+
+.map-footer
+  %a{:href => "http://www.openstreetmap.org/copyright"} &copy; OpenStreetMap contributors


### PR DESCRIPTION
#### What? Why?

Closes #5473

- Fixes recent regression introduced in #5377 which broke maps display in groups pages
- DRYs and refactors some maps code to make it nicer to work with

#### What should we test?
<!-- List which features should be tested and how. -->

- Maps display is working again on groups pages.
- Maps is working as normal on the main maps page.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed maps display in groups pages

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
