### PR TITLE
Remove sleep calls from select2 helper

### DIFF
--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -265,12 +265,12 @@ feature '
         it "displays a select box for producers, which filters line items by the selected supplier" do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
-          open_select2 "div.select2-container#s2id_supplier_filter"
+          open_select2 "#s2id_supplier_filter"
           expect(page).to have_selector "div.select2-drop-active ul.select2-results li", text: "All"
           Enterprise.is_primary_producer.map(&:name).each do |sn|
             expect(page).to have_selector "div.select2-drop-active ul.select2-results li", text: sn
           end
-          close_select2 "#s2id_supplier_filter"
+          close_select2
           select2_select s1.name, from: "supplier_filter"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
@@ -303,12 +303,12 @@ feature '
         it "displays a select box for distributors, which filters line items by the selected distributor" do
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "tr#li_#{li2.id}"
-          open_select2 "div.select2-container#s2id_distributor_filter"
+          open_select2 "#s2id_distributor_filter"
           expect(page).to have_selector "div.select2-drop-active ul.select2-results li", text: "All"
           Enterprise.is_distributor.map(&:name).each do |dn|
             expect(page).to have_selector "div.select2-drop-active ul.select2-results li", text: dn
           end
-          close_select2 "#s2id_distributor_filter"
+          close_select2
           select2_select d1.name, from: "distributor_filter"
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"

--- a/spec/features/admin/configuration/states_spec.rb
+++ b/spec/features/admin/configuration/states_spec.rb
@@ -37,7 +37,7 @@ describe "States" do
   context "creating and editing states" do
     it "should allow an admin to edit existing states", js: true do
       go_to_states_page
-      set_select2_field("country", country.id)
+      select2_select country.name, from: "country"
 
       click_link "new_state_link"
       fill_in "state_name", with: "Calgary"
@@ -49,7 +49,7 @@ describe "States" do
 
     it "should allow an admin to create states for non default countries", js: true do
       go_to_states_page
-      set_select2_field "#country", @hungary.id
+      select2_select @hungary.name, from: "country"
       # Just so the change event actually gets triggered in this spec
       # It is definitely triggered in the "real world"
       page.execute_script("$('#country').trigger('change');")
@@ -65,8 +65,7 @@ describe "States" do
 
     it "should show validation errors", js: true do
       go_to_states_page
-      set_select2_field("country", country.id)
-
+      select2_select country.name, from: "country"
       click_link "new_state_link"
 
       fill_in "state_name", with: ""

--- a/spec/features/admin/enterprise_groups_spec.rb
+++ b/spec/features/admin/enterprise_groups_spec.rb
@@ -33,8 +33,8 @@ feature '
     fill_in 'enterprise_group_name', with: 'EGEGEG'
     fill_in 'enterprise_group_description', with: 'This is a description'
     check 'enterprise_group_on_front_page'
-    targetted_select2_search e1.name, from: '#s2id_enterprise_group_enterprise_ids'
-    targetted_select2_search e2.name, from: '#s2id_enterprise_group_enterprise_ids'
+    select2_select e1.name, from: 'enterprise_group_enterprise_ids', search: true
+    select2_select e2.name, from: 'enterprise_group_enterprise_ids', search: true
     click_link 'Contact'
     fill_in 'enterprise_group_address_attributes_phone', with: '000'
     fill_in 'enterprise_group_address_attributes_address1', with: 'My Street'

--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -117,7 +117,7 @@ feature '
 
       it "allows adding new managers" do
         within 'table.managers' do
-          targetted_select2_search user3.email, from: '#s2id_ignored'
+          select2_select user3.email, from: 'ignored', search: true
 
           # user3 has been added and has an unconfirmed email address
           expect(page).to have_css "tr#manager-#{user3.id}"

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -125,7 +125,7 @@ feature '
     expect(page).to have_selector "#payment_methods"
     expect(page).to have_selector "#shipping_methods"
 
