### PR TITLE
Make charges update method update the first pending payment

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -432,8 +432,8 @@ Spree::Order.class_eval do
   # amount here.
   def charge_shipping_and_payment_fees!
     update_totals
-    return unless payments.any?
+    return unless pending_payments.any?
 
-    payments.first.update_attribute :amount, total
+    pending_payments.first.update_attribute :amount, total
   end
 end


### PR DESCRIPTION
Updating the first overall payment could select a failed payment and ignore the pending payment that is about to be processed

#### What? Why?

Closes #5774

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

