### PR TITLE
Make OC advanced settings work by permitting the extra parameter and make the OC edit page work with that option activated

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -63,8 +63,7 @@ Spree::Product.class_eval do
   scope :visible_for, lambda { |enterprise|
     joins('LEFT OUTER JOIN spree_variants AS o_spree_variants ON (o_spree_variants.product_id = spree_products.id)').
       joins('LEFT OUTER JOIN inventory_items AS o_inventory_items ON (o_spree_variants.id = o_inventory_items.variant_id)').
-      where('o_inventory_items.enterprise_id = (?) AND visible = (?)', enterprise, true).
-      select('DISTINCT spree_products.*')
+      where('o_inventory_items.enterprise_id = (?) AND visible = (?)', enterprise, true)
   }
 
   # -- Scopes

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -30,7 +30,9 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
   def products_scope
     products_relation = object.supplied_products
     if order_cycle.prefers_product_selection_from_coordinator_inventory_only?
-      products_relation = products_relation.visible_for(order_cycle.coordinator)
+      products_relation = products_relation.
+        visible_for(order_cycle.coordinator).
+        select('DISTINCT spree_products.*')
     end
     products_relation.order(:name)
   end

--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -34,7 +34,7 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
         visible_for(order_cycle.coordinator).
         select('DISTINCT spree_products.*')
     end
-    products_relation.order(:name)
+    products_relation
   end
 
   def products

--- a/app/services/permitted_attributes/order_cycle.rb
+++ b/app/services/permitted_attributes/order_cycle.rb
@@ -11,6 +11,7 @@ module PermittedAttributes
 
       @params.require(:order_cycle).permit(
         :name, :orders_open_at, :orders_close_at, :coordinator_id,
+        :preferred_product_selection_from_coordinator_inventory_only,
         incoming_exchanges: permitted_exchange_attributes,
         outgoing_exchanges: permitted_exchange_attributes,
         schedule_ids: [], coordinator_fee_ids: []

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -178,9 +178,21 @@ module Admin
 
           it "returns an error message" do
             spree_put :update, params
+
             json_response = JSON.parse(response.body)
             expect(json_response['errors']).to be
           end
+        end
+
+        it "can update preference product_selection_from_coordinator_inventory_only" do
+          expect(OrderCycleForm).to receive(:new).
+            with(order_cycle,
+                 { "preferred_product_selection_from_coordinator_inventory_only" => true },
+                 anything) { form_mock }
+          allow(form_mock).to receive(:save) { true }
+
+          spree_put :update, params.
+            merge(order_cycle: { preferred_product_selection_from_coordinator_inventory_only: true })
         end
       end
     end

--- a/spec/services/exchange_products_renderer_spec.rb
+++ b/spec/services/exchange_products_renderer_spec.rb
@@ -7,8 +7,9 @@ describe ExchangeProductsRenderer do
 
   describe "#exchange_products" do
     describe "for an incoming exchange" do
+      let(:exchange) { order_cycle.exchanges.incoming.first }
+
       it "loads products" do
-        exchange = order_cycle.exchanges.incoming.first
         products = renderer.exchange_products(true, exchange.sender)
 
         expect(products.first.supplier.name).to eq exchange.variants.first.product.supplier.name
@@ -16,13 +17,33 @@ describe ExchangeProductsRenderer do
     end
 
     describe "for an outgoing exchange" do
+      let(:exchange) { order_cycle.exchanges.outgoing.first }
+
       it "loads products" do
-        exchange = order_cycle.exchanges.outgoing.first
         products = renderer.exchange_products(false, exchange.receiver)
 
         suppliers = [exchange.variants[0].product.supplier.name, exchange.variants[1].product.supplier.name]
         expect(suppliers).to include products.first.supplier.name
         expect(suppliers).to include products.second.supplier.name
+      end
+
+      context "showing products from coordinator inventory only" do
+        before { order_cycle.update prefers_product_selection_from_coordinator_inventory_only: true }
+
+        it "loads no products if there are no products from the coordinator inventory" do
+          products = renderer.exchange_products(false, exchange.receiver)
+
+          expect(products).to be_empty
+        end
+
+        it "loads products from the coordinator inventory" do
+          # Add variant already in the exchange to the coordinator's inventory
+          exchange.variants.first.inventory_items = [create(:inventory_item, enterprise: order_cycle.coordinator)]
+
+          products = renderer.exchange_products(false, exchange.receiver)
+
+          expect(products).to eq [exchange.variants.first.product]
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #5773 & #5802

Setting the filter in the OC to products from coordinator inventory only was broken due to strong params permissions. That is fixed in this PR.
But the main issue 5773 was when the filter products from coordinator inventory only was active. For some reason in rails 4 the SQL query generation was going wrong and the list of fields in the select part of the SQL included the select from both the visible_for scope in product (which had a distinct in it) and the fields from the included table variants. In this PR I just remove the select from the visible_for scope as it is not needed for this exchange renderer.

#### What should we test?
I can see the problem with the live data on my local machine and I confirm the PR fixes the problem.
For this reason I havent tried to replicate the problem with other data/OC. I did write a auto test that validates the bug so I believe it as simple as activating the "inventory only" option and add some variants to the exchanges.

We should validate the OC page features around adding and removing different types of variants to the exchanges. This combined with activating the "inventory only" setting and validating it works as appropriate: only variants from the coordinators inventory should show in the page to be added to the OC.

#### Release notes
Changelog Category: Fixed
Fixed a bug in the Order Cycles edit page when the option "coordinator inventory only" was activated.