### PR TITLE
Flaky spec order_cycles/complex_updating_specific_time

### DIFF
--- a/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -87,6 +87,7 @@ feature '
     select 'Supplier fee 2', from: 'order_cycle_incoming_exchange_2_enterprise_fees_0_enterprise_fee_id'
 
     click_button 'Save and Next'
+    expect(page).to have_content 'Your order cycle has been updated.'
 
     # And I add a distributor and some products
     select 'My distributor', from: 'new_distributor_id'

--- a/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -69,7 +69,8 @@ feature '
     select 'My supplier', from: 'new_supplier_id'
     click_button 'Add supplier'
     expect(page).to have_selector("table.exchanges tr.supplier", text: "My supplier")
-    page.all("table.exchanges tr.supplier td.products").each(&:click)
+
+    open_all_exchange_product_tabs
 
     expect(page).to have_selector "#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}", visible: true
     page.find("#order_cycle_incoming_exchange_1_variants_#{initial_variants.last.id}", visible: true).click # uncheck (with visible:true filter)
@@ -106,14 +107,7 @@ feature '
       find(:css, "tags-input .tags input").set "wholesale\n"
     end
 
-    exchange_rows = page.all("table.exchanges tbody")
-    exchange_rows.each do |exchange_row|
-      exchange_row.find("td.products").click
-      within(exchange_row) do
-        # Wait for the products panel to be visible.
-        expect(page).to have_selector ".exchange-distributed-products"
-      end
-    end
+    open_all_exchange_product_tabs
 
     uncheck "order_cycle_outgoing_exchange_2_variants_#{v1.id}"
     check "order_cycle_outgoing_exchange_2_variants_#{v2.id}"
@@ -167,5 +161,16 @@ feature '
 
   def wait_for_edit_form_to_load_order_cycle(order_cycle)
     expect(page).to have_field "order_cycle_name", with: order_cycle.name
+  end
+
+  def open_all_exchange_product_tabs
+    exchange_rows = page.all("table.exchanges tbody")
+    exchange_rows.each do |exchange_row|
+      exchange_row.find("td.products").click
+      within(exchange_row) do
+        # Wait for the products panel to be visible.
+        expect(page).to have_selector ".exchange-products"
+      end
+    end
   end
 end

--- a/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -109,8 +109,10 @@ feature '
     exchange_rows = page.all("table.exchanges tbody")
     exchange_rows.each do |exchange_row|
       exchange_row.find("td.products").click
-      # Wait for the products panel to be visible.
-      expect(exchange_row).to have_selector "tr", count: 2
+      within(exchange_row) do
+        # Wait for the products panel to be visible.
+        expect(page).to have_selector ".exchange-distributed-products"
+      end
     end
 
     uncheck "order_cycle_outgoing_exchange_2_variants_#{v1.id}"


### PR DESCRIPTION
#### What? Why?

Closes #5634 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adjusts some #expect calls to improve waiting and page interactions.

#### What should we test?
<!-- List which features should be tested and how. -->

Less flaky build.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved flaky complex_updating_specific_time_spec

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

