### PR TITLE
Add Catalan to the list of moment.js files

### DIFF
--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -73,6 +73,7 @@
 //= require i18n/translations
 //= require darkswarm/i18n.translate.js
 //= require moment
+//= require moment/ca.js
 //= require moment/de.js
 //= require moment/en-gb.js
 //= require moment/es.js

--- a/app/assets/javascripts/darkswarm/all.js.coffee
+++ b/app/assets/javascripts/darkswarm/all.js.coffee
@@ -27,6 +27,7 @@
 #= require angular-flash.min.js
 #
 #= require moment
+#= require moment/ca.js
 #= require moment/de.js
 #= require moment/en-gb.js
 #= require moment/es.js


### PR DESCRIPTION
#### What? Why?

This will precompile the Catalan language file as well and thus, things like 

![Screenshot from 2020-06-03 18-14-28](https://user-images.githubusercontent.com/762088/83661230-1acd6f00-a5c6-11ea-8e34-701a1a4641f5.png)

should be shown in Catalan.

#### What should we test?

Check that OC timings are displayed in Catalan instead of English.

#### Release notes

Display time-related copies in Catalan when that's the selected language.

Changelog Category: Fixed
