### PR TITLE
Clean up AuthenticationWorkflow spec helper

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -644,7 +644,7 @@ Metrics/MethodLength:
   - spec/features/consumer/shopping/checkout_paypal_spec.rb
   - spec/features/consumer/shopping/variant_overrides_spec.rb
   - spec/models/product_importer_spec.rb
-  - spec/support/request/authentication_workflow.rb
+  - spec/support/request/authentication_helper.rb
 
 Metrics/ClassLength:
   Max: 100

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1338,7 +1338,7 @@ Style/FrozenStringLiteralComment:
     - 'spec/support/performance_helper.rb'
     - 'spec/support/products_helper.rb'
     - 'spec/support/request/admin_helper.rb'
-    - 'spec/support/request/authentication_workflow.rb'
+    - 'spec/support/request/authentication_helper.rb'
     - 'spec/support/request/checkout_workflow.rb'
     - 'spec/support/request/cookie_helper.rb'
     - 'spec/support/request/distribution_helper.rb'

--- a/engines/order_management/spec/features/order_management/reports/bulk_coop_spec.rb
+++ b/engines/order_management/spec/features/order_management/reports/bulk_coop_spec.rb
@@ -3,12 +3,11 @@
 require "spec_helper"
 
 feature "bulk coop" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   scenario "bulk co-op report" do
-    quick_login_as_admin
-    visit spree.admin_reports_path
+    login_as_admin_and_visit spree.admin_reports_path
     click_link 'Bulk Co-Op'
     click_button 'Generate Report'
 

--- a/engines/order_management/spec/features/order_management/reports/enterprise_fee_summaries_spec.rb
+++ b/engines/order_management/spec/features/order_management/reports/enterprise_fee_summaries_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 feature "enterprise fee summaries", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let!(:distributor) { create(:distributor_enterprise) }

--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Admin::BulkLineItemsController, type: :controller do
-  include AuthenticationWorkflow
-
   describe '#index' do
     render_views
 
@@ -17,7 +15,7 @@ describe Admin::BulkLineItemsController, type: :controller do
     let!(:line_item4) { FactoryBot.create(:line_item_with_shipment, order: order3) }
 
     context "as a normal user" do
-      before { allow(controller).to receive_messages spree_current_user: create_enterprise_user }
+      before { allow(controller).to receive_messages spree_current_user: create(:user) }
 
       it "should deny me access to the index action" do
         spree_get :index, format: :json

--- a/spec/controllers/admin/column_preferences_controller_spec.rb
+++ b/spec/controllers/admin/column_preferences_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::ColumnPreferencesController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "bulk_update" do
     let!(:user1) { create(:user) }

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::CustomersController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "index" do
     let(:enterprise) { create(:distributor_enterprise) }

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'open_food_network/order_cycle_permissions'
 
 describe Admin::EnterprisesController, type: :controller do
-  include AuthenticationWorkflow
-
   let(:user) { create(:user) }
   let(:admin_user) { create(:admin_user) }
   let(:distributor_manager) { create(:user, enterprise_limit: 10, enterprises: [distributor]) }
@@ -366,18 +364,8 @@ describe Admin::EnterprisesController, type: :controller do
   end
 
   describe "bulk updating enterprises" do
-    let!(:original_owner) do
-      user = create_enterprise_user
-      user.enterprise_limit = 2
-      user.save!
-      user
-    end
-    let!(:new_owner) do
-      user = create_enterprise_user
-      user.enterprise_limit = 2
-      user.save!
-      user
-    end
+    let!(:original_owner) { create(:user) }
+    let!(:new_owner) { create(:user) }
     let!(:profile_enterprise1) { create(:enterprise, sells: 'none', owner: original_owner ) }
     let!(:profile_enterprise2) { create(:enterprise, sells: 'none', owner: original_owner ) }
 
@@ -441,7 +429,7 @@ describe Admin::EnterprisesController, type: :controller do
   end
 
   describe "for_order_cycle" do
-    let!(:user) { create_enterprise_user }
+    let!(:user) { create(:user) }
     let!(:enterprise) { create(:enterprise, sells: 'any', owner: user) }
     let(:permission_mock) { double(:permission) }
 
@@ -487,7 +475,7 @@ describe Admin::EnterprisesController, type: :controller do
   end
 
   describe "visible" do
-    let!(:user) { create(:user, enterprise_limit: 10) }
+    let!(:user) { create(:user) }
     let!(:visible_enterprise) { create(:enterprise, sells: 'any', owner: user) }
     let!(:not_visible_enterprise) { create(:enterprise, sells: 'any') }
 
@@ -508,10 +496,10 @@ describe Admin::EnterprisesController, type: :controller do
   describe "index" do
     context "as super admin" do
       let(:super_admin) { create(:admin_user) }
-      let!(:user) { create_enterprise_user(enterprise_limit: 10) }
+      let!(:user) { create(:user) }
       let!(:enterprise1) { create(:enterprise, sells: 'any', owner: user) }
       let!(:enterprise2) { create(:enterprise, sells: 'own', owner: user) }
-      let!(:enterprise3) { create(:enterprise, sells: 'any', owner: create_enterprise_user ) }
+      let!(:enterprise3) { create(:enterprise, sells: 'any', owner: create(:user) ) }
 
       before do
         allow(controller).to receive_messages spree_current_user: super_admin
@@ -533,10 +521,10 @@ describe Admin::EnterprisesController, type: :controller do
     end
 
     context "as an enterprise user" do
-      let!(:user) { create_enterprise_user(enterprise_limit: 10) }
+      let!(:user) { create(:user) }
       let!(:enterprise1) { create(:enterprise, sells: 'any', owner: user) }
       let!(:enterprise2) { create(:enterprise, sells: 'own', owner: user) }
-      let!(:enterprise3) { create(:enterprise, sells: 'any', owner: create_enterprise_user ) }
+      let!(:enterprise3) { create(:enterprise, sells: 'any', owner: create(:user) ) }
 
       before do
         allow(controller).to receive_messages spree_current_user: user

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -136,7 +136,7 @@ describe Admin::EnterprisesController, type: :controller do
         let!(:property) { create(:property, name: "A nice name") }
 
         before do
-          login_as_enterprise_user [producer]
+          controller_login_as_enterprise_user [producer]
         end
 
         context "when a submitted property does not already exist" do
@@ -177,7 +177,7 @@ describe Admin::EnterprisesController, type: :controller do
         let!(:tag_rule) { create(:tag_rule, enterprise: enterprise) }
 
         before do
-          login_as_enterprise_user [enterprise]
+          controller_login_as_enterprise_user [enterprise]
         end
 
         context "discount order rules" do

--- a/spec/controllers/admin/inventory_items_controller_spec.rb
+++ b/spec/controllers/admin/inventory_items_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Admin::InventoryItemsController, type: :controller do
-  # include AuthenticationHelper
-
   describe "create" do
     context "json" do
       let(:format) { :json }

--- a/spec/controllers/admin/inventory_items_controller_spec.rb
+++ b/spec/controllers/admin/inventory_items_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::InventoryItemsController, type: :controller do
-  # include AuthenticationWorkflow
+  # include AuthenticationHelper
 
   describe "create" do
     context "json" do

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -102,7 +102,7 @@ module Admin
         let(:params) { { format: :json, order_cycle: {} } }
 
         before do
-          login_as_enterprise_user([shop])
+          controller_login_as_enterprise_user([shop])
           allow(OrderCycleForm).to receive(:new) { form_mock }
         end
 
@@ -148,7 +148,7 @@ module Admin
       end
 
       context "as a manager of the coordinator" do
-        before { login_as_enterprise_user([coordinator]) }
+        before { controller_login_as_enterprise_user([coordinator]) }
         let(:params) { { format: :json, id: order_cycle.id, order_cycle: {} } }
 
         context "when updating succeeds" do

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 module Admin
   describe OrderCyclesController, type: :controller do
-    include AuthenticationWorkflow
-
-    let!(:distributor_owner) { create_enterprise_user enterprise_limit: 2 }
+    let!(:distributor_owner) { create(:user) }
 
     before do
       allow(controller).to receive_messages spree_current_user: distributor_owner
@@ -300,7 +298,7 @@ module Admin
     end
 
     describe "notifying producers" do
-      let(:user) { create_enterprise_user }
+      let(:user) { create(:user) }
       let(:admin_user) do
         user = create(:user)
         user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')

--- a/spec/controllers/admin/proxy_orders_controller_spec.rb
+++ b/spec/controllers/admin/proxy_orders_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::ProxyOrdersController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe 'cancel' do
     let!(:user) { create(:user, enterprise_limit: 10) }

--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::SchedulesController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "index" do
     let!(:coordinated_order_cycle) { create(:simple_order_cycle) }

--- a/spec/controllers/admin/subscription_line_items_controller_spec.rb
+++ b/spec/controllers/admin/subscription_line_items_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::SubscriptionLineItemsController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "build" do
     let(:user) { create(:user) }

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::SubscriptionsController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include OpenFoodNetwork::EmailHelper
 
   describe 'index' do

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Admin::VariantOverridesController, type: :controller do
-  # include AuthenticationWorkflow
+  # include AuthenticationHelper
 
   describe "bulk_update" do
     context "json" do

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Admin::VariantOverridesController, type: :controller do
-  # include AuthenticationHelper
-
   describe "bulk_update" do
     context "json" do
       let(:format) { :json }

--- a/spec/controllers/api/customers_controller_spec.rb
+++ b/spec/controllers/api/customers_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Api
   describe CustomersController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
     render_views
 
     let(:user) { create(:user) }

--- a/spec/controllers/api/enterprise_fees_controller_spec.rb
+++ b/spec/controllers/api/enterprise_fees_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Api
   describe EnterpriseFeesController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
 
     let!(:unreferenced_fee) { create(:enterprise_fee) }
     let!(:referenced_fee) { create(:enterprise_fee) }

--- a/spec/controllers/api/enterprises_controller_spec.rb
+++ b/spec/controllers/api/enterprises_controller_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 
 describe Api::EnterprisesController, type: :controller do
-  include AuthenticationWorkflow
   render_views
 
   let(:enterprise) { create(:distributor_enterprise) }
 
   context "as an enterprise owner" do
-    let(:enterprise_owner) { create_enterprise_user enterprise_limit: 10 }
+    let(:enterprise_owner) { create(:user) }
     let!(:enterprise) { create(:distributor_enterprise, owner: enterprise_owner) }
 
     before do
@@ -52,7 +51,7 @@ describe Api::EnterprisesController, type: :controller do
   end
 
   context "as an enterprise manager" do
-    let(:enterprise_manager) { create_enterprise_user }
+    let(:enterprise_manager) { create(:user) }
 
     before do
       enterprise_manager.enterprise_roles.build(enterprise: enterprise).save
@@ -74,7 +73,7 @@ describe Api::EnterprisesController, type: :controller do
   end
 
   context "as an non-managing user" do
-    let(:non_managing_user) { create_enterprise_user }
+    let(:non_managing_user) { create(:user) }
 
     before do
       allow(Enterprise)

--- a/spec/controllers/api/exchange_products_controller_spec.rb
+++ b/spec/controllers/api/exchange_products_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Api
   describe ExchangeProductsController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
 
     let(:order_cycle) { create(:order_cycle) }
     let(:exchange) { order_cycle.exchanges.incoming.first }

--- a/spec/controllers/api/logos_controller_spec.rb
+++ b/spec/controllers/api/logos_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module Api
   describe LogosController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
 
     let(:admin_user) { create(:admin_user) }
     let(:enterprise_owner) { create(:user) }

--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Api
   describe OrdersController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
     render_views
 
     let!(:regular_user) { create(:user) }

--- a/spec/controllers/api/product_images_controller_spec.rb
+++ b/spec/controllers/api/product_images_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Api
   describe ProductImagesController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
     render_views
 
     describe "uploading an image" do

--- a/spec/controllers/api/promo_images_controller_spec.rb
+++ b/spec/controllers/api/promo_images_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module Api
   describe PromoImagesController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
 
     let(:admin_user) { create(:admin_user) }
     let(:enterprise_owner) { create(:user) }

--- a/spec/controllers/api/shops_controller_spec.rb
+++ b/spec/controllers/api/shops_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Api::ShopsController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   render_views
 
   context "as a non-authenticated user" do

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe RegistrationController, type: :controller do
-  include AuthenticationWorkflow
   describe "redirecting when user not logged in" do
     it "index" do
       get :index
@@ -10,7 +9,7 @@ describe RegistrationController, type: :controller do
   end
 
   describe "redirecting when user has reached enterprise ownership limit" do
-    let!(:user) { create_enterprise_user( enterprise_limit: 1 ) }
+    let!(:user) { create(:user, enterprise_limit: 1 ) }
     let!(:enterprise) { create(:distributor_enterprise, owner: user) }
 
     before do
@@ -24,7 +23,7 @@ describe RegistrationController, type: :controller do
   end
 
   describe "loading data when user is logged in" do
-    let!(:user) { create_enterprise_user }
+    let!(:user) { create(:user) }
 
     before do
       allow(controller).to receive_messages spree_current_user: user

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe Admin::AdjustmentsController, type: :controller do
-    include AuthenticationWorkflow
+    include AuthenticationHelper
 
     before { controller_login_as_admin }
 

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Admin::AdjustmentsController, type: :controller do
     include AuthenticationWorkflow
 
-    before { login_as_admin }
+    before { controller_login_as_admin }
 
     describe "setting included tax" do
       let(:order) { create(:order) }

--- a/spec/controllers/spree/admin/countries_controller_spec.rb
+++ b/spec/controllers/spree/admin/countries_controller_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module Spree
   module Admin
     describe CountriesController, type: :controller do
-      include AuthenticationWorkflow
+      include AuthenticationHelper
 
       describe "#update" do
         before { controller_login_as_admin }

--- a/spec/controllers/spree/admin/countries_controller_spec.rb
+++ b/spec/controllers/spree/admin/countries_controller_spec.rb
@@ -8,7 +8,7 @@ module Spree
       include AuthenticationWorkflow
 
       describe "#update" do
-        before { login_as_admin }
+        before { controller_login_as_admin }
 
         it "updates the name of an existing country" do
           country = create(:country)

--- a/spec/controllers/spree/admin/image_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/image_settings_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Admin::ImageSettingsController do
   include AuthenticationWorkflow
 
-  before { login_as_admin }
+  before { controller_login_as_admin }
 
   context "updating image settings" do
     it "should be able to update paperclip settings" do

--- a/spec/controllers/spree/admin/image_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/image_settings_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Admin::ImageSettingsController do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before { controller_login_as_admin }
 

--- a/spec/controllers/spree/admin/mail_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/mail_methods_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Admin::MailMethodsController do
   include AuthenticationWorkflow
 
-  before { login_as_admin }
+  before { controller_login_as_admin }
 
   context "#update" do
     it "should reinitialize the mail settings" do

--- a/spec/controllers/spree/admin/mail_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/mail_methods_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Admin::MailMethodsController do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before { controller_login_as_admin }
 

--- a/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -37,7 +37,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
       }
 
       before do
-        login_as_enterprise_user [order.distributor]
+        controller_login_as_enterprise_user [order.distributor]
       end
 
       it "advances the order state" do

--- a/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "#update" do
     context "adding customer details via newly created admin order" do

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::OrdersController, type: :controller do
   describe "#edit" do
     let!(:order) { create(:order_with_totals_and_distribution, ship_address: create(:address)) }
 
-    before { login_as_admin }
+    before { controller_login_as_admin }
 
     it "advances the order state" do
       expect {
@@ -40,7 +40,7 @@ describe Spree::Admin::OrdersController, type: :controller do
                  order_cycle_id: order.order_cycle_id } }
     end
 
-    before { login_as_admin }
+    before { controller_login_as_admin }
 
     context "complete order" do
       let(:order) { create :completed_order_with_totals }

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Spree::Admin::OrdersController, type: :controller do
-  include AuthenticationWorkflow
   include OpenFoodNetwork::EmailHelper
 
   describe "#edit" do
@@ -109,7 +108,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
   describe "#index" do
     context "as a regular user" do
-      before { allow(controller).to receive(:spree_current_user) { create_enterprise_user } }
+      before { allow(controller).to receive(:spree_current_user) { create(:user) } }
 
       it "should deny me access to the index action" do
         spree_get :index

--- a/spec/controllers/spree/admin/overview_controller_spec.rb
+++ b/spec/controllers/spree/admin/overview_controller_spec.rb
@@ -1,15 +1,13 @@
 require 'spec_helper'
 
 describe Spree::Admin::OverviewController, type: :controller do
-  include AuthenticationWorkflow
-
   describe "#index" do
     before do
       allow(controller).to receive(:spree_current_user).and_return(user)
     end
 
     context "when user owns only one enterprise" do
-      let(:user) { create_enterprise_user }
+      let(:user) { create(:user) }
       let!(:enterprise) { create(:distributor_enterprise, owner: user) }
 
       context "when the referer is not an admin page" do
@@ -48,7 +46,7 @@ describe Spree::Admin::OverviewController, type: :controller do
     end
 
     context "when user owns multiple enterprises" do
-      let(:user) { create_enterprise_user(enterprise_limit: 2) }
+      let(:user) { create(:user) }
 
       let!(:enterprise1) { create(:distributor_enterprise, owner: user) }
       before { create(:distributor_enterprise, owner: user) }

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -134,7 +134,7 @@ describe Spree::Admin::ProductsController, type: :controller do
     }
 
     before do
-      login_as_admin
+      controller_login_as_admin
       create(:stock_location)
     end
 

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -10,7 +10,7 @@ describe Spree::Admin::ProductsController, type: :controller do
       end
 
       before do
-        login_as_enterprise_user [s_managed]
+        controller_login_as_enterprise_user [s_managed]
         spree_post :bulk_update,
                    "products" => [{ "id" => product.id, "name" => "Pine nuts" }]
       end
@@ -38,7 +38,7 @@ describe Spree::Admin::ProductsController, type: :controller do
         )
       end
 
-      before { login_as_enterprise_user([producer]) }
+      before { controller_login_as_enterprise_user([producer]) }
 
       it 'fails' do
         spree_post :bulk_update,
@@ -92,7 +92,7 @@ describe Spree::Admin::ProductsController, type: :controller do
         )
       end
 
-      before { login_as_enterprise_user([producer]) }
+      before { controller_login_as_enterprise_user([producer]) }
 
       it 'does not fail' do
         spree_post :bulk_update,
@@ -174,7 +174,7 @@ describe Spree::Admin::ProductsController, type: :controller do
     let!(:product) { create(:simple_product, supplier: producer) }
 
     before do
-      login_as_enterprise_user [producer]
+      controller_login_as_enterprise_user [producer]
     end
 
     describe "change product supplier" do

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -191,7 +191,7 @@ describe Spree::Admin::ReportsController, type: :controller do
   end
 
   context "Products & Inventory" do
-    before { login_as_admin }
+    before { controller_login_as_admin }
 
     context "with distributors and suppliers" do
       let(:distributors) { [coordinator1, distributor1, distributor2] }
@@ -235,7 +235,7 @@ describe Spree::Admin::ReportsController, type: :controller do
   end
 
   context "My Customers" do
