### PR TITLE
Add space after translations so that translators dont have to guess a space is needed

### DIFF
--- a/app/assets/javascripts/darkswarm/filters/dates.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/dates.js.coffee
@@ -12,4 +12,4 @@ Darkswarm.filter "sensible_timeframe", (date_in_wordsFilter)->
     if moment().add(2, 'days') < moment(date, dateFormat)
       t 'orders_open'
     else
-      t('closing') + date_in_wordsFilter(date)
+      t('closing') + ' ' + date_in_wordsFilter(date)

--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -20,7 +20,7 @@ module Spree
       @user = user
       I18n.with_locale valid_locale(@user) do
         mail(to: user.email, from: from_address,
-             subject: t(:welcome_to) + Spree::Config[:site_name])
+             subject: t(:welcome_to) + ' ' + Spree::Config[:site_name])
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,8 +207,8 @@ en:
         explainer: Automatic processing of these orders failed for an unknown reason. This should not occur, please contact us if you are seeing this.
 
   home: "OFN"
-  title: Open Food Network
-  welcome_to: 'Welcome to '
+  title: "Open Food Network"
+  welcome_to: "Welcome to"
   site_meta_description: "We begin from the ground up. With farmers and growers ready to tell their stories proudly and truly. With distributors ready to connect people with products fairly and honestly. With buyers who believe that better weekly shopping decisions can…"
   search_by_name: Search by name or suburb...
   producers: 'Australian Producers'
@@ -1839,8 +1839,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   password: Password
   remember_me: Remember Me
   are_you_sure: "Are you sure?"
-  orders_open: Orders open
-  closing: "Closing "
+  orders_open: "Orders open"
+  closing: "Closing"
   going_back_to_home_page: "Taking you back to the home page"
   creating: Creating
   updating: Updating


### PR DESCRIPTION
#### What? Why?
This was seen in Brasil while the translations are correct without space at the end.

In the welcome email after confirmation:
![image](https://user-images.githubusercontent.com/1640378/86138837-dfe82980-bae6-11ea-9023-e1be9f0f3cf0.png)

In the shops page:
![image](https://user-images.githubusercontent.com/1640378/86138857-e8d8fb00-bae6-11ea-8c53-f809de8fea27.png)

There should spaces introduced by the code, not the translations.

We will need to remove the extra space in transifex for the languages where the space was added in transifex, the translation keys are: welcome_to and closing and, after this PR, they should NOT have extra space in the end.

#### What should we test?
Make sure the welcome email in pt-BR will come with a space and also /shops displays correctly.

#### Release notes
Changelog Category: Fixed
Corrected spacing issue in email subject and /shops
