### PR TITLE
Replace `create` with `build_stubbed` in address model specs

### DIFF
--- a/spec/models/spree/address_spec.rb
+++ b/spec/models/spree/address_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe Spree::Address do
   describe "clone" do
     it "creates a copy of the address with the exception of the id, updated_at and created_at attributes" do
-      state = create(:state)
-      original = create(:address,
+      state = build_stubbed(:state)
+      original = build_stubbed(:address,
                         address1: 'address1',
                         address2: 'address2',
                         alternative_phone: 'alternative_phone',
@@ -62,9 +62,9 @@ describe Spree::Address do
       end
     end
 
-    let(:state) { create(:state, name: 'maryland', abbr: 'md') }
+    let(:state) { build_stubbed(:state, name: 'maryland', abbr: 'md') }
     let(:country) { state.country }
-    let(:address) { create(:address, country: country, state: state) }
+    let(:address) { build_stubbed(:address, country: country, state: state) }
 
     before do
       country.states_required = true
@@ -77,15 +77,18 @@ describe Spree::Address do
     end
 
     it "full state name is in state_name and country does contain that state" do
-      allow(country.states).to receive_messages find_all_by_name_or_abbr: [create(:state, name: 'alabama', abbr: 'al')]
-      address.update state_name: 'alabama'
+      allow(country).to receive_message_chain(:states, :find_all_by_name_or_abbr) do
+        [build_stubbed(:state, name: 'alabama', abbr: 'al')]
+      end
+
+      address.state_name = 'alabama'
       expect(address).to be_valid
       expect(address.state.name).to eq 'alabama'
       expect(address.state_name).to eq 'alabama'
     end
 
     it "state abbr is in state_name and country does contain that state" do
-      allow(country.states).to receive_messages find_all_by_name_or_abbr: [state]
+      allow(country).to receive_message_chain(:states, :find_all_by_name_or_abbr) { [state] }
       address.state_name = state.abbr
       expect(address).to be_valid
       expect(address.state.abbr).to eq state.abbr
@@ -93,7 +96,7 @@ describe Spree::Address do
     end
 
     it "both state and state_name are entered and country does contain the state" do
-      allow(country.states).to receive_messages find_all_by_name_or_abbr: [state]
+      allow(country).to receive_message_chain(:states, :find_all_by_name_or_abbr) { [state] }
       address.state = state
       address.state_name = 'maryland'
       expect(address).to be_valid


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/6062

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We don't need objects in the database for the unit tests most of the time. This PR replaces `FactoryBot::Syntax::Methods#create` calls with `FactoryBot::Syntax::Methods#build_stubbed` in the `Address` model specs wherever possible.

#### What should we test?
<!-- List which features should be tested and how. -->

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
