### PR TITLE
Set flaky caching spec to pending

### DIFF
--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -29,7 +29,7 @@ feature "Darkswarm data caching", js: true, caching: true do
       visit shops_path
     end
 
-    it "invalidates caches for taxons and properties" do
+    xit "invalidates caches for taxons and properties" do
       visit shops_path
 
       taxon_timestamp1 = CacheService.latest_timestamp_by_class(Spree::Taxon)


### PR DESCRIPTION
#### What? Why?

Related to #5619

This flaky spec got re-enabled during the upgrade. It's still flaky. Passing locally but failing intermittently in Semaphore.

There's a tech-debt issue open to fix it.