### PR TITLE
4598 Add-to-cart buttons

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
@@ -1,0 +1,39 @@
+Darkswarm.controller "ShopVariantCtrl", ($scope, $modal, Cart) ->
+  $scope.$watchGroup [
+    'variant.line_item.quantity',
+    'variant.line_item.max_quantity'
+  ], (new_value, old_value) ->
+    return if old_value[0] == null && new_value[0] == null
+    Cart.adjust($scope.variant.line_item)
+
+  $scope.add = (quantity) ->
+    item = $scope.variant.line_item
+    item.quantity += quantity
+    if $scope.variant.product.group_buy
+      if item.quantity < 1 || item.max_quantity < item.quantity
+        item.max_quantity = item.quantity
+
+  $scope.addMax = (quantity) ->
+    item = $scope.variant.line_item
+    item.max_quantity += quantity
+    if item.max_quantity < item.quantity
+      item.quantity = item.max_quantity
+
+  $scope.canAdd = (quantity) ->
+    wantedQuantity = $scope.variant.line_item.quantity + quantity
+    $scope.quantityValid(wantedQuantity)
+
+  $scope.canAddMax = (quantity) ->
+    variant = $scope.variant
+    wantedQuantity = variant.line_item.max_quantity + quantity
+    $scope.quantityValid(wantedQuantity) && variant.line_item.quantity > 0
+
+  $scope.quantityValid = (quantity) ->
+    variant = $scope.variant
+    minimum = 0
+    maximum = variant.on_demand && Infinity || variant.on_hand
+    quantity >= minimum && quantity <= maximum
+
+  $scope.addBulk = (quantity) ->
+    $scope.add(quantity)
+    $modal.open(templateUrl: "bulk_buy_modal.html", scope: $scope)

--- a/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
@@ -4,42 +4,4 @@ Darkswarm.directive "shopVariant", ->
   templateUrl: 'shop_variant.html'
   scope:
     variant: '='
-  controller: ($scope, $modal, Cart) ->
-    $scope.$watchGroup [
-      'variant.line_item.quantity',
-      'variant.line_item.max_quantity'
-    ], (new_value, old_value) ->
-      return if old_value[0] == null && new_value[0] == null
-      Cart.adjust($scope.variant.line_item)
-
-    $scope.add = (quantity) ->
-      item = $scope.variant.line_item
-      item.quantity += quantity
-      if $scope.variant.product.group_buy
-        if item.quantity < 1 || item.max_quantity < item.quantity
-          item.max_quantity = item.quantity
-
-    $scope.addMax = (quantity) ->
-      item = $scope.variant.line_item
-      item.max_quantity += quantity
-      if item.max_quantity < item.quantity
-        item.quantity = item.max_quantity
-
-    $scope.canAdd = (quantity) ->
-      wantedQuantity = $scope.variant.line_item.quantity + quantity
-      $scope.quantityValid(wantedQuantity)
-
-    $scope.canAddMax = (quantity) ->
-      variant = $scope.variant
-      wantedQuantity = variant.line_item.max_quantity + quantity
-      $scope.quantityValid(wantedQuantity) && variant.line_item.quantity > 0
-
-    $scope.quantityValid = (quantity) ->
-      variant = $scope.variant
-      minimum = 0
-      maximum = variant.on_demand && Infinity || variant.on_hand
-      quantity >= minimum && quantity <= maximum
-
-    $scope.addBulk = (quantity) ->
-      $scope.add(quantity)
-      $modal.open(templateUrl: "bulk_buy_modal.html", scope: $scope)
+  controller: 'ShopVariantCtrl'

--- a/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
@@ -11,3 +11,11 @@ Darkswarm.directive "shopVariant", ->
     ], (new_value, old_value) ->
       return if old_value[0] == null && new_value[0] == null
       Cart.adjust($scope.variant.line_item)
+
+    $scope.add = (quantity) ->
+      $scope.variant.line_item.quantity += quantity
+
+    $scope.canAdd = (quantity) ->
+      variant = $scope.variant
+      wantedQuantity = variant.line_item.quantity + quantity
+      variant.on_demand || wantedQuantity <= variant.on_hand

--- a/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/shop_variant.js.coffee
@@ -4,7 +4,7 @@ Darkswarm.directive "shopVariant", ->
   templateUrl: 'shop_variant.html'
   scope:
     variant: '='