-    before { login_as_admin }
+    before { controller_login_as_admin }
 
     it "should have report types for customers" do
       expect(subject.report_types[:customers]).to eq([
@@ -286,7 +286,7 @@ describe Spree::Admin::ReportsController, type: :controller do
   end
 
   context "Admin" do
-    before { login_as_admin }
+    before { controller_login_as_admin }
 
     describe "users_and_enterprises" do
       let!(:present_objects) { [coordinator1] }

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -65,7 +65,7 @@ describe Spree::Admin::ReportsController, type: :controller do
   context "Coordinator Enterprise User" do
     let!(:present_objects) { [orderA1, orderA2, orderB1, orderB2] }
 
-    before { login_as_enterprise_user [coordinator1] }
+    before { controller_login_as_enterprise_user [coordinator1] }
 
     describe 'Orders & Fulfillment' do
       it "shows all orders in order cycles I coordinate" do
@@ -79,7 +79,7 @@ describe Spree::Admin::ReportsController, type: :controller do
 
   # As a Distributor Enterprise user for distributor1
   context "Distributor Enterprise User" do
-    before { login_as_enterprise_user [distributor1] }
+    before { controller_login_as_enterprise_user [distributor1] }
 
     describe 'Orders and Distributors' do
       let!(:present_objects) { [orderA1, orderA2, orderB1, orderB2] }
@@ -132,7 +132,7 @@ describe Spree::Admin::ReportsController, type: :controller do
 
   # As a Supplier Enterprise user for supplier1
   context "Supplier" do
-    before { login_as_enterprise_user [supplier1] }
+    before { controller_login_as_enterprise_user [supplier1] }
 
     describe 'index' do
       it "loads reports relevant to producers" do

--- a/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module Spree
   module Admin
     describe ReturnAuthorizationsController, type: :controller do
-      include AuthenticationWorkflow
+      include AuthenticationHelper
 
       let(:order) do
         create(:order, :with_line_item, :completed,

--- a/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -13,7 +13,7 @@ module Spree
       end
 
       before do
-        login_as_admin
+        controller_login_as_admin
 
         # Pay the order
         order.payments.first.complete

--- a/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/spec/controllers/spree/admin/search_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::SearchController, type: :controller do
     let!(:manager) { create(:user, email: "test2@email.com" ) }
     let!(:random) { create(:user, email: "test3@email.com" ) }
     let!(:enterprise) { create(:enterprise, owner: owner, users: [owner, manager]) }
-    before { login_as_enterprise_user [enterprise] }
+    before { controller_login_as_enterprise_user [enterprise] }
 
     describe 'searching for known users' do
       describe "when search query is not an exact match" do

--- a/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/spec/controllers/spree/admin/search_controller_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe Spree::Admin::SearchController, type: :controller do
-  include AuthenticationWorkflow
   context "Distributor Enterprise User" do
-    let!(:owner) { create_enterprise_user( email: "test1@email.com" ) }
-    let!(:manager) { create_enterprise_user( email: "test2@email.com" ) }
-    let!(:random) { create_enterprise_user( email: "test3@email.com" ) }
+    let!(:owner) { create(:user, email: "test1@email.com" ) }
+    let!(:manager) { create(:user, email: "test2@email.com" ) }
+    let!(:random) { create(:user, email: "test3@email.com" ) }
     let!(:enterprise) { create(:enterprise, owner: owner, users: [owner, manager]) }
     before { login_as_enterprise_user [enterprise] }
 

--- a/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
@@ -8,7 +8,7 @@ module Spree
       include AuthenticationWorkflow
 
       describe "#create and #update" do
-        before { login_as_admin }
+        before { controller_login_as_admin }
 
         it "creates a shipping shipping category" do
           expect {

--- a/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module Spree
   module Admin
     describe ShippingCategoriesController, type: :controller do
-      include AuthenticationWorkflow
+      include AuthenticationHelper
 
       describe "#create and #update" do
         before { controller_login_as_admin }

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Admin::ShippingMethodsController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "#update" do
     let(:shipping_method) { create(:shipping_method) }

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -16,7 +16,7 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
       }
     }
 
-    before { login_as_admin }
+    before { controller_login_as_admin }
 
     it "updates preferred_amount and preferred_currency of a FlatRate calculator" do
       shipping_method.calculator = create(:calculator_flat_rate, calculable: shipping_method)
@@ -81,7 +81,7 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
       let(:shipping_method) { create(:shipping_method) }
 
       scenario "is soft deleted" do
-        login_as_admin
+        controller_login_as_admin
         expect(shipping_method.deleted_at).to be_nil
 
         spree_delete :destroy, "id" => shipping_method.id
@@ -94,7 +94,7 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
       let(:order) { create(:order_with_line_items) }
 
       scenario "is not soft deleted" do
-        login_as_admin
+        controller_login_as_admin
         expect(order.shipping_method.deleted_at).to be_nil
 
         spree_delete :destroy, "id" => order.shipping_method.id

--- a/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Admin
     describe VariantsController, type: :controller do
-      before { login_as_admin }
+      before { controller_login_as_admin }
 
       describe "#index" do
         describe "deleted variants" do

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'support/request/authentication_workflow'
 
 describe Spree::CreditCardsController, type: :controller do
   let(:user) { create(:user) }

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 require 'support/request/authentication_workflow'
 
 describe Spree::CreditCardsController, type: :controller do
-  include AuthenticationWorkflow
-  let(:user) { create_enterprise_user }
+  let(:user) { create(:user) }
   let(:token) { "tok_234bd2c22" }
 
   before do

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe Spree::UserSessionsController, type: :controller do
-  include AuthenticationWorkflow
-
-  let(:user) { create_enterprise_user }
+  let(:user) { create(:user) }
 
   before do
     @request.env["devise.mapping"] = Devise.mappings[:spree_user]

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::UsersController, type: :controller do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "show" do
     let!(:u1) { create(:user) }

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe UserConfirmationsController, type: :controller do
-  include AuthenticationWorkflow
   include OpenFoodNetwork::EmailHelper
 
-  let!(:user) { create_enterprise_user }
-  let!(:confirmed_user) { create_enterprise_user(confirmed_at: nil) }
-  let!(:unconfirmed_user) { create_enterprise_user(confirmed_at: nil) }
+  let!(:user) { create(:user) }
+  let!(:confirmed_user) { create(:user, confirmed_at: nil) }
+  let!(:unconfirmed_user) { create(:user, confirmed_at: nil) }
   let!(:confirmed_token) { confirmed_user.confirmation_token }
 
   before do

--- a/spec/features/admin/adjustments_spec.rb
+++ b/spec/features/admin/adjustments_spec.rb
@@ -21,8 +21,7 @@ feature '
 
   scenario "adding taxed adjustments to an order" do
     # When I go to the adjustments page for the order
-    login_to_admin_section
-    visit spree.admin_orders_path
+    login_to_admin_and_visit spree.admin_orders_path
     page.find('td.actions a.icon-edit').click
     click_link 'Adjustments'
 
@@ -44,8 +43,7 @@ feature '
     adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order, amount: 110, included_tax: 10)
 
     # When I go to the adjustments page for the order
-    login_to_admin_section
-    visit spree.admin_orders_path
+    login_to_admin_and_visit spree.admin_orders_path
     page.find('td.actions a.icon-edit').click
     click_link 'Adjustments'
     page.find('tr', text: 'Extra Adjustment').find('a.icon-edit').click
@@ -68,8 +66,7 @@ feature '
     adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order, amount: 110, included_tax: 0)
 
     # When I go to the adjustments page for the order
-    login_to_admin_section
-    visit spree.admin_orders_path
+    login_to_admin_and_visit spree.admin_orders_path
     page.find('td.actions a.icon-edit').click
     click_link 'Adjustments'
     page.find('tr', text: 'Extra Adjustment').find('a.icon-edit').click

--- a/spec/features/admin/adjustments_spec.rb
+++ b/spec/features/admin/adjustments_spec.rb
@@ -21,7 +21,7 @@ feature '
 
   scenario "adding taxed adjustments to an order" do
     # When I go to the adjustments page for the order
-    login_to_admin_and_visit spree.admin_orders_path
+    login_as_admin_and_visit spree.admin_orders_path
     page.find('td.actions a.icon-edit').click
     click_link 'Adjustments'
 
@@ -43,7 +43,7 @@ feature '
     adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order, amount: 110, included_tax: 10)
 
     # When I go to the adjustments page for the order
-    login_to_admin_and_visit spree.admin_orders_path
+    login_as_admin_and_visit spree.admin_orders_path
     page.find('td.actions a.icon-edit').click
     click_link 'Adjustments'
     page.find('tr', text: 'Extra Adjustment').find('a.icon-edit').click
@@ -66,7 +66,7 @@ feature '
     adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order, amount: 110, included_tax: 0)
 
     # When I go to the adjustments page for the order
-    login_to_admin_and_visit spree.admin_orders_path
+    login_as_admin_and_visit spree.admin_orders_path
     page.find('td.actions a.icon-edit').click
     click_link 'Adjustments'
     page.find('tr', text: 'Extra Adjustment').find('a.icon-edit').click

--- a/spec/features/admin/adjustments_spec.rb
+++ b/spec/features/admin/adjustments_spec.rb
@@ -4,7 +4,7 @@ feature '
     As an administrator
     I want to manage adjustments on orders
 ', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let!(:user) { create(:user) }

--- a/spec/features/admin/authentication_spec.rb
+++ b/spec/features/admin/authentication_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature "Authentication", js: true do
   include UIComponentHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let(:user) { create(:user, password: "password", password_confirmation: "password") }

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -5,7 +5,7 @@ feature '
   I want to be able to manage orders in bulk
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   context "listing orders" do

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -723,7 +723,7 @@ feature '
       @enterprise_user.enterprise_roles.build(enterprise: s1).save
       @enterprise_user.enterprise_roles.build(enterprise: d1).save
 
-      quick_login_as @enterprise_user
+      login_as @enterprise_user
     end
 
     it "displays a Bulk Management Tab under the Orders item" do

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -719,7 +719,7 @@ feature '
     let!(:line_item_not_distributed) { create(:line_item_with_shipment, order: o2, product: create(:product, supplier: s1) ) }
 
     before(:each) do
-      @enterprise_user = create_enterprise_user
+      @enterprise_user = create(:user)
       @enterprise_user.enterprise_roles.build(enterprise: s1).save
       @enterprise_user.enterprise_roles.build(enterprise: d1).save
 

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -10,7 +10,7 @@ feature '
 
   context "listing orders" do
     before :each do
-      quick_login_as_admin
+      login_as_admin
     end
 
     it "displays a message when number of line items is zero" do
@@ -121,7 +121,7 @@ feature '
 
   context "altering line item properties" do
     before :each do
-      quick_login_as_admin
+      login_as_admin
     end
 
     context "tracking changes" do
@@ -177,7 +177,7 @@ feature '
 
   context "using page controls" do
     before :each do
-      quick_login_as_admin
+      login_as_admin
     end
 
     let!(:p1) { create(:product_with_option_types, group_buy: true, group_buy_unit_size: 5000, variant_unit: "weight", variants: [create(:variant, unit_value: 1000)] ) }

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -176,7 +176,7 @@ feature '
     shipping_category = create(:shipping_category)
     taxon = create(:taxon)
 
-    login_to_admin_and_visit spree.admin_products_path
+    login_as_admin_and_visit spree.admin_products_path
 
     find("a", text: "NEW PRODUCT").click
     expect(page).to have_content 'NEW PRODUCT'
@@ -511,7 +511,7 @@ feature '
       let!(:v2) { p2.variants.first }
 
       before do
-        login_to_admin_and_visit spree.admin_products_path
+        login_as_admin_and_visit spree.admin_products_path
       end
 
       it "shows an edit button for products, which takes the user to the standard edit page for that product in a new window" do
@@ -554,7 +554,7 @@ feature '
         p2 = FactoryBot.create(:product, name: "P2")
         p3 = FactoryBot.create(:product, name: "P3")
 
-        login_to_admin_and_visit spree.admin_products_path
+        login_as_admin_and_visit spree.admin_products_path
 
         expect(page).to have_selector "a.clone-product", count: 3
 
@@ -578,7 +578,7 @@ feature '
     describe "using column display dropdown" do
       it "shows a column display dropdown, which shows a list of columns when clicked" do
         FactoryBot.create(:simple_product)
-        login_to_admin_and_visit spree.admin_products_path
+        login_as_admin_and_visit spree.admin_products_path
 
         toggle_columns "Available On"
 
@@ -605,7 +605,7 @@ feature '
         p1 = FactoryBot.create(:simple_product, name: "product1", supplier: s1)
         p2 = FactoryBot.create(:simple_product, name: "product2", supplier: s2)
 
-        login_to_admin_and_visit spree.admin_products_path
+        login_as_admin_and_visit spree.admin_products_path
 
         # Page shows the filter controls
         expect(page).to have_select "producer_filter", visible: false
@@ -756,7 +756,7 @@ feature '
     let!(:product) { create(:simple_product, name: "Carrots") }
 
     it "displays product images and image upload modal" do
-      login_to_admin_and_visit spree.admin_products_path
+      login_as_admin_and_visit spree.admin_products_path
 
       within "table#listing_products tr#p_#{product.id}" do
         # Displays product images

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -5,7 +5,7 @@ feature '
   I want to be able to manage products in bulk
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   describe "listing products" do

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -10,7 +10,7 @@ feature '
 
   describe "listing products" do
     before do
-      quick_login_as_admin
+      login_as_admin
     end
 
     it "displays a list of products" do
@@ -101,7 +101,7 @@ feature '
 
   describe "listing variants" do
     before do
-      quick_login_as_admin
+      login_as_admin
     end
 
     it "displays a list of variants for each product" do
@@ -176,8 +176,7 @@ feature '
     shipping_category = create(:shipping_category)
     taxon = create(:taxon)
 
-    quick_login_as_admin
-    visit spree.admin_products_path
+    login_to_admin_and_visit spree.admin_products_path
 
     find("a", text: "NEW PRODUCT").click
     expect(page).to have_content 'NEW PRODUCT'
@@ -199,7 +198,7 @@ feature '
   scenario "creating new variants" do
     # Given a product without variants or a unit
     p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
-    quick_login_as_admin
+    login_as_admin
     visit spree.admin_products_path
 
     # I should see an add variant button
@@ -250,7 +249,7 @@ feature '
     t2 = FactoryBot.create(:taxon)
     p = FactoryBot.create(:product, supplier: s1, available_on: Date.current, variant_unit: 'volume', variant_unit_scale: 1, primary_taxon: t2, sku: "OLD SKU")
 
-    quick_login_as_admin
+    login_as_admin
     visit spree.admin_products_path
 
     toggle_columns "Available On", /^Category?/, "Inherits Properties?", "SKU"
@@ -290,7 +289,7 @@ feature '
   scenario "updating a product with a variant unit of 'items'" do
     p = FactoryBot.create(:product, variant_unit: 'weight', variant_unit_scale: 1000)
 
-    quick_login_as_admin
+    login_as_admin
     visit spree.admin_products_path
 
     expect(page).to have_select "variant_unit_with_scale", selected: "Weight (kg)"
@@ -317,7 +316,7 @@ feature '
     v.update_attribute(:on_demand, false)
     v.update_attribute(:on_hand, 9)
 
-    quick_login_as_admin
+    login_as_admin
     visit spree.admin_products_path
     expect(page).to have_selector "a.view-variants", count: 1
     find("a.view-variants").click
@@ -353,7 +352,7 @@ feature '
     p = FactoryBot.create(:product)
     v = FactoryBot.create(:variant, product: p, price: 3.0)
 
-    quick_login_as_admin
+    login_as_admin
     visit spree.admin_products_path
     expect(page).to have_selector "a.view-variants", count: 1
     find("a.view-variants").click
@@ -376,7 +375,7 @@ feature '
 
   scenario "updating a product mutiple times without refresh" do
     p = FactoryBot.create(:product, name: 'original name')
-    quick_login_as_admin
+    login_as_admin
 
     visit spree.admin_products_path
 
@@ -409,7 +408,7 @@ feature '
 
   scenario "updating a product after cloning a product" do
     p = FactoryBot.create(:product, name: "product 1")
-    quick_login_as_admin
+    login_as_admin
 
     visit spree.admin_products_path
 
@@ -435,7 +434,7 @@ feature '
     s2 = create(:supplier_enterprise)
     p1 = FactoryBot.create(:simple_product, name: "product1", supplier: s1)
     p2 = FactoryBot.create(:simple_product, name: "product2", supplier: s2)
-    quick_login_as_admin
+    login_as_admin
 
     visit spree.admin_products_path
 
@@ -463,7 +462,7 @@ feature '
       let!(:v3) { FactoryBot.create(:variant, product: p2 ) }
 
       before do
-        quick_login_as_admin
+        login_as_admin
         visit spree.admin_products_path
       end
 
@@ -512,8 +511,7 @@ feature '
       let!(:v2) { p2.variants.first }
 
       before do
-        quick_login_as_admin
-        visit spree.admin_products_path
+        login_to_admin_and_visit spree.admin_products_path
       end
 
       it "shows an edit button for products, which takes the user to the standard edit page for that product in a new window" do
@@ -555,9 +553,8 @@ feature '
         p1 = FactoryBot.create(:product, name: "P1")
         p2 = FactoryBot.create(:product, name: "P2")
         p3 = FactoryBot.create(:product, name: "P3")
-        quick_login_as_admin
 
-        visit spree.admin_products_path
+        login_to_admin_and_visit spree.admin_products_path
 
         expect(page).to have_selector "a.clone-product", count: 3
 
@@ -581,9 +578,7 @@ feature '
     describe "using column display dropdown" do
       it "shows a column display dropdown, which shows a list of columns when clicked" do
         FactoryBot.create(:simple_product)
-        quick_login_as_admin
-
-        visit spree.admin_products_path
+        login_to_admin_and_visit spree.admin_products_path
 
         toggle_columns "Available On"
 
@@ -609,9 +604,8 @@ feature '
         s2 = create(:supplier_enterprise)
         p1 = FactoryBot.create(:simple_product, name: "product1", supplier: s1)
         p2 = FactoryBot.create(:simple_product, name: "product2", supplier: s2)
-        quick_login_as_admin
 
-        visit spree.admin_products_path
+        login_to_admin_and_visit spree.admin_products_path
 
         # Page shows the filter controls
         expect(page).to have_select "producer_filter", visible: false
@@ -762,8 +756,7 @@ feature '
     let!(:product) { create(:simple_product, name: "Carrots") }
 
     it "displays product images and image upload modal" do
-      quick_login_as_admin
-      visit spree.admin_products_path
+      login_to_admin_and_visit spree.admin_products_path
 
       within "table#listing_products tr#p_#{product.id}" do
         # Displays product images

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -658,7 +658,7 @@ feature '
     end
 
     before do
-      @enterprise_user = create_enterprise_user
+      @enterprise_user = create(:user)
       @enterprise_user.enterprise_roles.build(enterprise: supplier_managed1).save
       @enterprise_user.enterprise_roles.build(enterprise: supplier_managed2).save
       @enterprise_user.enterprise_roles.build(enterprise: distributor_managed).save

