### PR TITLE
Replace `create` with `build_stubbed` in shipping rate model specs

### DIFF
--- a/spec/models/spree/shipping_rate_spec.rb
+++ b/spec/models/spree/shipping_rate_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Spree::ShippingRate do
   let(:shipment) { create(:shipment) }
-  let(:shipping_method) { create(:shipping_method) }
+  let(:shipping_method) { build_stubbed(:shipping_method) }
   let(:shipping_rate) {
     Spree::ShippingRate.new(shipment: shipment,
                             shipping_method: shipping_method,


### PR DESCRIPTION
#### What? Why?

Related to #6062

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Replaces `FactoryBot::Syntax::Methods#create` calls with `FactoryBot::Syntax::Methods#build_stubbed` in the `Spree::ShippingRate` model specs to improve the test suite performance.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improve specs' performance.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
