### PR TITLE
Fix payment translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3649,4 +3649,4 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     activerecord:
       models:
         spree/payment:
-          one: One
+          one: Payment


### PR DESCRIPTION
#### What? Why?

Fixes #5944

One in the i18n key refers to singular/plural not the copy itself. Now we see `Order #R587218174 -> Payment -> Cash on collection` instead of `Order #R587218174 -> One -> Cash on collection`.

#### What should we test?

Check that /admin/orders/R587218174/payments/xxx shows Payment and not One.

#### Release notes