--- a/spec/features/admin/configuration/general_settings_spec.rb
+++ b/spec/features/admin/configuration/general_settings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "General Settings" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before(:each) do
     login_as_admin_and_visit spree.admin_dashboard_path

--- a/spec/features/admin/configuration/general_settings_spec.rb
+++ b/spec/features/admin/configuration/general_settings_spec.rb
@@ -4,8 +4,7 @@ describe "General Settings" do
   include AuthenticationWorkflow
 
   before(:each) do
-    quick_login_as_admin
-    visit spree.admin_dashboard_path
+    login_to_admin_and_visit spree.admin_dashboard_path
     click_link "Configuration"
     click_link "General Settings"
   end

--- a/spec/features/admin/configuration/general_settings_spec.rb
+++ b/spec/features/admin/configuration/general_settings_spec.rb
@@ -4,7 +4,7 @@ describe "General Settings" do
   include AuthenticationWorkflow
 
   before(:each) do
-    login_to_admin_and_visit spree.admin_dashboard_path
+    login_as_admin_and_visit spree.admin_dashboard_path
     click_link "Configuration"
     click_link "General Settings"
   end

--- a/spec/features/admin/configuration/image_settings_spec.rb
+++ b/spec/features/admin/configuration/image_settings_spec.rb
@@ -4,8 +4,7 @@ describe "image settings" do
   include AuthenticationWorkflow
 
   before do
-    quick_login_as_admin
-    visit spree.admin_dashboard_path
+    login_to_admin_and_visit spree.admin_dashboard_path
     click_link "Configuration"
     click_link "Image Settings"
   end

--- a/spec/features/admin/configuration/image_settings_spec.rb
+++ b/spec/features/admin/configuration/image_settings_spec.rb
@@ -4,7 +4,7 @@ describe "image settings" do
   include AuthenticationWorkflow
 
   before do
-    login_to_admin_and_visit spree.admin_dashboard_path
+    login_as_admin_and_visit spree.admin_dashboard_path
     click_link "Configuration"
     click_link "Image Settings"
   end

--- a/spec/features/admin/configuration/image_settings_spec.rb
+++ b/spec/features/admin/configuration/image_settings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "image settings" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before do
     login_as_admin_and_visit spree.admin_dashboard_path

--- a/spec/features/admin/configuration/mail_methods_spec.rb
+++ b/spec/features/admin/configuration/mail_methods_spec.rb
@@ -4,7 +4,7 @@ describe "Mail Methods" do
   include AuthenticationHelper
 
   before(:each) do
-    login_as_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.edit_admin_general_settings_path
   end
 
   context "edit" do

--- a/spec/features/admin/configuration/mail_methods_spec.rb
+++ b/spec/features/admin/configuration/mail_methods_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Mail Methods" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before(:each) do
     login_as_admin_and_visit spree.admin_general_settings_path

--- a/spec/features/admin/configuration/mail_methods_spec.rb
+++ b/spec/features/admin/configuration/mail_methods_spec.rb
@@ -4,9 +4,7 @@ describe "Mail Methods" do
   include AuthenticationWorkflow
 
   before(:each) do
-    quick_login_as_admin
-    visit spree.admin_dashboard_path
-    click_link "Configuration"
+    login_to_admin_and_visit spree.admin_general_settings_path
   end
 
   context "edit" do

--- a/spec/features/admin/configuration/mail_methods_spec.rb
+++ b/spec/features/admin/configuration/mail_methods_spec.rb
@@ -4,7 +4,7 @@ describe "Mail Methods" do
   include AuthenticationWorkflow
 
   before(:each) do
-    login_to_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.admin_general_settings_path
   end
 
   context "edit" do

--- a/spec/features/admin/configuration/states_spec.rb
+++ b/spec/features/admin/configuration/states_spec.rb
@@ -6,7 +6,7 @@ describe "States" do
   let!(:country) { create(:country) }
 
   before(:each) do
-    quick_login_as_admin
+    login_as_admin
     @hungary = Spree::Country.create!(name: "Hungary", iso_name: "Hungary")
     Spree::Config[:default_country_id] = country.id
   end

--- a/spec/features/admin/configuration/states_spec.rb
+++ b/spec/features/admin/configuration/states_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "States" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let!(:country) { create(:country) }
 

--- a/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/spec/features/admin/configuration/tax_categories_spec.rb
@@ -4,7 +4,7 @@ describe "Tax Categories" do
   include AuthenticationWorkflow
 
   before(:each) do
-    login_to_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.admin_general_settings_path
   end
 
   context "admin visiting tax categories list" do

--- a/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/spec/features/admin/configuration/tax_categories_spec.rb
@@ -4,9 +4,7 @@ describe "Tax Categories" do
   include AuthenticationWorkflow
 
   before(:each) do
-    quick_login_as_admin
-    visit spree.admin_dashboard_path
-    click_link "Configuration"
+    login_to_admin_and_visit spree.admin_general_settings_path
   end
 
   context "admin visiting tax categories list" do

--- a/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/spec/features/admin/configuration/tax_categories_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Tax Categories" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before(:each) do
     login_as_admin_and_visit spree.admin_general_settings_path

--- a/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/spec/features/admin/configuration/tax_categories_spec.rb
@@ -4,7 +4,7 @@ describe "Tax Categories" do
   include AuthenticationHelper
 
   before(:each) do
-    login_as_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.edit_admin_general_settings_path
   end
 
   context "admin visiting tax categories list" do

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -7,7 +7,7 @@ describe "Tax Rates" do
   let!(:tax_rate) { create(:tax_rate, calculator: calculator) }
 
   before do
-    login_to_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.admin_general_settings_path
   end
 
   # Regression test for #535

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -7,7 +7,7 @@ describe "Tax Rates" do
   let!(:tax_rate) { create(:tax_rate, calculator: calculator) }
 
   before do
-    login_as_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.edit_admin_general_settings_path
   end
 
   # Regression test for #535

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Tax Rates" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let!(:calculator) { create(:calculator_per_item, calculable: create(:order)) }
   let!(:tax_rate) { create(:tax_rate, calculator: calculator) }

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -7,9 +7,7 @@ describe "Tax Rates" do
   let!(:tax_rate) { create(:tax_rate, calculator: calculator) }
 
   before do
-    quick_login_as_admin
-    visit spree.admin_dashboard_path
-    click_link "Configuration"
+    login_to_admin_and_visit spree.admin_general_settings_path
   end
 
   # Regression test for #535

--- a/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/spec/features/admin/configuration/taxonomies_spec.rb
@@ -4,9 +4,7 @@ describe "Taxonomies" do
   include AuthenticationWorkflow
 
   before(:each) do
-    quick_login_as_admin
-    visit spree.admin_dashboard_path
-    click_link "Configuration"
+    login_to_admin_and_visit spree.admin_general_settings_path
   end
 
   context "show" do

--- a/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/spec/features/admin/configuration/taxonomies_spec.rb
@@ -4,7 +4,7 @@ describe "Taxonomies" do
   include AuthenticationHelper
 
   before(:each) do
-    login_as_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.edit_admin_general_settings_path
   end
 
   context "show" do

--- a/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/spec/features/admin/configuration/taxonomies_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Taxonomies" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before(:each) do
     login_as_admin_and_visit spree.admin_general_settings_path

--- a/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/spec/features/admin/configuration/taxonomies_spec.rb
@@ -4,7 +4,7 @@ describe "Taxonomies" do
   include AuthenticationWorkflow
 
   before(:each) do
-    login_to_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.admin_general_settings_path
   end
 
   context "show" do

--- a/spec/features/admin/configuration/zones_spec.rb
+++ b/spec/features/admin/configuration/zones_spec.rb
@@ -4,16 +4,15 @@ describe "Zones" do
   include AuthenticationWorkflow
 
   before do
-    quick_login_as_admin
+    login_as_admin
     Spree::Zone.delete_all
   end
 
   scenario "list existing zones" do
-    visit spree.admin_dashboard_path
-    click_link "Configuration"
-
+    visit spree.admin_general_settings_path
     create(:zone, name: "eastern", description: "zone is eastern")
     create(:zone, name: "western", description: "cool san fran")
+
     click_link "Zones"
 
     within_row(1) { expect(page).to have_content("eastern") }

--- a/spec/features/admin/configuration/zones_spec.rb
+++ b/spec/features/admin/configuration/zones_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Zones" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before do
     login_as_admin

--- a/spec/features/admin/configuration/zones_spec.rb
+++ b/spec/features/admin/configuration/zones_spec.rb
@@ -9,7 +9,7 @@ describe "Zones" do
   end
 
   scenario "list existing zones" do
-    visit spree.admin_general_settings_path
+    visit spree.edit_admin_general_settings_path
     create(:zone, name: "eastern", description: "zone is eastern")
     create(:zone, name: "western", description: "cool san fran")
 

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -8,7 +8,7 @@ feature '
   include WebHelper
 
   before do
-    login_as_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.edit_admin_general_settings_path
     click_link 'Content'
   end
 

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -8,8 +8,7 @@ feature '
   include WebHelper
 
   before do
-    login_to_admin_section
-    click_link 'Configuration'
+    login_to_admin_and_visit spree.admin_general_settings_path
     click_link 'Content'
   end
 

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -8,7 +8,7 @@ feature '
   include WebHelper
 
   before do
-    login_to_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.admin_general_settings_path
     click_link 'Content'
   end
 

--- a/spec/features/admin/content_spec.rb
+++ b/spec/features/admin/content_spec.rb
@@ -4,7 +4,7 @@ feature '
   As a site administrator
   I want to configure the site content
 ' do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   before do

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -18,7 +18,7 @@ feature 'Customers' do
       let!(:customer4) { create(:customer, enterprise: managed_distributor2) }
 
       before do
-        quick_login_as user
+        login_as user
         visit admin_customers_path
       end
 

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -6,7 +6,7 @@ feature 'Customers' do
   include WebHelper
 
   context "as an enterprise user" do
-    let(:user) { create_enterprise_user(enterprise_limit: 10) }
+    let(:user) { create(:user, enterprise_limit: 10) }
     let(:managed_distributor1) { create(:distributor_enterprise, owner: user) }
     let(:managed_distributor2) { create(:distributor_enterprise, owner: user) }
     let(:unmanaged_distributor) { create(:distributor_enterprise) }

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Customers' do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   context "as an enterprise user" do

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -113,7 +113,7 @@ feature '
     before(:each) do
       enterprise_user.enterprise_roles.build(enterprise: distributor1).save
       enterprise_user.enterprise_roles.build(enterprise: distributor2).save
-      quick_login_as enterprise_user
+      login_as enterprise_user
     end
 
     it "creates enterprise fees" do

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want to manage enterprise fees
 ', js: true do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let!(:tax_category_gst) { create(:tax_category, name: 'GST') }
 

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -13,7 +13,7 @@ feature '
     fee = create(:enterprise_fee, name: '$0.50 / kg', fee_type: 'packing', tax_category: tax_category_gst)
     amount = fee.calculator.preferred_amount
 
-    login_as_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.edit_admin_general_settings_path
     click_link 'Enterprise Fees'
 
     expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -13,8 +13,7 @@ feature '
     fee = create(:enterprise_fee, name: '$0.50 / kg', fee_type: 'packing', tax_category: tax_category_gst)
     amount = fee.calculator.preferred_amount
 
-    login_to_admin_section
-    click_link 'Configuration'
+    login_to_admin_and_visit spree.admin_general_settings_path
     click_link 'Enterprise Fees'
 
     expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -29,8 +29,7 @@ feature '
     e = create(:supplier_enterprise, name: 'Feedme')
 
     # When I go to the enterprise fees page
-    quick_login_as_admin
-    visit admin_enterprise_fees_path
+    login_to_admin_and_visit admin_enterprise_fees_path
 
     # And I fill in the fields for a new enterprise fee and click update
     select 'Feedme', from: 'enterprise_fee_set_collection_attributes_0_enterprise_id'
@@ -58,8 +57,7 @@ feature '
     enterprise = create(:enterprise, name: 'Foo')
 
     # When I go to the enterprise fees page
-    quick_login_as_admin
-    visit admin_enterprise_fees_path
+    login_to_admin_and_visit admin_enterprise_fees_path
 
     # And I update the fields for the enterprise fee and click update
     select 'Foo', from: 'enterprise_fee_set_collection_attributes_0_enterprise_id'
@@ -92,8 +90,7 @@ feature '
     fee = create(:enterprise_fee)
 
     # When I go to the enterprise fees page
-    quick_login_as_admin
-    visit admin_enterprise_fees_path
+    login_to_admin_and_visit admin_enterprise_fees_path
 
     # And I click delete
     accept_alert do

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -4,8 +4,8 @@ feature '
     As an administrator
     I want to manage enterprise fees
 ', js: true do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   let!(:tax_category_gst) { create(:tax_category, name: 'GST') }
 
@@ -107,7 +107,7 @@ feature '
   end
 
   context "as an enterprise manager" do
-    let(:enterprise_user) { create_enterprise_user }
+    let(:enterprise_user) { create(:user) }
     let(:distributor1) { create(:distributor_enterprise, name: 'First Distributor') }
     let(:distributor2) { create(:distributor_enterprise, name: 'Second Distributor') }
     let(:distributor3) { create(:distributor_enterprise, name: 'Third Distributor') }

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -13,7 +13,7 @@ feature '
     fee = create(:enterprise_fee, name: '$0.50 / kg', fee_type: 'packing', tax_category: tax_category_gst)
     amount = fee.calculator.preferred_amount
 
-    login_to_admin_and_visit spree.admin_general_settings_path
+    login_as_admin_and_visit spree.admin_general_settings_path
     click_link 'Enterprise Fees'
 
     expect(page).to have_select "enterprise_fee_set_collection_attributes_0_enterprise_id"
@@ -29,7 +29,7 @@ feature '
     e = create(:supplier_enterprise, name: 'Feedme')
 
     # When I go to the enterprise fees page
-    login_to_admin_and_visit admin_enterprise_fees_path
+    login_as_admin_and_visit admin_enterprise_fees_path
 
     # And I fill in the fields for a new enterprise fee and click update
     select 'Feedme', from: 'enterprise_fee_set_collection_attributes_0_enterprise_id'
@@ -57,7 +57,7 @@ feature '
     enterprise = create(:enterprise, name: 'Foo')
 
     # When I go to the enterprise fees page
-    login_to_admin_and_visit admin_enterprise_fees_path
+    login_as_admin_and_visit admin_enterprise_fees_path
 
     # And I update the fields for the enterprise fee and click update
     select 'Foo', from: 'enterprise_fee_set_collection_attributes_0_enterprise_id'
@@ -90,7 +90,7 @@ feature '
     fee = create(:enterprise_fee)
 
     # When I go to the enterprise fees page
-    login_to_admin_and_visit admin_enterprise_fees_path
+    login_as_admin_and_visit admin_enterprise_fees_path
 
     # And I click delete
     accept_alert do

--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -4,8 +4,8 @@ feature '
     As an administrator
     I want to manage enterprise groups
 ' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   before(:each) do
     login_to_admin_section
@@ -107,7 +107,7 @@ feature '
   end
 
   context "as an enterprise user" do
-    let(:user) { create_enterprise_user }
+    let(:user) { create(:user) }
     let!(:enterprise) { create(:distributor_enterprise, owner: user) }
     let!(:group) { create(:enterprise_group, name: 'My Group', owner: user) }
 

--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -112,7 +112,7 @@ feature '
     let!(:group) { create(:enterprise_group, name: 'My Group', owner: user) }
 
     it "lets me access enterprise groups" do
-      quick_login_as user
+      login_as user
       visit spree.admin_dashboard_path
       click_link 'Groups'
       expect(page).to have_content 'My Group'

--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want to manage enterprise groups
 ' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before(:each) do
     login_to_admin_section

--- a/spec/features/admin/enterprise_relationships_spec.rb
+++ b/spec/features/admin/enterprise_relationships_spec.rb
@@ -4,8 +4,8 @@ feature '
   As an Administrator
   I want to manage relationships between enterprises
 ', js: true do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   context "as a site administrator" do
     before { quick_login_as_admin }
@@ -92,7 +92,7 @@ feature '
     let!(:d1) { create(:distributor_enterprise) }
     let!(:d2) { create(:distributor_enterprise) }
     let!(:d3) { create(:distributor_enterprise) }
-    let(:enterprise_user) { create_enterprise_user( enterprises: [d1] ) }
+    let(:enterprise_user) { create(:user, enterprises: [d1] ) }
 
     let!(:er1) { create(:enterprise_relationship, parent: d1, child: d2) }
     let!(:er2) { create(:enterprise_relationship, parent: d2, child: d1) }

--- a/spec/features/admin/enterprise_relationships_spec.rb
+++ b/spec/features/admin/enterprise_relationships_spec.rb
@@ -5,7 +5,7 @@ feature '
   I want to manage relationships between enterprises
 ', js: true do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   context "as a site administrator" do
     before { login_as_admin }

--- a/spec/features/admin/enterprise_relationships_spec.rb
+++ b/spec/features/admin/enterprise_relationships_spec.rb
@@ -98,7 +98,7 @@ feature '
     let!(:er2) { create(:enterprise_relationship, parent: d2, child: d1) }
     let!(:er3) { create(:enterprise_relationship, parent: d2, child: d3) }
 
-    before { quick_login_as enterprise_user }
+    before { login_as enterprise_user }
 
     scenario "enterprise user can only see relationships involving their enterprises" do
       visit admin_enterprise_relationships_path

--- a/spec/features/admin/enterprise_relationships_spec.rb
+++ b/spec/features/admin/enterprise_relationships_spec.rb
@@ -8,7 +8,7 @@ feature '
   include AuthenticationWorkflow
 
   context "as a site administrator" do
-    before { quick_login_as_admin }
+    before { login_as_admin }
 
     scenario "listing relationships" do
       # Given some enterprises with relationships

--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -4,7 +4,7 @@ feature '
   As an Administrator
   I want to manage relationships between users and enterprises
 ', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include OpenFoodNetwork::EmailHelper
 

--- a/spec/features/admin/enterprise_user_spec.rb
+++ b/spec/features/admin/enterprise_user_spec.rb
@@ -19,8 +19,7 @@ feature '
     context "with a limitted number of owned enterprises" do
       scenario "setting the enterprise ownership limit" do
         expect(user.enterprise_limit).to eq 5
-        login_to_admin_section
-        click_link 'Users'
+        login_to_admin_and_visit spree.admin_users_path
         click_link user.email
 
         fill_in "user_enterprise_limit", with: 2

--- a/spec/features/admin/enterprise_user_spec.rb
+++ b/spec/features/admin/enterprise_user_spec.rb
@@ -34,7 +34,7 @@ feature '
   describe "system management lockdown" do
     before do
       user.enterprise_roles.create!(enterprise: supplier1)
-      quick_login_as user
+      login_as user
     end
 
     scenario "should not be able to see system configuration" do

