### PR TITLE
Do not print the bill addr. name when there's none

### DIFF
--- a/app/views/spree/admin/orders/invoice.html.haml
+++ b/app/views/spree/admin/orders/invoice.html.haml
@@ -33,16 +33,19 @@
       %td{ align: "left" }
         %strong= "#{t('.to')}:"
         %br
-        = @order.bill_address.full_name
+        - if @order.bill_address
+          = @order.bill_address.full_name
         - if @order.andand.customer.andand.code.present?
           %br
           = "#{t('.code')}: #{@order.customer.code}"
         %br
-        = @order.bill_address.full_address
+        - if @order.bill_address
+          = @order.bill_address.full_address
         %br
         - if @order.andand.customer.andand.email.present?
           = "#{@order.customer.email},"
-        = "#{@order.bill_address.phone}"
+        - if @order.bill_address
+          = "#{@order.bill_address.phone}"
       %td
         &nbsp;
       %td{ align: "left", style: "border-left: .1em solid black; padding-left: 1em" }

--- a/app/views/spree/admin/orders/invoice2.html.haml
+++ b/app/views/spree/admin/orders/invoice2.html.haml
@@ -44,14 +44,17 @@
       %td{ :align => "right" }
         = t :invoice_billing_address
         %br
-        %strong= @order.bill_address.full_name
+        - if @order.bill_address
+          %strong= @order.bill_address.full_name
         - if @order.andand.customer.andand.code.present?
           %br
           = "Code: #{@order.customer.code}"
         %br
-        = @order.bill_address.address_part1
+        - if @order.bill_address
+          = @order.bill_address.address_part1
         %br
-        = @order.bill_address.address_part2
+        - if @order.bill_address
+          = @order.bill_address.address_part2
 
 = render 'spree/admin/orders/invoice_table2'
 


### PR DESCRIPTION
#### What? Why?

The error

```
ActionView::Template::Error: undefined method `full_name' for nil:NilClass
```

happens a few times a day and raises exceptions we don't pay attention to. They add unnecessary noise that hides other more relevant issues.

This, however, is a symptom of a deeper data integrity problem that needs solving at some point. This is just a countermeasure.


#### What should we test?

Check that the invoice is correctly displayed when the billing address is set. Let me know when you are testing the opposite scenario and I'll manually remove the address. I don't know how else to reproduce it.

#### Release notes

Make the invoice handle the inconsistent scenario where the order has no billing address.

Changelog Category: Changed
