### PR TITLE
Update dashboard link to point to enterprise shop

### DIFF
--- a/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
@@ -37,10 +37,8 @@
   .alpha.seven.columns.dashboard_item.single-ent#map
     .header
       %h3
-        %span.icon-map-marker
+        %span.icon-user
         = t "your_profil_live"
-      %p
-        = t "on_ofn_map"
     .list
       %a.button.bottom{href: main_app.enterprise_shop_url(@enterprise), target: '_blank'}
         = t "see"

--- a/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
@@ -42,8 +42,7 @@
       %p
         = t "on_ofn_map"
     .list
-      /-# Can we pass an anchor here to zoom to our enterprise?
-      %a.button.bottom{href: main_app.map_path, target: '_blank'}
+      %a.button.bottom{href: main_app.enterprise_shop_url(@enterprise), target: '_blank'}
         = t "see"
         = @enterprise.name
         = t "live"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,7 +84,7 @@ en:
       messages:
         inclusion: "is not included in the list"
       models:
-        order_management/subscriptions/validator:          
+        order_management/subscriptions/validator:
           attributes:
             subscription_line_items:
               at_least_one_product: "^Please add at least one product"
@@ -2182,7 +2182,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_user_enterprise_limit_error: "^%{email} is not permitted to own any more enterprises (limit is %{enterprise_limit})."
   spree_variant_product_error: must have at least one variant
   your_profil_live: "Your profile live"
-  on_ofn_map: "on the Open Food Network map"
   see: "See"
   live: "live"
   manage: "Manage"


### PR DESCRIPTION
#### What? Why?

The link to "your profile" on the admin dashboard currently points to the full map for your OFN instance, without zooming to the shop. I believe there's some work going on to revise the way the map works; this is a band-aid fix to at least show the user the public view of their shop. 

#### What should we test?
Visit the admin dashboard for a single enterprise user and click on Your Profile Live

#### Release notes
Bug fix: the link to Your Profile on the admin dashboard now takes you to your shop's profile, instead of the full map. 

Changelog Category: Fixed

#### How is this related to the Spree upgrade?
None

#### Discourse thread
https://community.openfoodnetwork.org/t/admin-link-to-profile-store-goes-to-the-full-map-instead-of-the-store/2010

#### Dependencies
None

#### Documentation updates
None

