### PR TITLE
Remove conflicting and duplicate route

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -59,7 +59,7 @@ module Spree
       if @user
         authorize! params[:action].to_sym, @user
       else
-        redirect_to spree.login_path
+        redirect_to main_app.login_path
       end
     end
 

--- a/app/controllers/user_passwords_controller.rb
+++ b/app/controllers/user_passwords_controller.rb
@@ -10,7 +10,7 @@ class UserPasswordsController < Spree::UserPasswordsController
 
     if resource.errors.empty?
       set_flash_message(:success, :send_instructions) if is_navigational_format?
-      respond_with resource, location: spree.login_path
+      respond_with resource, location: main_app.login_path
     else
       respond_to do |format|
         format.html do

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -15,7 +15,6 @@ Spree::Core::Engine.routes.draw do
   resources :users, :only => [:edit, :update]
 
   devise_scope :spree_user do
-    get '/login' => 'user_sessions#new', :as => :login
     post '/login' => 'user_sessions#create', :as => :create_new_session
     get '/logout' => 'user_sessions#destroy', :as => :logout
     get '/signup' => 'user_registrations#new', :as => :signup

--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -11,7 +11,9 @@ module Spree
       current_spree_user
     end
 
-    delegate :login_path, to: :spree, prefix: true
+    def spree_login_path
+      main_app.login_path
+    end
 
     delegate :signup_path, to: :spree, prefix: true
 


### PR DESCRIPTION
## What? Why?

Closes #5771

This Spree route conflicts with the one we define:

```
get "/login", to: redirect("/#/login")
```

for whatever reason there are 7 users that managed to hit the Spree one instead of ours when confirming their signup email. It's not clear to me though when this `/login?validation=confirmed` is really hit. The confirmation email link passes a token in the query params and this is not the case.

The idea is that `GET /login` makes the login modal to show up instead of Devise's default behavior (through inheritance) of showing a login form page. OFN was never prepared to handle this as this bug proofs.

#### What should we test?

Confirming a signup email and login should work as usual. I'd try both scenarios.

#### Release notes

Remove duplicate and conflicting Spree route to the login page. We don't have any.
Changelog Category: Fixed

