### PR TITLE
Fix flaky variant_override spec

### DIFF
--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -27,7 +27,7 @@ class VariantOverride < ActiveRecord::Base
   localize_number :price
 
   def self.indexed(hub)
-    for_hubs(hub).preload(:variant).index_by(&:variant)
+    for_hubs(hub).includes(:variant).index_by(&:variant)
   end
 
   def stock_overridden?


### PR DESCRIPTION
#### What? Why?

Closes #5735 

It looks like `#preload` on associated objects doesn't apply the soft-deleted scopes nicely, but `#includes` might work better.

Reference: https://github.com/ActsAsParanoid/acts_as_paranoid/pull/37


#### What should we test?
<!-- List which features should be tested and how. -->

Less flaky build...

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved flaky variant_override spec

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

