### PR TITLE
Fix price translation in Bulk Order Management

### DIFF
--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -151,7 +151,7 @@
             %th.final_weight_volume{ 'ng-show' => 'columns.final_weight_volume.visible' }
               = t("admin.orders.bulk_management.weight_volume")
             %th.price{ 'ng-show' => 'columns.price.visible' }
-              = t("admin.price (#{currency_symbol})")
+              = "#{t('admin.price')} (#{currency_symbol})"
             %th.actions
             %th.actions
               = t("admin.orders.bulk_management.ask")


### PR DESCRIPTION
Fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/5853

Moves the `currency_symbol` method call out of the `t` method call argument.

#### What should we test?

Go to the [Bulk Order Management page](http://localhost:3000/admin/orders/bulk_management) and enable the **Price** column. There should be no missing translation messages.

Changelog Category: Fixed

#### Screenshot

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/7039523/89841226-08c4fb00-db38-11ea-86f4-53344a55b641.png">
