### PR TITLE
Update Docker instructions to recommend creating your own fork

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -17,7 +17,13 @@ Better to have at least 2GB free on your computer in order to download images an
 
 Open a terminal with a shell.
 
-Clone the repository:
+Clone the repository. If you're planning on contributing code to the project (which we [LOVE](CONTRIBUTING.md)), it is a good idea to begin by forking this repo using the Fork button in the top-right corner of this screen. You should then be able to use git clone to copy your fork onto your local machine.
+
+```sh
+$ git clone https://github.com/YOUR_GITHUB_USERNAME_HERE/openfoodnetwork
+```
+
+Otherwise, if you just want to get things running, clone from the OFN main repo:
 
 ```sh
 $ git clone git@github.com:openfoodfoundation/openfoodnetwork.git


### PR DESCRIPTION
#### What? Why?

Hopefully this is okay to submit without creating an issue for first. I was getting things set up locally with Docker and first cloned the openfoodfoundation/openfoodnetwork repo and did all the Docker stuff there... but then noticed that I probably should have forked first and then done that. The Docker.md instructions only mention cloning the main repo, so I updated them to recommend making a fork and cloning it instead. 


#### What should we test?
Hopefully nothing needed :)


#### Release notes
Small improvement to developer documentation. 

Changelog Category: Added 

#### How is this related to the Spree upgrade?
Unrelated


#### Discourse thread
None


#### Dependencies
None


#### Documentation updates
None
