### PR TITLE
Delete dead code related to products without variants

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -158,18 +158,6 @@ Spree::Product.class_eval do
     self.class.in_order_cycle(order_cycle).include? self
   end
 
-  # overriding to check self.on_demand as well
-  def has_stock?
-    has_variants? ? variants.any?(&:in_stock?) : (on_demand || master.in_stock?)
-  end
-
-  def has_stock_for_distribution?(order_cycle, distributor)
-    # This product has stock for a distribution if it is available on-demand
-    # or if one of its variants in the distribution is in stock
-    (!has_variants? && on_demand) ||
-      variants_distributed_by(order_cycle, distributor).any?(&:in_stock?)
-  end
-
   def variants_distributed_by(order_cycle, distributor)
     order_cycle.variants_distributed_by(distributor).where(product_id: self)
   end

--- a/app/views/spree/admin/images/index.html.haml
+++ b/app/views/spree/admin/images/index.html.haml
@@ -15,15 +15,13 @@
     %colgroup
       %col{ style: "width: 5%" }/
       %col{ style: "width: 10%" }/
-      - if @product.has_variants?
-        %col{ style: "width: 25%" }/
+      %col{ style: "width: 25%" }/
       %col{ style: "width: 45%" }/
       %col{ style: "width: 15%" }/
     %thead
       %tr
         %th{:colspan => "2"}= t('spree.thumbnail')
-        - if @product.has_variants?
-          %th= Spree::Variant.model_name.human
+        %th= Spree::Variant.model_name.human
         %th= t('spree.alt_text')
         %th.actions
     %tbody
@@ -35,8 +33,7 @@
             %span.handle
           %td
             = link_to image_tag(image.attachment.url(:mini)), image.attachment.url(:product)
-          - if @product.has_variants?
-            %td= options_text_for(image)
+          %td= options_text_for(image)
           %td= image.alt
           %td.actions
             = link_to_with_icon 'icon-edit', t('spree.edit'), edit_admin_product_image_url(@product, image), no_text: true, data: { action: 'edit'}

--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -43,37 +43,6 @@
 
     .clear
 
-    - unless @product.has_variants?
-      = f.field_container :sku do
-        = f.label :sku, t(:sku)
-        = f.text_field :sku, :size => 16
-
-      .alpha.two.columns
-        = f.field_container :on_hand do
-          = f.label :on_hand, t(:on_hand)
-          = f.number_field :on_hand, :min => 0
-      .omega.two.columns
-        = f.field_container :on_demand, :class => ['checkbox'] do
-          %label
-            = f.check_box :on_demand
-            = t(:on_demand)
-
-      .clear
-
-      %ul#shipping_specs
-        %li#shipping_specs_weight_field.field.alpha.two.columns
-          = f.label :weight, t(:weight)
-          = f.text_field :weight, :size => 4
-        %li#shipping_specs_height_field.field.omega.two.columns
-          = f.label :height, t(:height)
-          = f.text_field :height, :size => 4
-        %li#shipping_specs_width_field.field.alpha.two.columns
-          = f.label :width, t(:width)
-          = f.text_field :width, :size => 4
-        %li#shipping_specs_depth_field.field.omega.two.columns
-          = f.label :depth, t(:depth)
-          = f.text_field :depth, :size => 4
-
     = f.field_container :shipping_categories do
       = f.label :shipping_category_id, t(:shipping_categories)
       = f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => 'None' }, { :class => 'select2' })

--- a/app/views/spree/admin/variants/index.html.haml
+++ b/app/views/spree/admin/variants/index.html.haml
@@ -3,40 +3,32 @@
 = render partial: 'spree/admin/shared/product_tabs', locals: {current: 'Variants'}
 
 #new_variant
-- if @variants.any?
-  %table.index.sortable{"data-sortable-link" => update_positions_admin_product_variants_path(@product)}
-    %colgroup
-      %col{style: "width: 5%"}/
-      %col{style: "width: 25%"}/
-      %col{style: "width: 20%"}/
-      %col{style: "width: 20%"}/
-      %col{style: "width: 15%"}/
-      %col{style: "width: 15%"}/
-    %thead
-      %tr
-        %th{colspan: "2"}= t('.options')
-        %th= t('.price')
-        %th= t('.sku')
-        %th.actions
-    %tbody
-      - @variants.each do |variant|
-        %tr{id: spree_dom_id(variant), class: cycle('odd', 'even'), style: "#{"color:red;" if variant.deleted? }" }
-          %td.no-border
-            %span.handle
-          %td= variant.full_name
-          %td.align-center= variant.display_price.to_html
-          %td.align-center= variant.sku
-          %td.actions
-            = link_to_edit(variant, no_text: true) unless variant.deleted?
-            = link_to_delete(variant, no_text: true) unless variant.deleted?
-    - unless @product.has_variants?
-      %tr
-        %td{colspan: "5"}= t(:none)
 
