### PR TITLE
Missing translation key for "permalink" and "shipping_categories"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2088,6 +2088,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   supplier: "Supplier"
   product_name: "Product Name"
   product_description: "Product Description"
+  permalink: "Permalink"
+  shipping_categories: "Shipping Categories"
   units: "Unit Size"
   coordinator: "Coordinator"
   distributor: "Distributor"


### PR DESCRIPTION
When edit product in path admin/products/PRODUCT_NAME/edit

#### What? Why?

Closes #[the issue number this PR is related to]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
In path: admin/products/PRODUCT_NAME/edit

![image](https://user-images.githubusercontent.com/928628/88076617-fa13a580-cb82-11ea-91e0-ff0a0fe64cbf.png)

![image](https://user-images.githubusercontent.com/928628/88076656-01d34a00-cb83-11ea-8f64-dc5b366793f8.png)


#### What should we test?
<!-- List which features should be tested and how. -->

I hope I inserted the keys in the right place

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security

#### How is this related to the Spree upgrade?
<!-- Any known conflicts with the Spree Upgrade?
Explain them or remove this section. -->



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

