### PR TITLE
Reports rewrite POC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem 'wkhtmltopdf-binary'
 gem 'foreigner'
 gem 'immigrant'
 gem 'roo', '~> 2.8.3'
+gem 'spreadsheet_architect'
 
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,9 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
+    axlsx_styler (1.0.0)
+      activesupport (>= 3.1)
+      caxlsx (>= 2.0.2)
     bcrypt (3.1.13)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
@@ -159,6 +162,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    caxlsx (3.0.1)
+      htmlentities (~> 4.3, >= 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
     childprocess (3.0.0)
     chronic (0.10.2)
     chunky_png (1.3.11)
@@ -411,6 +419,7 @@ GEM
     hashdiff (1.0.1)
     highline (1.6.18)
     hike (1.2.3)
+    htmlentities (4.3.4)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
     i18n (0.6.11)
@@ -448,6 +457,7 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.9.2)
     mime-types (1.25.1)
+    mimemagic (0.3.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     mini_racer (0.2.14)
@@ -560,6 +570,10 @@ GEM
     roadie-rails (1.3.0)
       railties (>= 3.0, < 5.3)
       roadie (~> 3.1)
+    rodf (1.1.1)
+      builder (>= 3.0)
+      dry-inflector (~> 0.1)
+      rubyzip (>= 1.0)
     roo (2.8.3)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
@@ -626,6 +640,10 @@ GEM
       tilt (>= 1.3, < 3)
     spinjs-rails (1.4)
       rails (>= 3.1)
+    spreadsheet_architect (4.0.0)
+      axlsx_styler (>= 1.0.0, < 2)
+      caxlsx (>= 2.0.2, < 4)
+      rodf (>= 1.0.0, < 2)
     spring (1.7.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -772,6 +790,7 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   spinjs-rails
+  spreadsheet_architect
   spree_core!
   spree_i18n!
   spree_paypal_express!

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  class ReportsController < BaseController
+    skip_authorization_check # Authorization is handled via permissions
+
+    def packing
+      render_missing_params && return if ransack_params.blank?
+
+      @report = ::Reporting::PackingReport.new(current_api_user, ransack_params, report_options)
+
+      render_report
+    end
+
+    private
+
+    def render_report
+      render json: @report.as_hashes
+    end
+
+    def render_missing_params
+      render json: { errors: 'Please supply Ransack search params in the request' }
+    end
+
+    def ransack_params
+      params[:q]
+    end
+
+    def report_options
+      params[:options]
+    end
+  end
+end

--- a/app/controllers/spree/admin/reports_controller.rb
+++ b/app/controllers/spree/admin/reports_controller.rb
@@ -63,16 +63,11 @@ module Spree
       end
 
       def packing
-        params[:q] ||= {}
+        return unless render_content?
 
-        @report_types = report_types[:packing]
-        @report_type = params[:report_type]
+        @report = Reporting::PackingReport.new(spree_current_user, params[:q], params[:options])
 
-        # -- Build Report with Order Grouper
-        @report = OpenFoodNetwork::PackingReport.new spree_current_user, params, render_content?
-        @table = order_grouper_table
-
-        render_report(@report.header, @table, params[:csv], "packing_#{timestamp}.csv")
+        export_report
       end
 
       def orders_and_distributors
@@ -184,6 +179,17 @@ module Spree
 
       def model_class
         Spree::Admin::ReportsController
+      end
+
+      def export_report
+        return unless ['xlsx', 'ods', 'csv'].include?(report_format)
+
+        render report_format.to_sym => @report.public_send("to_#{report_format}"),
+               :filename => "#{params[:report_type] || action_name}_#{timestamp}.#{report_format}"
+      end
+
+      def report_format
+        params[:report_format]
       end
 
       # Some actions are changing the `params` object. That is unfortunate Spree

--- a/app/models/reporting/packing_report.rb
+++ b/app/models/reporting/packing_report.rb
@@ -29,10 +29,8 @@ module Reporting
       :order_id
     end
 
-    def summary_rows
-      [
-        { title: 'TOTAL', sum: [:quantity] }
-      ]
+    def summary_row
+      { title: 'TOTAL', sum: [:quantity] }
     end
 
     def hide_columns

--- a/app/models/reporting/packing_report.rb
+++ b/app/models/reporting/packing_report.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Reporting
+  class PackingReport < Report
+    def collection
+      Spree::LineItem.includes(*line_item_includes).where(order_id: order_ids).uniq
+    end
+
+    def report_row(object)
+      {
+        order_id: object.order_id,
+        hub: orders[object.order_id].distributor.name,
+        customer_code: orders[object.order_id].customer.andand.code,
+        first_name: orders[object.order_id].bill_address.firstname,
+        last_name: orders[object.order_id].bill_address.lastname,
+        supplier: object.product.supplier.name,
+        product: object.product.name,
+        variant: object.full_name,
+        quantity: object.quantity,
+        is_temperature_controlled: object.product.shipping_category.andand.temperature_controlled ? "Yes" : "No"
+      }
+    end
+
+    def ordering
+      [:hub, :order_id, :product]
+    end
+
+    def summary_group
+      :order_id
+    end
+
+    def summary_rows
+      [
+        { title: 'TOTAL', sum: [:quantity] }
+      ]
+    end
+
+    def hide_columns
+      [:order_id]
+    end
+
+    private
+
+    def permissions
+      Permissions::Order.new(current_user, ransack_params)
+    end
+
+    def orders
+      @orders ||= permissions.visible_orders.
+        complete.not_state(:canceled).
+        includes(:bill_address, :distributor, :customer).
+        ransack(ransack_params).result.index_by(&:id)
+    end
+
+    def order_ids
+      orders.keys
+    end
+
+    def line_item_includes
+      [{
+        option_values: :option_type,
+        variant: { product: [:supplier, :shipping_category] }
+      }]
+    end
+  end
+end

--- a/app/models/reporting/packing_report.rb
+++ b/app/models/reporting/packing_report.rb
@@ -37,6 +37,14 @@ module Reporting
       [:order_id]
     end
 
+    def mask_data
+      {
+        columns: [:customer_code, :first_name, :last_name],
+        replacement: "< Hidden >",
+        rule: proc{ |line_item| !can_view_customer_data?(line_item) }
+      }
+    end
+
     private
 
     def permissions
@@ -59,6 +67,14 @@ module Reporting
         option_values: :option_type,
         variant: { product: [:supplier, :shipping_category] }
       }]