--- a/spec/features/admin/enterprise_user_spec.rb
+++ b/spec/features/admin/enterprise_user_spec.rb
@@ -4,10 +4,10 @@ feature '
     As a Super User
     I want to setup users to manage an enterprise
 ' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
-  let!(:user) { create_enterprise_user }
+  let!(:user) { create(:user) }
   let!(:supplier1) { create(:supplier_enterprise, name: 'Supplier 1') }
   let!(:supplier2) { create(:supplier_enterprise, name: 'Supplier 2') }
   let(:supplier_profile) { create(:supplier_enterprise, name: 'Supplier profile', sells: 'none') }

--- a/spec/features/admin/enterprise_user_spec.rb
+++ b/spec/features/admin/enterprise_user_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want to setup users to manage an enterprise
 ' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let!(:user) { create(:user) }
   let!(:supplier1) { create(:supplier_enterprise, name: 'Supplier 1') }

--- a/spec/features/admin/enterprise_user_spec.rb
+++ b/spec/features/admin/enterprise_user_spec.rb
@@ -19,7 +19,7 @@ feature '
     context "with a limitted number of owned enterprises" do
       scenario "setting the enterprise ownership limit" do
         expect(user.enterprise_limit).to eq 5
-        login_to_admin_and_visit spree.admin_users_path
+        login_as_admin_and_visit spree.admin_users_path
         click_link user.email
 
         fill_in "user_enterprise_limit", with: 2

--- a/spec/features/admin/enterprises/images_spec.rb
+++ b/spec/features/admin/enterprises/images_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 
 feature "Managing enterprise images" do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   context "as an Enterprise user", js: true do
-    let(:enterprise_user) { create_enterprise_user(enterprise_limit: 1) }
+    let(:enterprise_user) { create(:user, enterprise_limit: 1) }
     let(:distributor) { create(:distributor_enterprise, name: "First Distributor") }
 
     before do

--- a/spec/features/admin/enterprises/images_spec.rb
+++ b/spec/features/admin/enterprises/images_spec.rb
@@ -11,7 +11,7 @@ feature "Managing enterprise images" do
     before do
       enterprise_user.enterprise_roles.build(enterprise: distributor).save!
 
-      quick_login_as enterprise_user
+      login_as enterprise_user
       visit edit_admin_enterprise_path(distributor)
     end
 

--- a/spec/features/admin/enterprises/images_spec.rb
+++ b/spec/features/admin/enterprises/images_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 feature "Managing enterprise images" do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   context "as an Enterprise user", js: true do
     let(:enterprise_user) { create(:user, enterprise_limit: 1) }

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -44,8 +44,7 @@ feature 'Enterprises Index' do
 
       context "without violating rules" do
         before do
-          quick_login_as_admin
-          visit admin_enterprises_path
+          login_to_admin_and_visit admin_enterprises_path
         end
 
         it "updates the enterprises" do
@@ -71,8 +70,7 @@ feature 'Enterprises Index' do
           d_manager.enterprise_roles.build(enterprise: second_distributor).save
           expect(d.owner).to_not eq d_manager
 
-          quick_login_as_admin
-          visit admin_enterprises_path
+          login_to_admin_and_visit admin_enterprises_path
         end
 
         def enterprise_row_index(enterprise_name)

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -9,8 +9,7 @@ feature 'Enterprises Index' do
       s = create(:supplier_enterprise)
       d = create(:distributor_enterprise)
 
-      login_to_admin_section
-      click_link 'Enterprises'
+      login_to_admin_and_visit admin_enterprises_path
 
       within("tr.enterprise-#{s.id}") do
         expect(page).to have_content s.name

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -9,7 +9,7 @@ feature 'Enterprises Index' do
       s = create(:supplier_enterprise)
       d = create(:distributor_enterprise)
 
-      login_to_admin_and_visit admin_enterprises_path
+      login_as_admin_and_visit admin_enterprises_path
 
       within("tr.enterprise-#{s.id}") do
         expect(page).to have_content s.name
@@ -44,7 +44,7 @@ feature 'Enterprises Index' do
 
       context "without violating rules" do
         before do
-          login_to_admin_and_visit admin_enterprises_path
+          login_as_admin_and_visit admin_enterprises_path
         end
 
         it "updates the enterprises" do
@@ -70,7 +70,7 @@ feature 'Enterprises Index' do
           d_manager.enterprise_roles.build(enterprise: second_distributor).save
           expect(d.owner).to_not eq d_manager
 
-          login_to_admin_and_visit admin_enterprises_path
+          login_as_admin_and_visit admin_enterprises_path
         end
 
         def enterprise_row_index(enterprise_name)

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 feature 'Enterprises Index' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   context "as an admin user" do
     scenario "listing enterprises" do
@@ -36,7 +36,7 @@ feature 'Enterprises Index' do
     context "editing enterprises in bulk" do
       let!(:s){ create(:supplier_enterprise) }
       let!(:d){ create(:distributor_enterprise, sells: 'none') }
-      let!(:d_manager) { create_enterprise_user(enterprise_limit: 1) }
+      let!(:d_manager) { create(:user, enterprise_limit: 1) }
 
       before do
         d_manager.enterprise_roles.build(enterprise: d).save
@@ -107,7 +107,7 @@ feature 'Enterprises Index' do
     let(:distributor1) { create(:distributor_enterprise, name: 'First Distributor') }
     let(:distributor2) { create(:distributor_enterprise, name: 'Another Distributor') }
     let(:distributor3) { create(:distributor_enterprise, name: 'Yet Another Distributor') }
-    let(:enterprise_manager) { create_enterprise_user }
+    let(:enterprise_manager) { create(:user) }
     let!(:er) { create(:enterprise_relationship, parent: distributor3, child: distributor1, permissions_list: [:edit_profile]) }
 
     before(:each) do
@@ -165,7 +165,7 @@ feature 'Enterprises Index' do
   end
 
   describe "as the owner of an enterprise" do
-    let!(:user) { create_enterprise_user }
+    let!(:user) { create(:user) }
     let!(:owned_distributor) { create(:distributor_enterprise, name: 'Owned Distributor', owner: user) }
 
     before do

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Enterprises Index' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   context "as an admin user" do
     scenario "listing enterprises" do

--- a/spec/features/admin/enterprises/index_spec.rb
+++ b/spec/features/admin/enterprises/index_spec.rb
@@ -111,7 +111,7 @@ feature 'Enterprises Index' do
       enterprise_manager.enterprise_roles.build(enterprise: supplier1).save
       enterprise_manager.enterprise_roles.build(enterprise: distributor1).save
 
-      quick_login_as enterprise_manager
+      login_as enterprise_manager
     end
 
     context "listing enterprises", js: true do
@@ -166,7 +166,7 @@ feature 'Enterprises Index' do
     let!(:owned_distributor) { create(:distributor_enterprise, name: 'Owned Distributor', owner: user) }
 
     before do
-      quick_login_as user
+      login_as user
     end
 
     context "listing enterprises", js: true do

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -4,8 +4,8 @@ feature '
     As an administrator
     I want to manage enterprises
 ' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   scenario "viewing an enterprise" do
     e = create(:enterprise)
@@ -287,7 +287,7 @@ feature '
     let(:distributor1) { create(:distributor_enterprise, name: 'First Distributor') }
     let(:distributor2) { create(:distributor_enterprise, name: 'Another Distributor') }
     let(:distributor3) { create(:distributor_enterprise, name: 'Yet Another Distributor') }
-    let(:enterprise_user) { create_enterprise_user(enterprise_limit: 1) }
+    let(:enterprise_user) { create(:user, enterprise_limit: 1) }
     let!(:er) { create(:enterprise_relationship, parent: distributor3, child: distributor1, permissions_list: [:edit_profile]) }
 
     before(:each) do

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -25,7 +25,7 @@ feature '
     enterprise_fee = create(:enterprise_fee)
 
     # Navigating
-    admin = quick_login_as_admin
+    admin = login_as_admin
     visit '/admin/enterprises'
     click_link 'New Enterprise'
 
@@ -66,7 +66,7 @@ feature '
     enterprise_fee = create(:enterprise_fee, enterprise: @enterprise )
     user = create(:user)
 
-    admin = quick_login_as_admin
+    admin = login_as_admin
 
     visit '/admin/enterprises'
     within "tr.enterprise-#{@enterprise.id}" do
@@ -219,8 +219,7 @@ feature '
       s = create(:supplier_enterprise)
 
       # When I go to its properties page
-      quick_login_as_admin
-      visit admin_enterprises_path
+      login_to_admin_and_visit admin_enterprises_path
       within(".enterprise-#{s.id}") { click_link 'Properties' }
 
       # And I create a property
@@ -243,8 +242,7 @@ feature '
       s.producer_properties.create! property_name: 'Certified Organic', value: 'NASAA 12345'
 
       # When I go to its properties page
-      quick_login_as_admin
-      visit main_app.admin_enterprise_producer_properties_path(s)
+      login_to_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
 
       # And I update the property
       fill_in 'enterprise_producer_properties_attributes_0_property_name', with: "Biodynamic"
@@ -266,8 +264,7 @@ feature '
       pp = s.producer_properties.create! property_name: 'Certified Organic', value: 'NASAA 12345'
 
       # When I go to its properties page
-      quick_login_as_admin
-      visit main_app.admin_enterprise_producer_properties_path(s)
+      login_to_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
 
       # And I remove the property
       expect(page).to have_field 'enterprise_producer_properties_attributes_0_property_name', with: 'Certified Organic'

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want to manage enterprises
 ' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   scenario "viewing an enterprise" do
     e = create(:enterprise)

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -219,7 +219,7 @@ feature '
       s = create(:supplier_enterprise)
 
       # When I go to its properties page
-      login_to_admin_and_visit admin_enterprises_path
+      login_as_admin_and_visit admin_enterprises_path
       within(".enterprise-#{s.id}") { click_link 'Properties' }
 
       # And I create a property
@@ -242,7 +242,7 @@ feature '
       s.producer_properties.create! property_name: 'Certified Organic', value: 'NASAA 12345'
 
       # When I go to its properties page
-      login_to_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
+      login_as_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
 
       # And I update the property
       fill_in 'enterprise_producer_properties_attributes_0_property_name', with: "Biodynamic"
@@ -264,7 +264,7 @@ feature '
       pp = s.producer_properties.create! property_name: 'Certified Organic', value: 'NASAA 12345'
 
       # When I go to its properties page
-      login_to_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
+      login_as_admin_and_visit main_app.admin_enterprise_producer_properties_path(s)
 
       # And I remove the property
       expect(page).to have_field 'enterprise_producer_properties_attributes_0_property_name', with: 'Certified Organic'

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -291,7 +291,7 @@ feature '
       enterprise_user.enterprise_roles.build(enterprise: supplier1).save
       enterprise_user.enterprise_roles.build(enterprise: distributor1).save
 
-      quick_login_as enterprise_user
+      login_as enterprise_user
     end
 
     context "when I have reached my enterprise ownership limit" do

--- a/spec/features/admin/external_services_spec.rb
+++ b/spec/features/admin/external_services_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'External services' do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   describe "bugherd" do
     before do

--- a/spec/features/admin/image_settings_spec.rb
+++ b/spec/features/admin/image_settings_spec.rb
@@ -20,7 +20,7 @@ feature '
 
   scenario "setting the image format for a paperclip style" do
     # When I go to the image settings page
-    login_to_admin_and_visit spree.edit_admin_image_settings_path
+    login_as_admin_and_visit spree.edit_admin_image_settings_path
 
     # All the styles should default to "Unchanged"
     expect(page).to have_select 'attachment_styles_format_mini',    selected: 'Unchanged'

--- a/spec/features/admin/image_settings_spec.rb
+++ b/spec/features/admin/image_settings_spec.rb
@@ -20,8 +20,7 @@ feature '
 
   scenario "setting the image format for a paperclip style" do
     # When I go to the image settings page
-    login_to_admin_section
-    visit spree.edit_admin_image_settings_path
+    login_to_admin_and_visit spree.edit_admin_image_settings_path
 
     # All the styles should default to "Unchanged"
     expect(page).to have_select 'attachment_styles_format_mini',    selected: 'Unchanged'

--- a/spec/features/admin/image_settings_spec.rb
+++ b/spec/features/admin/image_settings_spec.rb
@@ -4,7 +4,7 @@ feature '
     As an admin
     I want to manage image formats
 ' do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   before(:all) do

--- a/spec/features/admin/multilingual_spec.rb
+++ b/spec/features/admin/multilingual_spec.rb
@@ -8,7 +8,7 @@ feature 'Multilingual', js: true do
 
   background do
     admin_user.spree_roles << admin_role
-    quick_login_as admin_user
+    login_as admin_user
     visit spree.admin_dashboard_path
   end
 

--- a/spec/features/admin/multilingual_spec.rb
+++ b/spec/features/admin/multilingual_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Multilingual', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   let(:admin_role) { Spree::Role.find_or_create_by!(name: 'admin') }
   let(:admin_user) { create(:user) }

--- a/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to create/update complex order cycles with a specific time
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let(:order_cycle_opening_time) { Time.zone.local(2040, 11, 0o6, 0o6, 0o0, 0o0).strftime("%F %T %z") }

--- a/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
@@ -33,7 +33,7 @@ feature '
     distributor_fee = create(:enterprise_fee, enterprise: distributor, name: 'Distributor fee')
 
     # When I go to the new order cycle page
-    login_to_admin_and_visit admin_order_cycles_path
+    login_as_admin_and_visit admin_order_cycles_path
     click_link 'New Order Cycle'
 
     # Select a coordinator since there are two available

--- a/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
@@ -33,8 +33,7 @@ feature '
     distributor_fee = create(:enterprise_fee, enterprise: distributor, name: 'Distributor fee')
 
     # When I go to the new order cycle page
-    quick_login_as_admin
-    visit admin_order_cycles_path
+    login_to_admin_and_visit admin_order_cycles_path
     click_link 'New Order Cycle'
 
     # Select a coordinator since there are two available

--- a/spec/features/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
@@ -20,7 +20,7 @@ feature '
     oc_outgoing = create(:simple_order_cycle, coordinator: c, distributors: [c])
 
     # When I edit the first order cycle, the exchange should appear as incoming
-    login_to_admin_and_visit admin_order_cycle_incoming_path(oc_incoming)
+    login_as_admin_and_visit admin_order_cycle_incoming_path(oc_incoming)
     expect(page).to have_selector 'table.exchanges tr.supplier'
     visit admin_order_cycle_outgoing_path(oc_incoming)
     expect(page).not_to have_selector 'table.exchanges tr.distributor'

--- a/spec/features/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
@@ -20,8 +20,7 @@ feature '
     oc_outgoing = create(:simple_order_cycle, coordinator: c, distributors: [c])
 
     # When I edit the first order cycle, the exchange should appear as incoming
-    quick_login_as_admin
-    visit admin_order_cycle_incoming_path(oc_incoming)
+    login_to_admin_and_visit admin_order_cycle_incoming_path(oc_incoming)
     expect(page).to have_selector 'table.exchanges tr.supplier'
     visit admin_order_cycle_outgoing_path(oc_incoming)
     expect(page).not_to have_selector 'table.exchanges tr.distributor'

--- a/spec/features/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_exchange_same_enterprise_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to manage complex order cycles
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   scenario "editing an order cycle with an exchange between the same enterprise" do

--- a/spec/features/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to manage complex order cycles
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   describe "editing an order cycle with multiple pages of products", js: true do

--- a/spec/features/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -18,7 +18,7 @@ feature '
     before do
       stub_const("#{Api::ExchangeProductsController}::DEFAULT_PER_PAGE", 1)
 
-      login_to_admin_and_visit admin_order_cycle_incoming_path(order_cycle)
+      login_as_admin_and_visit admin_order_cycle_incoming_path(order_cycle)
       expect(page).to have_content "1 / 2 selected"
 
       page.find("tr.supplier-#{supplier_enterprise.id} td.products").click

--- a/spec/features/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_multiple_product_pages_spec.rb
@@ -18,8 +18,7 @@ feature '
     before do
       stub_const("#{Api::ExchangeProductsController}::DEFAULT_PER_PAGE", 1)
 
-      quick_login_as_admin
-      visit admin_order_cycle_incoming_path(order_cycle)
+      login_to_admin_and_visit admin_order_cycle_incoming_path(order_cycle)
       expect(page).to have_content "1 / 2 selected"
 
       page.find("tr.supplier-#{supplier_enterprise.id} td.products").click

--- a/spec/features/admin/order_cycles/complex_editing_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_spec.rb
@@ -19,7 +19,7 @@ feature '
     oc.distributors.last.update_attribute :name, 'ZZZZ'
 
     # When I edit it
-    login_to_admin_and_visit edit_admin_order_cycle_path(oc)
+    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
 
     wait_for_edit_form_to_load_order_cycle(oc)
 

--- a/spec/features/admin/order_cycles/complex_editing_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to manage complex order cycles
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   scenario "editing an order cycle" do

--- a/spec/features/admin/order_cycles/complex_editing_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_spec.rb
@@ -19,8 +19,7 @@ feature '
     oc.distributors.last.update_attribute :name, 'ZZZZ'
 
     # When I edit it
-    quick_login_as_admin
-    visit edit_admin_order_cycle_path(oc)
+    login_to_admin_and_visit edit_admin_order_cycle_path(oc)
 
     wait_for_edit_form_to_load_order_cycle(oc)
 

--- a/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to create/update complex order cycles with a specific time
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let(:order_cycle_opening_time) { Time.zone.local(2040, 11, 0o6, 0o6, 0o0, 0o0).strftime("%F %T %z") }

--- a/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -40,7 +40,7 @@ feature '
     distributor_fee2 = create(:enterprise_fee, enterprise: distributor, name: 'Distributor fee 2')
 
     # When I go to its edit page
-    login_to_admin_and_visit admin_order_cycles_path
+    login_as_admin_and_visit admin_order_cycles_path
     within "tr.order-cycle-#{oc.id}" do
       find("a.edit-order-cycle").click
     end

--- a/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -40,8 +40,7 @@ feature '
     distributor_fee2 = create(:enterprise_fee, enterprise: distributor, name: 'Distributor fee 2')
 
     # When I go to its edit page
-    quick_login_as_admin
-    visit admin_order_cycles_path
+    login_to_admin_and_visit admin_order_cycles_path
     within "tr.order-cycle-#{oc.id}" do
       find("a.edit-order-cycle").click
     end

--- a/spec/features/admin/order_cycles/list_spec.rb
+++ b/spec/features/admin/order_cycles/list_spec.rb
@@ -128,8 +128,7 @@ feature '
 
     context 'using datepickers' do
       it "correctly opens the datepicker and changes the date field" do
-        quick_login_as_admin
-        visit admin_order_cycles_path
+        login_to_admin_and_visit admin_order_cycles_path
 
         within("tr.order-cycle-#{oc_pt.id}") do
           expect(find('input.datetimepicker', match: :first).value).to start_with '2012-01-01 00:00'

--- a/spec/features/admin/order_cycles/list_spec.rb
+++ b/spec/features/admin/order_cycles/list_spec.rb
@@ -30,7 +30,7 @@ feature '
     create(:proxy_order, subscription: create(:subscription, schedule: schedule1), order_cycle: oc1)
 
     # When I go to the admin order cycles page
