### PR TITLE
Tools to update images before deploys

### DIFF
--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -37,12 +37,20 @@ module Spree
     def find_dimensions
       return if attachment.errors.present?
 
-      temporary = attachment.queued_for_write[:original]
-      filename = temporary.path unless temporary.nil?
-      filename = attachment.path if filename.blank?
-      geometry = Paperclip::Geometry.from_file(filename)
+      geometry = Paperclip::Geometry.from_file(local_filename_of_original)
+
       self.attachment_width  = geometry.width
       self.attachment_height = geometry.height
+    end
+
+    def local_filename_of_original
+      temporary = attachment.queued_for_write[:original]
+
+      if temporary&.path.present?
+        temporary.path
+      else
+        attachment.path
+      end
     end
 
     # if there are errors from the plugin, then add a more meaningful message

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -35,6 +35,8 @@ module Spree
     end
 
     def find_dimensions
+      return if attachment.errors.present?
+
       temporary = attachment.queued_for_write[:original]
       filename = temporary.path unless temporary.nil?
       filename = attachment.path if filename.blank?

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -46,6 +46,22 @@ namespace :images do
     end
   end
 
+  desc "Regenerates thumbnails for a given CLASS (and optional ATTACHMENT and STYLES splitted by comma)."
+  task regenerate_thumbnails: :environment do
+    klass = Paperclip::Task.obtain_class
+    names = Paperclip::Task.obtain_attachments(klass)
+    styles = (ENV['STYLES'] || ENV['styles'] || '').split(',').map(&:to_sym)
+    names.each do |name|
+      Paperclip.each_instance_with_attachment(klass, name) do |instance|
+        instance.send(name).reprocess!(*styles)
+        unless instance.errors.blank?
+          puts "errors while processing #{klass} ID #{instance.id}:"
+          puts " " + instance.errors.full_messages.join("\n ") + "\n"
+        end
+      end
+    end
+  end
+
   desc "Restyle thumbnails for a future deployment."
   task restyle: ["images:reset_styles", "paperclip:refresh:thumbnails"]
 

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -51,8 +51,9 @@ namespace :images do
     klass = Paperclip::Task.obtain_class
     names = Paperclip::Task.obtain_attachments(klass)
     styles = (ENV['STYLES'] || ENV['styles'] || '').split(',').map(&:to_sym)
+    after_id = (ENV['AFTER_ID'] || ENV['after_id']).to_i
     names.each do |name|
-      instances_with_attachment(klass, name).find_each do |instance|
+      instances_with_attachment_after_id(klass, name, after_id).find_each do |instance|
         print "processing #{klass} ID #{instance.id}:"
         instance.send(name).reprocess!(*styles)
         if instance.errors.blank?
@@ -76,6 +77,15 @@ namespace :images do
     end
 
     Spree::Image.format_styles(JSON.parse(styles))
+  end
+
+  def instances_with_attachment_after_id(klass, name, id)
+    instances = instances_with_attachment(klass, name)
+    if id
+      instances.where("id > ?", id).order("id")
+    else
+      instances
+    end
   end
 
   def instances_with_attachment(klass, name)

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -53,9 +53,12 @@ namespace :images do
     styles = (ENV['STYLES'] || ENV['styles'] || '').split(',').map(&:to_sym)
     names.each do |name|
       Paperclip.each_instance_with_attachment(klass, name) do |instance|
+        print "processing #{klass} ID #{instance.id}:"
         instance.send(name).reprocess!(*styles)
-        unless instance.errors.blank?
-          puts "errors while processing #{klass} ID #{instance.id}:"
+        if instance.errors.blank?
+          puts " done."
+        else
+          puts " failed."
           puts " " + instance.errors.full_messages.join("\n ") + "\n"
         end
       end

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -77,7 +77,7 @@ namespace :images do
       raise 'Must specify styles like STYLE_DEFS=\'{"small":["227x227#","jpg"]}\''
     end
 
-    Spree::Image.format_styles(JSON.parse(styles))
+    format_styles(JSON.parse(styles))
   end
 
   def instances_with_attachment_after_id(klass, name, id)
@@ -91,5 +91,17 @@ namespace :images do
 
   def instances_with_attachment(klass, name)
     Paperclip.class_for(klass).unscoped.where("#{name}_file_name IS NOT NULL")
+  end
+
+  # Convert strings from JSON into symbols understood by Paperclip:
+  #
+  #   {'mini' => ['48x48>', 'png']} is converted to {mini: ['48x48>', :png]}
+  def format_styles(styles)
+    styles_a = styles.map do |name, style|
+      style[1] = style[1].to_sym if style.is_a? Array
+      [name.to_sym, style]
+    end
+
+    Hash[styles_a]
   end
 end

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -66,8 +66,8 @@ namespace :images do
     end
   end
 
