### PR TITLE
[T&Cs] Messages and tooltips

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -90,3 +90,7 @@ angular.module("admin.enterprises")
 
     $scope.translation = (key) ->
       t('js.admin.enterprises.form.images.' + key)
+
+    $scope.show_terms_and_conditions_warning = (event) ->
+      unless confirm("All your buyers will have to agree to the Terms and Conditions again at checkout. Are you sure?")
+        event.preventDefault()

--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -90,7 +90,3 @@ angular.module("admin.enterprises")
 
     $scope.translation = (key) ->
       t('js.admin.enterprises.form.images.' + key)
-
-    $scope.show_terms_and_conditions_warning = (event) ->
-      unless confirm("All your buyers will have to agree to the Terms and Conditions again at checkout. Are you sure?")
-        event.preventDefault()

--- a/app/assets/javascripts/admin/enterprises/directives/terms_and_conditions_warning.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/directives/terms_and_conditions_warning.js.coffee
@@ -7,8 +7,9 @@ angular.module("admin.enterprises").directive 'termsAndConditionsWarning', ($com
     scope.hold_file_input_and_show_warning_modal = (event) ->
       event.preventDefault()
       scope.template = $compile($templateCache.get('admin/modals/terms_and_conditions_warning.html'))(scope)
-      scope.template.dialog(DialogDefaults)
-      scope.template.dialog('open')
+      if scope.template.dialog
+        scope.template.dialog(DialogDefaults)
+        scope.template.dialog('open')
       scope.$apply()
 
     element.bind 'click', scope.hold_file_input_and_show_warning_modal

--- a/app/assets/javascripts/admin/enterprises/directives/terms_and_conditions_warning.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/directives/terms_and_conditions_warning.js.coffee
@@ -1,0 +1,29 @@
+angular.module("admin.enterprises").directive 'termsAndConditionsWarning', ($compile, $templateCache, DialogDefaults, $timeout) ->
+  restrict: 'A'
+  scope: true
+
+  link: (scope, element, attr) ->
+    # This file input click handler will hold the browser file input dialog and show a warning modal
+    scope.hold_file_input_and_show_warning_modal = (event) ->
+      event.preventDefault()
+      scope.template = $compile($templateCache.get('admin/modals/terms_and_conditions_warning.html'))(scope)
+      scope.template.dialog(DialogDefaults)
+      scope.template.dialog('open')
+      scope.$apply()
+
+    element.bind 'click', scope.hold_file_input_and_show_warning_modal
+
+    # When the user presses continue in the warning modal, we open the browser file input dialog
+    scope.continue = ->
+      scope.template.dialog('close')
+
+      # unbind warning modal handler and click file input again to open the browser file input dialog
+      element.unbind('click').trigger('click')
+      # afterwards, bind warning modal handler again so that the warning is shown the next time
+      $timeout ->
+        element.bind 'click', scope.hold_file_input_and_show_warning_modal
+      return
+
+    scope.close = ->
+      scope.template.dialog('close')
+      return

--- a/app/assets/javascripts/templates/admin/modals/terms_and_conditions_info.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/terms_and_conditions_info.html.haml
@@ -1,0 +1,13 @@
+%div
+  .margin-bottom-30.text-center
+    .text-big
+      {{ 'js.admin.modals.terms_and_conditions_info.title' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_info.message_1' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_info.message_2' | t }}
+
+  .text-center
+    %input.button.red.icon-plus{ type: 'button', value: t('js.admin.modals.got_it'), ng: { click: 'close()' } }

--- a/app/assets/javascripts/templates/admin/modals/terms_and_conditions_warning.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/terms_and_conditions_warning.html.haml
@@ -1,0 +1,14 @@
+%div
+  .margin-bottom-30.text-center
+    .text-big
+      {{ 'js.admin.modals.terms_and_conditions_warning.title' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_warning.message_1' | t }}
+  .margin-bottom-30
+    %p
+      {{ 'js.admin.modals.terms_and_conditions_warning.message_2' | t }}
+
+  .text-center
+    %input.button.red{ type: 'button', value: t('js.admin.modals.close'), ng: { click: 'close()' } }
+    %input.button.red{ type: 'button', value: t('js.admin.modals.continue'), ng: { click: 'continue()' } }

--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -6,7 +6,7 @@ module TermsAndConditionsHelper
   end
 
   def terms_and_conditions_already_accepted?
-    customer_terms_and_conditions_accepted_at = spree_current_user.
+    customer_terms_and_conditions_accepted_at = spree_current_user&.
       customer_of(current_order.distributor)&.terms_and_conditions_accepted_at
 
     customer_terms_and_conditions_accepted_at.present? &&

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -6,7 +6,8 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
              :preferred_product_selection_from_inventory_only,
              :preferred_show_customer_names_to_suppliers, :owner, :contact, :users, :tag_groups,
              :default_tag_group, :require_login, :allow_guest_orders, :allow_order_changes,
-             :logo, :promo_image, :terms_and_conditions, :terms_and_conditions_file_name
+             :logo, :promo_image, :terms_and_conditions,
+             :terms_and_conditions_file_name, :terms_and_conditions_updated_at
 
   has_one :owner, serializer: Api::Admin::UserSerializer
   has_many :users, serializer: Api::Admin::UserSerializer
@@ -21,9 +22,13 @@ class Api::Admin::EnterpriseSerializer < ActiveModel::Serializer
   end
 
   def terms_and_conditions
-    return unless @object.terms_and_conditions.file?
+    return unless object.terms_and_conditions.file?
 
-    @object.terms_and_conditions.url
+    object.terms_and_conditions.url
+  end
+
+  def terms_and_conditions_updated_at
+    object.terms_and_conditions_updated_at&.to_s
   end
 
   def tag_groups

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -40,7 +40,7 @@
     %a{ href: '{{ Enterprise.terms_and_conditions }}', target: '_blank', ng: { if: 'Enterprise.terms_and_conditions' } }
       = '{{ Enterprise.terms_and_conditions_file_name }}' " uploaded on " '{{ Enterprise.terms_and_conditions_updated_at }}'
     .pad-top
-      = f.file_field :terms_and_conditions
+      = f.file_field :terms_and_conditions, accept: 'application/pdf'
     .pad-top
       %a.button.red{ href: '', ng: {click: 'removeTermsAndConditions()', if: 'Enterprise.terms_and_conditions'} }
         = t('.remove_terms_and_conditions')

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -37,7 +37,7 @@
     = f.label :terms_and_conditions, t('.terms_and_conditions')
 
   .omega.eight.columns
-    %a{ href: '{{ Enterprise.terms_and_conditions }}', ng: { if: 'Enterprise.terms_and_conditions' } }
+    %a{ href: '{{ Enterprise.terms_and_conditions }}', target: "_blank", ng: { if: 'Enterprise.terms_and_conditions' } }
       = '{{ Enterprise.terms_and_conditions_file_name }}'
     .pad-top
       = f.file_field :terms_and_conditions

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -37,8 +37,8 @@
     = f.label :terms_and_conditions, t('.terms_and_conditions')
 
   .omega.eight.columns
-    %a{ href: '{{ Enterprise.terms_and_conditions }}', target: "_blank", ng: { if: 'Enterprise.terms_and_conditions' } }
-      = '{{ Enterprise.terms_and_conditions_file_name }}'
+    %a{ href: '{{ Enterprise.terms_and_conditions }}', target: '_blank', ng: { if: 'Enterprise.terms_and_conditions' } }
+      = '{{ Enterprise.terms_and_conditions_file_name }}' " uploaded on " '{{ Enterprise.terms_and_conditions_updated_at }}'
     .pad-top
       = f.file_field :terms_and_conditions
     .pad-top

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -35,6 +35,7 @@
 .row
   .alpha.three.columns
     = f.label :terms_and_conditions, t('.terms_and_conditions')
+    %i.text-big.icon-question-sign.help-modal{ template: 'admin/modals/terms_and_conditions_info.html' }
 
   .omega.eight.columns
     %a{ href: '{{ Enterprise.terms_and_conditions }}', target: '_blank', ng: { if: 'Enterprise.terms_and_conditions' } }

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -38,7 +38,9 @@
 
   .omega.eight.columns
     %a{ href: '{{ Enterprise.terms_and_conditions }}', target: '_blank', ng: { if: 'Enterprise.terms_and_conditions' } }
-      = '{{ Enterprise.terms_and_conditions_file_name }}' " uploaded on " '{{ Enterprise.terms_and_conditions_updated_at }}'
+      = '{{ Enterprise.terms_and_conditions_file_name }}'
+      = t('.uploaded_on')
+      = '{{ Enterprise.terms_and_conditions_updated_at }}'
     .pad-top
       = f.file_field :terms_and_conditions, accept: 'application/pdf'
     .pad-top

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -43,7 +43,7 @@
       = t('.uploaded_on')
       = '{{ Enterprise.terms_and_conditions_updated_at }}'
     .pad-top
-      = f.file_field :terms_and_conditions, accept: 'application/pdf', 'ng-click' => 'show_terms_and_conditions_warning($event)'
+      = f.file_field :terms_and_conditions, accept: 'application/pdf', 'terms-and-conditions-warning' => 'true'
     .pad-top
       %a.button.red{ href: '', ng: {click: 'removeTermsAndConditions()', if: 'Enterprise.terms_and_conditions'} }
         = t('.remove_terms_and_conditions')

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -42,7 +42,7 @@
       = t('.uploaded_on')
       = '{{ Enterprise.terms_and_conditions_updated_at }}'
     .pad-top
-      = f.file_field :terms_and_conditions, accept: 'application/pdf'
+      = f.file_field :terms_and_conditions, accept: 'application/pdf', 'ng-click' => 'show_terms_and_conditions_warning($event)'
     .pad-top
       %a.button.red{ href: '', ng: {click: 'removeTermsAndConditions()', if: 'Enterprise.terms_and_conditions'} }
         = t('.remove_terms_and_conditions')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2533,8 +2533,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           message_2: "Shoppers will only be required to accept Terms and Conditions once. However if you change you Terms and Conditions shoppers will again be required to accept them before they can checkout."
         terms_and_conditions_warning:
           title: "Uploading Terms and Conditions"
-          message_1: "All your buyers will have to agree to them again at checkout."
-          message_2: "For buyers with subscriptions, you need to email them the changes for now, nothing will notify them about this change."
+          message_1: "All your buyers will have to agree to them once at checkout. If you update the file, all your buyers will have to agree to them again at checkout."
+          message_2: "For buyers with subscriptions, you need to email them the Terms and Conditions (or the changes to them) for now, nothing will notify them about these new Terms and Conditions."
       panels:
         save: SAVE
         saved: SAVED

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -696,6 +696,7 @@ en:
           invoice_text: Add customized text at the end of invoices
           terms_and_conditions: "Terms and Conditions"
           remove_terms_and_conditions: "Remove File"
+          uploaded_on: "uploaded on"
         contact:
           name: Name
           name_placeholder: eg. Gustav Plum

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2508,6 +2508,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       modals:
         got_it: "Got it"
         close: "Close"
+        continue: "Continue"
         invite: "Invite"
         invite_title: "Invite an unregistered user"
         tag_rule_help:
@@ -2530,6 +2531,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           title: "Uploading Terms and Conditions"
           message_1: "Terms and Conditions are the contract between you, the seller, and the shopper. If you upload a file here shoppers must accept your Terms and Conditions in order to complete checkout. For the shopper this will appear as a checkbox at checkout that must be checked in order to proceed with checkout. We highly recommend you upload Terms and Conditions in alignment with national legislation."
           message_2: "Shoppers will only be required to accept Terms and Conditions once. However if you change you Terms and Conditions shoppers will again be required to accept them before they can checkout."
+        terms_and_conditions_warning:
+          title: "Uploading Terms and Conditions"
+          message_1: "All your buyers will have to agree to them again at checkout."
+          message_2: "For buyers with subscriptions, you need to email them the changes for now, nothing will notify them about this change."
       panels:
         save: SAVE
         saved: SAVED

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2506,7 +2506,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     admin:
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
       modals:
-        got_it: Got it
+        got_it: "Got it"
         close: "Close"
         invite: "Invite"
         invite_title: "Invite an unregistered user"
@@ -2526,6 +2526,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           customer_tagged_rules_text: >
             By creating rules related to a specific customer tag, you can override the default
             behaviour (whether it be to show or to hide items) for customers with the specified tag.
+        terms_and_conditions_info:
+          title: "Uploading Terms and Conditions"
+          message_1: "Terms and Conditions are the contract between you, the seller, and the shopper. If you upload a file here shoppers must accept your Terms and Conditions in order to complete checkout. For the shopper this will appear as a checkbox at checkout that must be checked in order to proceed with checkout. We highly recommend you upload Terms and Conditions in alignment with national legislation."
+          message_2: "Shoppers will only be required to accept Terms and Conditions once. However if you change you Terms and Conditions shoppers will again be required to accept them before they can checkout."
       panels:
         save: SAVE
         saved: SAVED

--- a/spec/features/admin/enterprises/terms_and_conditions_spec.rb
+++ b/spec/features/admin/enterprises/terms_and_conditions_spec.rb
@@ -16,7 +16,7 @@ feature "Uploading Terms and Conditions PDF" do
       visit edit_admin_enterprise_path(distributor)
     end
 
-    describe "images for an enterprise" do
+    describe "with terms and conditions to upload" do
       def go_to_business_details
         within(".side_menu") do
           click_link "Business Details"
@@ -49,20 +49,21 @@ feature "Uploading Terms and Conditions PDF" do
           expect(distributor.reload.terms_and_conditions_updated_at).to eq run_time
         end
         expect(page).
-          to have_content("Enterprise \"#{distributor.name}\" has been successfully updated!")
+          to have_content "Enterprise \"#{distributor.name}\" has been successfully updated!"
 
         go_to_business_details
-        expect(page).to have_selector("a[href*='logo-white.pdf']")
+        expect(page).to have_selector "a[href*='logo-white.pdf'][target=\"_blank\"]"
+        expect(page).to have_content "2002-04-13 00:00:00 +1000"
 
         # Replace PDF
         attach_file "enterprise[terms_and_conditions]", black_pdf_file_name
         click_button "Update"
         expect(page).
-          to have_content("Enterprise \"#{distributor.name}\" has been successfully updated!")
+          to have_content "Enterprise \"#{distributor.name}\" has been successfully updated!"
         expect(distributor.reload.terms_and_conditions_updated_at).to_not eq run_time
 
         go_to_business_details
-        expect(page).to have_selector("a[href*='logo-black.pdf']")
+        expect(page).to have_selector "a[href*='logo-black.pdf']"
       end
     end
   end

--- a/spec/javascripts/unit/admin/enterprises/directives/terms_and_conditions_warning_spec.js.coffee
+++ b/spec/javascripts/unit/admin/enterprises/directives/terms_and_conditions_warning_spec.js.coffee
@@ -1,0 +1,18 @@
+describe "termsAndConditionsWarning", ->
+  element = null
+  templatecache = null
+
+  beforeEach ->
+    module('admin.enterprises')
+
+    inject ($rootScope, $compile, $templateCache) ->
+      templatecache = $templateCache
+      el = angular.element("<input terms-and-conditions-warning=\"true\"></input>")
+      element = $compile(el)($rootScope)
+      $rootScope.$digest()
+
+  describe "terms and conditions warning", ->
+    it "should load template", ->
+      spyOn(templatecache, 'get')
+      element.triggerHandler('click');
+      expect(templatecache.get).toHaveBeenCalledWith('admin/modals/terms_and_conditions_warning.html')


### PR DESCRIPTION
#### What? Why?

Closes #6011
Closes #5515
Closes #5516

See video in the comment below to see what was done here.
There's a new tooltip on the question mark and also there is a warning modal that is shown when the user clicks on the file input "choose file". This works well but it's impossible to test. Some progress was done in testing ng directives though :+1: 
  
#### What should we test?
We need to validate the new features:
- tooltip modal
- warning modal when uploading a new file
- upload timestamp is shown
- file opens in new tab
- make sure the existing features still work: on checkout the file seen by the customer is the last uploaded, on the second checkout with same terms the checkbox is ticked by default, when new file is uploaded user needs to re-accept the terms :+1:  


#### Release notes
Changelog Category: Added
Final tweaks to Terms and Conditions upload: enterprise manager has a new info tooltip, a new warning when upload Terms and Conditions and the datetime of the last upload of Terms and Conditions is also displayed.