-  controller: ($scope, Cart) ->
+  controller: ($scope, $modal, Cart) ->
     $scope.$watchGroup [
       'variant.line_item.quantity',
       'variant.line_item.max_quantity'
@@ -13,9 +13,33 @@ Darkswarm.directive "shopVariant", ->
       Cart.adjust($scope.variant.line_item)
 
     $scope.add = (quantity) ->
-      $scope.variant.line_item.quantity += quantity
+      item = $scope.variant.line_item
+      item.quantity += quantity
+      if $scope.variant.product.group_buy
+        if item.quantity < 1 || item.max_quantity < item.quantity
+          item.max_quantity = item.quantity
+
+    $scope.addMax = (quantity) ->
+      item = $scope.variant.line_item
+      item.max_quantity += quantity
+      if item.max_quantity < item.quantity
+        item.quantity = item.max_quantity
 
     $scope.canAdd = (quantity) ->
+      wantedQuantity = $scope.variant.line_item.quantity + quantity
+      $scope.quantityValid(wantedQuantity)
+
+    $scope.canAddMax = (quantity) ->
       variant = $scope.variant
-      wantedQuantity = variant.line_item.quantity + quantity
-      variant.on_demand || wantedQuantity <= variant.on_hand
+      wantedQuantity = variant.line_item.max_quantity + quantity
+      $scope.quantityValid(wantedQuantity) && variant.line_item.quantity > 0
+
+    $scope.quantityValid = (quantity) ->
+      variant = $scope.variant
+      minimum = 0
+      maximum = variant.on_demand && Infinity || variant.on_hand
+      quantity >= minimum && quantity <= maximum
+
+    $scope.addBulk = (quantity) ->
+      $scope.add(quantity)
+      $modal.open(templateUrl: "bulk_buy_modal.html", scope: $scope)

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -1,0 +1,34 @@
+.row
+  .columns.small-12
+    %h3{"ng-bind" => "::variant.extended_name"}
+
+.row.variant-bulk-buy-price-summary
+  .columns.small-6
+    .variant-unit {{ ::variant.unit_to_display }}
+  .columns.small-6
+    {{ variant.line_item.total_price | localizeCurrency }}
+
+.row
+  .columns.small-6
+    .variant-bulk-buy-quantity-label
+      Min quantity
+    %div
+      %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
+        {{ "js.shop_variant_no_group_buy.decrement" | t }}
+      %span.bulk-buy.variant-quantity>
+        {{ variant.line_item.quantity }}
+      %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
+        {{ "js.shop_variant_no_group_buy.increment" | t }}
+  .columns.small-6
+    .variant-bulk-buy-quantity-label
+      Max quantity
+    %div
+      %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(-1)", disabled: "!canAddMax(-1)"}}>
+        {{ "js.shop_variant_no_group_buy.decrement" | t }}
+      %span.bulk-buy.variant-quantity>
+        {{ variant.line_item.max_quantity }}
+      %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(1)", disabled: "!canAddMax(1)"}}
+        {{ "js.shop_variant_no_group_buy.increment" | t }}
+
+
+%ng-include{src: "'partials/close.html'"}

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -30,5 +30,4 @@
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(1)", disabled: "!canAddMax(1)"}}
         {{ "js.shop_variant_no_group_buy.increment" | t }}
 
-
 %ng-include{src: "'partials/close.html'"}

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -11,7 +11,7 @@
 .row
   .columns.small-6
     .variant-bulk-buy-quantity-label
-      Min quantity
+      {{ "js.bulk_buy_modal.min_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
         {{ "js.shop_variant_no_group_buy.decrement" | t }}
@@ -21,7 +21,7 @@
         {{ "js.shop_variant_no_group_buy.increment" | t }}
   .columns.small-6
     .variant-bulk-buy-quantity-label
-      Max quantity
+      {{ "js.bulk_buy_modal.max_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(-1)", disabled: "!canAddMax(-1)"}}>
         {{ "js.shop_variant_no_group_buy.decrement" | t }}

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -11,7 +11,7 @@
 .row
   .columns.small-6
     .variant-bulk-buy-quantity-label
-      {{ "js.bulk_buy_modal.min_quantity" | t }}
+      {{ "js.shopfront.bulk_buy_modal.min_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
         －
@@ -21,7 +21,7 @@
         ＋
   .columns.small-6
     .variant-bulk-buy-quantity-label
-      {{ "js.bulk_buy_modal.max_quantity" | t }}
+      {{ "js.shopfront.bulk_buy_modal.max_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(-1)", disabled: "!canAddMax(-1)"}}>
         －

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -14,20 +14,24 @@
       {{ "js.shopfront.bulk_buy_modal.min_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
+        -# U+FF0D Fullwidth Hyphen-Minus
         －
       %span.bulk-buy.variant-quantity>
         {{ variant.line_item.quantity }}
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
+        -# U+FF0B Fullwidth Plus Sign
         ＋
   .columns.small-6
     .variant-bulk-buy-quantity-label
       {{ "js.shopfront.bulk_buy_modal.max_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(-1)", disabled: "!canAddMax(-1)"}}>
+        -# U+FF0D Fullwidth Hyphen-Minus
         －
       %span.bulk-buy.variant-quantity>
         {{ variant.line_item.max_quantity }}
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(1)", disabled: "!canAddMax(1)"}}
+        -# U+FF0B Fullwidth Plus Sign
         ＋
 
 %ng-include{src: "'partials/close.html'"}

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -14,20 +14,20 @@
       {{ "js.bulk_buy_modal.min_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
-        {{ "js.shop_variant_no_group_buy.decrement" | t }}
+        －
       %span.bulk-buy.variant-quantity>
         {{ variant.line_item.quantity }}
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
-        {{ "js.shop_variant_no_group_buy.increment" | t }}
+        ＋
   .columns.small-6
     .variant-bulk-buy-quantity-label
       {{ "js.bulk_buy_modal.max_quantity" | t }}
     %div
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(-1)", disabled: "!canAddMax(-1)"}}>
-        {{ "js.shop_variant_no_group_buy.decrement" | t }}
+        －
       %span.bulk-buy.variant-quantity>
         {{ variant.line_item.max_quantity }}
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(1)", disabled: "!canAddMax(1)"}}
-        {{ "js.shop_variant_no_group_buy.increment" | t }}
+        ＋
 
 %ng-include{src: "'partials/close.html'"}

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -1,14 +1,14 @@
 .small-5.medium-3.large-3.columns.text-right{"ng-if" => "::!variant.product.group_buy"}
 
-  %input{type: :number,
-  integer: true,
-  value: nil,
-  min: 0,
-  placeholder: "0",
-  "ofn-disable-scroll" => true,
-  "ng-debounce" => "500",
-  onwheel: "this.blur()",
-  "ng-model" => "variant.line_item.quantity",
-  "ofn-on-hand" => "{{variant.on_demand && 9999 || variant.on_hand }}",
-  "ng-disabled" => "!variant.on_demand && variant.on_hand == 0",
-  name: "variants[{{::variant.id}}]", id: "variants_{{::variant.id}}"}
+  %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
+    {{ "js.shop_variant_no_group_buy.add" | t }}
+  %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(-1)"}}>
+    {{ "js.shop_variant_no_group_buy.decrement" | t }}
+  %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
+    {{ "js.shop_variant_no_group_buy.increment" | t }}
+  %br
+  .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
+    {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: variant.line_item.quantity} }}
+  %input{type: :hidden,
+  name: "variants[{{::variant.id}}]",
+  ng: {model: "variant.line_item.quantity"}}

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -10,5 +10,5 @@
   .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
     {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: variant.line_item.quantity} }}
   %input{type: :hidden,
-  name: "variants[{{::variant.id}}]",
-  ng: {model: "variant.line_item.quantity"}}
+         name: "variants[{{::variant.id}}]",
+         ng: {model: "variant.line_item.quantity"}}

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -8,7 +8,7 @@
     {{ "js.shop_variant_no_group_buy.increment" | t }}
   %br
   .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
-    {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: variant.line_item.quantity} }}
+    {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: variant.line_item.quantity || 0} }}
   %input{type: :hidden,
          name: "variants[{{::variant.id}}]",
          ng: {model: "variant.line_item.quantity"}}

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -3,8 +3,10 @@
   %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
     {{ "js.shopfront.variant.add_to_cart" | t }}
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(-1)"}}>
+    -# U+FF0D Fullwidth Hyphen-Minus
     －
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
+    -# U+FF0B Fullwidth Plus Sign
     ＋
   %br
   .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -3,9 +3,9 @@
   %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
     {{ "js.shop_variant_no_group_buy.add" | t }}
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(-1)"}}>
-    {{ "js.shop_variant_no_group_buy.decrement" | t }}
+    －
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
-    {{ "js.shop_variant_no_group_buy.increment" | t }}
+    ＋
   %br
   .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
     {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: variant.line_item.quantity || 0} }}

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -1,14 +1,14 @@
 .small-5.medium-3.large-3.columns.text-right{"ng-if" => "::!variant.product.group_buy"}
 
   %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
