### PR TITLE
Bug/5467 Shopfront search box returns all records when none is expected

### DIFF
--- a/app/views/shops/_hubs.html.haml
+++ b/app/views/shops/_hubs.html.haml
@@ -9,9 +9,7 @@
 
   .row
     .small-12.columns
-      .name-matches{"ng-show" => "nameMatchesFiltered.length > 0"}
-        %h2
-          = t :hubs_matches
+      .name-matches{"ng-show" => "nameMatchesFiltered.length > 0 || query.length > 0"}
         = render "hubs_table", enterprises: "nameMatches"
 
       .distance-matches{"ng-if" => "nameMatchesFiltered.length == 0 || distanceMatchesShown"}


### PR DESCRIPTION
#### What? Why?

Closes #5467 
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Hey guys, this is a suggested fix. The showed shops are the "distance matches" shops. We can erase them too, but since I don't know the expected behavior from the product view, I only fixed it to show the message "No results found."

After:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27960597/83992319-46ce5480-a926-11ea-8594-3afc8f8965c7.gif)


#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Fix the shopfront search box to show only matching records



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category:  Fixed

