### PR TITLE
Fix #6090 (Inventory import fails for products with units other than "g")

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Push your changes to a branch on your fork:
 
 ## Submitting a Pull Request
 
-Use the GitHub UI to submit a [new pull request][pr] against upstream/master. To increase the chances that your pull request is swiftly accepted please have a look at our guide to [making a great pull request][great-pr].
+Use the GitHub UI to submit a [new pull request][pr] against upstream/master. To increase the chances that your pull request is swiftly accepted please have a look at our guide to [making a great pull request][great-pr]. 
 
 TL;DR:
 * Write tests

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -253,7 +253,7 @@ module ProductImport
 
       products.flat_map(&:variants).each do |existing_variant|
         unit_scale = existing_variant.product.variant_unit_scale
-        unscaled_units = entry.unscaled_units || 0
+        unscaled_units = entry.unscaled_units.to_f || 0
         entry.unit_value = unscaled_units * unit_scale unless unit_scale.nil?
 
         if entry_matches_existing_variant?(entry, existing_variant)

--- a/spec/models/product_import/entry_validator_spec.rb
+++ b/spec/models/product_import/entry_validator_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ProductImport::EntryValidator do
+  let(:current_user) { double(:current_user) }
+  let(:import_time) { double(:import_time) }
+  let(:spreadsheet_data) { double(:spreadsheet_data) }
+  let(:editable_enterprises) { double(:editable_enterprises) }
+  let(:inventory_permissions) { double(:inventory_permissions) }
+  let(:reset_counts) { double(:reset_counts) }
+  let(:import_settings) { double(:import_settings) }
+  let(:all_entries) { double(:all_entries) }
+
+  let(:entry_validator) do
+    described_class.new(
+      current_user,
+      import_time,
+      spreadsheet_data,
+      editable_enterprises,
+      inventory_permissions,
+      reset_counts,
+      import_settings,
+      all_entries
+    )
+  end
+
+  let(:enterprise) { create(:enterprise, name: "User Enterprise") }
+
+  let(:entry_g) do
+    ProductImport::SpreadsheetEntry.new(
+      unscaled_units: "500",
+      units: "500",
+      unit_type: "g",
+      name: 'Tomato',
+      enterprise: enterprise,
+      enterprise_id: enterprise.id,
+      producer: enterprise,
+      producer_id: enterprise.id,
+      distributor: enterprise
+    )
+  end
+
+  let(:entry_kg) do
+    ProductImport::SpreadsheetEntry.new(
+      unscaled_units: "1",
+      units: "1",
+      unit_type: "kg",
+      name: 'Potatoes',
+      enterprise: enterprise,
+      enterprise_id: enterprise.id,
+      producer: enterprise,
+      producer_id: enterprise.id,
+      distributor: enterprise
+    )
+  end
+
+  describe "inventory validation" do
+    before do
+      allow(entry_validator).to receive(:import_into_inventory?) { true }
+      allow(entry_validator).to receive(:enterprise_validation) {}
+      allow(entry_validator).to receive(:producer_validation) {}
+      allow(entry_validator).to receive(:variant_of_product_validation) {}
+    end
+
+    context "products exist" do
+      let!(:product_g) {
+        create(
+          :simple_product,
+          supplier: enterprise,
+          on_hand: '100',
+          name: 'Tomato',
+          unit_value: 500,
+          variant_unit_scale: 1,
+          variant_unit: 'weight'
+        )
+      }
+
+      let!(:product_kg) {
+        create(
+          :simple_product,
+          supplier: enterprise,
+          on_hand: '100',
+          name: 'Potatoes',
+          unit_value: 1000,
+          variant_unit_scale: 1000,
+          variant_unit: 'weight'
+        )
+      }
+
+      it "validates a spreadsheet entry in g" do
+        entries = [entry_g]
+        entry_validator.validate_all(entries)
+        expect(entries.first.errors.count).to eq(0)
+      end
+
+      it "validates a spreadsheet entry in kg" do
+        entries = [entry_kg]
+        entry_validator.validate_all(entries)
+        expect(entries.first.errors.count).to eq(0)
+      end
+    end
+
+    context "products do not exist" do
+      # stub
+    end
+  end
+
+  describe "enterprise validation" do
+    # stub
+  end
+
+  describe "producer_validation" do
+    # stub
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #6090 

The entry_validator was interpreting the entry's `unit_value` as a string, e.g. `"1"`, so if the existing variant's `unit_scale` was anything other than 1 (e.g. 1000 for a product in kg), we did `"1" * 1000` and got `"11111111111111....."` :)

#### What should we test?
See issue for test procedure (thanks @filipefurtad0! 😁). We could also test one in lbs while we're at it. 

#### Release notes
Bug fix: inventory import failed for units other than "g" but now works for all valid units.

Changelog Category: Fixed


#### Discourse thread


#### Dependencies


#### Documentation updates