### PR TITLE
Update Sell page to use User Guide links from configuration

### DIFF
--- a/app/views/home/sell.html.haml
+++ b/app/views/home/sell.html.haml
@@ -18,7 +18,7 @@
         %h3= t :sell_producers
         %p
           = t :sell_producers_detail
-          %a{href: "https://openfoodnetwork.org/user-guide/"}= t(:sell_user_guide)
+          %a{href: ContentConfig.user_guide_link}= t(:sell_user_guide)
         %a.button.transparent{href: signup_producers_path}
           = t :register_title
 
@@ -26,7 +26,7 @@
         %h3= t :sell_hubs
         %p
           = t :sell_hubs_detail
-          %a{href: "https://openfoodnetwork.org/user-guide/"}= t(:sell_user_guide)
+          %a{href: ContentConfig.user_guide_link}= t(:sell_user_guide)
         %a.button.transparent{href: signup_shops_path}
           = t :register_title
 
@@ -34,7 +34,7 @@
         %h3= t :sell_groups
         %p
           = t :sell_groups_detail
-          %a{href: "https://openfoodnetwork.org/user-guide/"}= t(:sell_user_guide)
+          %a{href: ContentConfig.user_guide_link}= t(:sell_user_guide)
         %a.button.transparent{href: signup_groups_path}
           = t :register_title
 


### PR DESCRIPTION
#### What? Why?
We (OFN Turkey) translated the user guide to Turkish and changed the configuration to link to that page but Sell page still links to global user guide because it doesn't use the configuration.

https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/views/home/sell.html.haml has hard links for user guides but it should use the configuration like in https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/views/admin/shared/_user_guide_link.html.haml.

This PR fixes that.

#### What should we test?
Sell page link to the URL set in configuration.

#### Release notes
Sell page now uses configuration for user guide links.

Changelog Category:  Fixed

#### Discourse thread
https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1592157142302400

