### PR TITLE
Depend on version of spree without controller helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/openfoodfoundation/spree.git
-  revision: 0b0c422369c82b6dd7e7cb627a24e3a9fca19a6c
+  revision: cbb24a6ed701166ffaf2ab60a402154100d74766
   branch: 2-1-0-stable
   specs:
     spree_core (2.1.0)

--- a/app/controllers/spree/base_controller.rb
+++ b/app/controllers/spree/base_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require 'cancan'
+require 'spree/core/controller_helpers/auth'
+require 'spree/core/controller_helpers/respond_with'
+require 'spree/core/controller_helpers/common'
+require 'spree/core/controller_helpers/ssl'
 
 module Spree
   class BaseController < ApplicationController

--- a/app/controllers/spree/store_controller.rb
+++ b/app/controllers/spree/store_controller.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'spree/core/controller_helpers/order'
+
 module Spree
   class StoreController < Spree::BaseController
     layout 'darkswarm'

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: false
+
+require 'spree/core/s3_support'
+
 class Enterprise < ActiveRecord::Base
   SELLS = %w(unspecified none own any).freeze
   ENTERPRISE_SEARCH_RADIUS = 100

--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EnterpriseRelationship < ActiveRecord::Base
   belongs_to :parent, class_name: 'Enterprise', touch: true
   belongs_to :child, class_name: 'Enterprise', touch: true


### PR DESCRIPTION
The spree change required here is in https://github.com/openfoodfoundation/spree/pull/47/files


#### What? Why?

Closes #5982
This PR just removes the duplicate code from spree.

#### What should we test?
I think we will be fine on the helpers not related to the issue: ssl, respondfers and common.
I think the testing required here is around multiple cart management as in #5982 and #5936 


#### Release notes
Changelog Category: Removed
Removed some code from spree to avoid conflicts with OFN. This will solve issues with customers seeing items from older carts being merged with current carts when they login.