### PR TITLE
Flaky caching spec

### DIFF
--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -53,6 +53,9 @@ feature "Darkswarm data caching", js: true, caching: true do
 
       visit shops_path
 
+      # Wait for /shops page to load properly before checking for new timestamps
+      expect(page).to_not have_selector ".row.filter-row", visible: true
+
       taxon_timestamp2 = CacheService.latest_timestamp_by_class(Spree::Taxon)
       expect_cached "views/#{CacheService::FragmentCaching.ams_all_taxons[0]}"
 

--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -29,7 +29,7 @@ feature "Darkswarm data caching", js: true, caching: true do
       visit shops_path
     end
 
-    xit "invalidates caches for taxons and properties" do
+    it "invalidates caches for taxons and properties" do
       visit shops_path
 
       taxon_timestamp1 = CacheService.latest_timestamp_by_class(Spree::Taxon)

--- a/spec/features/consumer/caching/darkwarm_caching_spec.rb
+++ b/spec/features/consumer/caching/darkwarm_caching_spec.rb
@@ -45,8 +45,8 @@ feature "Darkswarm data caching", js: true, caching: true do
         expect(page).to have_content property.presentation
       end
 
-      taxon.update_attributes!(name: "Changed Taxon")
-      property.update_attributes!(presentation: "Changed Property")
+      taxon.update!(name: "Changed Taxon")
+      property.update!(presentation: "Changed Property")
 
       # Clear timed shops cache so we can test uncached supplied properties
       clear_shops_cache


### PR DESCRIPTION
#### What? Why?

Closes #5619 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adjusts waiting and timings slightly to avoid flakyness in Semaphore.

#### What should we test?
<!-- List which features should be tested and how. -->

No flakyness in `darkswarm_caching_spec.rb`.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed a flaky spec in the test suite