### PR TITLE
Enhancement/5454 make links to shops under Groups > Producers open in new tab

### DIFF
--- a/app/views/producers/_fat.html.haml
+++ b/app/views/producers/_fat.html.haml
@@ -79,8 +79,8 @@
     .row.cta-container
       .columns.small-12
         %a.cta-hub{"ng-repeat" => "hub in producer.hubs | orderBy:'-active'",
-        "ng-href" => "{{::hub.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined }}",
-        "ng-class" => "::{primary: hub.active, secondary: !hub.active}"}
+        "ng-href" => "{{::hub.path}}", "ng-attr-target" => "_blank",
+        "ng-class" => "::{primary: hub.active, secondary: !hub.active}", "target" => "_blank"}
           %i.ofn-i_068-shop-reversed{"ng-if" => "::hub.active"}
           %i.ofn-i_068-shop-reversed{"ng-if" => "::!hub.active"}
           .hub-name{"ng-bind" => "::hub.name"}

--- a/app/views/producers/_skinny.html.haml
+++ b/app/views/producers/_skinny.html.haml
@@ -3,7 +3,7 @@
     %span{"ng-if" => "::producer.is_distributor" }
       .row.vertical-align-middle
         .columns.small-12
-          %a.is_distributor{"ng-href" => "{{::producer.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}", "data-is-link" => "true"}
+          %a.is_distributor{"ng-href" => "{{::producer.path}}", "ng-attr-target" => "_blank", "data-is-link" => "true", "target" => "_blank"}
             %i{ng: {class: "::producer.producer_icon_font"}}
             %span.margin-top
               %strong{"ng-bind" => "::producer.name"}


### PR DESCRIPTION
#### What? Why?

Closes #5454 

#### What should we test?
If the shops' links are opening in a new tab properly (both producers name and shops when the tab expands).

#### Release notes
Make shops' links on groups page open in a new tab (both producer name and shops when the tab expands).
Changelog Category: Changed

Result:
![ofn](https://user-images.githubusercontent.com/27960597/84611377-0f1a5c00-ae94-11ea-98d6-cd06efefaecd.gif)
![ofn](https://user-images.githubusercontent.com/27960597/85079773-05e40480-b19e-11ea-8516-9d5eecd62a1b.gif)