-    login_to_admin_and_visit admin_order_cycles_path
+    login_as_admin_and_visit admin_order_cycles_path
 
     # Then the order cycles should be ordered correctly
     expect(page).to have_selector "#listing_order_cycles tr td:first-child", count: 7
@@ -128,7 +128,7 @@ feature '
 
     context 'using datepickers' do
       it "correctly opens the datepicker and changes the date field" do
-        login_to_admin_and_visit admin_order_cycles_path
+        login_as_admin_and_visit admin_order_cycles_path
 
         within("tr.order-cycle-#{oc_pt.id}") do
           expect(find('input.datetimepicker', match: :first).value).to start_with '2012-01-01 00:00'

--- a/spec/features/admin/order_cycles/list_spec.rb
+++ b/spec/features/admin/order_cycles/list_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to list and filter order cycles
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   scenario "listing and filtering order cycles" do

--- a/spec/features/admin/order_cycles/list_spec.rb
+++ b/spec/features/admin/order_cycles/list_spec.rb
@@ -30,8 +30,7 @@ feature '
     create(:proxy_order, subscription: create(:subscription, schedule: schedule1), order_cycle: oc1)
 
     # When I go to the admin order cycles page
-    login_to_admin_section
-    click_link 'Order Cycles'
+    login_to_admin_and_visit admin_order_cycles_path
 
     # Then the order cycles should be ordered correctly
     expect(page).to have_selector "#listing_order_cycles tr td:first-child", count: 7

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -19,7 +19,7 @@ feature '
                  orders_close_at: Time.zone.local(2041, 12, 12, 12, 12, 12))
 
     # When I go to the order cycles page
-    login_to_admin_and_visit admin_order_cycles_path
+    login_as_admin_and_visit admin_order_cycles_path
 
     # And I fill in some new opening/closing times and save them
     within("tr.order-cycle-#{oc1.id}") do
@@ -76,7 +76,7 @@ feature '
     oc = create(:simple_order_cycle)
 
     # When I clone it
-    login_to_admin_and_visit admin_order_cycles_path
+    login_as_admin_and_visit admin_order_cycles_path
     within "tr.order-cycle-#{oc.id}" do
       find('a.clone-order-cycle').click
     end
@@ -98,7 +98,7 @@ feature '
       end
 
       it "displays a warning on the order cycles screen" do
-        login_to_admin_and_visit admin_order_cycles_path
+        login_as_admin_and_visit admin_order_cycles_path
         expect(page).to have_content "The hub #{hub.name} is listed in an active order cycle, but does not have valid shipping and payment methods. Until you set these up, customers will not be able to shop at this hub."
       end
     end
@@ -505,7 +505,7 @@ feature '
       ex.update! pickup_time: 'pickup time', pickup_instructions: 'pickup instructions'
 
       # When I edit it
-      login_to_admin_and_visit admin_order_cycles_path
+      login_as_admin_and_visit admin_order_cycles_path
       within "tr.order-cycle-#{oc.id}" do
         find("a.edit-order-cycle").click
       end
@@ -537,7 +537,7 @@ feature '
       ex.update! pickup_time: 'pickup time', pickup_instructions: 'pickup instructions'
 
       # When I edit it
-      login_to_admin_and_visit edit_admin_order_cycle_path oc
+      login_as_admin_and_visit edit_admin_order_cycle_path oc
 
       wait_for_edit_form_to_load_order_cycle(oc)
 
@@ -591,7 +591,7 @@ feature '
 
   scenario "deleting an order cycle" do
     order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
-    login_to_admin_and_visit admin_order_cycles_path
+    login_as_admin_and_visit admin_order_cycles_path
     expect(page).to have_selector "tr.order-cycle-#{order_cycle.id}"
     accept_alert do
       first('a.delete-order-cycle').click

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -100,8 +100,7 @@ feature '
       end
 
       it "displays a warning on the order cycles screen" do
-        quick_login_as_admin
-        visit admin_order_cycles_path
+        login_to_admin_and_visit admin_order_cycles_path
         expect(page).to have_content "The hub #{hub.name} is listed in an active order cycle, but does not have valid shipping and payment methods. Until you set these up, customers will not be able to shop at this hub."
       end
     end

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -153,7 +153,7 @@ feature '
         @new_user.enterprise_roles.build(enterprise: distributor_managed).save
         @new_user.enterprise_roles.build(enterprise: other_distributor_managed).save
 
-        quick_login_as @new_user
+        login_as @new_user
       end
 
       scenario "viewing a list of order cycles I am coordinating" do

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -151,7 +151,7 @@ feature '
 
     context "that is a manager of the coordinator" do
       before do
-        @new_user = create_enterprise_user
+        @new_user = create(:user)
         @new_user.enterprise_roles.build(enterprise: supplier_managed).save
         @new_user.enterprise_roles.build(enterprise: distributor_managed).save
         @new_user.enterprise_roles.build(enterprise: other_distributor_managed).save
@@ -288,7 +288,7 @@ feature '
     end
 
     context "that is a manager of a participating producer" do
-      let(:new_user) { create_enterprise_user }
+      let(:new_user) { create(:user) }
 
       before do
         new_user.enterprise_roles.build(enterprise: supplier_managed).save
@@ -354,7 +354,7 @@ feature '
 
     context "that is the manager of a participating hub" do
       let(:my_distributor) { create(:distributor_enterprise) }
-      let(:new_user) { create_enterprise_user }
+      let(:new_user) { create(:user) }
 
       before do
         create(:enterprise_relationship, parent: supplier_managed, child: my_distributor, permissions_list: [:add_to_order_cycle])
@@ -419,7 +419,7 @@ feature '
   end
 
   describe "simplified interface for enterprise users selling only their own produce" do
-    let(:user) { create_enterprise_user }
+    let(:user) { create(:user) }
     let(:enterprise) { create(:enterprise, is_primary_producer: true, sells: 'own') }
     let!(:p1) { create(:simple_product, supplier: enterprise) }
     let!(:p2) { create(:simple_product, supplier: enterprise) }

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to manage simple order cycles
 ', js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   scenario "updating many order cycle opening/closing times at once", js: true do

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -19,8 +19,7 @@ feature '
                  orders_close_at: Time.zone.local(2041, 12, 12, 12, 12, 12))
 
     # When I go to the order cycles page
-    quick_login_as_admin
-    visit admin_order_cycles_path
+    login_to_admin_and_visit admin_order_cycles_path
 
     # And I fill in some new opening/closing times and save them
     within("tr.order-cycle-#{oc1.id}") do
@@ -77,8 +76,7 @@ feature '
     oc = create(:simple_order_cycle)
 
     # When I clone it
-    quick_login_as_admin
-    visit admin_order_cycles_path
+    login_to_admin_and_visit admin_order_cycles_path
     within "tr.order-cycle-#{oc.id}" do
       find('a.clone-order-cycle').click
     end
@@ -507,8 +505,7 @@ feature '
       ex.update! pickup_time: 'pickup time', pickup_instructions: 'pickup instructions'
 
       # When I edit it
-      quick_login_as_admin
-      visit admin_order_cycles_path
+      login_to_admin_and_visit admin_order_cycles_path
       within "tr.order-cycle-#{oc.id}" do
         find("a.edit-order-cycle").click
       end
@@ -540,8 +537,7 @@ feature '
       ex.update! pickup_time: 'pickup time', pickup_instructions: 'pickup instructions'
 
       # When I edit it
-      quick_login_as_admin
-      visit edit_admin_order_cycle_path oc
+      login_to_admin_and_visit edit_admin_order_cycle_path oc
 
       wait_for_edit_form_to_load_order_cycle(oc)
 
@@ -595,8 +591,7 @@ feature '
 
   scenario "deleting an order cycle" do
     order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
-    quick_login_as_admin
-    visit admin_order_cycles_path
+    login_to_admin_and_visit admin_order_cycles_path
     expect(page).to have_selector "tr.order-cycle-#{order_cycle.id}"
     accept_alert do
       first('a.delete-order-cycle').click

--- a/spec/features/admin/order_cycles_complex_nav_check_spec.rb
+++ b/spec/features/admin/order_cycles_complex_nav_check_spec.rb
@@ -6,7 +6,7 @@ feature '
     As an administrator
     I want to be alerted when I navigate away from a dirty order cycle form
 ', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   scenario "alert when navigating away from dirty form" do
     # Given a 'complex' order cycle form

--- a/spec/features/admin/order_cycles_complex_nav_check_spec.rb
+++ b/spec/features/admin/order_cycles_complex_nav_check_spec.rb
@@ -13,8 +13,7 @@ feature '
     oc = create(:order_cycle)
 
     # When I edit the form
-    quick_login_as_admin
-    visit edit_admin_order_cycle_path(oc)
+    login_to_admin_and_visit edit_admin_order_cycle_path(oc)
 
     wait_for_edit_form_to_load_order_cycle(oc)
 

--- a/spec/features/admin/order_cycles_complex_nav_check_spec.rb
+++ b/spec/features/admin/order_cycles_complex_nav_check_spec.rb
@@ -13,7 +13,7 @@ feature '
     oc = create(:order_cycle)
 
     # When I edit the form
-    login_to_admin_and_visit edit_admin_order_cycle_path(oc)
+    login_as_admin_and_visit edit_admin_order_cycle_path(oc)
 
     wait_for_edit_form_to_load_order_cycle(oc)
 

--- a/spec/features/admin/order_print_ticket_spec.rb
+++ b/spec/features/admin/order_print_ticket_spec.rb
@@ -27,7 +27,7 @@ feature '
       @enterprise_user = create(:user)
       @enterprise_user.enterprise_roles.build(enterprise: distributor).save
 
-      quick_login_as @enterprise_user
+      login_as @enterprise_user
 
       Spree::Config[:enable_receipt_printing?] = true
     end

--- a/spec/features/admin/order_print_ticket_spec.rb
+++ b/spec/features/admin/order_print_ticket_spec.rb
@@ -6,8 +6,8 @@ feature '
     As an administrator
     I want to print a ticket for an order
 ', js: true do
-  include AuthenticationWorkflow
   include CheckoutHelper
+  include AuthenticationWorkflow
   include ActionView::Helpers::NumberHelper
 
   context "as an enterprise manager" do
@@ -24,7 +24,7 @@ feature '
     end
 
     before do
-      @enterprise_user = create_enterprise_user
+      @enterprise_user = create(:user)
       @enterprise_user.enterprise_roles.build(enterprise: distributor).save
 
       quick_login_as @enterprise_user

--- a/spec/features/admin/order_print_ticket_spec.rb
+++ b/spec/features/admin/order_print_ticket_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to print a ticket for an order
 ', js: true do
   include CheckoutHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include ActionView::Helpers::NumberHelper
 
   context "as an enterprise manager" do

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -43,8 +43,7 @@ feature '
     distributor_disabled = create(:distributor_enterprise)
     create(:simple_order_cycle, name: 'Two')
 
-    quick_login_as_admin
-    visit spree.admin_orders_path
+    login_to_admin_and_visit spree.admin_orders_path
     click_link 'New Order'
 
     # Distributors without an order cycle should be shown as disabled
@@ -79,8 +78,7 @@ feature '
   end
 
   scenario "can add a product to an existing order" do
-    quick_login_as_admin
-    visit spree.edit_admin_order_path(order)
+    login_to_admin_and_visit spree.edit_admin_order_path(order)
 
     targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
 
@@ -102,8 +100,7 @@ feature '
     order.user = nil
     order.save
 
-    quick_login_as_admin
-    visit spree.edit_admin_order_path(order)
+    login_to_admin_and_visit spree.edit_admin_order_path(order)
 
     expect(page).to have_select2 "order_distributor_id", with_options: [d.name]
     select2_select d.name, from: 'order_distributor_id'
@@ -117,15 +114,13 @@ feature '
   scenario "can't add products to an order outside the order's hub and order cycle" do
     product = create(:simple_product)
 
-    quick_login_as_admin
-    visit spree.edit_admin_order_path(order)
+    login_to_admin_and_visit spree.edit_admin_order_path(order)
 
     expect(page).not_to have_select2 "add_variant_id", with_options: [product.name]
   end
 
   scenario "can't change distributor or order cycle once order has been finalized" do
-    quick_login_as_admin
-    visit spree.edit_admin_order_path(order)
+    login_to_admin_and_visit spree.edit_admin_order_path(order)
 
     expect(page).not_to have_select2 'order_distributor_id'
     expect(page).not_to have_select2 'order_order_cycle_id'

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -43,7 +43,7 @@ feature '
     distributor_disabled = create(:distributor_enterprise)
     create(:simple_order_cycle, name: 'Two')
 
-    login_to_admin_and_visit spree.admin_orders_path
+    login_as_admin_and_visit spree.admin_orders_path
     click_link 'New Order'
 
     # Distributors without an order cycle should be shown as disabled
@@ -78,7 +78,7 @@ feature '
   end
 
   scenario "can add a product to an existing order" do
-    login_to_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin_and_visit spree.edit_admin_order_path(order)
 
     targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
 
@@ -100,7 +100,7 @@ feature '
     order.user = nil
     order.save
 
-    login_to_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin_and_visit spree.edit_admin_order_path(order)
 
     expect(page).to have_select2 "order_distributor_id", with_options: [d.name]
     select2_select d.name, from: 'order_distributor_id'
@@ -114,13 +114,13 @@ feature '
   scenario "can't add products to an order outside the order's hub and order cycle" do
     product = create(:simple_product)
 
-    login_to_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin_and_visit spree.edit_admin_order_path(order)
 
     expect(page).not_to have_select2 "add_variant_id", with_options: [product.name]
   end
 
   scenario "can't change distributor or order cycle once order has been finalized" do
-    login_to_admin_and_visit spree.edit_admin_order_path(order)
+    login_as_admin_and_visit spree.edit_admin_order_path(order)
 
     expect(page).not_to have_select2 'order_distributor_id'
     expect(page).not_to have_select2 'order_order_cycle_id'

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -6,8 +6,8 @@ feature '
     As an administrator
     I want to create and edit orders
 ', js: true do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   let(:user) { create(:user) }
   let(:product) { create(:simple_product) }
@@ -187,7 +187,7 @@ feature '
     let(:product) { order_cycle1.products.first }
 
     before(:each) do
-      @enterprise_user = create_enterprise_user
+      @enterprise_user = create(:user)
       @enterprise_user.enterprise_roles.build(enterprise: supplier1).save
       @enterprise_user.enterprise_roles.build(enterprise: coordinator1).save
       @enterprise_user.enterprise_roles.build(enterprise: distributor1).save

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -144,7 +144,7 @@ feature '
     order.shipping_method.update_attribute :require_ship_address, true
 
     # When I create a new order
-    quick_login_as user
+    login_as user
     new_order_with_distribution(distributor, order_cycle)
     targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
     find('button.add_variant').click
@@ -187,7 +187,7 @@ feature '
       @enterprise_user.enterprise_roles.build(enterprise: coordinator1).save
       @enterprise_user.enterprise_roles.build(enterprise: distributor1).save
 
-      quick_login_as @enterprise_user
+      login_as @enterprise_user
     end
 
     feature "viewing the edit page" do

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -7,7 +7,7 @@ feature '
     I want to create and edit orders
 ', js: true do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let(:user) { create(:user) }
   let(:product) { create(:simple_product) }

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -29,8 +29,7 @@ feature '
       create(:simple_order_cycle, name: 'Four', orders_close_at: 4.weeks.from_now)
       create(:simple_order_cycle, name: 'Three', orders_close_at: 3.weeks.from_now)
 
-      quick_login_as_admin
-      visit 'admin/orders'
+      login_to_admin_and_visit 'admin/orders'
 
       open_select2('#s2id_q_order_cycle_id_in')
 
@@ -50,8 +49,7 @@ feature '
       order4 = create(:order_with_credit_payment, user: user, distributor: distributor,
                                                   order_cycle: order_cycle4)
 
-      quick_login_as_admin
-      visit 'admin/orders'
+      login_to_admin_and_visit 'admin/orders'
 
       multi_select2_select 'Two', from: 'q_order_cycle_id_in'
       multi_select2_select 'Three', from: 'q_order_cycle_id_in'
@@ -71,9 +69,7 @@ feature '
       end
 
       scenario "capture payment" do
-        quick_login_as_admin
-
-        visit spree.admin_orders_path
+        login_to_admin_and_visit spree.admin_orders_path
         expect(page).to have_current_path spree.admin_orders_path
 
         # click the 'capture' link for the order
@@ -91,8 +87,7 @@ feature '
 
       scenario "ship order from the orders index page" do
         order.payments.first.capture!
-        quick_login_as_admin
-        visit spree.admin_orders_path
+        login_to_admin_and_visit spree.admin_orders_path
 
         page.find("[data-powertip=Ship]").click
 
@@ -106,9 +101,7 @@ feature '
     scenario "can edit order" do
       incomplete_order = create(:order, distributor: distributor, order_cycle: order_cycle)
 
-      quick_login_as_admin
-
-      visit spree.admin_orders_path
+      login_to_admin_and_visit spree.admin_orders_path
       uncheck 'Only show complete orders'
       page.find('a.icon-search').click
 

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -6,7 +6,7 @@ feature '
     As an administrator
     I want to manage orders
 ', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let(:user) { create(:user) }

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -29,7 +29,7 @@ feature '
       create(:simple_order_cycle, name: 'Four', orders_close_at: 4.weeks.from_now)
       create(:simple_order_cycle, name: 'Three', orders_close_at: 3.weeks.from_now)
 
-      login_to_admin_and_visit 'admin/orders'
+      login_as_admin_and_visit 'admin/orders'
 
       open_select2('#s2id_q_order_cycle_id_in')
 
@@ -49,7 +49,7 @@ feature '
       order4 = create(:order_with_credit_payment, user: user, distributor: distributor,
                                                   order_cycle: order_cycle4)
 
-      login_to_admin_and_visit 'admin/orders'
+      login_as_admin_and_visit 'admin/orders'
 
       multi_select2_select 'Two', from: 'q_order_cycle_id_in'
       multi_select2_select 'Three', from: 'q_order_cycle_id_in'
@@ -69,7 +69,7 @@ feature '
       end
 
       scenario "capture payment" do
-        login_to_admin_and_visit spree.admin_orders_path
+        login_as_admin_and_visit spree.admin_orders_path
         expect(page).to have_current_path spree.admin_orders_path
 
         # click the 'capture' link for the order
@@ -87,7 +87,7 @@ feature '
 
       scenario "ship order from the orders index page" do
         order.payments.first.capture!
-        login_to_admin_and_visit spree.admin_orders_path
+        login_as_admin_and_visit spree.admin_orders_path
 
         page.find("[data-powertip=Ship]").click
 
@@ -101,7 +101,7 @@ feature '
     scenario "can edit order" do
       incomplete_order = create(:order, distributor: distributor, order_cycle: order_cycle)
 
-      login_to_admin_and_visit spree.admin_orders_path
+      login_as_admin_and_visit spree.admin_orders_path
       uncheck 'Only show complete orders'
       page.find('a.icon-search').click
 

