### PR TITLE
Update StrongParams for Pin Payments

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -97,7 +97,7 @@ module Spree
           :name, :description, :type, :active,
           :environment, :display_on, :tag_list,
           :preferred_enterprise_id, :preferred_server, :preferred_login, :preferred_password,
-          :calculator_type,
+          :calculator_type, :preferred_api_key,
           :preferred_signature, :preferred_solution, :preferred_landing_page, :preferred_logourl,
           :preferred_test_mode, distributor_ids: []
         )

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -39,6 +39,20 @@ module Spree
         expect(response).to redirect_to spree.edit_admin_payment_method_path(assigns(:payment_method))
       end
 
+      it "can save Pin Payment payment method details" do
+        expect {
+          spree_post :create, payment_method: {
+            name: "Test Method", type: "Spree::Gateway::Pin", distributor_ids: [enterprise.id],
+            preferred_server: "test", preferred_api_key: "apikey123", preferred_test_mode: "1"
+          }
+        }.to change(Spree::PaymentMethod, :count).by(1)
+
+        payment_method = Spree::PaymentMethod.last
+        expect(payment_method.preferences[:server]).to eq "test"
+        expect(payment_method.preferences[:api_key]).to eq "apikey123"
+        expect(payment_method.preferences[:test_mode]).to eq true
+      end
+
       it "can not create a payment method of an invalid type" do
         expect {
           spree_post :create, payment_method: { name: "Invalid Payment Method", type: "Spree::InvalidType", distributor_ids: [enterprise.id] }


### PR DESCRIPTION
#### What? Why?

Closes #5767

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds missing Strong Params for form fields when updating "Pin" payment method type.

#### What should we test?
<!-- List which features should be tested and how. -->

Creating / Updating Pin Payments payment method works.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added Strong Params for admin pin payments form.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

