### PR TITLE
Allow instances to choose available units for products/variants

### DIFF
--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -37,7 +37,6 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
             ["#{I18n.t(unit_type)} (#{name})", "#{unit_type}_#{scale}"]
           else
             null
-      debugger
       options.push [[I18n.t('items'), 'items']]
       options = [].concat options...
       (option for option in options when option != null)

--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -29,17 +29,12 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
           system: 'metric'
 
     @variantUnitOptions: ->
-      availableUnits = availableUnits.split(",")
       options = for unit_type, _ of @units
-        for scale in @unitScales(unit_type)
+        for scale in @availableUnitScales(unit_type)
           name = @getUnitName(scale, unit_type)
-          if availableUnits.includes(name)
-            ["#{I18n.t(unit_type)} (#{name})", "#{unit_type}_#{scale}"]
-          else
-            null
+          ["#{I18n.t(unit_type)} (#{name})", "#{unit_type}_#{scale}"]
       options.push [[I18n.t('items'), 'items']]
       options = [].concat options...
-      (option for option in options when option != null)
 
     @getScale: (value, unitType) ->
       scaledValue = null
@@ -60,6 +55,14 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
 
     @unitScales: (unitType) ->
       (parseFloat(scale) for scale in Object.keys(@units[unitType])).sort (a, b) ->
+         a - b
+
+    @availableUnitScales: (unitType) ->
+      available = availableUnits.split(",")
+      units = @units
+      scales = Object.keys(@units[unitType]).filter (scale) ->
+        available.includes(units[unitType][scale]['name'])
+      (parseFloat(scale) for scale in scales).sort (a, b) ->
          a - b
 
     @compatibleUnitScales: (scale, unitType) ->

--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -1,4 +1,4 @@
-angular.module("admin.products").factory "VariantUnitManager", ->
+angular.module("admin.products").factory "VariantUnitManager", (availableUnits) ->
   class VariantUnitManager
     @units:
       'weight':
@@ -29,12 +29,18 @@ angular.module("admin.products").factory "VariantUnitManager", ->
           system: 'metric'
 
     @variantUnitOptions: ->
+      availableUnits = availableUnits.split(",")
       options = for unit_type, _ of @units
         for scale in @unitScales(unit_type)
           name = @getUnitName(scale, unit_type)
-          ["#{I18n.t(unit_type)} (#{name})", "#{unit_type}_#{scale}"]
+          if availableUnits.includes(name)
+            ["#{I18n.t(unit_type)} (#{name})", "#{unit_type}_#{scale}"]
+          else
+            null
+      debugger
       options.push [[I18n.t('items'), 'items']]
-      [].concat options...
+      options = [].concat options...
+      (option for option in options when option != null)
 
     @getScale: (value, unitType) ->
       scaledValue = null

--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -29,8 +29,9 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
           system: 'metric'
 
     @variantUnitOptions: ->
+      available = availableUnits.split(",")
       options = for unit_type, _ of @units
-        for scale in @availableUnitScales(unit_type)
+        for scale in @unitScales(unit_type, available)
           name = @getUnitName(scale, unit_type)
           ["#{I18n.t(unit_type)} (#{name})", "#{unit_type}_#{scale}"]
       options.push [[I18n.t('items'), 'items']]
@@ -53,15 +54,13 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
       else
         ''
 
-    @unitScales: (unitType) ->
-      (parseFloat(scale) for scale in Object.keys(@units[unitType])).sort (a, b) ->
-         a - b
-
-    @availableUnitScales: (unitType) ->
-      available = availableUnits.split(",")
+    @unitScales: (unitType, availableUnits = null) ->
+      scales = Object.keys(@units[unitType])
       units = @units
-      scales = Object.keys(@units[unitType]).filter (scale) ->
-        available.includes(units[unitType][scale]['name'])
+      if availableUnits
+        scales = scales.filter (scale) ->
+          availableUnits.includes(units[unitType][scale]['name'])
+
       (parseFloat(scale) for scale in scales).sort (a, b) ->
          a - b
 

--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -56,10 +56,9 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
 
     @unitScales: (unitType, availableUnits = null) ->
       scales = Object.keys(@units[unitType])
-      units = @units
       if availableUnits
         scales = scales.filter (scale) ->
-          availableUnits.includes(units[unitType][scale]['name'])
+          availableUnits.includes(VariantUnitManager.getUnitName(scale, unitType))
 
       (parseFloat(scale) for scale in scales).sort (a, b) ->
          a - b

--- a/app/controllers/spree/admin/general_settings_controller.rb
+++ b/app/controllers/spree/admin/general_settings_controller.rb
@@ -25,7 +25,7 @@ module Spree
 
       def merge_available_units_params
         params[:available_units] =
