### PR TITLE
Remove resend button on the orders edit page

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -80,7 +80,7 @@ module Spree
 
       def resend
         Spree::OrderMailer.confirm_email_for_customer(@order.id, true).deliver
-        flash[:success] = t(:order_email_resent)
+        flash[:success] = t('admin.orders.order_email_resent')
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
       end

--- a/app/views/spree/admin/orders/edit.html.haml
+++ b/app/views/spree/admin/orders/edit.html.haml
@@ -2,8 +2,6 @@
 - content_for :page_actions do
   - if can?(:fire, @order)
     %li= event_links
-  - if can?(:resend, @order)
-    %li= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'icon-email'
   = render partial: 'spree/admin/shared/order_links'
   - if can?(:admin, Spree::Order)
     %li= button_link_to t(:back_to_orders_list), admin_orders_path, :icon => 'icon-arrow-left'


### PR DESCRIPTION
#### What? Why?

Fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/5850

- Removes as the resend button link as it already exists on the **Actions** dropdown.
- Also fixes the `translation missing: en.order_email_resent` issue

Changelog Category: Removed

#### What should we test?
<!-- List which features should be tested and how. -->

Log in as an admin and go to an order's edit page. There shouldn't be a **Resend** button on the right.

##### Screenshot

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/7039523/89851480-299a4a00-db52-11ea-9262-9f12f0b8acda.png">


