### PR TITLE
Replace `build` with `build_stubbed` in price sack model specs

### DIFF
--- a/spec/models/calculator/price_sack_spec.rb
+++ b/spec/models/calculator/price_sack_spec.rb
@@ -8,7 +8,7 @@ describe Calculator::PriceSack do
     calculator.preferred_discount_amount = 1
     calculator
   end
-  let(:line_item) { build(:line_item, price: price, quantity: 2) }
+  let(:line_item) { build_stubbed(:line_item, price: price, quantity: 2) }
 
   context 'when the order amount is below preferred minimal' do
     let(:price) { 2 }


### PR DESCRIPTION
#### What? Why?

Related to #6062

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Replaces `FactoryBot::Syntax::Methods#build` calls with `FactoryBot::Syntax::Methods#build_stubbed` in the `Calculator::PriceSack` model specs to improve the test suite performance.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improve specs' performance.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
