### PR TITLE
Fix Payment Methods table to show proper provider name

### DIFF
--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -32,7 +32,7 @@
             - method.distributors.each do |distributor|
               = distributor.name
               %br/
-          %td= method.type
+          %td= method.class.clean_name
           %td.align-center= method.environment.to_s.titleize
           %td.align-center= method.display_on.blank? ? t('.both') : t('.' + method.display_on.to_s)
           %td.align-center= method.active ? t('.active_yes') : t('.active_no')

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -185,16 +185,6 @@ feature '
       expect(page).not_to have_content payment_method3.name
     end
 
-    it "shows only the providers of the existing payment methods" do
-      payment_method1
-      payment_method2
-      payment_method3
-
-      visit spree.admin_payment_methods_path
-
-      expect(page).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
-    end
-
     it "does not show duplicates of payment methods" do
       payment_method1
       payment_method2

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -185,6 +185,16 @@ feature '
       expect(page).not_to have_content payment_method3.name
     end
 
+    it "shows only the providers of the existing payment methods" do
+      payment_method1
+      payment_method2
+      payment_method3
+
+      visit spree.admin_payment_methods_path
+
+      expect(page).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
+    end
+
     it "does not show duplicates of payment methods" do
       payment_method1
       payment_method2

--- a/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe "spree/admin/payment_methods/index.html.haml" do
+  before do
+    controller.singleton_class.class_eval do
+      helper_method :new_object_url, :edit_object_url, :object_url
+
+      def new_object_url() "" end
+
+      def edit_object_url(object, options = {}) "" end
+
+      def object_url(object = nil, options = {}) "" end
+    end
+
+    assign(:payment_methods, [
+      create(:payment_method),
+      create(:payment_method)
+    ])
+  end
+
+  describe "payment methods index page" do
+    it "shows only the providers of the existing payment methods" do
+      render
+
+      expect(rendered).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #4592 

Before my fix, the provider name column in the Payment Methods table was showing the class name like: `Spree::Gateway::PaypalExpress`. The codebase already has a class method to clean those names, and I used it on the view.

#### What should we test?
Check if the Payment Methods table shows the provider name properly.

#### Release notes
Fix the Payment Method table to show the provider name properly

Changelog Category: Fixed

Before
![Screen Shot 2020-05-30 at 18 03 29](https://user-images.githubusercontent.com/27960597/83339070-6ddeb380-a2a0-11ea-8989-1200f41cb580.png)

After
![Screen Shot 2020-05-30 at 18 03 46](https://user-images.githubusercontent.com/27960597/83339071-73d49480-a2a0-11ea-9ecc-2c63b69c69d3.png)