+    end
+
+    def can_view_customer_data?(line_item)
+      managed_enterprise_ids.include? orders[line_item.order_id].distributor_id
+    end
+
+    def managed_enterprise_ids
+      @managed_enterprise_ids ||= Enterprise.managed_by(current_user).pluck(:id)
     end
   end
 end

--- a/app/models/reporting/report.rb
+++ b/app/models/reporting/report.rb
@@ -98,68 +98,7 @@ module Reporting
     end
 
     def summarise_group(group_column)
-      return if exclude_summaries?
-
-      grouped_rows = []
-      previous_grouping = nil
-
-      @report_rows.each_with_index do |row, row_index|
-        current_grouping = row[group_column]
-
-        if previous_grouping.present? && current_grouping != previous_grouping
-          grouped_rows.concat build_summary_rows(group_column, previous_grouping)
-        end
-
-        grouped_rows << row
-
-        if last_row?(row_index)
-          grouped_rows.concat build_summary_rows(group_column, previous_grouping)
-        end
-
-        previous_grouping = current_grouping
-      end
-
-      @report_rows = grouped_rows
-    end
-
-    def build_summary_rows(group_column, group_key)
-      summary_rows.map do |summary_options|
-        build_summary_row(group_column, group_key, summary_options)
-      end
-    end
-
-    def build_summary_row(group_column, group_key, options)
-      summary_row = initialize_empty_row
-      group_rows = @report_rows.select{ |row| row[group_column] == group_key }
-
-      summary_row[:summary_row_title] = options[:title]
-
-      (options[:sum] || []).each do |sum_column|
-        summary_row[sum_column] = group_rows.sum{ |group_row| group_row[sum_column] }
-      end
-
-      (options[:show_first] || []).each do |first_column|
-        summary_row[first_column] = group_rows.first[first_column]
-      end
-
-      summary_row
-    end
-
-    def last_row?(row_index)
-      @report_rows.length == row_index + 1
-    end
-
-    def initialize_empty_row
-      row = {}
-      headers.each do |key|
-        row[key.to_sym] = ""
-      end
-
-      row
-    end
-
-    def exclude_summaries?
-      options[:exclude_summaries]
+      @report_rows = ReportSummariser.new(group_column, @report_rows, self).call
     end
 
     def remove_columns(columns)