--- a/spec/features/admin/overview_spec.rb
+++ b/spec/features/admin/overview_spec.rb
@@ -4,13 +4,13 @@ feature '
   As a backend user
   I want to be given information about the state of my enterprises, products and order cycles
 ', js: true do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
   include ::Spree::TestingSupport::AuthorizationHelpers
 
   context "as an enterprise user" do
     before do
-      @enterprise_user = create_enterprise_user
+      @enterprise_user = create(:user)
       allow_any_instance_of(Spree::Admin::OverviewController).to receive(:spree_current_user).and_return @enterprise_user
       quick_login_as @enterprise_user
     end

--- a/spec/features/admin/overview_spec.rb
+++ b/spec/features/admin/overview_spec.rb
@@ -5,7 +5,7 @@ feature '
   I want to be given information about the state of my enterprises, products and order cycles
 ', js: true do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include ::Spree::TestingSupport::AuthorizationHelpers
 
   context "as an enterprise user" do

--- a/spec/features/admin/overview_spec.rb
+++ b/spec/features/admin/overview_spec.rb
@@ -12,7 +12,7 @@ feature '
     before do
       @enterprise_user = create(:user)
       allow_any_instance_of(Spree::Admin::OverviewController).to receive(:spree_current_user).and_return @enterprise_user
-      quick_login_as @enterprise_user
+      login_as @enterprise_user
     end
 
     context "with an enterprise" do

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -13,7 +13,7 @@ feature '
 
   describe "creating a payment method", js: true do
     scenario "assigning a distributor to the payment method" do
-      login_as_admin_and_visit spree.admin_general_settings_path
+      login_as_admin_and_visit spree.edit_admin_general_settings_path
       click_link 'Payment Methods'
       click_link 'New Payment Method'
 

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -13,9 +13,7 @@ feature '
 
   describe "creating a payment method", js: true do
     scenario "assigning a distributor to the payment method" do
-      login_to_admin_section
-
-      click_link 'Configuration'
+      login_to_admin_and_visit spree.admin_general_settings_path
       click_link 'Payment Methods'
       click_link 'New Payment Method'
 

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -4,8 +4,8 @@ feature '
     As a Super Admin
     I want to be able to set a distributor on each payment method
 ' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   background do
     @distributors = (1..3).map { create(:distributor_enterprise) }
@@ -131,7 +131,7 @@ feature '
   end
 
   context "as an enterprise user", js: true do
-    let(:enterprise_user) { create_enterprise_user }
+    let(:enterprise_user) { create(:user) }
     let(:distributor1) { create(:distributor_enterprise, name: 'First Distributor') }
     let(:distributor2) { create(:distributor_enterprise, name: 'Second Distributor') }
     let(:distributor3) { create(:distributor_enterprise, name: 'Third Distributor') }

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -45,7 +45,7 @@ feature '
       end
 
       it "communicates the status of the stripe connection to the user" do
-        quick_login_as user
+        login_as user
         visit spree.new_admin_payment_method_path
 
         select2_select "Stripe", from: "payment_method_type"
@@ -136,7 +136,7 @@ feature '
     before(:each) do
       enterprise_user.enterprise_roles.build(enterprise: distributor1).save
       enterprise_user.enterprise_roles.build(enterprise: distributor2).save
-      quick_login_as enterprise_user
+      login_as enterprise_user
     end
 
     it "I can get to the new enterprise page" do

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -13,7 +13,7 @@ feature '
 
   describe "creating a payment method", js: true do
     scenario "assigning a distributor to the payment method" do
-      login_to_admin_and_visit spree.admin_general_settings_path
+      login_as_admin_and_visit spree.admin_general_settings_path
       click_link 'Payment Methods'
       click_link 'New Payment Method'
 
@@ -68,12 +68,12 @@ feature '
 
     scenario "checking a single distributor is checked by default" do
       2.times.each { Enterprise.last.destroy }
-      login_to_admin_and_visit spree.new_admin_payment_method_path
+      login_as_admin_and_visit spree.new_admin_payment_method_path
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[0].id}", checked: true
     end
 
     scenario "checking more than a distributor displays no default choice" do
-      login_to_admin_and_visit spree.new_admin_payment_method_path
+      login_as_admin_and_visit spree.new_admin_payment_method_path
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[0].id}", checked: false
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[1].id}", checked: false
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[2].id}", checked: false
@@ -82,7 +82,7 @@ feature '
 
   scenario "updating a payment method", js: true do
     payment_method = create(:payment_method, distributors: [@distributors[0]])
-    login_to_admin_and_visit spree.edit_admin_payment_method_path payment_method
+    login_as_admin_and_visit spree.edit_admin_payment_method_path payment_method
 
     fill_in 'payment_method_name', with: 'New PM Name'
     find(:css, "tags-input .tags input").set "member\n"

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want to be able to set a distributor on each payment method
 ' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   background do
     @distributors = (1..3).map { create(:distributor_enterprise) }

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -68,14 +68,12 @@ feature '
 
     scenario "checking a single distributor is checked by default" do
       2.times.each { Enterprise.last.destroy }
-      quick_login_as_admin
-      visit spree.new_admin_payment_method_path
+      login_to_admin_and_visit spree.new_admin_payment_method_path
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[0].id}", checked: true
     end
 
     scenario "checking more than a distributor displays no default choice" do
-      quick_login_as_admin
-      visit spree.new_admin_payment_method_path
+      login_to_admin_and_visit spree.new_admin_payment_method_path
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[0].id}", checked: false
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[1].id}", checked: false
       expect(page).to have_field "payment_method_distributor_ids_#{@distributors[2].id}", checked: false
@@ -84,9 +82,7 @@ feature '
 
   scenario "updating a payment method", js: true do
     payment_method = create(:payment_method, distributors: [@distributors[0]])
-    quick_login_as_admin
-
-    visit spree.edit_admin_payment_method_path payment_method
+    login_to_admin_and_visit spree.edit_admin_payment_method_path payment_method
 
     fill_in 'payment_method_name', with: 'New PM Name'
     find(:css, "tags-input .tags input").set "member\n"

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -4,7 +4,7 @@ feature '
     As an admin
     I want to manage payments
 ' do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let(:order) { create(:completed_order_with_fees) }
 

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -9,7 +9,7 @@ feature '
   let(:order) { create(:completed_order_with_fees) }
 
   scenario "visiting the payment form" do
-    login_to_admin_and_visit spree.new_admin_order_payment_path order
+    login_as_admin_and_visit spree.new_admin_order_payment_path order
 
     expect(page).to have_content "New Payment"
   end
@@ -25,7 +25,7 @@ feature '
     end
 
     scenario "visiting the payment form" do
-      login_to_admin_and_visit spree.new_admin_order_payment_path order
+      login_as_admin_and_visit spree.new_admin_order_payment_path order
 
       expect(page).to have_content "New Payment"
     end
@@ -38,7 +38,7 @@ feature '
     end
 
     it "renders the payment details" do
-      login_to_admin_and_visit spree.admin_order_payments_path order
+      login_as_admin_and_visit spree.admin_order_payments_path order
 
       page.click_link("StripeSCA")
       expect(page).to have_content order.payments.last.source.last_digits
@@ -50,7 +50,7 @@ feature '
       end
 
       it "renders the payment details" do
-        login_to_admin_and_visit spree.admin_order_payments_path order
+        login_as_admin_and_visit spree.admin_order_payments_path order
 
         page.click_link("StripeSCA")
         expect(page).to have_content order.payments.last.amount

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -9,8 +9,7 @@ feature '
   let(:order) { create(:completed_order_with_fees) }
 
   scenario "visiting the payment form" do
-    quick_login_as_admin
-    visit spree.new_admin_order_payment_path order
+    login_to_admin_and_visit spree.new_admin_order_payment_path order
 
     expect(page).to have_content "New Payment"
   end
@@ -26,8 +25,7 @@ feature '
     end
 
     scenario "visiting the payment form" do
-      quick_login_as_admin
-      visit spree.new_admin_order_payment_path order
+      login_to_admin_and_visit spree.new_admin_order_payment_path order
 
       expect(page).to have_content "New Payment"
     end
@@ -40,8 +38,7 @@ feature '
     end
 
     it "renders the payment details" do
-      quick_login_as_admin
-      visit spree.admin_order_payments_path order
+      login_to_admin_and_visit spree.admin_order_payments_path order
 
       page.click_link("StripeSCA")
       expect(page).to have_content order.payments.last.source.last_digits
@@ -53,8 +50,7 @@ feature '
       end
 
       it "renders the payment details" do
-        quick_login_as_admin
-        visit spree.admin_order_payments_path order
+        login_to_admin_and_visit spree.admin_order_payments_path order
 
         page.click_link("StripeSCA")
         expect(page).to have_content order.payments.last.amount

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -7,8 +7,8 @@ feature "Product Import", js: true do
   include WebHelper
 
   let!(:admin) { create(:admin_user) }
-  let!(:user) { create_enterprise_user }
-  let!(:user2) { create_enterprise_user }
+  let!(:user) { create(:user) }
+  let!(:user2) { create(:user) }
   let!(:enterprise) { create(:supplier_enterprise, owner: user, name: "User Enterprise") }
   let!(:enterprise2) { create(:distributor_enterprise, owner: user2, name: "Another Enterprise") }
   let!(:relationship) { create(:enterprise_relationship, parent: enterprise, child: enterprise2, permissions_list: [:create_variant_overrides]) }

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -3,7 +3,7 @@ require 'open_food_network/permissions'
 
 feature "Product Import", js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let!(:admin) { create(:admin_user) }

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -31,7 +31,7 @@ feature "Product Import", js: true do
   let(:shipping_category_id_str) { Spree::ShippingCategory.all.first.id.to_s }
 
   describe "when importing products from uploaded file" do
-    before { quick_login_as_admin }
+    before { login_as_admin }
     after { File.delete('/tmp/test.csv') }
 
     it "validates entries and saves them if they are all valid and allows viewing new items in Bulk Products" do
@@ -342,7 +342,7 @@ feature "Product Import", js: true do
   end
 
   describe "when dealing with uploaded files" do
-    before { quick_login_as_admin }
+    before { login_as_admin }
 
     it "checks filetype on upload" do
       File.write('/tmp/test.txt', "Wrong filetype!")

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -408,7 +408,7 @@ feature "Product Import", js: true do
       end
       File.write('/tmp/test.csv', csv_data)
 
-      quick_login_as user
+      login_as user
       visit main_app.admin_product_import_path
 
       attach_file 'file', '/tmp/test.csv'
@@ -432,7 +432,7 @@ feature "Product Import", js: true do
     let(:tmp_csv_path) { "/tmp/test.csv" }
 
     before do
-      quick_login_as admin
+      login_as admin
       visit main_app.admin_product_import_path
     end
 

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -104,7 +104,7 @@ feature '
       create(:enterprise_relationship, parent: @supplier_permitted, child: @supplier2,
                                        permissions_list: [:manage_products])
 
-      quick_login_as @new_user
+      login_as @new_user
     end
 
     context "products do not require a tax category" do

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want to set a supplier and distributor(s) for a product
 ' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let!(:taxon) { create(:taxon) }
   let!(:stock_location) { create(:stock_location, backorderable_default: false) }

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -4,8 +4,8 @@ feature '
     As an admin
     I want to set a supplier and distributor(s) for a product
 ' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   let!(:taxon) { create(:taxon) }
   let!(:stock_location) { create(:stock_location, backorderable_default: false) }
@@ -97,7 +97,7 @@ feature '
     let!(:tax_category) { create(:tax_category) }
 
     before do
-      @new_user = create_enterprise_user
+      @new_user = create(:user)
       @supplier2 = create(:supplier_enterprise, name: 'Another Supplier')
       @supplier_permitted = create(:supplier_enterprise, name: 'Permitted Supplier')
       @new_user.enterprise_roles.build(enterprise: @supplier2).save

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -67,8 +67,7 @@ feature '
     end
 
     scenario "creating an on-demand product", js: true do
-      quick_login_as_admin
-      visit spree.admin_products_path
+      login_to_admin_and_visit spree.admin_products_path
 
       click_link 'New Product'
 

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -67,7 +67,7 @@ feature '
     end
 
     scenario "creating an on-demand product", js: true do
-      login_to_admin_and_visit spree.admin_products_path
+      login_as_admin_and_visit spree.admin_products_path
 
       click_link 'New Product'
 

--- a/spec/features/admin/properties_spec.rb
+++ b/spec/features/admin/properties_spec.rb
@@ -9,8 +9,7 @@ feature '
   include AuthenticationWorkflow
 
   scenario "creating and editing a property" do
-    login_to_admin_section
-    visit spree.admin_properties_path
+    login_to_admin_and_visit spree.admin_properties_path
 
     click_link 'New Property'
     fill_in 'property_name', with: 'New property!'

--- a/spec/features/admin/properties_spec.rb
+++ b/spec/features/admin/properties_spec.rb
@@ -9,7 +9,7 @@ feature '
   include AuthenticationWorkflow
 
   scenario "creating and editing a property" do
-    login_to_admin_and_visit spree.admin_properties_path
+    login_as_admin_and_visit spree.admin_properties_path
 
     click_link 'New Property'
     fill_in 'property_name', with: 'New property!'

--- a/spec/features/admin/properties_spec.rb
+++ b/spec/features/admin/properties_spec.rb
@@ -6,7 +6,7 @@ feature '
     As an admin
     I want to manage product properties
 ' do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   scenario "creating and editing a property" do
     login_as_admin_and_visit spree.admin_properties_path

--- a/spec/features/admin/reports/packing_report_spec.rb
+++ b/spec/features/admin/reports/packing_report_spec.rb
@@ -13,7 +13,7 @@ feature "Packing Reports", js: true do
   before do
     order.line_items << li1
     order.line_items << li2
-    quick_login_as_admin
+    login_as_admin
   end
 
   describe "viewing a report" do

--- a/spec/features/admin/reports/packing_report_spec.rb
+++ b/spec/features/admin/reports/packing_report_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 feature "Packing Reports", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let(:distributor) { create(:distributor_enterprise) }

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want numbers, all the numbers!
 ' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   context "Permissions for different reports" do
     context "As an enterprise user" do

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -31,8 +31,7 @@ feature '
 
   describe "Customers report" do
     before do
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
     end
 
     scenario "customers report" do
@@ -63,8 +62,7 @@ feature '
 
   describe "Order cycle management report" do
     before do
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
     end
 
     scenario "payment method report" do
@@ -90,8 +88,7 @@ feature '
 
   describe "Packing reports" do
     before do
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
     end
 
     let(:bill_address1) { create(:address, lastname: "Aman") }
@@ -147,8 +144,7 @@ feature '
   end
 
   scenario "orders and distributors report" do
-    quick_login_as_admin
-    visit spree.admin_reports_path
+    login_to_admin_and_visit spree.admin_reports_path
     click_link 'Orders And Distributors'
     click_button 'Search'
 
@@ -156,8 +152,7 @@ feature '
   end
 
   scenario "payments reports" do
-    quick_login_as_admin
-    visit spree.admin_reports_path
+    login_to_admin_and_visit spree.admin_reports_path
     click_link 'Payment Reports'
     click_button 'Search'
 
@@ -191,8 +186,7 @@ feature '
       order1.reload.update_distribution_charge!
       order1.finalize!
 
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
 
       click_link "Sales Tax"
       select("Tax types", from: "report_type")
@@ -227,8 +221,7 @@ feature '
 
   describe "orders & fulfilment reports" do
     it "loads the report page" do
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
       click_link 'Orders & Fulfillment Reports'
 
       expect(page).to have_content 'Supplier'
@@ -253,8 +246,7 @@ feature '
 
       it "is precise to time of day, not just date" do
         # When I generate a customer report with a timeframe that includes one order but not the other
-        quick_login_as_admin
-        visit spree.orders_and_fulfillment_admin_reports_path
+        login_to_admin_and_visit spree.orders_and_fulfillment_admin_reports_path
 
         fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
         fill_in 'q_completed_at_lt', with: '2013-04-25 15:00:00'
@@ -271,8 +263,7 @@ feature '
       oc = create(:simple_order_cycle, name: "My Order Cycle", distributors: [distributor], orders_open_at: Time.zone.now, orders_close_at: nil)
       o = create(:order, order_cycle: oc, distributor: distributor)
 
-      quick_login_as_admin
-      visit spree.orders_and_fulfillment_admin_reports_path
+      login_to_admin_and_visit spree.orders_and_fulfillment_admin_reports_path
 
       expect(page).to have_content "My Order Cycle"
     end
@@ -303,8 +294,7 @@ feature '
     end
 
     it "shows products and inventory report" do
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
 
       expect(page).to have_content "All products"
       expect(page).to have_content "Inventory (on hand)"
@@ -318,8 +308,7 @@ feature '
     end
 
     it "shows the LettuceShare report" do
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
       click_link 'LettuceShare'
       click_button "Go"
 
@@ -336,8 +325,7 @@ feature '
     before do
       enterprise3.enterprise_roles.build( user: enterprise1.owner ).save
 
-      quick_login_as_admin
-      visit spree.admin_reports_path
+      login_to_admin_and_visit spree.admin_reports_path
 
       click_link 'Users & Enterprises'
     end
@@ -414,8 +402,7 @@ feature '
         order1.update_attribute :email, 'customer@email.com'
         Timecop.travel(Time.zone.local(2015, 4, 25, 14, 0, 0)) { order1.finalize! }
 
-        quick_login_as_admin
-        visit spree.admin_reports_path
+        login_to_admin_and_visit spree.admin_reports_path
 
         click_link 'Xero Invoices'
       end

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -4,22 +4,22 @@ feature '
     As an administrator
     I want numbers, all the numbers!
 ' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   context "Permissions for different reports" do
     context "As an enterprise user" do
       let(:user) do
-        create_enterprise_user(enterprises: [
-                                 create(:distributor_enterprise)
-                               ])
+        create(:user, enterprises: [create(:distributor_enterprise)])
       end
+
       it "does not show super admin only report" do
         login_to_admin_as user
         click_link "Reports"
         expect(page).not_to have_content "Users & Enterprises"
       end
     end
+
     context "As an admin user" do
       it "shows the super admin only report" do
         login_to_admin_section
@@ -167,8 +167,8 @@ feature '
   describe "sales tax report" do
     let(:distributor1) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
     let(:distributor2) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
-    let(:user1) { create_enterprise_user enterprises: [distributor1] }
-    let(:user2) { create_enterprise_user enterprises: [distributor2] }
+    let(:user1) { create(:user, enterprises: [distributor1]) }
+    let(:user2) { create(:user, enterprises: [distributor2]) }
     let!(:shipping_method) { create(:shipping_method_with, :expensive_name, distributors: [distributor1]) }
     let(:enterprise_fee) { create(:enterprise_fee, enterprise: user1.enterprises.first, tax_category: product2.tax_category, calculator: Calculator::FlatRate.new(preferred_amount: 120.0)) }
     let(:order_cycle) { create(:simple_order_cycle, coordinator: distributor1, coordinator_fees: [enterprise_fee], distributors: [distributor1], variants: [product1.master]) }
@@ -329,9 +329,9 @@ feature '
   end
 
   describe "users and enterprises report" do
