### PR TITLE
[mobile ux] Fix missing drop-shadow

### DIFF
--- a/app/assets/stylesheets/darkswarm/distributor_header.css.scss
+++ b/app/assets/stylesheets/darkswarm/distributor_header.css.scss
@@ -11,7 +11,7 @@ section {
   display: block;
   background: $white;
   position: relative;
-  z-index: 2;
+  z-index: 20;
 
   .details {
     box-sizing: border-box;

--- a/app/assets/stylesheets/darkswarm/shop_tabs.css.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.css.scss
@@ -9,6 +9,7 @@
     color: $dark-grey;
     box-shadow: $distributor-header-shadow;
     position: relative;
+    z-index: 10;
 
     .columns {
       display: flex;


### PR DESCRIPTION

#### What? Why?

Closes #5477

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adjusts z-index on overlapping elements to ensure drop-shadow is shown. This was a small regression in the last release.

#### What should we test?
<!-- List which features should be tested and how. -->

Drop-shadow is show in desktop view between shop tabs and search bar:

![Screenshot from 2020-05-26 13-03-32](https://user-images.githubusercontent.com/9029026/82893697-b2411b00-9f51-11ea-8f80-566c0e96e433.png)

Also check the previous issue in the release is still fixed (the full area of the order cycle selector is clickable). See here for notes: https://github.com/openfoodfoundation/openfoodnetwork/issues/5433#issuecomment-630089588

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Re-added missing shadow under tabs in shop page

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
