### PR TITLE
Fix admin config separator withou highlight

### DIFF
--- a/app/controllers/spree/admin/mail_methods_controller.rb
+++ b/app/controllers/spree/admin/mail_methods_controller.rb
@@ -23,7 +23,7 @@ module Spree
       rescue StandardError => e
         flash[:error] = Spree.t('admin.mail_methods.testmail.error') % { e: e }
       ensure
-        redirect_to edit_admin_mail_method_url
+        redirect_to edit_admin_mail_methods_url
       end
 
       private

--- a/app/views/spree/admin/mail_methods/edit.html.haml
+++ b/app/views/spree/admin/mail_methods/edit.html.haml
@@ -5,11 +5,11 @@
 
 - content_for :page_actions do
   %li
-    = link_to_with_icon 'icon-envelope-alt', t("spree.admin.mail_methods.send_testmail"), testmail_admin_mail_method_path, method: :post, title: t("spree.admin.mail_methods.send_testmail"), class: 'send_mail button no-text'
+    = link_to_with_icon 'icon-envelope-alt', t("spree.admin.mail_methods.send_testmail"), testmail_admin_mail_methods_path, method: :post, title: t("spree.admin.mail_methods.send_testmail"), class: 'send_mail button no-text'
 
 = render partial: 'spree/shared/error_messages', locals: { target: @mail_method }
 
-= form_tag admin_mail_method_path, method: :put do |f|
+= form_tag admin_mail_methods_path, method: :put do |f|
   %fieldset.no-border-top
     = render partial: 'form', locals: { f: f }
     .form-buttons.filter-actions.actions= button t("spree.actions.update"), 'icon-refresh'

--- a/app/views/spree/admin/shared/_configuration_menu.html.haml
+++ b/app/views/spree/admin/shared/_configuration_menu.html.haml
@@ -6,7 +6,7 @@
     %ul.sidebar
       = configurations_sidebar_menu_item Spree.t(:general_settings), edit_admin_general_settings_path
       - if Spree::Config[:override_actionmailer_config]
-        = configurations_sidebar_menu_item Spree.t(:mail_method_settings), edit_admin_mail_method_path
+        = configurations_sidebar_menu_item Spree.t(:mail_method_settings), edit_admin_mail_methods_path
       = configurations_sidebar_menu_item Spree.t(:image_settings), edit_admin_image_settings_path
       = configurations_sidebar_menu_item Spree.t(:tax_categories), admin_tax_categories_path
       = configurations_sidebar_menu_item Spree.t(:tax_rates), admin_tax_rates_path

--- a/app/views/spree/admin/shared/_tabs.html.haml
+++ b/app/views/spree/admin/shared/_tabs.html.haml
@@ -3,7 +3,7 @@
 = tab :order_cycles, url: main_app.admin_order_cycles_path, icon: 'icon-refresh'
 = tab :orders, :subscriptions, :customer_details, :adjustments, :payments, :return_authorizations, url: admin_orders_path('q[s]' => 'completed_at desc'), icon: 'icon-shopping-cart'
 = tab :reports, icon: 'icon-file'
-= tab :general_settings, :mail_method, :image_settings, :tax_categories, :tax_rates, :tax_settings, :zones, :countries, :states, :payment_methods, :taxonomies, :shipping_methods, :shipping_categories, :enterprise_fees, :contents, :invoice_settings, :matomo_settings, :stripe_connect_settings, label: 'configuration', icon: 'icon-wrench', url: edit_admin_general_settings_path
+= tab :general_settings, :mail_methods, :image_settings, :tax_categories, :tax_rates, :tax_settings, :zones, :countries, :states, :payment_methods, :taxonomies, :shipping_methods, :shipping_categories, :enterprise_fees, :contents, :invoice_settings, :matomo_settings, :stripe_connect_settings, label: 'configuration', icon: 'icon-wrench', url: edit_admin_general_settings_path
 = tab :enterprises, :enterprise_relationships, url: main_app.admin_enterprises_path
 = tab :customers, url: main_app.admin_customers_path
 = tab :enterprise_groups, url: main_app.admin_enterprise_groups_path, label: 'groups'

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -131,7 +131,7 @@ Spree::Core::Engine.routes.draw do
 
     # Configuration section
     resource :general_settings
-    resource :mail_method, :only => [:edit, :update] do
+    resource :mail_methods, :only => [:edit, :update] do
       post :testmail, :on => :collection
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #4730 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
A little error caused by the name of the controller. My solution was to fix it, putting it on plural
Before:
![before](https://user-images.githubusercontent.com/30028621/83316480-61088400-a1fc-11ea-9bff-f2322eda30ec.png)

After:
![after](https://user-images.githubusercontent.com/30028621/83316487-6534a180-a1fc-11ea-9802-872097b4b7f0.png)



#### What should we test?
<!-- List which features should be tested and how. -->
Just go to configurations and access `mail method`


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Change the mail method route name to plural, to be recognized when selected in configurations on admin

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed



