### PR TITLE
Delete dead code brought from spree

### DIFF
--- a/app/controllers/spree/admin/tax_rates_controller.rb
+++ b/app/controllers/spree/admin/tax_rates_controller.rb
@@ -3,23 +3,12 @@ module Spree
     class TaxRatesController < ResourceController
       before_action :load_data
 
-      update.after :update_after
-      create.after :create_after
-
       private
 
       def load_data
         @available_zones = Zone.order(:name)
         @available_categories = TaxCategory.order(:name)
         @calculators = TaxRate.calculators.sort_by(&:name)
-      end
-
-      def update_after
-        Rails.cache.delete('vat_rates')
-      end
-
-      def create_after
-        Rails.cache.delete('vat_rates')
       end
 
       def permitted_resource_params


### PR DESCRIPTION
#### What? Why?

There's no such thing as vat_rates cache in ofn or spree now.
This was also deleted from spree in v2.3.
Spree 2.3 commits:
https://github.com/spree/spree/commit/5008f4a961994a37a0b57de6d09020178ae3f8a3#diff-950d8f740eb62b6d3815c4a185273837
https://github.com/spree/spree/commit/f9ce04b78c60e7c486faa83625b25f796fd6be95#diff-950d8f740eb62b6d3815c4a185273837

#### What should we test?
Green build is enough here.

#### Release notes
Changelog Category: Removed
Delete dead code related to tax rates.