### PR TITLE
Replace `build` with `build_stubbed` in flexi rate and per item model specs 

### DIFF
--- a/spec/models/calculator/flexi_rate_spec.rb
+++ b/spec/models/calculator/flexi_rate_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Calculator::FlexiRate do
-  let(:line_item) { build(:line_item, quantity: quantity) }
+  let(:line_item) { build_stubbed(:line_item, quantity: quantity) }
   let(:calculator) do
     Calculator::FlexiRate.new(
       preferred_first_item: 2,

--- a/spec/models/calculator/per_item_spec.rb
+++ b/spec/models/calculator/per_item_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Calculator::PerItem do
   let(:calculator) { Calculator::PerItem.new(preferred_amount: 10) }
   let(:shipping_calculable) { double(:calculable) }
-  let(:line_item) { build(:line_item, quantity: 5) }
+  let(:line_item) { build_stubbed(:line_item, quantity: 5) }
 
   it "correctly calculates on a single line item object" do
     allow(calculator).to receive_messages(calculable: shipping_calculable)


### PR DESCRIPTION
#### What? Why?

Related to #6062

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Replaces `FactoryBot::Syntax::Methods#build` calls with `FactoryBot::Syntax::Methods#build_stubbed` in `Calculator::FlexiRate` and `Calculator::PerItem` model specs to improve the test suite performance.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Improve specs' performance.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
