### PR TITLE
Enhancement/5210 - Add Actions dropdown menu to all pages of Order Details menu

### DIFF
--- a/app/views/spree/admin/adjustments/index.html.haml
+++ b/app/views/spree/admin/adjustments/index.html.haml
@@ -7,6 +7,7 @@
 
 - content_for :page_actions do
   %li= button_link_to t(:new_adjustment), new_admin_order_adjustment_url(@order), :icon => 'icon-plus'
+  = render partial: 'spree/admin/shared/order_links'
   %li= button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
 = render :partial => 'adjustments_table'

--- a/app/views/spree/admin/orders/customer_details/edit.html.haml
+++ b/app/views/spree/admin/orders/customer_details/edit.html.haml
@@ -8,6 +8,7 @@
   = Spree.t(:customer_details)
 
 - content_for :page_actions do
+  = render partial: 'spree/admin/shared/order_links'
   %li= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 
 - if @order.cart? || @order.address?

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -29,6 +29,3 @@
 
     %div{"data-hook" => "admin_order_edit_form"}
       = render :partial => 'form', :locals => { :order => @order }
-
-:coffee
-  angular.bootstrap(document.getElementById("links-dropdown"),['admin.dropdown'])

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -4,7 +4,7 @@
     %li= event_links
   - if can?(:resend, @order)
     %li= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'icon-email'
-  %li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
+  = render partial: 'spree/admin/shared/order_links'
   - if can?(:admin, Spree::Order)
     %li= button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'
 

--- a/app/views/spree/admin/payments/index.html.haml
+++ b/app/views/spree/admin/payments/index.html.haml
@@ -5,6 +5,7 @@
   - if @order.outstanding_balance?
     %li#new_payment_section
       = button_link_to t(:new_payment), new_admin_order_payment_url(@order), icon: 'icon-plus'
+  = render partial: 'spree/admin/shared/order_links'
   %li= button_link_to t(:back_to_orders_list), admin_orders_path, icon: 'icon-arrow-left'
 
 - content_for :page_title do

--- a/app/views/spree/admin/return_authorizations/index.html.haml
+++ b/app/views/spree/admin/return_authorizations/index.html.haml
@@ -5,6 +5,7 @@
   - if @order.shipments.any? &:shipped?
     %li
       = button_link_to t('.new_return_authorization'), new_admin_order_return_authorization_url(@order), icon: 'icon-plus'
+  = render partial: 'spree/admin/shared/order_links'
   %li= button_link_to t('.back_to_orders_list'), spree.admin_orders_path, icon: 'icon-arrow-left'
 
 - content_for :page_title do

--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -1,0 +1,1 @@
+%li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }

--- a/app/views/spree/admin/shared/_order_links.html.haml
+++ b/app/views/spree/admin/shared/_order_links.html.haml
@@ -1,1 +1,4 @@
 %li.links-dropdown#links-dropdown{ links: order_links(@order).to_json }
+
+:coffee
+  angular.bootstrap(document.getElementById("links-dropdown"),['admin.dropdown'])

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -35,4 +35,15 @@ describe "spree/admin/orders/edit.html.haml" do
       expect(rendered).to have_content("Order Total $36.00")
     end
   end
+
+  describe "actions dropwdown" do
+    it "contains all the actions buttons" do
+      render
+
+      expect(rendered).to have_content("Resend Confirmation")
+      expect(rendered).to have_content("Send Invoice")
+      expect(rendered).to have_content("Print Invoices")
+      expect(rendered).to have_content("Cancel Order")
+    end
+  end
 end

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -35,15 +35,4 @@ describe "spree/admin/orders/edit.html.haml" do
       expect(rendered).to have_content("Order Total $36.00")
     end
   end
-
-  describe "actions dropwdown" do
-    it "contains all the actions buttons" do
-      render
-
-      expect(rendered).to have_content("Resend Confirmation")
-      expect(rendered).to have_content("Send Invoice")
-      expect(rendered).to have_content("Print Invoices")
-      expect(rendered).to have_content("Cancel Order")
-    end
-  end
 end

--- a/spec/views/spree/admin/shared/_order_links.html.haml_spec.rb
+++ b/spec/views/spree/admin/shared/_order_links.html.haml_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "spree/admin/shared/_order_links.html.haml" do
+  helper Spree::BaseHelper # required to make pretty_time work
+
+  around do |example|
+    original_config = Spree::Config[:enable_invoices?]
+    example.run
+    Spree::Config[:enable_invoices?] = original_config
+  end
+
+  before do
+    order = create(:completed_order_with_fees)
+    assign(:order, order)
+  end
+
+  describe "actions dropwdown" do
+    it "contains all the actions buttons" do
+      render
+
+      expect(rendered).to have_content("links-dropdown")
+    end
+  end
+end

--- a/spec/views/spree/admin/shared/_order_links.html.haml_spec.rb
+++ b/spec/views/spree/admin/shared/_order_links.html.haml_spec.rb
@@ -3,14 +3,8 @@ require "spec_helper"
 describe "spree/admin/shared/_order_links.html.haml" do
   helper Spree::BaseHelper # required to make pretty_time work
 
-  around do |example|
-    original_config = Spree::Config[:enable_invoices?]
-    example.run
-    Spree::Config[:enable_invoices?] = original_config
-  end
-
   before do
-    order = create(:completed_order_with_fees)
+    order = create(:order)
     assign(:order, order)
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #5210 

Sometimes, when dealing with order adjustments, it is annoying to go back to the order page when you want to send an invoice (just an example). For simplicity questions, the issue asks to add the menu to all Order Details pages.

This PR replicates the same Actions dropdown menu inside all pages of the Order Details menu.

Before:
![Screen Shot 2020-06-28 at 22 57 04](https://user-images.githubusercontent.com/27960597/85966051-09913b80-b995-11ea-8a10-f84ac3baa14b.png)
![Screen Shot 2020-06-28 at 22 57 20](https://user-images.githubusercontent.com/27960597/85966053-0b5aff00-b995-11ea-99b6-391c4faece04.png)
![Screen Shot 2020-06-28 at 22 57 45](https://user-images.githubusercontent.com/27960597/85966055-0bf39580-b995-11ea-8745-9dc9c070d49e.png)
![Screen Shot 2020-06-28 at 22 58 05](https://user-images.githubusercontent.com/27960597/85966057-0c8c2c00-b995-11ea-8057-5ddd4be69e1d.png)

After:
![Screen Shot 2020-06-28 at 22 58 56](https://user-images.githubusercontent.com/27960597/85966064-16ae2a80-b995-11ea-83db-0f4885c43b8b.png)
![Screen Shot 2020-06-28 at 22 59 13](https://user-images.githubusercontent.com/27960597/85966068-17df5780-b995-11ea-86ff-8820e8d9a994.png)
![Screen Shot 2020-06-28 at 22 59 32](https://user-images.githubusercontent.com/27960597/85966071-19108480-b995-11ea-81ae-985468fc3e6c.png)
![Screen Shot 2020-06-28 at 22 59 49](https://user-images.githubusercontent.com/27960597/85966072-19a91b00-b995-11ea-903a-a17ef32fd4f2.png)



#### What should we test?
1. If the Actions dropdown menu appears correctly on all pages
2. If all the actions inside the menu are working properly.

#### Release notes
Add Actions dropdown menu to all pages of Order Details menu

Changelog Category: Added