@@ -186,7 +125,7 @@ module Reporting
       nil
     end
 
-    def summary_rows
+    def summary_row
       []
     end
 

--- a/app/models/reporting/report.rb
+++ b/app/models/reporting/report.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'spreadsheet_architect'
+
+module Reporting
+  class Report
+    delegate :to_json, to: :data_hashes
+    attr_reader :options
+
+    def initialize(current_user, ransack_params, options = {})
+      @current_user = current_user
+      @ransack_params = ransack_params.with_indifferent_access
+      @options = ( options || {} ).with_indifferent_access
+      @report_rows = []
+
+      build_report
+    end
+
+    def headers
+      @report_rows.first.andand.keys || []
+    end
+
+    def table_headers
+      data_arrays.first
+    end
+
+    def table_rows
+      data_arrays.drop(1)
+    end
+
+    def to_csv
+      ::SpreadsheetArchitect.to_csv(headers: table_headers, data: table_rows)
+    end
+
+    def to_ods
+      ::SpreadsheetArchitect.to_ods(headers: table_headers, data: table_rows)
+    end
+
+    def to_xlsx
+      ::SpreadsheetArchitect.to_xlsx(headers: table_headers, data: table_rows)
+    end
+
+    def data_hashes
+      @report_rows
+    end
+
+    def data_arrays
+      @data_arrays ||= rows_as_arrays
+    end
+
+    private
+
+    attr_reader :current_user, :ransack_params
+
+    def rows_as_arrays
+      report_array = [headers]
+
+      @report_rows.each do |row|
+        report_array << row_with_summaries(row)
+      end
+
+      report_array
+    end
+
+    def row_with_summaries(row)
+      summary_row_title = row.delete :summary_row_title
+      row_values = row.values
+      row_values[0] = summary_row_title if summary_row_title
+
+      row_values
+    end
+
+    def build_report
+      build_rows
+      order_by(ordering)
+      summarise_group(summary_group)
+      remove_columns(*hide_columns)
+    end
+
+    def build_rows
+      collection.each do |object|
+        @report_rows << report_row(object)
+      end
+    end
+
+    def order_by(columns)
+      return unless columns.length
+
+      reverse_columns = columns.select { |head| head.to_s.ends_with?('!') }
+      sort = columns.map { |head| head.to_s.sub(/\!\z/, '').to_sym }
+      reverse_sort = reverse_columns.map { |head| head.to_s.sub(/\!\z/, '').to_sym }
+
+      @report_rows.sort! do |row1, row2|
+        key1 = sort.map { |column| reverse_sort.include?(column) ? row2[column] : row1[column] }
+        key2 = sort.map { |column| reverse_sort.include?(column) ? row1[column] : row2[column] }
+        key1 <=> key2
+      end
+    end
+
+    def summarise_group(group_column)
+      return if exclude_summaries?
+
+      grouped_rows = []
+      previous_grouping = nil
+
+      @report_rows.each_with_index do |row, row_index|
+        current_grouping = row[group_column]
+
+        if previous_grouping.present? && current_grouping != previous_grouping
+          grouped_rows.concat build_summary_rows(group_column, previous_grouping)
+        end
+
+        grouped_rows << row
+
+        if last_row?(row_index)
+          grouped_rows.concat build_summary_rows(group_column, previous_grouping)
+        end
+
+        previous_grouping = current_grouping
+      end
+
+      @report_rows = grouped_rows
+    end
+
+    def build_summary_rows(group_column, group_key)
+      summary_rows.map do |summary_options|
+        build_summary_row(group_column, group_key, summary_options)
+      end
+    end
+
+    def build_summary_row(group_column, group_key, options)
+      summary_row = initialize_empty_row
+      group_rows = @report_rows.select{ |row| row[group_column] == group_key }
+
+      summary_row[:summary_row_title] = options[:title]
+
+      (options[:sum] || []).each do |sum_column|
+        summary_row[sum_column] = group_rows.sum{ |group_row| group_row[sum_column] }
+      end
+
+      (options[:show_first] || []).each do |first_column|
+        summary_row[first_column] = group_rows.first[first_column]
+      end
+
+      summary_row
+    end
+
+    def last_row?(row_index)
+      @report_rows.length == row_index + 1
+    end
+
+    def initialize_empty_row
+      row = {}
+      headers.each do |key|
+        row[key.to_sym] = ""
+      end
+
+      row
+    end
+
+    def exclude_summaries?
+      options[:exclude_summaries]
+    end
+
+    def remove_columns(columns)
+      return unless columns.length
+
+      @report_rows.each do |row|
+        row.except!(columns)
+      end
+    end
+
+    # Implement the methods below to create a custom report.
+
+    def collection; end
+
+    def report_row(object)
+      {}
+    end
+
+    def ordering
+      []
+    end
+
+    def summary_group
+      nil
+    end
+
+    def summary_rows
+      []
+    end
+
+    def hide_columns
+      []
+    end
+  end
+end

