### PR TITLE
Add required plural form to locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3652,3 +3652,4 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       models:
         spree/payment:
           one: Payment
+          other: Payments


### PR DESCRIPTION

#### What? Why?

Follow up of #5944 and #5963.
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Transifex complained:

> Key 'spree.activerecord.models.spree/payment' has the wrong number of plurals

While our application may not need that translation, Transifex won't accept the source file and our updates were broken.


#### What should we test?
<!-- List which features should be tested and how. -->

Same as in #5963:

> Check that /admin/orders/R587218174/payments/xxx shows Payment and not One.

Use another order number if that one doesn't exist on your staging server.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Text changes are available for translation again.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed

