### PR TITLE
Tax display

### DIFF
--- a/app/services/order_tax_adjustments_fetcher.rb
+++ b/app/services/order_tax_adjustments_fetcher.rb
@@ -32,7 +32,7 @@ class OrderTaxAdjustmentsFetcher
   end
 
   def line_item_adjustments
-    table[:adjustable_id].eq(order.line_item_ids.join(','))
+    table[:adjustable_id].eq_any(order.line_item_ids)
       .and(table[:adjustable_type].eq('Spree::LineItem'))
   end
 

--- a/spec/services/order_tax_adjustments_fetcher_spec.rb
+++ b/spec/services/order_tax_adjustments_fetcher_spec.rb
@@ -90,8 +90,7 @@ describe OrderTaxAdjustmentsFetcher do
       expect(subject.size).to eq(4)
     end
 
-    xit "contains tax on line_item" do
-      # This should be the sum of tax on all line items, but only returns tax for one.
+    it "contains tax on all line_items" do
       expect(subject[tax_rate10]).to eq(8.0)
     end
 

--- a/spec/services/order_tax_adjustments_fetcher_spec.rb
+++ b/spec/services/order_tax_adjustments_fetcher_spec.rb
@@ -54,11 +54,12 @@ describe OrderTaxAdjustmentsFetcher do
                                   distributors: [coordinator],
                                   variants: [variant])
     end
-    let(:line_item) { create(:line_item, variant: variant, price: 44.0) }
+    let(:line_item1) { create(:line_item, variant: variant, price: 44.0) }
+    let(:line_item2) { create(:line_item, variant: variant, price: 44.0) }
     let(:order) do
       create(
         :order,
-        line_items: [line_item],
+        line_items: [line_item1, line_item2],
         bill_address: create(:address),
         order_cycle: order_cycle,
         distributor: coordinator,
@@ -89,8 +90,9 @@ describe OrderTaxAdjustmentsFetcher do
       expect(subject.size).to eq(4)
     end
 
-    it "contains tax on line_item" do
-      expect(subject[tax_rate10]).to eq(4.0)
+    xit "contains tax on line_item" do
+      # This should be the sum of tax on all line items, but only returns tax for one.
+      expect(subject[tax_rate10]).to eq(8.0)
     end
 
     it "contains tax on shipping_fee" do


### PR DESCRIPTION
#### What? Why?

Closes #5986

The `OrderTaxAdjustmentsFetcher` service was not correctly summing tax on all line items in the order, but only returning the tax on one line item.

#### What should we test?
<!-- List which features should be tested and how. -->

With multiple line items in an order that have different tax rates; displayed tax totals in invoice template and sales tax report should be correct for the order (screenshots in issue).

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed display of tax totals in invoices and tax reports.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

