### PR TITLE
Added more key to en.yml to translate More dropdown text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2907,6 +2907,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   last: "Last"
 
   spree:
+    more: "More"
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"
     name_or_sku: "Name or SKU (enter at least first 4 characters of product name)"


### PR DESCRIPTION
#### What? Why?

Closes #2617 

On admin page (dashboard) all tabs were being translated except for 'More' on the dropdown tab. Added key config/locales/en.yml file to resolve. 'More' is not being translated. 

#### What should we test?
Login as Admin and check Dashboard (main) page in a non-English instance. 'More' on the dropdown should be translated, or ready to be translated

#### Release notes
Added translation key in config/locales/en.yml file to add translation to dropdown on Admin dashboard (main) page. 

Changelog Category: Added