### PR TITLE
Fix uninitialized constant error when running model specs

### DIFF
--- a/spec/models/adjustment_metadata_spec.rb
+++ b/spec/models/adjustment_metadata_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe AdjustmentMetadata do
   it "is valid when build from factory" do
     adjustment = create(:adjustment)


### PR DESCRIPTION
#### What? Why?

When running the model specs with `bundle exec rspec spec/models`, the following error occurs:

```
An error occurred while loading ./spec/models/adjustment_metadata_spec.rb.
Failure/Error:
  describe AdjustmentMetadata do
    it "is valid when build from factory" do
      adjustment = create(:adjustment)
      expect(adjustment).to be_valid
    end
  end
NameError:
  uninitialized constant AdjustmentMetadata
# ./spec/models/adjustment_metadata_spec.rb:1:in `<top (required)>'
```

The PR fixes the issue by requiring `spec_helper` in the `AdjustmentMetadata` model spec.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Run `bundle exec rspec spec` and make sure the tests pass.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

