### PR TITLE
Bring the spree_get spec helpers from spree and move them together with the api_get spec helpers

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -142,7 +142,6 @@ Layout/LineLength:
   - spec/controllers/api/product_images_controller_spec.rb
   - spec/controllers/api/products_controller_spec.rb
   - spec/controllers/api/promo_images_controller_spec.rb
-  - spec/controllers/api/shipments_controller_spec.rb
   - spec/controllers/api/variants_controller_spec.rb
   - spec/controllers/cart_controller_spec.rb
   - spec/controllers/checkout_controller_spec.rb

--- a/spec/controllers/api/shipments_controller_spec.rb
+++ b/spec/controllers/api/shipments_controller_spec.rb
@@ -4,7 +4,9 @@ describe Api::ShipmentsController, type: :controller do
   render_views
 
   let!(:shipment) { create(:shipment) }
-  let!(:attributes) { [:id, :tracking, :number, :cost, :shipped_at, :stock_location_name, :order_id] }
+  let!(:attributes) do
+    [:id, :tracking, :number, :cost, :shipped_at, :stock_location_name, :order_id]
+  end
   let(:current_api_user) { build(:user) }
 
   before do
@@ -110,18 +112,24 @@ describe Api::ShipmentsController, type: :controller do
       let(:order) { create :completed_order_with_totals }
 
       it 'adds a variant to a shipment' do
-        api_put :add, variant_id: variant.to_param, quantity: 2, order_id: order.to_param, id: order.shipments.first.to_param
+        api_put :add, variant_id: variant.to_param,
+                      quantity: 2,
+                      order_id: order.to_param,
+                      id: order.shipments.first.to_param
 
         expect(response.status).to eq(200)
-        expect(order.shipment.reload.inventory_units.select { |h| h['variant_id'] == variant.id }.size).to eq 2
+        expect(inventory_units_for(variant).size).to eq 2
       end
 
       it 'removes a variant from a shipment' do
         order.contents.add(variant, 2)
-        api_put :remove, variant_id: variant.to_param, quantity: 1, order_id: order.to_param, id: order.shipments.first.to_param
+        api_put :remove, variant_id: variant.to_param,
+                         quantity: 1,
+                         order_id: order.to_param,
+                         id: order.shipments.first.to_param
 
         expect(response.status).to eq(200)
-        expect(order.shipment.reload.inventory_units.select { |h| h['variant_id'] == variant.id }.size).to eq(1)
+        expect(inventory_units_for(variant).size).to eq(1)
       end
     end
 
@@ -138,7 +146,9 @@ describe Api::ShipmentsController, type: :controller do
 
       it "can transition a shipment from ready to ship" do
         shipment.reload
-        api_put :ship, order_id: shipment.order.to_param, id: shipment.to_param, shipment: { tracking: "123123" }
+        api_put :ship, order_id: shipment.order.to_param,
+                       id: shipment.to_param,
+                       shipment: { tracking: "123123" }
 
         expect(attributes.all?{ |attr| json_response.key? attr.to_s }).to be_truthy
         expect(json_response["state"]).to eq("shipped")

--- a/spec/controllers/api/shipments_controller_spec.rb
+++ b/spec/controllers/api/shipments_controller_spec.rb
@@ -5,7 +5,6 @@ describe Api::ShipmentsController, type: :controller do
 
   let!(:shipment) { create(:shipment) }
   let!(:attributes) { [:id, :tracking, :number, :cost, :shipped_at, :stock_location_name, :order_id] }
-  let!(:resource_scoping) { { order_id: shipment.order.to_param, id: shipment.to_param } }
   let(:current_api_user) { build(:user) }
 
   before do
@@ -14,12 +13,12 @@ describe Api::ShipmentsController, type: :controller do
 
   context "as a non-admin" do
     it "cannot make a shipment ready" do
-      api_put :ready
+      api_put :ready, order_id: shipment.order.to_param, id: shipment.to_param
       assert_unauthorized!
     end
 
     it "cannot make a shipment shipped" do
-      api_put :ship
+      api_put :ship, order_id: shipment.order.to_param, id: shipment.to_param
       assert_unauthorized!
     end
   end
@@ -92,7 +91,7 @@ describe Api::ShipmentsController, type: :controller do
 
     it "can make a shipment ready" do
       allow_any_instance_of(Spree::Order).to receive_messages(paid?: true, complete?: true)
