### PR TITLE
Mobile product listing tweaks

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
@@ -36,4 +36,4 @@ Darkswarm.controller "ShopVariantCtrl", ($scope, $modal, Cart) ->
 
   $scope.addBulk = (quantity) ->
     $scope.add(quantity)
-    $modal.open(templateUrl: "bulk_buy_modal.html", scope: $scope)
+    $modal.open(templateUrl: "bulk_buy_modal.html", scope: $scope, windowClass: "product-bulk-modal")

--- a/app/assets/javascripts/templates/price_breakdown.html.haml
+++ b/app/assets/javascripts/templates/price_breakdown.html.haml
@@ -2,7 +2,7 @@
   %span.joyride-nub.top
   .background{ng: {click: "tt_isOpen = false"}}
   .joyride-content-wrapper
-    %h6= t("price_breakdown")
+    %h6 {{ "js.shopfront.price_breakdown" | t }}
     %ul
       %li
         .right {{ ::variant.price | localizeCurrency }}

--- a/app/assets/javascripts/templates/price_breakdown.html.haml
+++ b/app/assets/javascripts/templates/price_breakdown.html.haml
@@ -2,6 +2,7 @@
   %span.joyride-nub.top
   .background{ng: {click: "tt_isOpen = false"}}
   .joyride-content-wrapper
+    %h6= t("price_breakdown")
     %ul
       %li
         .right {{ ::variant.price | localizeCurrency }}

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -58,7 +58,7 @@ button.add-variant {
 button.variant-quantity {
   width: 3rem;
 
-  &:nth-of-type(1) {
+  &:nth-of-type(1):not(.bulk-buy):not(.bulk-buy-add) {
     border-right: .1em solid $orange-400;
   }
 }

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -8,6 +8,10 @@
   @include placeholder(rgba(0, 0, 0, 0.4), #777);
 }
 
+.reveal-modal.product-bulk-modal {
+  width: 26em;
+}
+
 // Components to add variants to cart and change quantities
 //
 // They are not nested so that they can be used in modals.

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -83,7 +83,15 @@ button.bulk-buy.variant-quantity {
 }
 
 button.bulk-buy-add.variant-quantity {
-  width: 2.5rem
+  width: 2.5rem;
+
+  &[disabled] {
+    background-color: $grey-400;
+
+    &:hover, &:focus {
+      background-color: $grey-400;
+    }
+  }
 }
 
 span.bulk-buy.variant-quantity {

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -11,9 +11,7 @@
   @include box-shadow(0 2px 8px 0 rgba(0, 0, 0, 0.35));
 
   .joyride-content-wrapper {
-    padding: 1.125rem 1.25rem 1.5rem;
-    padding: 1rem;
-    margin: 1%;
+    padding: .625rem;
     width: 98%;
     background-color: $grey-800;
     color: white;
@@ -21,8 +19,9 @@
 
   h6 {
     font-size: 0.937rem;
+    line-height: 1;
     border-bottom: .1em solid $grey-700;
-    padding: .5em 0.25rem;
+    padding: 0 0 .625em 0;
     margin-bottom: 2px;
   }
 
@@ -48,14 +47,15 @@
   }
 
   li {
+    line-height: 1;
     border-bottom: .1em solid $grey-700;
-    padding: 0 0.25rem;
+    padding: 0.625rem 0;
     margin-bottom: 2px;
   }
 
   li:last-child {
     border-bottom: 0;
-    margin-bottom: 0.75rem;
+    padding-bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -4,6 +4,8 @@
 // Pop over
 // Foundation overrides
 .joyride-tip-guide.price_breakdown {
+  width: 16rem;
+  max-width: 65%;
   // JS needs to be tweaked to adjust for left alignment - this is dynamic can't rewrite in CSS
   margin-left: -7.4rem;
   margin-top: 0.1rem;

--- a/app/assets/stylesheets/darkswarm/_shop-popovers.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-popovers.scss
@@ -19,8 +19,11 @@
     color: white;
   }
 
-  h1, h2, h3, h4, h5, h6 {
-    color: #1f1f1f;
+  h6 {
+    font-size: 0.937rem;
+    border-bottom: .1em solid $grey-700;
+    padding: .5em 0.25rem;
+    margin-bottom: 2px;
   }
 
   .joyride-nub.top {

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -50,7 +50,7 @@
           }
 
           & > *:nth-child(n + 2) {
-            color: #888;
+            color: $grey-550;
             font-size: 0.875rem;
             font-style: italic;
             line-height: normal;
@@ -107,7 +107,7 @@
           }
 
           .product-producer {
-            color: #888;
+            color: $grey-550;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -107,6 +107,7 @@
           }
 
           .product-producer {
+            color: #888;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -161,6 +161,12 @@
                   border-color: #ccc;
                 }
               }
+
+              // Foundation doesn't show the nub on mobile.
+              // Repeating the style to show it here.
+              .nub {
+                border-color: transparent transparent #333333 transparent;
+              }
             }
           }
         }

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -33,9 +33,11 @@
         }
 
         .variant-name,
-        .variant-price,
         .total-price {
-          line-height: 2.5em;
+          padding-top: .74em;
+        }
+        .variant-price {
+          padding-top: .65em;
         }
 
         // Variant name
@@ -51,7 +53,6 @@
             color: #888;
             font-size: 0.875rem;
             line-height: normal;
