### PR TITLE
Make keyboard UI close on iOS when done searching

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/disable_enter_with_blur.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/disable_enter_with_blur.js.coffee
@@ -1,0 +1,9 @@
+Darkswarm.directive "disableEnterWithBlur", ()->
+  # Stops enter from doing normal enter things, and blurs the input
+  restrict: 'A'
+  link: (scope, element, attrs)->
+    element.bind "keydown keypress", (e)->
+      code = e.keyCode || e.which
+      if code == 13
+        element.blur()
+        e.preventDefault()

--- a/app/views/shop/products/_searchbar.haml
+++ b/app/views/shop/products/_searchbar.haml
@@ -6,7 +6,7 @@
               type: 'search',
               placeholder: t(:products_search),
               "ng-debounce" => "200",
-              "ofn-disable-enter" => true}
+              "disable-enter-with-blur" => true}
         %a.clear{type: 'button', ng: {show: 'query', click: 'clearQuery()'}, 'focus-search' => true}
           = image_tag "icn-close.png"
 


### PR DESCRIPTION
### What? Why?

Closes #5434

Change to new directive that prevents enter default and blurs the input field. This closes the keyboard UI when the user selects the 'search' button (an alias for enter)



#### What should we test?
- navigate to a shop on an iOS device
- click on the search field
- enter a search string
- click search (on the iOS keyboard)

The search results are displayed (updated on each key press) and the keyboard is hidden

#### Release notes
Fixed hiding of keyboard when done searching products in a shop

Changelog Category: Changed 
