### PR TITLE
Do not add stripe JS code to layout if stripe is disabled at instance level

### DIFF
--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -38,9 +38,12 @@
     %loading
 
     = render "layouts/bugsnag_js"
-    %script{:src => "https://js.stripe.com/v3/", :type => "text/javascript"}
+
+    - if Spree::Config.stripe_connect_enabled
+      %script{:src => "https://js.stripe.com/v3/", :type => "text/javascript"}
     - if !ContentConfig.open_street_map_enabled
       %script{src: "//maps.googleapis.com/maps/api/js?libraries=places,geometry#{ ENV['GOOGLE_MAPS_API_KEY'] ? '&key=' + ENV['GOOGLE_MAPS_API_KEY'] : ''} "}
+
     = javascript_include_tag "darkswarm/all"
     = javascript_include_tag "web/all"
     = render "layouts/i18n_script"


### PR DESCRIPTION
#### What? Why?

This closes the stripe part of #5078 
the stripe js code is not loaded if stripe is deactivated in the instance.

#### What should we test?
We need to verify that stripe payments can be made after de-activating and re-activating stripe again.
Go to Configuration > Stripe and de-active stripe.
Go to the frontoffice, any page, and verify the stripe JS code is not loaded:
![image](https://user-images.githubusercontent.com/1640378/90534161-4eee1000-e171-11ea-8529-4fb329066c10.png)
This tag should not be there when stripe is de-activated.
Go to Configuration > Stripe and re-activate stripe.
Go to the frontoffice, verify the stripe JS code is loaded and that you can make a Stripe payment.

#### Release notes
Changelog Category: Changed
Stripe javascript code is only loaded if stripe is enabled in the instance.
