### PR TITLE
[Rails 4.1] Permalink check CSRF

### DIFF
--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -6,6 +6,8 @@ class EnterprisesController < BaseController
   include OrderCyclesHelper
   include SerializerHelper
 
+  protect_from_forgery except: :check_permalink
+
   # These prepended filters are in the reverse order of execution
   prepend_before_action :set_order_cycles, :require_distributor_chosen, :reset_order, only: :shop
 


### PR DESCRIPTION
#### What? Why?

Part of #5606

Fixes a number of CSRF errors (I'm not sure if it's all of them) eg:

```
ActionController::InvalidCrossOriginRequest: Security warning: an embedded <script> tag on another site requested protected JavaScript.
If you know what you're doing, go ahead and disable forgery protection on this action to permit cross-origin JavaScript embedding.
```

This PR disables strict CSRF protection for the `EnterprisesController#check_permalink` action.

The new tighter security in Rails 4.1 was blocking access to this route for requests originating from javascript. The route is not a security concern (it just checks if a given enterprise permalink is already taken or not) and allowing access to it from javascript without strict CSRF checks seems reasonable.

#### What should we test?
<!-- List which features should be tested and how. -->

Fixed CSRF errors in `spec/features/admin/enterprise_roles_spec.rb` and `spec/features/admin/enterprise_spec.rb`.


