### PR TITLE
Make button border radius consistent

### DIFF
--- a/app/views/spree/orders/form/_update_buttons.html.haml
+++ b/app/views/spree/orders/form/_update_buttons.html.haml
@@ -16,7 +16,7 @@
         %i.ofn-i_009-close
         = t(:cancel_order)
     .columns.small-12.medium-3
-      = button_tag :class => 'button primary radius expand', :id => 'update-button', "ng-disabled" => 'update_order_form.$pristine' do
+      = button_tag :class => 'button primary expand', :id => 'update-button', "ng-disabled" => 'update_order_form.$pristine' do
         %i.ofn-i_051-check-big
         %span{ ng: { show: 'update_order_form.$dirty' } }= t(:save_changes)
         %span{ ng: { hide: 'update_order_form.$dirty' } }= t(:order_saved)


### PR DESCRIPTION
#### What? Why?

This makes this button consistent with the others next to it. From

![Screenshot from 2020-06-29 12-00-39](https://user-images.githubusercontent.com/762088/85999637-b5c23900-ba0c-11ea-814e-8c1f077d5fea.png)

to

![Screenshot from 2020-06-29 12-00-59](https://user-images.githubusercontent.com/762088/85999643-b955c000-ba0c-11ea-9b42-2c2f39ed6de4.png)

#### What should we test?

The "saved order" button from the order confirmation page should have the same border radius as the other two buttons

#### Release notes

Fix radius of order saved button in the order confirmation page

Changelog Category: Fixed
