### PR TITLE
Fix embedded shops failing javascript because jQuery is try to be accessed before being loaded 

### DIFF
--- a/app/views/layouts/_shopfront_script.html.haml
+++ b/app/views/layouts/_shopfront_script.html.haml
@@ -1,29 +1,34 @@
 :javascript
-  $(document).ready(function() {
-    var in_iframe = function(){
-      try {
-        return window.self !== window.top;
-      } catch (e) {
-        return true;
+  var isInIframe = function(){
+    try {
+      return window.self !== window.top;
+    } catch (e) {
+      return true;
+    }
+  };
+
+  document.addEventListener(
+    'DOMContentLoaded',
+    function() {
+      var inIframe = isInIframe();
+      var embedded_styles_active = $('body.off-canvas').hasClass('embedded');
+
+      var set_shopfront_styles = function (state) {
+        $.ajax({
+          url: '/embedded_shopfront/' + state,
+          type: 'POST'
+        });
+      };
+
+      if (inIframe && !embedded_styles_active){
+        $('body.off-canvas').addClass('embedded');
+        set_shopfront_styles('enable');
       }
-    };
 
-    var embedded_styles_active = $('body.off-canvas').hasClass('embedded');
-
-    var set_shopfront_styles = function(state) {
-      $.ajax({
-        url: '/embedded_shopfront/'+state,
-        type: 'POST'
-      });
-    };
-
-    if (in_iframe() && !embedded_styles_active){
-      $('body.off-canvas').addClass('embedded');
-      set_shopfront_styles('enable');
-    }
-
-    if (!in_iframe() && embedded_styles_active) {
-      $('body.off-canvas').removeClass('embedded');
-      set_shopfront_styles('disable');
-    }
-  });
+      if (!inIframe && embedded_styles_active) {
+        $('body.off-canvas').removeClass('embedded');
+        set_shopfront_styles('disable');
+      }
+    },
+    false
+  );


### PR DESCRIPTION


#### What? Why?
We check for `$(document).ready` when jQuery is not downloaded yet in the browser. The solution is to check if document is ready with plain DOM javascript event `DOMContentLoaded`

This is the error in a client's page [biodynamic.org.uk/where-to-buy](https://www.biodynamic.org.uk/where-to-buy/) when embedding the map:

![image](https://user-images.githubusercontent.com/49499/92326893-d2569f00-f055-11ea-967f-6d6cb63ef6dc.png)

Closes #2723 (Maybe, I'm not sure)

#### What should we test?
After deployed the change check browser console on this page [biodynamic.org.uk/where-to-buy](https://www.biodynamic.org.uk/where-to-buy/) and also check the issue. [No Zoom Buttons on Maps in Embedded Groups](https://github.com/openfoodfoundation/openfoodnetwork/issues/2723)

Changelog Category: Fixed
