### PR TITLE
Available locales bug

### DIFF
--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -6,7 +6,6 @@ module Spree
     include Spree::Core::ControllerHelpers::Common
     include Spree::Core::ControllerHelpers::Order
     include Spree::Core::ControllerHelpers::SSL
-    include I18nHelper
 
     ssl_required :new, :create, :destroy, :update
     ssl_allowed :login_bar
@@ -54,9 +53,8 @@ module Spree
     def ensure_valid_locale_persisted
       # When creating a new user session we have to wait until after a successful
       # login to be able to persist a locale on the current user
-      return unless spree_current_user && !available_locale?(spree_current_user.locale)
 
-      spree_current_user.update!(locale: I18n.default_locale)
+      UserLocaleSetter.ensure_valid_locale_persisted(spree_current_user)
     end
   end
 end

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -12,7 +12,7 @@ module Spree
     ssl_allowed :login_bar
 
     before_action :set_checkout_redirect, only: :create
-    after_action :ensure_valid_locale, only: :create
+    after_action :ensure_valid_locale_persisted, only: :create
 
     def create
       authenticate_spree_user!
@@ -51,7 +51,9 @@ module Spree
       session["spree_user_return_to"] = nil
     end
 
-    def ensure_valid_locale
+    def ensure_valid_locale_persisted
+      # When creating a new user session we have to wait until after a successful
+      # login to be able to persist a locale on the current user
       return unless spree_current_user && !available_locale?(spree_current_user.locale)
 
       spree_current_user.update!(locale: I18n.default_locale)

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -6,11 +6,13 @@ module Spree
     include Spree::Core::ControllerHelpers::Common
     include Spree::Core::ControllerHelpers::Order
     include Spree::Core::ControllerHelpers::SSL
+    include I18nHelper
 
     ssl_required :new, :create, :destroy, :update
     ssl_allowed :login_bar
 
     before_action :set_checkout_redirect, only: :create
+    after_action :ensure_valid_locale, only: :create
 
     def create
       authenticate_spree_user!
@@ -47,6 +49,12 @@ module Spree
     def redirect_back_or_default(default)
       redirect_to(session["spree_user_return_to"] || default)
       session["spree_user_return_to"] = nil
+    end
+
+    def ensure_valid_locale
+      return unless spree_current_user && !available_locale?(spree_current_user.locale)
+
+      spree_current_user.update!(locale: I18n.default_locale)
     end
   end
 end

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -52,9 +52,10 @@ module Spree
 
     def ensure_valid_locale_persisted
       # When creating a new user session we have to wait until after a successful
-      # login to be able to persist a locale on the current user
+      # login to be able to persist a selected locale on the current user
 
-      UserLocaleSetter.ensure_valid_locale_persisted(spree_current_user)
+      UserLocaleSetter.new(spree_current_user, params[:locale], cookies).
+        ensure_valid_locale_persisted
     end
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,6 +1,6 @@
 module I18nHelper
   def set_locale
-    UserLocaleSetter.new(spree_current_user, params[:locale], cookies).call
+    UserLocaleSetter.new(spree_current_user, params[:locale], cookies).set_locale
   end
 
   def valid_locale(user)

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -4,6 +4,6 @@ module I18nHelper
   end
 
   def valid_locale(user)
-    UserLocaleSetter.new(user).valid_locale_for_user
+    UserLocaleSetter.new(user).valid_current_locale
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -24,11 +24,11 @@ module I18nHelper
     end
   end
 
-  private
-
   def available_locale?(locale)
     Rails.application.config.i18n.available_locales.include?(locale)
   end
+
+  private
 
   def current_user_locale
     spree_current_user.andand.locale

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,17 +1,17 @@
 module I18nHelper
   def set_locale
-    # Save a given locale
+    # Save a given locale from params
     if params[:locale] && available_locale?(params[:locale])
       spree_current_user&.update!(locale: params[:locale])
       cookies[:locale] = params[:locale]
     end
 
     # After logging in, check if the user chose a locale before
-    if spree_current_user && spree_current_user.locale.nil? && cookies[:locale]
-      spree_current_user.update!(locale: params[:locale])
+    if current_user_locale.nil? && cookies[:locale]
+      spree_current_user&.update!(locale: params[:locale])
     end
 
