### PR TITLE
Check taxon's attribute instead of object identity

### DIFF
--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -281,7 +281,7 @@ feature '
     expect(p.variant_unit).to eq "weight"
     expect(p.variant_unit_scale).to eq 1000 # Kg
     expect(p.available_on).to eq 3.days.ago.beginning_of_day
-    expect(p.primary_taxon).to eq t1
+    expect(p.primary_taxon.permalink).to eq t1.permalink
     expect(p.inherits_properties).to be false
     expect(p.sku).to eq "NEW SKU"
   end


### PR DESCRIPTION
#### What? Why?

Closes #5900

We don't care about the Ruby object instance but the actual DB record it represents.

#### What should we test?

A green build is enough.

#### Release notes

Fix unreliable bulk product update spec

Changelog Category: Fixed
