### PR TITLE
Add rescue statements with bugsnag alerts to subs jobs

### DIFF
--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -50,6 +50,8 @@ class SubscriptionConfirmJob
     else
       send_failed_payment_email(order)
     end
+  rescue StandardError => e
+    Bugsnag.notify(e, order: order)
   end
 
   def process_payment!(order)

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -61,13 +61,16 @@ class SubscriptionConfirmJob
     raise if order.errors.present?
     return unless order.payment_required?
 
+    prepare_for_payment!(order)
+    order.process_payments!
+    raise if order.errors.any?
+  end
+
+  def prepare_for_payment!(order)
     setup_payment!(order)
     raise if order.errors.any?
 
     authorize_payment!(order)
-    raise if order.errors.any?
-
-    order.process_payments!
     raise if order.errors.any?
   end
 

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -94,5 +94,7 @@ class SubscriptionConfirmJob
     order.update!
     record_and_log_error(:failed_payment, order, error_message)
     SubscriptionMailer.failed_payment_email(order).deliver
+  rescue StandardError => e
+    Bugsnag.notify(e, order: order, error_message: error_message)
   end
 end

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -52,6 +52,7 @@ class SubscriptionConfirmJob
     end
   rescue StandardError => e
     Bugsnag.notify(e, order: order)
+    send_failed_payment_email(order, e.message)
   end
 
   def process_payment!(order)
@@ -89,9 +90,9 @@ class SubscriptionConfirmJob
     SubscriptionMailer.confirmation_email(order).deliver
   end
 
-  def send_failed_payment_email(order)
+  def send_failed_payment_email(order, error_message = nil)
     order.update!
-    record_and_log_error(:failed_payment, order)
+    record_and_log_error(:failed_payment, order, error_message)
     SubscriptionMailer.failed_payment_email(order).deliver
   end
 end

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -29,8 +29,14 @@ class SubscriptionPlacementJob
 
   def place_order_for(proxy_order)
     JobLogger.logger.info("Placing Order for Proxy Order #{proxy_order.id}")
-    proxy_order.initialise_order!
+    initialise_order(proxy_order)
     place_order(proxy_order.order)
+  end
+
+  def initialise_order(proxy_order)
+    proxy_order.initialise_order!
+  rescue StandardError => e
+    Bugsnag.notify(e, subscription: proxy_order.subscription, proxy_order: proxy_order)
   end
 
   def place_order(order)
@@ -42,8 +48,9 @@ class SubscriptionPlacementJob
 
     move_to_completion(order)
     send_placement_email(order, changes)
-  rescue StateMachine::InvalidTransition
-    record_and_log_error(:processing, order)
+  rescue StandardError => e
+    record_and_log_error(:processing, order, e.message)
+    Bugsnag.notify(e, order: order)
   end
 
   def cap_quantity_and_store_changes(order)

--- a/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
@@ -22,12 +22,15 @@ module OrderManagement
         summary_for(order).record_issue(type, order, message)
       end
 
-      def record_and_log_error(type, order)
+      def record_and_log_error(type, order, error_message = nil)
         return record_issue(type, order) unless order.errors.any?
 
         error = "Subscription#{type.to_s.camelize}Error"
         line1 = "#{error}: Cannot process order #{order.number} due to errors"
-        line2 = "Errors: #{order.errors.full_messages.join(', ')}"
+
+        error_message ||= order.errors.full_messages.join(', ')
+        line2 = "Errors: #{error_message}"
+
         JobLogger.logger.info("#{line1}\n#{line2}")
         record_issue(type, order, line2)
       end

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -216,7 +216,7 @@ describe SubscriptionConfirmJob do
 
     it "records and logs an error and sends the email" do
       expect(order).to receive(:update!)
-      expect(job).to receive(:record_and_log_error).with(:failed_payment, order).once
+      expect(job).to receive(:record_and_log_error).with(:failed_payment, order, nil).once
       job.send(:send_failed_payment_email, order)
       expect(SubscriptionMailer).to have_received(:failed_payment_email).with(order)
       expect(mail_mock).to have_received(:deliver)


### PR DESCRIPTION
## What? Why?

With this, when an order placement or confirmation fails, there's a bugsnag alert for it and the job continues processing the rest of the orders.
This basically fixes both #4981 and #4983
Closes #4981 and #4983

#### What should we test?
Subscriptions are really tricky to test with all the processing scenarios. I think this is a good opportunity to think about and improve our test scenarios for error cases. Let's work this together when this comes to Test Ready?

We need to test some error scenarios in subscriptions:
- for confirm job: expired credit card in one of the orders, confirm the rest of the orders still go through (I dont think there's a way to ensure the order with the error is not the last one. maybe we should have two orders with problems in one given test and make sure both errors show up in bugssnag)
- for placement job: tbh I cant remember a real case where the placement job failed... thoughts?

#### Release notes
Changelog Category: Added
The jobs that process subscriptions orders placement and completion are more resilient now and will always process all orders even if one specific order fails.