-    I18n.locale = spree_current_user.andand.locale || cookies[:locale] || I18n.default_locale
+    I18n.locale = current_user_locale || cookies[:locale] || I18n.default_locale
   end
 
   def valid_locale(user)
@@ -28,5 +28,9 @@ module I18nHelper
 
   def available_locale?(locale)
     Rails.application.config.i18n.available_locales.include?(locale)
+  end
+
+  def current_user_locale
+    spree_current_user.andand.locale
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,10 +1,6 @@
 module I18nHelper
   def set_locale
-    # Save a given locale from params
-    if params[:locale] && available_locale?(params[:locale])
-      spree_current_user&.update!(locale: params[:locale])
-      cookies[:locale] = params[:locale]
-    end
+    save_locale_from_params
 
     # After logging in, check if the user chose a locale before
     if current_user_locale.nil? && cookies[:locale] && available_locale?(params[:locale])
@@ -29,6 +25,13 @@ module I18nHelper
   end
 
   private
+
+  def save_locale_from_params
+    return unless params[:locale] && available_locale?(params[:locale])
+
+    spree_current_user&.update!(locale: params[:locale])
+    cookies[:locale] = params[:locale]
+  end
 
   def current_user_locale
     spree_current_user.andand.locale

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -4,6 +4,6 @@ module I18nHelper
   end
 
   def valid_locale(user)
-    UserLocaleSetter.valid_locale_for_user(user)
+    UserLocaleSetter.new(user).valid_locale_for_user
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -11,7 +11,7 @@ module I18nHelper
       spree_current_user&.update!(locale: params[:locale])
     end
 
-    I18n.locale = current_user_locale || cookies[:locale] || I18n.default_locale
+    I18n.locale = valid_current_locale
   end
 
   def valid_locale(user)
@@ -32,5 +32,15 @@ module I18nHelper
 
   def current_user_locale
     spree_current_user.andand.locale
+  end
+
+  def valid_current_locale
+    if available_locale?(current_user_locale)
+      current_user_locale
+    elsif available_locale?(cookies[:locale])
+      cookies[:locale]
+    else
+      I18n.default_locale
+    end
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,49 +1,9 @@
 module I18nHelper
   def set_locale
-    save_locale_from_params
-
-    # After logging in, check if the user chose a locale before
-    if current_user_locale.nil? && cookies[:locale] && available_locale?(params[:locale])
-      spree_current_user&.update!(locale: params[:locale])
-    end
-
-    I18n.locale = valid_current_locale
+    UserLocaleSetter.new(spree_current_user, params[:locale], cookies).call
   end
 
   def valid_locale(user)
-    if user.present? &&
-       user.locale.present? &&
-       available_locale?(user.locale)
-      user.locale
-    else
-      I18n.default_locale
-    end
-  end
-
-  def available_locale?(locale)
-    Rails.application.config.i18n.available_locales.include?(locale)
-  end
-
-  private
-
-  def save_locale_from_params
-    return unless params[:locale] && available_locale?(params[:locale])
-
-    spree_current_user&.update!(locale: params[:locale])
-    cookies[:locale] = params[:locale]
-  end
-
-  def current_user_locale
-    spree_current_user.andand.locale
-  end
-
-  def valid_current_locale
-    if available_locale?(current_user_locale)
-      current_user_locale
-    elsif available_locale?(cookies[:locale])
-      cookies[:locale]
-    else
-      I18n.default_locale
-    end
+    UserLocaleSetter.valid_locale_for_user(user)
   end
 end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -7,7 +7,7 @@ module I18nHelper
     end
 
     # After logging in, check if the user chose a locale before
-    if current_user_locale.nil? && cookies[:locale]
+    if current_user_locale.nil? && cookies[:locale] && available_locale?(params[:locale])
       spree_current_user&.update!(locale: params[:locale])
     end
 

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -19,8 +19,14 @@ class UserLocaleSetter
     current_user.update!(locale: valid_current_locale)
   end
 
-  def valid_locale_for_user
-    valid_current_locale
+  def valid_current_locale
+    if current_user_locale && available_locale?(current_user_locale)
+      current_user_locale
+    elsif cookies[:locale] && available_locale?(cookies[:locale])
+      cookies[:locale]
+    else
+      I18n.default_locale
+    end
   end
 
   private
