### PR TITLE
Make broken spec fail reliably and set it pending

### DIFF
--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -194,14 +194,16 @@ feature "As a consumer I want to shop with a distributor", js: true do
       end
 
       it "returns search results for products where the search term matches one of the product's variant names" do
+        pending "has been broken for a while"
+
         visit shop_path
         fill_in "search", with: "Badg"           # For variant with display_name "Badgers"
 
         within('div.pad-top') do
-          expect(page).to have_content product.name
-          expect(page).to have_content variant2.display_name
           expect(page).not_to have_content product2.name
           expect(page).not_to have_content variant3.display_name
+          expect(page).to have_content product.name
+          expect(page).to have_content variant2.display_name
         end
       end
 


### PR DESCRIPTION

#### What? Why?

This spec has been broken for a long time, at least eight months. But it
regularly passed because the search filter is applied with a delay and
in that time the content matches. And once the filter is applied, no
products are shown and the negative matchers pass.


#### What should we test?
<!-- List which features should be tested and how. -->

No test.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

More accurate tests.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
