### PR TITLE
Terms and Conditions - shoppers only need to accept T&Cs once, unless they are updated by enterprise

### DIFF
--- a/app/assets/javascripts/admin/enterprises/directives/terms_and_conditions_warning.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/directives/terms_and_conditions_warning.js.coffee
@@ -1,0 +1,30 @@
+angular.module("admin.enterprises").directive 'termsAndConditionsWarning', ($compile, $templateCache, DialogDefaults, $timeout) ->
+  restrict: 'A'
+  scope: true
+
+  link: (scope, element, attr) ->
+    # This file input click handler will hold the browser file input dialog and show a warning modal
+    scope.hold_file_input_and_show_warning_modal = (event) ->
+      event.preventDefault()
+      scope.template = $compile($templateCache.get('admin/modals/terms_and_conditions_warning.html'))(scope)
+      if scope.template.dialog
+        scope.template.dialog(DialogDefaults)
+        scope.template.dialog('open')
+      scope.$apply()
+
+    element.bind 'click', scope.hold_file_input_and_show_warning_modal
+
+    # When the user presses continue in the warning modal, we open the browser file input dialog
+    scope.continue = ->
+      scope.template.dialog('close')
+
+      # unbind warning modal handler and click file input again to open the browser file input dialog
+      element.unbind('click').trigger('click')
+      # afterwards, bind warning modal handler again so that the warning is shown the next time
+      $timeout ->
+        element.bind 'click', scope.hold_file_input_and_show_warning_modal
+      return
+
+    scope.close = ->
+      scope.template.dialog('close')
+      return

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -46,7 +46,6 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
       munged_order =
         default_bill_address: !!@default_bill_address
         default_ship_address: !!@default_ship_address
-        terms_and_conditions_accepted: true
 
       for name, value of @order # Clone all data from the order JSON object
         switch name
@@ -96,6 +95,10 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
               last_name: @order.bill_address.lastname
               save_requested_by_customer: @secrets.save_requested_by_customer
           }
+
+      if @terms_and_conditions_accepted()
+        munged_order["terms_and_conditions_accepted"] = true
+
       munged_order
 
     shippingMethod: ->
@@ -115,3 +118,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
 
     cartTotal: ->
       @order.display_total + @shippingPrice() + @paymentPrice()
+
+    terms_and_conditions_accepted: ->
+      terms_and_conditions_checkbox = angular.element("#accept_terms")[0]
+      terms_and_conditions_checkbox? && terms_and_conditions_checkbox.checked