--- a/app/models/reporting/report.rb
+++ b/app/models/reporting/report.rb
@@ -20,19 +20,7 @@ module Reporting
       @report_rows.first.andand.keys || []
     end
 
-    private
-
-    attr_reader :current_user, :ransack_params
-
-    def build_report
-      @report_rows = ReportBuilder.new(@report_rows, self).call
-    end
-
-    def report_renderer
-      @report_renderer ||= ReportRenderer.new(@report_rows, self)
-    end
-
-    # Implement the methods below to create a custom report.
+    # Implement the template methods below to create a custom report.
 
     def collection; end
 
@@ -54,6 +42,18 @@ module Reporting
 
     def hide_columns
       []
+    end
+
+    private
+
+    attr_reader :current_user, :ransack_params
+
+    def build_report
+      @report_rows = ReportBuilder.new(@report_rows, self).call
+    end
+
+    def report_renderer
+      @report_renderer ||= ReportRenderer.new(@report_rows, self)
     end
   end
 end

--- a/app/models/reporting/report.rb
+++ b/app/models/reporting/report.rb
@@ -44,6 +44,10 @@ module Reporting
       []
     end
 
+    def mask_data
+      nil
+    end
+
     private
 
     attr_reader :current_user, :ransack_params

--- a/app/services/report_builder.rb
+++ b/app/services/report_builder.rb
@@ -19,7 +19,11 @@ class ReportBuilder
 
   def build_rows
     @report.collection.each do |object|
-      @report_rows << @report.report_row(object)
+      row = @report.report_row(object)
+
+      replace_sensitive_data!(object, row) if mask_data
+
+      @report_rows << row
     end
   end
 
@@ -47,5 +51,17 @@ class ReportBuilder
     @report_rows.each do |row|
       row.except!(*columns)
     end
+  end
+
+  def replace_sensitive_data!(object, row)
+    return unless mask_data[:rule].call(object)
+
+    mask_data[:columns].each do |column|
+      row[column] = mask_data[:replacement]
+    end
+  end
+
+  def mask_data
+    @report.mask_data
   end
 end

