### PR TITLE
Bug/4592 - Hide Environment column on Payment Methods page when user is not admin

### DIFF
--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -11,7 +11,8 @@
       %col{style: "width: 13%"}
       %col{style: "width: 14%"}
       %col{style: "width: 32%"}
-      %col{style: "width: 14%"}
+      - if spree_current_user.admin?
+        %col{style: "width: 14%"}
       %col{style: "width:  8%"}
       %col{style: "width:  8%"}
       %col{style: "width: 11%"}
@@ -20,7 +21,8 @@
         %th= t('.name')
         %th= t('.products_distributor')
         %th= t('.provider')
-        %th= t('.environment')
+        - if spree_current_user.admin?
+          %th= t('.environment')
         %th= t('.display')
         %th= t('.active')
         %th.actions
@@ -33,7 +35,8 @@
               = distributor.name
               %br/
           %td= method.class.clean_name
-          %td.align-center= method.environment.to_s.titleize
+          - if spree_current_user.admin?
+            %td.align-center= method.environment.to_s.titleize
           %td.align-center= method.display_on.blank? ? t('.both') : t('.' + method.display_on.to_s)
           %td.align-center= method.active ? t('.active_yes') : t('.active_no')
           %td.actions

--- a/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "spree/admin/payment_methods/index.html.haml" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before do
     controller.singleton_class.class_eval do
@@ -23,7 +23,7 @@ describe "spree/admin/payment_methods/index.html.haml" do
   describe "payment methods index page" do
     context "when user is not admin" do
       before do
-        allow(view).to receive_messages spree_current_user: create_enterprise_user
+        allow(view).to receive_messages spree_current_user: create(:user)
       end
 
       it "shows only the providers of the existing payment methods" do

--- a/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe "spree/admin/payment_methods/index.html.haml" do
+  include AuthenticationWorkflow
+
   before do
     controller.singleton_class.class_eval do
       helper_method :new_object_url, :edit_object_url, :object_url
@@ -19,10 +21,52 @@ describe "spree/admin/payment_methods/index.html.haml" do
   end
 
   describe "payment methods index page" do
-    it "shows only the providers of the existing payment methods" do
-      render
+    context "when user is not admin" do
+      before do
+        allow(view).to receive_messages spree_current_user: create_enterprise_user
+      end
 
-      expect(rendered).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
+      it "shows only the providers of the existing payment methods" do
+        render
+
+        expect(rendered).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
+      end
+
+      it "does not show Enviroment column when user is not admin" do
+        render
+
+        expect(rendered).not_to have_content "Environment"
+      end
+
+      it "does not show column content when user is not admin" do
+        render
+
+        expect(rendered).not_to have_content "Test"
+      end
+    end
+
+    context "when user is admin" do
+      before do
+        allow(view).to receive_messages spree_current_user: create(:admin_user)
+      end
+
+      it "shows only the providers of the existing payment methods" do
+        render
+
+        expect(rendered).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
+      end
+
+      it "does not show Enviroment column when user is not admin" do
+        render
+
+        expect(rendered).to have_content "Environment"
+      end
+
+      it "does not show column content when user is not admin" do
+        render
+
+        expect(rendered).to have_content "Test"
+      end
     end
   end
 end

--- a/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
@@ -32,13 +32,13 @@ describe "spree/admin/payment_methods/index.html.haml" do
         expect(rendered).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
       end
 
-      it "does not show Enviroment column when user is not admin" do
+      it "does not show Enviroment column" do
         render
 
         expect(rendered).not_to have_content "Environment"
       end
 
-      it "does not show column content when user is not admin" do
+      it "does not show column content" do
         render
 
         expect(rendered).not_to have_content "Test"
@@ -56,13 +56,13 @@ describe "spree/admin/payment_methods/index.html.haml" do
         expect(rendered).to have_content "Cash/EFT/etc. (payments for which automatic validation is not required)", count: 2
       end
 
-      it "does not show Enviroment column when user is not admin" do
+      it "shows the Enviroment column" do
         render
 
         expect(rendered).to have_content "Environment"
       end
 
-      it "does not show column content when user is not admin" do
+      it "shows the column content" do
         render
 
         expect(rendered).to have_content "Test"


### PR DESCRIPTION
#### What? Why?

Closes #4592 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

On the table in the Payment Methods page, we have a column "Environment" that is kind of "tech-oriented" information. This PR hides the column when the user is not an admin.

#### What should we test?
Check if the column "Environment" is displayed when the user is admin and hidden when it is not.



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning because you did it for a reason. -->
Hide the column "Environment" from the Payment Methods page in the admin section when the user is not a super admin.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed
