### PR TITLE
5579 missing translation subscriptions

### DIFF
--- a/app/views/admin/subscriptions/_form.html.haml
+++ b/app/views/admin/subscriptions/_form.html.haml
@@ -4,7 +4,7 @@
       %a.button{ href: main_app.admin_subscriptions_path, ng: { show: "['details','review'].indexOf(view) >= 0" } }= t(:cancel)
       %input{ type: "button", value: t(:back), ng: { click: 'back()', show: '!!backCallbacks[view]'} }
       %input.red{ type: "button", value: t(:next), ng: { click: 'next()', show: '!!nextCallbacks[view]' } }
-      %input.red{ type: "submit", value: t('admin.subscriptions.create'), ng: { show: "view == 'review'" } }
+      %input.red{ type: "submit", value: t('.create'), ng: { show: "view == 'review'" } }
     %div{ ng: { show: 'subscription.id' } }
       %a.button{ href: main_app.admin_subscriptions_path }= t(:close)
       %input.red{ type: "button", value: t(:review), ng: { click: "setView('review')", show: "view != 'review'" } }

--- a/app/views/admin/subscriptions/edit.html.haml
+++ b/app/views/admin/subscriptions/edit.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  =t('admin.subscriptions.edit')
+  =t('.title')
 
 -# - content_for :page_actions do
 -#   %li= button_link_to "Back to subscriptions list", main_app.admin_subscriptions_path, icon: 'icon-arrow-left'

--- a/app/views/admin/subscriptions/index.html.haml
+++ b/app/views/admin/subscriptions/index.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  = t('admin.subscriptions.subscriptions')
+  = t('.title')
 
 - content_for :main_ng_app_name do
   = "admin.subscriptions"
@@ -7,7 +7,7 @@
 - content_for :page_actions do
   %li
     %a.button.icon-plus#new-subscription{ href: "javascript:void(0)", "new-subscription-dialog" => true }
-      = t('admin.subscriptions.new')
+      = t('.new')
 
 = render :partial => 'spree/admin/shared/order_sub_menu'
 

--- a/app/views/admin/subscriptions/new.html.haml
+++ b/app/views/admin/subscriptions/new.html.haml
@@ -1,7 +1,7 @@
 -# = render :partial => 'spree/shared/error_messages', :locals => { :target => @enterprise }
 
 - content_for :page_title do
-  =t('admin.subscriptions.new')
+  =t('.title')
 
 -# - content_for :page_actions do
 -#   %li= button_link_to "Back to subscriptions list", main_app.admin_subscriptions_path, icon: 'icon-arrow-left'

--- a/app/views/admin/subscriptions/setup_explanation.html.haml
+++ b/app/views/admin/subscriptions/setup_explanation.html.haml
@@ -1,4 +1,4 @@
-%h1.text-center.margin-bottom-30= t('admin.subscription.subscriptions')
+%h1.text-center.margin-bottom-30= t('.title')
 
 .row
   .four.columns.alpha &nbsp;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,8 +347,6 @@ en:
     volume: Volume
     items: Items
     select_all: Select all
-    subscription:
-      subscriptions: Subscriptions
 
     # General form elements
     quick_search: Quick Search
@@ -1093,10 +1091,13 @@ en:
         name: "Enterprise Fee Summary"
         description: "Summary of Enterprise Fees collected"
     subscriptions:
-      subscriptions: Subscriptions
-      new: New Subscription
-      create: Create Subscription
-      edit: Edit Subscription
+      index:
+        title: "Subscriptions"
+        new: "New Subscription"
+      new:
+        title: "New Subscription"
+      edit:
+        title: "Edit Subscription"
       table:
         edit_subscription: Edit Subscription
         pause_subscription: Pause Subscription
@@ -1105,6 +1106,7 @@ en:
       filters:
         query_placeholder: "Search by email..."
       setup_explanation:
+        title: "Subscriptions"
         just_a_few_more_steps: 'Just a few more steps before you can begin:'
         enable_subscriptions: "Enable subscriptions for at least one of your shops"
         enable_subscriptions_step_1_html: 1. Go to the %{enterprises_link} page, find your shop, and click "Manage"
@@ -1118,6 +1120,8 @@ en:
         create_at_least_one_schedule_step_3: 3. Click '+ New Schedule', and fill out the form
         once_you_are_done_you_can_html: Once you are done, you can %{reload_this_page_link}
         reload_this_page: reload this page
+      form:
+        create: "Create Subscription"
       steps:
         details: 1. Basic Details
         address: 2. Address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,6 +347,8 @@ en:
     volume: Volume
     items: Items
     select_all: Select all
+    subscription:
+      subscriptions: Subscriptions
 
     # General form elements
     quick_search: Quick Search


### PR DESCRIPTION
#### What? Why?

Closes #5579

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
The heading of "Subscriptions" on admin/subscriptions was not being translated. 

#### What should we test?
<!-- List which features should be tested and how. -->
Go to admin/subscriptions on a non-English instance and verify the heading "Subscriptions" is being translated. 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Will allow for translation of "Subscriptions" heading

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added
