### PR TITLE
Fix incorrect translation of state for CA

### DIFF
--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -3301,7 +3301,7 @@ en_CA:
         sortable_header:
           name: "Name"
           number: "Number"
-          state: "Province"
+          state: "State"
           payment_state: "Payment State"
           shipment_state: "Shipment State"
           email: "Email"


### PR DESCRIPTION
#### What? Why?

@tschumilas mentioned that a while ago she had searched for "state" and replaced all occurrences with "province", resulting in an incorrect column header that was intended to mean the "state" of an order. 

#### What should we test?
The column header should now be correct. 

#### Release notes
Fixed an admin column header that was incorrectly translated for Canadian stores. 

Changelog Category: Fixed

#### Discourse thread

#### Dependencies


#### Documentation updates

