### PR TITLE
Point better_spree_paypal_express to its latest commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,9 @@ gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'
 # Our branch contains two changes
 # - Pass customer email and phone number to PayPal (merged to upstream master)
 # - Change type of password from string to password to hide it in the form
+# - Skip CA cert file and use the ones provided by the OS
 gem 'spree_paypal_express', github: 'openfoodfoundation/better_spree_paypal_express', branch: '2-1-0-stable'
+
 gem 'stripe'
 
 # We need at least this version to have Digicert's root certificate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/better_spree_paypal_express.git
-  revision: e28e4a8c5cedba504eea9cdad4be440d277d7e68
+  revision: 1736e3268239a841576d2719a1f276cf9b74c5c5
   branch: 2-1-0-stable
   specs:
     spree_paypal_express (2.0.3)


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/5855

This brings in the fix for the intermittent PayPal connection failures due to SSL verification failed. Checkout that gem's commit for details.

#### What should we test?

Checkout an order with PayPal express payment method.

#### Release notes

Fix intermittently failing PayPal checkout requests due to SSL verification failed.

Changelog Category: Fixed