### PR TITLE
Migrate all spree pref. keys to the new format

### DIFF
--- a/db/migrate/20200623140437_fix_preferences_keys.rb
+++ b/db/migrate/20200623140437_fix_preferences_keys.rb
@@ -1,6 +1,9 @@
 class FixPreferencesKeys < ActiveRecord::Migration
   def up
-    new_preferences = Spree::Preference.where("key like '/%'")
+    unmigrated_preferences = Spree::Preference.exists?(['key NOT LIKE ?', '/%'])
+    return unless unmigrated_preferences
+
+    new_preferences = Spree::Preference.where("key LIKE '/%'")
     new_preferences.delete_all
 
     Spree::Preference.update_all("key = '/' || key")

--- a/db/migrate/20200623140437_fix_preferences_keys.rb
+++ b/db/migrate/20200623140437_fix_preferences_keys.rb
@@ -7,6 +7,8 @@ class FixPreferencesKeys < ActiveRecord::Migration
     new_preferences.delete_all
 
     Spree::Preference.update_all("key = '/' || key")
+
+    Rails.cache.clear
   end
 
   def down

--- a/db/migrate/20200623140437_fix_preferences_keys.rb
+++ b/db/migrate/20200623140437_fix_preferences_keys.rb
@@ -1,0 +1,11 @@
+class FixPreferencesKeys < ActiveRecord::Migration
+  def up
+    new_preferences = Spree::Preference.where("key like '/%'")
+    new_preferences.delete_all
+
+    Spree::Preference.update_all("key = '/' || key")
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200508101630) do
+ActiveRecord::Schema.define(version: 20200623140437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
#### What? Why?

Added by Luis:
Closes #5657

We realized in Spree v2.1 they follow this format instead and this is what's causing issues to Katuma production. 

This will remove the duplicate ones and convert the current preferences to the new thus, keeping the values.

https://github.com/spree/spree/issues/3905 is exactly what happened to us.

#### What should we test?

All instance configurations should contain the correct values after running the migration.

#### Release notes

Fix the spree preferences keys to conform to Spree's v2.1 format

Changelog Category: Fixed