### PR TITLE
Enterprises Controller: reset_distributor must be called before any call to memoized current_distributor

### DIFF
--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -65,7 +65,10 @@ class EnterprisesController < BaseController
   def reset_order
     order = current_order(true)
 
-    OrderCartReset.new(order, params[:id], try_spree_current_user, current_customer).call
+    # reset_distributor must be called before any call to current_customer or current_distributor
+    order_cart_reset = OrderCartReset.new(order, params[:id])
+    order_cart_reset.reset_distributor
+    order_cart_reset.reset_other!(try_spree_current_user, current_customer)
   rescue ActiveRecord::RecordNotFound
     flash[:error] = I18n.t(:enterprise_shop_show_error)
     redirect_to shops_path

--- a/app/services/order_cart_reset.rb
+++ b/app/services/order_cart_reset.rb
@@ -2,24 +2,11 @@
 
 # Resets an order by verifying it's state and fixing any issues
 class OrderCartReset
-  def initialize(order, distributor_id, current_user, current_customer)
+  def initialize(order, distributor_id)
     @order = order
     @distributor ||= Enterprise.is_distributor.find_by_permalink(distributor_id) ||
                      Enterprise.is_distributor.find(distributor_id)
-    @current_user = current_user
-    @current_customer = current_customer
   end
-
-  def call
-    reset_distributor
-    reset_user_and_customer if current_user
-    reset_order_cycle
-    order.save!
-  end
-
-  private
-
-  attr_reader :order, :distributor, :current_user, :current_customer
 
   def reset_distributor
     if order.distributor && order.distributor != distributor
@@ -29,12 +16,24 @@ class OrderCartReset
     order.distributor = distributor
   end
 
-  def reset_user_and_customer
+  def reset_other!(current_user, current_customer)
+    reset_user_and_customer(current_user)
+    reset_order_cycle(current_customer)
+    order.save!
+  end
+
+  private
+
+  attr_reader :order, :distributor, :current_user
+
+  def reset_user_and_customer(current_user)
+    return unless current_user
+
     order.associate_user!(current_user) if order.user.blank? || order.email.blank?
     order.__send__(:associate_customer) if order.customer.nil? # Only associates existing customers
   end
 
-  def reset_order_cycle
+  def reset_order_cycle(current_customer)
     listed_order_cycles = Shop::OrderCyclesList.new(distributor, current_customer).call
 
     if order_cycle_not_listed?(order.order_cycle, listed_order_cycles)

--- a/spec/services/order_cart_reset_spec.rb
+++ b/spec/services/order_cart_reset_spec.rb
@@ -10,7 +10,7 @@ describe OrderCartReset do
     let(:new_distributor) { create(:distributor_enterprise) }
 
     it "empties order" do
-      OrderCartReset.new(order, new_distributor.id.to_s, nil, nil).call
+      OrderCartReset.new(order, new_distributor.id.to_s).reset_distributor
 
       expect(order.line_items).to be_empty
     end
@@ -28,7 +28,7 @@ describe OrderCartReset do
     it "empties order and makes order cycle nil" do
       expect(order_cycle_list).to receive(:call).and_return([])
 
-      OrderCartReset.new(order, distributor.id.to_s, nil, nil).call
+      OrderCartReset.new(order, distributor.id.to_s).reset_other!(nil, nil)
 
       expect(order.line_items).to be_empty
       expect(order.order_cycle).to be_nil
@@ -38,7 +38,7 @@ describe OrderCartReset do
       other_order_cycle = create(:simple_order_cycle, distributors: [distributor])
       expect(order_cycle_list).to receive(:call).and_return([other_order_cycle])
 
-      OrderCartReset.new(order, distributor.id.to_s, nil, nil).call
+      OrderCartReset.new(order, distributor.id.to_s).reset_other!(nil, nil)
 
       expect(order.order_cycle).to eq other_order_cycle
     end


### PR DESCRIPTION
#### What? Why?

Closes #5496

The bug was caused by a hidden logical problem created by memoized current_distributor, current_customer that uses current_distributor cant be called before reset_distributor, otherwise the original (and outdated) distributor was memoized and returned by current_distributor...

The new spec in enterprises_controller validates the problem is fixed.

Moving current_distributor and current_customer to a service would be awesome here but would take too much time because they are called from quite a few places.

#### What should we test?
Verify bug is resolved.
We should probably give it a simple validation of #5440 as well

#### Release notes
Fix stale data problem when navigating across different shops.