-- else
-  .alpha.twelve.columns.no-objects-found
-    = t('.no_results')
-    \.
+%table.index.sortable{"data-sortable-link" => update_positions_admin_product_variants_path(@product)}
+  %colgroup
+    %col{style: "width: 5%"}/
+    %col{style: "width: 25%"}/
+    %col{style: "width: 20%"}/
+    %col{style: "width: 20%"}/
+    %col{style: "width: 15%"}/
+    %col{style: "width: 15%"}/
+  %thead
+    %tr
+      %th{colspan: "2"}= t('.options')
+      %th= t('.price')
+      %th= t('.sku')
+      %th.actions
+  %tbody
+    - @variants.each do |variant|
+      %tr{id: spree_dom_id(variant), class: cycle('odd', 'even'), style: "#{"color:red;" if variant.deleted? }" }
+        %td.no-border
+          %span.handle
+        %td= variant.full_name
+        %td.align-center= variant.display_price.to_html
+        %td.align-center= variant.sku
+        %td.actions
+          = link_to_edit(variant, no_text: true) unless variant.deleted?
+          = link_to_delete(variant, no_text: true) unless variant.deleted?
 
 - if @product.empty_option_values?
   %p.first_add_option_types.no-objects-found

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -579,57 +579,6 @@ module Spree
       end
     end
 
-    describe "stock filtering" do
-      it "considers products that are on_demand as being in stock" do
-        product = create(:simple_product, on_demand: true)
-        product.master.update_attribute(:on_hand, 0)
-        expect(product.has_stock?).to eq(true)
-      end
-
-      describe "finding products in stock for a particular distribution" do
-        it "returns on-demand products" do
-          p = create(:simple_product, on_demand: true)
-          p.variants.first.update_attributes!(on_hand: 0, on_demand: true)
-          d = create(:distributor_enterprise)
-          oc = create(:simple_order_cycle, distributors: [d])
-          oc.exchanges.outgoing.first.variants << p.variants.first
-
-          expect(p).to have_stock_for_distribution(oc, d)
-        end
-
-        it "returns products with in-stock variants" do
-          p = create(:simple_product)
-          v = create(:variant, product: p)
-          v.update_attribute(:on_hand, 1)
-          d = create(:distributor_enterprise)
-          oc = create(:simple_order_cycle, distributors: [d])
-          oc.exchanges.outgoing.first.variants << v
-
-          expect(p).to have_stock_for_distribution(oc, d)
-        end
-
-        it "returns products with on-demand variants" do
-          p = create(:simple_product)
-          v = create(:variant, product: p, on_demand: true)
-          v.update_attribute(:on_hand, 0)
-          d = create(:distributor_enterprise)
-          oc = create(:simple_order_cycle, distributors: [d])
-          oc.exchanges.outgoing.first.variants << v
-
-          expect(p).to have_stock_for_distribution(oc, d)
-        end
-
-        it "does not return products that have stock not in the distribution" do
-          p = create(:simple_product)
-          p.master.update_attribute(:on_hand, 1)
-          d = create(:distributor_enterprise)
-          oc = create(:simple_order_cycle, distributors: [d])
-
-          expect(p).not_to have_stock_for_distribution(oc, d)
-        end
-      end
-    end
-
     describe "taxons" do
       let(:taxon1) { create(:taxon) }
       let(:taxon2) { create(:taxon) }


### PR DESCRIPTION
#### What? Why?

Related to #5385 
A product always has what's called a standard variant. This variant is created on saving a product without variants. This means has_variants? will always return true except before saving a product. We can delete all calls to has_variants in places where the product has been saved.

#### What should we test?
We should verify we can create and edit a product as well as create and edit variants.
We should try to delete the last variant from a product and see that it is not possible.
Adding variant specific images should also work correctly (altough they cant be used, the shopfront will only use the main product image).

#### Release notes
Changelog Category: Removed
Deleted dead code related to handling products without variants.