-          params[:available_units].select { |unit, checked| checked == "1" }.keys.join(",")
+          params[:available_units].select { |_unit, checked| checked == "1" }.keys.join(",")
       end
     end
   end

--- a/app/controllers/spree/admin/general_settings_controller.rb
+++ b/app/controllers/spree/admin/general_settings_controller.rb
@@ -10,13 +10,7 @@ module Spree
       end
 
       def update
-        available_units = []
-        params.each do |name, value|
-          if value == "1" && unit = name.match(/available_units_(.*)/)&.captures&.first
-            available_units << unit
-          end
-        end
-        Spree::Config[:available_units] = available_units.join(",")
+        combine_available_units_params
         params.each do |name, value|
           next unless Spree::Config.has_preference? name
 
@@ -25,6 +19,18 @@ module Spree
         flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:general_settings))
 
         redirect_to spree.edit_admin_general_settings_path
+      end
+
+      private
+
+      def combine_available_units_params
+        available_units = []
+        params.each do |name, value|
+          if value == "1" && unit = name.match(/available_units_(.*)/)&.captures&.first
+            available_units << unit
+          end
+        end
+        params[:available_units] = available_units.join(",")
       end
     end
   end

--- a/app/controllers/spree/admin/general_settings_controller.rb
+++ b/app/controllers/spree/admin/general_settings_controller.rb
@@ -10,6 +10,13 @@ module Spree
       end
 
       def update
+        available_units = []
+        params.each do |name, value|
+          if value == "1" && unit = name.match(/available_units_(.*)/)&.captures&.first
+            available_units << unit
+          end
+        end
+        Spree::Config[:available_units] = available_units.join(",")
         params.each do |name, value|
           next unless Spree::Config.has_preference? name
 

--- a/app/controllers/spree/admin/general_settings_controller.rb
+++ b/app/controllers/spree/admin/general_settings_controller.rb
@@ -10,7 +10,7 @@ module Spree
       end
 
       def update
-        merge_available_units_params
+        merge_available_units_params unless params[:available_units].nil?
         params.each do |name, value|
           next unless Spree::Config.has_preference? name
 

--- a/app/controllers/spree/admin/general_settings_controller.rb
+++ b/app/controllers/spree/admin/general_settings_controller.rb
@@ -10,7 +10,7 @@ module Spree
       end
 
       def update
-        combine_available_units_params
+        merge_available_units_params
         params.each do |name, value|
           next unless Spree::Config.has_preference? name
 
@@ -23,14 +23,9 @@ module Spree
 
       private
 
-      def combine_available_units_params
-        available_units = []
-        params.each do |name, value|
-          if value == "1" && unit = name.match(/available_units_(.*)/)&.captures&.first
-            available_units << unit
-          end
-        end
-        params[:available_units] = available_units.join(",")
+      def merge_available_units_params
+        params[:available_units] =
+          params[:available_units].select { |unit, checked| checked == "1" }.keys.join(",")
       end
     end
   end

--- a/app/helpers/admin/injection_helper.rb
+++ b/app/helpers/admin/injection_helper.rb
@@ -184,6 +184,12 @@ module Admin
                        json: "'#{@spree_api_key}'" }
     end
 
+    def admin_inject_available_units
+      admin_inject_json "admin.products",
+                        "availableUnits",
+                        "#{Spree::Config.available_units}"
+    end
+
     def admin_inject_json(ng_module, name, data)
       json = data.to_json
       render partial: "admin/json/injection_ams",

--- a/app/helpers/admin/injection_helper.rb
+++ b/app/helpers/admin/injection_helper.rb
@@ -187,7 +187,7 @@ module Admin
     def admin_inject_available_units
       admin_inject_json "admin.products",
                         "availableUnits",
-                        "#{Spree::Config.available_units}"
+                        Spree::Config.available_units
     end
 
     def admin_inject_json(ng_module, name, data)

--- a/app/helpers/spree/admin/general_settings_helper.rb
+++ b/app/helpers/spree/admin/general_settings_helper.rb
@@ -8,6 +8,10 @@ module Spree
         end
         options_from_collection_for_select(currencies, :first, :last, Spree::Config[:currency])
       end
+
+      def all_units
+        ["g", "oz", "lb", "kg", "T", "mL", "L", "kL"]
+      end
     end
   end
 end

--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -144,5 +144,8 @@ module Spree
     # Enable cache
     preference :enable_products_cache?, :boolean,
                default: (Rails.env.production? || Rails.env.staging?)
+
+    # Available units
+    preference :available_units, :string, default: "g,kg,T,mL,L,kL"
   end
 end

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -87,6 +87,15 @@
             .field
               = preference_field_tag(:enable_localized_number?, Spree::Config[:enable_localized_number?], type: Spree::Config.preference_type(:enable_localized_number?))
               = label_tag(:enable_localized_number?, t('admin.number_localization.enable_localized_number')) + tag(:br)
