### PR TITLE
Make charges update method update the first pending payment

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -432,8 +432,8 @@ Spree::Order.class_eval do
   # amount here.
   def charge_shipping_and_payment_fees!
     update_totals
-    return unless payments.any?
+    return unless pending_payments.any?
 
-    payments.first.update_attribute :amount, total
+    pending_payments.first.update_attribute :amount, total
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5774

In the order workflow there's a step where the fees are recalculated, charge_shipping_and_payment_fees! (there are multiple places where the fees are updated, this is one of them see_no_evil). In this method we are updating the payment amount based on the order total, but the process is selecting the first payment of the order (not the first pending payment) which can result in updating the total in a past failed payment, not the payment that will be processed.
For some reason in rails 3 the first payment was the pending one and now in rails 4 the first one is coming up as one of the previous/failed payments. The amount of the previous/failed payment is updated and the pending payment that will be charged now keeps the amount without fees and thus the issue reported.  

This PR updates the code to look at pending payments only heavy_check_mark
I could replicate the problem locally with live AUS data and I could verify the PR fixes the issue. This has been deployed in AUS live as v3.1.2 and it has fixed the issue.

There are auto specs missing (I didnt have time to add them this week). I think we can create an issue to add them next week. 


#### What should we test?
Try to replicate the issue. I am not sure exactly how (I couldnt replicate this with sample data, only with live aus data with a broken stripe setup) but it's all about making the first checkout attempt fail and then try again and see that the payment in the second checkout attempt doesn't include fees.  
Sorry, not very specific instructions.

#### Release notes
Changelog Category: Fixed
Several checkout attempts will now always charge all the fees of the order. 