### PR TITLE
Make checkout js error handling a bit more defensive

### DIFF
--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -27,10 +27,12 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
             throw error # generate a BugsnagJS alert
 
     handle_checkout_error_response: (response) =>
-      if response.data.path
+      throw response unless response.data?
+
+      if response.data.path?
         Navigation.go response.data.path
       else
-        throw response unless response.data.flash
+        throw response unless response.data.flash?
 
         @errors = response.data.errors
         @loadFlash(response.data.flash)


### PR DESCRIPTION
#### What? Why?

Closes #5583

If response.data is not present it will throw response, and that will end in bugsnag.

#### What should we test?
I dont think we can test this in the UI.

#### Release notes
Changelog Category: Changed
Checkout code is now more resilient handling error scenarios.
