### PR TITLE
Make shop tabs black and capitalized in smaller screens

### DIFF
--- a/app/assets/stylesheets/darkswarm/shop_tabs.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.scss
@@ -44,7 +44,7 @@
       background: transparent;
       text-transform: capitalize;
       line-height: 1;
-      font-size: 0.875em;
+      font-size: 1em;
       padding: 1em 2em;
       border: none;
 
@@ -58,6 +58,7 @@
 
       @include breakpoint(phablet) {
         padding: 0.35em 0 0.65em 0;
+        font-size: 0.875em;
       }
     }
 

--- a/app/assets/stylesheets/darkswarm/shop_tabs.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.scss
@@ -34,7 +34,7 @@
     >a {
       outline: none;
       display: block;
-      color: $grey-500;
+      color: $black;
       font-family: "Oswald", sans-serif;
     }
 
@@ -42,7 +42,7 @@
       @include headingFont;
 
       background: transparent;
-      text-transform: uppercase;
+      text-transform: capitalize;
       line-height: 1;
       font-size: 0.875em;
       padding: 1em 2em;


### PR DESCRIPTION
#### What? Why?

Closes #4567
We make shop tabs black and capitalized if display width is below 640px to improve readability.

![image](https://user-images.githubusercontent.com/1640378/93908097-1e603f80-fcf6-11ea-8b44-82fff98d7dad.png)


#### What should we test?
We need to test readability.

#### Release notes
Changelog Category: Changed
Improved readability of shop tabs on smaller displays.
