### PR TITLE
Handle credit validation errors

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -61,7 +61,7 @@ module Spree
         else
           flash[:error] = t(:cannot_perform_operation)
         end
-      rescue Spree::Core::GatewayError => e
+      rescue StandardError => e
         flash[:error] = e.message
       ensure
         redirect_to request.referer

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -187,7 +187,7 @@ module Spree
     # Makes newly entered payments invalidate previously entered payments so the most recent payment
     # is used by the gateway.
     def invalidate_old_payments
-      order.payments.with_state('checkout').where("id != ?", id).each do |payment|
+      order.payments.with_state('checkout').where.not(id: id).each do |payment|
         # Using update_column skips validations and so it skips validate_source. As we are just
         # invalidating past payments here, we don't want to validate all of them at this stage.
         payment.update_column(:state, 'invalid')

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -188,7 +188,6 @@ module Spree
     # is used by the gateway.
     def invalidate_old_payments
       order.payments.with_state('checkout').where("id != ?", id).each do |payment|
-
         # Using update_column skips validations and so it skips validate_source. As we are just
         # invalidating past payments here, we don't want to validate all of them at this stage.
         payment.update_column(:state, 'invalid')

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -22,7 +22,7 @@ module Spree
 
     has_one :adjustment, as: :source, dependent: :destroy
 
-    before_validation :validate_source
+    validate :validate_source
     before_save :set_unique_identifier
 
     after_save :create_payment_profile, if: :profiles_supported?

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -191,6 +191,7 @@ module Spree
         # Using update_column skips validations and so it skips validate_source. As we are just
         # invalidating past payments here, we don't want to validate all of them at this stage.
         payment.update_column(:state, 'invalid')
+        payment.ensure_correct_adjustment
       end
     end
 

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -147,7 +147,7 @@ module Spree
           record_response(response)
 
           if response.success?
-            self.class.create(order: order,
+            self.class.create!(order: order,
                               source: self,
                               payment_method: payment_method,
                               amount: refund_amount.abs * -1,

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -152,7 +152,8 @@ module Spree
                               payment_method: payment_method,
                               amount: refund_amount.abs * -1,
                               response_code: response.authorization,
-                              state: 'completed')
+                              state: 'completed',
+                              skip_source_validation: true)
           else
             gateway_error(response)
           end

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -114,7 +114,8 @@ module Spree
               payment_method: payment_method,
               amount: credit_amount.abs * -1,
               response_code: response.authorization,
-              state: 'completed'
+              state: 'completed',
+              skip_source_validation: true
             )
           else
             gateway_error(response)

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -108,7 +108,7 @@ module Spree
           record_response(response)
 
           if response.success?
