### PR TITLE
Fix taxonomies flaky spec

### DIFF
--- a/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/spec/features/admin/configuration/taxonomies_spec.rb
@@ -14,8 +14,10 @@ describe "Taxonomies" do
       create(:taxonomy, name: 'Brand')
       create(:taxonomy, name: 'Categories')
       click_link "Taxonomies"
-      within_row(1) { expect(page).to have_content("Brand") }
-      within_row(2) { expect(page).to have_content("Categories") }
+      within("table.index tbody") do
+        expect(page).to have_content("Brand")
+        expect(page).to have_content("Categories")
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #5652

I could verify it but this must be a problem with the position on the table or the order of the elements. The assertion within_row from spree is very precise, we don't need that here.


#### What should we test?
Green build.

#### Release notes
Changelog Category: Fixed
The build is a very little bit more resilient now.

