### PR TITLE
Eager load spree_option_values_line_items

### DIFF
--- a/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
+++ b/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
@@ -138,8 +138,13 @@ module OrderManagement
         private
 
         def line_item_includes
-          [{ order: [:bill_address],
-             variant: [{ option_values: :option_type }, { product: :supplier }] }]
+          [
+            {
+              order: [:bill_address],
+              variant: [{ option_values: :option_type }, { product: :supplier }]
+            },
+            :option_values
+          ]
         end
 
         def order_permissions


### PR DESCRIPTION
#### What? Why?

Mitigates #5814 by removing an N+1 relate to spree_option_values_line_items to speed up the BulkCoop report. We move from an output like

```
web_1     |   CACHE (0.3ms)  SELECT id FROM "spree_line_items" WHERE "spree_line_items"."order_id" IN (SELECT id FROM "spree_orders" WHERE (("spree_orders"."distributor_id" IN (SELECT enterprises.id FROM "enterprises") OR "spree_orders"."order_cycle_id" IN (SELECT id FROM "order_cycles"))))
web_1     |   CACHE (0.0ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_line_items" ON "spree_option_values"."id" = "spree_option_values_line_items"."option_value_id" WHERE "spree_option_values_line_items"."line_item_id" = $1 ORDER BY spree_option_types.position asc  [["line_item_id", 4]]
web_1     |   CACHE (0.0ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_line_items" ON "spree_option_values"."id" = "spree_option_values_line_items"."option_value_id" WHERE "spree_option_values_line_items"."line_item_id" = $1 ORDER BY spree_option_types.position asc  [["line_item_id", 6]]
web_1     |   CACHE (0.0ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_line_items" ON "spree_option_values"."id" = "spree_option_values_line_items"."option_value_id" WHERE "spree_option_values_line_items"."line_item_id" = $1 ORDER BY spree_option_types.position asc  [["line_item_id", 8]]
web_1     |   CACHE (0.0ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_line_items" ON "spree_option_values"."id" = "spree_option_values_line_items"."option_value_id" WHERE "spree_option_values_line_items"."line_item_id" = $1 ORDER BY spree_option_types.position asc  [["line_item_id", 5]]
web_1     |   CACHE (0.0ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_line_items" ON "spree_option_values"."id" = "spree_option_values_line_items"."option_value_id" WHERE "spree_option_values_line_items"."line_item_id" = $1 ORDER BY spree_option_types.position asc  [["line_item_id", 7]]
web_1     |   CACHE (0.0ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_line_items" ON "spree_option_values"."id" = "spree_option_values_line_items"."option_value_id" WHERE "spree_option_values_line_items"."line_item_id" = $1 ORDER BY spree_option_types.position asc  [["line_item_id", 4]]
web_1     |   CACHE (0.0ms)  SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_line_items" ON "spree_option_values"."id" = "spree_option_values_line_items"."option_value_id" WHERE "spree_option_values_line_items"."line_item_id" = $1 ORDER BY spree_option_types.position asc  [["line_item_id", 5]]
web_1     |   Rendered engines/order_management/app/views/order_management/reports/_report.html.haml (158.5ms)
web_1     |   Rendered engines/order_management/app/views/order_management/reports/bulk_coop/create.html.haml within spree/layouts/admin (187.3ms)
```

to

```
web_1     |   CACHE (0.0ms)  SELECT id FROM "spree_line_items" WHERE "spree_line_items"."order_id" IN (SELECT id FROM "spree_orders" WHERE (("spree_orders"."distributor_id" IN (SELECT enterprises.id FROM "enterprises") OR "spree_orders"."order_cycle_id" IN (SELECT id FROM "order_cycles"))))
web_1     |   CACHE (0.0ms)  SELECT "spree_option_types".* FROM "spree_option_types" WHERE "spree_option_types"."id" = $1 ORDER BY spree_option_types.position LIMIT 1  [["id", 1]]
web_1     |   Rendered engines/order_management/app/views/order_management/reports/_report.html.haml (101.1ms)
web_1     |   Rendered engines/order_management/app/views/order_management/reports/bulk_coop/create.html.haml within spree/layouts/admin (107.9ms)
```

#### What should we test?

Rendering any of the Bulk Coop report types there should be a noticeable response-time reduction. Things should keep working as usual as there is no behavior change.

#### Release notes

Speed up Bulk Coop report by removing an N+1.

Changelog Category: Changed

