### PR TITLE
Add translation keys to en.yml file for variant_override error messag…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,8 @@ en:
         base: "Credit Card"
       order_cycle:
         orders_close_at: Close date
+      variant_override:
+        count_on_hand: "On Hand"
     errors:
       models:
         spree/user:


### PR DESCRIPTION
#### What? Why?
Closes #5204 
On admin/inventory, the "Count on Hand" error is not being translated like the rest of the message is. 
<img width="600" alt="Screen Shot 2020-06-09 at 4 09 42 pm" src="https://user-images.githubusercontent.com/30268789/84112332-e21d1200-aa6b-11ea-9750-3fb3197ede8f.png">
Needed to add translation keys to locales/en.yml file. This error was tracked to an Activerecord attribute and adding the key to en.activerecord.attributes.variant_override.count_on_hand, allowed the error to be translated. 

#### What should we test?

1. Go to /admin/inventory
2. Leave 'On Hand' field blank
3. Set 'On Demand?' to 'No'
4. Click Save
5. With translations added, the message should be fully translated. 
6. I tested locally by changing the en.activerecord.attributes.variant_override.count_on_hand string to "COH"
<img width="600" alt="Screen Shot 2020-06-09 at 4 18 15 pm" src="https://user-images.githubusercontent.com/30268789/84112949-02999c00-aa6d-11ea-9e27-c12ea93046f3.png">

#### Release notes
Added translations keys to allow full error message to be properly translated.

Changelog Category: Added