### PR TITLE
Index spree_state_changes.stateful_id column

### DIFF
--- a/db/migrate/20200702112157_add_stateful_id_index_to_state_changes.rb
+++ b/db/migrate/20200702112157_add_stateful_id_index_to_state_changes.rb
@@ -1,0 +1,5 @@
+class AddStatefulIdIndexToStateChanges < ActiveRecord::Migration
+  def change
+    add_index :spree_state_changes, :stateful_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200630070422) do
+ActiveRecord::Schema.define(version: 20200702112157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -884,6 +884,8 @@ ActiveRecord::Schema.define(version: 20200630070422) do
     t.string   "stateful_type"
     t.string   "next_state"
   end
+
+  add_index "spree_state_changes", ["stateful_id"], name: "index_spree_state_changes_on_stateful_id", using: :btree
 
   create_table "spree_states", force: true do |t|
     t.string  "name"


### PR DESCRIPTION
#### What? Why?

This speeds up a great deal one of the most awful queries our DB servers execute. It's not rare to see traces above 20s in Datadog :scream:. Source: https://app.datadoghq.com/apm/traces?from_ts=1591104006364&index=apm-search&live=true&query=env%3Aproduction+service%3Arails-postgres+operation_name%3Apostgres.query+resource_name%3A%22SELECT+COUNT+%28+%2A+%29+FROM+spree_state_changes+WHERE+spree_state_changes+.+stateful_id+%3D+%3F+AND+spree_state_changes+.+stateful_type+%3D+%3F%22&spanID&stream_sort=desc&to_ts=1593696006364&trace&traceID

In staging, with no traffic, we go from

```
EXPLAIN ANALYZE SELECT COUNT ( * )
FROM spree_state_changes
WHERE spree_state_changes . stateful_id = 2024
  AND spree_state_changes . stateful_type = 'Spree::Order';

Planning time: 0.142 ms
Execution time: 9.073 ms
```

to

```
EXPLAIN ANALYZE SELECT COUNT ( * )
FROM spree_state_changes
WHERE spree_state_changes . stateful_id = 2024
  AND spree_state_changes . stateful_type = 'Spree::Order';

Planning time: 0.284 ms
Execution time: 0.202 ms
```

There's no point on indexing any other column because apparently there's only a `stateful_type`, `Spree::Order`.

#### What should we test?

There's not much we can test. As far as I know this query is only executed when accessing /admin/orders/Rxxxxx/edit. It should keep working but an index can't break it anyway.

#### Release notes

Speed up order edition from admin and lower the pressure it exerts on the DB.
Changelog Category: Changed
