### PR TITLE
Fix flaky shopping_spec

### DIFF
--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -96,6 +96,7 @@ module ShopWorkflow
 
   def within_variant(variant = nil)
     selector = variant ? "#variant-#{variant.id}" : ".variants"
+    expect(page).to have_selector selector
     within(selector) do
       yield
     end


### PR DESCRIPTION
#### What? Why?

Closes ?

Ensures products list has loaded before interacting with product list UI elements

Flaky spec:
```
1) As a consumer I want to shop with a distributor Viewing a distributor adding and removing products from cart when a variant is soft-deleted when the soft-deleted variant has an associated override adding the soft-deleted variant to the cart handles it as if the variant has gone out of stock
     Failure/Error:
       within(selector) do
         yield
       end
     
     Capybara::ElementNotFound:
       Unable to find visible css "#variant-78"
     # ./spec/support/request/shop_workflow.rb:99:in `within_variant'
     # ./spec/support/request/shop_workflow.rb:62:in `click_add_to_cart'
     # ./spec/features/consumer/shopping/shopping_spec.rb:430:in `block (7 levels) in <top (required)>
```

Build: https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/branches/pull-request-5741/builds/2


#### What should we test?
<!-- List which features should be tested and how. -->

Less flaky build.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved flaky shopping spec

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