@@ -39,16 +45,6 @@ class UserLocaleSetter
   end
 
   def current_user_locale
-    current_user.andand.locale
-  end
-
-  def valid_current_locale
-    if current_user_locale && available_locale?(current_user_locale)
-      current_user_locale
-    elsif cookies[:locale] && available_locale?(cookies[:locale])
-      cookies[:locale]
-    else
-      I18n.default_locale
-    end
+    current_user&.locale
   end
 end

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -61,9 +61,9 @@ class UserLocaleSetter
   end
 
   def valid_current_locale
-    if available_locale?(current_user_locale)
+    if current_user_locale && available_locale?(current_user_locale)
       current_user_locale
-    elsif available_locale?(cookies[:locale])
+    elsif cookies[:locale] && available_locale?(cookies[:locale])
       cookies[:locale]
     else
       I18n.default_locale

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -45,9 +45,9 @@ class UserLocaleSetter
 
   def save_locale_from_cookies
     return unless current_user_locale.nil? && cookies[:locale] &&
-                  available_locale?(params_locale)
+                  available_locale?(cookies[:locale])
 
-    current_user&.update!(locale: params_locale)
+    current_user&.update!(locale: cookies[:locale])
   end
 
   def available_locale?(locale)

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -9,11 +9,7 @@ class UserLocaleSetter
 
   def call
     save_locale_from_params
-
-    # After logging in, check if the user chose a locale before
-    if current_user_locale.nil? && cookies[:locale] && available_locale?(params_locale)
-      current_user&.update!(locale: params_locale)
-    end
+    save_locale_from_cookies
 
     I18n.locale = valid_current_locale
   end
@@ -45,6 +41,13 @@ class UserLocaleSetter
 
     current_user&.update!(locale: params_locale)
     cookies[:locale] = params_locale
+  end
+
+  def save_locale_from_cookies
+    return unless current_user_locale.nil? && cookies[:locale] &&
+                  available_locale?(params_locale)
+
+    current_user&.update!(locale: params_locale)
   end
 
   def available_locale?(locale)

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -21,7 +21,7 @@ class UserLocaleSetter
   end
 
   def self.valid_locale_for_user(user)
-    if user.present? && user.locale.present? && available_locale?(user.locale)
+    if user.andand.locale.present? && available_locale?(user.locale)
       user.locale
     else
       I18n.default_locale

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -44,6 +44,8 @@ class UserLocaleSetter
   end
 
   def save_locale_from_cookies
+    # If the user account has a selected locale: we ignore the locale set in cookies,
+    # which is persisted per-device but not per-user.
     return unless current_user_locale.nil? && cookies[:locale] &&
                   available_locale?(cookies[:locale])
 

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -7,17 +7,17 @@ class UserLocaleSetter
     @cookies = cookies
   end
 
-  def call
+  def set_locale
     save_locale_from_params
     save_locale_from_cookies
 
     I18n.locale = valid_current_locale
   end
 
-  def self.ensure_valid_locale_persisted(user)
-    return unless user && !available_locale?(user.locale)
+  def ensure_valid_locale_persisted
+    return unless current_user && !available_locale?(current_user.locale)
 
-    user.update!(locale: I18n.default_locale)
+    current_user.update!(locale: valid_current_locale)
   end
 
   def self.valid_locale_for_user(user)

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserLocaleSetter
-  def initialize(current_user, params_locale, cookies)
+  def initialize(current_user, params_locale = nil, cookies = {})
     @current_user = current_user
     @params_locale = params_locale
     @cookies = cookies
@@ -19,16 +19,8 @@ class UserLocaleSetter
     current_user.update!(locale: valid_current_locale)
   end
 
-  def self.valid_locale_for_user(user)
-    if user.andand.locale.present? && available_locale?(user.locale)
-      user.locale
-    else
-      I18n.default_locale
-    end
-  end
-
-  def self.available_locale?(locale)
-    Rails.application.config.i18n.available_locales.include?(locale)
+  def valid_locale_for_user
+    valid_current_locale
   end
 
   private
@@ -43,7 +35,7 @@ class UserLocaleSetter
   end
 
   def available_locale?(locale)