-    multi_select2_select eg1.name, from: 'enterprise_group_ids'
+    select2_select eg1.name, from: 'enterprise_group_ids'
 
     accept_alert do
       click_link "Payment Methods"

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -191,7 +191,7 @@ feature '
         fill_in 'order_cycle_orders_open_at', with: '2040-11-06 06:00:00'
         fill_in 'order_cycle_orders_close_at', with: '2040-11-13 17:00:00'
         expect(page).not_to have_select2 'schedule_ids', with_options: [schedule_of_other_managed_distributor.name]
-        multi_select2_select schedule.name, from: 'schedule_ids'
+        select2_select schedule.name, from: 'schedule_ids'
 
         click_button 'Add coordinator fee'
         select 'Managed distributor fee', from: 'order_cycle_coordinator_fee_0_id'
@@ -246,7 +246,7 @@ feature '
         visit edit_admin_order_cycle_path(oc)
 
         expect(page).to have_field 'order_cycle_name', with: oc.name
-        multi_select2_select schedule.name, from: 'schedule_ids'
+        select2_select schedule.name, from: 'schedule_ids'
         expect(page).not_to have_select2 'schedule_ids', with_options: [schedule_of_other_managed_distributor.name]
 
         click_button 'Save and Next'

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -50,7 +50,7 @@ feature '
     open_select2('#s2id_order_distributor_id')
     expect(page).to have_selector "ul.select2-results li.select2-result.select2-disabled",
                                   text: distributor_disabled.name
-    close_select2('#s2id_order_distributor_id')
+    close_select2
 
     # Order cycle selector should be disabled
     expect(page).to have_selector "#s2id_order_order_cycle_id.select2-container-disabled"
@@ -64,7 +64,7 @@ feature '
     # it suppresses validation errors when setting distribution
     expect(page).not_to have_selector '#errorExplanation'
     expect(page).to have_content 'ADD PRODUCT'
-    targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+    select2_select product.name, from: 'add_variant_id', search: true
     find('button.add_variant').click
     page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr" # Wait for JS
     expect(page).to have_selector 'td', text: product.name
@@ -80,7 +80,7 @@ feature '
   scenario "can add a product to an existing order" do
     login_as_admin_and_visit spree.edit_admin_order_path(order)
 
-    targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+    select2_select product.name, from: 'add_variant_id', search: true
 
     find('button.add_variant').click
 
@@ -146,7 +146,7 @@ feature '
     # When I create a new order
     login_as user
     new_order_with_distribution(distributor, order_cycle)
-    targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+    select2_select product.name, from: 'add_variant_id', search: true
     find('button.add_variant').click
     page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr" # Wait for JS
     click_button 'Update'
@@ -157,8 +157,7 @@ feature '
     expect(page).to have_selector '#select-customer'
 
     # And I select that customer's email address and save the order
-    targetted_select2_search customer.email, from: '#customer_search_override',
-                                             dropdown_css: '.select2-drop'
+    select2_select customer.email, from: 'customer_search_override', search: true
     click_button 'Update'
     expect(page).to have_selector "h1.js-admin-page-title", text: "Customer Details"
 
@@ -323,7 +322,7 @@ feature '
       new_order_with_distribution(distributor1, order_cycle1)
 
       expect(page).to have_content 'ADD PRODUCT'
-      targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+      select2_select product.name, from: 'add_variant_id', search: true
 
       find('button.add_variant').click
       page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr"

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -51,8 +51,8 @@ feature '
 
       login_as_admin_and_visit 'admin/orders'
 
-      multi_select2_select 'Two', from: 'q_order_cycle_id_in'
-      multi_select2_select 'Three', from: 'q_order_cycle_id_in'
+      select2_select 'Two', from: 'q_order_cycle_id_in'
+      select2_select 'Three', from: 'q_order_cycle_id_in'
 
       page.find('.filter-actions .button.icon-search').click
 

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -168,7 +168,7 @@ feature "Product Import", js: true do
       end
 
       expect(page).to have_selector 'div#s2id_import_date_filter'
-      import_time = carrots.import_date.to_date.to_formatted_s(:long)
+      import_time = carrots.import_date.to_date.to_formatted_s(:long).gsub('  ', ' ')
       select2_select import_time, from: "import_date_filter"
       page.find('.button.icon-search').click
 

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -534,7 +534,7 @@ feature 'Subscriptions' do
   def add_variant_to_subscription(variant, quantity)
     row_count = all("#subscription-line-items .item").length
     variant_name = variant.full_name.present? ? "#{variant.name} - #{variant.full_name}" : variant.name
