### PR TITLE
Fix translation for password reset instruction mailer subject

### DIFF
--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -8,10 +8,12 @@ module Spree
     def reset_password_instructions(user, token, _opts = {})
       @edit_password_reset_url = spree.
         edit_spree_user_password_url(reset_password_token: token)
+      subject = "#{Spree::Config[:site_name]} " \
+        "#{I18n.t('spree.user_mailer.reset_password_instructions.subject')}"
 
-      mail(to: user.email, from: from_address,
-           subject: Spree::Config[:site_name] + ' ' +
-             I18n.t(:subject, scope: [:devise, :mailer, :reset_password_instructions]))
+      I18n.with_locale valid_locale(user) do
+        mail(to: user.email, from: from_address, subject: subject)
+      end
     end
 
     # This is a OFN specific email, not from Devise::Mailer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3571,6 +3571,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         issue_text: |
           If the above URL does not work try copying and pasting it into your browser.
           If you continue to have problems please feel free to contact us.
+        subject: "Reset password instructions"
       confirmation_instructions:
         subject: "Please confirm your OFN account"
     shipment_mailer:

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -48,23 +48,35 @@ describe Spree::UserMailer do
   # adapted from https://github.com/spree/spree_auth_devise/blob/70737af/spec/mailers/user_mailer_spec.rb
   describe '#reset_password_instructions' do
     describe 'message contents' do
-      before do
-        @message = described_class.reset_password_instructions(user, nil)
-      end
+      let(:message) { described_class.reset_password_instructions(user, nil) }
 
       context 'subject includes' do
         it 'translated devise instructions' do
-          expect(@message.subject).to include "Reset password instructions"
+          expect(message.subject).to include "Reset password instructions"
         end
 
         it 'Spree site name' do
-          expect(@message.subject).to include Spree::Config[:site_name]
+          expect(message.subject).to include Spree::Config[:site_name]
         end
       end
 
       context 'body includes' do
         it 'password reset url' do
-          expect(@message.body.raw_source).to include spree.edit_spree_user_password_url
+          expect(message.body.raw_source).to include spree.edit_spree_user_password_url
+        end
+      end
+
+      context 'when the language is Spanish' do
+        let(:user) { build(:user, locale: 'es') }
+
+        it 'calls with_locale method with user selected locale' do
+          expect(I18n).to receive(:with_locale).with('es')
+          message
+        end
+
+        it 'calls devise reset_password_instructions subject' do
+          expect(I18n).to receive(:t).with('spree.user_mailer.reset_password_instructions.subject')
+          message
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #6007 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

I am adding devise-i18 gem that will help the translations for different languages that using devise locale scope. 

#### What should we test?
<!-- List which features should be tested and how. -->
Test the forgot password feature on the website.

How to do: 

1. Make sure that you are not logged in and set the language that is not English
2. Go to homepage
3. Click login on the top right of the screen
4. Go to forgot password tab
5. Enter your email
6. Click Reset Password 
7. You will receive the email with the subject in your selected language

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->
Fix email subject for reset password instruction to use selected language.


<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Fixed
