### PR TITLE
Show product description in creation form after errors appeared

### DIFF
--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -78,6 +78,7 @@
           = f.label :product_description, t(".product_description")
           %br/
           %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', "textangular-links-target-blank" => true, 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]"}
+            = sanitize(@product.description)
           = f.error_message_on :description
   .four.columns.omega{ style: "text-align: center" }
     %fieldset.no-border-bottom{ id: "image" }


### PR DESCRIPTION
## What? Why?
Closes #6118

#### What should we test?
We need to verify the issue is fixed.

#### Release notes
Changelog Category: Fixed
Fixed a problem when creating a product, in case of errors the original entered product description will not be lost.
