### PR TITLE
Replace `create` with `build_stubbed` in coordinator model specs

### DIFF
--- a/engines/order_management/spec/services/order_management/stock/coordinator_spec.rb
+++ b/engines/order_management/spec/services/order_management/stock/coordinator_spec.rb
@@ -5,7 +5,12 @@ require 'spec_helper'
 module OrderManagement
   module Stock
     describe Coordinator do
-      let!(:order) { create(:order_with_line_items, distributor: create(:distributor_enterprise)) }
+      let!(:order) do
+        build_stubbed(
+          :order_with_line_items,
+          distributor: build_stubbed(:distributor_enterprise)
+        )
+      end
 
       subject { Coordinator.new(order) }
 


### PR DESCRIPTION
#### What? Why?

Related to #6062

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Replaces `FactoryBot::Syntax::Methods#create` calls with `FactoryBot::Syntax::Methods#build_stubbed` in the `OrderManagement::Stock::Coordinator` model specs to improve the test suite performance.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
