### PR TITLE
Data cleanup

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,6 +11,9 @@ env "MAILTO", app_config["SCHEDULE_NOTIFICATIONS"] if app_config["SCHEDULE_NOTIF
 job_type :run_file, "cd :path; :environment_variable=:environment bundle exec script/rails runner :task :output"
 job_type :enqueue_job,  "cd :path; :environment_variable=:environment bundle exec script/enqueue :task :priority :output"
 
+every 1.month do
+  rake 'ofn:data:remove_transient_data'
+end
 
 every 1.day, at: '2:45am' do
   rake 'db2fog:clean' if app_config['S3_BACKUPS_BUCKET']

--- a/lib/tasks/data/remove_transient_data.rake
+++ b/lib/tasks/data/remove_transient_data.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'highline'
+require 'tasks/data/remove_transient_data'
+
+namespace :ofn do
+  namespace :data do
+    desc 'Remove transient data'
+    task remove_transient_data: :environment do
+      RemoveTransientData.new.call
+    end
+  end
+end

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -10,7 +10,7 @@ class RemoveTransientData
   def call
     Rails.logger.info("#{self.class.name}: processing")
 
-    Spree::StateChange.delete_all("created_at < '#{retention_period}'")
+    Spree::StateChange.where("created_at < ?", retention_period).delete_all
     Spree::LogEntry.delete_all("created_at < '#{retention_period}'")
     Session.delete_all("updated_at < '#{retention_period}'")
   end

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RemoveTransientData
+  # This model lets us operate on the sessions DB table using ActiveRecord's
+  # methods within the scope of this service. This relies on the AR's
+  # convention where a Session model maps to a sessions table.
+  class Session < ActiveRecord::Base
+  end
+
+  def call
+    Rails.logger.info("RemoveTransientData: processing")
+
+    Spree::StateChange.delete_all("created_at < '#{1.month.ago.to_date}'")
+    Spree::LogEntry.delete_all("created_at < '#{1.month.ago.to_date}'")
+    Session.delete_all("created_at < '#{2.weeks.ago.to_date}'")
+  end
+end

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -11,8 +11,8 @@ class RemoveTransientData
     Rails.logger.info("#{self.class.name}: processing")
 
     Spree::StateChange.where("created_at < ?", retention_period).delete_all
-    Spree::LogEntry.delete_all("created_at < '#{retention_period}'")
-    Session.delete_all("updated_at < '#{retention_period}'")
+    Spree::LogEntry.where("created_at < ?", retention_period).delete_all
+    Session.where("updated_at < ?", retention_period).delete_all
   end
 
   private

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RemoveTransientData
+  RETENTION_PERIOD = 2.months.ago.to_date
+
   # This model lets us operate on the sessions DB table using ActiveRecord's
   # methods within the scope of this service. This relies on the AR's
   # convention where a Session model maps to a sessions table.
@@ -10,14 +12,8 @@ class RemoveTransientData
   def call
     Rails.logger.info("#{self.class.name}: processing")
 
-    Spree::StateChange.where("created_at < ?", retention_period).delete_all
-    Spree::LogEntry.where("created_at < ?", retention_period).delete_all
-    Session.where("updated_at < ?", retention_period).delete_all
-  end
-
-  private
-
-  def retention_period
-    2.months.ago.to_date
+    Spree::StateChange.where("created_at < ?", RETENTION_PERIOD).delete_all
+    Spree::LogEntry.where("created_at < ?", RETENTION_PERIOD).delete_all
+    Session.where("updated_at < ?", RETENTION_PERIOD).delete_all
   end
 end

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -10,8 +10,14 @@ class RemoveTransientData
   def call
     Rails.logger.info("RemoveTransientData: processing")
 
-    Spree::StateChange.delete_all("created_at < '#{1.month.ago.to_date}'")
-    Spree::LogEntry.delete_all("created_at < '#{1.month.ago.to_date}'")
-    Session.delete_all("created_at < '#{2.weeks.ago.to_date}'")
+    Spree::StateChange.delete_all("created_at < '#{retention_period}'")
+    Spree::LogEntry.delete_all("created_at < '#{retention_period}'")
+    Session.delete_all("updated_at < '#{retention_period}'")
+  end
+
+  private
+
+  def retention_period
+    2.months.ago.to_date
   end
 end

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -8,7 +8,7 @@ class RemoveTransientData
   end
 
   def call
-    Rails.logger.info("RemoveTransientData: processing")
+    Rails.logger.info("#{self.class.name}: processing")
 
     Spree::StateChange.delete_all("created_at < '#{retention_period}'")
     Spree::LogEntry.delete_all("created_at < '#{retention_period}'")

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RemoveTransientData
-  RETENTION_PERIOD = 2.months.ago.to_date
+  RETENTION_PERIOD = 6.months.ago.to_date
 
   # This model lets us operate on the sessions DB table using ActiveRecord's
   # methods within the scope of this service. This relies on the AR's

--- a/lib/tasks/data/truncate_data.rb
+++ b/lib/tasks/data/truncate_data.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class TruncateData
-  # This model lets us operate on the sessions DB table using ActiveRecord's
-  # methods within the scope of this service. This relies on the AR's
-  # convention where a Session model maps to a sessions table.
-  class Session < ActiveRecord::Base
-  end
-
   def initialize(months_to_keep = nil)
     @date = (months_to_keep || 24).to_i.months.ago
   end
@@ -25,8 +19,6 @@ class TruncateData
       sql_delete_from "order_cycles #{where_ocs_to_delete}"
 
       Spree::TokenizedPermission.where("created_at < '#{date}'").delete_all
-
-      remove_transient_data
     end
   end
 
@@ -45,12 +37,6 @@ class TruncateData
     sql_delete_from "spree_payments #{where_order_id_in_orders_to_delete}"
     sql_delete_from "spree_shipments #{where_order_id_in_orders_to_delete}"
     sql_delete_from "spree_return_authorizations #{where_order_id_in_orders_to_delete}"
-  end
-
-  def remove_transient_data
-    Spree::StateChange.delete_all("created_at < '#{1.month.ago.to_date}'")
-    Spree::LogEntry.delete_all("created_at < '#{1.month.ago.to_date}'")
-    Session.delete_all("created_at < '#{2.weeks.ago.to_date}'")
   end
 
   def truncate_subscriptions

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -21,12 +21,11 @@ describe RemoveTransientData do
       expect(Spree::StateChange.all).to be_empty
     end
 
-    it 'deletes log entries older than a month' do
+    it 'deletes log entries older than retention_period' do
       Spree::LogEntry.create(created_at: retention_period - 1.day)
 
-      RemoveTransientData.new.call
-
-      expect(Spree::LogEntry.all).to be_empty
+      expect { RemoveTransientData.new.call }
+        .to change(Spree::LogEntry, :count).by(-1)
     end
 
     it 'deletes sessions older than retention_period' do

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -5,7 +5,7 @@ require 'tasks/data/remove_transient_data'
 
 describe RemoveTransientData do
   describe '#call' do
-    let(:retention_period) { RemoveTransientData.new.__send__(:retention_period) }
+    let(:retention_period) { RemoveTransientData::RETENTION_PERIOD }
 
     before do
       allow(Spree::StateChange).to receive(:delete_all)

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -14,28 +14,27 @@ describe RemoveTransientData do
       allow(Rails.logger).to receive(:info)
     end
 
-    it 'deletes state changes older than a month' do
-      RemoveTransientData.new.call
+    it 'deletes state changes older than rentention_period' do
+      Spree::StateChange.create(created_at: retention_period - 1.day)
 
-      expect(Spree::StateChange)
-        .to have_received(:delete_all)
-        .with("created_at < '#{retention_period}'")
+      RemoveTransientData.new.call
+      expect(Spree::StateChange.all).to be_empty
     end
 
     it 'deletes log entries older than a month' do
+      Spree::LogEntry.create(created_at: retention_period - 1.day)
+
       RemoveTransientData.new.call
 
-      expect(Spree::LogEntry)
-        .to have_received(:delete_all)
-        .with("created_at < '#{retention_period}'")
+      expect(Spree::LogEntry.all).to be_empty
     end
 
-    it 'deletes sessions older than two weeks' do
+    it 'deletes sessions older than retention_period' do
+      RemoveTransientData::Session.create(session_id: 1, updated_at: retention_period - 1.day)
+
       RemoveTransientData.new.call
 
-      expect(RemoveTransientData::Session)
-        .to have_received(:delete_all)
-        .with("updated_at < '#{retention_period}'")
+      expect(RemoveTransientData::Session.all).to be_empty
     end
   end
 end

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tasks/data/remove_transient_data'
+
+describe RemoveTransientData do
+  describe '#call' do
+    before do
+      allow(Spree::StateChange).to receive(:delete_all)
+      allow(Spree::LogEntry).to receive(:delete_all)
+      allow(RemoveTransientData::Session).to receive(:delete_all)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it 'deletes state changes older than a month' do
+      RemoveTransientData.new.call
+
+      expect(Spree::StateChange)
+        .to have_received(:delete_all)
+        .with("created_at < '#{1.month.ago.to_date}'")
+    end
+
+    it 'deletes log entries older than a month' do
+      RemoveTransientData.new.call
+
+      expect(Spree::LogEntry)
+        .to have_received(:delete_all)
+        .with("created_at < '#{1.month.ago.to_date}'")
+    end
+
+    it 'deletes sessions older than two weeks' do
+      RemoveTransientData.new.call
+
+      expect(RemoveTransientData::Session)
+        .to have_received(:delete_all)
+        .with("created_at < '#{2.weeks.ago.to_date}'")
+    end
+  end
+end

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -5,6 +5,8 @@ require 'tasks/data/remove_transient_data'
 
 describe RemoveTransientData do
   describe '#call' do
+    let(:retention_period) { RemoveTransientData.new.__send__(:retention_period) }
+
     before do
       allow(Spree::StateChange).to receive(:delete_all)
       allow(Spree::LogEntry).to receive(:delete_all)
@@ -17,7 +19,7 @@ describe RemoveTransientData do
 
       expect(Spree::StateChange)
         .to have_received(:delete_all)
-        .with("created_at < '#{1.month.ago.to_date}'")
+        .with("created_at < '#{retention_period}'")
     end
 
     it 'deletes log entries older than a month' do
@@ -25,7 +27,7 @@ describe RemoveTransientData do
 
       expect(Spree::LogEntry)
         .to have_received(:delete_all)
-        .with("created_at < '#{1.month.ago.to_date}'")
+        .with("created_at < '#{retention_period}'")
     end
 
     it 'deletes sessions older than two weeks' do
@@ -33,7 +35,7 @@ describe RemoveTransientData do
 
       expect(RemoveTransientData::Session)
         .to have_received(:delete_all)
-        .with("created_at < '#{2.weeks.ago.to_date}'")
+        .with("updated_at < '#{retention_period}'")
     end
   end
 end

--- a/spec/lib/tasks/data/truncate_data_spec.rb
+++ b/spec/lib/tasks/data/truncate_data_spec.rb
@@ -7,9 +7,6 @@ describe TruncateData do
   describe '#call' do
     before do
       allow(Spree::ReturnAuthorization).to receive(:delete_all)
-      allow(Spree::StateChange).to receive(:delete_all)
-      allow(Spree::LogEntry).to receive(:delete_all)
-      allow(TruncateData::Session).to receive(:delete_all)
       allow(Rails.logger).to receive(:info)
     end
 
@@ -24,30 +21,6 @@ describe TruncateData do
 
         expect(OrderCycle.all).to be_empty
       end
-
-      it 'deletes state changes older than a month' do
-        TruncateData.new.call
-
-        expect(Spree::StateChange)
-          .to have_received(:delete_all)
-          .with("created_at < '#{1.month.ago.to_date}'")
-      end
-
-      it 'deletes log entries older than a month' do
-        TruncateData.new.call
-
-        expect(Spree::LogEntry)
-          .to have_received(:delete_all)
-          .with("created_at < '#{1.month.ago.to_date}'")
-      end
-
-      it 'deletes sessions older than two weeks' do
-        TruncateData.new.call
-
-        expect(TruncateData::Session)
-          .to have_received(:delete_all)
-          .with("created_at < '#{2.weeks.ago.to_date}'")
-      end
     end
 
     context 'when months_to_keep is nil' do
@@ -60,30 +33,6 @@ describe TruncateData do
         TruncateData.new(nil).call
 
         expect(OrderCycle.all).to be_empty
-      end
-
-      it 'deletes state changes older than a month' do
-        TruncateData.new.call
-
-        expect(Spree::StateChange)
-          .to have_received(:delete_all)
-          .with("created_at < '#{1.month.ago.to_date}'")
-      end
-
-      it 'deletes log entries older than a month' do
-        TruncateData.new.call
-
-        expect(Spree::LogEntry)
-          .to have_received(:delete_all)
-          .with("created_at < '#{1.month.ago.to_date}'")
-      end
-
-      it 'deletes sessions older than two weeks' do
-        TruncateData.new.call
-
-        expect(TruncateData::Session)
-          .to have_received(:delete_all)
-          .with("created_at < '#{2.weeks.ago.to_date}'")
       end
     end
 
@@ -101,30 +50,6 @@ describe TruncateData do
         TruncateData.new(6).call
 
         expect(OrderCycle.all).to contain_exactly(recent_order_cycle)
-      end
-
-      it 'deletes state changes older than a month' do
-        TruncateData.new.call
-
-        expect(Spree::StateChange)
-          .to have_received(:delete_all)
-          .with("created_at < '#{1.month.ago.to_date}'")
-      end
-
-      it 'deletes log entries older than a month' do
-        TruncateData.new.call
-
-        expect(Spree::LogEntry)
-          .to have_received(:delete_all)
-          .with("created_at < '#{1.month.ago.to_date}'")
-      end
-
-      it 'deletes sessions older than two weeks' do
-        TruncateData.new.call
-
-        expect(TruncateData::Session)
-          .to have_received(:delete_all)
-          .with("created_at < '#{2.weeks.ago.to_date}'")
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #3608
Closes #2247

- Puts our databases on a much-needed diet by clearing out old data from the `spree_state_changes`, `spree_log_entries`, and `sessions` tables.
- Extracts `#remove_transient_data` from `TruncateData` and moves it to a separate rake task.
- Adds an entry in `config/schedule.rb` to run the task once per month.

#### What should we test?
<!-- List which features should be tested and how. -->

Running `rake ofn:data:remove_transient_data` clears transient data as expected. Tailing the log shows an entry like this after running the task:

![Screenshot from 2020-08-15 11-30-04](https://user-images.githubusercontent.com/9029026/90310601-586a4480-def3-11ea-86bc-ae874727f913.png)

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added scheduled task to clear old transient data from the database

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