+          %fieldset.available_units.no-border-bottom
+            %legend{:align => "center"}= t('admin.available_units')
+            .field
+              - all_units = ["g", "oz", "lb", "kg", "T", "mL", "L", "kL"]
+              - selected_units = Spree::Config[:available_units].split(",")
+              - all_units.each do |unit|
+                - selected = selected_units.include?(unit)
+                = preference_field_tag("available_units_#{unit}", selected, { type: :boolean, selected: selected })
+                = label_tag(unit, unit.downcase) + tag(:br)
 
       .form-buttons.filter-actions.actions{"data-hook" => "buttons"}
         = button Spree.t('actions.update'), 'icon-refresh'

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -90,7 +90,6 @@
           %fieldset.available_units.no-border-bottom
             %legend{:align => "center"}= t('admin.available_units')
             .field
-              - all_units = ["g", "oz", "lb", "kg", "T", "mL", "L", "kL"]
               - selected_units = Spree::Config[:available_units].split(",")
               - all_units.each do |unit|
                 - selected = selected_units.include?(unit)

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -90,10 +90,10 @@
           %fieldset.available_units.no-border-bottom
             %legend{:align => "center"}= t('admin.available_units')
             .field
-              - selected_units = Spree::Config[:available_units].split(",")
+              - available_units = Spree::Config[:available_units].split(",")
               - all_units.each do |unit|
-                - selected = selected_units.include?(unit)
-                = preference_field_tag("available_units_#{unit}", selected, { type: :boolean, selected: selected })
+                - selected = available_units.include?(unit)
+                = preference_field_tag("available_units[#{unit}]", selected, { type: :boolean, selected: selected })
                 = label_tag(unit, unit.downcase) + tag(:br)
 
       .form-buttons.filter-actions.actions{"data-hook" => "buttons"}

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -10,6 +10,7 @@
 = render :partial => 'spree/admin/shared/order_sub_menu'
 
 = admin_inject_column_preferences module: 'admin.lineItems'
+= admin_inject_available_units
 
 %div{ ng: { controller: 'LineItemsCtrl' } }
   %save-bar{ dirty: "bulk_order_form.$dirty", persist: "false" }

--- a/app/views/spree/admin/products/index.html.haml
+++ b/app/views/spree/admin/products/index.html.haml
@@ -1,5 +1,6 @@
 = render 'spree/admin/products/index/header'
 = render 'spree/admin/products/index/data'
+= admin_inject_available_units
 
 %div{ ng: { app: 'ofn.admin', controller: 'AdminProductEditCtrl', init: 'initialise()' } }
 

--- a/app/views/spree/admin/variants/edit.html.haml
+++ b/app/views/spree/admin/variants/edit.html.haml
@@ -4,6 +4,8 @@
 
 = render partial: 'spree/shared/error_messages', locals: { target: @variant }
 
+= admin_inject_available_units
+
 = form_for [:admin, @product, @variant], :url => admin_product_variant_path(@product, @variant, @url_filters) do |f|
   %fieldset.no-border-top
     %div

--- a/app/views/spree/admin/variants/new.html.haml
+++ b/app/views/spree/admin/variants/new.html.haml
@@ -1,5 +1,7 @@
 = render partial: 'spree/shared/error_messages', locals: { target: @variant }
 
+= admin_inject_available_units
+
 = form_for [:admin, @product, @variant], :url => admin_product_variants_path(@product, @url_filters) do |f|
   %fieldset{'data-hook' => "admin_variant_new_form"}
     %legend{align: "center"}= t('.new_variant')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,8 @@ en:
     unsaved_confirm_leave: "There are unsaved changed on this page. Continue without saving?"
     unsaved_changes: "You have unsaved changes"
 
+    available_units: "Available Units"
+
     shopfront_settings:
       embedded_shopfront_settings: "Embedded Shopfront Settings"
       enable_embedded_shopfronts: "Enable Embedded Shopfronts"

--- a/spec/controllers/spree/admin/general_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/general_settings_controller_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Admin::GeneralSettingsController, type: :controller do
 
     it "updates available units" do
       expect(Spree::Config.available_units).to_not include("lb")
-      settings_params = { available_units_lb: "1" }
+      settings_params = { available_units: { lb: "1" } }
       spree_put :update, settings_params
       expect(Spree::Config.available_units).to include("lb")
     end

--- a/spec/controllers/spree/admin/general_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/general_settings_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Spree::Admin::GeneralSettingsController, type: :controller do
+  include AuthenticationHelper
+
+  describe 'updating general settings' do
+    let!(:user) { create(:admin_user) }
+
+    before do
+      allow(controller).to receive(:spree_current_user) { user }
+    end
+
+    it "updates available units" do
+      expect(Spree::Config.available_units).to_not include("lb")
+      settings_params = { available_units_lb: "1" }
+      spree_put :update, settings_params
+      expect(Spree::Config.available_units).to include("lb")
+    end
+  end
+end

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -257,6 +257,10 @@ describe "AdminProductEditCtrl", ->
       $provide.value 'SpreeApiKey', 'API_KEY'
       $provide.value 'columns', []
       null