--- a/app/services/report_builder.rb
+++ b/app/services/report_builder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class ReportBuilder
+  def initialize(report_rows, report)
+    @report_rows = report_rows
+    @report = report
+  end
+
+  def call
+    build_rows
+    order_by(@report.ordering)
+    summarise_group(@report.summary_group)
+    remove_columns(@report.hide_columns)
+
+    @report_rows
+  end
+
+  private
+
+  def build_rows
+    @report.collection.each do |object|
+      @report_rows << @report.report_row(object)
+    end
+  end
+
+  def order_by(columns)
+    return unless columns.length
+
+    reverse_columns = columns.select { |head| head.to_s.ends_with?('!') }
+    sort = columns.map { |head| head.to_s.sub(/\!\z/, '').to_sym }
+    reverse_sort = reverse_columns.map { |head| head.to_s.sub(/\!\z/, '').to_sym }
+
+    @report_rows.sort! do |row1, row2|
+      key1 = sort.map { |column| reverse_sort.include?(column) ? row2[column] : row1[column] }
+      key2 = sort.map { |column| reverse_sort.include?(column) ? row1[column] : row2[column] }
+      key1 <=> key2
+    end
+  end
+
+  def summarise_group(group_column)
+    @report_rows = ReportSummariser.new(group_column, @report_rows, @report).call
+  end
+
+  def remove_columns(columns)
+    return unless columns.length
+
+    @report_rows.each do |row|
+      row.except!(*columns)
+    end
+  end
+end

--- a/app/services/report_renderer.rb
+++ b/app/services/report_renderer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spreadsheet_architect'
+
+class ReportRenderer
+  def initialize(report_rows, report)
+    @report_rows = report_rows
+    @report = report
+  end
+
+  def table_headers
+    as_arrays.first
+  end
+
+  def table_rows
+    as_arrays.drop(1)
+  end
+
+  def as_hashes
+    @report_rows
+  end
+
+  def as_arrays
+    @as_arrays ||= rows_as_arrays
+  end
+
+  def to_csv
+    SpreadsheetArchitect.to_csv(headers: table_headers, data: table_rows)
+  end
+
+  def to_ods
+    SpreadsheetArchitect.to_ods(headers: table_headers, data: table_rows)
+  end
+
+  def to_xlsx
+    SpreadsheetArchitect.to_xlsx(headers: table_headers, data: table_rows)
+  end
+
+  private
+
+  def rows_as_arrays
+    report_array = [@report.headers]
+
+    @report_rows.each do |row|
+      report_array << row_or_summary(row)
+    end
+
+    report_array
+  end
+
+  def row_or_summary(row)
+    summary_row_title = row.delete :summary_row_title
+    row_values = row.values
+    row_values[0] = summary_row_title if summary_row_title
+
+    row_values
+  end
+end

--- a/app/services/report_summariser.rb
+++ b/app/services/report_summariser.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class ReportSummariser
+  def initialize(group_column, report_rows, report)
+    @group_column = group_column
+    @report_rows = report_rows
+    @report = report
+  end
+
+  def call
+    insert_summary_rows unless exclude_summaries?
+
+    @report_rows
+  end
+
+  private
+
+  def insert_summary_rows
+    grouped_rows = []
+    previous_grouping = nil
+
+    @report_rows.each_with_index do |row, row_index|
+      current_grouping = row[@group_column]
+
+      if previous_grouping.present? && current_grouping != previous_grouping
+        grouped_rows << build_summary_row(@group_column, previous_grouping, @report.summary_row)
+      end
+
+      grouped_rows << row
+
+      if last_row?(row_index)
+        grouped_rows << build_summary_row(@group_column, previous_grouping, @report.summary_row)
+      end
+
+      previous_grouping = current_grouping
+    end
+
+    @report_rows = grouped_rows
+  end
+
+  def build_summary_row(group_column, group_key, options)
+    summary_row = initialize_empty_row
+    group_rows = @report_rows.select{ |row| row[group_column] == group_key }
+
+    summary_row[:summary_row_title] = options[:title]
+
+    (options[:sum] || []).each do |sum_column|
+      summary_row[sum_column] = group_rows.sum{ |group_row| group_row[sum_column] }
+    end
+
+    (options[:show_first] || []).each do |first_column|
+      summary_row[first_column] = group_rows.first[first_column]
+    end
+
+    summary_row
+  end
+
+  def initialize_empty_row
+    row = {}
+    @report.headers.each do |key|
+      row[key.to_sym] = ""
+    end
+
+    row
+  end
+
+  def last_row?(row_index)
+    @report_rows.length == row_index + 1
+  end
+
+  def exclude_summaries?
+    @report.options[:exclude_summaries]
+  end
+end

