### PR TITLE
Performance improvement of the outgoing products page when editing OCs

### DIFF
--- a/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/enterprise_serializer.rb
@@ -31,8 +31,7 @@ class Api::Admin::ForOrderCycle::EnterpriseSerializer < ActiveModel::Serializer
     products_relation = object.supplied_products
     if order_cycle.prefers_product_selection_from_coordinator_inventory_only?
       products_relation = products_relation.
-        visible_for(order_cycle.coordinator).
-        select('DISTINCT spree_products.*')
+        visible_for(order_cycle.coordinator)
     end
     products_relation
   end


### PR DESCRIPTION
#### What? Why?

Testing #5775 in production we realized loading the enterprise is taking a very long time (15secs for the enterprise experiencing the bug, it's an OC with 400+ products coming from 20+ suppliers). I looked at the code I realized I could improve performance a little. See commit message.

This improvement will mitigate the problem in #5813, but wont solve it.

#### What should we test?
Like in #5775 verify the OC page, specifically outgoing exchanges, is still working with the option "coordinator inventory only". It should just be faster, I wonder if that can be seen before and after the PR :-)

#### Release notes
Changelog Category: Changed
Performance improvement of the outgoing products page when editing OCs with large numbers of products.
