### PR TITLE
Add feature specs to stripe payments in the BackOffice

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -553,10 +553,6 @@ module Spree
       line_item_adjustments.destroy_all
     end
 
-    def has_step?(step)
-      checkout_steps.include?(step)
-    end
-
     def state_changed(name)
       state = "#{name}_state"
       return unless persisted?
@@ -803,7 +799,6 @@ module Spree
     end
 
     def has_available_shipment
-      return unless has_step?("delivery")
       return unless address?
       return unless ship_address&.valid?
       # errors.add(:base, :no_shipping_methods_available) if available_shipping_methods.empty?

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -9,7 +9,6 @@ module Spree
           class_attribute :previous_states
           class_attribute :checkout_flow
           class_attribute :checkout_steps
-          class_attribute :removed_transitions
 
           def self.checkout_flow(&block)
             if block_given?
@@ -24,7 +23,6 @@ module Spree
             self.checkout_steps = {}
             self.next_event_transitions = []
             self.previous_states = [:cart]
-            self.removed_transitions = []
 
             # Build the checkout flow using the checkout_flow defined either
             # within the Order class, or a decorator for that class.
@@ -95,43 +93,6 @@ module Spree
             end
           end
 
-          def self.insert_checkout_step(name, options = {})
-            before = options.delete(:before)
-            after = options.delete(:after) unless before
-            after = checkout_steps.keys.last unless before || after
-
-            cloned_steps = checkout_steps.clone
-            cloned_removed_transitions = removed_transitions.clone
-            checkout_flow do
-              cloned_steps.each_pair do |key, value|
-                go_to_state(name, options) if key == before
-                go_to_state(key, value)
-                go_to_state(name, options) if key == after
-              end
-              cloned_removed_transitions.each do |transition|
-                remove_transition(transition)
-              end
-            end
-          end
-
-          def self.remove_checkout_step(name)
-            cloned_steps = checkout_steps.clone
-            cloned_removed_transitions = removed_transitions.clone
-            checkout_flow do
-              cloned_steps.each_pair do |key, value|
-                go_to_state(key, value) unless key == name
-              end
-              cloned_removed_transitions.each do |transition|
-                remove_transition(transition)
-              end
-            end
-          end
-
-          def self.remove_transition(options = {})
-            removed_transitions << options
-            next_event_transitions.delete(find_transition(options))
-          end
-
           def self.find_transition(options = {})
             return nil if options.nil? || !options.include?(:from) || !options.include?(:to)
 
@@ -171,10 +132,6 @@ module Spree
 
           def checkout_step_index(step)
             checkout_steps.index(step)
-          end
-
-          def self.removed_transitions
-            @removed_transitions ||= []
           end
 
           def can_go_to_state?(state)

--- a/spec/features/admin/payments_spec.rb
+++ b/spec/features/admin/payments_spec.rb
@@ -30,31 +30,4 @@ feature '
       expect(page).to have_content "New Payment"
     end
   end
-
-  context "with a StripeSCA payment method" do
-    before do
-      stripe_payment_method = create(:stripe_sca_payment_method, distributors: [order.distributor])
-      order.payments << create(:payment, payment_method: stripe_payment_method, order: order)
-    end
-
-    it "renders the payment details" do
-      login_as_admin_and_visit spree.admin_order_payments_path order
-
-      page.click_link("StripeSCA")
-      expect(page).to have_content order.payments.last.source.last_digits
-    end
-
-    context "with a deleted credit card" do
-      before do
-        order.payments.last.update_attribute(:source, nil)
-      end
-
-      it "renders the payment details" do
-        login_as_admin_and_visit spree.admin_order_payments_path order
-
-        page.click_link("StripeSCA")
-        expect(page).to have_content order.payments.last.amount
-      end
-    end
-  end
 end

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -43,26 +43,50 @@ feature '
       stub_hub_payment_methods_request
       stub_payment_intents_post_request order: order, stripe_account_header: true
       stub_payment_intent_get_request
-      stub_successful_capture_request order: order
     end
 
     context "for a complete order" do
-      it "adds a payment with state complete", js: true do
-        login_as_admin_and_visit spree.new_admin_order_payment_path order
+      before {  stub_successful_capture_request order: order }
 
