### PR TITLE
Fix #5989 Item counter accepts higher amount than available stock

### DIFF
--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -14,7 +14,7 @@
           = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
       - unless shipment.shipped?
         %td.item-qty-edit.hidden
-          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5
+          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :max => item.variant.on_hand
       %td.item-total.align-center
         = line_item_shipment_price(line_item, item.quantity)
 

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -14,7 +14,7 @@
           = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
       - unless shipment.shipped?
         %td.item-qty-edit.hidden
-          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :max => item.variant.on_hand
+          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5, :max => item.variant.on_hand
       %td.item-total.align-center
         = line_item_shipment_price(line_item, item.quantity)
 


### PR DESCRIPTION
#### What? Why?
Added `max` attribute to the number input in the item counter for the back office order that would allow for the order creator to order more items than the available stock. In the current state, this can create order conflicts where more items can be ordered and paid for than are available without showing the proper information on credit owed due to overpayment.

Closes #5989 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Explained in the #5989 issue report and in the steps to reproduce, there are 2 parts to this problem. Adding the max attribute to the number input for the item counter would prevent the order creator from ordering more than is available via the stepwise incremental approach.



#### What should we test?
<!-- List which features should be tested and how. -->
- Check the stepwise approach to incrementing the item counter does not get the items to be ordered past the available stock as described in the first part in the steps to reproduce.



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category:  Fixed
