### PR TITLE
Gitignore pyenv's Python version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bundle
 .rbenv-version
+.python-version
 .byebug_history
 .swp
 *.swo


### PR DESCRIPTION
#### What? Why?

I use pyenv to manage the Python version to run the Transifex client. That's the only bit of Python I use in this repo.

Without this, I have to select the version each time and remove the file after preparing the release. Annoying.

#### What should we test?

Nothing.

#### Release notes

Git-ignore the .python-version manager file used by pyenv
Changelog Category: Changed