### PR TITLE
Replace `build` with `build_stubbed` in flat percent item total specs

### DIFF
--- a/spec/models/calculator/flat_percent_item_total_spec.rb
+++ b/spec/models/calculator/flat_percent_item_total_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Calculator::FlatPercentItemTotal do
   let(:calculator) { Calculator::FlatPercentItemTotal.new }
-  let(:line_item) { build(:line_item, price: 10, quantity: 1) }
+  let(:line_item) { build_stubbed(:line_item, price: 10, quantity: 1) }
 
   before { allow(calculator).to receive_messages preferred_flat_percent: 10 }
 


### PR DESCRIPTION
#### What? Why?

Related to #6062

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Replaces `FactoryBot::Syntax::Methods#build` calls with `FactoryBot::Syntax::Methods#build_stubbed` in the `Calculator::FlatPercentItemTotal` model specs to improve the test suite performance. Note that `build` can create records for associations.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improve specs' performance.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
