### PR TITLE
Rename Angular Geo service

### DIFF
--- a/app/assets/javascripts/darkswarm/services/enterprises.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprises.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'Enterprises', (enterprises, ShopsResource, CurrentHub, Taxons, Dereferencer, Matcher, Geo, $rootScope) ->
+Darkswarm.factory 'Enterprises', (enterprises, ShopsResource, CurrentHub, Taxons, Dereferencer, Matcher, GmapsGeo, $rootScope) ->
   new class Enterprises
     enterprises: []
     enterprises_by_id: {}
@@ -59,7 +59,7 @@ Darkswarm.factory 'Enterprises', (enterprises, ShopsResource, CurrentHub, Taxons
           false
 
     calculateDistance: (query, firstMatching) ->
-      if query?.length > 0 and Geo.OK
+      if query?.length > 0 and GmapsGeo.OK
         if firstMatching?
           @setDistanceFrom firstMatching
         else
@@ -68,9 +68,9 @@ Darkswarm.factory 'Enterprises', (enterprises, ShopsResource, CurrentHub, Taxons
         @resetDistance()
 
     calculateDistanceGeo: (query) ->
-      Geo.geocode query, (results, status) =>
+      GmapsGeo.geocode query, (results, status) =>
         $rootScope.$apply =>
-          if status == Geo.OK
+          if status == GmapsGeo.OK
             #console.log "Geocoded #{query} -> #{results[0].geometry.location}."
             @setDistanceFrom results[0].geometry.location
           else
@@ -79,7 +79,7 @@ Darkswarm.factory 'Enterprises', (enterprises, ShopsResource, CurrentHub, Taxons
 
     setDistanceFrom: (locatable) ->
       for enterprise in @enterprises
-        enterprise.distance = Geo.distanceBetween enterprise, locatable
+        enterprise.distance = GmapsGeo.distanceBetween enterprise, locatable
       $rootScope.$broadcast 'enterprisesChanged'
 
     resetDistance: ->

--- a/app/assets/javascripts/darkswarm/services/gmaps_geo.js.erb.coffee
+++ b/app/assets/javascripts/darkswarm/services/gmaps_geo.js.erb.coffee
@@ -1,5 +1,5 @@
-Darkswarm.service "Geo", ->
-  new class Geo
+Darkswarm.service "GmapsGeo", ->
+  new class GmapsGeo
     OK: google?.maps?.GeocoderStatus?.OK
 
     # Usage:

--- a/spec/javascripts/unit/darkswarm/services/enterprise_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/enterprise_spec.js.coffee
@@ -1,7 +1,7 @@
 describe "Enterprises service", ->
   Enterprises = $rootScope = null
   CurrentHubMock = {}
-  Geo =
+  GmapsGeo =
     OK: 'ok'
     succeed: true
     geocode: (query, callback) ->
@@ -31,7 +31,7 @@ describe "Enterprises service", ->
     module 'Darkswarm'
     module ($provide)->
       $provide.value "CurrentHub", CurrentHubMock
-      $provide.value "Geo", Geo
+      $provide.value "GmapsGeo", GmapsGeo
       null
     angular.module('Darkswarm').value('enterprises', enterprises)
     angular.module('Darkswarm').value('taxons', taxons)
@@ -118,12 +118,12 @@ describe "Enterprises service", ->
       spyOn(Enterprises, "setDistanceFrom")
 
     it "calculates distance for all enterprises when geocoding succeeds", ->
-      Geo.succeed = true
+      GmapsGeo.succeed = true
       Enterprises.calculateDistanceGeo('query')
       expect(Enterprises.setDistanceFrom).toHaveBeenCalledWith("location")
 
     it "resets distance when geocoding fails", ->
-      Geo.succeed = false
+      GmapsGeo.succeed = false
       spyOn(Enterprises, "resetDistance")
       Enterprises.calculateDistanceGeo('query')
       expect(Enterprises.setDistanceFrom).not.toHaveBeenCalled()

--- a/spec/javascripts/unit/darkswarm/services/map_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/map_spec.js.coffee
@@ -1,7 +1,7 @@
 describe "Hubs service", ->
   OfnMap = null
   CurrentHubMock = {}
-  Geo = {}
+  GmapsGeo = {}
   enterprises = [
     {
       id: 2
@@ -54,7 +54,7 @@ describe "Hubs service", ->
     angular.module('Darkswarm').value('enterprises', enterprises)
     module ($provide)->
       $provide.value "CurrentHub", CurrentHubMock
-      $provide.value "Geo", Geo
+      $provide.value "GmapsGeo", GmapsGeo
       null
     inject ($injector)->
       OfnMap = $injector.get("OfnMap")

--- a/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/products_spec.js.coffee
@@ -12,7 +12,7 @@ describe 'Products service', ->
   productWithImage = null
   properties = null
   taxons = null
-  Geo = {}
+  GmapsGeo = {}
   endpoint = "/api/order_cycles/1/products?distributor=1"
 
   beforeEach ->
@@ -53,7 +53,7 @@ describe 'Products service', ->
       $provide.value "currentOrder", currentOrder
       $provide.value "taxons", taxons
       $provide.value "properties", properties
-      $provide.value "Geo", Geo
+      $provide.value "GmapsGeo", GmapsGeo
       $provide.value "OrderCycle", OrderCycle
       $provide.value "railsFlash", null
       null


### PR DESCRIPTION
Related to #5542 

#### What? Why?

Renames our Angular `Geo` service to `GmapsGeo` for clarity, as it depends on direct calls to the google maps javascript included in the darkswarm layout. 

This is another small step towards moving away from dependency on Google for maps functionality. We'll need an alternate Angular service that provides the same functionality by different means. See notes in the epic: #5542 

#### What should we test?

Sanity check that maps is working and searching in the /shops page returns results by location, eg "London".

#### Release notes

Renamed Angular "Geo" service to "GmapsGeo"