### PR TITLE
Reset order state to cart in case the stripe SCA authorization step fails

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -254,6 +254,9 @@ class CheckoutController < Spree::StoreController
   end
 
   def rescue_from_spree_gateway_error(error)
+    Bugsnag.notify(error)
+    checkout_failed
+
     flash[:error] = t(:spree_gateway_error_flash_for_checkout, error: error.message)
     # This can also happen during the edit action
     #   but the response needed here is the same as when the update action fails

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -255,10 +255,9 @@ class CheckoutController < Spree::StoreController
 
   def rescue_from_spree_gateway_error(error)
     flash[:error] = t(:spree_gateway_error_flash_for_checkout, error: error.message)
-    respond_to do |format|
-      format.html { render :edit }
-      format.json { render json: { flash: flash.to_hash }, status: :bad_request }
-    end
+    # This can also happen during the edit action
+    #   but the response needed here is the same as when the update action fails
+    update_failed_response
   end
 
   def permitted_params

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -254,13 +254,10 @@ class CheckoutController < Spree::StoreController
   end
 
   def rescue_from_spree_gateway_error(error)
-    Bugsnag.notify(error)
-    checkout_failed
-
     flash[:error] = t(:spree_gateway_error_flash_for_checkout, error: error.message)
     # This can also happen during the edit action
-    #   but the response needed here is the same as when the update action fails
-    update_failed_response
+    #   but the actions and response needed are exactly the same as when the update action fails
+    update_failed(error)
   end
 
   def permitted_params

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -175,9 +175,7 @@ class CheckoutController < Spree::StoreController
         return if redirect_to_payment_gateway
       end
 
-      @order.select_shipping_method(shipping_method_id) if @order.state == "delivery"
-
-      next if OrderWorkflow.new(@order).next
+      next if OrderWorkflow.new(@order).next({ shipping_method_id: shipping_method_id })
 
       return update_failed
     end

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -152,20 +152,8 @@ class CheckoutController < Spree::StoreController
       checkout_succeeded
       redirect_to(order_path(@order)) && return
     else
-      persist_all_payments if @order.state == "payment"
       flash[:error] = order_error
       checkout_failed
-    end
-  end
-
-  # When a payment fails, the order state machine rollbacks all transactions
-  #   Here we ensure we always persist all payments
-  def persist_all_payments
-    @order.payments.each do |payment|
-      original_payment_state = payment.state
-      if original_payment_state != payment.reload.state
-        payment.update(state: original_payment_state)
-      end
     end
   end
 

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -138,14 +138,6 @@ class CheckoutController < Spree::StoreController
     current_order.payments.destroy_all if request.put?
   end
 
-  def rescue_from_spree_gateway_error(error)
-    flash[:error] = t(:spree_gateway_error_flash_for_checkout, error: error.message)
-    respond_to do |format|
-      format.html { render :edit }
-      format.json { render json: { flash: flash.to_hash }, status: :bad_request }
-    end
-  end
-
   def valid_payment_intent_provided?
     return false unless params["payment_intent"]&.starts_with?("pi_")
 
@@ -258,6 +250,14 @@ class CheckoutController < Spree::StoreController
       format.json do
         render json: { errors: @order.errors, flash: flash.to_hash }.to_json, status: :bad_request
       end
+    end
+  end
+
+  def rescue_from_spree_gateway_error(error)
+    flash[:error] = t(:spree_gateway_error_flash_for_checkout, error: error.message)
+    respond_to do |format|
+      format.html { render :edit }
+      format.json { render json: { flash: flash.to_hash }, status: :bad_request }
     end
   end
 

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -51,6 +51,8 @@ class CheckoutController < Spree::StoreController
 
     checkout_workflow(params_adapter.shipping_method_id)
   rescue Spree::Core::GatewayError => e
+    # This rescue is not replaceable by the generic rescue_from above because otherwise the rescue
+    #   below (StandardError) would catch the GatewayError and report it as a generic error
     rescue_from_spree_gateway_error(e)
   rescue StandardError => e
     flash[:error] = I18n.t("checkout.failed")

--- a/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -23,7 +23,7 @@ module Spree
               @order.associate_user!(Spree.user_class.find_by(email: @order.email))
             end
 