--- a/app/views/spree/admin/reports/_date_range_form.html.haml
+++ b/app/views/spree/admin/reports/_date_range_form.html.haml
@@ -2,8 +2,8 @@
   = label_tag nil, t(:date_range)
   %br
   = label_tag nil, t(:start), :class => 'inline'
-  = f.text_field :completed_at_gt, :class => 'datetimepicker datepicker-from'
+  = text_field_tag "q[completed_at_gt]", params[:q].andand[:completed_at_gt], :class => 'datetimepicker datepicker-from'
   %span.range-divider
     %i.icon-arrow-right
-  = f.text_field :completed_at_lt, :class => 'datetimepicker datepicker-to'
+  = text_field_tag "q[completed_at_lt]", params[:q].andand[:completed_at_lt], :class => 'datetimepicker datepicker-to'
   = label_tag nil, t(:end), :class => 'inline'

--- a/app/views/spree/admin/reports/_table.html.haml
+++ b/app/views/spree/admin/reports/_table.html.haml
@@ -3,21 +3,19 @@
   %table.report__table{id: id}
     %thead
       %tr
-        - @header.each do |heading|
-          %th= heading
+        - @report.table_headers.each do |heading|
+          %th
+            = heading
     %tbody
-      - @table.each do |row|
+      - @report.table_rows.each do |row|
+        - if row
+          %tr
+            - row.each do |cell|
+              %td
+                = cell
+      - if @report.table_rows.empty?
         %tr
-          - row.each_with_index do |cell_value, column_index|
-            %td
-              - partial = column_partials[column_index]
-              - if partial
-                = render partial, value: cell_value
-              - else
-                = cell_value
-      - if @table.empty?
-        %tr
-          %td{colspan: @header.count}= t(:none)
+          %td{colspan: @report.table_headers.count}= t(:none)
 - else
   %p.report__message
     = t(".select_and_search", option: msg_option.upcase)

--- a/app/views/spree/admin/reports/packing.html.haml
+++ b/app/views/spree/admin/reports/packing.html.haml
@@ -1,26 +1,32 @@
-= form_for @report.search, :url => spree.packing_admin_reports_path do |f|
-  = render 'date_range_form', f: f
+= form_tag spree.packing_admin_reports_path, :method => :post do
+  = render 'date_range_form'
 
   .row
     .alpha.two.columns= label_tag nil, t(:report_hubs)
-    .omega.fourteen.columns= f.collection_select(:distributor_id_in, @distributors, :id, :name, {}, {class: "select2 fullwidth", multiple: true})
+    .omega.fourteen.columns
+      = collection_select("q", "distributor_id_in", @distributors, :id, :name, {selected: params[:q].andand[:distributor_id_in]}, {class: "select2 fullwidth", multiple: true})
 
   .row
     .alpha.two.columns= label_tag nil, t(:report_producers)
-    .omega.fourteen.columns= select_tag(:supplier_id_in, options_from_collection_for_select(@suppliers, :id, :name, params[:supplier_id_in]), {class: "select2 fullwidth", multiple: true})
-
-  .row
-    .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
     .omega.fourteen.columns
-      = f.select(:order_cycle_id_in, report_order_cycle_options(@order_cycles), {selected: params[:q][:order_cycle_id_in]}, {class: "select2 fullwidth", multiple: true})
+      = select_tag("q[supplier_id_in]", options_from_collection_for_select(@suppliers, :id, :name, params[:supplier_id_in]), {class: "select2 fullwidth", multiple: true})
+
+  -#.row
+  -#  .alpha.two.columns= label_tag nil, t(:report_customers_cycle)
+  -#  .omega.fourteen.columns
+  -#    = f.select(:order_cycle_id_in, report_order_cycle_options(@order_cycles), {selected: params[:q].andand[:order_cycle_id_in]}, {class: "select2 fullwidth", multiple: true})
+  -#
+  -# .row
+  -#   .alpha.two.columns= label_tag nil, t(:report_type)
+  -#   .omega.fourteen.columns= select_tag(:report_type, options_for_select(@report_types, @report_type))
 
   .row
