### PR TITLE
Missing translation key "return_authorizations"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2905,7 +2905,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   first: "First"
   previous: "Previous"
   last: "Last"
-  
   spree:
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2879,7 +2879,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   customer_details: "Customer Details"
   adjustments: "Adjustments"
   payments: "Payments"
-
+  return_authorizations: "Return Authorizations"
   payment: "Payment"
   payment_method: "Payment Method"
   shipment: "Shipment"
@@ -2905,7 +2905,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   previous: "Previous"
   last: "Last"
   
-  return_authorizations: "Return Authorizations"
   spree:
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2880,7 +2880,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   adjustments: "Adjustments"
   payments: "Payments"
   return_authorizations: "Return Authorizations"
-  
+
   payment: "Payment"
   payment_method: "Payment Method"
   shipment: "Shipment"
@@ -2905,7 +2905,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   first: "First"
   previous: "Previous"
   last: "Last"
-  
+
   spree:
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2904,7 +2904,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   first: "First"
   previous: "Previous"
   last: "Last"
-
+  
+  return_authorizations: "Return Authorizations"
   spree:
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2905,6 +2905,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   first: "First"
   previous: "Previous"
   last: "Last"
+  
   spree:
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2879,8 +2879,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   customer_details: "Customer Details"
   adjustments: "Adjustments"
   payments: "Payments"
-  
   return_authorizations: "Return Authorizations"
+  
   payment: "Payment"
   payment_method: "Payment Method"
   shipment: "Shipment"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2879,6 +2879,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   customer_details: "Customer Details"
   adjustments: "Adjustments"
   payments: "Payments"
+  
   return_authorizations: "Return Authorizations"
   payment: "Payment"
   payment_method: "Payment Method"


### PR DESCRIPTION
#### What? Why?

Add missing translation on orders tabs.

#### What should we test?
Return authorizations tab entry is translated. See screenshot below.

#### Release notes
Changelog Category: Added
Added missing translation for return authorizations menu entry.