### PR TITLE
Fix flash error issues in checkout requests

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -235,6 +235,7 @@ class CheckoutController < Spree::StoreController
         render :edit
       end
       format.json do
+        xhr_flash_errors
         render json: { errors: @order.errors, flash: flash.to_hash }.to_json, status: :bad_request
       end
     end
@@ -247,5 +248,12 @@ class CheckoutController < Spree::StoreController
 
   def permitted_params
     PermittedAttributes::Checkout.new(params).call
+  end
+
+  def xhr_flash_errors
+    # Marks flash errors for deletion after the current action has completed.
+    # This ensures flash errors generated during XHR requests are not persisted in the
+    # session for longer than expected.
+    flash.discard(:error)
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5895

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Flash error messages created during checkout submission were being persisted in the flash session in unexpected ways, e.g. showing a checkout error message again after navigating away from the checkout page, or showing a message twice.

This was due to saving the errors in the flash session in XHR requests. The session is usually cleared after the subsequent action picks up the flash message, but here we needed to clear it after the current action, as the error is shown immediately via Angular on the checkout page (and shouldn't be persisted after that).

#### What should we test?
<!-- List which features should be tested and how. -->

Using different test cards with Stripe Connect that should give different errors shows the flash errors as expected.

Submitting the checkout with a test card that generates an error and then navigating to the home page does not re-display the flash error.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved flash message display on checkout

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
