### PR TITLE
Suppress Selenium warnings in test log output.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -181,6 +181,10 @@ RSpec.configure do |config|
 
   config.include JsonSpec::Helpers
 
+  # Suppress Selenium deprecation warnings. Stops a flood of pointless warnings filling the
+  # test output. We can remove this in the future after upgrading Rails, Rack, and Capybara.
+  Selenium::WebDriver.logger.level = :error
+
   # Profiling
   #
   # This code shouldn't be run in normal circumstances. But if you want to know

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -183,7 +183,13 @@ RSpec.configure do |config|
 
   # Suppress Selenium deprecation warnings. Stops a flood of pointless warnings filling the
   # test output. We can remove this in the future after upgrading Rails, Rack, and Capybara.
-  Selenium::WebDriver.logger.level = :error
+  if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR == 0
+    Selenium::WebDriver.logger.level = :error
+  else
+    ActiveSupport::Deprecation.warn(
+      "Suppressing Selenium deprecation warnings is not needed any more."
+    )
+  end
 
   # Profiling
   #


### PR DESCRIPTION
Committing this spec helper suggestion from @mkllnk as agreed in Slack, so we can finally return to having usable test output when running feature specs in dev :tada:

I think this will help with the Rails 4.1 upgrade too.