-    {{ "js.shop_variant_no_group_buy.add" | t }}
+    {{ "js.shopfront.variant.add_to_cart" | t }}
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(-1)"}}>
     －
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
     ＋
   %br
   .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
-    {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: variant.line_item.quantity || 0} }}
+    {{ "js.shopfront.variant.quantity_in_cart" | t:{quantity: variant.line_item.quantity || 0} }}
   %input{type: :hidden,
          name: "variants[{{::variant.id}}]",
          ng: {model: "variant.line_item.quantity"}}

--- a/app/assets/javascripts/templates/partials/shop_variant_with_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_with_group_buy.html.haml
@@ -1,28 +1,17 @@
 .small-5.medium-3.large-3.columns.text-right{"ng-if" => "::variant.product.group_buy"}
 
-  %span.bulk-input-container
-    %span.bulk-input
-      %input.bulk.first{type: :number,
-      value: nil,
-      integer: true,
-      min: 0,
-      "ng-model" => "variant.line_item.quantity",
-      placeholder: "{{::'shop_variant_quantity_min' | t}}",
-      "ofn-disable-scroll" => true,
-      "ng-debounce" => "500",
-      onwheel: "this.blur()",
-      "ofn-on-hand" => "{{variant.on_demand && 9999 || variant.on_hand }}",
-      name: "variants[{{::variant.id}}]", id: "variants_{{::variant.id}}"}
-    %span.bulk-input
-      %input.bulk.second{type: :number,
-      "ng-disabled" => "!variant.line_item.quantity",
-      integer: true,
-      min: 0,
-      "ng-model" => "variant.line_item.max_quantity",
-      placeholder: "{{::'shop_variant_quantity_max' | t}}",
-      "ofn-disable-scroll" => true,
-      "ng-debounce" => "500",
-      onwheel: "this.blur()",
-      min: "{{variant.line_item.quantity}}",
-      name: "variant_attributes[{{::variant.id}}][max_quantity]",
-      id: "variants_{{::variant.id}}_max"}
+  %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "addBulk(1)", disabled: "!canAdd(1)"}}
+    {{ "js.shop_variant_no_group_buy.add" | t }}
+  %button.bulk-buy.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "addBulk(0)"}}>
+    {{ variant.line_item.quantity }}
+  %button.bulk-buy.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "addBulk(0)"}}
+    {{ variant.line_item.max_quantity || "-" }}
+  %br
+  .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
+    {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: ''} }}
+  %input{type: :hidden,
+         name: "variants[{{::variant.id}}]",
+         ng: {model: "variant.line_item.quantity"}}
+  %input{type: :hidden,
+         name: "variants[{{::variant.id}}]",
+         ng: {model: "variant.line_item.max_quantity"}}

--- a/app/assets/javascripts/templates/partials/shop_variant_with_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_with_group_buy.html.haml
@@ -1,14 +1,14 @@
 .small-5.medium-3.large-3.columns.text-right{"ng-if" => "::variant.product.group_buy"}
 
   %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "addBulk(1)", disabled: "!canAdd(1)"}}
-    {{ "js.shop_variant_no_group_buy.add" | t }}
+    {{ "js.shopfront.variant.add_to_cart" | t }}
   %button.bulk-buy.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "addBulk(0)"}}>
     {{ variant.line_item.quantity }}
   %button.bulk-buy.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "addBulk(0)"}}
     {{ variant.line_item.max_quantity || "-" }}
   %br
   .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
-    {{ "js.shop_variant_no_group_buy.in_cart" | t:{quantity: ''} }}
+    {{ "js.shopfront.variant.in_cart" | t }}
   %input{type: :hidden,
          name: "variants[{{::variant.id}}]",
          ng: {model: "variant.line_item.quantity"}}

--- a/app/assets/javascripts/templates/shop_variant.html.haml
+++ b/app/assets/javascripts/templates/shop_variant.html.haml
@@ -2,10 +2,6 @@
   .small-3.medium-4.large-6.columns.variant-name
     .inline{"ng-if" => "::variant.display_name"} {{ ::variant.display_name }}
     .variant-unit {{ ::variant.unit_to_display }}
