### PR TITLE
Add matomo tag to admin pages

### DIFF
--- a/app/views/spree/layouts/_admin_body.html.haml
+++ b/app/views/spree/layouts/_admin_body.html.haml
@@ -67,3 +67,5 @@
 
 %script
   = raw "Spree.api_key = \"#{spree_current_user.try(:spree_api_key).to_s}\";"
+
+= render "layouts/matomo_tag"


### PR DESCRIPTION
#### What? Why?
Closes #6031

Adds the matomo tracking code to admin pages, as decided by the product team

#### What should we test?
- In the Matomo Configuration admin screen add Matomo instance settings as per the [super admin guide instructions](https://ofn-user-guide.gitbook.io/ofn-super-admin-guide/ofn-platform-configuration/matomo). It's probably best to use a low usage Matomo site for this test, so your logs aren't mixed up in regular traffic
- Navigate around some admin pages.
- In the Matomo instance, access Visitors -> Visits Log and ensure the date is today's date
- You should see logs for the admin pages you visited:
<img width="1192" alt="Screen Shot 2020-10-01 at 9 36 23 pm" src="https://user-images.githubusercontent.com/2467577/94805250-6d614f80-042f-11eb-8e2b-79194b646a34.png">



#### Release notes
Added Matomo tracking of Admin pages

Changelog Category: Added 