-            self.class.create(
+            self.class.create!(
               order: order,
               source: self,
               payment_method: payment_method,

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -147,13 +147,15 @@ module Spree
           record_response(response)
 
           if response.success?
-            self.class.create!(order: order,
-                              source: self,
-                              payment_method: payment_method,
-                              amount: refund_amount.abs * -1,
-                              response_code: response.authorization,
-                              state: 'completed',
-                              skip_source_validation: true)
+            self.class.create!(
+              order: order,
+              source: self,
+              payment_method: payment_method,
+              amount: refund_amount.abs * -1,
+              response_code: response.authorization,
+              state: 'completed',
+              skip_source_validation: true
+            )
           else
             gateway_error(response)
           end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
       spree/payment:
         amount: Amount
         state: State
+        source: Source
       spree/product:
         primary_taxon: "Product Category"
         supplier: "Supplier"

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -157,6 +157,8 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
       let(:params) { { e: 'credit', order_id: order.number, id: payment.id } }
 
+      let(:successful_response) { ActiveMerchant::Billing::Response.new(true, "Yay!") }
+
       before do
         allow(request).to receive(:referer) { 'http://foo.com' }
         allow(Spree::Payment).to receive(:find).with(payment.id.to_s) { payment }
@@ -179,6 +181,14 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
         expect(flash[:error]).to eq('validation error')
         expect(response).to redirect_to('http://foo.com')
+      end
+
+      it 'displays a success message and redirects to the referer' do
+        allow(payment_method).to receive(:credit) { successful_response }
+
+        spree_put :fire, params
+
+        expect(flash[:success]).to eq(I18n.t(:payment_updated))
       end
     end
   end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -725,7 +725,7 @@ describe Spree::Payment do
       end
     end
 
-    describe "refunding" do
+    describe "refund!" do
       let(:payment) { create(:payment) }
       let(:success) { double(success?: true, authorization: 'abc123') }
       let(:failure) { double(success?: false) }

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -391,13 +391,13 @@ describe Spree::Payment do
 
         context "when response is successful" do
           it "should create an offsetting payment" do
-            Spree::Payment.should_receive(:create!)
+            expect(Spree::Payment).to receive(:create!)
             payment.credit!
           end
 
           it "resulting payment should have correct values" do
-            payment.order.stub :outstanding_balance => 100
-            payment.stub :credit_allowed => 10
+            allow(payment.order).to receive(:outstanding_balance) { 100 }
+            allow(payment).to receive(:credit_allowed) { 10 }
 
             offsetting_payment = payment.credit!
             expect(offsetting_payment.amount.to_f).to eq(-10)

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -391,7 +391,7 @@ describe Spree::Payment do
 
         context "when response is successful" do
           it "should create an offsetting payment" do
-            Spree::Payment.should_receive(:create)
+            Spree::Payment.should_receive(:create!)
             payment.credit!
           end
 

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -401,6 +401,25 @@ describe Spree::Payment do
             expect(offsetting_payment.response_code).to eq('12345')
             expect(offsetting_payment.source).to eq(payment)
           end
+
+          context 'and the source payment card is expired' do
+            let(:card) do
+              Spree::CreditCard.new(month: 12, year: 1995, number: '4111111111111111')
+            end
+
+            let(:successful_response) do
+              ActiveMerchant::Billing::Response.new(true, "Yay!")
+            end
+
+            it 'lets the new payment to be saved' do
+              allow(payment.order).to receive(:outstanding_balance) { 100 }
+              allow(payment).to receive(:credit_allowed) { 10 }
+
+              offsetting_payment = payment.credit!
+
+              expect(offsetting_payment).to be_valid
+            end
+          end
         end
       end
     end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -2,11 +2,7 @@ require 'spec_helper'
 
 describe Spree::Payment do
   context 'original specs from Spree' do
-    let(:order) do
-      order = Spree::Order.new(:bill_address => Spree::Address.new,
-                               :ship_address => Spree::Address.new)
-    end
-
+    let(:order) { create(:order) }
     let(:gateway) do
       gateway = Spree::Gateway::Bogus.new(:environment => 'test', :active => true)
       gateway.stub :source_required => true
@@ -339,7 +335,7 @@ describe Spree::Payment do
 
       context "#credit" do
         before do
-          payment.state = 'complete'
+          payment.state = 'completed'
           payment.response_code = '123'
         end
 


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/5449

Note this is based on #5806.

I'm not particularly happy about having to come down to the `attr_accessor` trick to skip a callback but this prevents this fix from growing exponentially on LOCs and avoids the risk of making the wrong assumptions. What I like about it is that `skip_source_validation` is explicit enough to pave the way for extracting specific per use-case service objects in the future.

#### What should we test?

We need to cover all payment scenarios:

* Issue a partial credit with each supported payment gateway
* Issue a void operation with each supported payment gateway
* Issue a capture operation with each supported payment gateway
* Place a regular order as a consumer
* Place an order as an admin

When performing these actions as admin, the payment total should be accurate, taking into account any payment fees.

#### Release notes

Handle credit and other payment actions whose credit card is now expired. Stripe kept track of them and we weren't
Changelog Category: Fixed
