### PR TITLE
Remove fire_event method usage

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -47,8 +47,6 @@ class CheckoutController < Spree::StoreController
     params_adapter = Checkout::FormDataAdapter.new(permitted_params, @order, spree_current_user)
     return action_failed unless @order.update(params_adapter.params[:order])
 
-    fire_event('spree.checkout.update')
-
     checkout_workflow(params_adapter.shipping_method_id)
   rescue Spree::Core::GatewayError => e
     rescue_from_spree_gateway_error(e)

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -78,11 +78,7 @@ module Spree
         discard_empty_line_items
         with_open_adjustments { update_totals_and_taxes }
 
-        if @order == current_order
-          fire_event('spree.order.contents_changed')
-        else
-          @order.update_distribution_charge!
-        end
+        @order.update_distribution_charge!
 
         respond_with(@order) do |format|
           format.html do

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -6,11 +6,6 @@ require 'open_food_network/feature_toggle'
 require 'open_food_network/tag_rule_applicator'
 require 'concerns/order_shipment'
 
-ActiveSupport::Notifications
-  .subscribe('spree.order.contents_changed') do |_name, _start, _finish, _id, payload|
-  payload[:order].reload.update_distribution_charge!
-end
-
 module Spree
   class Order < ActiveRecord::Base
     prepend OrderShipment

--- a/lib/spree/core/controller_helpers/common.rb
+++ b/lib/spree/core/controller_helpers/common.rb
@@ -16,20 +16,6 @@ module Spree
 
           protected
 
-          # Convenience method for firing instrumentation events with the default payload hash
-          def fire_event(name, extra_payload = {})
-            ActiveSupport::Notifications.instrument(name, default_notification_payload.
-                                                            merge(extra_payload))
-          end
-
-          # Creates the hash that is sent as the payload for all notifications.
-          #   Specific notifications will add additional keys as appropriate.
-          #   This method can be overriden to provide additional data when
-          # responding to a notification
-          def default_notification_payload
-            { user: spree_current_user, order: current_order }
-          end
-
           # This can be used in views as well as controllers.
           # e.g. <% self.title = 'This is a custom title for this view' %>
           attr_writer :title

--- a/spec/controllers/checkout_controller_concurrency_spec.rb
+++ b/spec/controllers/checkout_controller_concurrency_spec.rb
@@ -48,12 +48,6 @@ describe CheckoutController, concurrency: true, type: :controller do
     # New threads start running straight away. The breakpoint is after loading
     # the order and before advancing the order's state and making payments.
     breakpoint.lock
-    expect(controller).to receive(:fire_event).with("spree.checkout.update") do
-      breakpoint.synchronize {}
-      # This is what fire_event does.
-      # I did not find out how to call the original code otherwise.
-      ActiveSupport::Notifications.instrument("spree.checkout.update")
-    end
 
     # Starting two checkout threads. The controller code will determine if
     # these two threads are synchronised correctly or run into a race condition.


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/5324

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

- Removes the instrumentation of the following events:

  * `spree.checkout.update` - it does not have any consumers
  * `spree.order.contents_changed`- it has a consumer but it isn't necessary at all — the controller calls `update_distribution_charge` on the order
- Removes `fire_event` and  `default_notification_payload` methods
- Updates specs

#### What should we test?
<!-- List which features should be tested and how. -->

From @luisramos0: We should test EnterpriseFees and verify if fees are calculated correctly on checkout and when creating orders in the back-office.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
