### PR TITLE
Filter orders on inclusive dates in admin/orders

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -23,10 +23,13 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, $timeout, Reque
     $scope.fetchResults()
 
   $scope.fetchResults = (page=1) ->
+    startDateWithTime = $scope.appendStringIfNotEmpty($scope['q']['completed_at_gteq'], ' 00:00:00')
+    endDateWithTime = $scope.appendStringIfNotEmpty($scope['q']['completed_at_lteq'], ' 23:59:59')
+
     $scope.resetSelected()
     params = {
-      'q[completed_at_lt]': $scope['q']['completed_at_lt'],
-      'q[completed_at_gt]': $scope['q']['completed_at_gt'],
+      'q[completed_at_gteq]': startDateWithTime,
+      'q[completed_at_lteq]': endDateWithTime,
       'q[state_eq]': $scope['q']['state_eq'],
       'q[number_cont]': $scope['q']['number_cont'],
       'q[email_cont]': $scope['q']['email_cont'],
@@ -41,6 +44,11 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, $timeout, Reque
       page: page
     }
     RequestMonitor.load(Orders.index(params).$promise)
+
+  $scope.appendStringIfNotEmpty = (baseString, stringToAppend) ->
+    return baseString unless baseString
+
+    baseString + stringToAppend
 
   $scope.resetSelected = ->
     $scope.selected_orders.length = 0

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -4,10 +4,10 @@
       .date-range-filter.field
         = label_tag nil, t(:date_range)
         .date-range-fields
-          = text_field_tag "q[completed_at_gt]", nil, class: 'datepicker', datepicker: 'q.completed_at_gt', 'ng-model' => 'q.completed_at_gt', :placeholder => t(:start)
+          = text_field_tag "q[completed_at_gteq]", nil, class: 'datepicker', datepicker: 'q.completed_at_gteq', 'ng-model' => 'q.completed_at_gteq', :placeholder => t(:start)
           %span.range-divider
             %i.icon-arrow-right
-          = text_field_tag "q[completed_at_lt]", nil, class: 'datepicker', datepicker: 'q.completed_at_lt', 'ng-model' => 'q.completed_at_lt', :placeholder => t(:stop)
+          = text_field_tag "q[completed_at_lteq]", nil, class: 'datepicker', datepicker: 'q.completed_at_lteq', 'ng-model' => 'q.completed_at_lteq', :placeholder => t(:stop)
       .field
         = label_tag nil, t(:status)
         = select_tag("q[state_eq]",

--- a/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/orders/controllers/orders_controller_spec.js.coffee
@@ -63,3 +63,14 @@ describe "ordersCtrl", ->
       expect(Orders.index).toHaveBeenCalledWith(jasmine.objectContaining({
         'q[order_cycle_id_in][]': ['4', '5']
       }))
+
+    it "filters orders on inclusive dates", ->
+      $scope['q']['completed_at_gteq'] = '2020-06-08'
+      $scope['q']['completed_at_lteq'] = '2020-06-09'
+
+      $scope.fetchResults()
+
+      expect(Orders.index).toHaveBeenCalledWith(jasmine.objectContaining({
+        'q[completed_at_gteq]': '2020-06-08 00:00:00'
+        'q[completed_at_lteq]': '2020-06-09 23:59:59'
+      }))


### PR DESCRIPTION
#### What? Why?

Closes #5555

Dates from the date range weren't inclusive when filtering orders.

#### What should we test?
Test the date range on `admin/orders`.

#### Release notes
Filter orders on inclusive dates in admin/orders

Changelog Category: Changed