### PR TITLE
Improve checkout panels UX

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/checkout/details_controller.js.coffee
@@ -3,14 +3,6 @@ Darkswarm.controller "DetailsCtrl", ($scope, $timeout, $http, CurrentUser, Authe
   $scope.name = "details"
   $scope.nextPanel = "billing"
 
-  $scope.login_or_next = (event) ->
-    event.preventDefault()
-    unless CurrentUser.id
-      $scope.ensureUserIsGuest($scope.next)
-      return
-
-    $scope.next()
-
   $scope.summary = ->
     [$scope.fullName(),
     $scope.order.email,

--- a/app/assets/javascripts/darkswarm/mixins/fieldset_mixin.js.coffee
+++ b/app/assets/javascripts/darkswarm/mixins/fieldset_mixin.js.coffee
@@ -1,10 +1,4 @@
 window.FieldsetMixin = ($scope)->
-  $scope.next = (event = false)->
-    event.preventDefault() if event
-    return unless $scope.nextPanel
-    $scope.accordion[$scope.name] = false
-    $scope.show $scope.nextPanel
-
   $scope.onTimeout = ->
     $scope.accordion[$scope.name] = !$scope[$scope.name].$valid
 

--- a/app/views/checkout/_billing.html.haml
+++ b/app/views/checkout/_billing.html.haml
@@ -39,8 +39,3 @@
 
             .small-6.columns.right
               = validated_select t(:country), "order.bill_address.country_id", {}, {"ng-init" => "order.bill_address.country_id = order.bill_address.country_id || #{Spree::Config[:default_country_id]}", "ng-options" => "c.id as c.name for c in countries"}
-
-      .row
-        .small-12.columns.text-right
-          %button.primary{"ng-disabled" => "billing.$invalid", "ng-click" => "next($event)"}
-            = t :next

--- a/app/views/checkout/_details.html.haml
+++ b/app/views/checkout/_details.html.haml
@@ -25,9 +25,3 @@
 
         .small-6.columns
           = validated_input t(:phone), 'order.bill_address.phone', inputmode: "tel"
-
-      .row
-        .small-12.columns.text-right
-          %button.primary{"ng-disabled" => "details.$invalid", "ng-click" => "login_or_next($event)"}
-            = t :next
-

--- a/app/views/checkout/_shipping.html.haml
+++ b/app/views/checkout/_shipping.html.haml
@@ -54,8 +54,3 @@
         .small-12.columns
           %label{ for: 'order_special_instructions'}= t(:checkout_instructions)
           = f.text_area :special_instructions, size: "60x4", "ng-model" => "order.special_instructions"
-
-      .row
-        .small-12.columns.text-right
-          %button.primary{"ng-disabled" => "shipping.$invalid", "ng-click" => "next($event)"}
-            = t :next

--- a/spec/features/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/features/consumer/shopping/checkout_auth_spec.rb
@@ -70,9 +70,7 @@ feature "As a consumer I want to check out my cart", js: true do
         fill_in 'Email', with: user.email
         fill_in 'Phone', with: '098712736'
 
-        within '#details' do
-          click_button 'Next'
-        end
+        click_button 'Place order now'
 
         expect(page).to have_selector 'div.login-modal', visible: true
         expect(page).to have_content I18n.t('devise.failure.already_registered')


### PR DESCRIPTION
#### What? Why?

Removes the "Next" buttons on checkout panels and the jumping around caused by closing the current panel. Going back to good old-fashioned scrolling. It also means the only big primary button on the page is the place order button :ok_hand: 

#### What should we test?
<!-- List which features should be tested and how. -->

Checkout panel "Next" buttons are removed.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Removed "Next" buttons in checkout panels.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->



#### Animated GIF

![Checkout](https://user-images.githubusercontent.com/9029026/97510432-0169fc80-1985-11eb-911a-785bd12f7da0.gif)

Nothing jumps around or scrolls or moves unexpectedly :tada: