### PR TITLE
[Spree 2.1] Fix "subquery has too many columns" in reports query

### DIFF
--- a/app/controllers/spree/admin/reports_controller.rb
+++ b/app/controllers/spree/admin/reports_controller.rb
@@ -247,7 +247,7 @@ module Spree
       end
 
       def suppliers_of_products_distributed_by(distributors)
-        supplier_ids = Spree::Product.in_distributors(distributors).
+        supplier_ids = Spree::Product.in_distributors(distributors.select('enterprises.id')).
           select('spree_products.supplier_id')
 
         Enterprise.where(id: supplier_ids)


### PR DESCRIPTION
Fixes "subquery has too many columns" in reports query.