### PR TITLE
Fix flaky embedded shopping spec

### DIFF
--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -67,6 +67,7 @@ module UIComponentHelper
 
   def toggle_cart
     page.find("#cart").click
+    sleep 0.3 # Allow 300ms for sidebar animation to finish
   end
 
   def wait_for_ajax


### PR DESCRIPTION
#### What? Why?

Closes #3918 

The new cart sidebar takes 300ms to animate into the page. If we try to click inside the cart sidebar on the button on the left during this time, we may click the button on the right as it slides in, and we end up on the checkout page instead of the cart page. This adjustment might help with other flaky specs as well...

#### What should we test?
<!-- List which features should be tested and how. -->

Less flaky build. 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved flaky spec for embedded shopfronts.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