-      api_put :ready
+      api_put :ready, order_id: shipment.order.to_param, id: shipment.to_param
 
       expect(attributes.all?{ |attr| json_response.key? attr.to_s }).to be_truthy
       expect(json_response["state"]).to eq("ready")
@@ -101,7 +100,7 @@ describe Api::ShipmentsController, type: :controller do
 
     it "cannot make a shipment ready if the order is unpaid" do
       allow_any_instance_of(Spree::Order).to receive_messages(paid?: false)
-      api_put :ready
+      api_put :ready, order_id: shipment.order.to_param, id: shipment.to_param
 
       expect(json_response["error"]).to eq("Cannot ready shipment.")
       expect(response.status).to eq(422)
@@ -109,10 +108,9 @@ describe Api::ShipmentsController, type: :controller do
 
     context 'for completed shipments' do
       let(:order) { create :completed_order_with_totals }
-      let!(:resource_scoping) { { order_id: order.to_param, id: order.shipments.first.to_param } }
 
       it 'adds a variant to a shipment' do
-        api_put :add, variant_id: variant.to_param, quantity: 2
+        api_put :add, variant_id: variant.to_param, quantity: 2, order_id: order.to_param, id: order.shipments.first.to_param
 
         expect(response.status).to eq(200)
         expect(order.shipment.reload.inventory_units.select { |h| h['variant_id'] == variant.id }.size).to eq 2
@@ -120,7 +118,7 @@ describe Api::ShipmentsController, type: :controller do
 
       it 'removes a variant from a shipment' do
         order.contents.add(variant, 2)
-        api_put :remove, variant_id: variant.to_param, quantity: 1
+        api_put :remove, variant_id: variant.to_param, quantity: 1, order_id: order.to_param, id: order.shipments.first.to_param
 
         expect(response.status).to eq(200)
         expect(order.shipment.reload.inventory_units.select { |h| h['variant_id'] == variant.id }.size).to eq(1)

--- a/spec/controllers/api/shops_controller_spec.rb
+++ b/spec/controllers/api/shops_controller_spec.rb
@@ -34,7 +34,7 @@ module Api
 
       describe "#closed_shops" do
         it "returns data for all closed shops" do
-          spree_get :closed_shops, nil
+          spree_get :closed_shops, {}
 
           expect(json_response).not_to match hub.name
 

--- a/spec/controllers/api/variants_controller_spec.rb
+++ b/spec/controllers/api/variants_controller_spec.rb
@@ -113,7 +113,6 @@ describe Api::VariantsController, type: :controller do
 
     let(:product) { create(:product) }
     let(:variant) { product.master }
-    let(:resource_scoping) { { product_id: variant.product.to_param } }
 
     context "deleted variants" do
       before do
@@ -121,7 +120,7 @@ describe Api::VariantsController, type: :controller do
       end
 
       it "are visible by admin" do
-        api_get :index, show_deleted: 1
+        api_get :index, show_deleted: 1, product_id: variant.product.to_param
 
         expect(json_response.count).to eq(2)
       end
@@ -129,7 +128,7 @@ describe Api::VariantsController, type: :controller do
 
     it "can create a new variant" do
       original_number_of_variants = variant.product.variants.count
-      api_post :create, variant: { sku: "12345", unit_value: "weight", unit_description: "L" }
+      api_post :create, variant: { sku: "12345", unit_value: "weight", unit_description: "L" }, product_id: variant.product.to_param
 
       expect(attributes.all?{ |attr| json_response.include? attr.to_s }).to eq(true)
       expect(response.status).to eq(201)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,8 +148,9 @@ RSpec.configure do |config|
   config.include Spree::UrlHelpers
   config.include Spree::CheckoutHelpers
   config.include Spree::MoneyHelper
