### PR TITLE
Make checkout JS code send bugsnag alert even if there's an error processing an error

### DIFF
--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -21,8 +21,10 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
         try
           @handle_checkout_error_response(response)
         catch error
-          @loadFlash(error: t("checkout.failed")) # inform the user about the unexpected error
-          throw error # generate a BugsnagJS alert
+          try
+            @loadFlash(error: t("checkout.failed")) # inform the user about the unexpected error
+          finally
+            throw error # generate a BugsnagJS alert
 
     handle_checkout_error_response: (response) =>
       if response.data.path


### PR DESCRIPTION
#### What? Why?
Relates to #5402
It looks like there's an error inside a catch and no bugsnag error so we move the re-throwing of the error to the finally so that it is always executed.

#### What should we test?
This is such a simple change to the way the bugsnag alert is sent that we don't really need to test it.
A green build will be enough I think.

#### Release notes
Changelog Category: Added
Make checkout JS code a bit more resilient and create a bugsnag alert even if there is an error processing an error.
