### PR TITLE
Missing translation key for description, display, tags

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2902,6 +2902,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   shipping_tax_rate: "Shipping Tax Rate"
   category: "Category"
   delivery: "Delivery"
+  description: "Description"
+  display: "Display"
+  tags: "Tags"
   temperature_controlled: "Temperature Controlled"
   new_product: "New Product"
 


### PR DESCRIPTION
In admin/shipping_methods/new

#### What? Why?

Closes #[the issue number this PR is related to]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
When creating a new shipping method in path "admin/shipping_methods/new" some keys not translated

![image](https://user-images.githubusercontent.com/928628/87949696-09c1ba00-caaf-11ea-83dc-9df929dda020.png)

![image](https://user-images.githubusercontent.com/928628/87949726-10503180-caaf-11ea-839a-97439f055c78.png)

![image](https://user-images.githubusercontent.com/928628/87949746-16461280-caaf-11ea-8c86-cbaa5e67a8cc.png)

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

