### PR TITLE
Do not require view overrides

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,11 +18,6 @@ module Openfoodnetwork
       Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
-
-      # Load application's view overrides
-      Dir.glob(File.join(File.dirname(__FILE__), "../app/overrides/*.rb")) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-      end
     end
 
     # Settings dependent on locale


### PR DESCRIPTION
#### What? Why?

View overrides were removed long ago, so no need to require an empty list.

The next step will be class decorators.

#### What should we test?

A green build is enough.

#### Release notes

Do not require long gone view overrides
Changelog Category: Removed