-    targetted_select2_search variant.name, from: "#s2id_add_variant_id", dropdown_css: ".select2-drop", select_text: variant_name
+    select2_select variant.name, from: "add_variant_id", search: true, select_text: variant_name
     fill_in "add_quantity", with: quantity
     click_link "Add"
     expect(page).to have_selector("#subscription-line-items .item", count: row_count + 1)

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -409,7 +409,7 @@ feature "
 
       # Reproducing a bug, issue #1446
       it "shows the overridden price" do
-        targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
+        select2_select product.name, from: 'add_variant_id', search: true
         find('button.add_variant').click
         expect(page).to have_selector("table.index tbody tr") # Wait for JS
         expect(page).to have_content(product.variants.first.variant_overrides.first.price)

--- a/spec/support/matchers/select2_matchers.rb
+++ b/spec/support/matchers/select2_matchers.rb
@@ -94,7 +94,7 @@ RSpec::Matchers.define :have_select2 do |id, options = {}|
   def with_select2_open(from)
     open_select2 from
     r = yield
-    close_select2 from
+    close_select2
     r
   end
 end

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -112,8 +112,9 @@ module WebHelper
   end
 
   def select_select2_result(value)
-    sleep(1)
-    page.execute_script(%Q{$("div.select2-result-label:contains('#{value}')").mouseup()})
+    page.find(:xpath, '//body')
+      .find(:css, '.select2-drop-active .select2-result-label', text: value)
+      .click
   end
 
   # Support having different texts to search for and to click in the select2

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -100,46 +100,26 @@ module WebHelper
   end
 
   def select2_select(value, options)
-    id = options[:from]
-    options[:from] = "#s2id_#{id}"
-    targetted_select2(value, options)
-  end
+    open_select2("#s2id_#{options[:from]}")
 
-  def targetted_select2(value, options)
-    # find select2 element and click it
-    find(options[:from]).find('a').click
-    select_select2_result(value)
-  end
+    if options[:search]
+      page.find(:xpath, '//body')
+        .find(:css, '.select2-drop-active input.select2-input, .select2-dropdown-open input.select2-input')
+        .set(value)
+    end
 
-  def select_select2_result(value)
     page.find(:xpath, '//body')
-      .find(:css, '.select2-drop-active .select2-result-label', text: value)
+      .find(:css, '.select2-drop-active .select2-result-label', text: options[:select_text] || value)
       .click
   end
 
-  # Support having different texts to search for and to click in the select2
-  # field.
-  def targetted_select2_search(value, options)
-    page.execute_script %{$('#{options[:from]}').select2('open')}
-    page.execute_script "$('#{options[:dropdown_css]} input.select2-input').val('#{value}').trigger('keyup-change');"
-    select_select2_result(options[:select_text] || value)
-  end
-
-  def multi_select2_select(value, options)
-    find("#s2id_#{options[:from]}").find('ul li.select2-search-field').click
-    select_select2_result(value)
-  end
-
   def open_select2(selector)
-    page.execute_script "jQuery('#{selector}').select2('open');"
+    page.find(selector).find(:css, '.select2-choice, .select2-search-field').click
   end
 
-  def close_select2(selector)
-    page.execute_script "jQuery('#{selector}').select2('close');"
-  end
-
-  def set_select2_field(field, value)
-    page.execute_script %Q{$('#{field}').select2('val', '#{value}')}
+  def close_select2
+    # A click outside the select2 container should close it
+    page.find(:css, 'body').click
   end
 
   def accept_js_alert


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/5972

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

- Removes `sleep` calls to improve specs' performance.
- Simplifies the code by removing `targetted_select2`, `targetted_select2_search`, `multi_select2_select`, and `set_select2_field` helpers. The `select2_select` helper now handles multi select2 lists and searching for options. It opens the select2 container, searches for an option if the `search` key is passed, and selects the option or `select_text` (if passed). Ref: https://github.com/Hirurg103/capybara_select2

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
