### PR TITLE
Remove Hash#diff from cancan helper

### DIFF
--- a/spec/support/cancan_helper.rb
+++ b/spec/support/cancan_helper.rb
@@ -13,7 +13,8 @@ module Spree
       ability_hash.each do |action, _true_or_false|
         @ability_result[action] = ability.can?(action, target)
       end
-      ability_hash.diff(@ability_result).none?
+
+      expect(ability_hash).to eq(@ability_result)
     end
 
     failure_message do |user|
@@ -21,7 +22,7 @@ module Spree
       ability_hash = { ability_hash => true } if ability_hash.is_a? Symbol # e.g.: :create
       ability_hash = ability_hash.inject({}){ |member, i| member.merge(i => true) } if ability_hash.is_a? Array # e.g.: [:create, :read] => {:create=>true, :read=>true}
       target = options[:for]
-      message = "expected User:#{user} to have ability:#{ability_hash} for #{target}, but actual result is #{@ability_result}"
+      message = "expected User:#{user} to have ability: #{ability_hash} for #{target}, but actual result is #{@ability_result}"
     end
 
     # to clean up output of RSpec Documentation format


### PR DESCRIPTION
#### What? Why?

Replaces `Hash#diff` with `Enumerable#inject` to remove a bunch of the following deprecation warnings on `Hash#diff` usage in `spec/support/cancan_helper.rb`. 
```
DEPRECATION WARNING: Hash#diff is no longer used inside of Rails, and is being deprecated with no replacement. If you're using it to compare hashes for the purpose of testing, please use MiniTest's assert_equal instead. (called from block (2 levels) in <module:Spree> at /spec/support/cancan_helper.rb:16)
```

And updates the failure message of the `have_ability` matcher for readability.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Run `bundle exec rspec spec/models/spree/ability_spec.rb` and make sure the tests pass. 

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are their any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

