### PR TITLE
[Spree 2.1] Make devise play nicely with controller specs in Rails 4

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -133,6 +133,13 @@ RSpec.configure do |config|
 
   config.before(:all) { restart_driver }
 
+  # Configure Devise to work nicely with controller specs
+  # See: https://github.com/openfoodfoundation/openfoodnetwork/issues/5533
+  config.before(:each, :controller) do
+    setup_controller_for_warden
+    @request.env["devise.mapping"] = Devise.mappings[:spree_user]
+  end
+
   # Geocoding
   config.before(:each) { allow_any_instance_of(Spree::Address).to receive(:geocode).and_return([1, 1]) }
 


### PR DESCRIPTION
#### What? Why?

Hopefully closes #5504 and #5533...

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Looks like an obscure issue related to setting up devise with custom user mappings (`spree_user`) in controller tests. We've had a few devise issues so far, hopefully this is the last... 

More info here: https://stackoverflow.com/questions/4291755/rspec-test-of-custom-devise-session-controller-fails-with-abstractcontrollerac

#### What should we test?
<!-- List which features should be tested and how. -->

Green specs on controllers, no `AbstractController::ActionNotFound` errors like this:

```
1) EnterprisesController as an enterprise owner creating an enterprise creates as sells=any when it is not a producer
     Failure/Error: spree_post :create, { enterprise: new_enterprise_params }
     
     AbstractController::ActionNotFound:
       The action 'create' could not be found for EnterprisesController
     # ./spec/controllers/api/enterprises_controller_spec.rb:33:in `block (4 levels) in <module:Api>'
```