-  desc "Restyle thumbnails for a future deployment."
-  task restyle: ["images:reset_styles", "paperclip:refresh:thumbnails"]
+  desc "Restyle thumbnails for a future deployment. Use CLASS, STYLE_DEFS and AFTER_ID."
+  task restyle: ["images:reset_styles", "images:regenerate_thumbnails"]
 
   def obtain_styles
     # Env var STYLES is used by paperclip for a list of styles.

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -46,7 +46,8 @@ namespace :images do
     end
   end
 
-  desc "Regenerates thumbnails for a given CLASS (and optional ATTACHMENT and STYLES splitted by comma)."
+  desc "Regenerates thumbnails for a given CLASS"\
+       " (and optional ATTACHMENT and STYLES splitted by comma)."
   task regenerate_thumbnails: :environment do
     klass = Paperclip::Task.obtain_class
     names = Paperclip::Task.obtain_attachments(klass)
@@ -55,7 +56,7 @@ namespace :images do
     names.each do |name|
       instances_with_attachment_after_id(klass, name, after_id).find_each do |instance|
         print "processing #{klass} ID #{instance.id}:"
-        instance.send(name).reprocess!(*styles)
+        instance.public_send(name).reprocess!(*styles)
         if instance.errors.blank?
           puts " done."
         else
@@ -66,7 +67,7 @@ namespace :images do
     end
   end
 
-  desc "Restyle thumbnails for a future deployment. Use CLASS, STYLE_DEFS and AFTER_ID."
+  desc "Restyle thumbnails for a future deployment, use CLASS, STYLE_DEFS and AFTER_ID."
   task restyle: ["images:reset_styles", "images:regenerate_thumbnails"]
 
   def obtain_styles

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+namespace :images do
+  task reset_styles: :environment do
+    klass = Paperclip::Task.obtain_class
+    names = Paperclip::Task.obtain_attachments(klass)
+    styles = obtain_styles
+
+    names.each do |name|
+      Kernel.const_get(klass).attachment_definitions[name][:styles] = styles
+    end
+  end
+
+  desc "Restyle thumbnails for a future deployment."
+  task restyle: ["images:reset_styles", "paperclip:refresh:thumbnails"]
+
+  def obtain_styles
+    # Env var STYLES is used by paperclip for a list of styles.
+    # Choosing a different name for a hash of style definitions here.
+    styles = ENV.fetch("STYLE_DEFS") do
+      raise 'Must specify styles like STYLE_DEFS=\'{"small":["227x227#","jpg"]}\''
+    end
+
+    Spree::Image.format_styles(JSON.parse(styles))
+  end
+end

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -52,7 +52,7 @@ namespace :images do
     names = Paperclip::Task.obtain_attachments(klass)
     styles = (ENV['STYLES'] || ENV['styles'] || '').split(',').map(&:to_sym)
     names.each do |name|
-      Paperclip.each_instance_with_attachment(klass, name) do |instance|
+      instances_with_attachment(klass, name).find_each do |instance|
         print "processing #{klass} ID #{instance.id}:"
         instance.send(name).reprocess!(*styles)
         if instance.errors.blank?
@@ -76,5 +76,9 @@ namespace :images do
     end
 
     Spree::Image.format_styles(JSON.parse(styles))
+  end
+
+  def instances_with_attachment(klass, name)
+    Paperclip.class_for(klass).unscoped.where("#{name}_file_name IS NOT NULL")
   end
 end

--- a/script/restyle-images.sh
+++ b/script/restyle-images.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Starts and resumes reprocessing of all thumbnail images.
+
+set -e
+
+log="log/images-restyle.log"
+last_id="0"
+styles="$1"
+
+if [ -r "$log" ]; then
+  last_id="$(tail -1 "$log" | sed 's/^processing Spree::Image ID \([0-9]*\): done.$/\1/')"
+fi
+
+bundle exec rake images:restyle\
+  CLASS=Spree::Image\
+  AFTER_ID="$last_id"\
+  STYLE_DEFS="$styles"\
+  >> "$log"

--- a/spec/lib/tasks/images_rake_spec.rb
+++ b/spec/lib/tasks/images_rake_spec.rb
@@ -92,7 +92,9 @@ describe "images.rake" do
         "STYLES" => "small",
       }
       stub_const("ENV", ENV.to_hash.merge(env))
-      subject.execute
+      expect {
+        subject.execute
+      }.to output(/ done\./).to_stdout
     end
   end
 end

--- a/spec/lib/tasks/images_rake_spec.rb
+++ b/spec/lib/tasks/images_rake_spec.rb
@@ -96,5 +96,29 @@ describe "images.rake" do
         subject.execute
       }.to output(/ done\./).to_stdout
     end