+    module "admin.products"
+    module ($provide)->
+      $provide.value "availableUnits", "g,kg,T,mL,L,kL"
+      null
 
   beforeEach inject((_$controller_, _$timeout_, $rootScope, _$httpBackend_, _BulkProducts_, _DirtyProducts_, _DisplayProperties_, _ProductFiltersUrl_) ->
     $scope = $rootScope.$new()

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -7,6 +7,10 @@ describe "LineItemsCtrl", ->
     module ($provide) ->
       $provide.value 'columns', []
       null
+    module "admin.products"
+    module ($provide)->
+      $provide.value "availableUnits", "g,kg,T,mL,L,kL"
+      null
 
     jasmine.addMatchers
       toDeepEqual: (util, customEqualityTesters) ->

--- a/spec/javascripts/unit/admin/products/services/option_value_namer_spec.js.coffee
+++ b/spec/javascripts/unit/admin/products/services/option_value_namer_spec.js.coffee
@@ -3,6 +3,9 @@ describe "OptionValueNamer", ->
 
   beforeEach ->
     module('admin.products')
+    module ($provide)->
+      $provide.value "availableUnits", "g,kg,T,mL,L,kL"
+      null
     inject (_OptionValueNamer_) ->
       subject = new _OptionValueNamer_
 

--- a/spec/javascripts/unit/admin/products/units_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/products/units_controller_spec.js.coffee
@@ -5,9 +5,13 @@ describe "unitsCtrl", ->
 
   beforeEach ->
     module('admin.products')
+    module ($provide)->
+      $provide.value "availableUnits", "g,kg,T,mL,L,kL"
+      null
     inject ($rootScope, $controller, VariantUnitManager) ->
       scope = $rootScope
       ctrl = $controller 'unitsCtrl', {$scope: scope, VariantUnitManager: VariantUnitManager}
+
 
   describe "interpretting variant_unit_with_scale", ->
     it "splits string with one underscore and stores the two parts", ->

--- a/spec/javascripts/unit/admin/services/option_value_namer_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/option_value_namer_spec.js.coffee
@@ -3,6 +3,10 @@ describe "Option Value Namer", ->
 
   beforeEach ->
     module "ofn.admin"
+    module "admin.products"
+    module ($provide)->
+      $provide.value "availableUnits", "g,kg,T,mL,L,kL"
+      null
 
   beforeEach inject (_OptionValueNamer_) ->
     OptionValueNamer = _OptionValueNamer_

--- a/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
@@ -43,8 +43,6 @@ describe "VariantUnitManager", ->
     it "returns an array of options", ->
       expect(VariantUnitManager.variantUnitOptions()).toEqual [
         ["Weight (g)", "weight_1"],
-        ["Weight (oz)", "weight_28.35"],
-        ["Weight (lb)", "weight_453.6"],
         ["Weight (kg)", "weight_1000"],
         ["Weight (T)", "weight_1000000"],
         ["Volume (mL)", "volume_0.001"],

--- a/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
@@ -3,6 +3,9 @@ describe "VariantUnitManager", ->
 
   beforeEach ->
     module "admin.products"
+    module ($provide)->
+      $provide.value "availableUnits", "g,kg,T,mL,L,kL"
+      null
 
   beforeEach inject (_VariantUnitManager_) ->
     VariantUnitManager = _VariantUnitManager_


### PR DESCRIPTION
#### What? Why?

Closes #6082 

After merging #5888 it came to light that some countries legally require products to only be sold in certain units. This PR allows an instance manager to specify which units appear during product creation/editing, allowing them to exclude units that are not allowed or just never used. 

The default units are metric, so new instances will likely never have to adjust this setting. 

We could make the settings UI a bit nicer and separate metric units, but I held off on putting too much time into that because it seems like there's some urgency to get this released. 

<img width="351" alt="Screen Shot 2020-10-06 at 5 18 21 PM" src="https://user-images.githubusercontent.com/35588/95276566-61470a80-0800-11eb-9074-2b86476964e0.png">

#### What should we test?
Updating the available units in Configuration, going to the products tab and confirming that the correct units appear. 

#### Release notes
Added a setting to allow instance managers to select which units (kg, lb, etc) are available for products. 

Changelog Category: Added

#### Discourse thread
https://community.openfoodnetwork.org/t/allow-enterprises-to-choose-what-available-units-for-products-variants/2060

#### Dependencies

#### Documentation updates
