### PR TITLE
5785 Notify Bugsnag when sending card to Stripe fails during checkout

### DIFF
--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $rootScope, $resource, localStorageService, RailsFlashLoader) ->
+Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $rootScope, $resource, localStorageService, Messages) ->
   # Handles syncing of current cart/order state to server
   new class Cart
     dirty: false
@@ -50,7 +50,7 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
         @popQueue() if @update_enqueued
 
       .error (response, status)=>
-        RailsFlashLoader.loadFlash({error: t('js.cart.add_to_cart_failed')})
+        Messages.flash({error: t('js.cart.add_to_cart_failed')})
         @update_running = false
 
     compareAndNotifyStockLevels: (stockLevels) =>

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeElements, PaymentMethods, $http, Navigation, CurrentHub, RailsFlashLoader, Loading)->
+Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeElements, PaymentMethods, $http, Navigation, CurrentHub, Messages)->
   new class Checkout
     errors: {}
     secrets: {}
@@ -13,7 +13,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
         @submit()
 
     submit: =>
-      Loading.message = t 'submitting_order'
+      Messages.loading(t 'submitting_order')
       $http.put('/checkout.json', {order: @preprocess()})
       .then (response) =>
         Navigation.go response.data.path
@@ -39,8 +39,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
         @loadFlash(response.data.flash)
 
     loadFlash: (flash) =>
-      Loading.clear()
-      RailsFlashLoader.loadFlash(flash)
+      Messages.flash(flash)
 
     # Rails wants our Spree::Address data to be provided with _attributes
     preprocess: ->

--- a/app/assets/javascripts/darkswarm/services/credit_card.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_card.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'CreditCard', ($injector, $rootScope, CreditCards, StripeElements, Navigation, $http, RailsFlashLoader, Loading)->
+Darkswarm.factory 'CreditCard', ($injector, $rootScope, CreditCards, StripeElements, Navigation, $http, Messages)->
   new class CreditCard
     visible: false
     errors: {}
@@ -12,16 +12,15 @@ Darkswarm.factory 'CreditCard', ($injector, $rootScope, CreditCards, StripeEleme
       params = @process_params()
       $http.put('/credit_cards/new_from_token', params )
         .success (data, status) =>
-          Loading.clear()
+          Messages.clear()
           @reset()
           CreditCards.add(data)
         .error (response, status) =>
           if response.path
             Navigation.go response.path
           else
-            Loading.clear()
             @errors = response.errors
-            RailsFlashLoader.loadFlash(response.flash)
+            Messages.flash(response.flash)
 
     setFullName: ->
       @secrets.name = "#{@secrets.first_name} #{@secrets.last_name}"

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, RailsFlashLoader)->
+Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages)->
   new class CreditCard
     saved: $filter('orderBy')(savedCreditCards,'-is_default')
 
@@ -10,6 +10,6 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, RailsFlashLo
       for othercard in @saved when othercard != card
         othercard.is_default = false
       $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
-        RailsFlashLoader.loadFlash({success: t('js.default_card_updated')})
+        Messages.success(t('js.default_card_updated'))
       , (response) ->
-        RailsFlashLoader.loadFlash({error: response.data.flash.error})
+        Messages.flash(response.data.flash)