+
+    it "reprocesses some images" do
+      images = [1, 2].map do
+        Spree::Image.create!(
+          attachment: image_file,
+          viewable_id: variant.id,
+          viewable_type: variant.class.name,
+        )
+      end
+
+      attachment = double(Paperclip::Attachment)
+      allow(Paperclip::Attachment).to receive(:new).and_return(attachment)
+      expect(attachment).to receive(:reprocess!).with(:small).once
+
+      env = {
+        "CLASS" => "Spree::Image",
+        "STYLES" => "small",
+        "AFTER_ID" => images.first.id.to_s,
+      }
+      stub_const("ENV", ENV.to_hash.merge(env))
+      expect {
+        subject.execute
+      }.to output(/ done\./).to_stdout
+    end
   end
 end

--- a/spec/lib/tasks/images_rake_spec.rb
+++ b/spec/lib/tasks/images_rake_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rake'
+
+describe "images.rake" do
+  before(:all) do
+    Rake.application.rake_require 'tasks/images'
+    Rake.application.rake_require 'tasks/paperclip'
+    Rake::Task.define_task(:environment)
+  end
+
+  describe ":reset_styles" do
+    let(:subject) { Rake::Task["images:reset_styles"] }
+
+    it "parses and sets given image styles" do
+      env = {
+        "CLASS" => "Spree::Image",
+        "STYLE_DEFS" => '{"small":["227x227#","jpg"]}',
+      }
+      stub_const("ENV", ENV.to_hash.merge(env))
+
+      subject.execute
+
+      expect(Spree::Image.attachment_definitions[:attachment][:styles]).to eq(
+        small: ["227x227#", :jpg]
+      )
+    end
+  end
+end

--- a/spec/lib/tasks/users_rake_spec.rb
+++ b/spec/lib/tasks/users_rake_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 require 'rake'
 
 describe 'users.rake' do
+  before(:all) do
+    Rake.application.rake_require 'tasks/users'
+    Rake::Task.define_task(:environment)
+  end
+
   describe ':remove_enterprise_limit' do
     context 'when the user exists' do
       it 'sets the enterprise_limit to the maximum integer' do
-        Rake.application.rake_require 'tasks/users'
-        Rake::Task.define_task(:environment)
-
         max_integer = 2_147_483_647
         user = create(:user)
 


### PR DESCRIPTION
#### What? Why?

The new product listing #4598 requires bigger product images. This pull request contains a fix and tools to clean up and regenerate existing images.

Since regenerating all images takes a long time, it would be good to apply some other tweaks to the image formats. While we are probably not going ahead with https://github.com/openfoodfoundation/ofn-install/pull/651, the styles listed there is what we want to use in the future:
```json
{"mini":["48x48#","jpg"],"small":["227x227#","jpg"],"product":["240x240>","jpg"],"large":["600x600>","jpg"]}
```

Applying the new styles is blocking the final merge of the product listing feature branch.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Dev test.

- Choose a staging server different to au-staging. I tested these scripts there already and the images are already converted.
- Deploy this pull request.
- Identify a product image that was uploaded as PNG (or upload one).
- Check that the image is displayed in the shopfront in the listing (style: small) and in the product modal (style: product).
- Check the `:product` or `:large` thumbnail which is still PNG.
- Load the URL of a thumbnail in the browser.
- Change the URL to `.jpg` instead of `.png`.
- The image should be missing. Otherwise this was generated on this server before.
- Then ssh into the server:

```sh
cd apps/openfoodnetwork/current

# Identify which images are still physically present.
bundle exec rake paperclip:refresh:metadata CLASS=Spree::Image # This can take a while.

# Remove records of non-existing images to speed things up:
bundle exec rails runner script/delete-orphaned-image-records.rb
DELETE_IMAGES=true bundle exec rails runner script/delete-orphaned-image-records.rb

# Create new thumbnails with new styles:
bundle exec rake images:restyle CLASS=Spree::Image AFTER_ID=0 STYLE_DEFS='{"mini":["48x48#","jpg"],"small":["227x227#","jpg"],"product":["240x240\u003E","jpg"],"large":["600x600\u003E","jpg"]}'

# Cancel the restyle task with ctrl+c and repeat the above command with another AFTER_ID.
# The task should start processing images after that id.
```

- Reload the previously missing JPG. It should now exist.
- If you now change the style in Admin/Settings/Images, the shopfront should still display the image.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added development tools to resize images and change file types.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

These are the tools to resize images and two things depend on this:

- Image format standardisation #5911. Before we change the styles in production, we need to generate the new image files.
- Mobile product listing #4598. It needs larger images. But before we apply this, we should standardise the styles.

We can run this on all servers with Ansible:
```sh
ansible all-staging -u openfoodnetwork -a "cd ~/apps/openfoodnetwork/current && bundle exec rake images:restyle ... > log/restyle.log"
```