--- a/app/assets/javascripts/darkswarm/services/checkout.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/checkout.js.coffee
@@ -46,6 +46,7 @@ Darkswarm.factory 'Checkout', ($injector, CurrentOrder, ShippingMethods, StripeE
       munged_order =
         default_bill_address: !!@default_bill_address
         default_ship_address: !!@default_ship_address
+        terms_and_conditions_accepted: true
 
       for name, value of @order # Clone all data from the order JSON object
         switch name

--- a/app/assets/javascripts/templates/admin/modals/terms_and_conditions_info.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/terms_and_conditions_info.html.haml
@@ -1,0 +1,13 @@
+%div
+  .margin-bottom-30.text-center
+    .text-big
+      {{ 'js.admin.modals.terms_and_conditions_info.title' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_info.message_1' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_info.message_2' | t }}
+
+  .text-center
+    %input.button.red.icon-plus{ type: 'button', value: t('js.admin.modals.got_it'), ng: { click: 'close()' } }

--- a/app/assets/javascripts/templates/admin/modals/terms_and_conditions_warning.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/terms_and_conditions_warning.html.haml
@@ -1,0 +1,14 @@
+%div
+  .margin-bottom-30.text-center
+    .text-big
+      {{ 'js.admin.modals.terms_and_conditions_warning.title' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_warning.message_1' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_warning.message_2' | t }}
+
+  .text-center
+    %input.button.red{ type: 'button', value: t('js.admin.modals.close'), ng: { click: 'close()' } }
+    %input.button.red{ type: 'button', value: t('js.admin.modals.continue'), ng: { click: 'continue()' } }

--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module TermsAndConditionsHelper
+  def terms_and_conditions_activated
+    current_order.distributor.terms_and_conditions.file?
+  end
+
+  def terms_and_conditions_already_accepted
+    customer_terms_and_conditions_accepted_at = spree_current_user.
+      customer_of(current_order.distributor)&.terms_and_conditions_accepted_at
+
+    customer_terms_and_conditions_accepted_at.present? &&
+      (customer_terms_and_conditions_accepted_at >
+        current_order.distributor.terms_and_conditions_updated_at)
+  end
+end

--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -6,7 +6,7 @@ module TermsAndConditionsHelper
   end
 
   def terms_and_conditions_already_accepted?
-    customer_terms_and_conditions_accepted_at = spree_current_user.
+    customer_terms_and_conditions_accepted_at = spree_current_user&.
       customer_of(current_order.distributor)&.terms_and_conditions_accepted_at
 
     customer_terms_and_conditions_accepted_at.present? &&

--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module TermsAndConditionsHelper
-  def terms_and_conditions_activated
+  def terms_and_conditions_activated?
     current_order.distributor.terms_and_conditions.file?
   end
 
-  def terms_and_conditions_already_accepted
+  def terms_and_conditions_already_accepted?
     customer_terms_and_conditions_accepted_at = spree_current_user.
       customer_of(current_order.distributor)&.terms_and_conditions_accepted_at
 

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -6,7 +6,8 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
              :preferred_product_selection_from_inventory_only,
              :preferred_show_customer_names_to_suppliers, :owner, :contact, :users, :tag_groups,
              :default_tag_group, :require_login, :allow_guest_orders, :allow_order_changes,
-             :logo, :promo_image, :terms_and_conditions, :terms_and_conditions_file_name
+             :logo, :promo_image, :terms_and_conditions,
+             :terms_and_conditions_file_name, :terms_and_conditions_updated_at
 
   has_one :owner, serializer: Api::Admin::UserSerializer
   has_many :users, serializer: Api::Admin::UserSerializer
@@ -21,9 +22,13 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
   end
 
   def terms_and_conditions
-    return unless @object.terms_and_conditions.file?
+    return unless object.terms_and_conditions.file?
 
-    @object.terms_and_conditions.url
+    object.terms_and_conditions.url
+  end
+
+  def terms_and_conditions_updated_at
+    object.terms_and_conditions_updated_at&.to_s
   end
 
   def tag_groups

--- a/app/services/checkout/post_checkout_actions.rb
+++ b/app/services/checkout/post_checkout_actions.rb
@@ -8,6 +8,7 @@ module Checkout
     end
 
     def success(controller, params, current_user)
+      set_customer_terms_and_conditions_accepted_at(params)
       save_order_addresses_as_user_default(params, current_user)
       OrderCompletionReset.new(controller, @order).call
     end
@@ -25,6 +26,10 @@ module Checkout
       user_default_address_setter = UserDefaultAddressSetter.new(@order, current_user)
       user_default_address_setter.set_default_bill_address if params[:order][:default_bill_address]
       user_default_address_setter.set_default_ship_address if params[:order][:default_ship_address]
+    end
+
+    def set_customer_terms_and_conditions_accepted_at(params)
+      @order.customer.update(terms_and_conditions_accepted_at: Time.zone.now) if params[:order][:terms_and_conditions_accepted]
     end
   end
 end

--- a/app/services/checkout/post_checkout_actions.rb
+++ b/app/services/checkout/post_checkout_actions.rb
@@ -29,6 +29,8 @@ module Checkout
     end
 
     def set_customer_terms_and_conditions_accepted_at(params)
+      return unless params[:order]
+
       @order.customer.update(terms_and_conditions_accepted_at: Time.zone.now) if params[:order][:terms_and_conditions_accepted]
     end
   end

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -35,12 +35,15 @@
 .row
   .alpha.three.columns
     = f.label :terms_and_conditions, t('.terms_and_conditions')
+    %i.text-big.icon-question-sign.help-modal{ template: 'admin/modals/terms_and_conditions_info.html' }
 
   .omega.eight.columns
-    %a{ href: '{{ Enterprise.terms_and_conditions }}', ng: { if: 'Enterprise.terms_and_conditions' } }
+    %a{ href: '{{ Enterprise.terms_and_conditions }}', target: '_blank', ng: { if: 'Enterprise.terms_and_conditions' } }
       = '{{ Enterprise.terms_and_conditions_file_name }}'
+      = t('.uploaded_on')
+      = '{{ Enterprise.terms_and_conditions_updated_at }}'
     .pad-top
-      = f.file_field :terms_and_conditions
+      = f.file_field :terms_and_conditions, accept: 'application/pdf', 'terms-and-conditions-warning' => 'true'
     .pad-top
       %a.button.red{ href: '', ng: {click: 'removeTermsAndConditions()', if: 'Enterprise.terms_and_conditions'} }
         = t('.remove_terms_and_conditions')

--- a/app/views/checkout/_terms_and_conditions.html.haml
+++ b/app/views/checkout/_terms_and_conditions.html.haml
@@ -1,5 +1,7 @@
 - terms_and_conditions_activated = current_order.distributor.terms_and_conditions.file?
+- customer_terms_and_conditions_accepted_at = spree_current_user.customer_of(current_order.distributor).andand.terms_and_conditions_accepted_at
+- terms_and_conditions_already_accepted = customer_terms_and_conditions_accepted_at.present? && (customer_terms_and_conditions_accepted_at > current_order.distributor.terms_and_conditions_updated_at)
 - if terms_and_conditions_activated
   %p
-    %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_activated=#{terms_and_conditions_activated}" } }
+    %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_activated=#{terms_and_conditions_activated}; terms_and_conditions_accepted=#{terms_and_conditions_already_accepted}" } }
       %label.small{for: "accept_terms"}= t('.message_html', terms_and_conditions_link: link_to( t( '.link_text' ), current_order.distributor.terms_and_conditions.url, target: '_blank'))

--- a/app/views/checkout/_terms_and_conditions.html.haml
+++ b/app/views/checkout/_terms_and_conditions.html.haml
@@ -1,6 +1,3 @@
-- terms_and_conditions_activated = current_order.distributor.terms_and_conditions.file?
-- customer_terms_and_conditions_accepted_at = spree_current_user.customer_of(current_order.distributor).andand.terms_and_conditions_accepted_at
-- terms_and_conditions_already_accepted = customer_terms_and_conditions_accepted_at.present? && (customer_terms_and_conditions_accepted_at > current_order.distributor.terms_and_conditions_updated_at)
 - if terms_and_conditions_activated
   %p
     %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_activated=#{terms_and_conditions_activated}; terms_and_conditions_accepted=#{terms_and_conditions_already_accepted}" } }

--- a/app/views/checkout/_terms_and_conditions.html.haml
+++ b/app/views/checkout/_terms_and_conditions.html.haml
@@ -1,4 +1,4 @@
-- if terms_and_conditions_activated
+- if terms_and_conditions_activated?
   %p
-    %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_activated=#{terms_and_conditions_activated}; terms_and_conditions_accepted=#{terms_and_conditions_already_accepted}" } }
+    %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_activated=#{terms_and_conditions_activated?}; terms_and_conditions_accepted=#{terms_and_conditions_already_accepted?}" } }
       %label.small{for: "accept_terms"}= t('.message_html', terms_and_conditions_link: link_to( t( '.link_text' ), current_order.distributor.terms_and_conditions.url, target: '_blank'))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -696,6 +696,7 @@ en:
           invoice_text: Add customized text at the end of invoices
           terms_and_conditions: "Terms and Conditions"
           remove_terms_and_conditions: "Remove File"
+          uploaded_on: "uploaded on"
         contact:
           name: Name
           name_placeholder: eg. Gustav Plum
@@ -2505,8 +2506,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     admin:
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
       modals:
-        got_it: Got it
+        got_it: "Got it"
         close: "Close"
+        continue: "Continue"
         invite: "Invite"
         invite_title: "Invite an unregistered user"
         tag_rule_help:
@@ -2525,6 +2527,14 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           customer_tagged_rules_text: >
             By creating rules related to a specific customer tag, you can override the default
             behaviour (whether it be to show or to hide items) for customers with the specified tag.
+        terms_and_conditions_info:
+          title: "Uploading Terms and Conditions"
+          message_1: "Terms and Conditions are the contract between you, the seller, and the shopper. If you upload a file here shoppers must accept your Terms and Conditions in order to complete checkout. For the shopper this will appear as a checkbox at checkout that must be checked in order to proceed with checkout. We highly recommend you upload Terms and Conditions in alignment with national legislation."
+          message_2: "Shoppers will only be required to accept Terms and Conditions once. However if you change you Terms and Conditions shoppers will again be required to accept them before they can checkout."
+        terms_and_conditions_warning:
+          title: "Uploading Terms and Conditions"
+          message_1: "All your buyers will have to agree to them once at checkout. If you update the file, all your buyers will have to agree to them again at checkout."
+          message_2: "For buyers with subscriptions, you need to email them the Terms and Conditions (or the changes to them) for now, nothing will notify them about these new Terms and Conditions."
       panels:
         save: SAVE
         saved: SAVED

--- a/db/migrate/20200907140555_add_customer_terms_and_conditions_accepted.rb
+++ b/db/migrate/20200907140555_add_customer_terms_and_conditions_accepted.rb
@@ -1,0 +1,5 @@
+class AddCustomerTermsAndConditionsAccepted < ActiveRecord::Migration
+  def change
+    add_column :customers, :terms_and_conditions_accepted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200817150002) do
+ActiveRecord::Schema.define(version: 20200907140555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,16 +47,17 @@ ActiveRecord::Schema.define(version: 20200817150002) do
   add_index "coordinator_fees", ["order_cycle_id"], name: "index_coordinator_fees_on_order_cycle_id", using: :btree
 
   create_table "customers", force: true do |t|
-    t.string   "email",                           null: false
-    t.integer  "enterprise_id",                   null: false
+    t.string   "email",                                            null: false
+    t.integer  "enterprise_id",                                    null: false
     t.string   "code"
     t.integer  "user_id"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
     t.integer  "bill_address_id"
     t.integer  "ship_address_id"
     t.string   "name"
-    t.boolean  "allow_charges",   default: false, null: false
+    t.boolean  "allow_charges",                    default: false, null: false
+    t.datetime "terms_and_conditions_accepted_at"
   end
 
   add_index "customers", ["bill_address_id"], name: "index_customers_on_bill_address_id", using: :btree

--- a/spec/features/admin/enterprises/terms_and_conditions_spec.rb
+++ b/spec/features/admin/enterprises/terms_and_conditions_spec.rb
@@ -43,7 +43,11 @@ feature "Uploading Terms and Conditions PDF" do
 
         # Add PDF
         attach_file "enterprise[terms_and_conditions]", white_pdf_file_name
-        click_button "Update"
+
+        Timecop.freeze(run_time = Time.zone.local(2002, 4, 13, 0, 0, 0)) do
+          click_button "Update"
+          expect(distributor.reload.terms_and_conditions_updated_at).to eq run_time
+        end
         expect(page).
           to have_content("Enterprise \"#{distributor.name}\" has been successfully updated!")
 
@@ -55,6 +59,7 @@ feature "Uploading Terms and Conditions PDF" do
         click_button "Update"
         expect(page).
           to have_content("Enterprise \"#{distributor.name}\" has been successfully updated!")
+        expect(distributor.reload.terms_and_conditions_updated_at).to_not eq run_time
 
         go_to_business_details
         expect(page).to have_selector("a[href*='logo-black.pdf']")

--- a/spec/features/admin/enterprises/terms_and_conditions_spec.rb
+++ b/spec/features/admin/enterprises/terms_and_conditions_spec.rb
@@ -16,7 +16,7 @@ feature "Uploading Terms and Conditions PDF" do
       visit edit_admin_enterprise_path(distributor)
     end
 
-    describe "images for an enterprise" do
+    describe "with terms and conditions to upload" do
       def go_to_business_details
         within(".side_menu") do
           click_link "Business Details"
@@ -49,20 +49,21 @@ feature "Uploading Terms and Conditions PDF" do
           expect(distributor.reload.terms_and_conditions_updated_at).to eq run_time
         end
         expect(page).
-          to have_content("Enterprise \"#{distributor.name}\" has been successfully updated!")
+          to have_content "Enterprise \"#{distributor.name}\" has been successfully updated!"
 
         go_to_business_details
-        expect(page).to have_selector("a[href*='logo-white.pdf']")
+        expect(page).to have_selector "a[href*='logo-white.pdf'][target=\"_blank\"]"
+        expect(page).to have_content "2002-04-13 00:00:00 +1000"
 
         # Replace PDF
         attach_file "enterprise[terms_and_conditions]", black_pdf_file_name
         click_button "Update"
         expect(page).
-          to have_content("Enterprise \"#{distributor.name}\" has been successfully updated!")
+          to have_content "Enterprise \"#{distributor.name}\" has been successfully updated!"
         expect(distributor.reload.terms_and_conditions_updated_at).to_not eq run_time
 
         go_to_business_details
-        expect(page).to have_selector("a[href*='logo-black.pdf']")
+        expect(page).to have_selector "a[href*='logo-black.pdf']"
       end
     end
   end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -126,7 +126,7 @@ feature "As a consumer I want to check out my cart", js: true do
       end
     end
 
-    context "when distributor has terms and conditions" do
+    context "when distributor has T&Cs" do
       let(:fake_terms_and_conditions_path) { Rails.root.join("app/assets/images/logo-white.png") }
       let(:terms_and_conditions_file) { Rack::Test::UploadedFile.new(fake_terms_and_conditions_path, "application/pdf") }
 
@@ -135,14 +135,29 @@ feature "As a consumer I want to check out my cart", js: true do
         order.distributor.save
       end
 
-      it "shows a link to the terms and conditions" do
-        visit checkout_path
-        expect(page).to have_link("Terms and Conditions", href: order.distributor.terms_and_conditions.url)
+      describe "when customer has not accepted T&Cs before" do
+        it "shows a link to the T&Cs and disabled checkout button until terms are accepted" do
+          visit checkout_path
+          expect(page).to have_link("Terms and Conditions", href: order.distributor.terms_and_conditions.url)
 
-        expect(page).to have_button("Place order now", disabled: true)
+          expect(page).to have_button("Place order now", disabled: true)
 
-        check "accept_terms"
-        expect(page).to have_button("Place order now", disabled: false)
+          check "accept_terms"
+          expect(page).to have_button("Place order now", disabled: false)
+        end
+      end
+
+      describe "when customer has already accepted T&Cs before" do
+        before do
+          customer = create(:customer, enterprise: order.distributor, user: user)
+          customer.update terms_and_conditions_accepted_at: Time.zone.now
+        end
+
+        it "enables checkout because T&Cs are accepted by default" do
+          visit checkout_path
+
+          expect(page).to have_button("Place order now", disabled: false)
+        end
       end
     end
 

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -136,7 +136,7 @@ feature "As a consumer I want to check out my cart", js: true do
       end
 
       describe "when customer has not accepted T&Cs before" do
-        it "shows a link to the T&Cs and disabled checkout button until terms are accepted" do
+        it "shows a link to the T&Cs and disables checkout button until terms are accepted" do
           visit checkout_path
           expect(page).to have_link("Terms and Conditions", href: order.distributor.terms_and_conditions.url)
 
@@ -153,10 +153,18 @@ feature "As a consumer I want to check out my cart", js: true do
           customer.update terms_and_conditions_accepted_at: Time.zone.now
         end
 
-        it "enables checkout because T&Cs are accepted by default" do
+        it "enables checkout button (because T&Cs are accepted by default)" do
           visit checkout_path
-
           expect(page).to have_button("Place order now", disabled: false)
+        end
+
+        describe "but afterwards the enterprise has uploaded a new T&Cs file" do
+          before { order.distributor.update terms_and_conditions_updated_at: Time.zone.now }
+
+          it "disables checkout button until terms are accepted" do
+            visit checkout_path
+            expect(page).to have_button("Place order now", disabled: true)
+          end
         end
       end
     end

--- a/spec/javascripts/unit/admin/enterprises/directives/terms_and_conditions_warning_spec.js.coffee
+++ b/spec/javascripts/unit/admin/enterprises/directives/terms_and_conditions_warning_spec.js.coffee
@@ -1,0 +1,18 @@
+describe "termsAndConditionsWarning", ->
+  element = null
+  templatecache = null
+
+  beforeEach ->
+    module('admin.enterprises')
+
+    inject ($rootScope, $compile, $templateCache) ->
+      templatecache = $templateCache
+      el = angular.element("<input terms-and-conditions-warning=\"true\"></input>")
+      element = $compile(el)($rootScope)
+      $rootScope.$digest()
+
+  describe "terms and conditions warning", ->
+    it "should load template", ->
+      spyOn(templatecache, 'get')
+      element.triggerHandler('click');
+      expect(templatecache.get).toHaveBeenCalledWith('admin/modals/terms_and_conditions_warning.html')

--- a/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/checkout_spec.js.coffee
@@ -65,6 +65,7 @@ describe 'Checkout service', ->
     inject ($injector, _$httpBackend_, $rootScope)->
       $httpBackend = _$httpBackend_
       Checkout = $injector.get("Checkout")
+      spyOn(Checkout, "terms_and_conditions_accepted")
       scope = $rootScope.$new()
       scope.Checkout = Checkout
       Navigation = $injector.get("Navigation")

--- a/spec/services/checkout/post_checkout_actions_spec.rb
+++ b/spec/services/checkout/post_checkout_actions_spec.rb
@@ -24,7 +24,7 @@ describe Checkout::PostCheckoutActions do
     end
 
     describe "setting customer terms_and_conditions_accepted_at" do
-      before { order.customer = build_stubbed(:customer) }
+      before { order.customer = build(:customer) }
 
       it "does not set customer's terms_and_conditions to the current time if terms have not been accepted" do
         postCheckoutActions.success(controller, params, current_user)

--- a/spec/services/checkout/post_checkout_actions_spec.rb
+++ b/spec/services/checkout/post_checkout_actions_spec.rb
@@ -23,6 +23,21 @@ describe Checkout::PostCheckoutActions do
       postCheckoutActions.success(controller, params, current_user)
     end
 
+    describe "setting customer terms_and_conditions_accepted_at" do
+      before { order.customer = build_stubbed(:customer) }
+
+      it "does not set customer's terms_and_conditions to the current time if terms have not been accepted" do
+        postCheckoutActions.success(controller, params, current_user)
+        expect(order.customer.terms_and_conditions_accepted_at).to be_nil
+      end
+
+      it "sets customer's terms_and_conditions to the current time if terms have been accepted" do
+        params = { order: { terms_and_conditions_accepted: true } }
+        postCheckoutActions.success(controller, params, current_user)
+        expect(order.customer.terms_and_conditions_accepted_at).to_not be_nil
+      end
+    end
+
     describe "setting the user default address" do
       let(:user_default_address_setter) { instance_double(UserDefaultAddressSetter) }
 


### PR DESCRIPTION
#### What? Why?

Closes #5514

We add a field to the customer (a customer is a user in an enterprise)  terms_and_conditions_accepted_at to keep when the terms were accepted last time by this customer on this enterprise.
We tick the T&Cs checkbox by default if the customer already has a value in this field.
When the customer checkout we update the timestamp.
We only tick the checkbox if the customer timestamp is greater than the timestmap of the enterprise's terms_and_conditions, this way, when the enterprise uploads a new file all customers will have to tick the T&Cs again.

#### What should we test?
After uploading a new file to an enterprise, verify that checking out will show the terms and conditions checkbox unticked.
We can then verify the checkbox is ticked automatically on a second checkout.
After that we can upload a new file on the backoffice and verify that for the same user, the checkbox becomes again unticked by default and the user needs to click on it again.

#### Release notes
Changelog Category: Added
Users only have to tick the Terms and Conditions checkbox on checkout once for each version of the file uploaded by the enterprise.