-    let!(:enterprise1) { create( :enterprise, owner: create_enterprise_user ) }
-    let!(:enterprise2) { create( :enterprise, owner: create_enterprise_user ) }
-    let!(:enterprise3) { create( :enterprise, owner: create_enterprise_user ) }
+    let!(:enterprise1) { create( :enterprise, owner: create(:user) ) }
+    let!(:enterprise2) { create( :enterprise, owner: create(:user) ) }
+    let!(:enterprise3) { create( :enterprise, owner: create(:user) ) }
 
     before do
       enterprise3.enterprise_roles.build( user: enterprise1.owner ).save
@@ -379,8 +379,8 @@ feature '
   describe "Xero invoices report" do
     let(:distributor1) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
     let(:distributor2) { create(:distributor_enterprise, with_payment_and_shipping: true, charges_sales_tax: true) }
-    let(:user1) { create_enterprise_user enterprises: [distributor1] }
-    let(:user2) { create_enterprise_user enterprises: [distributor2] }
+    let(:user1) { create(:user, enterprises: [distributor1]) }
+    let(:user2) { create(:user, enterprises: [distributor2]) }
     let(:shipping_method) { create(:shipping_method_with, :expensive_name) }
     let(:shipment) { create(:shipment_with, :shipping_method, shipping_method: shipping_method) }
 

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -31,7 +31,7 @@ feature '
 
   describe "Customers report" do
     before do
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
     end
 
     scenario "customers report" do
@@ -62,7 +62,7 @@ feature '
 
   describe "Order cycle management report" do
     before do
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
     end
 
     scenario "payment method report" do
@@ -88,7 +88,7 @@ feature '
 
   describe "Packing reports" do
     before do
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
     end
 
     let(:bill_address1) { create(:address, lastname: "Aman") }
@@ -144,7 +144,7 @@ feature '
   end
 
   scenario "orders and distributors report" do
-    login_to_admin_and_visit spree.admin_reports_path
+    login_as_admin_and_visit spree.admin_reports_path
     click_link 'Orders And Distributors'
     click_button 'Search'
 
@@ -152,7 +152,7 @@ feature '
   end
 
   scenario "payments reports" do
-    login_to_admin_and_visit spree.admin_reports_path
+    login_as_admin_and_visit spree.admin_reports_path
     click_link 'Payment Reports'
     click_button 'Search'
 
@@ -186,7 +186,7 @@ feature '
       order1.reload.update_distribution_charge!
       order1.finalize!
 
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
 
       click_link "Sales Tax"
       select("Tax types", from: "report_type")
@@ -221,7 +221,7 @@ feature '
 
   describe "orders & fulfilment reports" do
     it "loads the report page" do
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
       click_link 'Orders & Fulfillment Reports'
 
       expect(page).to have_content 'Supplier'
@@ -246,7 +246,7 @@ feature '
 
       it "is precise to time of day, not just date" do
         # When I generate a customer report with a timeframe that includes one order but not the other
-        login_to_admin_and_visit spree.orders_and_fulfillment_admin_reports_path
+        login_as_admin_and_visit spree.orders_and_fulfillment_admin_reports_path
 
         fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
         fill_in 'q_completed_at_lt', with: '2013-04-25 15:00:00'
@@ -263,7 +263,7 @@ feature '
       oc = create(:simple_order_cycle, name: "My Order Cycle", distributors: [distributor], orders_open_at: Time.zone.now, orders_close_at: nil)
       o = create(:order, order_cycle: oc, distributor: distributor)
 
-      login_to_admin_and_visit spree.orders_and_fulfillment_admin_reports_path
+      login_as_admin_and_visit spree.orders_and_fulfillment_admin_reports_path
 
       expect(page).to have_content "My Order Cycle"
     end
@@ -294,7 +294,7 @@ feature '
     end
 
     it "shows products and inventory report" do
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
 
       expect(page).to have_content "All products"
       expect(page).to have_content "Inventory (on hand)"
@@ -308,7 +308,7 @@ feature '
     end
 
     it "shows the LettuceShare report" do
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
       click_link 'LettuceShare'
       click_button "Go"
 
@@ -325,7 +325,7 @@ feature '
     before do
       enterprise3.enterprise_roles.build( user: enterprise1.owner ).save
 
-      login_to_admin_and_visit spree.admin_reports_path
+      login_as_admin_and_visit spree.admin_reports_path
 
       click_link 'Users & Enterprises'
     end
@@ -402,7 +402,7 @@ feature '
         order1.update_attribute :email, 'customer@email.com'
         Timecop.travel(Time.zone.local(2015, 4, 25, 14, 0, 0)) { order1.finalize! }
 
-        login_to_admin_and_visit spree.admin_reports_path
+        login_as_admin_and_visit spree.admin_reports_path
 
         click_link 'Xero Invoices'
       end

--- a/spec/features/admin/schedules_spec.rb
+++ b/spec/features/admin/schedules_spec.rb
@@ -16,7 +16,7 @@ feature 'Schedules', js: true do
     let!(:oc5) { create(:simple_order_cycle, coordinator: managed_enterprise2, name: 'oc5') }
     let!(:weekly_schedule) { create(:schedule, name: 'Weekly', order_cycles: [oc1, oc2, oc3, oc4]) }
 
-    before { quick_login_as user }
+    before { login_as user }
 
     describe "Adding a new Schedule" do
       it "immediately shows the schedule in the order cycle list once created" do

--- a/spec/features/admin/schedules_spec.rb
+++ b/spec/features/admin/schedules_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Schedules', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   context "as an enterprise user" do

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'shipping methods' do
   include WebHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   before :each do
     @shipping_method = create(:shipping_method)

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -10,7 +10,7 @@ feature 'shipping methods' do
 
   context "as a site admin" do
     before(:each) do
-      quick_login_as_admin
+      login_as_admin
     end
 
     scenario "creating a shipping method owned by some distributors" do

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -94,7 +94,7 @@ feature 'shipping methods' do
     before(:each) do
       enterprise_user.enterprise_roles.build(enterprise: distributor1).save
       enterprise_user.enterprise_roles.build(enterprise: distributor2).save
-      quick_login_as enterprise_user
+      login_as enterprise_user
     end
 
     it "creating a shipping method" do

--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 feature 'shipping methods' do
-  include AuthenticationWorkflow
   include WebHelper
+  include AuthenticationWorkflow
 
   before :each do
     @shipping_method = create(:shipping_method)
@@ -82,7 +82,7 @@ feature 'shipping methods' do
   end
 
   context "as an enterprise user", js: true do
-    let(:enterprise_user) { create_enterprise_user }
+    let(:enterprise_user) { create(:user) }
     let(:distributor1) { create(:distributor_enterprise, name: 'First Distributor') }
     let(:distributor2) { create(:distributor_enterprise, name: 'Second Distributor') }
     let(:distributor3) { create(:distributor_enterprise, name: 'Third Distributor') }

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -11,7 +11,7 @@ feature 'Subscriptions' do
     let!(:shop2) { create(:distributor_enterprise, owner: user, enable_subscriptions: true) }
     let!(:shop_unmanaged) { create(:distributor_enterprise, enable_subscriptions: true) }
 
-    before { quick_login_as user }
+    before { login_as user }
 
     context 'listing subscriptions' do
       let!(:subscription) { create(:subscription, shop: shop, with_items: true, with_proxy_orders: true) }

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -6,7 +6,7 @@ feature 'Subscriptions' do
   include WebHelper
 
   context "as an enterprise user", js: true do
-    let!(:user) { create_enterprise_user(enterprise_limit: 10) }
+    let!(:user) { create(:user) }
     let!(:shop) { create(:distributor_enterprise, owner: user, enable_subscriptions: true) }
     let!(:shop2) { create(:distributor_enterprise, owner: user, enable_subscriptions: true) }
     let!(:shop_unmanaged) { create(:distributor_enterprise, enable_subscriptions: true) }

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Subscriptions' do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   context "as an enterprise user", js: true do

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -242,8 +242,7 @@ feature 'Tag Rules', js: true do
   end
 
   def visit_tag_rules
-    login_to_admin_section
-    visit main_app.edit_admin_enterprise_path(enterprise)
+    login_to_admin_and_visit main_app.edit_admin_enterprise_path(enterprise)
     expect(page).to have_content "PRIMARY DETAILS"
     click_link "Tag Rules"
   end

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -242,7 +242,7 @@ feature 'Tag Rules', js: true do
   end
 
   def visit_tag_rules
-    login_to_admin_and_visit main_app.edit_admin_enterprise_path(enterprise)
+    login_as_admin_and_visit main_app.edit_admin_enterprise_path(enterprise)
     expect(page).to have_content "PRIMARY DETAILS"
     click_link "Tag Rules"
   end

--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Tag Rules', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   let!(:enterprise) { create(:distributor_enterprise) }

--- a/spec/features/admin/tax_settings_spec.rb
+++ b/spec/features/admin/tax_settings_spec.rb
@@ -16,12 +16,11 @@ feature 'Account and Billing Settings' do
     end
 
     before do
-      quick_login_as_admin
+      login_as_admin
     end
 
     context "as an admin user" do
       it "loads the page" do
-        visit spree.admin_dashboard_path
         click_link "Configuration"
         click_link "Tax Settings"
 

--- a/spec/features/admin/tax_settings_spec.rb
+++ b/spec/features/admin/tax_settings_spec.rb
@@ -5,8 +5,6 @@ feature 'Account and Billing Settings' do
   include WebHelper
 
   describe "updating" do
-    let!(:admin) { create(:admin_user) }
-
     before do
       Spree::Config.set(
         products_require_tax_category: false,
@@ -15,13 +13,9 @@ feature 'Account and Billing Settings' do
       )
     end
 
-    before do
-      login_as_admin
-    end
-
     context "as an admin user" do
       it "loads the page" do
-        click_link "Configuration"
+        login_as_admin_and_visit spree.edit_admin_general_settings_path
         click_link "Tax Settings"
 
         expect(page).to have_unchecked_field 'preferences_products_require_tax_category'
@@ -30,7 +24,7 @@ feature 'Account and Billing Settings' do
       end
 
       it "attributes can be changed" do
-        visit spree.edit_admin_tax_settings_path
+        login_as_admin_and_visit spree.edit_admin_tax_settings_path
 
         check 'preferences_products_require_tax_category'
         check 'preferences_shipment_inc_vat'

--- a/spec/features/admin/tax_settings_spec.rb
+++ b/spec/features/admin/tax_settings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Account and Billing Settings' do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   describe "updating" do

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 feature "Managing users" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include OpenFoodNetwork::EmailHelper
 
   context "as super-admin" do

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -7,7 +7,7 @@ feature "Managing users" do
   context "as super-admin" do
     before do
       setup_email
-      quick_login_as_admin
+      login_as_admin
     end
 
     context "from the index page" do

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -6,7 +6,7 @@ feature "
   Without affecting other hubs that share the same products
 ", js: true do
   include AdminHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   context "as the manager of a hub" do

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -24,7 +24,7 @@ feature "
       create(:enterprise_relationship, parent: producer_related, child: hub,
                                        permissions_list: [:create_variant_overrides])
     }
-    let(:user) { create_enterprise_user enterprises: [hub, producer_managed] }
+    let(:user) { create(:user, enterprises: [hub, producer_managed]) }
 
     before { quick_login_as user }
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -401,9 +401,7 @@ feature "
       let(:product) { order_cycle.products.first }
 
       before do
-        login_to_admin_section
-
-        visit 'admin/orders/new'
+        login_to_admin_and_visit 'admin/orders/new'
         select2_select distributor.name, from: 'order_distributor_id'
         select2_select order_cycle.name, from: 'order_order_cycle_id'
         click_button 'Next'

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -401,7 +401,7 @@ feature "
       let(:product) { order_cycle.products.first }
 
       before do
-        login_to_admin_and_visit 'admin/orders/new'
+        login_as_admin_and_visit 'admin/orders/new'
         select2_select distributor.name, from: 'order_distributor_id'
         select2_select order_cycle.name, from: 'order_order_cycle_id'
         click_button 'Next'

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -401,7 +401,7 @@ feature "
       let(:product) { order_cycle.products.first }
 
       before do
-        login_as_admin_and_visit 'admin/orders/new'
+        login_as_admin_and_visit spree.new_admin_order_path
         select2_select distributor.name, from: 'order_distributor_id'
         select2_select order_cycle.name, from: 'order_order_cycle_id'
         click_button 'Next'

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -26,7 +26,7 @@ feature "
     }
     let(:user) { create(:user, enterprises: [hub, producer_managed]) }
 