-    self.class.available_locale?(locale)
+    Rails.application.config.i18n.available_locales.include?(locale)
   end
 
   def current_user_locale

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class UserLocaleSetter
+  def initialize(current_user, params_locale, cookies)
+    @current_user = current_user
+    @params_locale = params_locale
+    @cookies = cookies
+  end
+
+  def call
+    save_locale_from_params
+
+    # After logging in, check if the user chose a locale before
+    if current_user_locale.nil? && cookies[:locale] && available_locale?(params_locale)
+      current_user&.update!(locale: params_locale)
+    end
+
+    I18n.locale = valid_current_locale
+  end
+
+  def self.ensure_valid_locale_persisted(user)
+    return unless user && !available_locale?(user.locale)
+
+    user.update!(locale: I18n.default_locale)
+  end
+
+  def self.valid_locale_for_user(user)
+    if user.present? && user.locale.present? && available_locale?(user.locale)
+      user.locale
+    else
+      I18n.default_locale
+    end
+  end
+
+  def self.available_locale?(locale)
+    Rails.application.config.i18n.available_locales.include?(locale)
+  end
+
+  private
+
+  attr_reader :current_user, :params_locale, :cookies
+
+  def save_locale_from_params
+    return unless params_locale && available_locale?(params_locale)
+
+    current_user&.update!(locale: params_locale)
+    cookies[:locale] = params_locale
+  end
+
+  def available_locale?(locale)
+    self.class.available_locale?(locale)
+  end
+
+  def current_user_locale
+    current_user.andand.locale
+  end
+
+  def valid_current_locale
+    if available_locale?(current_user_locale)
+      current_user_locale
+    elsif available_locale?(cookies[:locale])
+      cookies[:locale]
+    else
+      I18n.default_locale
+    end
+  end
+end

--- a/app/services/user_locale_setter.rb
+++ b/app/services/user_locale_setter.rb
@@ -9,7 +9,6 @@ class UserLocaleSetter
 
   def set_locale
     save_locale_from_params
-    save_locale_from_cookies
 
     I18n.locale = valid_current_locale
   end
@@ -41,15 +40,6 @@ class UserLocaleSetter
 
     current_user&.update!(locale: params_locale)
     cookies[:locale] = params_locale
-  end
-
-  def save_locale_from_cookies
-    # If the user account has a selected locale: we ignore the locale set in cookies,
-    # which is persisted per-device but not per-user.
-    return unless current_user_locale.nil? && cookies[:locale] &&
-                  available_locale?(cookies[:locale])
-
-    current_user&.update!(locale: cookies[:locale])
   end
 
   def available_locale?(locale)

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -175,7 +175,7 @@ feature "Authentication", js: true do
           user.update!(locale: nil)
         end
 
-        xit "logs in successfully and uses the locale from cookies" do
+        it "logs in successfully and uses the locale from cookies" do
           page.driver.browser.manage.add_cookie(name: 'locale', value: 'es')
 
           fill_in_and_submit_login_form(user)

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -169,6 +169,24 @@ feature "Authentication", js: true do
           expect(user.reload.locale).to eq "en"
         end
       end
+
+      context "when the user has never selected a locale, but one has been selected before login" do
+        before do
+          user.update!(locale: nil)
+        end
+
+        xit "logs in successfully and uses the locale from cookies" do
+          page.driver.browser.manage.add_cookie(name: 'locale', value: 'es')
+
+          fill_in_and_submit_login_form(user)
+          expect_logged_in
+
+          expect(page).to have_content I18n.t(:home_shop, locale: :es).upcase
+          expect(user.reload.locale).to eq "es"
+
+          page.driver.browser.manage.delete_cookie('locale')
+        end
+      end
     end
   end
 end

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 feature "Authentication", js: true do
+  include AuthenticationWorkflow
   include UIComponentHelper
   include OpenFoodNetwork::EmailHelper
 
@@ -134,6 +135,40 @@ feature "Authentication", js: true do
       visit "/login"
       uri = URI.parse(current_url)
       expect(uri.path + "#" + uri.fragment).to eq('/#/login')
