### PR TITLE
Set :path in `whenever` configs.

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,11 +6,11 @@ require 'yaml'
 app_config = YAML.load_file(File.join(__dir__, 'application.yml'))
 
 env "MAILTO", app_config["SCHEDULE_NOTIFICATIONS"] if app_config["SCHEDULE_NOTIFICATIONS"]
+set :path, ENV['WHENEVER_PATH'] if ENV['WHENEVER_PATH']
 
 # If we use -e with a file containing specs, rspec interprets it and filters out our examples
 job_type :run_file, "cd :path; :environment_variable=:environment bundle exec script/rails runner :task :output"
 job_type :enqueue_job,  "cd :path; :environment_variable=:environment bundle exec script/enqueue :task :priority :output"
-
 
 every 1.day, at: '2:45am' do
   rake 'db2fog:clean' if app_config['S3_BACKUPS_BUCKET']


### PR DESCRIPTION
This was defaulting to the new symlinked app path target, creating a new value each time, which causes whenever to create duplicate crontab entries for each deploy...

#### What? Why?

Part of #5535 

Fixes a config issue causing the whenever gem to create duplicate crontab entries.

#### What should we test?
<!-- List which features should be tested and how. -->

Duplicate crontab entries are not created on each deploy.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed an issue with scheduled cron jobs.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
