### PR TITLE
adding required argument to resolve Places error

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -43,7 +43,7 @@ Darkswarm.directive 'mapSearch', ($timeout, Search) ->
     # When the map loads, and we have a search from ?query, perform that search
     scope.performUrlSearch = (map) ->
       google.maps.event.addListenerOnce map, "idle", =>
-        google.maps.event.trigger(scope.input, 'focus');
+        google.maps.event.trigger(scope.input, 'focus',{});
         google.maps.event.trigger(scope.input, 'keydown', {keyCode: 13});
 
     # Bias the SearchBox results towards places that are within the bounds of the


### PR DESCRIPTION

#### What? Why?

Closes #[the issue number this PR is related to]

- this is a small fix to a console error, just to get used to the process
- error is outputting maps API key to the console in production
- added missing empty required argument in maps trigger

#### What should we test?
to repro the error: 
- open chrome dev tools, enter a local OFN instance (I tested Australia, France, and Canada and got the console error in all of them) and click on the map link in top menu
- currently in production (it seems like every time) you'll see `js?libraries=places,geometry&key=AIzaSyCtWUCiicryMj0betf86u3kyD4obkvEcRk:105 Uncaught TypeError: Cannot set property 'handled' of undefined....`, which is being through by the google maps places library because the current version requires the empty argument which is added in this PR
if fixed:
- we should not see this error in dev tools on opening the map page in local instances anymore. 

<img width="1413" alt="Screen Shot 2020-08-16 at 9 00 29 PM" src="https://user-images.githubusercontent.com/69178980/90348339-99517e80-e003-11ea-8d01-44de6d09e388.png">

#### Release notes
Fix for console error related to google maps places API. 


Changelog Category: Fixed