+    end
+
+    describe "with user locales" do
+      before do
+        visit root_path
+        open_login_modal
+      end
+
+      context "when the user has a valid locale saved" do
+        before do
+          user.update!(locale: "es")
+        end
+
+        it "logs in successfully, applying the saved locale" do
+          fill_in_and_submit_login_form(user)
+          expect_logged_in
+
+          expect(page).to have_content I18n.t(:home_shop, locale: :es).upcase
+        end
+      end
+
+      context "when the user has an unavailable locale saved" do
+        before do
+          user.update!(locale: "xx")
+        end
+
+        xit "logs in successfully and resets the user's locale to the default" do
+          fill_in_and_submit_login_form(user)
+          expect_logged_in
+
+          expect(page).to have_content I18n.t(:home_shop, locale: :en).upcase
+          expect(user.reload.locale).to eq "en"
+        end
+      end
     end
   end
 end

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -161,7 +161,7 @@ feature "Authentication", js: true do
           user.update!(locale: "xx")
         end
 
-        xit "logs in successfully and resets the user's locale to the default" do
+        it "logs in successfully and resets the user's locale to the default" do
           fill_in_and_submit_login_form(user)
           expect_logged_in
 

--- a/spec/services/user_locale_setter_spec.rb
+++ b/spec/services/user_locale_setter_spec.rb
@@ -120,38 +120,28 @@ describe UserLocaleSetter do
     end
   end
 
-  describe "self#valid_locale_for_user" do
+  describe "#valid_locale_for_user" do
+    let(:service) { UserLocaleSetter.new(user) }
+
     context "when the user has a locale set" do
       it "returns the user's locale" do
         user.update(locale: "es")
-        expect(UserLocaleSetter.valid_locale_for_user(user)).to eq "es"
+        expect(service.valid_locale_for_user).to eq "es"
       end
     end
 
     context "when the user has no locale set" do
       it "returns the default locale" do
-        expect(UserLocaleSetter.valid_locale_for_user(user)).to eq default_locale
+        expect(service.valid_locale_for_user).to eq default_locale
       end
     end
 
     context "when the given user argument is nil" do
+      let(:user) { nil }
+
       it "returns the default locale" do
-        expect(UserLocaleSetter.valid_locale_for_user(nil)).to eq default_locale
+        expect(service.valid_locale_for_user).to eq default_locale
       end
-    end
-  end
-
-  describe "self#available_locale?" do
-    it "returns true if locale is available" do
-      expect(UserLocaleSetter.available_locale?("es")).to be true
-    end
-
-    it "returns false if locale is not available" do
-      expect(UserLocaleSetter.available_locale?("xx")).to be false
-    end
-
-    it "returns false if nil is given for locale" do
-      expect(UserLocaleSetter.available_locale?(nil)).to be false
     end
   end
 end

--- a/spec/services/user_locale_setter_spec.rb
+++ b/spec/services/user_locale_setter_spec.rb
@@ -120,19 +120,19 @@ describe UserLocaleSetter do
     end
   end
 
-  describe "#valid_locale_for_user" do
+  describe "#valid_current_locale" do
     let(:service) { UserLocaleSetter.new(user) }
 
     context "when the user has a locale set" do
       it "returns the user's locale" do
         user.update(locale: "es")
-        expect(service.valid_locale_for_user).to eq "es"
+        expect(service.valid_current_locale).to eq "es"
       end
     end
 
     context "when the user has no locale set" do
       it "returns the default locale" do
-        expect(service.valid_locale_for_user).to eq default_locale
+        expect(service.valid_current_locale).to eq default_locale
       end
     end
 
@@ -140,7 +140,7 @@ describe UserLocaleSetter do
       let(:user) { nil }
 
       it "returns the default locale" do
-        expect(service.valid_locale_for_user).to eq default_locale
+        expect(service.valid_current_locale).to eq default_locale
       end
     end
   end

