### PR TITLE
Fix link from report to order

### DIFF
--- a/app/views/spree/admin/reports/_link_order.html.haml
+++ b/app/views/spree/admin/reports/_link_order.html.haml
@@ -1,1 +1,2 @@
-%a.edit-order{href: "/admin/orders/#{value}"}= value
+- order_number = value
+= link_to order_number, edit_admin_order_url(order_number), class: 'edit-order'


### PR DESCRIPTION
#### What? Why?

Fixes the link which now points to a page that doesn't exist and thus causes a slug.

I haven't found any other report rendering the order number.

#### What should we test?

Render any of the tax reports and click on any order number. It should lead to the order edit page.

#### Release notes

Fix broken order link from tax reports
Changelog Category: Fixed