-            AdvanceOrderService.new(@order).call
+            OrderWorkflow.new(@order).complete
 
             @order.shipments.map(&:refresh_rates)
             flash[:success] = Spree.t('customer_details_updated')

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -35,7 +35,7 @@ module Spree
       def edit
         @order.shipments.map(&:refresh_rates)
 
-        AdvanceOrderService.new(@order).call
+        OrderWorkflow.new(@order).complete
 
         # The payment step shows an error of 'No pending payments'
         # Clearing the errors from the order object will stop this error

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -37,7 +37,7 @@ module Spree
 
             redirect_to admin_order_payments_path(@order)
           else
-            AdvanceOrderService.new(@order).call!
+            OrderWorkflow.new(@order).complete!
 
             flash[:success] = Spree.t(:new_order_completed)
             redirect_to edit_admin_order_url(@order)

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -66,7 +66,7 @@ class SubscriptionPlacementJob
   end
 
   def move_to_completion(order)
-    AdvanceOrderService.new(order).call!
+    OrderWorkflow.new(order).complete!
   end
 
   def unavailable_stock_lines_for(order)

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -1,0 +1,182 @@
+module Spree
+  class Order < ActiveRecord::Base
+    module Checkout
+      def self.included(klass)
+        klass.class_eval do
+          class_attribute :next_event_transitions
+          class_attribute :previous_states
+          class_attribute :checkout_flow
+          class_attribute :checkout_steps
+          class_attribute :removed_transitions
+
+          def self.checkout_flow(&block)
+            if block_given?
+              @checkout_flow = block
+              define_state_machine!
+            else
+              @checkout_flow
+            end
+          end
+
+          def self.define_state_machine!
+            self.checkout_steps = {}
+            self.next_event_transitions = []
+            self.previous_states = [:cart]
+            self.removed_transitions = []
+
+            # Build the checkout flow using the checkout_flow defined either
+            # within the Order class, or a decorator for that class.
+            #
+            # This method may be called multiple times depending on if the
+            # checkout_flow is re-defined in a decorator or not.
+            instance_eval(&checkout_flow)
+
+            klass = self
+
+            # To avoid a ton of warnings when the state machine is re-defined
+            StateMachine::Machine.ignore_method_conflicts = true
+            # To avoid multiple occurrences of the same transition being defined
+            # On first definition, state_machines will not be defined
+            state_machines.clear if respond_to?(:state_machines)
+            state_machine :state, :initial => :cart do
+              klass.next_event_transitions.each { |t| transition(t.merge(:on => :next)) }
+
+              # Persist the state on the order
+              after_transition do |order|
+                order.state = order.state
+                order.save
+              end
+
+              event :cancel do
+                transition :to => :canceled, :if => :allow_cancel?
+              end
+
+              event :return do
+                transition :to => :returned, :from => :awaiting_return, :unless => :awaiting_returns?
+              end
+
+              event :resume do
+                transition :to => :resumed, :from => :canceled, :if => :allow_resume?
+              end
+
+              event :authorize_return do
+                transition :to => :awaiting_return
+              end
+
+              if states[:payment]
+                before_transition :to => :complete do |order|
+                  order.process_payments! if order.payment_required?
+                end
+              end
+
+              before_transition :from => :cart, :do => :ensure_line_items_present
+
+              before_transition :to => :delivery, :do => :create_proposed_shipments
+              before_transition :to => :delivery, :do => :ensure_available_shipping_rates
+
+              after_transition :to => :complete, :do => :finalize!
+              after_transition :to => :delivery, :do => :create_tax_charge!
+              after_transition :to => :resumed,  :do => :after_resume
+              after_transition :to => :canceled, :do => :after_cancel
+            end
+          end
+
+          def self.go_to_state(name, options={})
+            self.checkout_steps[name] = options
+            previous_states.each do |state|
+              add_transition({:from => state, :to => name}.merge(options))
+            end
+            if options[:if]
+              self.previous_states << name
+            else
+              self.previous_states = [name]
+            end
+          end
+
+          def self.insert_checkout_step(name, options = {})
+            before = options.delete(:before)
+            after = options.delete(:after) unless before
+            after = self.checkout_steps.keys.last unless before || after
+
+            cloned_steps = self.checkout_steps.clone
+            cloned_removed_transitions = self.removed_transitions.clone
+            self.checkout_flow do
+              cloned_steps.each_pair do |key, value|
+                self.go_to_state(name, options) if key == before
+                self.go_to_state(key, value)
+                self.go_to_state(name, options) if key == after
+              end
+              cloned_removed_transitions.each do |transition|
+                self.remove_transition(transition)
+              end
+            end
+          end
+
+          def self.remove_checkout_step(name)
+            cloned_steps = self.checkout_steps.clone
+            cloned_removed_transitions = self.removed_transitions.clone
+            self.checkout_flow do
+              cloned_steps.each_pair do |key, value|
+                self.go_to_state(key, value) unless key == name
+              end
+              cloned_removed_transitions.each do |transition|
+                self.remove_transition(transition)
+              end
+            end
+          end
+
+          def self.remove_transition(options={})
+            self.removed_transitions << options
+            self.next_event_transitions.delete(find_transition(options))
+          end
+
+          def self.find_transition(options={})
+            return nil if options.nil? || !options.include?(:from) || !options.include?(:to)
+            self.next_event_transitions.detect do |transition|
+              transition[options[:from].to_sym] == options[:to].to_sym
+            end
+          end
+
+          def self.next_event_transitions
+            @next_event_transitions ||= []
+          end
+
+          def self.checkout_steps
+            @checkout_steps ||= {}
+          end
+
+          def self.add_transition(options)
+            self.next_event_transitions << { options.delete(:from) => options.delete(:to) }.merge(options)
+          end
+
+          def checkout_steps
+            steps = self.class.checkout_steps.each_with_object([]) { |(step, options), checkout_steps|
+              next if options.include?(:if) && !options[:if].call(self)
+              checkout_steps << step
+            }.map(&:to_s)
+            # Ensure there is always a complete step
+            steps << "complete" unless steps.include?("complete")
+            steps
+          end
+
+          def has_checkout_step?(step)
+            step.present? ? self.checkout_steps.include?(step) : false
+          end
+
+          def checkout_step_index(step)
+            self.checkout_steps.index(step)
+          end
+
+          def self.removed_transitions
+            @removed_transitions ||= []
+          end
+
+          def can_go_to_state?(state)
+            return false unless self.state.present? && has_checkout_step?(state) && has_checkout_step?(self.state)
+            checkout_step_index(state) > checkout_step_index(self.state)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -13,6 +13,14 @@ class OrderWorkflow
     advance_order!(advance_order_options)
   end
 
