### PR TITLE
5764 Provide credit card brand to Pin Payments

### DIFF
--- a/app/services/checkout/form_data_adapter.rb
+++ b/app/services/checkout/form_data_adapter.rb
@@ -12,6 +12,8 @@ module Checkout
 
       move_payment_source_to_payment_attributes!
 
+      fill_in_card_type
+
       set_amount_in_payments_attributes
 
       construct_saved_card_attributes if @params[:order][:existing_card_id]
@@ -29,6 +31,18 @@ module Checkout
                     payment_source_params = delete_payment_source_params!
 
       @params[:order][:payments_attributes].first[:source_attributes] = payment_source_params
+    end
+
+    def fill_in_card_type
+      payment = params[:order][:payments_attributes]&.first&.dig(:source_attributes)
+
+      return if payment&.dig(:number).blank?
+
+      payment[:cc_type] ||= card_brand(payment[:number])
+    end
+
+    def card_brand(number)
+      ActiveMerchant::Billing::CreditCard.brand?(number)
     end
 
     def delete_payment_source_params!

--- a/app/services/checkout/form_data_adapter.rb
+++ b/app/services/checkout/form_data_adapter.rb
@@ -34,11 +34,16 @@ module Checkout
     end
 
     def fill_in_card_type
-      payment = params[:order][:payments_attributes]&.first&.dig(:source_attributes)
+      return unless payment_source_attributes
 
-      return if payment&.dig(:number).blank?
+      return if payment_source_attributes.dig(:number).blank?
 
-      payment[:cc_type] ||= card_brand(payment[:number])
+      payment_source_attributes[:cc_type] ||= card_brand(payment_source_attributes[:number])
+    end
+
+    def payment_source_attributes
+      @payment_source_attributes ||=
+        params[:order][:payments_attributes]&.first&.dig(:source_attributes)
     end
 
     def card_brand(number)

--- a/app/services/checkout/form_data_adapter.rb
+++ b/app/services/checkout/form_data_adapter.rb
@@ -33,6 +33,11 @@ module Checkout
       @params[:order][:payments_attributes].first[:source_attributes] = payment_source_params
     end
 
+    # Ensures cc_type is always passed to the model by inferring the type when
+    # the frontend didn't provide it. This fixes Pin Payments specifically
+    # although it might be useful for future payment gateways.
+    #
+    # More details:  app/assets/javascripts/darkswarm/services/checkout.js.coffee#L70-L98
     def fill_in_card_type
       return unless payment_source_attributes
 

--- a/spec/services/checkout/form_data_adapter_spec.rb
+++ b/spec/services/checkout/form_data_adapter_spec.rb
@@ -36,6 +36,26 @@ describe Checkout::FormDataAdapter do
         end
       end
 
+      describe "and a credit card is provided" do
+        before do
+          params[:order][:payments_attributes].first[:source_attributes] = {number: "4444333322221111"}
+        end
+
+        it "fills in missing credit card brand" do
+          expect(adapter.params[:order][:payments_attributes].first[:source_attributes][:cc_type]).to eq "visa"
+        end
+
+        it "leaves an existing credit card brand" do
+          params[:order][:payments_attributes].first[:source_attributes][:cc_type] = "test"
+          expect(adapter.params[:order][:payments_attributes].first[:source_attributes][:cc_type]).to eq "test"
+        end
+
+        it "doesn't touch the credit card brand without a number" do
+          params[:order][:payments_attributes].first[:source_attributes][:number] = ""
+          expect(adapter.params[:order][:payments_attributes].first[:source_attributes].key?(:cc_type)).to eq false
+        end
+      end
+
       describe "and existing credit card is provided" do
         before { params[:order][:existing_card_id] = credit_card.id }
 


### PR DESCRIPTION
#### What? Why?

Closes #5764

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Spree changed the way they determine the brand of a credit card. They do it via Javascript and removed the Ruby code. We were missing the card's name and without it a payment method can't determine if it supports that credit card. :bomb: 

#### What should we test?
<!-- List which features should be tested and how. -->

* Create a payment method with Pin Payments.
* You can obtain a test API key by creating an account at Pin Payments or use the one I saved in Bitwarden.
* Set the server to `test` and check test test mode box.
* Open an order cycle with that enterprise.
* Check out using a test credit card: https://pinpayments.com/developers/api-reference/test-cards
* The error message from the issue should not come up.
* If you use an unsupported card brand like Diners `30000000056030` you should see the error message:
  > That payment method is unsupported. Please choose another one.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed Pin Payments payment method

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->

The last Spree upgrade caused the bug.
