### PR TITLE
Added translation key to config/locales/en.yml file for shipping_cat…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,7 @@ en:
   on_hand: "On Hand"
   "on hand": "On Hand"
   ship: "Ship"
+  shipping_category: "Shipping Category"
 
   actions:
     create_and_add_another: "Create and Add Another"


### PR DESCRIPTION
…egory

#### What? Why?

Closes #5558 
Translation key was missing for 'Shipping Category' label on the new products page. 

#### What should we test?
On the `/admin/products/new` page, the 'Shipping Category' label should be ready for translation

#### Release notes
Translation key added to config/locales/en.yml file to enable translation on New Products page

Changelog Category: Added