-    .inline{"ng-if" => "::variant.product.group_buy"}
-      %i.ofn-i_056-bulk><
-      %em><
-        \ {{::'bulk' | t}}
   .small-4.medium-3.large-2.columns.variant-price
     %price-breakdown{"price-breakdown" => "_", variant: "variant",
       "price-breakdown-append-to-body" => "true",

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -9,54 +9,6 @@
 
   // ordering
   product {
-    input {
-      @include border-radius(0);
-
-      @include csstrans;
-
-      margin: 0;
-      width: 10rem;
-      display: inline;
-
-      @include box-shadow(none);
-
-      border-color: #b3b3b3;
-      text-align: right;
-
-      @include breakpoint(desktop) {
-        width: 8rem;
-      }
-
-      @include breakpoint(tablet) {
-        width: 7rem;
-      }
-
-      @include breakpoint(phablet) {
-        float: left !important;
-        font-size: 0.75rem;
-        padding-left: 0.25rem;
-        padding-right: 0.25rem;
-      }
-
-      @include breakpoint(mobile) {
-        width: 5.8rem;
-      }
-
-      &:hover {
-        @include box-shadow(none);
-
-        border-color: #888;
-        background-color: #fafafa;
-      }
-
-      &:active, &:focus, &.active {
-        @include box-shadow(none);
-
-        background-color: #f9f4b9;
-        border-color: #666;
-      }
-    }
-
     // BULK
 
     input.bulk {
@@ -94,5 +46,63 @@
         float: left;
       }
     }
+  }
+}
+
+// Components to add variants to cart and change quanities
+//
+// They are not nested so that they can be used in modals.
+button.add-variant, button.variant-quantity {
+  height: 2.5rem;
+  border-radius: 0;
+  background-color: $orange-500;
+  color: white;
+  // Override foundation button styles:
+  font-size: 1rem;
+  margin: 0;
+  padding: 0;
+  transition: none;
+
+  &[disabled] {
+    &:hover, &:focus {
+      background-color: $orange-500;
+    }
+  }
+  &:nth-of-type(1) {
+    border-bottom-left-radius: 0.25em;
+    border-top-left-radius: 0.25em;
+  }
+  &:nth-last-of-type(1) {
+    border-top-right-radius: 0.25em;
+    border-bottom-right-radius: 0.25em;
+  }
+}
+button.add-variant {
+  min-width: 6rem;
+  padding: 0 1em;
+
+  &[disabled] {
+    &:hover, &:focus {
+      background-color: $orange-500;
+    }
+  }
+}
+button.variant-quantity {
+  width: 3rem;
+
+  &:nth-of-type(1) {
+    border-right: .1em solid $orange-400;
+  }
+}
+.variant-quantity-display {
+  display: inline-block;
+  font-size: 0.875em;
+  margin-top: 0.25em;
+  text-align: center;
+  width: 6rem;
+  visibility: hidden;
+
+  &.visible {
+    visibility: visible;
   }
 }

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -6,47 +6,6 @@
 .darkswarm {
   // #search
   @include placeholder(rgba(0, 0, 0, 0.4), #777);
-
-  // ordering
-  product {
-    // BULK
-
-    input.bulk {
-      width: 5rem;
-
-      @include breakpoint(desktop) {
-        width: 4rem;
-      }
-
-      @include breakpoint(tablet) {
-        width: 3.5rem;
-      }
-
-      @include breakpoint(mobile) {
-        width: 2.8rem;
-      }
-    }
-
-    input.bulk.first {
-      border-right: 0;
-    }
-
-    input.bulk.second {
-      border-left: 0;
-    }
-
-    .bulk-input-container {
-      float: right;
-
-      @include breakpoint(phablet) {
-        float: left !important;
-      }
-
-      .bulk-input {
-        float: left;
-      }
-    }
-  }
 }
 
 // Components to add variants to cart and change quanities
@@ -105,4 +64,30 @@ button.variant-quantity {
   &.visible {
     visibility: visible;
   }
+}
+
+button.bulk-buy.variant-quantity {
+  background-color: transparent;
+  border: .1em solid $grey-200;
+  color: inherit;
+}
+button.bulk-buy-add.variant-quantity {
+  width: 2.5rem
+}
+span.bulk-buy.variant-quantity {
+  border: .1em solid $grey-200;
+  height: 2.5rem;
+  display: inline-block;
+  min-width: 3em;
+  padding: .5em;
+  text-align: center;
+  vertical-align: top;
+}
+.variant-bulk-buy-price-summary {
+  color: $disabled-med;
+  margin-bottom: 1em;
+}
+.variant-bulk-buy-quantity-label {
+  font-size: 0.875rem;
+  margin-bottom: .5em;
 }

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -8,7 +8,7 @@
   @include placeholder(rgba(0, 0, 0, 0.4), #777);
 }
 
-// Components to add variants to cart and change quanities
+// Components to add variants to cart and change quantities
 //
 // They are not nested so that they can be used in modals.
 button.add-variant, button.variant-quantity {
@@ -36,6 +36,7 @@ button.add-variant, button.variant-quantity {
     border-bottom-right-radius: 0.25em;
   }
 }
+
 button.add-variant {
   min-width: 6rem;
   padding: 0 1em;
@@ -46,6 +47,7 @@ button.add-variant {
     }
   }
 }
+
 button.variant-quantity {
   width: 3rem;
 
@@ -53,6 +55,7 @@ button.variant-quantity {
     border-right: .1em solid $orange-400;
   }
 }