-    before { quick_login_as user }
+    before { login_as user }
 
     describe "selecting a hub" do
       let!(:er1) {
@@ -471,7 +471,7 @@ feature "
       last_variant = inventory_items.last.variant
       first_variant.product.update!(name: "A First Product")
       last_variant.product.update!(name: "Z Last Product")
-      quick_login_as supplier.users.first
+      login_as supplier.users.first
       visit admin_inventory_path
 
       expect(page).to have_text first_variant.name

--- a/spec/features/admin/variants_spec.rb
+++ b/spec/features/admin/variants_spec.rb
@@ -12,7 +12,7 @@ feature '
     product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
 
     # When I create a variant on the product
-    login_to_admin_and_visit spree.admin_product_variants_path product
+    login_as_admin_and_visit spree.admin_product_variants_path product
     click_link 'New Variant'
 
     fill_in 'unit_value_human', with: '1'
@@ -34,7 +34,7 @@ feature '
       product.option_types << variant.option_values.first.option_type
 
       # When I view the variant
-      login_to_admin_and_visit spree.admin_product_variants_path product
+      login_as_admin_and_visit spree.admin_product_variants_path product
       page.find('table.index .icon-edit').click
 
       # Then I should not see a traditional option value field for the unit-related option value
@@ -60,7 +60,7 @@ feature '
       variant = product.variants.first
       variant.update(unit_description: 'foo')
 
-      login_to_admin_and_visit spree.edit_admin_product_variant_path(product, variant)
+      login_as_admin_and_visit spree.edit_admin_product_variant_path(product, variant)
 
       expect(page).to_not have_field "unit_value_human"
       expect(page).to have_field "variant_unit_description", with: "foo"
@@ -117,7 +117,7 @@ feature '
     product = create(:simple_product)
     variant = create(:variant, product: product)
 
-    login_to_admin_and_visit spree.admin_product_variants_path product
+    login_as_admin_and_visit spree.admin_product_variants_path product
 
     within "tr#spree_variant_#{variant.id}" do
       accept_alert do
@@ -134,7 +134,7 @@ feature '
     variant = product.variants.first
 
     # When I view the variant
-    login_to_admin_and_visit spree.admin_product_variants_path product
+    login_as_admin_and_visit spree.admin_product_variants_path product
     page.find('table.index .icon-edit').click
 
     # It should allow the display name to be changed

--- a/spec/features/admin/variants_spec.rb
+++ b/spec/features/admin/variants_spec.rb
@@ -12,8 +12,7 @@ feature '
     product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
 
     # When I create a variant on the product
-    login_to_admin_section
-    visit spree.admin_product_variants_path product
+    login_to_admin_and_visit spree.admin_product_variants_path product
     click_link 'New Variant'
 
     fill_in 'unit_value_human', with: '1'
@@ -35,8 +34,7 @@ feature '
       product.option_types << variant.option_values.first.option_type
 
       # When I view the variant
-      login_to_admin_section
-      visit spree.admin_product_variants_path product
+      login_to_admin_and_visit spree.admin_product_variants_path product
       page.find('table.index .icon-edit').click
 
       # Then I should not see a traditional option value field for the unit-related option value
@@ -62,8 +60,7 @@ feature '
       variant = product.variants.first
       variant.update(unit_description: 'foo')
 
-      login_to_admin_section
-      visit spree.edit_admin_product_variant_path(product, variant)
+      login_to_admin_and_visit spree.edit_admin_product_variant_path(product, variant)
 
       expect(page).to_not have_field "unit_value_human"
       expect(page).to have_field "variant_unit_description", with: "foo"
@@ -120,8 +117,7 @@ feature '
     product = create(:simple_product)
     variant = create(:variant, product: product)
 
-    login_to_admin_section
-    visit spree.admin_product_variants_path product
+    login_to_admin_and_visit spree.admin_product_variants_path product
 
     within "tr#spree_variant_#{variant.id}" do
       accept_alert do
@@ -138,8 +134,7 @@ feature '
     variant = product.variants.first
 
     # When I view the variant
-    login_to_admin_section
-    visit spree.admin_product_variants_path product
+    login_to_admin_and_visit spree.admin_product_variants_path product
     page.find('table.index .icon-edit').click
 
     # It should allow the display name to be changed

--- a/spec/features/admin/variants_spec.rb
+++ b/spec/features/admin/variants_spec.rb
@@ -4,7 +4,7 @@ feature '
     As an admin
     I want to manage product variants
 ' do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   scenario "creating a new variant" do

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "Credit Cards", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   describe "as a logged in user" do
     let(:user) { create(:user) }
     let!(:customer) { create(:customer, user: user) }

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -9,7 +9,7 @@ feature "Credit Cards", js: true do
     let!(:non_default_card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_FDTG') }
 
     before do
-      quick_login_as user
+      login_as user
 
       allow(Stripe).to receive(:api_key) { "sk_test_xxxx" }
       allow(Stripe).to receive(:publishable_key) { "some_token" }

--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -14,7 +14,7 @@ feature "Account Settings", js: true do
 
     before do
       setup_email
-      quick_login_as user
+      login_as user
       visit "/account"
       click_link I18n.t('spree.users.show.tabs.settings')
       expect(page).to have_content I18n.t('spree.users.form.account_settings')

--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "Account Settings", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include OpenFoodNetwork::EmailHelper
 
   describe "as a logged in user" do

--- a/spec/features/consumer/account_spec.rb
+++ b/spec/features/consumer/account_spec.rb
@@ -6,7 +6,7 @@ feature '
     and view any outstanding balance.
 ', js: true do
   include UIComponentHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let(:user) { create(:user) }
   let!(:distributor1) { create(:distributor_enterprise) }

--- a/spec/features/consumer/authentication_spec.rb
+++ b/spec/features/consumer/authentication_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "Authentication", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include UIComponentHelper
   include OpenFoodNetwork::EmailHelper
 

--- a/spec/features/consumer/groups_spec.rb
+++ b/spec/features/consumer/groups_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Groups', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include UIComponentHelper
 
   let(:enterprise) { create(:distributor_enterprise) }

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Multilingual', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include ShopWorkflow
   include UIComponentHelper

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -77,14 +77,14 @@ feature 'Multilingual', js: true do
 
       expect_menu_and_cookie_in_es
       expect(user.locale).to be_nil
-      quick_login_as user
+      login_as user
       visit root_path
 
       expect_menu_and_cookie_in_es
     end
 
     it 'updates user locale and stays in cookie after logout' do
-      quick_login_as user
+      login_as user
       visit root_path(locale: 'es')
       user.reload
 

--- a/spec/features/consumer/producers_spec.rb
+++ b/spec/features/consumer/producers_spec.rb
@@ -5,7 +5,7 @@ feature '
     I want to see a list of producers
     So that I can shop at hubs distributing their products
 ', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include UIComponentHelper
 

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "Registration", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
 
   describe "Registering a Profile" do

--- a/spec/features/consumer/registration_spec.rb
+++ b/spec/features/consumer/registration_spec.rb
@@ -154,7 +154,7 @@ feature "Registration", js: true do
     let!(:user2) { create(:user) }
 
     before do
-      quick_login_as user2
+      login_as user2
     end
 
     context "if accepting Terms of Service is not required" do

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -262,7 +262,7 @@ feature "full-page cart", js: true do
         order.distributor.allow_order_changes = true
         order.distributor.save
         add_product_to_cart order, product_with_tax
-        quick_login_as user
+        login_as user
         visit main_app.cart_path
       end
 

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "full-page cart", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include ShopWorkflow
   include UIComponentHelper

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -24,7 +24,7 @@ feature "As a consumer I want to check out my cart", js: true do
     end
 
     it "does not render the login form when logged in" do
-      quick_login_as user
+      login_as user
       visit checkout_path
       within "section[role='main']" do
         expect(page).to have_no_content "Login"

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "As a consumer I want to check out my cart", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include ShopWorkflow
   include CheckoutWorkflow

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "As a consumer I want to check out my cart", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include ShopWorkflow
   include CheckoutWorkflow
   include WebHelper

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -65,7 +65,7 @@ feature "As a consumer I want to check out my cart", js: true do
       let(:user) { create(:user) }
 
       before do
-        quick_login_as(user)
+        login_as(user)
       end
 
       context "with details filled out" do
@@ -292,7 +292,7 @@ feature "As a consumer I want to check out my cart", js: true do
           expect(page).to have_content "Donkeys"
           expect(page).not_to have_content "Local"
 
-          quick_login_as(user)
+          login_as(user)
           visit checkout_path
 
           # Default rule in still effect, disallows access to 'Local'

--- a/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
+++ b/spec/features/consumer/shopping/embedded_shopfronts_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature "Using embedded shopfront functionality", js: true do
   include OpenFoodNetwork::EmbeddedPagesHelper
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include ShopWorkflow
   include CheckoutWorkflow

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "Order Management", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include OpenFoodNetwork::EmailHelper
 
   describe "viewing a completed order" do

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -109,7 +109,7 @@ feature "Order Management", js: true do
       order.save
       order.reload
 
-      quick_login_as user
+      login_as user
     end
 
     it 'shows the name of the shipping method' do

--- a/spec/features/consumer/shopping/products_spec.rb
+++ b/spec/features/consumer/shopping/products_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "As a consumer I want to view products", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include ShopWorkflow
   include UIComponentHelper

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "As a consumer I want to shop with a distributor", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include ShopWorkflow
   include UIComponentHelper

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -485,7 +485,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
         let(:user) { create(:user, bill_address: address, ship_address: address) }
 
         before do
-          quick_login_as user
+          login_as user
         end
 
         context "as non-customer" do
@@ -533,7 +533,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
         let!(:returning_user) { create(:user, email: unregistered_customer.email) }
 
         before do
-          quick_login_as returning_user
+          login_as returning_user
         end
 
         it "shows the products without customer only message" do

--- a/spec/features/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/features/consumer/shopping/variant_overrides_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "shopping with variant overrides defined", js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include WebHelper
   include ShopWorkflow
   include CheckoutWorkflow

--- a/spec/features/consumer/shops_spec.rb
+++ b/spec/features/consumer/shops_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Shops', js: true do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include UIComponentHelper
   include WebHelper
 

--- a/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_form_applicator_spec.rb
@@ -4,9 +4,7 @@ require 'open_food_network/order_cycle_form_applicator'
 
 module OpenFoodNetwork
   describe OrderCycleFormApplicator do
-    include AuthenticationWorkflow
-
-    let!(:user) { create_enterprise_user }
+    let!(:user) { create(:user) }
 
     context "unit specs" do
       it "creates new exchanges for incoming_exchanges" do

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 require 'open_food_network/order_cycle_management_report'
 
-include AuthenticationWorkflow
-
 module OpenFoodNetwork
   describe OrderCycleManagementReport do
     context "as a site admin" do
@@ -37,7 +35,7 @@ module OpenFoodNetwork
     end
 
     context "as an enterprise user" do
-      let!(:user) { create_enterprise_user }
+      let!(:user) { create(:user) }
 
       subject { OrderCycleManagementReport.new user, {}, true }
 

--- a/spec/lib/open_food_network/orders_and_fulfillments_report_spec.rb
+++ b/spec/lib/open_food_network/orders_and_fulfillments_report_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'open_food_network/orders_and_fulfillments_report'
 
 describe OpenFoodNetwork::OrdersAndFulfillmentsReport do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let(:distributor) { create(:distributor_enterprise) }
   let(:order_cycle) { create(:simple_order_cycle) }

--- a/spec/lib/open_food_network/packing_report_spec.rb
+++ b/spec/lib/open_food_network/packing_report_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'open_food_network/packing_report'
 
-include AuthenticationWorkflow
+include AuthenticationHelper
 
 module OpenFoodNetwork
   describe PackingReport do

--- a/spec/lib/open_food_network/users_and_enterprises_report_spec.rb
+++ b/spec/lib/open_food_network/users_and_enterprises_report_spec.rb
@@ -3,8 +3,6 @@ require 'open_food_network/users_and_enterprises_report'
 
 module OpenFoodNetwork
   describe UsersAndEnterprisesReport do
-    include AuthenticationWorkflow
-
     describe "users_and_enterprises" do
       let!(:owners_and_enterprises) { double(:owners_and_enterprises) }
       let!(:managers_and_enterprises) { double(:managers_and_enterprises) }
@@ -63,8 +61,8 @@ module OpenFoodNetwork
     end
 
     describe "filtering results" do
-      let!(:enterprise1) { create(:enterprise, owner: create_enterprise_user ) }
-      let!(:enterprise2) { create(:enterprise, owner: create_enterprise_user ) }
+      let!(:enterprise1) { create(:enterprise, owner: create(:user) ) }
+      let!(:enterprise2) { create(:enterprise, owner: create(:user) ) }
 
       describe "for owners and enterprises" do
         describe "by enterprise id" do
@@ -103,8 +101,8 @@ module OpenFoodNetwork
         end
 
         describe "by user id" do
-          let!(:manager1) { create_enterprise_user }
-          let!(:manager2) { create_enterprise_user }
+          let!(:manager1) { create(:user) }
+          let!(:manager2) { create(:user) }
           let!(:params) { { user_id_in: [manager1.id.to_s] } }
           let!(:subject) { OpenFoodNetwork::UsersAndEnterprisesReport.new params, true }
 

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -1,11 +1,9 @@
 require 'spec_helper'
 
 describe Enterprise do
-  include AuthenticationWorkflow
-
   describe "sending emails" do
     describe "on creation" do
-      let!(:user) { create_enterprise_user( enterprise_limit: 2 ) }
+      let!(:user) { create(:user) }
       let!(:enterprise) { create(:enterprise, owner: user) }
 
       it "sends a welcome email" do
@@ -82,8 +80,8 @@ describe Enterprise do
     end
 
     describe "ownership" do
-      let(:u1) { create_enterprise_user }
-      let(:u2) { create_enterprise_user }
+      let(:u1) { create(:user) }
+      let(:u2) { create(:user) }
       let!(:e) { create(:enterprise, owner: u1 ) }
 
       it "adds new owner to list of managers" do

--- a/spec/models/product_importer_spec.rb
+++ b/spec/models/product_importer_spec.rb
@@ -2,12 +2,10 @@ require 'spec_helper'
 require 'open_food_network/permissions'
 
 describe ProductImport::ProductImporter do
-  include AuthenticationWorkflow
-
   let!(:admin) { create(:admin_user) }
-  let!(:user) { create_enterprise_user }
-  let!(:user2) { create_enterprise_user }
-  let!(:user3) { create_enterprise_user }
+  let!(:user) { create(:user) }
+  let!(:user2) { create(:user) }
+  let!(:user3) { create(:user) }
   let!(:enterprise) { create(:enterprise, is_primary_producer: true, owner: user, name: "User Enterprise") }
   let!(:enterprise2) { create(:distributor_enterprise, is_primary_producer: true, owner: user2, name: "Another Enterprise") }
   let!(:enterprise3) { create(:distributor_enterprise, is_primary_producer: true, owner: user3, name: "And Another Enterprise") }

--- a/spec/requests/checkout/stripe_connect_spec.rb
+++ b/spec/requests/checkout/stripe_connect_spec.rb
@@ -244,7 +244,7 @@ describe "checking out an order with a Stripe Connect payment method", type: :re
 
     before do
       params[:order][:existing_card_id] = credit_card.id
-      quick_login_as(order.user)
+      login_as(order.user)
 
       # Requests a token
       stub_request(:post, "https://api.stripe.com/v1/tokens")

--- a/spec/requests/checkout/stripe_connect_spec.rb
+++ b/spec/requests/checkout/stripe_connect_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "checking out an order with a Stripe Connect payment method", type: :request do
   include ShopWorkflow
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include OpenFoodNetwork::ApiHelper
 
   let!(:order_cycle) { create(:simple_order_cycle) }

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -289,7 +289,7 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
 
       before do
         params[:order][:existing_card_id] = credit_card.id
-        quick_login_as(order.user)
+        login_as(order.user)
       end
 
       context "and the payment intent and payment method requests are accepted" do

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe "checking out an order with a Stripe SCA payment method", type: :request do
   include ShopWorkflow
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   include OpenFoodNetwork::ApiHelper
 
   let!(:order_cycle) { create(:simple_order_cycle) }

--- a/spec/requests/embedded_shopfronts_headers_spec.rb
+++ b/spec/requests/embedded_shopfronts_headers_spec.rb
@@ -7,7 +7,7 @@ describe "setting response headers for embedded shopfronts", type: :request do
   let(:user) { enterprise.owner }
 
   before do
-    quick_login_as(user)
+    login_as(user)
   end
 
   context "with embedded shopfront disabled" do

--- a/spec/requests/embedded_shopfronts_headers_spec.rb
+++ b/spec/requests/embedded_shopfronts_headers_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "setting response headers for embedded shopfronts", type: :request do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
 
   let(:enterprise) { create(:distributor_enterprise) }
   let(:user) { enterprise.owner }

--- a/spec/serializers/api/admin/index_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/admin/index_enterprise_serializer_spec.rb
@@ -1,11 +1,9 @@
 require 'spec_helper'
 
 describe Api::Admin::IndexEnterpriseSerializer do
-  include AuthenticationWorkflow
-
   let(:enterprise) { create(:distributor_enterprise) }
   context "when spree_current_user is a manager" do
-    let(:user) { create_enterprise_user }
+    let(:user) { create(:user) }
     before do
       user.enterprise_roles.create(enterprise: enterprise)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -201,4 +201,5 @@ RSpec.configure do |config|
   # config.after :suite do
   # PerfTools::CpuProfiler.stop
   # end
+  config.infer_spec_type_from_file_location!
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -10,7 +10,7 @@ module OpenFoodNetwork
       allow(controller).to receive_messages(spree_current_user: @admin_user)
     end
 
-    def login_as_enterprise_user(enterprises)
+    def controller_login_as_enterprise_user(enterprises)
       @enterprise_user ||= begin
         user = create(:user)
         user.spree_roles = []

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -1,6 +1,6 @@
 module OpenFoodNetwork
   module ControllerHelper
-    def login_as_admin
+    def controller_login_as_admin
       @admin_user ||= begin
         user = create(:user)
         user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -1,4 +1,4 @@
-module AuthenticationWorkflow
+module AuthenticationHelper
   include Warden::Test::Helpers
 
   def login_as(user)
@@ -46,7 +46,7 @@ module AuthenticationWorkflow
 end
 
 RSpec.configure do |config|
-  config.extend AuthenticationWorkflow, type: :feature
+  config.extend AuthenticationHelper, type: :feature
 
   # rspec-rails 3 will no longer automatically infer an example group's spec type
   # from the file location. You can explicitly opt-in to the feature using this

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -2,15 +2,7 @@ module AuthenticationHelper
   include Warden::Test::Helpers
 
   def login_as_admin
-    admin_role = Spree::Role.find_or_create_by!(name: 'admin')
-    admin_user = create(:user,
-                        password: 'passw0rd',
-                        password_confirmation: 'passw0rd',
-                        remember_me: false,
-                        persistence_token: 'pass',
-                        login: 'admin@ofn.org')
-
-    admin_user.spree_roles << admin_role
+    admin_user = create(:admin_user)
     login_as admin_user
     admin_user
   end

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -1,10 +1,6 @@
 module AuthenticationHelper
   include Warden::Test::Helpers
 
-  def login_as(user)
-    login_as user
-  end
-
   def login_as_admin
     admin_role = Spree::Role.find_or_create_by!(name: 'admin')
     admin_user = create(:user,

--- a/spec/support/request/authentication_helper.rb
+++ b/spec/support/request/authentication_helper.rb
@@ -32,18 +32,3 @@ module AuthenticationHelper
     expect(page).to_not have_selector ".menu #login-link"
   end
 end
-
-RSpec.configure do |config|
-  config.extend AuthenticationHelper, type: :feature
-
-  # rspec-rails 3 will no longer automatically infer an example group's spec type
-  # from the file location. You can explicitly opt-in to the feature using this
-  # config option.
-  # To explicitly tag specs without using automatic inference, set the `:type`
-  # metadata manually:
-  #
-  #     describe ThingsController, :type => :controller do
-  #       # Equivalent to being in spec/controllers
-  #     end
-  config.infer_spec_type_from_file_location!
-end

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -5,7 +5,7 @@ module AuthenticationWorkflow
     login_as user
   end
 
-  def quick_login_as_admin
+  def login_as_admin
     admin_role = Spree::Role.find_or_create_by!(name: 'admin')
     admin_user = create(:user,
                         password: 'passw0rd',
@@ -20,12 +20,12 @@ module AuthenticationWorkflow
   end
 
   def login_to_admin_and_visit(path_visit)
-    quick_login_as_admin
+    login_as_admin
     visit path_visit
   end
 
   def login_to_admin_section
-    login_to_admin__and_visit(spree.admin_dashboard_path)
+    login_to_admin_and_visit(spree.admin_dashboard_path)
   end
 
   def login_to_admin_as(user)

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -19,9 +19,13 @@ module AuthenticationWorkflow
     admin_user
   end
 
-  def login_to_admin_section
+  def login_to_admin_and_visit(path_visit)
     quick_login_as_admin
-    visit spree.admin_dashboard_path
+    visit path_visit
+  end
+
+  def login_to_admin_section
+    login_to_admin__and_visit(spree.admin_dashboard_path)
   end
 
   def login_to_admin_as(user)

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -1,7 +1,7 @@
 module AuthenticationWorkflow
   include Warden::Test::Helpers
 
-  def quick_login_as(user)
+  def login_as(user)
     login_as user
   end
 
@@ -15,7 +15,7 @@ module AuthenticationWorkflow
                         login: 'admin@ofn.org')
 
     admin_user.spree_roles << admin_role
-    quick_login_as admin_user
+    login_as admin_user
     admin_user
   end
 
@@ -29,7 +29,7 @@ module AuthenticationWorkflow
   end
 
   def login_to_admin_as(user)
-    quick_login_as user
+    login_as user
     visit spree.admin_dashboard_path
   end
 

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -19,13 +19,13 @@ module AuthenticationWorkflow
     admin_user
   end
 
-  def login_to_admin_and_visit(path_visit)
+  def login_as_admin_and_visit(path_visit)
     login_as_admin
     visit path_visit
   end
 
   def login_to_admin_section
-    login_to_admin_and_visit(spree.admin_dashboard_path)
+    login_as_admin_and_visit(spree.admin_dashboard_path)
   end
 
   def login_to_admin_as(user)

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -24,19 +24,6 @@ module AuthenticationWorkflow
     visit spree.admin_dashboard_path
   end
 
-  # TODO: Should probably just rename this to create_user
-  def create_enterprise_user( attrs = {} )
-    new_user = build(:user, attrs)
-    new_user.spree_roles = [Spree::Role.find_or_create_by!(name: 'user')]
-    new_user.save
-    if attrs.key? :enterprises
-      attrs[:enterprises].each do |enterprise|
-        enterprise.users << new_user
-      end
-    end
-    new_user
-  end
-
   def login_to_admin_as(user)
     quick_login_as user
     visit spree.admin_dashboard_path

--- a/spec/support/request/authentication_workflow.rb
+++ b/spec/support/request/authentication_workflow.rb
@@ -40,10 +40,6 @@ module AuthenticationWorkflow
   def login_to_admin_as(user)
     quick_login_as user
     visit spree.admin_dashboard_path
-    # visit spree.admin_dashboard_path
-    # fill_in 'spree_user_email', :with => user.email
-    # fill_in 'spree_user_password', :with => user.password
-    # click_button 'Login'
   end
 
   def fill_in_and_submit_login_form(user)

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe "spree/admin/orders/edit.html.haml" do
-  include AuthenticationWorkflow
   helper Spree::BaseHelper # required to make pretty_time work
 
   around do |example|
@@ -17,7 +16,7 @@ describe "spree/admin/orders/edit.html.haml" do
       end
     end
 
-    allow(view).to receive_messages spree_current_user: create_enterprise_user
+    allow(view).to receive_messages spree_current_user: create(:user)
 
     order = create(:completed_order_with_fees)
     order.distributor = create(:distributor_enterprise)

--- a/spec/views/spree/admin/orders/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/index.html.haml_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe "spree/admin/orders/index.html.haml" do
-  include AuthenticationWorkflow
-
   around do |example|
     original_config = Spree::Config[:enable_invoices?]
     example.run
@@ -16,7 +14,7 @@ describe "spree/admin/orders/index.html.haml" do
       end
     end
 
-    allow(view).to receive_messages spree_current_user: create_enterprise_user
+    allow(view).to receive_messages spree_current_user: create(:user)
   end
 
   describe "print invoices button" do

--- a/spec/views/spree/shared/_order_details.html.haml_spec.rb
+++ b/spec/views/spree/shared/_order_details.html.haml_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "spree/shared/_order_details.html.haml" do
-  include AuthenticationWorkflow
+  include AuthenticationHelper
   helper Spree::BaseHelper
 
   let(:order) { create(:completed_order_with_fees) }


### PR DESCRIPTION
#### What? Why?

Originated from #5827 I did a few things here:
- rename AuthenticationWorkflow to AuthenticationHelper
- delete create_enterprise_user and use the existing user factory: create(:user)
- rename the methods in ControllerHelper to be more specific, they are really setting up mocks, not logging in
- rename the methods quick_login_ to simply login_ as they are the main methods that should be used to login
- added method login_as_admin_and_visit and used it in quite a few places, this not only removes some lines of code from the specs but most importantly removes quite a lot of useless page loads of the admin dashboard page in login_to_admin_as

#### What should we test?
This is only changing specs, a green build is enough.

#### Release notes
Changelog Category: Changed
Simplified the code and improved speed of specs.