-        fill_in "payment_amount", with: order.total.to_s
-        fill_in_stripe_cards_details_in_backoffice
-        click_button "Update"
+      context "with a valid credit card" do
+        it "adds a payment with state complete", js: true do
+          login_as_admin_and_visit spree.new_admin_order_payment_path order
 
-        expect(page).to have_link "StripeSCA"
-        expect(order.payments.reload.first.state).to eq "completed"
+          fill_in "payment_amount", with: order.total.to_s
+          fill_in_stripe_cards_details_in_backoffice
+          click_button "Update"
+
+          expect(page).to have_link "StripeSCA"
+          expect(order.payments.reload.first.state).to eq "completed"
+        end
+      end
+
+      context "with a card that fails the paymet capture step" do
+        let(:error_message) { "Card was declined: insufficient funds." }
+
+        before { stub_failed_capture_request order: order, response: { message: error_message } }
+
+        it "fails to add a payment due to card error", js: true do
+          login_as_admin_and_visit spree.new_admin_order_payment_path order
+
+          fill_in "payment_amount", with: order.total.to_s
+          fill_in_stripe_cards_details_in_backoffice
+          click_button "Update"
+
+          expect(page).to have_link "StripeSCA"
+          expect(page).to have_content "FAILED"
+          expect(order.payments.reload.second.state).to eq "failed"
+        end
       end
     end
 
     context "for an order in payment state" do
       let!(:order) { create(:order_with_line_items, distributor: create(:enterprise)) }
 
-      before { while !order.payment? do break unless order.next! end }
+      before do
+        stub_successful_capture_request order: order
+        while !order.payment? do break unless order.next! end
+      end
 
       it "adds a payment with state complete", js: true do
         login_as_admin_and_visit spree.new_admin_order_payment_path order

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 feature '
@@ -8,7 +10,9 @@ feature '
   include StripeHelper
 
   let!(:order) { create(:completed_order_with_fees) }
-  let!(:stripe_payment_method) { create(:stripe_sca_payment_method, distributors: [order.distributor]) }
+  let!(:stripe_payment_method) do
+    create(:stripe_sca_payment_method, distributors: [order.distributor])
+  end
 
   context "with a payment using a StripeSCA payment method" do
     before do
@@ -24,7 +28,7 @@ feature '
 
     context "with a deleted credit card" do
       before do
-        order.payments.last.update_attribute(:source, nil)
+        order.payments.last.update source: nil
       end
 
       it "renders the payment details" do
@@ -37,7 +41,9 @@ feature '
   end
 
   context "making a new Stripe payment", js: true do
-    let!(:stripe_account) { create(:stripe_account, enterprise: order.distributor, stripe_user_id: "abc123") }
+    let!(:stripe_account) do
+      create(:stripe_account, enterprise: order.distributor, stripe_user_id: "abc123")
+    end
 
     before do
       stub_hub_payment_methods_request
@@ -82,7 +88,7 @@ feature '
         end
       end
 