+  def next
+    tries ||= 3
+    order.next
+  rescue ActiveRecord::StaleObjectError
+    retry unless (tries -= 1).zero?
+    false
+  end
+
   private
 
   def advance_order_options

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -64,8 +64,8 @@ class OrderWorkflow
   def persist_all_payments
     order.payments.each do |payment|
       original_payment_state = payment.state
-      if original_payment_state != payment.reload.state
-        payment.update(state: original_payment_state)
+      if original_payment_state != Spree::Payment.find(payment.id).state
+        payment.reload.update(state: original_payment_state)
       end
     end
   end

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -1,15 +1,15 @@
-class AdvanceOrderService
+class OrderWorkflow
   attr_reader :order
 
   def initialize(order)
     @order = order
   end
 
-  def call
+  def complete
     advance_order(advance_order_options)
   end
 
-  def call!
+  def complete!
     advance_order!(advance_order_options)
   end
 

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -13,9 +13,13 @@ class OrderWorkflow
     advance_order!(advance_order_options)
   end
 
-  def next
+  def next(options = {})
     tries ||= 3
-    order.next
+    result = order.next
+
+    after_transition_hook(options)
+
+    result
   rescue ActiveRecord::StaleObjectError
     retry unless (tries -= 1).zero?
     false

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -14,15 +14,11 @@ class OrderWorkflow
   end
 
   def next(options = {})
-    tries ||= 3
-    result = order.next
+    result = advance_order_one_step
 
     after_transition_hook(options)
 
     result
-  rescue ActiveRecord::StaleObjectError
-    retry unless (tries -= 1).zero?
-    false
   end
 
   private
@@ -45,6 +41,14 @@ class OrderWorkflow
       order.next!
       after_transition_hook(options)
     end
+  end
+
+  def advance_order_one_step
+    tries ||= 3
+    order.next
+  rescue ActiveRecord::StaleObjectError
+    retry unless (tries -= 1).zero?
+    false
   end
 
   def after_transition_hook(options)

