### PR TITLE
fix method to use .map{ }.sum to calculate total fees correctly

### DIFF
--- a/app/models/calculator/default_tax.rb
+++ b/app/models/calculator/default_tax.rb
@@ -49,11 +49,11 @@ module Calculator
     # Finds relevant fees for each line_item,
     #   calculates the tax on them, and returns the total tax
     def per_item_fees_total(order, calculator)
-      order.line_items.sum do |line_item|
+      order.line_items.map do |line_item|
         calculator.per_item_enterprise_fee_applicators_for(line_item.variant)
           .select { |applicator| applicable_rate?(applicator, line_item) }
           .sum { |applicator| applicator.enterprise_fee.compute_amount(line_item) }
-      end
+      end.sum
     end
 
     def applicable_rate?(applicator, line_item)


### PR DESCRIPTION
#### What? Why?

Closes #5632 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The method to calculate the total fees per item was not working because the sum method changed on Rails 4.1. I changed it to work properly using `.map{ }.sum` instead of just `.sum`.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Fix method `per_items_fees_total` on `app/models/calculator/default_tax.rb` to sum fees of the items correctly.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

