### PR TITLE
[Spree 2.1] Make backoffice stripe payments work in rails 4

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -84,7 +84,11 @@ module Spree
            source_params = params.delete(:payment_source)[params[:payment][:payment_method_id]]
           params[:payment][:source_attributes] = source_params
         end
-        params.require(:payment).permit(:amount, :payment_method_id, :source_attributes)
+
+        params.require(:payment).permit(
+          :amount, :payment_method_id,
+          source_attributes: ::PermittedAttributes::PaymentSource.attributes
+        )
       end
 
       def load_data

--- a/app/services/permitted_attributes/checkout.rb
+++ b/app/services/permitted_attributes/checkout.rb
@@ -13,24 +13,13 @@ module PermittedAttributes
           :existing_card_id, :shipping_method_id,
           payments_attributes: [
             :payment_method_id,
-            source_attributes: payment_source_attributes
+            source_attributes: PermittedAttributes::PaymentSource.attributes
           ],
           ship_address_attributes: PermittedAttributes::Address.attributes,
           bill_address_attributes: PermittedAttributes::Address.attributes
         ],
-        payment_source: payment_source_attributes
+        payment_source: PermittedAttributes::PaymentSource.attributes
       )
-    end
-
-    private
-
-    def payment_source_attributes
-      [
-        :gateway_payment_profile_id, :cc_type, :last_digits,
-        :month, :year, :first_name, :last_name,
-        :number, :verification_value,
-        :save_requested_by_customer
-      ]
     end
   end
 end

--- a/app/services/permitted_attributes/payment_source.rb
+++ b/app/services/permitted_attributes/payment_source.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PermittedAttributes
+  class PaymentSource
+    def self.attributes
+      [
+        :gateway_payment_profile_id, :cc_type, :last_digits,
+        :month, :year, :first_name, :last_name,
+        :number, :verification_value,
+        :save_requested_by_customer
+      ]
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #5525

Backoffice Stripe payments were not working in rails 4 at all, the card attributes were not permitted and so the details were not being saved in the database.
Added a missing automated test to payments controller.

#### What should we test?
Verify backoffice stripe payments are now working for both StripeConnect and StripeSCA.

#### Release notes
Changelog Category: Fixed
Fixed stripe payments in the BackOffice in rails 4.
