### PR TITLE
Adds a spec to cover the input and display of dynamic content in the …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,4 +828,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/spec/features/admin/configuration/dynamic_content_spec.rb
+++ b/spec/features/admin/configuration/dynamic_content_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+
+# Defines the test link string
+TEST_LINK = "ofn test link"
+
+# Defines the test href string. This one should contain all non-encoding characters, for a URL
+TEST_HREF = ":/?#@!$&'()*+,;=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+describe 'add dynamic content to homepage' do
+	include AuthenticationHelper
+
+	before(:each) do
+		login_as_admin_and_visit spree.edit_admin_general_settings_path
+	end 
+	
+		
+	context 'edit the Content section', js: true do	
+		before(:each) do
+			click_link ("Content")
+		end 
+
+
+		# makes sure we are on the right page
+		scenario 'while on the Content section' do
+			
+			#Q1: option 1 and/or
+			expect(page).to have_current_path("/admin/contents/edit")
+
+			#option 2?
+			expect(page).to have_content("FOOTER AND EXTERNAL LINKS")
+
+		end
+		
+
+		scenario 'insert content on Footer and Links and check homepage' do
+			
+			# adds content - text and a TEST_URL constant
+			fill_in "footer_links_md", with: "[" + TEST_LINK + "]" + "(/" + TEST_HREF + ")"
+       
+        	# saves changes
+        	click_button "Update"
+        	
+        	#sees "Update" banner
+        	expect(page).to have_content("successfully updated!")
+
+        	# logout and redirection to Homepage
+            visit("/logout")
+
+            # checks whether link and href are correctly converted and displayed in the homepage, after logout
+            # Q2: would it be best to check this in separate "expect" lines? Or better this way, all in one line?
+        	expect(page).to have_selector :link, TEST_LINK, href: "/" + TEST_HREF
+
+
+			#Q3 - is defining strings in constants TEST_HREF TEST_LINK a good idea/practice? Or would it make sense to just use the strings directl on the examples above?        
+			
+        end
+
+    end
+
+end
+


### PR DESCRIPTION
…homepage

#### What? Why?

Closes #4118.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

The main goal is to increase automated testing coverage. Specifically, it aims to provide a spec covering the Redcarpet dependency. It does so by verifying that the content added to the backoffice is correctly converted and displayed in the homepage.

#### What should we test?
<!-- List which features should be tested and how. -->

Transpec output for this spec:
0 conversions, 0 incompletes, 0 warnings, 0 errors

Is this worth double checking maybe?

The build should be green.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

This spec checks if the content added under "Footer and External Links" (found under Content, as superadmin) shows up correctly in the "Keep in touch" section in the homepage.

I've documented the PR with a few questions as well - these can be removed during the review process.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