-  config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Preferences
+  config.include Spree::TestingSupport::ControllerRequests, type: :controller
+  config.include ControllerRequestsHelper, type: :controller
   config.include Devise::TestHelpers, type: :controller
   config.extend  Spree::Api::TestingSupport::Setup, type: :controller
   config.include OpenFoodNetwork::ApiHelper, type: :controller

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,6 @@ WebMock.disable_net_connect!(
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
-require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/capybara_ext'
 require 'spree/api/testing_support/setup'
 require 'spree/testing_support/authorization_helpers'
@@ -149,7 +148,6 @@ RSpec.configure do |config|
   config.include Spree::CheckoutHelpers
   config.include Spree::MoneyHelper
   config.include Spree::TestingSupport::Preferences
-  config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include ControllerRequestsHelper, type: :controller
   config.include Devise::TestHelpers, type: :controller
   config.extend  Spree::Api::TestingSupport::Setup, type: :controller

--- a/spec/support/controller_hacks.rb
+++ b/spec/support/controller_hacks.rb
@@ -18,10 +18,8 @@ module ControllerHacks
   end
 
   def api_process(action, params = {}, session = nil, flash = nil, method = "get")
-    scoping = respond_to?(:resource_scoping) ? resource_scoping : {}
     process(action,
             params.
-              merge(scoping).
               reverse_merge!(use_route: :spree, format: :json),
             session,
             flash,

--- a/spec/support/controller_requests_helper.rb
+++ b/spec/support/controller_requests_helper.rb
@@ -19,23 +19,23 @@ module ControllerRequestsHelper
     api_process(action, params, session, flash, "DELETE")
   end
 
-  def spree_get(action, parameters = nil, session = nil, flash = nil)
-    process_spree_action(action, parameters, session, flash, "GET")
+  def spree_get(action, params = {}, session = nil, flash = nil)
+    process_spree_action(action, params, session, flash, "GET")
   end
 
   # Executes a request simulating POST HTTP method and set/volley the response
-  def spree_post(action, parameters = nil, session = nil, flash = nil)
-    process_spree_action(action, parameters, session, flash, "POST")
+  def spree_post(action, params = {}, session = nil, flash = nil)
+    process_spree_action(action, params, session, flash, "POST")
   end
 
   # Executes a request simulating PUT HTTP method and set/volley the response
-  def spree_put(action, parameters = nil, session = nil, flash = nil)
-    process_spree_action(action, parameters, session, flash, "PUT")
+  def spree_put(action, params = {}, session = nil, flash = nil)
+    process_spree_action(action, params, session, flash, "PUT")
   end
 
   # Executes a request simulating DELETE HTTP method and set/volley the response
-  def spree_delete(action, parameters = nil, session = nil, flash = nil)
-    process_spree_action(action, parameters, session, flash, "DELETE")
+  def spree_delete(action, params = {}, session = nil, flash = nil)
+    process_spree_action(action, params, session, flash, "DELETE")
   end
 
   private
@@ -48,9 +48,9 @@ module ControllerRequestsHelper
                          method)
   end
 
-  def process_spree_action(action, parameters = {}, session = nil, flash = nil, method = "GET")
+  def process_spree_action(action, params = {}, session = nil, flash = nil, method = "GET")
     process(action,
-            parameters.merge!(use_route: :spree),
+            params.merge!(use_route: :spree),
             session,
             flash,
             method)

--- a/spec/support/controller_requests_helper.rb
+++ b/spec/support/controller_requests_helper.rb
@@ -50,7 +50,7 @@ module ControllerRequestsHelper
 
   def process_spree_action(action, params = {}, session = nil, flash = nil, method = "GET")
     process(action,
-            params.merge!(use_route: :spree),
+            params.merge!(use_route: :main_app),
             session,
             flash,
             method)

--- a/spec/support/controller_requests_helper.rb
+++ b/spec/support/controller_requests_helper.rb
@@ -41,16 +41,18 @@ module ControllerRequestsHelper
   private
 
   def api_process(action, params = {}, session = nil, flash = nil, method = "get")
+    process_spree_action(action,
+                         params.reverse_merge!(format: :json),
+                         session,
+                         flash,
+                         method)
+  end
+
+  def process_spree_action(action, parameters = {}, session = nil, flash = nil, method = "GET")
     process(action,
-            params.
-              reverse_merge!(use_route: :spree, format: :json),
+            parameters.merge!(use_route: :spree),
             session,
             flash,
             method)
-  end
-
-  def process_spree_action(action, parameters = nil, session = nil, flash = nil, method = "GET")
-    parameters ||= {}
-    process(action, parameters.merge!(use_route: :spree), session, flash, method)
   end
 end

--- a/spec/support/controller_requests_helper.rb
+++ b/spec/support/controller_requests_helper.rb
@@ -4,53 +4,50 @@ require 'active_support/all'
 
 module ControllerRequestsHelper
   def api_get(action, params = {}, session = nil, flash = nil)
-    api_process(action, params, session, flash, "GET")
+    process_json_action(action, params, session, flash, "GET")
   end
 
   def api_post(action, params = {}, session = nil, flash = nil)
-    api_process(action, params, session, flash, "POST")
+    process_json_action(action, params, session, flash, "POST")
   end
 
   def api_put(action, params = {}, session = nil, flash = nil)
-    api_process(action, params, session, flash, "PUT")
+    process_json_action(action, params, session, flash, "PUT")
   end
 
   def api_delete(action, params = {}, session = nil, flash = nil)
-    api_process(action, params, session, flash, "DELETE")
+    process_json_action(action, params, session, flash, "DELETE")
   end
 
   def spree_get(action, params = {}, session = nil, flash = nil)
-    process_spree_action(action, params, session, flash, "GET")
+    process_action_with_route(action, params, session, flash, "GET")
   end
 
-  # Executes a request simulating POST HTTP method and set/volley the response
   def spree_post(action, params = {}, session = nil, flash = nil)
-    process_spree_action(action, params, session, flash, "POST")
+    process_action_with_route(action, params, session, flash, "POST")
   end
 
-  # Executes a request simulating PUT HTTP method and set/volley the response
   def spree_put(action, params = {}, session = nil, flash = nil)
-    process_spree_action(action, params, session, flash, "PUT")
+    process_action_with_route(action, params, session, flash, "PUT")
   end
 
-  # Executes a request simulating DELETE HTTP method and set/volley the response
   def spree_delete(action, params = {}, session = nil, flash = nil)
-    process_spree_action(action, params, session, flash, "DELETE")
+    process_action_with_route(action, params, session, flash, "DELETE")
   end
 
   private
 
-  def api_process(action, params = {}, session = nil, flash = nil, method = "get")
-    process_spree_action(action,
+  def process_json_action(action, params = {}, session = nil, flash = nil, method = "get")
+    process_action_with_route(action,
                          params.reverse_merge!(format: :json),
                          session,
                          flash,
                          method)
   end
 
-  def process_spree_action(action, params = {}, session = nil, flash = nil, method = "GET")
+  def process_action_with_route(action, params = {}, session = nil, flash = nil, method = "GET")
     process(action,
-            params.merge!(use_route: :main_app),
+            params.reverse_merge!(use_route: :main_app),
             session,
             flash,
             method)

--- a/spec/support/controller_requests_helper.rb
+++ b/spec/support/controller_requests_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/all'
 
 module ControllerRequestsHelper
@@ -17,6 +19,27 @@ module ControllerRequestsHelper
     api_process(action, params, session, flash, "DELETE")
   end
 
+  def spree_get(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, "GET")
+  end
+
+  # Executes a request simulating POST HTTP method and set/volley the response
+  def spree_post(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, "POST")
+  end
+
+  # Executes a request simulating PUT HTTP method and set/volley the response
+  def spree_put(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, "PUT")
+  end
+
+  # Executes a request simulating DELETE HTTP method and set/volley the response
+  def spree_delete(action, parameters = nil, session = nil, flash = nil)
+    process_spree_action(action, parameters, session, flash, "DELETE")
+  end
+
+  private
+
   def api_process(action, params = {}, session = nil, flash = nil, method = "get")
     process(action,
             params.
@@ -24,5 +47,10 @@ module ControllerRequestsHelper
             session,
             flash,
             method)
+  end
+
+  def process_spree_action(action, parameters = nil, session = nil, flash = nil, method = "GET")
+    parameters ||= {}
+    process(action, parameters.merge!(use_route: :spree), session, flash, method)
   end
 end

--- a/spec/support/controller_requests_helper.rb
+++ b/spec/support/controller_requests_helper.rb
@@ -1,6 +1,6 @@
 require 'active_support/all'
 
-module ControllerHacks
+module ControllerRequestsHelper
   def api_get(action, params = {}, session = nil, flash = nil)
     api_process(action, params, session, flash, "GET")
   end
@@ -25,8 +25,4 @@ module ControllerHacks
             flash,
             method)
   end
-end
-
-RSpec.configure do |config|
-  config.include ControllerHacks, type: :controller
 end


### PR DESCRIPTION
#### What? Why?

I refactored this code as I was investigating #5533

The main change is that the spree_get actions are now setting use_route to :main_app and not :spree.

In rails 4.2 we will be able to replace this use_route with the `routes` entry as Spree did in v3:
https://github.com/spree/spree/commit/bd881d9d34e418eeb73a30440013bfeb31ebea45
This will mandatory for upgrading to rails 5.

Anyway, this did not fix #5533, I have created another PR to fix #5533 and #5504 

#### What should we test?
This only changes test code, needs a green build.

#### Release notes
Changelog Category: Changed
Improved test support code related to routing and controllers.
