### PR TITLE
Fix fatal error in reports helper for orders without payments

### DIFF
--- a/app/helpers/spree/reports_helper.rb
+++ b/app/helpers/spree/reports_helper.rb
@@ -11,10 +11,13 @@ module Spree
     end
 
     def report_payment_method_options(orders)
-      orders.map do |o|
-        pm = o.payments.first.payment_method
-        [pm.andand.name, pm.andand.id]
-      end.uniq
+      orders.map do |order|
+        payment_method = order.payments.first.andand.payment_method
+
+        next unless payment_method
+
+        [payment_method.name, payment_method.id]
+      end.compact.uniq
     end
 
     def report_shipping_method_options(orders)

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -69,12 +69,12 @@ module OpenFoodNetwork
 
     def payment_method_row(order)
       ba = order.billing_address
-      [ba.firstname,
-       ba.lastname,
+      [ba.andand.firstname,
+       ba.andand.lastname,
        order.distributor.andand.name,
        customer_code(order.email),
        order.email,
-       ba.phone,
+       ba.andand.phone,
        order.shipping_method.andand.name,
        order.payments.first.andand.payment_method.andand.name,
        order.payments.first.andand.amount,

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -77,7 +77,7 @@ module OpenFoodNetwork
        ba.phone,
        order.shipping_method.andand.name,
        order.payments.first.andand.payment_method.andand.name,
-       order.payments.first.amount,
+       order.payments.first.andand.amount,
        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance]
     end
 
@@ -92,7 +92,7 @@ module OpenFoodNetwork
        sa.phone,
        order.shipping_method.andand.name,
        order.payments.first.andand.payment_method.andand.name,
-       order.payments.first.amount,
+       order.payments.first.andand.amount,
        OpenFoodNetwork::UserBalanceCalculator.new(order.email, order.distributor).balance,
        has_temperature_controlled_items?(order),
        order.special_instructions]

--- a/spec/helpers/spree/admin/reports_helper_spec.rb
+++ b/spec/helpers/spree/admin/reports_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+
+describe Spree::ReportsHelper, type: :helper do
+  describe "#report_payment_method_options" do
+    let(:order_with_payments) { create(:order_ready_to_ship) }
+    let(:order_without_payments) { create(:order_with_line_items) }
+    let(:orders) { [order_with_payments, order_without_payments] }
+    let(:payment_method) { order_with_payments.payments.first.payment_method }
+
+    it "returns payment method select options for given orders" do
+      select_options = helper.report_payment_method_options([order_with_payments])
+
+      expect(select_options).to eq [[payment_method.name, payment_method.id]]
+    end
+
+    it "handles orders that don't have payments, without error" do
+      select_options = helper.report_payment_method_options(orders)
+
+      expect(select_options).to eq [[payment_method.name, payment_method.id]]
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #5572

A form helper was trying to write create options for a dropdown of payment methods on orders, but the orders did not necessarily have payments (or payment methods), resulting in a slug.


#### What should we test?
<!-- List which features should be tested and how. -->

The payment methods report page loads correctly if the hub has orders without payments

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed an issue in payments report for orders without payments.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

