### PR TITLE
Fix #5730 content header overlap with long product names

### DIFF
--- a/app/assets/stylesheets/admin/shared/layout.scss
+++ b/app/assets/stylesheets/admin/shared/layout.scss
@@ -24,7 +24,7 @@
     }
     &:last-child {
       padding-right: 0;
-      width: 30%;    
+      width: 30%;
     }
   }
 }

--- a/app/assets/stylesheets/admin/shared/layout.scss
+++ b/app/assets/stylesheets/admin/shared/layout.scss
@@ -20,9 +20,11 @@
 
     &:first-child {
       padding-left: 0;
+      width: 70%;
     }
     &:last-child {
       padding-right: 0;
+      width: 30%    
     }
   }
 }

--- a/app/assets/stylesheets/admin/shared/layout.scss
+++ b/app/assets/stylesheets/admin/shared/layout.scss
@@ -24,7 +24,7 @@
     }
     &:last-child {
       padding-right: 0;
-      width: 30%    
+      width: 30%;    
     }
   }
 }


### PR DESCRIPTION
#### What? Why?

Closes #5730 by wrapping long text

![image](https://user-images.githubusercontent.com/985240/88234051-b332b800-cc35-11ea-9edf-219c7011bb2b.png)



#### What should we test?

- Go to page /admin/products/<hub_name>/variants and page /admin/products/<hub_name>/images
- Edit the product name as seen above (make the length longer than page width)
- Verify that a long product name does not overlap button(s) to the right of the product name

- Check in different browsers (verified on Chrome)


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed content header overlap with buttons when product names are long
Changelog Category: Fixed
