### PR TITLE
Added Bash scripts for logging the long screen output of routine tasks

### DIFF
--- a/build-log.sh
+++ b/build-log.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set +e
+
+docker-compose down -v --remove-orphans
+wait
+echo '###########################'
+echo 'BEGIN: docker-compose build'
+echo '###########################'
+docker-compose build
+echo '##############################'
+echo 'FINISHED: docker-compose build'
+echo '##############################'

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+DATE=`date +%Y%m%d-%H%M%S-%3N`
+bash build-log.sh 2>&1 | tee log/build-$DATE.log

--- a/build.sh
+++ b/build.sh
@@ -3,3 +3,4 @@ set -e
 
 DATE=`date +%Y%m%d-%H%M%S-%3N`
 bash build-log.sh 2>&1 | tee log/build-$DATE.log
+bash seed.sh 2>&1 | tee log/seed-$DATE.log

--- a/cop.sh
+++ b/cop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose run web bundle exec rubocop -D

--- a/nuke.sh
+++ b/nuke.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script destroys all Docker containers and images.
+# SOURCE: https://gist.github.com/JeffBelback/5687bb02f3618965ca8f
+
+bash nukec.sh
+
+echo '--------------------------------------'
+echo 'Killing and removing all Docker images'
+for i in $(docker images -a -q)
+do
+  docker kill $i; wait;
+  docker rmi -f $i; wait;
+done;
+
+echo '------------'
+echo 'docker ps -a'
+docker ps -a
+
+echo '----------------'
+echo 'docker images -a'
+docker images -a
+
+wait

--- a/nukec.sh
+++ b/nukec.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script destroys all Docker containers and networks but leaves the Docker images alone.
+
+echo '-----------------------'
+echo 'docker network prune -f'
+docker network prune -f
+
+echo '------------------------------------------'
+echo 'Killing and removing all Docker containers'
+for i in $(docker ps -a -q)
+do
+  docker kill $i; wait;
+  docker rm -f $i; wait;
+done;
+
+echo '------------'
+echo 'docker ps -a'
+docker ps -a

--- a/seed.sh
+++ b/seed.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo '-------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:reset'
+echo '-------------------------------------------------------'
+docker-compose run web bundle exec rake db:reset
+echo '-----------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:reset'
+echo '-----------------------------------------------------'
+
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake db:test:prepare
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo '------------------------------------------------------------'
+
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake ofn:sample_data'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake ofn:sample_data
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake ofn:sample_data'
+echo '------------------------------------------------------------'

--- a/server-log.sh
+++ b/server-log.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set +e
+
+echo '########################'
+echo 'BEGIN: docker-compose up'
+echo '########################'
+echo 'View this app in your web browser at'
+echo 'http://localhost:3000/'
+docker-compose up

--- a/server.sh
+++ b/server.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+DATE=`date +%Y%m%d-%H%M%S-%3N`
+bash server-log.sh 2>&1 | tee log/server-$DATE.log

--- a/test-log.sh
+++ b/test-log.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake db:test:prepare
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo '------------------------------------------------------------'
+
+echo '----------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rspec spec'
+echo '----------------------------------------------------'
+docker-compose run web bundle exec rspec spec
+echo '--------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rspec spec'
+echo '--------------------------------------------------'

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+DATE=`date +%Y%m%d-%H%M%S-%3N`
+bash test-log.sh 2>&1 | tee log/test-$DATE.log

--- a/testc.sh
+++ b/testc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script runs the controller tests and RuboCop.
+
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake db:test:prepare
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo '------------------------------------------------------------'
+
+echo '----------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec spec/controllers'
+echo '----------------------------------------------------------'
+docker-compose run web bundle exec rspec spec/controllers
+echo '--------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rspec spec/controllers'
+echo '--------------------------------------------------------------'
+
+bash cop.sh

--- a/testm.sh
+++ b/testm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script runs the model tests and RuboCop.
+
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake db:test:prepare
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo '------------------------------------------------------------'
+
+echo '-----------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec spec/models'
+echo '-----------------------------------------------------'
+docker-compose run web bundle exec rspec spec/models
+echo '---------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rspec spec/models'
+echo '---------------------------------------------------------'
+
+bash cop.sh


### PR DESCRIPTION
The nuke.sh and nukec.sh scripts are for cleaning up all Docker images and containers.  This makes a fresh start possible, which is necessary for making sure that the setup procedure is comprehensive and isn't out-of-date.

Some routine tasks (especially testing) produce a flood of screen output.  I've added other Bash scripts for executing these tasks AND logging the screen output.  I find these logs to be necessary for troubleshooting and debugging.