### PR TITLE
Replace `create` with `build_stubbed` in variant override model specs

### DIFF
--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -54,7 +54,7 @@ describe VariantOverride do
           let(:count_on_hand) { nil }
 
           it "is valid" do
-            expect(variant_override.save).to be_truthy
+            expect(variant_override).to be_valid
           end
         end
 
@@ -77,7 +77,7 @@ describe VariantOverride do
           let(:count_on_hand) { nil }
 
           it "is valid" do
-            expect(variant_override.save).to be_truthy
+            expect(variant_override).to be_valid
           end
         end
 
@@ -85,7 +85,7 @@ describe VariantOverride do
           let(:count_on_hand) { 1 }
 
           it "is invalid" do
-            expect(variant_override.save).to be_falsey
+            expect(variant_override).not_to be_valid
             error_message = I18n.t("on_demand_but_count_on_hand_set",
                                    scope: [i18n_scope_for_error, "count_on_hand"])
             expect(variant_override.errors[:count_on_hand]).to eq([error_message])
@@ -100,7 +100,7 @@ describe VariantOverride do
           let(:count_on_hand) { nil }
 
           it "is invalid" do
-            expect(variant_override.save).to be_falsey
+            expect(variant_override).not_to be_valid
             error_message = I18n.t("limited_stock_but_no_count_on_hand",
                                    scope: [i18n_scope_for_error, "count_on_hand"])
             expect(variant_override.errors[:count_on_hand]).to eq([error_message])
@@ -111,7 +111,7 @@ describe VariantOverride do
           let(:count_on_hand) { 1 }
 
           it "is valid" do
-            expect(variant_override.save).to be_truthy
+            expect(variant_override).to be_valid
           end
         end
       end
@@ -139,7 +139,7 @@ describe VariantOverride do
   end
 
   describe "with price" do
-    let(:variant_override) { create(:variant_override, variant: variant, hub: hub, price: 12.34) }
+    let(:variant_override) { build_stubbed(:variant_override, variant: variant, hub: hub, price: 12.34) }
 
     it "returns the numeric price" do
       expect(variant_override.price).to eq(12.34)
@@ -147,7 +147,7 @@ describe VariantOverride do
   end
 
   describe "with nil count on hand" do
-    let(:variant_override) { create(:variant_override, variant: variant, hub: hub, count_on_hand: nil, on_demand: true) }
+    let(:variant_override) { build_stubbed(:variant_override, variant: variant, hub: hub, count_on_hand: nil, on_demand: true) }
 
     describe "stock_overridden?" do
       it "returns false" do
@@ -196,12 +196,12 @@ describe VariantOverride do
 
   describe "checking default stock value is present" do
     it "returns true when a default stock level has been set" do
-      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 20)
+      vo = build_stubbed(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: 20)
       expect(vo.default_stock?).to be true
     end
 
     it "returns false when the override has no default stock level" do
-      vo = create(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: nil)
+      vo = build_stubbed(:variant_override, variant: variant, hub: hub, count_on_hand: 12, default_stock: nil)
       expect(vo.default_stock?).to be false
     end
   end


### PR DESCRIPTION
#### What? Why?

Related to #6062

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Replaces `FactoryBot::Syntax::Methods#create` calls with `FactoryBot::Syntax::Methods#build_stubbed` in the `VariantOverride` model specs wherever possible to improve the specs' performance.

#### What should we test?
<!-- List which features should be tested and how. -->


#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