-    .alpha.two.columns= label_tag nil, t(:report_type)
-    .omega.fourteen.columns= select_tag(:report_type, options_for_select(@report_types, @report_type))
-
+    = label_tag :report_format, "Generate report:"
+    %br
+    = select_tag :report_format, options_for_select({'On screen' => '', 'CSV Spreadsheet' => 'csv', 'Excel Spreadsheet' => 'xlsx', 'OpenOffice Spreadsheet' => 'ods'})
   .row
-    = check_box_tag :csv
-    = label_tag :csv, t(:report_customers_csv)
+    = check_box_tag "options[exclude_summaries]", true, params[:options].andand[:exclude_summaries]
+    = label_tag "hide_summary_rows"
 
   .row
   = button t(:search)

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -73,5 +73,9 @@ Openfoodnetwork::Application.routes.draw do
         end
       end
     end
+
+    namespace :reports do
+      get :packing
+    end
   end
 end


### PR DESCRIPTION
I had a little play around over the weekend with what a reports rewrite might look like and I came up with this... 

I implemented a new base Report class using the template method pattern and extracted the main bits of functionality into 3 services that basically deal with: data wrangling, aggregating/summarising, and rendering. 

I re-implemented the "Packing by Customer" report with the new Report class. I had to hack some of the views a bit, so this will definitely break other reports in it's current state (it's a quick POC)... 

With the new packing report:

- The report's output is the same as before
- The definition of the packing report is 10 times easier to read, and a lot more concise
- I did some quick performance comparison using production data, and the packing report renders **twice as fast** as before
- The report can be rendered in various file formats or fetched via the API

In general, with reports based on this new class:

- Defining a new report or changing an existing one is so easy we could put the `good-first-issue` tag on it
- Any report can be created with 3 simple inputs (current user, search params, customisation options) and rendered on the screen, as plain CSV format, as Excel spreadsheets, as OpenOffice spreadsheets, or as JSON in an API endpoint, with the same data
- There's various places we could add additional aggregating/grouping/reordering functions very easily, and they would be available in all reports
- The report's data is easy to adjust, sort and generally manipulate before it's rendered, so it'll be easy to add various UX options that would have been difficult before, for example the user could: show/hide columns, reorder columns, show/hide summary rows, etc. before exporting to a spreadsheet
- It should be incredibly easy to switch existing reports to this new style


### Examples of a report definition:

Defining the main collection of objects looks like this:
```ruby
def collection
   Spree::LineItem.includes(:product, :order).where(order_id: visible_orders).
      ransack(ransack_params).result
end
```

Defining the report's headings and what the rows should contain looks like this:
```ruby
def report_rows(objects)
   {
      order_number: object.order.number,
      product_name: object.variant.product.name,
      quantity: object.quantity,
      amount: object.amount
   }
end
```

Defining ordering of the results by several different columns looks like this:
```ruby
def order_by
   [:supplier, :order, :last_name]
end
```

Defining a grouping and including a summary row after each group that includes the sum of values for that group for :quantity and :price columns would look like this:
```ruby
def summary_group
   [:supplier]
end

def summary_row
   { title: 'TOTALS:', sum: [:quantity, :price] }
end
```

Hiding a column that was used in grouping or ordering but shouldn't be output in the report would look like this:
```ruby
def hide_columns
   [:customer_id]
end
```

The report definition doesn't need much more than that, and the new Report class handles the rest...

### Examples of rendering the packing report:

#### Rendering options:

![Screenshot from 2020-06-09 19-22-10](https://user-images.githubusercontent.com/9029026/84181715-9da06f00-aa89-11ea-9e1e-e4904fa840f0.png)

#### Downloading in Excel format:

![Screenshot from 2020-06-09 19-26-42](https://user-images.githubusercontent.com/9029026/84181719-9ed19c00-aa89-11ea-9ee9-3167b86c76d3.png)

#### Output from the corresponding API endpoint:

![Screenshot from 2020-06-09 09-30-32](https://user-images.githubusercontent.com/9029026/84183076-a2662280-aa8b-11ea-93cb-3813135447b1.png)
