### PR TITLE
Improve Dev onboarding docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing
-We love pull requests from everyone. Any contribution is valuable, but there are two issue streams that we especially love people to work on:
+We love pull requests from everyone. Any contribution is valuable!
 
-1) Our delivery backlog, is managed via a ZenHub board (ZenHub extensions are available for most major browsers). We use a Kanban-style approach, whereby devs pick issues from the top of the backlog which has been organised according to current priorities. If you have some time and are interested in working on some issues from the backlog, please make yourself known on the [#dev][slack-dev] channel on Slack and we can direct you to the most appropriate issue to pick up.
+If you have some time and are interested in working on some issues please make yourself known on the [#dev][slack-dev] channel on Slack.
 
-2) Our list of bugs and other self-contained issues that we consider to be a good starting point for new contributors, or devs who aren’t able to commit to seeing a whole feature through. These issues are marked with the `# good first issue` label.
+We have curated all issues we consider to be a good starting point for new members of the community within the [Welcome New Developers project board][welcome-dev]. Have a look and pick the one you would prefer working on!
 
 ## Set up
 
@@ -18,10 +18,6 @@ Create a new branch on your local machine to make your changes against (based on
 If you want to run the whole test suite, we recommend using a free CI service to run your tests in parallel. Running the whole suite locally in series is likely to take > 40 minutes. [TravisCI][travis] and [SemaphoreCI][semaphore] both work great in our experience. Either way, make sure the tests pass on your new branch:
 
     bundle exec rspec spec
-
-## Which issue to pick first?
-
-We have curated all issues interesting for new members of the community within the [Welcome New Developers project board][welcome-dev]. Have a look and pick the one you would prefer working on!
 
 ## Internationalisation (i18n)
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -2,21 +2,17 @@
 
 This is a general guide to setting up an Open Food Network development environment on your local machine.
 
-The fastest way to make it work locally is to use Docker, see the [Docker setup guide](DOCKER.md).
+### Requirements
 
-The following guides are located in the wiki and provide more OS-specific step-by-step instructions:
-
-- [Ubuntu Setup Guide][ubuntu]
-- [macOS Sierra Setup Guide][sierra]
-- [OSX El Capitan Setup Guide][el-capitan]
-
-### Dependencies
-
-* Rails 3.2.x
-* Ruby 2.3.7
+The fastest way to make it work locally is to use Docker, you only need to setup git, see the [Docker setup guide](DOCKER.md).
+Otherwise, for a local setup you will need:
+* Ruby 2.3.7 and bundler
 * PostgreSQL database
-* PhantomJS (for testing)
-* See Gemfile for a list of gems required
+* Chrome (for testing)
+
+The following guides will provide OS-specific step-by-step instructions to get these requirements installed:
+- [Ubuntu Setup Guide][ubuntu]
+- [OSX Setup Guide][osx]
 
 If you are likely to need to manage multiple version of ruby on your local machine, we recommend version managers such as [rbenv](https://github.com/rbenv/rbenv) or [RVM](https://rvm.io/).
 
@@ -52,13 +48,11 @@ This will create the "ofn" user as superuser and allowing it to create databases
 
 Once done, run `script/setup`. If the script succeeds you're ready to start developing. If not, take a look at the output as it should be informative enough to help you troubleshoot.
 
-If you run into any other issues getting your local environment up and running please consult [the wiki][wiki].
-
-If still you get stuck do not hesitate to open an issue reporting the full output of the script.
-
 Now, your dreams of spinning up a development server can be realised:
 
     bundle exec rails server
+
+Go to [http://localhost:3000](http://localhost:3000) to play around!
 
 To login as the default user, use:
 
@@ -79,7 +73,7 @@ The tests of all custom engines can be run with:
 
     bundle exec rake ofn:specs:engines:rspec
 
-Note: If your OS is not explicitly supported in the setup guides then not all tests may pass. However, you may still be able to develop. Get in touch with the [#dev][slack-dev] channel on Slack to troubleshoot issues and determine if they will preclude you from contributing to OFN.
+Note: If your OS is not explicitly supported in the setup guides then not all tests may pass. However, you may still be able to develop.
 
 Note: The time zone on your machine should match the one defined in `config/application.yml`.
 
@@ -120,8 +114,7 @@ $ createdb open_food_network_test --owner=ofn
 If these commands succeed, you should be able to [continue the setup process](#get-it-running).
 
 [developer-wiki]: https://github.com/openfoodfoundation/openfoodnetwork/wiki
-[sierra]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup%3A-macOS-%28Sierra%2C-HighSierra%2C-Mojave-and-Catalina%29
-[el-capitan]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup:-OS-X-(El-Capitan)
+[osx]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup:-OS-X
 [ubuntu]: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup:-Ubuntu
 [wiki]: https://github.com/openfoodfoundation/openfoodnetwork/wiki
 [zeus]: https://github.com/burke/zeus


### PR DESCRIPTION
Making GETTING STARTED and CONTRIBUTING a bit simpler.

I also made the wiki menu more simple:
![image](https://user-images.githubusercontent.com/1640378/83362358-99d56400-a388-11ea-895f-c1bf21ac36c2.png)

And finally I managed to merge the 3 OSX setup pages into one :tada: 
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Development-Environment-Setup%3A-OS-X

I think the create db user step is still repeated between GETTING STARTED and the OSX setup page but I am not sure there are differences so I left it as is.