--- a/lib/tasks/sample_data/order_factory.rb
+++ b/lib/tasks/sample_data/order_factory.rb
@@ -45,7 +45,7 @@ class OrderFactory
 
   def create_complete_order
     order = create_cart_order
-    AdvanceOrderService.new(order).call
+    OrderWorkflow.new(order).complete
     order
   end
 

--- a/spec/controllers/admin/proxy_orders_controller_spec.rb
+++ b/spec/controllers/admin/proxy_orders_controller_spec.rb
@@ -77,7 +77,7 @@ describe Admin::ProxyOrdersController, type: :controller do
     before do
       # Processing order to completion
       allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver: true) }
-      AdvanceOrderService.new(order).call!
+      OrderWorkflow.new(order).complete!
       proxy_order.reload
       proxy_order.cancel
       allow(controller).to receive(:spree_current_user) { user }

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -67,10 +67,31 @@ describe CheckoutController, type: :controller do
         allow(order).to receive_message_chain(:insufficient_stock_lines, :empty?).and_return true
       end
 
-      it "does not redirect" do
-        expect(order_cycle_distributed_variants).to receive(:distributes_order_variants?).with(order).and_return(true)
-        get :edit
-        expect(response).to be_success
+      describe "order variants are distributed in the OC" do
+        before do
+          expect(order_cycle_distributed_variants).to receive(:distributes_order_variants?).with(order).and_return(true)
+        end
+
+        it "does not redirect" do
+          get :edit
+          expect(response).to be_success
+        end
+
+        it "returns a specific flash message when Spree::Core::GatewayError occurs" do
+          order_checkout_restart = double(:order_checkout_restart)
+          allow(OrderCheckoutRestart).to receive(:new) { order_checkout_restart }
+          call_count = 0
+          allow(order_checkout_restart).to receive(:call) do
+            call_count += 1
+            raise Spree::Core::GatewayError.new("Gateway blow up") if call_count == 1
+          end
+
+          spree_post :edit
+
+          expect(response.status).to eq(200)
+          flash_message = I18n.t(:spree_gateway_error_flash_for_checkout, error: "Gateway blow up")
+          expect(flash[:error]).to eq flash_message
+        end
       end
 
       describe "when the order is in payment state and a stripe payment intent is provided" do
@@ -228,6 +249,15 @@ describe CheckoutController, type: :controller do
       spree_post :update, format: :json, order: {}
       expect(response.status).to eq(400)
       expect(response.body).to eq({ errors: {}, flash: { error: I18n.t("checkout.failed") } }.to_json)
+    end
+
+    it "returns a specific error on Spree::Core::GatewayError" do
+      allow(order).to receive(:update).and_raise(Spree::Core::GatewayError.new("Gateway blow up"))
+      spree_post :update, format: :json, order: {}
+
+      expect(response.status).to eq(400)
+      flash_message = I18n.t(:spree_gateway_error_flash_for_checkout, error: "Gateway blow up")
+      expect(json_response["flash"]["error"]).to eq flash_message
     end
 
     describe "stale object handling" do

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -298,7 +298,7 @@ describe CheckoutController, type: :controller do
     end
   end
 
-  describe "#update_failed" do
+  describe "#action_failed" do
     let(:restart_checkout) { instance_double(OrderCheckoutRestart, call: true) }
 
     before do
@@ -312,7 +312,7 @@ describe CheckoutController, type: :controller do
       expect(restart_checkout).to receive(:call)
       expect(controller).to receive(:respond_to)
 
-      controller.send(:update_failed)
+      controller.send(:action_failed)
     end
   end
 end

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -19,7 +19,7 @@ describe SubscriptionConfirmJob do
     let(:proxy_orders) { job.send(:unconfirmed_proxy_orders) }
 
     before do
-      AdvanceOrderService.new(order).call!
+      OrderWorkflow.new(order).complete!
     end
 
     it "returns proxy orders that meet all of the criteria" do
@@ -126,7 +126,7 @@ describe SubscriptionConfirmJob do
     let(:order) { proxy_order.initialise_order! }
 
     before do
-      AdvanceOrderService.new(order).call!
+      OrderWorkflow.new(order).complete!
       allow(job).to receive(:send_confirmation_email).and_call_original
       setup_email
       expect(job).to receive(:record_order)

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -34,7 +34,7 @@ describe Spree::Order do
 
     it '.remove_transition' do
       options = { from: transitions.first.keys.first, to: transitions.first.values.first }
