### PR TITLE
v3 image precompile

### DIFF
--- a/app/assets/stylesheets/admin/welcome.css.scss
+++ b/app/assets/stylesheets/admin/welcome.css.scss
@@ -7,7 +7,7 @@
 
     @include fullbg;
     background-color: black;
-    background-image: url("/assets/home/tagline-bg.jpg");
+    background-image: image-url("home/tagline-bg.jpg");
     background-repeat: no-repeat;
     background-position: center center;
     margin-bottom: 2em;

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.css.scss
@@ -62,7 +62,7 @@ ordercycle {
     }
 
     select {
-      background-image: url('/assets/white-caret.svg');
+      background-image: image-url('white-caret.svg');
       background-size: 30px auto;
       background-position-x: 102%;
     }
@@ -147,7 +147,7 @@ shop ordercycle {
 
       select {
         background-color: $white;
-        background-image: url('/assets/black-caret.svg');
+        background-image: image-url('black-caret.svg');
         color: $grey-500;
         font-style: italic;
       }

--- a/app/assets/stylesheets/darkswarm/_shop-taxon-flag.css.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-taxon-flag.css.scss
@@ -4,7 +4,7 @@
   products {
     product {
       .taxon-flag {
-        background: transparent url("/assets/flag.svg") top center no-repeat;
+        background: transparent image-url("flag.svg") top center no-repeat;
         background-size: 34px 39px;
         min-height: 40px;
         width: 34px;

--- a/app/assets/stylesheets/darkswarm/footer.scss
+++ b/app/assets/stylesheets/darkswarm/footer.scss
@@ -50,7 +50,7 @@ footer {
 
         width: 100%;
         border: 1px solid rgba($dark-grey, 0.35);
-        background-image: url("/assets/tile-wide.png");
+        background-image: image-url("tile-wide.png");
         background-position: center center;
         background-color: #bbb;
         padding: 12px 0 8px 0;

--- a/app/assets/stylesheets/darkswarm/home_panes.css.scss
+++ b/app/assets/stylesheets/darkswarm/home_panes.css.scss
@@ -42,7 +42,7 @@
 }
 
 #stats.pane {
-  background-image: url("/assets/home/background-blurred-oranges.jpg");
+  background-image: image-url("home/background-blurred-oranges.jpg");
   background-position: center center;
   background-color: $ofn-grey;
 
@@ -94,7 +94,7 @@
   }
 
   .home-icon-box {
-    background-image: url("/assets/ofn-o.png");
+    background-image: image-url("ofn-o.png");
     background-position: center center;
     background-repeat: no-repeat;
     background-size: auto 100%;
@@ -121,15 +121,15 @@
       background-size: auto 100%;
 
       &.search {
-        background-image: url("/assets/icon-mask-magnifier.png");
+        background-image: image-url("icon-mask-magnifier.png");
       }
 
       &.shop {
-        background-image: url("/assets/icon-mask-apple.png");
+        background-image: image-url("icon-mask-apple.png");
       }
 
       &.pick-up-delivery {
-        background-image: url("/assets/icon-mask-truck.png");
+        background-image: image-url("icon-mask-truck.png");
       }
     }
   }

--- a/app/assets/stylesheets/darkswarm/home_tagline.css.scss
+++ b/app/assets/stylesheets/darkswarm/home_tagline.css.scss
@@ -13,7 +13,7 @@
     @include fullbg;
 
     background-color: $ofn-grey;
-    background-image: url("/assets/home/home.jpg");
+    background-image: image-url("home/home.jpg");
     position: fixed;
     left: 0;
     right: 0;

--- a/app/assets/stylesheets/darkswarm/mixins.scss
+++ b/app/assets/stylesheets/darkswarm/mixins.scss
@@ -5,7 +5,7 @@
 // Generic \\
 
 @mixin tiledPane {
-  background-image: url("/assets/tile-wide.png");
+  background-image: image-url("tile-wide.png");
   background-color: $brand-colour;
   background-position: center center;
 
@@ -236,7 +236,7 @@
 
 @mixin producersbg {
   background-color: lighten($clr-turquoise, 68%);
-  background-image: url("/assets/producers.svg");
+  background-image: image-url("producers.svg");
   background-position: center 50px;
   background-repeat: no-repeat;
   background-size: 922px 763px;
@@ -244,13 +244,13 @@
 
 @mixin hubsbg {
   background-color: $brand-colour;
-  background-image: url("/assets/hubs-bg.jpg");
+  background-image: image-url("hubs-bg.jpg");
   background-position: center center;
 }
 
 @mixin groupsbg {
   background-color: lighten($clr-brick, 56%);
-  background-image: url("/assets/groups.svg");
+  background-image: image-url("groups.svg");
   background-position: center 50px;
   background-repeat: no-repeat;
   background-size: 922px 922px;

--- a/app/assets/stylesheets/darkswarm/page_alert.css.scss
+++ b/app/assets/stylesheets/darkswarm/page_alert.css.scss
@@ -14,7 +14,7 @@ $page-alert-height: 55px;
     border-left: none;
     border-right: none;
     background-color: #bbb;
-    background-image: url("/assets/tile-wide.png");
+    background-image: image-url("tile-wide.png");
     background-position: center center;
     padding: 12px 0 8px 0;
     margin: 0;

--- a/app/assets/stylesheets/darkswarm/shop_search.css.scss
+++ b/app/assets/stylesheets/darkswarm/shop_search.css.scss
@@ -32,7 +32,7 @@
     padding: 0 2.25em 0 2.75em;
     width: 100%;
     min-width: 0;
-    background: $white url("/assets/icn-search-grey.png") 1em center no-repeat;
+    background: $white image-url("icn-search-grey.png") 1em center no-repeat;
     font-size: 1rem; // avoid zoom on iphone, see issue #4535
 
     &::placeholder {

--- a/app/views/admin/customers/index.html.haml
+++ b/app/views/admin/customers/index.html.haml
@@ -35,7 +35,7 @@
 
   .row{ 'ng-if' => 'shop_id && RequestMonitor.loading' }
     .sixteen.columns.alpha#loading
-      %img.spinner{ src: "/assets/spinning-circles.svg" }
+      %img.spinner{ src: image_path("spinning-circles.svg") }
       %h1
         =t :loading_customers
 

--- a/app/views/admin/enterprises/_enterprise_user_index.html.haml
+++ b/app/views/admin/enterprises/_enterprise_user_index.html.haml
@@ -9,7 +9,7 @@
       %columns-dropdown{ action: "#{controller_name}_#{action_name}" }
   .row{ 'ng-if' => '!loaded' }
     .sixteen.columns.alpha#loading
-      %img.spinner{ src: "/assets/spinning-circles.svg" }
+      %img.spinner{ src: image_path("spinning-circles.svg") }
       %h1= t('.loading_enterprises')
   .row{ :class => "sixteen columns alpha", 'ng-show' => 'loaded && filteredEnterprises.length == 0'}
     %h1#no_results= t('.no_enterprises_found')

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -59,7 +59,7 @@
     .six.columns
       = f.text_field :permalink, { 'ng-model' => "Enterprise.permalink", placeholder: "eg. your-shop-name", 'ng-model-options' => "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }" }
     .two.columns.omega
-      %img.spinner{ src: "/assets/spinning-circles.svg", width: "30px", ng: { show: "checking" } }
+      %img.spinner{ src: image_path("spinning-circles.svg"), width: "30px", ng: { show: "checking" } }
       %span{ ng: { class: 'availability.toLowerCase()', hide: "checking" } }
         {{ availability }}
         %i{ ng: { class: "{'icon-ok-sign': availability == 'Available', 'icon-remove-sign': availability == 'Unavailable'}" } }

--- a/app/views/admin/order_cycles/_loading_flash.html.haml
+++ b/app/views/admin/order_cycles/_loading_flash.html.haml
@@ -1,5 +1,5 @@
 %div.sixteen.columns.alpha.omega#loading{ ng: { cloak: true, if: 'RequestMonitor.loading' } }
-  %img.spinner{ src: "/assets/spinning-circles.svg" }
+  %img.spinner{ src: image_path("spinning-circles.svg") }
   %h1{ ng: { hide: 'orderCycles.length > 0' } }
     =t('.loading_order_cycles')
   %h1{ ng: { show: 'orderCycles.length > 0' } }

--- a/app/views/admin/subscriptions/_loading_flash.html.haml
+++ b/app/views/admin/subscriptions/_loading_flash.html.haml
@@ -1,3 +1,3 @@
 %div.sixteen.columns.alpha.omega#loading{ ng: { cloak: true, if: 'shop_id && RequestMonitor.loading' } }
-  %img.spinner{ src: "/assets/spinning-circles.svg" }
+  %img.spinner{ src: image_path("spinning-circles.svg") }
   %h1= t('.loading')

--- a/app/views/admin/variant_overrides/_loading_flash.html.haml
+++ b/app/views/admin/variant_overrides/_loading_flash.html.haml
@@ -1,3 +1,3 @@
 %div.sixteen.columns.alpha.omega#loading{ ng: { cloak: true, if: 'hub_id && products.length == 0 && RequestMonitor.loading' } }
-  %img.spinner{ src: "/assets/spinning-circles.svg" }
+  %img.spinner{ src: image_path("spinning-circles.svg") }
   %h1= t('.loading_inventory')

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -22,7 +22,7 @@
           - if @group.logo.present?
             %img.group-logo{"src" => @group.logo}
           - else
-            %img.group-logo{"src" => '/assets/noimage/group.png'}
+            %img.group-logo{"src" => image_path('noimage/group.png') }
           %h2.group-name= @group.name
           %p= @group.description
 

--- a/app/views/home/_tagline.html.haml
+++ b/app/views/home/_tagline.html.haml
@@ -3,7 +3,7 @@
     .small-12.text-center.columns
       %h1
         / TODO: Rohan - logo asset & width is content manageable:
-        %img{src: "/assets/logo-white-notext.png", title: Spree::Config.site_name}
+        %img{src: image_path("logo-white-notext.png"), title: Spree::Config.site_name}
         %br/
         %a.button.transparent{href: "/shops"}
           = t :home_shop

--- a/app/views/layouts/registration.html.haml
+++ b/app/views/layouts/registration.html.haml
@@ -13,7 +13,7 @@
     = stylesheet_link_tag "darkswarm/all"
     = csrf_meta_tags
 
-  %body.off-canvas{"ng-app" => "Darkswarm", style: 'background-image: url("/assets/tile-wide.png")' }
+  %body.off-canvas{"ng-app" => "Darkswarm", style: "background-image: url(#{image_path('tile-wide.png')})" }
     / [if lte IE 8]
       = render partial: "shared/ie_warning"
       = javascript_include_tag "iehack"

--- a/app/views/producers/_fat.html.haml
+++ b/app/views/producers/_fat.html.haml
@@ -1,7 +1,7 @@
 .row.active_table_row{"ng-if" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : open()}"}
   .columns.small-12.fat.text-center{"ng-show" => "open() && shopfront_loading"}
     %p
-      %img.spinner.text-center{ src: "/assets/spinning-circles.svg" }
+      %img.spinner.text-center{ src: image_path("spinning-circles.svg") }
 
   .columns.small-12.medium-7.large-7.fat{"ng-show" => "open() && !shopfront_loading"}
     / Will add in long description available once clean up HTML formatting producer.long_description

--- a/app/views/registration/steps/_limit_reached.html.haml
+++ b/app/views/registration/steps/_limit_reached.html.haml
@@ -6,7 +6,7 @@
         %h4= t(".message")
   .row
     .small-12.medium-3.large-2.columns.text-right.hide-for-small-only
-      %img{:src => "/assets/potatoes.png"}
+      %img{:src => image_path("potatoes.png") }
     .small-12.medium-9.large-10.columns
       %p
         = t(".text")

--- a/app/views/registration/steps/_logo.html.haml
+++ b/app/views/registration/steps/_logo.html.haml
@@ -41,6 +41,6 @@
               .message{ ng: { hide: "imageSrc() || imageUploader.isUploading" } }
                 = t(".logo_placeholder")
               .loading{ ng: { hide: "!imageUploader.isUploading" } }
-                %img.spinner{ src: "/assets/spinning-circles.svg" }
+                %img.spinner{ src: image_path("spinning-circles.svg") }
                 %br/
                 = t("registration.steps.images.uploading")

--- a/app/views/registration/steps/_promo.html.haml
+++ b/app/views/registration/steps/_promo.html.haml
@@ -39,6 +39,6 @@
               .message{ ng: { hide: "imageSrc() || imageUploader.isUploading" } }
                 = t(".promo_image_placeholder")
               .loading{ ng: { hide: "!imageUploader.isUploading" } }
-                %img.spinner{ src: "/assets/spinning-circles.svg" }
+                %img.spinner{ src: image_path("spinning-circles.svg") }
                 %br/
                 = t("registration.steps.images.uploading")

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -3,7 +3,7 @@
     .row
       .small-12.columns.text-center
         .logo
-          %img{src: "/assets/logo-white-notext.png"}
+          %img{src: image_path("logo-white-notext.png") }
     .row
       .small-12.medium-8.medium-offset-2.columns.text-center
         .alert-box

--- a/app/views/shared/_ie_warning.html.haml
+++ b/app/views/shared/_ie_warning.html.haml
@@ -10,17 +10,17 @@
   .row
     .small-4.columns.browserbtn
       %a.browserlogo{href: "https://www.google.com/intl/en_au/chrome/browser/", target: "_blank"} 
-        %img{src: "assets/browser-logos/chrome.png"}
+        %img{src: image_path("browser-logos/chrome.png") }
       %a{href: "https://www.google.com/intl/en_au/chrome/browser/", target: "_blank"}
         = t :ie_warning_chrome
     .small-4.columns.browserbtn
       %a.browserlogo{href: "http://www.mozilla.org/en-US/firefox/new/", target: "_blank"} 
-        %img{src: "assets/browser-logos/firefox.png"}
+        %img{src: image_path("browser-logos/firefox.png") }
       %a{href: "http://www.mozilla.org/en-US/firefox/new/", target: "_blank"}
         = t :ie_warning_firefox
     .small-4.columns.browserbtn  
       %a.browserlogo{href: "http://windows.microsoft.com/en-AU/internet-explorer/download-ie", target: "_blank"} 
-        %img{src: "assets/browser-logos/internet-explorer.png"}
+        %img{src: image_path("browser-logos/internet-explorer.png") }
       %a{href: "http://windows.microsoft.com/en-AU/internet-explorer/download-ie", target: "_blank"}
         = t :ie_warning_ie
   .row.ie-msg

--- a/app/views/shared/menu/_cart.html.haml
+++ b/app/views/shared/menu/_cart.html.haml
@@ -3,7 +3,7 @@
     %span
       = t '.cart'
     %span.count
-      %img{ src: "/assets/menu/icn-cart.svg" }
+      %img{ src: image_path("menu/icn-cart.svg") }
       %span
         {{ Cart.total_item_count() }}
 

--- a/app/views/shared/menu/_mobile_menu.html.haml
+++ b/app/views/shared/menu/_mobile_menu.html.haml
@@ -14,7 +14,7 @@
         %span
           = t '.cart'
         %span.count
-          %img{ src: "/assets/menu/icn-cart.svg" }
+          %img{ src: image_path("menu/icn-cart.svg") }
           %span
             {{ Cart.total_item_count() }}
 

--- a/app/views/shared/menu/_signed_in.html.haml
+++ b/app/views/shared/menu/_signed_in.html.haml
@@ -7,7 +7,7 @@
 %li.user-menu.has-dropdown.not-click
 
   %a{href: "#", class: "top-bar--menu-item-with-icon"}
-    %img{ src: "/assets/menu/icn-profile.svg" }
+    %img{ src: image_path("menu/icn-profile.svg") }
     %span
       = t '.profile'
 

--- a/app/views/shared/menu/_signed_out.html.haml
+++ b/app/views/shared/menu/_signed_out.html.haml
@@ -1,5 +1,5 @@
 %li#login-link
   %a{"auth" => "login"}
-    %img{ src: "/assets/menu/icn-login.svg" }
+    %img{ src: image_path("menu/icn-login.svg") }
     %span
       = t 'label_login'

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -21,7 +21,7 @@
                       = t :products_loading
                   .row
                     .small-12.columns.text-center
-                      %img.spinner{ src: "/assets/spinning-circles.svg" }
+                      %img.spinner{ src: image_path("spinning-circles.svg") }
 
             .hide-for-medium-down.large-2.columns
               %h5

--- a/app/views/shop/products/_searchbar.haml
+++ b/app/views/shop/products/_searchbar.haml
@@ -8,7 +8,7 @@
               "ng-debounce" => "200",
               "ofn-disable-enter" => true}
         %a.clear{type: 'button', ng: {show: 'query', click: 'clearQuery()'}, 'focus-search' => true}
-          %img{ src: "/assets/icn-close.png" }
+          = image_tag "icn-close.png"
 
       .hide-for-large-up
         %button{type: 'button', ng: {click: 'toggleFilterSidebar()'}}

--- a/app/views/shops/_fat.html.haml
+++ b/app/views/shops/_fat.html.haml
@@ -1,7 +1,7 @@
 .row.active_table_row{"ng-show" => "open()", "ng-click" => "toggle($event)", "ng-class" => "{'open' : open()}"}
   .columns.small-12.fat.text-center{"ng-show" => "open() && shopfront_loading"}
     %p
-      %img.spinner.text-center{ src: "/assets/spinning-circles.svg" }
+      %img.spinner.text-center{ src: image_path("spinning-circles.svg") }
 
   .columns.small-12.medium-6.large-5.fat{"ng-show" => "open() && !shopfront_loading"}
     %div{"ng-if" => "::hub.taxons"}

--- a/app/views/shops/_hubs.html.haml
+++ b/app/views/shops/_hubs.html.haml
@@ -26,7 +26,7 @@
         %a{href: "", "ng-click" => "showDistanceMatches()"}
           = t :hubs_distance_filter, location: "{{ nameMatchesFiltered[0].name }}"
   .more-controls
-    %img.spinner.text-center{ng: {show: "closed_shops_loading"}, src: "/assets/spinning-circles.svg" }
+    %img.spinner.text-center{ng: {show: "closed_shops_loading"}, src: image_path("spinning-circles.svg") }
     %span{ng: {if: "!show_closed", cloak: true}}
       %a.button{href: "", ng: {click: "showClosedShops()"}}
         = t '.show_closed_shops'

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -102,7 +102,7 @@
     %columns-dropdown{ action: "#{controller_name}_#{action_name}" }
 
   %div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
-    %img.spinner{ src: "/assets/spinning-circles.svg" }
+    %img.spinner{ src: image_path("spinning-circles.svg") }
     %h1
       = t("admin.orders.bulk_management.loading")
 

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -81,7 +81,7 @@
         %span{'ng-bind-html' => 'order.display_total'}
       %td.actions
         %div.row-loading-icons
-          %img.spinner{src: "/assets/spinning-circles.svg", ng: {show: 'rowStatus[order.id] == "loading"'} }
+          %img.spinner{src: image_path("spinning-circles.svg"), ng: {show: 'rowStatus[order.id] == "loading"'} }
           %i.success.icon-ok-sign{ng: {show: 'rowStatus[order.id] == "success"'} }
           %i.error.icon-remove-sign.with-tip{ng: {show: 'rowStatus[order.id] == "error"'}, 'ofn-with-tip' => t('.order_not_updated')}
         %a.icon_link.with-tip.icon-edit.no-text{'ng-href' => '{{order.edit_path}}', 'data-action' => 'edit', 'ofn-with-tip' => t('.edit')}
@@ -93,7 +93,7 @@
 .orders-loading{'ng-show' => 'RequestMonitor.loading'}
   .row
     .small-12.columns.fullwidth.text-center
-      %img.spinner{ src: "/assets/spinning-circles.svg" }
+      %img.spinner{ src: image_path("spinning-circles.svg") }
   .row
     .small-12.columns.fullwidth.text-center
       %span= t('.loading')

--- a/app/views/spree/admin/products/index/_indicators.html.haml
+++ b/app/views/spree/admin/products/index/_indicators.html.haml
@@ -1,6 +1,6 @@
 %div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
   %br
-  %img.spinner{ src: "/assets/spinning-circles.svg" }
+  %img.spinner{ src: image_path("spinning-circles.svg") }
   %h1= t('.title')
 
 %div.sixteen.columns.alpha{ 'ng-show' => '!RequestMonitor.loading && products.length == 0 && query.length==0' }

--- a/app/views/spree/admin/variants/_autocomplete.js.erb
+++ b/app/views/spree/admin/variants/_autocomplete.js.erb
@@ -4,7 +4,7 @@
       {{#if variant.image }}
         <img src='{{variant.image}}' />
       {{ else }}
-        <img src='/assets/noimage/mini.png' />
+        <img src='<%= image_path("noimage/mini.png") %>' />
       {{/if}}
     </figure>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -160,6 +160,7 @@ module Openfoodnetwork
     config.assets.precompile += ['mail/all.css']
     config.assets.precompile += ['shared/*']
     config.assets.precompile += ['qz/*']
+    config.assets.precompile += ['*.jpg', '*.jpeg', '*.png', '*.gif' '*.svg']
 
     config.active_support.escape_html_entities_in_json = true
   end


### PR DESCRIPTION
#### What? Why?

Closes #5622

Ensures images in `/assets/images**` are precompiled and moved correctly to `/public/assets/images` in Rails 4.


#### What should we test?
<!-- List which features should be tested and how. -->

All images load correctly in Rails 4. This search icon seems to be a good test (it's been missing):

![Screenshot from 2020-06-16 16-50-17](https://user-images.githubusercontent.com/9029026/84791980-a34f0500-aff3-11ea-9273-b4f6ac1e24f0.png)


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed missing image issues in Rails 4 asset compilation

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
