### PR TITLE
Fix default image display in admin order edit

### DIFF
--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -4,7 +4,7 @@
   - if line_item.present?
     %tr.stock-item{ "data-item-quantity" => "#{item.quantity}" }
       %td.item-image
-        = mini_image(item.variant)
+        = render 'spree/shared/variant_thumbnail', variant: item.variant
       %td.item-name
         = item.variant.product_and_full_name
       %td.item-price.align-center


### PR DESCRIPTION
#### What? Why?

Closes #5724 
Related to #5701

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Fixes product thumbnails in admin order edit.

#### What should we test?
<!-- List which features should be tested and how. -->

Default image and regular images are both displayed correctly for products in order edit page.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Updated thumbnail image paths in admin order edit

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
