### PR TITLE
Improve StripeAccountsController#connect spec

### DIFF
--- a/spec/controllers/admin/stripe_accounts_controller_spec.rb
+++ b/spec/controllers/admin/stripe_accounts_controller_spec.rb
@@ -13,11 +13,9 @@ describe Admin::StripeAccountsController, type: :controller do
     end
 
     it "redirects to Stripe Authorization url constructed OAuth" do
-      spree_get :connect
-      expect(response.location).to match %r(\Ahttps://connect.stripe.com)
-      uri = URI.parse(response.location)
-      params = CGI.parse(uri.query)
-      expect(params.keys).to include 'client_id', 'response_type', 'state', 'scope'
+      spree_get :connect, enterprise_id: 1 # A deterministic id results in a deterministic state JWT token
+
+      expect(response).to redirect_to("https://connect.stripe.com/oauth/authorize?state=eyJhbGciOiJIUzI1NiJ9.eyJlbnRlcnByaXNlX2lkIjoiMSJ9.jSSFGn0bLhwuiQYK5ORmHWW7aay1l030bcfGwn1JbFg&scope=read_write&client_id=some_id&response_type=code")
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Related to #5923. Improves the spec so we no longer test it manually to be fully confident. Hopefully, this will shorten the time it takes to ship a change touching this.

#### What should we test?

A green build is enough.

#### Release notes

Make the test covering the connection of a Stripe account to an OFN instance more comprehensive so we don't manually test it.
Changelog Category: Changed