### PR TITLE
Re-enable and fix flaky exchange products renderer spec

### DIFF
--- a/spec/services/exchange_products_renderer_spec.rb
+++ b/spec/services/exchange_products_renderer_spec.rb
@@ -36,8 +36,8 @@ describe ExchangeProductsRenderer do
         expect(variants.first.product.supplier.name).to eq exchange.variants.first.product.supplier.name
       end
 
-      xdescribe "when OC is showing only the coordinators inventory" do
-        let(:exchange_with_visible_variant) { order_cycle.exchanges.incoming.second }
+      describe "when OC is showing only the coordinators inventory" do
+        let(:exchange_with_visible_variant) { order_cycle.exchanges.incoming.last }
         let(:exchange_with_hidden_variant) { order_cycle.exchanges.incoming.first }
         let!(:visible_inventory_item) { create(:inventory_item, enterprise: order_cycle.coordinator, variant: exchange_with_visible_variant.variants.first, visible: true) }
         let!(:hidden_inventory_item) { create(:inventory_item, enterprise: order_cycle.coordinator, variant: exchange_with_hidden_variant.variants.first, visible: false) }


### PR DESCRIPTION
#### What? Why?

Closes #4899

For some inexplicable reason `order_cycle.exchanges.incoming.first` and `order_cycle.exchanges.incoming.second` were returning the same exchange here. Subsequently the inventory items being created were for the same variant, which then threw a fatal error due to a uniqueness validation in `InventoryItem` on `variant_id`. Changing from #first and #second to #first and #last results in the correct exchanges being assigned.

#### What should we test?
<!-- List which features should be tested and how. -->

Less flaky build.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved flaky spec for exchange_products_renderer

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