--- a/app/assets/javascripts/darkswarm/services/customer.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/customer.js.coffee
@@ -1,4 +1,4 @@
-angular.module("Darkswarm").factory 'Customer', ($resource, RailsFlashLoader) ->
+angular.module("Darkswarm").factory 'Customer', ($resource, Messages) ->
   Customer = $resource('/api/customers/:id/:action.json', {}, {
     'index':
       method: 'GET'
@@ -13,8 +13,8 @@ angular.module("Darkswarm").factory 'Customer', ($resource, RailsFlashLoader) ->
 
   Customer.prototype.update = ->
     @$update().then (response) =>
-      RailsFlashLoader.loadFlash({success: t('js.changes_saved')})
+      Messages.success(t('js.changes_saved'))
     , (response) =>
-      RailsFlashLoader.loadFlash({error: response.data.error})
+      Messages.error(response.data.error)
 
   Customer

--- a/app/assets/javascripts/darkswarm/services/loading.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/loading.js.coffee
@@ -1,5 +1,5 @@
 Darkswarm.factory "Loading", ->
   new class Loading
-    message: null 
+    message: null
     clear: =>
       @message = null

--- a/app/assets/javascripts/darkswarm/services/messages.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/messages.js.coffee
@@ -1,0 +1,17 @@
+Darkswarm.factory "Messages", (Loading, RailsFlashLoader)->
+  new class Messages
+    loading: (message) ->
+      Loading.message = message
+
+    success: (message) ->
+      @flash(success: message)
+
+    error: (message) ->
+      @flash(error: message)
+
+    flash: (flash) ->
+      @clear()
+      RailsFlashLoader.loadFlash(flash)
+
+    clear: ->
+      Loading.clear()

--- a/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
+Darkswarm.factory 'StripeElements', ($rootScope, Messages) ->
   new class StripeElements
     # These are both set from the StripeElements directive
     stripe: null
@@ -8,13 +8,12 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
     requestToken: (secrets, submit, loading_message = t("processing_payment")) ->
       return unless @stripe? && @card?
 
-      Loading.message = loading_message
+      Messages.loading loading_message
       cardData = @makeCardData(secrets)
 
       @stripe.createToken(@card, cardData).then (response) =>
         if(response.error)
-          Loading.clear()
-          RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
+          Messages.error(t("error") + ": #{response.error.message}")
           @triggerAngularDigest()
           console.error(JSON.stringify(response.error))
         else
@@ -27,13 +26,12 @@ Darkswarm.factory 'StripeElements', ($rootScope, Loading, RailsFlashLoader) ->
     createPaymentMethod: (secrets, submit, loading_message = t("processing_payment")) ->
       return unless @stripe? && @card?
 
-      Loading.message = loading_message
+      Messages.loading loading_message
       cardData = @makeCardData(secrets)
 
       @stripe.createPaymentMethod({ type: 'card', card: @card }, @card, cardData).then (response) =>
         if(response.error)
-          Loading.clear()
-          RailsFlashLoader.loadFlash({error: t("error") + ": #{response.error.message}"})
+          Messages.error(t("error") + ": #{response.error.message}")
           @triggerAngularDigest()
           console.error(JSON.stringify(response.error))
         else

--- a/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
@@ -13,9 +13,7 @@ Darkswarm.factory 'StripeElements', ($rootScope, Messages) ->
 
       @stripe.createToken(@card, cardData).then (response) =>
         if(response.error)
-          Messages.error(t("error") + ": #{response.error.message}")
-          @triggerAngularDigest()
-          console.error(JSON.stringify(response.error))
+          @reportError(response.error, t("error") + ": #{response.error.message}")
         else
           secrets.token = response.token.id
           secrets.cc_type = @mapTokenApiCardBrand(response.token.card.brand)
@@ -31,14 +29,17 @@ Darkswarm.factory 'StripeElements', ($rootScope, Messages) ->
 
       @stripe.createPaymentMethod({ type: 'card', card: @card }, @card, cardData).then (response) =>
         if(response.error)
-          Messages.error(t("error") + ": #{response.error.message}")
-          @triggerAngularDigest()
-          console.error(JSON.stringify(response.error))
+          @reportError(response.error, t("error") + ": #{response.error.message}")
         else
           secrets.token = response.paymentMethod.id
           secrets.cc_type = @mapPaymentMethodsApiCardBrand(response.paymentMethod.card.brand)
           secrets.card = response.paymentMethod.card
           submit()
+
+    reportError: (error, messageForUser) ->
+      Messages.error(messageForUser)
+      @triggerAngularDigest()
+      console.error(JSON.stringify(error))
 
     triggerAngularDigest: ->
       # $evalAsync is improved way of triggering a digest without calling $apply

--- a/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
@@ -19,6 +19,11 @@ Darkswarm.factory 'StripeElements', ($rootScope, Messages) ->
           secrets.cc_type = @mapTokenApiCardBrand(response.token.card.brand)
           secrets.card = response.token.card
           submit()
+      .catch (response) =>
+        # Stripe handles errors in the response above. This code may never be
+        # reached. But if we get here, we want to know.
+        @reportError(response, t("js.stripe_elements.unknown_error_from_stripe"))
+        throw response
 
     # Create Payment Method to be used with the Stripe Payment Intents API
     createPaymentMethod: (secrets, submit, loading_message = t("processing_payment")) ->
@@ -35,11 +40,17 @@ Darkswarm.factory 'StripeElements', ($rootScope, Messages) ->
           secrets.cc_type = @mapPaymentMethodsApiCardBrand(response.paymentMethod.card.brand)
           secrets.card = response.paymentMethod.card
           submit()
+      .catch (response) =>
+        # Stripe handles errors in the response above. This code may never be
+        # reached. But if we get here, we want to know.
+        @reportError(response, t("js.stripe_elements.unknown_error_from_stripe"))
+        throw response
 
     reportError: (error, messageForUser) ->
       Messages.error(messageForUser)
       @triggerAngularDigest()
-      console.error(JSON.stringify(error))
+      console.error(error)
+      Bugsnag.notify(new Error(JSON.stringify(error)))
 
     triggerAngularDigest: ->
       # $evalAsync is improved way of triggering a digest without calling $apply

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2767,6 +2767,11 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       signup_or_login: "Start By Signing Up (or logging in)"
       have_an_account: "Already have an account?"
       action_login: "Log in now."
+    stripe_elements:
+      unknown_error_from_stripe: |
+        Uh oh, the Stripe integration failed. You can try again but there is
+        a very small chance that the payment came through already. It's best to
+        check your bank account first.
 
   # Singular and plural forms of commonly used words.
   # We use these entries to pluralize unit names in every language.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2769,9 +2769,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       action_login: "Log in now."
     stripe_elements:
       unknown_error_from_stripe: |
-        Uh oh, the Stripe integration failed. You can try again but there is
-        a very small chance that the payment came through already. It's best to
-        check your bank account first.
+        There was a problem setting up your card in our payments gateway.
+        Please refresh the page and try again, if it fails a second time,
+        please contact us for support.
 
   # Singular and plural forms of commonly used words.
   # We use these entries to pluralize unit names in every language.

--- a/spec/javascripts/unit/darkswarm/services/credit_card_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/credit_card_spec.js.coffee
@@ -1,5 +1,9 @@
 describe 'CreditCard service', ->
   CreditCard = null
+  CreditCards = null
+  $http = null
+  Loading = null
+  RailsFlashLoader = null
 
   beforeEach ->
     module 'Darkswarm'
@@ -8,19 +12,43 @@ describe 'CreditCard service', ->
       $provide.value "railsFlash", null
       null
 
-    inject (_CreditCard_)->
+    inject (_CreditCard_, _CreditCards_, _$httpBackend_, _Loading_, _RailsFlashLoader_)->
       CreditCard = _CreditCard_
+      CreditCards = _CreditCards_
+      $http = _$httpBackend_
+      Loading = _Loading_
+      RailsFlashLoader = _RailsFlashLoader_
+
+    CreditCard.secrets =
+      card:
+        exp_month: "12"
+        exp_year: "2030"
+        last4: "1234"
+      cc_type: 'mastercard'
+      token: "token123"
+
+  describe "submit", ->
+    it "adds a credit card", ->
+      $http.expectPUT("/credit_cards/new_from_token").respond(200, {})
+      spyOn(CreditCards, "add")
+
+      CreditCard.submit()
+      $http.flush()
+
+      expect(CreditCards.add).toHaveBeenCalled()
+
+    it "reports errors", ->
+      $http.expectPUT("/credit_cards/new_from_token").respond(500, {})
+      spyOn(Loading, "clear")
+      spyOn(RailsFlashLoader, "loadFlash")
+
+      CreditCard.submit()
+      $http.flush()
+
+      expect(Loading.clear).toHaveBeenCalled()
+      expect(RailsFlashLoader.loadFlash).toHaveBeenCalled()
 
   describe "process_params", ->
-    beforeEach ->
-      CreditCard.secrets =
-        card:
-          exp_month: "12"
-          exp_year: "2030"
-          last4: "1234"
-        cc_type: 'mastercard'
-        token: "token123"
-
     it "uses cc_type, rather than fetching the brand from the card", ->
       # This is important for processing the card with activemerchant
       process_params = CreditCard.process_params()

--- a/spec/javascripts/unit/darkswarm/services/messages_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/messages_spec.js.coffee
@@ -1,0 +1,41 @@
+describe 'Messages service', ->
+  Messages = null
+  Loading = null
+  RailsFlashLoader = null
+
+  beforeEach ->
+    module 'Darkswarm'
+
+    module ($provide)->
+      $provide.value "railsFlash", null
+      null
+
+    inject (_Messages_, _Loading_, _RailsFlashLoader_)->
+      Messages = _Messages_
+      Loading = _Loading_
+      RailsFlashLoader = _RailsFlashLoader_
+
+  it "shows a loading message", ->
+    Messages.loading("Hang on...")
+    expect(Loading.message).toEqual "Hang on..."
+
+  it "shows a success message", ->
+    spyOn(RailsFlashLoader, "loadFlash")
+    Messages.success("Yay!")
+    expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({success: "Yay!"})
+
+  it "shows a error message", ->
+    spyOn(RailsFlashLoader, "loadFlash")
+    Messages.error("Boo!")
+    expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: "Boo!"})
+
+  it "shows a flash message", ->
+    data = {info: "thinking"}
+    spyOn(RailsFlashLoader, "loadFlash")
+    Messages.flash(data)
+    expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith(data)
+
+  it "clears a loading message", ->
+    Messages.loading("Hang on...")
+    Messages.success("Done.")
+    expect(Loading.message).toEqual null

