### PR TITLE
Add oz and lb as allowed units in product import

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -159,7 +159,7 @@ module ProductImport
     end
 
     def unit_fields_validation(entry)
-      unit_types = ['g', 'kg', 't', 'ml', 'l', 'kl', '']
+      unit_types = ['g', 'oz', 'lb', 'kg', 't', 'ml', 'l', 'kl', '']
 
       unless entry.units&.present?
         mark_as_invalid(entry, attribute: 'units',


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/6042

This is another example of why it would be *really nice* to have a single place where our units all live... if we could do something like `Units.keys` in the entry_validator, when we change it once it changes everywhere. 

I think it'd be better to get this patch out along with the rest of the imperial units changes, but I can look at refactoring in a separate PR. 

#### What should we test?
I used the following .csv files, slightly modified from those in the issue, to work with the default seed data: 

lb:
```
producer,sku,name,display_name,category,description,units,unit_type,variant_unit_name,price,on_hand,available_on,on_demand,shipping_category,tax_category
Fredo's Farm Hub,1,lb product,LB,Products,,1,lb,,3,50,,,Default,Tax Category
```

oz:
```
producer,sku,name,display_name,category,description,units,unit_type,variant_unit_name,price,on_hand,available_on,on_demand,shipping_category,tax_category
Fredo's Farm Hub,1,oz product,OZ,Products,,1,oz,,3,50,,,Default,Tax Category
```

Uploading these files should not throw a unit error in product import. 

#### Release notes
Pounds and ounces are now supported in product import. 

Changelog Category: Added

#### Discourse thread

#### Dependencies

#### Documentation updates
