### PR TITLE
Add support for an env var to override DB port

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,7 @@ defaults: &defaults
   host: <%= ENV.fetch('OFN_DB_HOST', 'localhost') %>
   username: <%= ENV.fetch('OFN_DB_USERNAME', 'ofn') %>
   password: <%= ENV.fetch('OFN_DB_PASSWORD', 'f00d') %>
+  port:  <%= ENV.fetch('OFN_DB_PORT', 5432) %>
 
 development:
   <<: *defaults


### PR DESCRIPTION
#### What? Why?
I have other projects on my machine that use a different PostgreSQL database engine to OFN. I run PostgreSQL 11 for OFN on a different port to the default. Supporting an env var to override the port makes for an easier dev experience as I don't need to edit databse.yml or worry about accidentally committing it.

I thought about adding this just to dev and test sections, but the default section felt DRYer

#### What should we test?
Run your postgres engine on a non standard port
Add an env var (eg to application.yml that is picked up by the Figaro gem): `OFN_DB_PORT: 5431`
Run the app and/or tests to ensure the database engine is targeted
Also test with the db engine on the default port 5432 and no env var to ensure default behavior works

#### Documentation updates
Add to "Installing And Setting up Postgres" sections
Override you database port. If you wish to run your database engine on a non standard port, you can override the port with an env var: `OFN_DB_PORT: 5431`
