### PR TITLE
[Bye bye Spree] Make OFN independent of all spree spec factories

### DIFF
--- a/engines/order_management/spec/services/order_management/stock/estimator_spec.rb
+++ b/engines/order_management/spec/services/order_management/stock/estimator_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module OrderManagement
   module Stock
     describe Estimator do
-      let!(:shipping_method) { create(:shipping_method, zones: [Spree::Zone.global] ) }
+      let!(:shipping_method) { create(:shipping_method, zones: [create(:zone)] ) }
       let(:package) { build(:stock_package_fulfilled) }
       let(:order) { package.order }
       subject { Estimator.new(order) }

--- a/spec/controllers/api/shipments_controller_spec.rb
+++ b/spec/controllers/api/shipments_controller_spec.rb
@@ -29,7 +29,7 @@ describe Api::ShipmentsController, type: :controller do
     let(:current_api_user) { build(:admin_user) }
     let!(:order) { shipment.order }
     let(:order_ship_address) { create(:address) }
-    let!(:stock_location) { create(:stock_location_with_items) }
+    let!(:stock_location) { Spree::StockLocation.first || create(:stock_location) }
     let!(:variant) { create(:variant) }
     let(:params) do
       { quantity: 2,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -160,10 +160,3 @@ FactoryBot.define do
     stripe_publishable_key "xyz456"
   end
 end
-
-FactoryBot.modify do
-  factory :shipping_category, class: Spree::ShippingCategory do
-    initialize_with { DefaultShippingCategory.find_or_create }
-    transient { name 'Default' }
-  end
-end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,9 @@
 require 'ffaker'
 
 FactoryBot.define do
+  sequence(:random_description) { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
+  sequence(:random_email)       { Faker::Internet.email }
+
   factory :classification, class: Spree::Classification do
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -162,17 +162,6 @@ FactoryBot.define do
 end
 
 FactoryBot.modify do
-  factory :payment do
-    transient do
-      distributor {
-        order.distributor ||
-          Enterprise.is_distributor.first ||
-          FactoryBot.create(:distributor_enterprise)
-      }
-    end
-    payment_method { FactoryBot.create(:payment_method, distributors: [distributor]) }
-  end
-
   factory :payment_method do
     distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -81,6 +81,16 @@ FactoryBot.define do
     calculator { build(:calculator_per_item, preferred_amount: amount) }
 
     after(:create) { |ef| ef.calculator.save! }
+
+    trait :flat_rate do
+      transient { amount 1 }
+      calculator { build(:calculator_flat_rate, preferred_amount: amount) }
+    end
+
+    trait :per_item do
+      transient { amount 1 }
+      calculator { build(:calculator_per_item, preferred_amount: amount) }
+    end
   end
 
   factory :adjustment_metadata, class: AdjustmentMetadata do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,7 @@
 require 'ffaker'
 
 FactoryBot.define do
+  sequence(:random_string)      { Faker::Lorem.sentence }
   sequence(:random_description) { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
   sequence(:random_email)       { Faker::Internet.email }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -162,17 +162,6 @@ FactoryBot.define do
 end
 
 FactoryBot.modify do
-  factory :stock_location, class: Spree::StockLocation do
-    # keeps the test stock_location unique
-    initialize_with { DefaultStockLocation.find_or_create }
-
-    # Ensures the name attribute is not assigned after instantiating the default location
-    transient { name 'default' }
-
-    # sets the default value for variant.on_demand
-    backorderable_default false
-  end
-
   factory :shipping_category, class: Spree::ShippingCategory do
     initialize_with { DefaultShippingCategory.find_or_create }
     transient { name 'Default' }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -162,10 +162,6 @@ FactoryBot.define do
 end
 
 FactoryBot.modify do
-  factory :payment_method do
-    distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
-  end
-
   factory :option_type do
     # Prevent inconsistent ordering in specs when all option types have the same (0) position
     sequence(:position)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -162,10 +162,6 @@ FactoryBot.define do
 end
 
 FactoryBot.modify do
-  factory :credit_card do
-    cc_type 'visa'
-  end
-
   factory :payment do
     transient do
       distributor {

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,20 +1,4 @@
 require 'ffaker'
-require 'spree/testing_support/factories'
-
-# http://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md
-#
-# The spree_core gem defines factories in several files. For example:
-#
-# - lib/spree/core/testing_support/factories/calculator_factory.rb
-#   * calculator
-#   * no_amount_calculator
-#
-# - lib/spree/core/testing_support/factories/order_factory.rb
-#   * order
-#   * order_with_totals
-#   * order_with_inventory_unit_shipped
-#   * completed_order_with_totals
-#
 
 FactoryBot.define do
   factory :classification, class: Spree::Classification do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -162,11 +162,6 @@ FactoryBot.define do
 end
 
 FactoryBot.modify do
-  factory :address do
-    state { Spree::State.find_by name: 'Victoria' }
-    country { Spree::Country.find_by name: 'Australia' || Spree::Country.first }
-  end
-
   factory :credit_card do
     cc_type 'visa'
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -105,35 +105,6 @@ FactoryBot.define do
     enterprise_role 'distributor'
   end
 
-  factory :line_item_with_shipment, parent: :line_item do
-    transient do
-      shipping_fee 3
-      shipping_method nil
-    end
-
-    after(:build) do |line_item, evaluator|
-      shipment = line_item.order.reload.shipments.first
-      if shipment.nil?
-        shipping_method = evaluator.shipping_method
-        unless shipping_method
-          shipping_method = create(:shipping_method_with, :shipping_fee, shipping_fee: evaluator.shipping_fee)
-          shipping_method.distributors << line_item.order.distributor if line_item.order.distributor
-        end
-        shipment = create(:shipment_with, :shipping_method, shipping_method: shipping_method,
-                                                            order: line_item.order)
-      end
-      line_item.target_shipment = shipment
-    end
-  end
-
-  factory :zone_with_member, parent: :zone do
-    default_tax true
-
-    after(:create) do |zone|
-      Spree::ZoneMember.create!(zone: zone, zoneable: Spree::Country.find_by(name: 'Australia'))
-    end
-  end
-
   factory :producer_property, class: ProducerProperty do
     value 'abc123'
     producer { create(:supplier_enterprise) }
@@ -146,26 +117,6 @@ FactoryBot.define do
     code { SecureRandom.base64(150) }
     user
     bill_address { create(:address) }
-  end
-
-  # A card that has been added to the user's profile and can be re-used.
-  factory :stored_credit_card, parent: :credit_card do
-    gateway_customer_profile_id "cus_F2T..."
-    gateway_payment_profile_id "card_1EY..."
-  end
-
-  factory :stripe_payment_method, class: Spree::Gateway::StripeConnect do
-    name 'Stripe'
-    environment 'test'
-    distributors { [FactoryBot.create(:enterprise)] }
-    preferred_enterprise_id { distributors.first.id }
-  end
-
-  factory :stripe_sca_payment_method, class: Spree::Gateway::StripeSCA do
-    name 'StripeSCA'
-    environment 'test'
-    distributors { [FactoryBot.create(:stripe_account).enterprise] }
-    preferred_enterprise_id { distributors.first.id }
   end
 
   factory :stripe_account do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -162,11 +162,6 @@ FactoryBot.define do
 end
 
 FactoryBot.modify do
-  factory :option_type do
-    # Prevent inconsistent ordering in specs when all option types have the same (0) position
-    sequence(:position)
-  end
-
   factory :stock_location, class: Spree::StockLocation do
     # keeps the test stock_location unique
     initialize_with { DefaultStockLocation.find_or_create }

--- a/spec/factories/address_factory.rb
+++ b/spec/factories/address_factory.rb
@@ -1,5 +1,18 @@
-FactoryBot.modify do
-  factory :address do
+FactoryBot.define do
+  factory :address, aliases: [:bill_address, :ship_address], class: Spree::Address do
+    firstname 'John'
+    lastname 'Doe'
+    company 'Company'
+    address1 '10 Lovely Street'
+    address2 'Northwest'
+    city 'Herndon'
+    zipcode '20170'
+    phone '123-456-7890'
+    alternative_phone '123-456-7899'
+
+    state { Spree::State.find_by name: 'Victoria' }
+    country { Spree::Country.find_by name: 'Australia' || Spree::Country.first }
+
     trait :randomized do
       firstname { Faker::Name.first_name }
       lastname { Faker::Name.last_name }

--- a/spec/factories/adjustment_factory.rb
+++ b/spec/factories/adjustment_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :adjustment, class: Spree::Adjustment do
+    association(:adjustable, factory: :order)
+    amount 100.0
+    label 'Shipping'
+    association(:source, factory: :shipment)
+    eligible true
+  end
+end

--- a/spec/factories/adjustment_factory.rb
+++ b/spec/factories/adjustment_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :adjustment, class: Spree::Adjustment do
     association(:adjustable, factory: :order)

--- a/spec/factories/calculated_adjustment_factory.rb
+++ b/spec/factories/calculated_adjustment_factory.rb
@@ -3,21 +3,3 @@ FactoryBot.define do
     preferred_amount { generate(:calculator_amount) }
   end
 end
-
-FactoryBot.modify do
-  attach_calculator_traits = proc do
-    trait :flat_rate do
-      transient { amount 1 }
-      calculator { build(:calculator_flat_rate, preferred_amount: amount) }
-    end
-
-    trait :per_item do
-      transient { amount 1 }
-      calculator { build(:calculator_per_item, preferred_amount: amount) }
-    end
-  end
-
-  factory :payment_method, &attach_calculator_traits
-  factory :shipping_method, &attach_calculator_traits
-  factory :enterprise_fee, &attach_calculator_traits
-end

--- a/spec/factories/calculator_factory.rb
+++ b/spec/factories/calculator_factory.rb
@@ -1,4 +1,12 @@
 FactoryBot.define do
+  factory :calculator, class: Spree::Calculator::FlatRate do
+    after(:create) { |c| c.set_preference(:amount, 10.0) }
+  end
+
+  factory :no_amount_calculator, class: Spree::Calculator::FlatRate do
+    after(:create) { |c| c.set_preference(:amount, 0) }
+  end
+
   sequence(:calculator_amount)
   factory :calculator_per_item, class: Calculator::PerItem do
     preferred_amount { generate(:calculator_amount) }

--- a/spec/factories/country_factory.rb
+++ b/spec/factories/country_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :country, class: Spree::Country do
+    iso_name 'UNITED STATES'
+    name 'United States of America'
+    iso 'US'
+    iso3 'USA'
+    numcode 840
+  end
+end

--- a/spec/factories/country_factory.rb
+++ b/spec/factories/country_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :country, class: Spree::Country do
     iso_name 'UNITED STATES'

--- a/spec/factories/credit_card_factory.rb
+++ b/spec/factories/credit_card_factory.rb
@@ -3,7 +3,7 @@ class TestCard < Spree::CreditCard
   def remove_readonly_attributes(attributes) attributes; end
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :credit_card, class: TestCard do
     verification_value 123
     month 12

--- a/spec/factories/credit_card_factory.rb
+++ b/spec/factories/credit_card_factory.rb
@@ -1,0 +1,15 @@
+# allows credit card info to be saved to the database which is needed for factories to work properly
+class TestCard < Spree::CreditCard
+  def remove_readonly_attributes(attributes) attributes; end
+end
+
+FactoryGirl.define do
+  factory :credit_card, class: TestCard do
+    verification_value 123
+    month 12
+    year { Time.now.year + 1 }
+    number '4111111111111111'
+
+    cc_type 'visa'
+  end
+end

--- a/spec/factories/credit_card_factory.rb
+++ b/spec/factories/credit_card_factory.rb
@@ -12,4 +12,10 @@ FactoryBot.define do
 
     cc_type 'visa'
   end
+
+  # A card that has been added to the user's profile and can be re-used.
+  factory :stored_credit_card, parent: :credit_card do
+    gateway_customer_profile_id "cus_F2T..."
+    gateway_payment_profile_id "card_1EY..."
+  end
 end

--- a/spec/factories/credit_card_factory.rb
+++ b/spec/factories/credit_card_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # allows credit card info to be saved to the database which is needed for factories to work properly
 class TestCard < Spree::CreditCard
   def remove_readonly_attributes(attributes) attributes; end
@@ -7,7 +9,7 @@ FactoryBot.define do
   factory :credit_card, class: TestCard do
     verification_value 123
     month 12
-    year { Time.now.year + 1 }
+    year { Time.zone.now.year + 1 }
     number '4111111111111111'
 
     cc_type 'visa'

--- a/spec/factories/inventory_unit_factory.rb
+++ b/spec/factories/inventory_unit_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :inventory_unit, class: Spree::InventoryUnit do
     variant

--- a/spec/factories/inventory_unit_factory.rb
+++ b/spec/factories/inventory_unit_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :inventory_unit, class: Spree::InventoryUnit do
+    variant
+    order
+    state 'on_hand'
+    association(:shipment, factory: :shipment, state: 'pending')
+  end
+end

--- a/spec/factories/line_item_factory.rb
+++ b/spec/factories/line_item_factory.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :line_item, class: Spree::LineItem do
     quantity 1
-    price { BigDecimal.new('10.00') }
+    price { BigDecimal('10.00') }
     order
     variant
   end

--- a/spec/factories/line_item_factory.rb
+++ b/spec/factories/line_item_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :line_item, class: Spree::LineItem do
+    quantity 1
+    price { BigDecimal.new('10.00') }
+    order
+    variant
+  end
+end

--- a/spec/factories/line_item_factory.rb
+++ b/spec/factories/line_item_factory.rb
@@ -5,4 +5,25 @@ FactoryBot.define do
     order
     variant
   end
+
+  factory :line_item_with_shipment, parent: :line_item do
+    transient do
+      shipping_fee 3
+      shipping_method nil
+    end
+
+    after(:build) do |line_item, evaluator|
+      shipment = line_item.order.reload.shipments.first
+      if shipment.nil?
+        shipping_method = evaluator.shipping_method
+        unless shipping_method
+          shipping_method = create(:shipping_method_with, :shipping_fee, shipping_fee: evaluator.shipping_fee)
+          shipping_method.distributors << line_item.order.distributor if line_item.order.distributor
+        end
+        shipment = create(:shipment_with, :shipping_method, shipping_method: shipping_method,
+                                                            order: line_item.order)
+      end
+      line_item.target_shipment = shipment
+    end
+  end
 end

--- a/spec/factories/options_factory.rb
+++ b/spec/factories/options_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :option_value, class: Spree::OptionValue do
     name 'Size'
     presentation 'S'

--- a/spec/factories/options_factory.rb
+++ b/spec/factories/options_factory.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :option_value, class: Spree::OptionValue do
+    name 'Size'
+    presentation 'S'
+    option_type
+  end
+
+  factory :option_type, class: Spree::OptionType do
+    name 'foo-size'
+    presentation 'Size'
+
+    # Prevent inconsistent ordering in specs when all option types have the same (0) position
+    sequence(:position)
+  end
+end

--- a/spec/factories/options_factory.rb
+++ b/spec/factories/options_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :option_value, class: Spree::OptionValue do
     name 'Size'

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -108,7 +108,7 @@ FactoryBot.modify do
 
     trait :with_line_item do
       transient do
-        variant { FactoryGirl.create(:variant) }
+        variant { FactoryBot.create(:variant) }
       end
 
       after(:create) do |order, evaluator|

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -123,6 +123,7 @@ FactoryBot.define do
       product_price 0
       tax_rate_amount 0
       tax_rate_name ""
+      zone { create(:zone_with_member) }
     end
 
     distributor { create(:distributor_enterprise) }
@@ -130,13 +131,11 @@ FactoryBot.define do
 
     after(:create) do |order, proxy|
       order.distributor.update_attribute(:charges_sales_tax, true)
-      Spree::Zone.global.update_attribute(:default_tax, true)
-
-      p = FactoryBot.create(:taxed_product, zone: Spree::Zone.global,
-                                            price: proxy.product_price,
-                                            tax_rate_amount: proxy.tax_rate_amount,
-                                            tax_rate_name: proxy.tax_rate_name)
-      FactoryBot.create(:line_item, order: order, product: p, price: p.price)
+      product = FactoryBot.create(:taxed_product, zone: proxy.zone,
+                                                  price: proxy.product_price,
+                                                  tax_rate_amount: proxy.tax_rate_amount,
+                                                  tax_rate_name: proxy.tax_rate_name)
+      FactoryBot.create(:line_item, order: order, product: product, price: product.price)
       order.reload
     end
   end

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -35,13 +35,11 @@ FactoryBot.define do
 
       factory :completed_order_with_totals do
         state 'complete'
-        completed_at { Time.now }
+        completed_at { Time.zone.now }
 
         distributor { create(:distributor_enterprise) }
 
-        after(:create) do |order|
-          order.refresh_shipment_rates
-        end
+        after(:create, &:refresh_shipment_rates)
 
         factory :order_ready_to_ship do
           payment_state 'paid'
@@ -95,7 +93,7 @@ FactoryBot.define do
         while !order.completed? do break unless a = order.next! end
         order.select_shipping_method(evaluator.shipping_method.id)
       end
-    end    
+    end
   end
 
   factory :order_with_totals_and_distribution, parent: :order_with_distributor do

--- a/spec/factories/payment_factory.rb
+++ b/spec/factories/payment_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :payment, class: Spree::Payment do
     transient do
       distributor {

--- a/spec/factories/payment_factory.rb
+++ b/spec/factories/payment_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :payment, class: Spree::Payment do
     transient do

--- a/spec/factories/payment_factory.rb
+++ b/spec/factories/payment_factory.rb
@@ -1,0 +1,25 @@
+FactoryGirl.define do
+  factory :payment, class: Spree::Payment do
+    transient do
+      distributor {
+        order.distributor ||
+          Enterprise.is_distributor.first ||
+          FactoryBot.create(:distributor_enterprise)
+      }
+    end
+
+    amount 45.75
+    association(:source, factory: :credit_card)
+    order
+    state 'checkout'
+    response_code '12345'
+
+    payment_method { FactoryBot.create(:payment_method, distributors: [distributor]) }
+  end
+
+  factory :check_payment, class: Spree::Payment do
+    amount 45.75
+    payment_method
+    order
+  end
+end

--- a/spec/factories/payment_method_factory.rb
+++ b/spec/factories/payment_method_factory.rb
@@ -4,6 +4,16 @@ FactoryBot.define do
     environment 'test'
 
     distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
+
+    trait :flat_rate do
+      transient { amount 1 }
+      calculator { build(:calculator_flat_rate, preferred_amount: amount) }
+    end
+
+    trait :per_item do
+      transient { amount 1 }
+      calculator { build(:calculator_per_item, preferred_amount: amount) }
+    end
   end
 
   factory :bogus_payment_method, class: Spree::Gateway::Bogus do

--- a/spec/factories/payment_method_factory.rb
+++ b/spec/factories/payment_method_factory.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :payment_method, class: Spree::PaymentMethod::Check do
+    name 'Check'
+    environment 'test'
+
+    distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
+  end
+
+  factory :bogus_payment_method, class: Spree::Gateway::Bogus do
+    name 'Credit Card'
+    environment 'test'
+  end
+end

--- a/spec/factories/payment_method_factory.rb
+++ b/spec/factories/payment_method_factory.rb
@@ -20,4 +20,18 @@ FactoryBot.define do
     name 'Credit Card'
     environment 'test'
   end
+
+  factory :stripe_payment_method, class: Spree::Gateway::StripeConnect do
+    name 'Stripe'
+    environment 'test'
+    distributors { [FactoryBot.create(:enterprise)] }
+    preferred_enterprise_id { distributors.first.id }
+  end
+
+  factory :stripe_sca_payment_method, class: Spree::Gateway::StripeSCA do
+    name 'StripeSCA'
+    environment 'test'
+    distributors { [FactoryBot.create(:stripe_account).enterprise] }
+    preferred_enterprise_id { distributors.first.id }
+  end
 end

--- a/spec/factories/payment_method_factory.rb
+++ b/spec/factories/payment_method_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :payment_method, class: Spree::PaymentMethod::Check do
     name 'Check'

--- a/spec/factories/payment_method_factory.rb
+++ b/spec/factories/payment_method_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :payment_method, class: Spree::PaymentMethod::Check do
     name 'Check'
     environment 'test'

--- a/spec/factories/product_factory.rb
+++ b/spec/factories/product_factory.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     shipping_category { DefaultShippingCategory.find_or_create }
 
     # ensure stock item will be created for this products master
-    before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
+    before(:create) { DefaultStockLocation.find_or_create }
 
     factory :product do
       transient do

--- a/spec/factories/product_factory.rb
+++ b/spec/factories/product_factory.rb
@@ -1,4 +1,46 @@
 FactoryBot.define do
+  factory :base_product, class: Spree::Product do
+    sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
+    description { generate(:random_description) }
+    price 19.99
+    cost_price 17.00
+    sku 'ABC'
+    available_on { 1.year.ago }
+    deleted_at nil
+
+    supplier { Enterprise.is_primary_producer.first || FactoryBot.create(:supplier_enterprise) }
+    primary_taxon { Spree::Taxon.first || FactoryBot.create(:taxon) }
+
+    unit_value 1
+    unit_description ''
+
+    variant_unit 'weight'
+    variant_unit_scale 1
+    variant_unit_name ''
+
+    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
+
+    # ensure stock item will be created for this products master
+    before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
+
+    factory :product do
+      transient do
+        on_hand { 5 }
+      end
+
+      tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
+
+      after(:create) do |product, evaluator|
+        product.master.on_hand = evaluator.on_hand
+        product.variants.first.on_hand = evaluator.on_hand
+      end
+
+      factory :product_with_option_types do
+        after(:create) { |product| create(:product_option_type, product: product) }
+      end
+    end
+  end
+
   factory :product_with_image, parent: :product do
     after(:create) do |product|
       image = File.open(Rails.root.join('app', 'assets', 'images', 'logo-white.png'))
@@ -40,32 +82,5 @@ FactoryBot.define do
                         zone: proxy.zone,
                         name: proxy.tax_rate_name)
     end
-  end
-end
-
-FactoryBot.modify do
-  factory :product do
-    transient do
-      on_hand { 5 }
-    end
-
-    primary_taxon { Spree::Taxon.first || FactoryBot.create(:taxon) }
-
-    after(:create) do |product, evaluator|
-      product.master.on_hand = evaluator.on_hand
-      product.variants.first.on_hand = evaluator.on_hand
-    end
-  end
-
-  factory :base_product do
-    supplier { Enterprise.is_primary_producer.first || FactoryBot.create(:supplier_enterprise) }
-    primary_taxon { Spree::Taxon.first || FactoryBot.create(:taxon) }
-
-    unit_value 1
-    unit_description ''
-
-    variant_unit 'weight'
-    variant_unit_scale 1
-    variant_unit_name ''
   end
 end

--- a/spec/factories/product_factory.rb
+++ b/spec/factories/product_factory.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     variant_unit_scale 1
     variant_unit_name ''
 
-    shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
+    shipping_category { DefaultShippingCategory.find_or_create }
 
     # ensure stock item will be created for this products master
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }

--- a/spec/factories/product_factory.rb
+++ b/spec/factories/product_factory.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     shipping_category { DefaultShippingCategory.find_or_create }
 
     # ensure stock item will be created for this products master
-    before(:create) { DefaultStockLocation.find_or_create }
+    before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
 
     factory :product do
       transient do

--- a/spec/factories/product_option_type_factory.rb
+++ b/spec/factories/product_option_type_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :product_option_type, class: Spree::ProductOptionType do
+    product
+    option_type
+  end
+end

--- a/spec/factories/product_option_type_factory.rb
+++ b/spec/factories/product_option_type_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :product_option_type, class: Spree::ProductOptionType do
     product

--- a/spec/factories/product_property_factory.rb
+++ b/spec/factories/product_property_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :product_property, class: Spree::ProductProperty do
+    product
+    property
+  end
+end

--- a/spec/factories/product_property_factory.rb
+++ b/spec/factories/product_property_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :product_property, class: Spree::ProductProperty do
     product

--- a/spec/factories/property_factory.rb
+++ b/spec/factories/property_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :property, class: Spree::Property do
+    name 'baseball_cap_color'
+    presentation 'cap color'
+  end
+end

--- a/spec/factories/property_factory.rb
+++ b/spec/factories/property_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :property, class: Spree::Property do
     name 'baseball_cap_color'

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -1,4 +1,25 @@
 FactoryBot.define do
+  factory :shipment, class: Spree::Shipment do
+    # keeps test shipments unique per order
+    initialize_with { Spree::Shipment.find_or_create_by(order_id: order.id) }
+
+    tracking 'U10000'
+    number '100'
+    cost 100.00
+    state 'pending'
+    order
+    address
+    stock_location
+
+    after(:create) do |shipment, evalulator|
+      shipment.add_shipping_method(create(:shipping_method), true)
+
+      shipment.order.line_items.each do |line_item|
+        line_item.quantity.times { shipment.inventory_units.create(variant_id: line_item.variant_id) }
+      end
+    end
+  end
+
   factory :shipment_with, class: Spree::Shipment do
     tracking 'U10000'
     number '100'
@@ -25,12 +46,5 @@ FactoryBot.define do
         end
       end
     end
-  end
-end
-
-FactoryBot.modify do
-  factory :shipment, class: Spree::Shipment do
-    # keeps test shipments unique per order
-    initialize_with { Spree::Shipment.find_or_create_by(order_id: order.id) }
   end
 end

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     state 'pending'
     order
     address
-    stock_location
+    stock_location { DefaultStockLocation.find_or_create }
 
     after(:create) do |shipment, evalulator|
       shipment.add_shipping_method(create(:shipping_method), true)
@@ -27,7 +27,7 @@ FactoryBot.define do
     state 'pending'
     order
     address
-    stock_location
+    stock_location { DefaultStockLocation.find_or_create }
 
     trait :shipping_method do
       transient do

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     address
     stock_location { Spree::StockLocation.first || create(:stock_location) }
 
-    after(:create) do |shipment, evalulator|
+    after(:create) do |shipment, _evalulator|
       shipment.add_shipping_method(create(:shipping_method), true)
 
       shipment.order.line_items.each do |line_item|

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     state 'pending'
     order
     address
-    stock_location { DefaultStockLocation.find_or_create }
+    stock_location { Spree::StockLocation.first || create(:stock_location) }
 
     after(:create) do |shipment, evalulator|
       shipment.add_shipping_method(create(:shipping_method), true)
@@ -27,7 +27,7 @@ FactoryBot.define do
     state 'pending'
     order
     address
-    stock_location { DefaultStockLocation.find_or_create }
+    stock_location { Spree::StockLocation.first || create(:stock_location) }
 
     trait :shipping_method do
       transient do

--- a/spec/factories/shipping_category_factory.rb
+++ b/spec/factories/shipping_category_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :shipping_category, class: Spree::ShippingCategory do   
     initialize_with { DefaultShippingCategory.find_or_create }
     transient { name 'Default' }

--- a/spec/factories/shipping_category_factory.rb
+++ b/spec/factories/shipping_category_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :shipping_category, class: Spree::ShippingCategory do   
+    initialize_with { DefaultShippingCategory.find_or_create }
+    transient { name 'Default' }
+    sequence(:name) { |n| "ShippingCategory ##{n}" }
+  end
+end

--- a/spec/factories/shipping_category_factory.rb
+++ b/spec/factories/shipping_category_factory.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
-  factory :shipping_category, class: Spree::ShippingCategory do   
+  factory :shipping_category, class: Spree::ShippingCategory do
     initialize_with { DefaultShippingCategory.find_or_create }
   end
 end

--- a/spec/factories/shipping_category_factory.rb
+++ b/spec/factories/shipping_category_factory.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :shipping_category, class: Spree::ShippingCategory do   
     initialize_with { DefaultShippingCategory.find_or_create }
-    transient { name 'Default' }
-    sequence(:name) { |n| "ShippingCategory ##{n}" }
   end
 end

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
     display_on ''
 
-    before(:create) do |shipping_method, evaluator|
+    before(:create) do |shipping_method, _evaluator|
       shipping_method.shipping_categories << DefaultShippingCategory.find_or_create
     end
 

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -1,4 +1,34 @@
 FactoryBot.define do
+  factory :base_shipping_method, class: Spree::ShippingMethod do
+    zones { [] }
+    name 'UPS Ground'
+
+    distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
+    display_on ''
+
+    before(:create) do |shipping_method, evaluator|
+      shipping_method.shipping_categories << (Spree::ShippingCategory.first || create(:shipping_category))
+    end
+
+    trait :flat_rate do
+      transient { amount 1 }
+      calculator { build(:calculator_flat_rate, preferred_amount: amount) }
+    end
+
+    trait :per_item do
+      transient { amount 1 }
+      calculator { build(:calculator_per_item, preferred_amount: amount) }
+    end
+
+    factory :shipping_method, class: Spree::ShippingMethod do
+      association(:calculator, factory: :calculator, strategy: :build)
+    end
+
+    factory :free_shipping_method, class: Spree::ShippingMethod do
+      association(:calculator, factory: :no_amount_calculator, strategy: :build)
+    end
+  end
+
   factory :shipping_method_with, parent: :shipping_method do
     trait :delivery do
       require_ship_address { true }
@@ -33,24 +63,6 @@ FactoryBot.define do
       calculator { build(:calculator_per_item, preferred_amount: shipping_fee) }
       require_ship_address { false }
       distributors { [create(:distributor_enterprise_with_tax)] }
-    end
-  end
-end
-
-FactoryBot.modify do
-  factory :shipping_method, parent: :base_shipping_method do
-    distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
-    display_on ''
-    zones { [] }
-
-    trait :flat_rate do
-      transient { amount 1 }
-      calculator { build(:calculator_flat_rate, preferred_amount: amount) }
-    end
-
-    trait :per_item do
-      transient { amount 1 }
-      calculator { build(:calculator_per_item, preferred_amount: amount) }
     end
   end
 end

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -42,5 +42,15 @@ FactoryBot.modify do
     distributors { [Enterprise.is_distributor.first || FactoryBot.create(:distributor_enterprise)] }
     display_on ''
     zones { [] }
+
+    trait :flat_rate do
+      transient { amount 1 }
+      calculator { build(:calculator_flat_rate, preferred_amount: amount) }
+    end
+
+    trait :per_item do
+      transient { amount 1 }
+      calculator { build(:calculator_per_item, preferred_amount: amount) }
+    end
   end
 end

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     display_on ''
 
     before(:create) do |shipping_method, evaluator|
-      shipping_method.shipping_categories << (Spree::ShippingCategory.first || create(:shipping_category))
+      shipping_method.shipping_categories << DefaultShippingCategory.find_or_create
     end
 
     trait :flat_rate do

--- a/spec/factories/stock_factory.rb
+++ b/spec/factories/stock_factory.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :stock_package, class: Spree::Stock::Package do
+    ignore do
+      stock_location { build(:stock_location) }
+      order { create(:order_with_line_items, line_items_count: 2) }
+      contents []
+    end
+
+    initialize_with { new(stock_location, order, contents) }
+
+    factory :stock_package_fulfilled do
+      after(:build) do |package, evaluator|
+        evaluator.order.line_items.reload
+        evaluator.order.line_items.each do |line_item|
+          package.add line_item.variant, line_item.quantity, :on_hand
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/stock_factory.rb
+++ b/spec/factories/stock_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :stock_package, class: Spree::Stock::Package do
     ignore do

--- a/spec/factories/stock_location_factory.rb
+++ b/spec/factories/stock_location_factory.rb
@@ -1,0 +1,36 @@
+FactoryGirl.define do
+  factory :stock_location, class: Spree::StockLocation do
+    # Ensures the name attribute is not assigned after instantiating the default location
+    transient { name 'default' }
+
+    # keeps the test stock_location unique
+    initialize_with { DefaultStockLocation.find_or_create }
+
+    name 'NY Warehouse'
+    address1 '1600 Pennsylvania Ave NW'
+    city 'Washington'
+    zipcode '20500'
+    phone '(202) 456-1111'
+    active true
+
+    # sets the default value for variant.on_demand
+    backorderable_default false
+
+    country  { |stock_location| Spree::Country.first || stock_location.association(:country) }
+    state do |stock_location|
+      stock_location.country.states.first || stock_location.association(:state, :country => stock_location.country)
+    end
+
+    factory :stock_location_with_items do
+      after(:create) do |stock_location, evaluator|
+        # variant will add itself to all stock_locations in an after_create
+        # creating a product will automatically create a master variant
+        product_1 = create(:product)
+        product_2 = create(:product)
+
+        stock_location.stock_items.where(:variant_id => product_1.master.id).first.adjust_count_on_hand(10)
+        stock_location.stock_items.where(:variant_id => product_2.master.id).first.adjust_count_on_hand(20)
+      end
+    end
+  end
+end

--- a/spec/factories/stock_location_factory.rb
+++ b/spec/factories/stock_location_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :stock_location, class: Spree::StockLocation do
     # keeps the test stock_location unique
@@ -14,7 +16,7 @@ FactoryBot.define do
 
     country  { |stock_location| Spree::Country.first || stock_location.association(:country) }
     state do |stock_location|
-      stock_location.country.states.first || stock_location.association(:state, :country => stock_location.country)
+      stock_location.country.states.first || stock_location.association(:state, country: stock_location.country)
     end
   end
 end

--- a/spec/factories/stock_location_factory.rb
+++ b/spec/factories/stock_location_factory.rb
@@ -1,8 +1,5 @@
 FactoryBot.define do
   factory :stock_location, class: Spree::StockLocation do
-    # Ensures the name attribute is not assigned after instantiating the default location
-    transient { name 'default' }
-
     # keeps the test stock_location unique
     initialize_with { DefaultStockLocation.find_or_create }
 

--- a/spec/factories/stock_location_factory.rb
+++ b/spec/factories/stock_location_factory.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :stock_location, class: Spree::StockLocation do
     # keeps the test stock_location unique
-    initialize_with { DefaultStockLocation.find_or_create }
+    initialize_with { Spree::StockLocation.first || DefaultStockLocation.find_or_create }
 
-    name 'NY Warehouse'
     address1 '1600 Pennsylvania Ave NW'
     city 'Washington'
     zipcode '20500'
@@ -16,18 +15,6 @@ FactoryBot.define do
     country  { |stock_location| Spree::Country.first || stock_location.association(:country) }
     state do |stock_location|
       stock_location.country.states.first || stock_location.association(:state, :country => stock_location.country)
-    end
-
-    factory :stock_location_with_items do
-      after(:create) do |stock_location, evaluator|
-        # variant will add itself to all stock_locations in an after_create
-        # creating a product will automatically create a master variant
-        product_1 = create(:product)
-        product_2 = create(:product)
-
-        stock_location.stock_items.where(:variant_id => product_1.master.id).first.adjust_count_on_hand(10)
-        stock_location.stock_items.where(:variant_id => product_2.master.id).first.adjust_count_on_hand(20)
-      end
     end
   end
 end

--- a/spec/factories/stock_location_factory.rb
+++ b/spec/factories/stock_location_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :stock_location, class: Spree::StockLocation do
     # Ensures the name attribute is not assigned after instantiating the default location
     transient { name 'default' }

--- a/spec/factories/tax_category_factory.rb
+++ b/spec/factories/tax_category_factory.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :tax_category, class: Spree::TaxCategory do
-    name { "TaxCategory - #{rand(999999)}" }
+    name { "TaxCategory - #{rand(999_999)}" }
     description { generate(:random_string) }
   end
 end

--- a/spec/factories/tax_category_factory.rb
+++ b/spec/factories/tax_category_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tax_category, class: Spree::TaxCategory do
+    name { "TaxCategory - #{rand(999999)}" }
+    description { generate(:random_string) }
+  end
+end

--- a/spec/factories/tax_rate_factory.rb
+++ b/spec/factories/tax_rate_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :tax_rate, class: Spree::TaxRate do
     zone

--- a/spec/factories/tax_rate_factory.rb
+++ b/spec/factories/tax_rate_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :tax_rate, class: Spree::TaxRate do
+    zone
+    amount 100.00
+    tax_category
+  end
+end

--- a/spec/factories/taxon_factory.rb
+++ b/spec/factories/taxon_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :taxon, class: Spree::Taxon do
+    name 'Ruby on Rails'
+    taxonomy
+    parent_id nil
+  end
+end

--- a/spec/factories/taxon_factory.rb
+++ b/spec/factories/taxon_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :taxon, class: Spree::Taxon do
     name 'Ruby on Rails'

--- a/spec/factories/taxonomy_factory.rb
+++ b/spec/factories/taxonomy_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :taxonomy, class: Spree::Taxonomy do
+    name 'Brand'
+  end
+end

--- a/spec/factories/taxonomy_factory.rb
+++ b/spec/factories/taxonomy_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :taxonomy, class: Spree::Taxonomy do
     name 'Brand'

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -31,14 +31,14 @@ FactoryBot.define do
       user.spree_roles.clear # Remove admin role
 
       user.enterprises << proxy.enterprises
-    end    
+    end
 
     factory :admin_user do
       spree_roles { [Spree::Role.find_or_create_by!(name: 'admin')] }
 
       after(:create) do |user|
         user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')
-      end      
+      end
     end
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,8 +1,18 @@
-FactoryBot.modify do
-  factory :user do
+FactoryBot.define do
+  sequence :user_authentication_token do |n|
+    "xxxx#{Time.now.to_i}#{rand(1000)}#{n}xxxxxxxxxxxxx"
+  end
+
+  factory :user, class: Spree.user_class do
     transient do
       enterprises []
     end
+
+    email { generate(:random_email) }
+    login { email }
+    password 'secret'
+    password_confirmation { password }
+    authentication_token { generate(:user_authentication_token) } if Spree.user_class.attribute_method? :authentication_token
 
     confirmation_sent_at '1970-01-01 00:00:00'
     confirmed_at '1970-01-01 00:00:01'
@@ -21,15 +31,14 @@ FactoryBot.modify do
       user.spree_roles.clear # Remove admin role
 
       user.enterprises << proxy.enterprises
-    end
-  end
+    end    
 
-  factory :admin_user do
-    confirmation_sent_at '1970-01-01 00:00:00'
-    confirmed_at '1970-01-01 00:00:01'
+    factory :admin_user do
+      spree_roles { [Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')] }
 
-    after(:create) do |user|
-      user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')
+      after(:create) do |user|
+        user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')
+      end      
     end
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
     end    
 
     factory :admin_user do
-      spree_roles { [Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')] }
+      spree_roles { [Spree::Role.find_or_create_by!(name: 'admin')] }
 
       after(:create) do |user|
         user.spree_roles << Spree::Role.find_or_create_by!(name: 'admin')

--- a/spec/factories/variant_factory.rb
+++ b/spec/factories/variant_factory.rb
@@ -22,7 +22,6 @@ FactoryBot.define do
         on_hand { 5 }
       end
 
-      # on_hand 5
       product { |p| p.association(:product) }
       unit_value 1
       unit_description ''

--- a/spec/factories/variant_factory.rb
+++ b/spec/factories/variant_factory.rb
@@ -1,46 +1,66 @@
-FactoryBot.modify do
-  factory :variant do
-    transient do
-      on_demand { false }
-      on_hand { 5 }
-    end
+FactoryBot.define do
+  sequence(:random_float) { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
 
-    unit_value 1
-    unit_description ''
+  factory :base_variant, class: Spree::Variant do
+    price 19.99
+    cost_price 17.00
+    sku    { SecureRandom.hex }
+    weight { generate(:random_float) }
+    height { generate(:random_float) }
+    width  { generate(:random_float) }
+    depth  { generate(:random_float) }
 
-    after(:create) do |variant, evaluator|
-      variant.on_demand = evaluator.on_demand
-      variant.on_hand = evaluator.on_hand
-      variant.save
-    end
+    product { |p| p.association(:base_product) }
+    option_values { [create(:option_value)] }
 
-    trait :with_order_cycle do
+    # ensure stock item will be created for this variant
+    before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
+
+    factory :variant do
       transient do
-        order_cycle { create(:order_cycle) }
-        producer { product.supplier }
-        coordinator { create(:distributor_enterprise) }
-        distributor { create(:distributor_enterprise) }
-        incoming_exchange_fees { [] }
-        outgoing_exchange_fees { [] }
+        on_demand { false }
+        on_hand { 5 }
       end
 
+      # on_hand 5
+      product { |p| p.association(:product) }
+      unit_value 1
+      unit_description ''
+
       after(:create) do |variant, evaluator|
-        exchange_attributes = { order_cycle_id: evaluator.order_cycle.id, incoming: true,
-                                sender_id: evaluator.producer.id,
-                                receiver_id: evaluator.coordinator.id }
-        exchange = Exchange.where(exchange_attributes).first_or_create!(exchange_attributes)
-        exchange.variants << variant
-        evaluator.incoming_exchange_fees.each do |enterprise_fee|
-          exchange.enterprise_fees << enterprise_fee
+        variant.on_demand = evaluator.on_demand
+        variant.on_hand = evaluator.on_hand
+        variant.save
+      end
+
+      trait :with_order_cycle do
+        transient do
+          order_cycle { create(:order_cycle) }
+          producer { product.supplier }
+          coordinator { create(:distributor_enterprise) }
+          distributor { create(:distributor_enterprise) }
+          incoming_exchange_fees { [] }
+          outgoing_exchange_fees { [] }
         end
 
-        exchange_attributes = { order_cycle_id: evaluator.order_cycle.id, incoming: false,
-                                sender_id: evaluator.coordinator.id,
-                                receiver_id: evaluator.distributor.id }
-        exchange = Exchange.where(exchange_attributes).first_or_create!(exchange_attributes)
-        exchange.variants << variant
-        (evaluator.outgoing_exchange_fees || []).each do |enterprise_fee|
-          exchange.enterprise_fees << enterprise_fee
+        after(:create) do |variant, evaluator|
+          exchange_attributes = { order_cycle_id: evaluator.order_cycle.id, incoming: true,
+                                  sender_id: evaluator.producer.id,
+                                  receiver_id: evaluator.coordinator.id }
+          exchange = Exchange.where(exchange_attributes).first_or_create!(exchange_attributes)
+          exchange.variants << variant
+          evaluator.incoming_exchange_fees.each do |enterprise_fee|
+            exchange.enterprise_fees << enterprise_fee
+          end
+
+          exchange_attributes = { order_cycle_id: evaluator.order_cycle.id, incoming: false,
+                                  sender_id: evaluator.coordinator.id,
+                                  receiver_id: evaluator.distributor.id }
+          exchange = Exchange.where(exchange_attributes).first_or_create!(exchange_attributes)
+          exchange.variants << variant
+          (evaluator.outgoing_exchange_fees || []).each do |enterprise_fee|
+            exchange.enterprise_fees << enterprise_fee
+          end
         end
       end
     end

--- a/spec/factories/variant_factory.rb
+++ b/spec/factories/variant_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  sequence(:random_float) { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+  sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }
 
   factory :base_variant, class: Spree::Variant do
     price 19.99

--- a/spec/factories/zone_factory.rb
+++ b/spec/factories/zone_factory.rb
@@ -3,4 +3,12 @@ FactoryBot.define do
     name { generate(:random_string) }
     description { generate(:random_string) }
   end
+
+  factory :zone_with_member, parent: :zone do
+    default_tax true
+
+    after(:create) do |zone|
+      Spree::ZoneMember.create!(zone: zone, zoneable: Spree::Country.find_by(name: 'Australia'))
+    end
+  end
 end

--- a/spec/factories/zone_factory.rb
+++ b/spec/factories/zone_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :zone, class: Spree::Zone do
     name { generate(:random_string) }

--- a/spec/factories/zone_factory.rb
+++ b/spec/factories/zone_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :zone, class: Spree::Zone do
+    name { generate(:random_string) }
+    description { generate(:random_string) }
+  end
+end

--- a/spec/features/admin/configuration/states_spec.rb
+++ b/spec/features/admin/configuration/states_spec.rb
@@ -25,7 +25,7 @@ describe "States" do
   end
 
   context "admin visiting states listing" do
-    let!(:state) { create(:state, country: country) }
+    let!(:state) { Spree::State.create(name: 'Alabama', country: country) }
 
     it "should correctly display the states" do
       visit spree.admin_country_states_path(country)

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -63,7 +63,7 @@ describe Spree::Order do
     end
 
     it "transitions to address" do
-      order.line_items << FactoryGirl.create(:line_item)
+      order.line_items << FactoryBot.create(:line_item)
       order.email = "user@example.com"
       order.next!
       expect(order.state).to eq "address"

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Spree::StockItem do
     product_1 = create(:product)
     product_2 = create(:product)
 
-    stock_location.stock_items.where(:variant_id => product_1.master.id).first.adjust_count_on_hand(10)
-    stock_location.stock_items.where(:variant_id => product_2.master.id).first.adjust_count_on_hand(20)
+    stock_location.stock_items.where(variant_id: product_1.master.id).first.adjust_count_on_hand(10)
+    stock_location.stock_items.where(variant_id: product_2.master.id).first.adjust_count_on_hand(20)
   end
 
   subject { stock_location.stock_items.order(:id).first }

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -3,7 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe Spree::StockItem do
-  let(:stock_location) { create(:stock_location_with_items) }
+  let(:stock_location) { create(:stock_location) }
+
+  before do
+    product_1 = create(:product)
+    product_2 = create(:product)
+
+    stock_location.stock_items.where(:variant_id => product_1.master.id).first.adjust_count_on_hand(10)
+    stock_location.stock_items.where(:variant_id => product_2.master.id).first.adjust_count_on_hand(20)
+  end
 
   subject { stock_location.stock_items.order(:id).first }
 

--- a/spec/services/default_stock_location_spec.rb
+++ b/spec/services/default_stock_location_spec.rb
@@ -33,7 +33,7 @@ describe DefaultStockLocation do
     context 'when a location named default already exists' do
       let!(:location) do
         country = create(:country)
-        state = create(:state, country: country)
+        state = Spree::State.create(name: 'Alabama', country: country)
         Spree::StockLocation.create!(
           name: 'default',
           country_id: country.id,

--- a/spec/services/default_stock_location_spec.rb
+++ b/spec/services/default_stock_location_spec.rb
@@ -22,7 +22,7 @@ describe DefaultStockLocation do
 
   describe '.destroy_all' do
     it "removes all stock locations named 'default'" do
-      create(:stock_location, name: 'default')
+      create(:stock_location)
 
       expect { described_class.destroy_all }
         .to change { Spree::StockLocation.count }.to(0)

--- a/spec/services/tax_rate_finder_spec.rb
+++ b/spec/services/tax_rate_finder_spec.rb
@@ -6,11 +6,10 @@ describe TaxRateFinder do
     let(:included_tax) { BigDecimal(20) }
     let(:tax_rate) { create_rate(0.2) }
     let(:tax_category) { create(:tax_category, tax_rates: [tax_rate]) }
-    # This zone is used by :order_with_taxes and needs to match it
-    let(:zone) { create(:zone, name: "GlobalZone") }
+    let(:zone) { create(:zone_with_member) }
     let(:shipment) { create(:shipment) }
     let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_category) }
-    let(:order) { create(:order_with_taxes) }
+    let(:order) { create(:order_with_taxes, zone: zone) }
 
     it "finds the tax rate of a shipping fee" do
       rates = TaxRateFinder.new.tax_rates(


### PR DESCRIPTION
#### What? Why?
Relates to #4826 
Move all necessary factories from spree_core to ofn.

#### What should we test?
A green build is enough here, only test code changed.

#### Release notes
Changelog Category: Changed
Brought test support code from spree so that we can make OFN independent of Spree.
