### PR TITLE
Hide Stripe during payment method creation if Stripe hasn't been configured

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -138,7 +138,8 @@ module Spree
       # Don't show stripe as an option if Stripe Connect hasn't been set up for any hubs.
       def show_stripe?
         hubs = Enterprise.managed_by(spree_current_user).is_distributor
-        return false unless hubs.map { |h| h.stripe_account }.compact.count > 0
+        return false unless hubs.map(&:stripe_account).compact.count.positive?
+
         Spree::Config.stripe_connect_enabled ||
           stripe_payment_method?
       end

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -134,8 +134,11 @@ module Spree
       end
 
       # Show Stripe as an option if enabled, or if the
-      # current payment_method is already a Stripe method
+      # current payment_method is already a Stripe method.
+      # Don't show stripe as an option if Stripe Connect hasn't been set up for any hubs.
       def show_stripe?
+        hubs = Enterprise.managed_by(spree_current_user).is_distributor
+        return false unless hubs.map { |h| h.stripe_account }.compact.count > 0
         Spree::Config.stripe_connect_enabled ||
           stripe_payment_method?
       end


### PR DESCRIPTION
Hide stripe in payment method creation if no enterprises have set up stripe connect. 

Addresses (and maybe completely solves) #4713 

#### What? Why?

Closes #4713, if we decide it's sufficient. 

If I understand the issue correctly, we'd like to not allow people to create a payment method that uses Stripe if they haven't set up Stripe connect. The 500 error looks like it was addressed already in https://github.com/openfoodfoundation/openfoodnetwork/pull/4758. This goes further and hides the Stripe methods from the drop down during payment method creation. 

We could go further and validate based on which enterprises the payment method is being added to; for example, if one out of four enterprises that a user manages has Stripe Connect set up, the option will appear in the drop down. The user could then choose it, and select an enterprise that *doesn't* have it set up. We could try catching this case as well if it seems like it would have sufficient impact. 

We could also go further and include a link below the drop down if the Stripe options are not shown, explaining why they're not shown and giving the user a link to connect to Stripe. 

#### What should we test?
With an enterprise that doesn't have Stripe connected, create a new payment method. The drop down for Provider should not have Stripe providers as an option. 

#### Release notes
Only show Stripe as a provider during payment method creation if Stripe Connect has been configured. 

Changelog Category: Changed

#### Discourse thread
#### Dependencies
#### Documentation updates