-      Spree::Order.stub(:next_event_transition).and_return([options])
+      allow(Spree::Order).to receive(:next_event_transition).and_return([options])
       expect(Spree::Order.remove_transition(options)).to be_truthy
     end
 
@@ -44,14 +44,14 @@ describe Spree::Order do
 
     context "#checkout_steps" do
       context "when payment not required" do
-        before { order.stub payment_required?: false }
+        before { allow(order).to receive_messages payment_required?: false }
         specify do
           expect(order.checkout_steps).to eq %w(address delivery complete)
         end
       end
 
       context "when payment required" do
-        before { order.stub payment_required?: true }
+        before { allow(order).to receive_messages payment_required?: true }
         specify do
           expect(order.checkout_steps).to eq %w(address delivery payment complete)
         end
@@ -78,14 +78,14 @@ describe Spree::Order do
     context "from address" do
       before do
         order.state = 'address'
-        order.stub(:has_available_payment)
+        allow(order).to receive(:has_available_payment)
         order.shipments << create(:shipment)
         order.email = "user@example.com"
         order.save!
       end
 
       it "transitions to delivery" do
-        order.stub(ensure_available_shipping_rates: true)
+        allow(order).to receive_messages(ensure_available_shipping_rates: true)
         order.next!
         expect(order.state).to eq "delivery"
       end
@@ -108,7 +108,7 @@ describe Spree::Order do
 
       context "with payment required" do
         before do
-          order.stub payment_required?: true
+          allow(order).to receive_messages payment_required?: true
         end
 
         it "transitions to payment" do
@@ -119,7 +119,7 @@ describe Spree::Order do
 
       context "without payment required" do
         before do
-          order.stub payment_required?: false
+          allow(order).to receive_messages payment_required?: false
         end
 
         it "transitions to complete" do
@@ -136,8 +136,8 @@ describe Spree::Order do
 
      context "when payment is required" do
         before do
-          order.stub confirmation_required?: false
-          order.stub payment_required?: true
+          allow(order).to receive_messages confirmation_required?: false
+          allow(order).to receive_messages payment_required?: true
         end
 
         it "transitions to complete" do
@@ -150,7 +150,7 @@ describe Spree::Order do
       # Regression test for #2028
       context "when payment is not required" do
         before do
-          order.stub payment_required?: false
+          allow(order).to receive_messages payment_required?: false
         end
 
         it "does not call process payments" do
@@ -174,7 +174,7 @@ describe Spree::Order do
 
     it "should only call default transitions once when checkout_flow is redefined" do
       order = SubclassedOrder.new
-      order.stub payment_required?: true
+      allow(order).to receive_messages payment_required?: true
       expect(order).to receive(:process_payments!).once
       order.state = "payment"
       order.next!
@@ -227,7 +227,7 @@ describe Spree::Order do
     end
 
     it "does not attempt to process payments" do
-      order.stub_chain(:line_items, :present?).and_return(true)
+      allow(order).to receive_message_chain(:line_items, :present?).and_return(true)
       expect(order).to_not receive(:payment_required?)
       expect(order).to_not receive(:process_payments!)
       order.next!

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -1,6 +1,337 @@
 require 'spec_helper'
 
 describe Spree::Order do
