### PR TITLE
Make Zones editable again

### DIFF
--- a/app/controllers/spree/admin/zones_controller.rb
+++ b/app/controllers/spree/admin/zones_controller.rb
@@ -24,8 +24,13 @@ module Spree
 
       def permitted_resource_params
         params.require(:zone).permit(
-          :name, :description, :default_tax
+          :name, :description, :default_tax, :kind,
+          zone_members_attributes: [:id, :zoneable_id, :zoneable_type, :_destroy]
         )
+      end
+
+      def location_after_save
+        edit_object_url(@zone)
       end
     end
   end

--- a/spec/features/admin/configuration/zones_spec.rb
+++ b/spec/features/admin/configuration/zones_spec.rb
@@ -36,4 +36,22 @@ describe "Zones" do
 
     expect(page).to have_content("successfully created!")
   end
+
+  scenario "edit existing zone", js: true do
+    zone = create(:zone_with_member)
+    visit spree.edit_admin_zone_path(zone.id)
+
+    expect(page).to have_checked_field "country_based"
+
+    # Toggle to state based zone
+    choose "State Based"
+
+    # click Add State
+    page.find("#nested-state").click
+    # select first state available
+    find('.select2').find(:xpath, 'option[2]').select_option
+
+    click_button "Update"
+    expect(page).to have_content("successfully updated!")
+  end
 end

--- a/spec/features/admin/configuration/zones_spec.rb
+++ b/spec/features/admin/configuration/zones_spec.rb
@@ -3,38 +3,37 @@ require 'spec_helper'
 describe "Zones" do
   include AuthenticationWorkflow
 
-  before(:each) do
+  before do
     quick_login_as_admin
     Spree::Zone.delete_all
+  end
+
+  scenario "list existing zones" do
     visit spree.admin_dashboard_path
     click_link "Configuration"
+
+    create(:zone, name: "eastern", description: "zone is eastern")
+    create(:zone, name: "western", description: "cool san fran")
+    click_link "Zones"
+
+    within_row(1) { expect(page).to have_content("eastern") }
+    within_row(2) { expect(page).to have_content("western") }
+
+    click_link "zones_order_by_description_title"
+
+    within_row(1) { expect(page).to have_content("western") }
+    within_row(2) { expect(page).to have_content("eastern") }
   end
 
-  context "show" do
-    it "should display existing zones" do
-      create(:zone, name: "eastern", description: "zone is eastern")
-      create(:zone, name: "western", description: "cool san fran")
-      click_link "Zones"
+  scenario "create a new zone" do
+    visit spree.admin_zones_path
+    click_link "admin_new_zone_link"
+    expect(page).to have_content("New Zone")
 
-      within_row(1) { expect(page).to have_content("eastern") }
-      within_row(2) { expect(page).to have_content("western") }
+    fill_in "zone_name", with: "japan"
+    fill_in "zone_description", with: "japanese time zone"
+    click_button "Create"
 
-      click_link "zones_order_by_description_title"
-
-      within_row(1) { expect(page).to have_content("western") }
-      within_row(2) { expect(page).to have_content("eastern") }
-    end
-  end
-
-  context "create" do
-    it "should allow an admin to create a new zone" do
-      click_link "Zones"
-      click_link "admin_new_zone_link"
-      expect(page).to have_content("New Zone")
-      fill_in "zone_name", with: "japan"
-      fill_in "zone_description", with: "japanese time zone"
-      click_button "Create"
-      expect(page).to have_content("successfully created!")
-    end
+    expect(page).to have_content("successfully created!")
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5620

Missing permitted attributes...
I added a spec to cover the bug.

#### What should we test?
Verify the bug is fixed.

#### Release notes
Changelog Category: Fixed
Zones can now be edited: add or remove countries or states.
