### PR TITLE
Fix the bulk coop report date and distributor filters.

### DIFF
--- a/engines/order_management/app/controllers/order_management/reports/bulk_coop_controller.rb
+++ b/engines/order_management/app/controllers/order_management/reports/bulk_coop_controller.rb
@@ -46,8 +46,8 @@ module OrderManagement
             completed_at_gt: params[:report][:start_at],
             completed_at_lt: params[:report][:end_at],
             distributor_id_in: params[:report][:distributor_ids],
-            report_type: params[:report][:report_type]
-          }
+          },
+          report_type: params[:report][:report_type]
         }
       end
 

--- a/engines/order_management/app/controllers/order_management/reports/bulk_coop_controller.rb
+++ b/engines/order_management/app/controllers/order_management/reports/bulk_coop_controller.rb
@@ -13,7 +13,8 @@ module OrderManagement
 
         @report_parameters.authorize!(@permissions)
 
-        @report = report_klass::ReportService.new(@permissions, params[:report], spree_current_user)
+        @report = report_klass::ReportService.new(@permissions, legacy_format_report_params,
+                                                  spree_current_user)
         renderer.render(self)
       rescue ::Reports::Authorizer::ParameterNotAllowedError => e
         flash[:error] = e.message
@@ -37,6 +38,17 @@ module OrderManagement
 
       def report_klass
         OrderManagement::Reports::BulkCoop
+      end
+
+      def legacy_format_report_params
+        {
+          q: {
+            completed_at_gt: params[:report][:start_at],
+            completed_at_lt: params[:report][:end_at],
+            distributor_id_in: params[:report][:distributor_ids],
+            report_type: params[:report][:report_type]
+          }
+        }
       end
 
       def load_report_parameters

--- a/engines/order_management/spec/features/order_management/reports/bulk_coop_spec.rb
+++ b/engines/order_management/spec/features/order_management/reports/bulk_coop_spec.rb
@@ -6,11 +6,70 @@ feature "bulk coop" do
   include AuthenticationHelper
   include WebHelper
 
-  scenario "bulk co-op report" do
-    login_as_admin_and_visit spree.admin_reports_path
-    click_link 'Bulk Co-Op'
+  scenario "generating Bulk Coop Supplier Report" do
+    login_as_admin_and_visit new_order_management_reports_bulk_coop_path
+    select "Bulk Coop Supplier Report", from: "report_report_type"
     click_button 'Generate Report'
 
-    expect(page).to have_content 'Supplier'
+    expect(page).to have_table_row [
+      "Supplier",
+      "Product",
+      "Bulk Unit Size",
+      "Variant",
+      "Variant Value",
+      "Variant Unit",
+      "Weight",
+      "Sum Total",
+      "Units Required",
+      "Unallocated",
+      "Max Quantity Excess"
+    ]
+  end
+
+  scenario "generating Bulk Co-op Allocation report" do
+    login_as_admin_and_visit new_order_management_reports_bulk_coop_path
+    select "Bulk Coop Allocation", from: "report_report_type"
+    click_button 'Generate Report'
+
+    expect(page).to have_table_row [
+      "Customer",
+      "Product",
+      "Bulk Unit Size",
+      "Variant",
+      "Variant Value",
+      "Variant Unit",
+      "Weight",
+      "Sum Total",
+      "Total available",
+      "Unallocated",
+      "Max Quantity Excess"
+    ]
+  end
+
+  scenario "generating Bulk Co-op Packing Sheets report" do
+    login_as_admin_and_visit new_order_management_reports_bulk_coop_path
+    select "Bulk Coop Packing Sheets", from: "report_report_type"
+    click_button 'Generate Report'
+
+    expect(page).to have_table_row [
+      "Customer",
+      "Product",
+      "Variant",
+      "Sum Total"
+    ]
+  end
+
+  scenario "generating Bulk Co-op Customer Payments report" do
+    login_as_admin_and_visit new_order_management_reports_bulk_coop_path
+    select "Bulk Coop Customer Payments", from: "report_report_type"
+    click_button 'Generate Report'
+
+    expect(page).to have_table_row [
+      "Customer",
+      "Date of Order",
+      "Total Cost",
+      "Amount Owing",
+      "Amount Paid"
+    ]
   end
 end

--- a/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
@@ -36,7 +36,7 @@ describe OrderManagement::Reports::BulkCoop::BulkCoopReport do
         o2.line_items << li2
 
         report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new user, {}, true
-        expect(report.table_items).to eq([li1, li2])
+        expect(report.table_items).to match_array [li1, li2]
 
         report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new(
           user, { q: { completed_at_gt: 2.days.ago } }, true
@@ -60,7 +60,7 @@ describe OrderManagement::Reports::BulkCoop::BulkCoopReport do
         o2.line_items << li2
 
         report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new user, {}, true
-        expect(report.table_items).to eq([li1, li2])
+        expect(report.table_items).to match_array [li1, li2]
 
         report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new(
           user, { q: { distributor_id_in: [d1.id] } }, true

--- a/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
@@ -28,6 +28,52 @@ describe OrderManagement::Reports::BulkCoop::BulkCoopReport do
       end
     end
 
+    context "filtering by date" do
+      it do
+        user = create(:admin_user)
+        o2 = create(:order, completed_at: 3.days.ago, order_cycle: oc1, distributor: d1)
+        li2 = build(:line_item_with_shipment)
+        o2.line_items << li2
+
+        report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new user, {}, true
+        expect(report.table_items).to eq([li1, li2])
+
+        report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new(
+          user, { q: { completed_at_gt: 2.days.ago } }, true
+        )
+        expect(report.table_items).to eq([li1])
+
+        report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new(
+          user, { q: { completed_at_lt: 2.days.ago } }, true
+        )
+        expect(report.table_items).to eq([li2])
+      end
+    end
+
+    context "filtering by distributor" do
+      it do
+        user = create(:admin_user)
+        d2 = create(:distributor_enterprise)
+        o2 = create(:order, distributor: d2, order_cycle: oc1,
+                            completed_at: Time.zone.now)
+        li2 = build(:line_item_with_shipment)
+        o2.line_items << li2
+
+        report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new user, {}, true
+        expect(report.table_items).to eq([li1, li2])
+
+        report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new(
+          user, { q: { distributor_id_in: [d1.id] } }, true
+        )
+        expect(report.table_items).to eq([li1])
+
+        report = OrderManagement::Reports::BulkCoop::BulkCoopReport.new(
+          user, { q: { distributor_id_in: [d2.id] } }, true
+        )
+        expect(report.table_items).to eq([li2])
+      end
+    end
+
     context "as a manager of a supplier" do
       let!(:user) { create(:user) }
       subject { OrderManagement::Reports::BulkCoop::BulkCoopReport.new user, {}, true }


### PR DESCRIPTION
#### What? Why?

Closes #5837 

Before the date and distributor filters would have no effect. This is because the BulkCoopReport is still generated using an older style method, and isn't generated using the newer method like in the EnterpriseFeeSummaryReport. This older style report expects to receive a `q` parameter but it actually received the newer style `report` parameter so the filters were not being applied.

This keeps the newer style report params but converts them, after they are authorised as safe, into the older style in the controller.

There is a test already for checking that the parameters are authorised correctly [here](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/engines/order_management/spec/controllers/order_management/reports/bulk_coop_controller_spec.rb#L51).

#### What should we test?

1. Go to /order_management/reports/bulk_coop/new
2. Generate report with no filters, then filter it by date and distributor to see the difference.

#### Release notes

Fix the bulk coop report date and distributor filters.

Changelog Category: Fixed