### PR TITLE
When searching for shop products check the variant :display_name and :display_as fields too

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
@@ -68,7 +68,7 @@ Darkswarm.controller "ProductsCtrl", ($scope, $sce, $filter, $rootScope, Product
       id: $scope.order_cycle.order_cycle_id,
       page: page || $scope.page,
       per_page: $scope.per_page,
-      'q[name_or_meta_keywords_or_supplier_name_cont]': $scope.query,
+      'q[name_or_meta_keywords_or_variants_display_as_or_variants_display_name_or_supplier_name_cont]': $scope.query,
       'q[properties_id_or_supplier_properties_id_in_any][]': $scope.activeProperties,
       'q[primary_taxon_id_in_any][]': $scope.activeTaxons
     }

--- a/app/controllers/api/order_cycles_controller.rb
+++ b/app/controllers/api/order_cycles_controller.rb
@@ -75,7 +75,7 @@ module Api
     end
 
     def permitted_ransack_params
-      [:name_or_meta_keywords_or_supplier_name_cont,
+      [:name_or_meta_keywords_or_variants_display_as_or_variants_display_name_or_supplier_name_cont,
        :properties_id_or_supplier_properties_id_in_any,
        :primary_taxon_id_in_any]
     end

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -194,8 +194,6 @@ feature "As a consumer I want to shop with a distributor", js: true do
       end
 
       it "returns search results for products where the search term matches one of the product's variant names" do
-        pending "has been broken for a while"
-
         visit shop_path
         fill_in "search", with: "Badg"           # For variant with display_name "Badgers"
 


### PR DESCRIPTION
#### What? Why?

Closes #5757

#### What should we test?

See _Steps to Reproduce_ in #5757

#### Release notes

Fix shop product search so it finds products by their variant names too.

Changelog Category: Fixed