--- a/spec/services/user_locale_setter_spec.rb
+++ b/spec/services/user_locale_setter_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe UserLocaleSetter do
+  let(:user) { create(:user) }
+  let(:default_locale) { I18n.default_locale }
+  let(:locale_params) { {} }
+  let(:cookies) { {} }
+  let(:service) { UserLocaleSetter.new(user, locale_params, cookies) }
+
+  describe "#set_locale" do
+    describe "persists selected locale from params" do
+      let(:locale_params) { "es" }
+
+      context "when the user is logged in" do
+        it "saves selected locale to user.locale and cookies[:locale]" do
+          service.set_locale
+
+          expect(user.reload.locale).to eq "es"
+          expect(cookies).to eq({ locale: "es" })
+        end
+      end
+
+      context "when the user is not logged in" do
+        it "saves selected locale to cookies[:locale]" do
+          service.set_locale
+
+          expect(cookies).to eq({ locale: "es" })
+        end
+      end
+    end
+
+    describe "sets the current locale" do
+      context "when the user is logged in" do
+        context "and has a valid locale saved" do
+          before { user.update(locale: "es") }
+
+          it "applies the user's locale" do
+            service.set_locale
+
+            expect(I18n.locale).to eq :es
+          end
+        end
+
+        context "and has an invalid locale saved" do
+          before { user.update(locale: "xx") }
+
+          it "applies the default locale" do
+            service.set_locale
+
+            expect(I18n.locale).to eq I18n.default_locale
+          end
+        end
+
+        context "and has no locale saved" do
+          before { user.update(locale: nil) }
+
+          it "applies the locale from cookies if present" do
+            cookies[:locale] = "es"
+            service.set_locale
+
+            expect(I18n.locale).to eq :es
+          end
+
+          it "applies the default locale otherwise " do
+            service.set_locale
+
+            expect(I18n.locale).to eq I18n.default_locale
+          end
+        end
+      end
+
+      context "when the user is not logged in" do
+        let(:user) { nil }
+
+        context "with a locale set in cookies" do
+          it "applies the value from cookies" do
+            cookies[:locale] = "es"
+            service.set_locale
+
+            expect(I18n.locale).to eq :es
+          end
+        end
+
+        context "with no locale set in cookies" do
+          it "applies the default locale" do
+            service.set_locale
+
+            expect(I18n.locale).to eq I18n.default_locale
+          end
+        end
+      end
+    end
+  end
+
+  describe "#ensure_valid_locale_persisted" do
+    context "when a user is present" do
+      context "and has an unavailable locale saved" do
+        before { user.update(locale: "xx") }
+
+        context "with no locale set in cookies" do
+          it "set the user's locale to the default" do
+            service.ensure_valid_locale_persisted
+
+            expect(user.reload.locale).to eq default_locale.to_s
+          end
+        end
+
+        context "with a locale set in cookies" do
+          let(:cookies) { {locale: "es"} }
+
+          it "set the user's locale to the cookie value" do
+            service.ensure_valid_locale_persisted
+
+            expect(user.reload.locale).to eq "es"
+          end
+        end
+      end
+    end
+  end
+
+  describe "self#valid_locale_for_user" do
+    context "when the user has a locale set" do
+      it "returns the user's locale" do
+        user.update(locale: "es")
+        expect(UserLocaleSetter.valid_locale_for_user(user)).to eq "es"
+      end
+    end
+
+    context "when the user has no locale set" do
+      it "returns the default locale" do
+        expect(UserLocaleSetter.valid_locale_for_user(user)).to eq default_locale
+      end
+    end
+
+    context "when the given user argument is nil" do
+      it "returns the default locale" do
+        expect(UserLocaleSetter.valid_locale_for_user(nil)).to eq default_locale
+      end
+    end
+  end
+
+  describe "self#available_locale?" do
+    it "returns true if locale is available" do
+      expect(UserLocaleSetter.available_locale?("es")).to be true
+    end
+
+    it "returns false if locale is not available" do
+      expect(UserLocaleSetter.available_locale?("xx")).to be false
+    end
+
+    it "returns false if nil is given for locale" do
+      expect(UserLocaleSetter.available_locale?(nil)).to be false
+    end
+  end
+end

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -68,6 +68,11 @@ module AuthenticationWorkflow
     fill_in "password", with: user.password
     click_button "Login"
   end
+
+  def expect_logged_in
+    # Ensure page has been reloaded after submitting login form
+    expect(page).to_not have_selector ".menu #login-link"
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
#### What? Why?

Closes #5669 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds some defensive code to guard against cases where a user has a locale saved that is not in the available_locales list, possibly due to the available locales changing between user logins. This was causing fatal errors in some edge cases.

#### What should we test?
<!-- List which features should be tested and how. -->

Login with an account that has selected a locale that is not in the available_locales list on the server resets the locale to the default, and does not cause a fatal error.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed error caused by available locales changing between logins

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