--- a/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
@@ -46,10 +46,12 @@ describe 'StripeElements Service', ->
       it "doesn't submit the form, shows an error message instead", inject (Loading, RailsFlashLoader) ->
         spyOn(Loading, "clear")
         spyOn(RailsFlashLoader, "loadFlash")
+        spyOn(Bugsnag, "notify")
         StripeElements.requestToken(secrets, submit).then (data) ->
           expect(submit).not.toHaveBeenCalled()
           expect(Loading.clear).toHaveBeenCalled()
           expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: "Error: There was a problem"})
+          expect(Bugsnag.notify).toHaveBeenCalled()
 
   describe 'mapTokenApiCardBrand', ->
     it "maps the brand returned by Stripe's tokenAPI to that required by activemerchant", ->


### PR DESCRIPTION
#### What? Why?

Closes #5785 and part of #5858.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Issue #5785 describes a checkout problem that we couldn't investigate properly because of missing logging. This pull request adds more logging to paying by card via Stripe.

#### What should we test?
<!-- List which features should be tested and how. -->

* Test on a staging server with BugsnagJS set up.
* Test the checkout via Stripe using a non-saved card:
  - Success with valid card.
  - Fail with invalid card.
* A failed payment should show up in Bugsnag.
* Repeat the above with StripeSCA.


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

The checkout with Stripe is more resilient and currently unknown errors can be reported to the user and our logging.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed



