### PR TITLE
Add migration to fix calculator preferences

### DIFF
--- a/db/migrate/20200721135726_move_calculators_preferences_outside_spree_namespace.rb
+++ b/db/migrate/20200721135726_move_calculators_preferences_outside_spree_namespace.rb
@@ -1,0 +1,23 @@
+# As we moved the calculators outside the Spree namespace in migration MoveAllCalculatorsOutsideTheSpreeNamespace
+#   We need to move their preferences too (currency, value, etc), otherwise they are not used
+class MoveCalculatorsPreferencesOutsideSpreeNamespace < ActiveRecord::Migration
+  def up
+    replace_preferences_key("/spree/calculator", "/calculator")
+  end
+
+  def down
+    replace_preferences_key("/calculator", "/spree/calculator")
+  end
+
+  private
+
+  def replace_preferences_key(from_pattern, to_pattern)
+    updated_pref_key = "replace( pref.key, '" + from_pattern + "', '" + to_pattern + "')"
+    Spree::Preference.connection.execute(
+      "UPDATE spree_preferences pref SET key = " + updated_pref_key + "
+        WHERE pref.key like '" + from_pattern + "%'
+          AND NOT EXISTS (SELECT 1 FROM spree_preferences existing_pref
+                           WHERE existing_pref.key = " + updated_pref_key + ")"
+    )
+  end
+end

--- a/db/migrate/20200721135726_move_calculators_preferences_outside_spree_namespace.rb
+++ b/db/migrate/20200721135726_move_calculators_preferences_outside_spree_namespace.rb
@@ -19,5 +19,7 @@ class MoveCalculatorsPreferencesOutsideSpreeNamespace < ActiveRecord::Migration
           AND NOT EXISTS (SELECT 1 FROM spree_preferences existing_pref
                            WHERE existing_pref.key = " + updated_pref_key + ")"
     )
+
+    Rails.cache.clear
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200702112157) do
+ActiveRecord::Schema.define(version: 20200721135726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
#### What? Why?

Closes #5795

This will change all adjustments config in spree_preferences to the new calculators without the Spree namespace.

#### What should we test?
Before staging this PR you should replicate the problem, for example, in FR staging now in fredo's farm hub shop the 10eur shipping fee are not applied:
https://staging.openfoodfrance.org/fredo-s-farm-hub/shop
I am pointing this one out because not all fees are broken (all the fees that have been edited manually since v3 release will be working correctly).
You need to test this **with existing fees** on the server, you cant edit any fees otherwise the problem is gone.
After this PR is staged the fees should be applied again.

#### Release notes
Changelog Category: Fixed
Fixed a data migration bug in a recent change to fees calculators where fees were not applied at checkout.
