### PR TITLE
Improve subs logging

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class OrderCyclesController < ResourceController
     include OrderCyclesHelper
+    include PaperTrailLogging
 
     prepend_before_action :set_order_cycle_id, only: [:incoming, :outgoing]
     before_action :load_data_for_index, only: :index

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -142,7 +142,7 @@ module Admin
     end
 
     def permitted_resource_params
-      params.require(:schedule).permit(:id, :name)
+      params.require(:schedule).permit(:id, :name, order_cycle_ids: [])
     end
   end
 end

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -3,6 +3,8 @@ require 'order_management/subscriptions/proxy_order_syncer'
 
 module Admin
   class SchedulesController < ResourceController
+    include PaperTrailLogging
+
     before_action :adapt_params, only: [:update]
     before_action :editable_order_cycle_ids_for_create, only: [:create]
     before_action :editable_order_cycle_ids_for_update, only: [:update]

--- a/app/controllers/concerns/paper_trail_logging.rb
+++ b/app/controllers/concerns/paper_trail_logging.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This concern adds additional Papertrail logging options so that the id of the
+# user that modified the record is also logged.
+# See: https://github.com/paper-trail-gem/paper_trail#setting-whodunnit-with-a-controller-callback
+
+module PaperTrailLogging
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_paper_trail_whodunnit
+  end
+
+  def user_for_paper_trail
+    spree_current_user
+  end
+end


### PR DESCRIPTION
#### What? Why?

Related to #5743 
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds some minor improvements to subs logging, but the problems are not completely resolved yet. See issue notes.

#### What should we test?
<!-- List which features should be tested and how. -->

- PaperTrail records user ids in records for schedules and order cycles in the `whodunnit` field.
- The Rails logs don't show a `Unpermitted attribute: order_cycle_ids` warning when creating/updating schedules.

![Screenshot from 2020-08-15 19-26-13](https://user-images.githubusercontent.com/9029026/90319141-aacc5500-df35-11ea-98b2-99b1ddd943e1.png)

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improved PaperTrail logging for subscriptions

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->