-      context "with a card that fails on registration (requires extra SCA auth: redirects to stripe" do
+      context "with a card that fails on registration because it requires(redirects) extra auth" do
         let(:stripe_redirect_url) { checkout_path(payment_intent: "pi_123") }
         let(:payment_intent_authorize_response) do
           { status: 200, body: JSON.generate(id: "pi_123",

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -5,12 +5,13 @@ feature '
     I want to make Stripe payments
 ' do
   include AuthenticationHelper
+  include StripeHelper
 
-  let(:order) { create(:completed_order_with_fees) }
+  let!(:order) { create(:completed_order_with_fees) }
+  let!(:stripe_payment_method) { create(:stripe_sca_payment_method, distributors: [order.distributor]) }
 
   context "with a payment using a StripeSCA payment method" do
     before do
-      stripe_payment_method = create(:stripe_sca_payment_method, distributors: [order.distributor])
       order.payments << create(:payment, payment_method: stripe_payment_method, order: order)
     end
 
@@ -32,6 +33,32 @@ feature '
         page.click_link("StripeSCA")
         expect(page).to have_content order.payments.last.amount
       end
+    end
+  end
+
+  context "making a new Stripe payment" do
+    let!(:stripe_account) { create(:stripe_account, enterprise: order.distributor, stripe_user_id: "abc123") }
+
+    before do
+      stub_hub_payment_methods_request
+      stub_payment_intents_post_request order: order, stripe_account_header: true
+      stub_payment_intent_get_request
+      stub_successful_capture_request order: order
+    end
+
+    it "adds a payment with state complete", js: true do
+      login_as_admin_and_visit spree.new_admin_order_payment_path order
+
+      choose "StripeSCA"
+      fill_in "payment_amount", with: order.total.to_s
+      fill_in "cardholder_name", with: "David Gilmour"
+      fill_in "stripe-cardnumber", with: "4242424242424242"
+      fill_in "exp-date", with: "01-01-2050"
+      fill_in "cvc", with: "678"
+      click_button "Update"
+
+      expect(page).to have_link "StripeSCA"
+      expect(order.payments.reload.first.state).to eq "completed"
     end
   end
 end

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -89,21 +89,9 @@ feature '
       end
 
       context "with a card that fails on registration because it requires(redirects) extra auth" do
-        let(:stripe_redirect_url) { checkout_path(payment_intent: "pi_123") }
-        let(:payment_intent_authorize_response) do
-          { status: 200, body: JSON.generate(id: "pi_123",
-                                             object: "payment_intent",
-                                             next_source_action: {
-                                               type: "authorize_with_url",
-                                               authorize_with_url: { url: stripe_redirect_url }
-                                             },
-                                             status: "requires_source_action") }
-        end
-
         before do
-          stub_request(:post, "https://api.stripe.com/v1/payment_intents")
-            .with(basic_auth: ["sk_test_12345", ""], body: /.*#{order.number}/)
-            .to_return(payment_intent_authorize_response)
+          stub_payment_intents_post_request_with_redirect order: order,
+                                                          redirect_url: "www.dummy.org"
         end
 
         it "fails to add a payment due to card error" do

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -46,7 +46,7 @@ feature '
     end
 
     before do
-      stub_hub_payment_methods_request
+      stub_payment_methods_post_request
       stub_payment_intent_get_request
     end
 
@@ -61,7 +61,7 @@ feature '
             login_as_admin_and_visit spree.new_admin_order_payment_path order
 
             fill_in "payment_amount", with: order.total.to_s
-            fill_in_stripe_cards_details_in_backoffice
+            fill_in_card_details_in_backoffice
             click_button "Update"
 
             expect(page).to have_link "StripeSCA"
@@ -78,7 +78,7 @@ feature '
             login_as_admin_and_visit spree.new_admin_order_payment_path order
 
             fill_in "payment_amount", with: order.total.to_s
-            fill_in_stripe_cards_details_in_backoffice
+            fill_in_card_details_in_backoffice
             click_button "Update"
 
             expect(page).to have_link "StripeSCA"
@@ -110,7 +110,7 @@ feature '
           login_as_admin_and_visit spree.new_admin_order_payment_path order
 
           fill_in "payment_amount", with: order.total.to_s
-          fill_in_stripe_cards_details_in_backoffice
+          fill_in_card_details_in_backoffice
           click_button "Update"
 
           expect(page).to have_link "StripeSCA"
@@ -134,7 +134,7 @@ feature '
         login_as_admin_and_visit spree.new_admin_order_payment_path order
 
         fill_in "payment_amount", with: order.total.to_s
-        fill_in_stripe_cards_details_in_backoffice
+        fill_in_card_details_in_backoffice
         click_button "Update"
 
         expect(page).to have_link "StripeSCA"

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -14,32 +14,6 @@ feature '
     create(:stripe_sca_payment_method, distributors: [order.distributor])
   end
 
-  context "with a payment using a StripeSCA payment method" do
-    before do
-      order.payments << create(:payment, payment_method: stripe_payment_method, order: order)
-    end
-
-    it "renders the payment details" do
-      login_as_admin_and_visit spree.admin_order_payments_path order
-
-      page.click_link("StripeSCA")
-      expect(page).to have_content order.payments.last.source.last_digits
-    end
-
-    context "with a deleted credit card" do
-      before do
-        order.payments.last.update source: nil
-      end
-
-      it "renders the payment details" do
-        login_as_admin_and_visit spree.admin_order_payments_path order
-
-        page.click_link("StripeSCA")
-        expect(page).to have_content order.payments.last.amount
-      end
-    end
-  end
-
   context "making a new Stripe payment", js: true do
     let!(:stripe_account) do
       create(:stripe_account, enterprise: order.distributor, stripe_user_id: "abc123")
@@ -127,6 +101,32 @@ feature '
 
         expect(page).to have_link "StripeSCA"
         expect(OrderPaymentFinder.new(order.reload).last_payment.state).to eq "completed"
+      end
+    end
+  end
+
+  context "with a payment using a StripeSCA payment method" do
+    before do
+      order.payments << create(:payment, payment_method: stripe_payment_method, order: order)
+    end
+
+    it "renders the payment details" do
+      login_as_admin_and_visit spree.admin_order_payments_path order
+
+      page.click_link("StripeSCA")
+      expect(page).to have_content order.payments.last.source.last_digits
+    end
+
+    context "with a deleted credit card" do
+      before do
+        order.payments.last.update source: nil
+      end
+
+      it "renders the payment details" do
+        login_as_admin_and_visit spree.admin_order_payments_path order
+
+        page.click_link("StripeSCA")
+        expect(page).to have_content order.payments.last.amount
       end
     end
   end

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+feature '
+    As an hub manager
+    I want to make Stripe payments
+' do
+  include AuthenticationHelper
+
+  let(:order) { create(:completed_order_with_fees) }
+
+  context "with a payment using a StripeSCA payment method" do
+    before do
+      stripe_payment_method = create(:stripe_sca_payment_method, distributors: [order.distributor])
+      order.payments << create(:payment, payment_method: stripe_payment_method, order: order)
+    end
+
+    it "renders the payment details" do
+      login_as_admin_and_visit spree.admin_order_payments_path order
+
+      page.click_link("StripeSCA")
+      expect(page).to have_content order.payments.last.source.last_digits
+    end
+
+    context "with a deleted credit card" do
+      before do
+        order.payments.last.update_attribute(:source, nil)
+      end
+
+      it "renders the payment details" do
+        login_as_admin_and_visit spree.admin_order_payments_path order
+
+        page.click_link("StripeSCA")
+        expect(page).to have_content order.payments.last.amount
+      end
+    end
+  end
+end

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -24,7 +24,7 @@ feature '
     end
 
     context "for a complete order" do
-      context "with a card that succceeds on card registration" do
+      context "with a card that succeeds on card registration" do
         before { stub_payment_intents_post_request order: order, stripe_account_header: true }
 
         context "and succeeds on payment capture" do

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -17,6 +17,8 @@ feature '
     create(:stripe_account, enterprise: order.distributor, stripe_user_id: "abc123")
   end
 
+  before { setup_stripe }
+
   context "making a new Stripe payment", js: true do
     before do
       stub_payment_methods_post_request

--- a/spec/features/consumer/shopping/checkout_stripe_spec.rb
+++ b/spec/features/consumer/shopping/checkout_stripe_spec.rb
@@ -127,21 +127,10 @@ feature "Check out with Stripe", js: true do
       end
 
       context "when the card needs extra SCA authorization", js: true do
-        let(:stripe_redirect_url) { checkout_path(payment_intent: "pi_123") }
-        let(:payment_intent_authorize_response) do
-          { status: 200, body: JSON.generate(id: "pi_123",
-                                             object: "payment_intent",
-                                             next_source_action: {
-                                               type: "authorize_with_url",
-                                               authorize_with_url: { url: stripe_redirect_url }
-                                             },
-                                             status: "requires_source_action") }
-        end
-
         before do
-          stub_request(:post, "https://api.stripe.com/v1/payment_intents")
-            .with(basic_auth: ["sk_test_12345", ""], body: /.*#{order.number}/)
-            .to_return(payment_intent_authorize_response)
+          stripe_redirect_url = checkout_path(payment_intent: "pi_123")
+          stub_payment_intents_post_request_with_redirect order: order,
+                                                          redirect_url: stripe_redirect_url
         end
 
         describe "and the authorization succeeds" do

--- a/spec/features/consumer/shopping/checkout_stripe_spec.rb
+++ b/spec/features/consumer/shopping/checkout_stripe_spec.rb
@@ -93,7 +93,7 @@ feature "Check out with Stripe", js: true do
     context "with guest checkout" do
       before do
         stub_payment_intent_get_request
-        stub_hub_payment_methods_request
+        stub_payment_methods_post_request
       end
 
       context "when the card is accepted" do

--- a/spec/lib/open_food_network/group_buy_report_spec.rb
+++ b/spec/lib/open_food_network/group_buy_report_spec.rb
@@ -13,24 +13,23 @@ module OpenFoodNetwork
       @variant1 = create(:variant)
       @variant1.product.supplier = @supplier1
       @variant1.product.save!
+      @variant1.reload
+
       shipping_instructions = "pick up on thursday please!"
 
       order1 = create(:order, distributor: distributor, bill_address: bill_address, special_instructions: shipping_instructions)
       line_item11 = create(:line_item, variant: @variant1, order: order1)
-      order1.line_items << line_item11
-      @orders << order1
+      @orders << order1.reload
 
       order2 = create(:order, distributor: distributor, bill_address: bill_address, special_instructions: shipping_instructions)
       line_item21 = create(:line_item, variant: @variant1, order: order2)
-      order2.line_items << line_item21
 
       @variant2 = create(:variant)
       @variant2.product.supplier = @supplier1
       @variant2.product.save!
 
       line_item22 = create(:line_item, variant: @variant2, order: order2)
-      order2.line_items << line_item22
-      @orders << order2
+      @orders << order2.reload
 
       @supplier2 = create(:supplier_enterprise)
       @variant3 = create(:variant, weight: nil)
@@ -39,8 +38,7 @@ module OpenFoodNetwork
 
       order3 = create(:order, distributor: distributor, bill_address: bill_address, special_instructions: shipping_instructions)
       line_item31 = create(:line_item, variant: @variant3, order: order3)
-      order3.line_items << line_item31
-      @orders << order3
+      @orders << order3.reload
     end
 
     it "should return a header row describing the report" do

--- a/spec/models/spree/calculator_spec.rb
+++ b/spec/models/spree/calculator_spec.rb
@@ -10,9 +10,7 @@ module Spree
     let!(:line_item2) { create(:line_item, order: order) }
 
     before do
-      order.line_items << line_item
-      order.line_items << line_item2
-      order.shipments = [shipment]
+      order.reload.shipments = [shipment]
     end
 
     describe "#line_items_for" do

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -150,26 +150,6 @@ describe Spree::Order::Checkout do
     end
   end
 
-  context "subclassed order" do
-    # This causes another test above to fail, but fixing this test should make
-    #   the other test pass
-    class SubclassedOrder < Spree::Order
-      checkout_flow do
-        go_to_state :payment
-        go_to_state :complete
-      end
-    end
-
-    it "should only call default transitions once when checkout_flow is redefined" do
-      order = SubclassedOrder.new
-      allow(order).to receive_messages payment_required?: true
-      expect(order).to receive(:process_payments!).once
-      order.state = "payment"
-      order.next!
-      expect(order.state).to eq "complete"
-    end
-  end
-
   describe 'event :restart_checkout' do
     let(:order) { build_stubbed(:order) }
 

--- a/spec/services/order_checkout_restart_spec.rb
+++ b/spec/services/order_checkout_restart_spec.rb
@@ -23,7 +23,7 @@ describe OrderCheckoutRestart do
         order.update_attribute(:state, "payment")
       end
 
-      xcontext "when order ship address is nil" do
+      context "when order ship address is nil" do
         before { order.ship_address = nil }
 
         it "resets the order state, and clears incomplete shipments and payments" do
@@ -33,7 +33,7 @@ describe OrderCheckoutRestart do
         end
       end
 
-      xcontext "when order ship address is not empty" do
+      context "when order ship address is not empty" do
         before { order.ship_address = order.address_from_distributor }
 
         it "resets the order state, and clears incomplete shipments and payments" do

--- a/spec/support/request/stripe_helper.rb
+++ b/spec/support/request/stripe_helper.rb
@@ -27,10 +27,11 @@ module StripeHelper
     Spree::Config.set(stripe_connect_enabled: true)
   end
 
-  def stub_payment_intents_post_request(order:, response: {})
-    stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+  def stub_payment_intents_post_request(order:, response: {}, stripe_account_header: true)
+    stub = stub_request(:post, "https://api.stripe.com/v1/payment_intents")
       .with(basic_auth: ["sk_test_12345", ""], body: /.*#{order.number}/)
-      .to_return(payment_intent_authorize_response_mock(response))
+    stub = stub.with(headers: { 'Stripe-Account' => 'abc123' }) if stripe_account_header
+    stub.to_return(payment_intent_authorize_response_mock(response))
   end
 
   def stub_payment_intent_get_request(response: {}, stripe_account_header: true)

--- a/spec/support/request/stripe_helper.rb
+++ b/spec/support/request/stripe_helper.rb
@@ -21,7 +21,7 @@ module StripeHelper
     fill_in 'CVC', with: '123'
   end
 
-  def fill_in_stripe_cards_details_in_backoffice
+  def fill_in_card_details_in_backoffice
     choose "StripeSCA"
     fill_in "cardholder_name", with: "David Gilmour"
     fill_in "stripe-cardnumber", with: "4242424242424242"
@@ -48,7 +48,7 @@ module StripeHelper
     stub.to_return(payment_intent_authorize_response_mock(response))
   end
 
-  def stub_hub_payment_methods_request(response: {})
+  def stub_payment_methods_post_request(response: {})
     stub_request(:post, "https://api.stripe.com/v1/payment_methods")
       .with(body: { payment_method: "pm_123" },
             headers: { 'Stripe-Account' => 'abc123' })

--- a/spec/support/request/stripe_helper.rb
+++ b/spec/support/request/stripe_helper.rb
@@ -21,6 +21,14 @@ module StripeHelper
     fill_in 'CVC', with: '123'
   end
 
+  def fill_in_stripe_cards_details_in_backoffice
+    choose "StripeSCA"
+    fill_in "cardholder_name", with: "David Gilmour"
+    fill_in "stripe-cardnumber", with: "4242424242424242"
+    fill_in "exp-date", with: "01-01-2050"
+    fill_in "cvc", with: "678"
+  end
+
   def setup_stripe
     allow(Stripe).to receive(:api_key) { "sk_test_12345" }
     allow(Stripe).to receive(:publishable_key) { "pk_test_12345" }

--- a/spec/support/request/stripe_helper.rb
+++ b/spec/support/request/stripe_helper.rb
@@ -76,6 +76,13 @@ module StripeHelper
       .to_return(response_mock)
   end
 
+  def stub_refund_request
+    stub_request(:post, "https://api.stripe.com/v1/charges/ch_1234/refunds")
+      .with(body: { amount: 2000, expand: ["charge"] },
+            headers: { 'Stripe-Account' => 'abc123' })
+      .to_return(payment_successful_refund_mock)
+  end
+
   private
 
   def payment_intent_authorize_response_mock(options)
@@ -115,5 +122,12 @@ module StripeHelper
   def hub_payment_method_response_mock(options)
     { status: options[:code] || 200,
       body: JSON.generate(id: "pm_456", customer: "cus_A123") }
+  end
+
+  def payment_successful_refund_mock
+    { status: 200,
+      body: JSON.generate(object: "refund",
+                          amount: 2000,
+                          charge: "ch_1234") }
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #6127

Adds spec to:
- [x] add stripe payment in a completed order
- [x] failed stripe payment due to card error
- [x] failed stripe payment due to extra SCA auth required
- [x] add stripe payment in a incomplete order to complete it
- [x] refunds a stripe payment

This was breaking similarly to https://github.com/openfoodfoundation/openfoodnetwork/issues/6142 we found the problem in the checkout_spec with some class evals that were leaving the checkout_flow in a specific non standard way. So this PR closes #6142 by removing some spree specific unnecessary specs from checkout_spec.

#### What should we test?
Green build

#### Release notes
Changelog Category: Added
Adds automated test that validate that stripe payments can be taken in the backoffice by hub managers.
Adds automated test that validate that refunds can be issued for stripe payments in the backoffice by hub managers.