-            margin-top: -0.75em;
           }
         }
 

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -52,6 +52,7 @@
           & > *:nth-child(n + 2) {
             color: #888;
             font-size: 0.875rem;
+            font-style: italic;
             line-height: normal;
           }
         }

--- a/app/assets/stylesheets/darkswarm/_shop-product-thumb.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-thumb.scss
@@ -12,6 +12,18 @@
         @include breakpoint(phablet) {
           width: calc(33.333%);
         }
+
+        // Make this an anchor for the bulk label.
+        position: relative;
+
+        .product-thumb__bulk-label {
+          background-color: $grey-700;
+          color: white;
+          position: absolute;
+          right: 0;
+          top: .8em;
+          padding: .25em .5em;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/darkswarm/branding.scss
+++ b/app/assets/stylesheets/darkswarm/branding.scss
@@ -47,6 +47,7 @@ $grey-200: #ddd;
 $grey-300: #ccc;
 $grey-400: #bbb;
 $grey-500: #999;
+$grey-550: #888;
 $grey-600: #777;
 $grey-650: #666;
 $grey-700: #555;

--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -1,5 +1,7 @@
 .product-thumb
   %a{"ng-click" => "triggerProductModal()"}
+    %span.product-thumb__bulk-label{"ng-if" => "::product.group_buy"}
+      = t("products_bulk")
     %img{"ng-src" => "{{::product.primaryImageOrMissing}}"}
 
 .summary

--- a/app/views/shop/products/_summary.html.haml
+++ b/app/views/shop/products/_summary.html.haml
@@ -1,7 +1,7 @@
 .product-thumb
   %a{"ng-click" => "triggerProductModal()"}
     %span.product-thumb__bulk-label{"ng-if" => "::product.group_buy"}
-      = t("products_bulk")
+      = t(".bulk")
     %img{"ng-src" => "{{::product.primaryImageOrMissing}}"}
 
 .summary

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2052,7 +2052,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   shop_for_products_html: "Shop for <span class=\"turquoise\">%{enterprise}</span> products at:"
   change_shop: "Change shop to:"
   shop_at: "Shop now at:"
-  price_breakdown: "Price breakdown"
   admin_fee: "Admin fee"
   sales_fee: "Sales fee"
   packing_fee: "Packing fee"
@@ -2732,6 +2731,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       bulk_buy_modal:
         min_quantity: "Min quantity"
         max_quantity: "Max quantity"
+      price_breakdown: "Price breakdown"
     variants:
       on_demand:
         "yes": "On demand"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1282,6 +1282,9 @@ en:
         require_customer_html: "If you'd like to start shopping here, please %{contact} %{enterprise} to ask about joining."
       select_oc:
         select_oc_html: "Please <span class='highlighted'>choose when you want your order</span>, to see what products are available."
+    products:
+      summary:
+        bulk: "Bulk"
 
   # Front-end controller translations
   card_could_not_be_updated: Card could not be updated
@@ -1700,7 +1703,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   products_updating_cart: "Updating cart..."
   products_cart_empty: "Cart empty"
   products_edit_cart: "Edit your cart"
-  products_bulk: "Bulk"
   products_from: from
   products_change: "No changes to save."
   products_update_error: "Saving failed with the following error(s):"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1700,6 +1700,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   products_updating_cart: "Updating cart..."
   products_cart_empty: "Cart empty"
   products_edit_cart: "Edit your cart"
+  products_bulk: "Bulk"
   products_from: from
   products_change: "No changes to save."
   products_update_error: "Saving failed with the following error(s):"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2049,7 +2049,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   shop_for_products_html: "Shop for <span class=\"turquoise\">%{enterprise}</span> products at:"
   change_shop: "Change shop to:"
   shop_at: "Shop now at:"
-  price_breakdown: "Full price breakdown"
+  price_breakdown: "Price breakdown"
   admin_fee: "Admin fee"
   sales_fee: "Sales fee"
   packing_fee: "Packing fee"


### PR DESCRIPTION
#### What? Why?

Closes #6080

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

A few more tweaks to the new product listing design for mobile. They were found in the last testing round and documented in:
https://docs.google.com/document/d/1WZZSuMCLHiZ_UY_nLJZ8MI-HGadTQmVty7zXeS7H6VE

Two issue were skipped because the effort to implement them seems out of proportion to the problem.


#### What should we test?
<!-- List which features should be tested and how. -->

The remaining issues

##### Price breakdown modal
- [x] Price breakdown modal is missing it's title (see testing doc for screenshots)
- [x] Padding/margins in the modal aren't quite right (see testing docs for css changes provided by @yukoosawa)
- [x] Price breakdown modal extends to the far right side of the screen on mobile, requires right side padding (see testing doc for screenshots)

##### Adding bulk products to cart

- [x] The bulk visual indicator that displays over the product image is missing (see testing doc for screenshots)
- [x] Add bulk products modal is too wide on desktop and tablet (see testing doc for screenshots)
- [x] Disabled button colour needs to be light grey (#bbbbbb) rather than faded orange.

##### Displaying product property descriptions when hover/click on a property tag

- [x] Property description hover box caret does not display on mobile/tablet (see testing doc for screenshots)

##### Variants

- [x] When a variant name wraps on multiple lines the line height is too big (see testing doc for screenshots)
- [x] Unit size: update the text to: `font-style: italic` to help separate it from the variant name

##### Product list layout and styling

- [x] The "from" before the producer name on the listing should be grey, not black.

Reference design: https://app.zeplin.io/project/59532764a6c78ff3c534b372/dashboard