### PR TITLE
Make display only shops work again

### DIFF
--- a/app/views/shopping_shared/tabs/_shop.html.haml
+++ b/app/views/shopping_shared/tabs/_shop.html.haml
@@ -4,7 +4,8 @@
 
   - if no_open_order_cycles?
     = render partial: "shop/messages/closed_shop"
-
   - else
     = render partial: "shop/messages/select_oc"
-    = render partial: "shop/products/form"
+
+  -# Rendering the form, even if there are no open OCs, makes display only shops possible
+  = render partial: "shop/products/form"


### PR DESCRIPTION
#### What? Why?

Closes #5423

When a distributor has an open OC but it doesnt have valid ship/pay methods, the shop should still render.
It's a simple change that was reverted recently, I added a feature spec to validate the current behaviour.

We could improve the UX, for example, not letting user add to cart or don't redirect user to /shops but keep user in shop page. We agreed we would just add the feature back as it was before because it was only an half a hour job :heavy_check_mark: 

#### What should we test?
We need to test the shop front renders correctly in different scenarios:
- when there are no open OCs
- when there is an open OC but it's hidden by some tag
- when the shop requires login
- (verify issue) when there is an open OC but the shop doesnt have ship/payment methods defined
In this last case, products can be added to the cart, but when user goes to the cart or checkout, it should be redirected to shops saying the shop is closed.

#### Release notes
Changelog Category: Changed
Make display only shops work again