+  let(:order) { Spree::Order.new }
+
+  context "with default state machine" do
+    let(:transitions) do
+      [
+        { :address => :delivery },
+        { :delivery => :payment },
+        { :payment => :confirm },
+        { :confirm => :complete },
+        { :payment => :complete },
+        { :delivery => :complete }
+      ]
+    end
+
+    it "has the following transitions" do
+      transitions.each do |transition|
+        transition = Spree::Order.find_transition(:from => transition.keys.first, :to => transition.values.first)
+        transition.should_not be_nil
+      end
+    end
+
+    it "does not have a transition from delivery to confirm" do
+      transition = Spree::Order.find_transition(:from => :delivery, :to => :confirm)
+      transition.should be_nil
+    end
+      
+    it '.find_transition when contract was broken' do
+      Spree::Order.find_transition({foo: :bar, baz: :dog}).should be_false
+    end
+
+    it '.remove_transition' do
+      options = {:from => transitions.first.keys.first, :to => transitions.first.values.first}
+      Spree::Order.stub(:next_event_transition).and_return([options])
+      Spree::Order.remove_transition(options).should be_true
+    end
+
+    it '.remove_transition when contract was broken' do
+      Spree::Order.remove_transition(nil).should be_false
+    end
+
+    context "#checkout_steps" do
+      context "when confirmation not required" do
+        before do
+          order.stub :confirmation_required? => false
+          order.stub :payment_required? => true
+        end
+
+        specify do
+          order.checkout_steps.should == %w(address delivery payment complete)
+        end
+      end
+
+      context "when confirmation required" do
+        before do
+          order.stub :confirmation_required? => true
+          order.stub :payment_required? => true
+        end
+
+        specify do
+          order.checkout_steps.should == %w(address delivery payment confirm complete)
+        end
+      end
+
+      context "when payment not required" do
+        before { order.stub :payment_required? => false }
+        specify do
+          order.checkout_steps.should == %w(address delivery complete)
+        end
+      end
+
+      context "when payment required" do
+        before { order.stub :payment_required? => true }
+        specify do
+          order.checkout_steps.should == %w(address delivery payment complete)
+        end
+      end
+    end
+
+    it "starts out at cart" do
+      order.state.should == "cart"
+    end
+
+    it "transitions to address" do
+      order.line_items << FactoryGirl.create(:line_item)
+      order.email = "user@example.com"
+      order.next!
+      order.state.should == "address"
+    end
+
+    it "cannot transition to address without any line items" do
+      order.line_items.should be_blank
+      lambda { order.next! }.should raise_error(StateMachine::InvalidTransition, /#{Spree.t(:there_are_no_items_for_this_order)}/)
+    end
+
+    context "from address" do
+      before do
+        order.state = 'address'
+        order.stub(:has_available_payment)
+        shipment = FactoryGirl.create(:shipment, :order => order)
+        order.email = "user@example.com"
+        order.save!
+      end
+
+      it "transitions to delivery" do
+        order.stub(:ensure_available_shipping_rates => true)
+        order.next!
+        order.state.should == "delivery"
+      end
+
+      context "cannot transition to delivery" do
+        context "if there are no shipping rates for any shipment" do
+          specify do
+            transition = lambda { order.next! }
+            transition.should raise_error(StateMachine::InvalidTransition, /#{Spree.t(:items_cannot_be_shipped)}/)
+          end
+        end
+      end
+    end
+
+    context "from delivery" do
+      before do
+        order.state = 'delivery'
+      end
+
+      context "with payment required" do
+        before do
+          order.stub :payment_required? => true
+        end
+
+        it "transitions to payment" do
+          order.next!
+          order.state.should == 'payment'
+        end
+      end
+
+      context "without payment required" do
+        before do
+          order.stub :payment_required? => false
+        end
+
+        it "transitions to complete" do
+          order.next!
+          order.state.should == "complete"
+        end
+      end
+    end
+
+    context "from payment" do
+      before do
+        order.state = 'payment'
+      end
+
+      context "with confirmation required" do
+        before do
+          order.stub :confirmation_required? => true
+        end
+
+        it "transitions to confirm" do
+          order.next!
+          order.state.should == "confirm"
+        end
+      end
+
+      context "without confirmation required" do
+        before do
+          order.stub :confirmation_required? => false
+          order.stub :payment_required? => true
+        end
+
+        it "transitions to complete" do
+          order.should_receive(:process_payments!).once.and_return true
+          order.next!
+          order.state.should == "complete"
+        end
+      end
+
+      # Regression test for #2028
+      context "when payment is not required" do
+        before do
+          order.stub :payment_required? => false
+        end
+
+        it "does not call process payments" do
+          order.should_not_receive(:process_payments!)
+          order.next!
+          order.state.should == "complete"
+        end
+      end
+    end
+  end
+
+  context "subclassed order" do
+    # This causes another test above to fail, but fixing this test should make
+    #   the other test pass
+    class SubclassedOrder < Spree::Order
+      checkout_flow do
+        go_to_state :payment
+        go_to_state :complete
+      end
+    end
+
+    it "should only call default transitions once when checkout_flow is redefined" do
+      order = SubclassedOrder.new
+      order.stub :payment_required? => true
+      order.should_receive(:process_payments!).once
+      order.state = "payment"
+      order.next!
+      order.state.should == "complete"
+    end
+  end
+
+  context "re-define checkout flow" do
+    before do
+      @old_checkout_flow = Spree::Order.checkout_flow
+      Spree::Order.class_eval do
+        checkout_flow do
+          go_to_state :payment
+          go_to_state :complete
+        end
+      end
+    end
+
+    after do
+      Spree::Order.checkout_flow(&@old_checkout_flow)
+    end
+
+    it "should not keep old event transitions when checkout_flow is redefined" do
+      Spree::Order.next_event_transitions.should == [{:cart=>:payment}, {:payment=>:complete}]
+    end
+
+    it "should not keep old events when checkout_flow is redefined" do
+      state_machine = Spree::Order.state_machine
+      state_machine.states.any? { |s| s.name == :address }.should be_false
+      known_states = state_machine.events[:next].branches.map(&:known_states).flatten
+      known_states.should_not include(:address)
+      known_states.should_not include(:delivery)
+      known_states.should_not include(:confirm)
+    end
+  end
+
+  # Regression test for #3665
+  context "with only a complete step" do
+    before do
+      @old_checkout_flow = Spree::Order.checkout_flow
+      Spree::Order.class_eval do
+        checkout_flow do
+          go_to_state :complete
+        end
+      end
+    end
+
+    after do
+      Spree::Order.checkout_flow(&@old_checkout_flow)
+    end
+
+    it "does not attempt to process payments" do
+      order.stub_chain(:line_items, :present?).and_return(true)
+      order.should_not_receive(:payment_required?)
+      order.should_not_receive(:process_payments!)
+      order.next!
+    end
+
+  end
+
+  context "insert checkout step" do
+    before do
+      @old_checkout_flow = Spree::Order.checkout_flow
+      Spree::Order.class_eval do
+        insert_checkout_step :new_step, before: :address
+      end
+    end
+
+    after do
+      Spree::Order.checkout_flow(&@old_checkout_flow)
+    end
+
+    it "should maintain removed transitions" do
+      transition = Spree::Order.find_transition(:from => :delivery, :to => :confirm)
+      transition.should be_nil
+    end
+
+    context "before" do
+      before do
+        Spree::Order.class_eval do
+          insert_checkout_step :before_address, before: :address
+        end
+      end
+
+      specify do
+        order = Spree::Order.new
+        order.checkout_steps.should == %w(new_step before_address address delivery complete)
+      end
+    end
+
+    context "after" do
+      before do
+        Spree::Order.class_eval do
+          insert_checkout_step :after_address, after: :address
+        end
+      end
+
+      specify do
+        order = Spree::Order.new
+        order.checkout_steps.should == %w(new_step address after_address delivery complete)
+      end
+    end
+  end
+
+  context "remove checkout step" do
+    before do
+      @old_checkout_flow = Spree::Order.checkout_flow
+      Spree::Order.class_eval do
+        remove_checkout_step :address
+      end
+    end
+
+    after do
+      Spree::Order.checkout_flow(&@old_checkout_flow)
+    end
+
+    it "should maintain removed transitions" do
+      transition = Spree::Order.find_transition(:from => :delivery, :to => :confirm)
+      transition.should be_nil
+    end
+
+    specify do
+      order = Spree::Order.new
+      order.checkout_steps.should == %w(delivery complete)
+    end
+  end
+
   describe 'event :restart_checkout' do
     let(:order) { create(:order) }
 

--- a/spec/services/order_factory_spec.rb
+++ b/spec/services/order_factory_spec.rb
@@ -47,7 +47,7 @@ describe OrderFactory do
     end
 
     it "retains address, delivery, and payment attributes until completion of the order" do
-      AdvanceOrderService.new(order).call
+      OrderWorkflow.new(order).complete
 
       order.reload
 

--- a/spec/services/order_syncer_spec.rb
+++ b/spec/services/order_syncer_spec.rb
@@ -409,7 +409,7 @@ describe OrderSyncer do
 
       context "when order is complete" do
         it "does not update the line_item quantities and adds the order to order_update_issues with insufficient stock" do
-          AdvanceOrderService.new(order).call
+          OrderWorkflow.new(order).complete
 
           expect(syncer.sync!).to be true
 
@@ -423,7 +423,7 @@ describe OrderSyncer do
         it "does not update the line_item quantities and adds the order to order_update_issues with out of stock" do
           # this single item available is used when the order is completed below, making the item out of stock
           variant.update_attribute(:on_hand, 1)
-          AdvanceOrderService.new(order).call
+          OrderWorkflow.new(order).complete
 
           expect(syncer.sync!).to be true
 
@@ -507,7 +507,7 @@ describe OrderSyncer do
       end
 
       context "when order is complete" do
-        before { AdvanceOrderService.new(order).call }
+        before { OrderWorkflow.new(order).complete }
 
         it "does not add line_item and adds the order to order_update_issues" do
           expect(syncer.sync!).to be true

--- a/spec/services/order_workflow_spec.rb
+++ b/spec/services/order_workflow_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe AdvanceOrderService do
+describe OrderWorkflow do
   let!(:distributor) { create(:distributor_enterprise) }
   let!(:order) do
     create(:order_with_totals_and_distribution, distributor: distributor,
@@ -13,7 +13,7 @@ describe AdvanceOrderService do
 
   it "transitions the order multiple steps" do
     expect(order.state).to eq("cart")
-    service.call
+    service.complete
     order.reload
     expect(order.state).to eq("complete")
   end
@@ -30,7 +30,7 @@ describe AdvanceOrderService do
 
     it "retains delivery method of the order" do
       order.select_shipping_method(shipping_method_b.id)
-      service.call
+      service.complete
       order.reload
       expect(order.shipping_method).to eq(shipping_method_b)
     end
@@ -38,7 +38,7 @@ describe AdvanceOrderService do
 
   context "when raising on error" do
     it "transitions the order multiple steps" do
-      service.call!
+      service.complete!
       order.reload
       expect(order.state).to eq("complete")
     end
@@ -49,7 +49,7 @@ describe AdvanceOrderService do
       end
 
       it "raises error" do
-        expect { service.call! }.to raise_error(StateMachine::InvalidTransition)
+        expect { service.complete! }.to raise_error(StateMachine::InvalidTransition)
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #5816 and #5818
I am putting these two fixes together in one PR because they are not too big but mostly so we can test these things together, they are different but closely related.

Regarding #5816
The handler of any gateway exceptions is used for the StripeSCA authorization step. Whenever there's an error on checkout we need to reset the order to cart state.
We were not doing that before and that was causing the order to stay in the payment state after an authorization error. Because the order was in the payment state, the callback to update order totals was not executed on the second attempt and that caused not all fees to be collected #5816

This is a generic improvement so it will make the checkout code more resilient for some other cases as well.

Regarding #5818
Here we are adding an alternative to [the infamous after_rollback callback called persist_invalid for the payment model](https://github.com/openfoodfoundation/spree/blob/0b0c422369c82b6dd7e7cb627a24e3a9fca19a6c/core/app/models/spree/payment.rb#L35).
On checkout, in the situation where we are [handling a redirect from stripe](https://github.com/openfoodfoundation/openfoodnetwork/blob/add7bb489f52e73b6763ad32c033cf401c57fac7/app/controllers/checkout_controller.rb#L159) and capturing the payment, the payment is correctly set to **failed state** but the order workflow state machine rolls it back to **pending state** causing #5818. Here we are adding some logic to the OrderWorkflow service to persist the payments after a failure so we get the data for debugging.
Related to this there's a good refactoring with code moved from checkout controller to the OrderWorkflow service.

Additionally, while investigating I thought I'd have to patch the checkout workflow code, in the end I didnt but I ended up bringing the checkout.rb file from spree_core to OFN. No changes to it, just rubocop and transpec.
 
#### What should we test?
We need to verify the issue is solved.
The code changed is related to any errors that happen on the stripe side so we can test any other error scenario on stripe and verify that fixing it will process the payment in stripe with the correct amount. For example, we can check if this will also work if we use a card that needs external authorization and we fail the validation.

I just verified that #5816 is also present when we use a card like 4000 0027 6000 3184 and press "fail authentication". So:
- on first attempt use 4000 0027 6000 3184 and press "FAIL authentication"
- on second attempt use 4000 0027 6000 3184 and press "COMPLETE authentication"
This test case should fail before this PR and pass after this PR :+1:


#### Release notes
Changelog Category: Fixed
Fixes StripeSCA problem where the second attempt to make a payment would fail even the card and details were valid.
