### PR TITLE
4600 Restyle price breakdown

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/price_breakdown.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/price_breakdown.js.coffee
@@ -2,7 +2,7 @@ Darkswarm.directive "priceBreakdown", ($tooltip)->
   # We use the $tooltip service from Angular foundation to give us boilerplate
   # Subsequently we patch the scope, template and restrictions
   tooltip = $tooltip 'priceBreakdown', 'priceBreakdown', 'click'
-  tooltip.scope = 
+  tooltip.scope =
     variant: "="
   tooltip.templateUrl = "price_breakdown_button.html"
   tooltip.replace = true

--- a/app/assets/javascripts/templates/price_breakdown.html.haml
+++ b/app/assets/javascripts/templates/price_breakdown.html.haml
@@ -1,5 +1,6 @@
 .joyride-tip-guide.price_breakdown{"ng-class" => "{ in: tt_isOpen, fade: tt_animation }"}
   %span.joyride-nub.top
+  .background{ng: {show: "tt_isOpen", click: "tt_isOpen = false"}}
   .joyride-content-wrapper
     %ul
       %li

--- a/app/assets/javascripts/templates/price_breakdown.html.haml
+++ b/app/assets/javascripts/templates/price_breakdown.html.haml
@@ -1,5 +1,5 @@
 .joyride-tip-guide.price_breakdown{"ng-class" => "{ in: tt_isOpen, fade: tt_animation }"}
-  %span.joyride-nub.right
+  %span.joyride-nub.top
   .joyride-content-wrapper
     %ul
       %li

--- a/app/assets/javascripts/templates/shop_variant.html.haml
+++ b/app/assets/javascripts/templates/shop_variant.html.haml
@@ -5,7 +5,7 @@
   .small-4.medium-3.large-2.columns.variant-price
     %price-breakdown{"price-breakdown" => "_", variant: "variant",
       "price-breakdown-append-to-body" => "true",
-      "price-breakdown-placement" => "left",
+      "price-breakdown-placement" => "bottom",
       "price-breakdown-animation" => true}
     {{ variant.price_with_fees | localizeCurrency }}
   .medium-2.large-1.columns.total-price

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -75,13 +75,13 @@ button.graph-button {
     background-color: rgba(255, 255, 255, 1);
 
     &:before {
-      color: $clr-brick-bright;
+      color: $teal-500;
     }
   }
 }
 
 button.graph-button.open {
-  background-color: $clr-brick-bright;
+  background-color: $teal-500;
 
   &:before {
     content: "";

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -5,7 +5,8 @@
 // Foundation overrides
 .joyride-tip-guide.price_breakdown {
   // JS needs to be tweaked to adjust for left alignment - this is dynamic can't rewrite in CSS
-  margin-left: -8px;
+  margin-left: -7.4rem;
+  margin-top: 0.1rem;
 
   @include box-shadow(0 2px 8px 0 rgba(0, 0, 0, 0.35));
 
@@ -22,12 +23,8 @@
     color: #1f1f1f;
   }
 
-  .joyride-nub.right {
-    top: 38px;
-    border-color: $grey-800 !important;
-    border-top-color: transparent !important;
-    border-right-color: transparent !important;
-    border-bottom-color: transparent !important;
+  .joyride-nub.top {
+    left: 7.4rem;
   }
 
   ul, li {

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -27,6 +27,16 @@
     left: 7.4rem;
   }
 
+  .background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    cursor: pointer;
+  }
+
   ul, li {
     list-style: none;
     margin: 0;

--- a/app/assets/stylesheets/darkswarm/embedded_shopfront.scss
+++ b/app/assets/stylesheets/darkswarm/embedded_shopfront.scss
@@ -59,13 +59,6 @@ body.embedded {
         line-height: $large-menu-height;
         height: $large-menu-height;
         vertical-align: top;
-
-        &.cart {
-          div.joyride-tip-guide { // Cart Dropdown
-            top: 75px;
-            overflow: visible;
-          }
-        }
       }
     }
 


### PR DESCRIPTION
#### What? Why?

Closes #4600 and #4536.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The price breakdown is now visible on mobile and is closed when you click somewhere else.

![Screenshot from 2020-06-26 18-09-19](https://user-images.githubusercontent.com/3524483/85835332-3a784180-b7d8-11ea-9d07-624c107315bb.png)

#### What should we test?
<!-- List which features should be tested and how. -->

* Set up an order cycle with fees attached to some products (e.g. multiple suppliers but only one has a fee).
* Go to the shop front.
* Check the specs in #4600.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

The price breakdown is now visible on mobile and is closed when you click somewhere else.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

This branch currently includes commits from #5640. This shouldn't be merged unless that one is merged as well. Or it should be rebased.