+
 .variant-quantity-display {
   display: inline-block;
   font-size: 0.875em;
@@ -71,9 +74,11 @@ button.bulk-buy.variant-quantity {
   border: .1em solid $grey-200;
   color: inherit;
 }
+
 button.bulk-buy-add.variant-quantity {
   width: 2.5rem
 }
+
 span.bulk-buy.variant-quantity {
   border: .1em solid $grey-200;
   height: 2.5rem;
@@ -83,10 +88,12 @@ span.bulk-buy.variant-quantity {
   text-align: center;
   vertical-align: top;
 }
+
 .variant-bulk-buy-price-summary {
   color: $disabled-med;
   margin-bottom: 1em;
 }
+
 .variant-bulk-buy-quantity-label {
   font-size: 0.875rem;
   margin-bottom: .5em;

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -52,9 +52,8 @@ button.graph-button {
   // z-index: 9999999
   padding: 0;
   margin: 0;
-  display: inline;
+  display: inline-block;
   background-color: rgba(255, 255, 255, 0.5);
-  vertical-align: bottom;
 
   @include box-shadow(none);
 

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -50,7 +50,6 @@
 
 button.graph-button {
   // z-index: 9999999
-  border: 1px solid transparent;
   padding: 0;
   margin: 0;
   display: inline;
@@ -69,7 +68,6 @@ button.graph-button {
   }
 
   &:focus {
-    border: 1px solid #e0e0e0;
     background-color: rgba(255, 255, 255, 1);
 
     &:before {
@@ -79,7 +77,6 @@ button.graph-button {
 
   &:hover, &:active {
     background-color: rgba(255, 255, 255, 1);
-    border: 1px solid transparent;
 
     &:before {
       color: $clr-brick-bright;
@@ -88,7 +85,6 @@ button.graph-button {
 }
 
 button.graph-button.open {
-  border: 1px solid transparent;
   background-color: $clr-brick-bright;
 
   &:before {

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -14,6 +14,15 @@
         }
       }
 
+      .shop-variants {
+        padding-left: 7.9375rem;
+
+        @include breakpoint(phablet) {
+          padding-left: 0;
+          clear: left;
+        }
+      }
+
       // ROW VARIANTS
       .row.variants {
         margin: 0 0 1em 0;
@@ -30,7 +39,7 @@
 
         // Variant name
         .variant-name {
-          padding-left: 7.9375rem;
+          padding-left: 0;
 
           @include breakpoint(phablet) {
             padding-left: 0.5rem;
@@ -68,7 +77,7 @@
       }
 
       // ROW SUMMARY
-      .row.summary {
+      .summary {
         margin-left: 0;
         margin-right: 0;
         margin-bottom: 1.25em;

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -22,6 +22,12 @@
           opacity: 0.2;
         }
 
+        .variant-name,
+        .variant-price,
+        .total-price {
+          line-height: 2.5em;
+        }
+
         // Variant name
         .variant-name {
           padding-left: 7.9375rem;

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -33,7 +33,7 @@
           padding-left: 7.9375rem;
 
           @include breakpoint(phablet) {
-            padding-left: 0.9375rem;
+            padding-left: 0.5rem;
           }
 
           & > *:nth-child(n + 2) {

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -48,6 +48,8 @@
           & > *:nth-child(n + 2) {
             color: #888;
             font-size: 0.875rem;
+            line-height: normal;
+            margin-top: -0.75em;
           }
         }
 

--- a/app/assets/stylesheets/darkswarm/shop.scss
+++ b/app/assets/stylesheets/darkswarm/shop.scss
@@ -59,7 +59,6 @@
 
       border-top: 1px solid #e5e5e5;
       padding-bottom: 1px;
-      margin-bottom: 20px !important;
       position: relative;
       display: block;
       color: $med-drk-grey;

--- a/app/assets/stylesheets/darkswarm/shop.scss
+++ b/app/assets/stylesheets/darkswarm/shop.scss
@@ -16,6 +16,16 @@
       padding-right: 0;
       padding-left: 0;
     }
+
+    .row.full {
+      width: 100%;
+      margin: 0;
+
+      .columns.full {
+        padding-right: 0;
+        padding-left: 0;
+      }
+    }
   }
 
   products {

--- a/app/assets/stylesheets/darkswarm/shop.scss
+++ b/app/assets/stylesheets/darkswarm/shop.scss
@@ -72,21 +72,6 @@
         width: 100px;
         margin-bottom: 20px;
       }
-
-      // ICONS
-      i {
-        font-size: 0.75em;
-        padding-right: 0.9375rem;
-
-        @include breakpoint(phablet) {
-          padding-right: 0.25rem;
-        }
-      }
-
-      i.ofn-i_056-bulk {
-        font-size: 1rem;
-        padding-right: 0rem;
-      }
     }
   }
 

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -9,7 +9,7 @@
           .medium-12.large-10.columns
             = render partial: "shop/products/search_feedback"
 
-            %div.pad-top{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading' }
+            %div{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading' }
               %product.animate-repeat{"ng-controller" => "ProductNodeCtrl", "ng-repeat" => "product in Products.products track by product.id", "id" => "product-{{ product.id }}"}
                 = render "shop/products/summary"
                 %shop-variant{variant: 'variant', "ng-repeat" => "variant in product.variants | orderBy: ['name_to_display','unit_value'] track by variant.id", "id" => "variant-{{ variant.id }}", "ng-class" => "{'out-of-stock': !variant.on_demand && variant.on_hand == 0}"}

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -5,8 +5,8 @@
 
     .row
       .footer-pad.small-12.columns.product-listing
-        .row
-          .medium-12.large-10.columns
+        .row.full
+          .medium-12.large-10.columns.full
             = render partial: "shop/products/search_feedback"
 
             %div{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading' }
@@ -19,7 +19,7 @@
                 .summary
                   .small-12.columns.text-center
                     = t :products_loading
-                .row
+                .row.full
                   .small-12.columns.text-center
                     %img.spinner{ src: image_path("spinning-circles.svg") }
 

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -12,10 +12,11 @@
             %div{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading' }
               %product.animate-repeat{"ng-controller" => "ProductNodeCtrl", "ng-repeat" => "product in Products.products track by product.id", "id" => "product-{{ product.id }}"}
                 = render "shop/products/summary"
-                %shop-variant{variant: 'variant', "ng-repeat" => "variant in product.variants | orderBy: ['name_to_display','unit_value'] track by variant.id", "id" => "variant-{{ variant.id }}", "ng-class" => "{'out-of-stock': !variant.on_demand && variant.on_hand == 0}"}
+                .shop-variants
+                  %shop-variant{variant: 'variant', "ng-repeat" => "variant in product.variants | orderBy: ['name_to_display','unit_value'] track by variant.id", "id" => "variant-{{ variant.id }}", "ng-class" => "{'out-of-stock': !variant.on_demand && variant.on_hand == 0}"}
 
               %product{"ng-show" => "Products.loading"}
-                .row.summary
+                .summary
                   .small-12.columns.text-center
                     = t :products_loading
                 .row

--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -2,7 +2,7 @@
   %a{"ng-click" => "triggerProductModal()"}
     %img{"ng-src" => "{{::product.primaryImageOrMissing}}"}
 
-.row.summary
+.summary
   .summary-header
     %h3
       %a{"ng-click" => "triggerProductModal()", href: 'javascript:void(0)'}

--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -7,7 +7,7 @@
     %h3
       %a{"ng-click" => "triggerProductModal()", href: 'javascript:void(0)'}
         %span{"ng-bind" => "::product.name"}
-    %p.product-description{ng: {bind: "::product.description", click: "triggerProductModal()"}}
+    %p.product-description{ng: {bind: "::product.description", click: "triggerProductModal()", show: "product.description.length"}}
     .product-producer
       = t :products_from
       %span

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2690,6 +2690,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       increment: "＋" # U+FF0B Fullwidth Plus Sign
       decrement: "－" # U+FF0D Fullwidth Hyphen-Minus
       in_cart: "%{quantity} in cart"
+    bulk_buy_modal:
+      min_quantity: "Min quantity"
+      max_quantity: "Max quantity"
     variants:
       on_demand:
         "yes": "On demand"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2685,6 +2685,11 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         in your cart have reduced. Here's what's changed:
       now_out_of_stock: is now out of stock.
       only_n_remainging: "now only has %{num} remaining."
+    shop_variant_no_group_buy:
+      add: "Add"
+      increment: "＋" # U+FF0B Fullwidth Plus Sign
+      decrement: "－" # U+FF0D Fullwidth Hyphen-Minus
+      in_cart: "%{quantity} in cart"
     variants:
       on_demand:
         "yes": "On demand"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2687,8 +2687,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       only_n_remainging: "now only has %{num} remaining."
     shop_variant_no_group_buy:
       add: "Add"
-      increment: "＋" # U+FF0B Fullwidth Plus Sign
-      decrement: "－" # U+FF0D Fullwidth Hyphen-Minus
       in_cart: "%{quantity} in cart"
     bulk_buy_modal:
       min_quantity: "Min quantity"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2685,9 +2685,11 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         in your cart have reduced. Here's what's changed:
       now_out_of_stock: is now out of stock.
       only_n_remainging: "now only has %{num} remaining."
-    shop_variant_no_group_buy:
-      add: "Add"
-      in_cart: "%{quantity} in cart"
+    shopfront:
+      variant:
+        add_to_cart: "Add"
+        in_cart: "in cart"
+        quantity_in_cart: "%{quantity} in cart"
     bulk_buy_modal:
       min_quantity: "Min quantity"
       max_quantity: "Max quantity"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2690,9 +2690,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         add_to_cart: "Add"
         in_cart: "in cart"
         quantity_in_cart: "%{quantity} in cart"
-    bulk_buy_modal:
-      min_quantity: "Min quantity"
-      max_quantity: "Max quantity"
+      bulk_buy_modal:
+        min_quantity: "Min quantity"
+        max_quantity: "Max quantity"
     variants:
       on_demand:
         "yes": "On demand"

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -311,7 +311,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
         within_variant(variant) do
           expect(page).to have_content "5 in cart"
-          expect(page).to have_button "＋", disabled: true
+          expect(page).to have_button increase_quantity_symbol, disabled: true
         end
       end
 
@@ -364,7 +364,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
             # -- Messaging
             within(".reveal-modal") do
-              page.all("button", text: "＋").last.click
+              page.all("button", text: increase_quantity_symbol).last.click
             end
             close_modal
             wait_for_cart

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -243,20 +243,24 @@ feature "As a consumer I want to shop with a distributor", js: true do
         it "should save group buy data to the cart and display it on shopfront reload" do
           # -- Quantity
           click_add_bulk_to_cart variant, 6
+          close_modal
           expect(page).to have_in_cart product.name
           toggle_cart
 
           expect(order.reload.line_items.first.quantity).to eq(6)
 
           # -- Max quantity
-          click_add_bulk_max_to_cart variant, 7
+          open_bulk_quantity_modal(variant)
+          click_add_bulk_max_to_cart variant, 1
 
           expect(order.reload.line_items.first.max_quantity).to eq(7)
 
           # -- Reload
           visit shop_path
-          expect(page).to have_field "variants[#{variant.id}]", with: 6
-          expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: 7
+          within_variant(variant) do
+            expect(page).to have_selector "button.bulk-buy:nth-of-type(1)", text: "6"
+            expect(page).to have_selector "button.bulk-buy:nth-last-of-type(1)", text: "7"
+          end
         end
       end
     end
@@ -372,12 +376,14 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
             # -- Page updates
             # Update amount in cart
-            expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: '0', disabled: true
+            within_variant(variant) do
+              expect(page).to have_button "Add", disabled: true
+              expect(page).to have_no_content "in cart"
+            end
 
             # Update amount available in product list
-            #   If amount falls to zero, variant should be greyed out and input disabled
+            #   If amount falls to zero, variant should be greyed out
             expect(page).to have_selector "#variant-#{variant.id}.out-of-stock"
-            expect(page).to have_selector "#variants_#{variant.id}_max[disabled='disabled']"
           end
         end
 
@@ -400,7 +406,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
             it "does not update max_quantity" do
               click_add_bulk_to_cart variant, 2
-              click_add_bulk_max_to_cart variant, 3
+              click_add_bulk_max_to_cart variant, 1
               close_modal
 
               variant.update! on_hand: 1
@@ -412,8 +418,10 @@ feature "As a consumer I want to shop with a distributor", js: true do
                 expect(page).to have_content "#{product.name} - #{variant.unit_to_display} now only has 1 remaining"
               end
 
-              expect(page).to have_field "variants[#{variant.id}]", with: '1'
-              expect(page).to have_field "variant_attributes[#{variant.id}][max_quantity]", with: '3'
+              within_variant(variant) do
+                expect(page).to have_selector "button.bulk-buy:nth-of-type(1)", text: "1"
+                expect(page).to have_selector "button.bulk-buy:nth-last-of-type(1)", text: "3"
+              end
             end
           end
         end

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -294,19 +294,21 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
         click_add_to_cart variant, 10
 
-        expect(page).to have_field "variants[#{variant.id}]", with: '10'
+        within_variant(variant) do
+          expect(page).to have_content "10 in cart"
+        end
       end
 
       it "alerts us when we enter a quantity greater than the stock available" do
         variant.update on_hand: 5
         visit shop_path
 
-        
-        accept_alert 'Insufficient stock available, only 5 remaining' do
-          fill_in "variants[#{variant.id}]", with: '10'
-        end
+        click_add_to_cart variant, 5
 
-        expect(page).to have_field "variants[#{variant.id}]", with: '5'
+        within_variant(variant) do
+          expect(page).to have_content "5 in cart"
+          expect(page).to have_button "＋", disabled: true
+        end
       end
 
       describe "when a product goes out of stock just before it's added to the cart" do
@@ -325,8 +327,13 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
           # -- Page updates
           # Update amount in cart
-          expect(page).to have_field "variants[#{variant.id}]", with: '0', disabled: true
-          expect(page).to have_field "variants[#{variant2.id}]", with: ''
+          within_variant(variant) do
+            expect(page).to have_button "Add", disabled: true
+            expect(page).to have_no_content "in cart"
+          end
+          within_variant(variant2) do
+            expect(page).to have_button "Add", disabled: false
+          end
 
           # Update amount available in product list
           #   If amount falls to zero, variant should be greyed out and input disabled
@@ -352,7 +359,11 @@ feature "As a consumer I want to shop with a distributor", js: true do
             variant.update! on_hand: 0
 
             # -- Messaging
-            click_add_bulk_max_to_cart variant
+            within(".reveal-modal") do
+              page.all("button", text: "＋").last.click
+            end
+            close_modal
+            wait_for_cart
 
             within(".out-of-stock-modal") do
               expect(page).to have_content "stock levels for one or more of the products in your cart have reduced"
@@ -390,6 +401,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
             it "does not update max_quantity" do
               click_add_bulk_to_cart variant, 2
               click_add_bulk_max_to_cart variant, 3
+              close_modal
 
               variant.update! on_hand: 1
 
@@ -554,9 +566,10 @@ feature "As a consumer I want to shop with a distributor", js: true do
     end
 
     # Removes the item from the client-side cart and marks the variant as unavailable
-    expect(page).to have_field "variants[#{variant.id}]", with: '0', disabled: true
     expect(page).to have_selector "#variant-#{variant.id}.out-of-stock"
-    expect(page).to have_selector "#variants_#{variant.id}[ofn-on-hand='0']"
-    expect(page).to have_selector "#variants_#{variant.id}[disabled='disabled']"
+    within_variant(variant) do
+      expect(page).to have_button "Add", disabled: true
+      expect(page).to have_no_content "in cart"
+    end
   end
 end

--- a/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
@@ -1,0 +1,91 @@
+describe "ShopVariantCtrl", ->
+  ctrl = null
+  scope = null
+
+  beforeEach ->
+    module 'Darkswarm'
+    scope =
+      $watchGroup: ->
+      variant: {
+        on_demand: true
+        product: {group_buy: false}
+        line_item: {
+          quantity: 0
+          max_quantity: 0
+        }
+      }
+
+    inject ($controller, $modal)->
+      ctrl = $controller 'ShopVariantCtrl', {$scope: scope, $modal: $modal, Cart: null}
+
+  it "adds an item to the cart", ->
+    scope.add 1
+    expect(scope.variant.line_item.quantity).toEqual 1
+
+  it "adds to the existing quantity", ->
+    scope.add 1
+    scope.add 5
+    expect(scope.variant.line_item.quantity).toEqual 6
+
+  it "adds to the max quantity", ->
+    scope.addMax 5
+    expect(scope.variant.line_item.quantity).toEqual 0
+    expect(scope.variant.line_item.max_quantity).toEqual 5
+
+  it "adds to the max quantity to be at least min quantity", ->
+    scope.variant.product.group_buy = true
+    scope.variant.line_item.max_quantity = 2
+
+    scope.add 3
+
+    expect(scope.variant.line_item.quantity).toEqual 3
+    expect(scope.variant.line_item.max_quantity).toEqual 3
+
+  it "decreases the min quantity to not exceed max quantity", ->
+    scope.variant.product.group_buy = true
+    scope.variant.line_item.quantity = 3
+    scope.variant.line_item.max_quantity = 5
+
+    scope.addMax -3
+
+    expect(scope.variant.line_item.quantity).toEqual 2
+    expect(scope.variant.line_item.max_quantity).toEqual 2
+
+  it "allows adding when variant is on demand", ->
+    expect(scope.canAdd(5000)).toEqual true
+
+  it "denies adding if variant is out of stock", ->
+    scope.variant.on_demand = false
+    scope.variant.on_hand = 0
+
+    expect(scope.canAdd(1)).toEqual false
+
+  it "denies adding if stock is limitted", ->
+    scope.variant.on_demand = false
+    scope.variant.on_hand = 5
+
+    expect(scope.canAdd(4)).toEqual true
+    expect(scope.canAdd(5)).toEqual true
+    expect(scope.canAdd(6)).toEqual false
+
+    scope.add 3
+    expect(scope.canAdd(2)).toEqual true
+    expect(scope.canAdd(3)).toEqual false
+
+  it "denies declaring max quantity before item is in cart", ->
+    expect(scope.canAddMax(1)).toEqual false
+
+  it "allows declaring max quantity when item is in cart", ->
+    scope.add 1
+    expect(scope.canAddMax(1)).toEqual true
+
+  it "denies adding if stock is limitted", ->
+    scope.variant.on_demand = false
+    scope.variant.on_hand = 5
+    scope.variant.line_item.quantity = 1
+    scope.variant.line_item.max_quantity = 1
+
+    expect(scope.canAddMax(3)).toEqual true
+    expect(scope.canAddMax(4)).toEqual true
+    expect(scope.canAddMax(5)).toEqual false
+    expect(scope.canAddMax(6)).toEqual false

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -50,28 +50,17 @@ module ShopWorkflow
   end
 
   # Add an item to the cart
-  #
-  # At the moment, the user enters the quantity into an input field.
-  # But with the coming mobile-friendly UX, the user will click a button to
-  # add an item, hence the naming.
-  #
-  # This is temporary code. The duplication will be removed by the mobile
-  # product listings feature. This has been backported to avoid merge
-  # conflicts and to make the current build more stable.
   def click_add_to_cart(variant = nil, quantity = 1)
     within_variant(variant) do
-      input = page.find("input")
-      new_quantity = input.value.to_i + quantity
-      fill_in input[:name], with: new_quantity
+      click_button "Add"
+      (quantity - 1).times { click_button "＋" }
     end
     wait_for_cart
   end
 
   def click_remove_from_cart(variant = nil, quantity = 1)
     within_variant(variant) do
-      input = page.find("input")
-      new_quantity = input.value.to_i - quantity
-      fill_in input[:name], with: new_quantity
+      quantity.times { click_button "－" }
     end
     wait_for_cart
   end

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -6,12 +6,6 @@ module ShopWorkflow
   end
 
   def wait_for_cart
-    # Wait for debounce
-    #
-    # The auto-submit on these specific form elements (add to cart) now has a small built-in
-    # waiting period before submitting the data...
-    sleep 0.6
-
     within find_body do
       # We ignore visibility in case the cart dropdown is not open.
       within '.cart-sidebar', visible: false do
@@ -67,18 +61,21 @@ module ShopWorkflow
 
   def click_add_bulk_to_cart(variant = nil, quantity = 1)
     within_variant(variant) do
-      input = page.find("input")
-      new_quantity = input.value.to_i + quantity
-      fill_in input[:name], with: new_quantity
+      click_button "Add"
+    end
+    within(".reveal-modal") do
+      (quantity - 1).times do
+        first(:button, "＋").click
+      end
     end
     wait_for_cart
   end
 
   def click_add_bulk_max_to_cart(variant = nil, quantity = 1)
-    within_variant(variant) do
-      input = page.find(:field, "variant_attributes[#{variant.id}][max_quantity]")
-      new_quantity = input.value.to_i + quantity
-      fill_in input[:name], with: new_quantity
+    within(".reveal-modal") do
+      quantity.times do
+        page.all("button", text: "＋").last.click
+      end
     end
     wait_for_cart
   end
@@ -88,6 +85,12 @@ module ShopWorkflow
     expect(page).to have_selector selector
     within(selector) do
       yield
+    end
+  end
+
+  def open_bulk_quantity_modal(variant)
+    within_variant(variant) do
+      page.first("button.bulk-buy").click
     end
   end
 

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -47,14 +47,14 @@ module ShopWorkflow
   def click_add_to_cart(variant = nil, quantity = 1)
     within_variant(variant) do
       click_button "Add"
-      (quantity - 1).times { click_button "＋" }
+      (quantity - 1).times { click_button increase_quantity_symbol }
     end
     wait_for_cart
   end
 
   def click_remove_from_cart(variant = nil, quantity = 1)
     within_variant(variant) do
-      quantity.times { click_button "－" }
+      quantity.times { click_button decrease_quantity_symbol }
     end
     wait_for_cart
   end
@@ -65,7 +65,7 @@ module ShopWorkflow
     end
     within(".reveal-modal") do
       (quantity - 1).times do
-        first(:button, "＋").click
+        first(:button, increase_quantity_symbol).click
       end
     end
     wait_for_cart
@@ -74,7 +74,7 @@ module ShopWorkflow
   def click_add_bulk_max_to_cart(variant = nil, quantity = 1)
     within(".reveal-modal") do
       quantity.times do
-        page.all("button", text: "＋").last.click
+        page.all("button", text: increase_quantity_symbol).last.click
       end
     end
     wait_for_cart
@@ -92,6 +92,14 @@ module ShopWorkflow
     within_variant(variant) do
       page.first("button.bulk-buy").click
     end
+  end
+
+  def increase_quantity_symbol
+    "＋"
+  end
+
+  def decrease_quantity_symbol
+    "－"
   end
 
   def toggle_accordion(name)

--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -54,6 +54,10 @@ module UIComponentHelper
     end
   end
 
+  def close_modal
+    find("a.close-reveal-modal").click
+  end
+
   def have_reset_password
     have_content "An email with instructions on resetting your password has been sent!"
   end


### PR DESCRIPTION
#### What? Why?

Basic part of #4598. There are some outstanding issues which will be addressed in a separate pull request.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Clicking a button to add a product to the cart is much easier than entering a number, especially on mobile. This pull request replaces the number input fields with Add buttons. Adjusting bulk quantities moves into a new modal.

![Screenshot from 2020-06-19 17-24-07](https://user-images.githubusercontent.com/3524483/85107863-fa521580-b251-11ea-898a-ce39a5f7a42c.png) ![Screenshot from 2020-06-19 17-25-45](https://user-images.githubusercontent.com/3524483/85107872-fd4d0600-b251-11ea-97d4-19dfd9110cc5.png)


#### What should we test?
<!-- List which features should be tested and how. -->

See issue #4598.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

The shop now features add-to-cart buttons to simplify adding products, especially on mobile.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

We will probably need a few new screenshots in the user guide.