### PR TITLE
Add coverage threshold for simplecov.

### DIFF
--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+
+SimpleCov.minimum_coverage 94
+SimpleCov.start 'rails' do
+  add_filter '/bin/'
+  add_filter '/config/'
+  add_filter '/jobs/application_job.rb'
+  add_filter '/schemas/'
+  add_filter '/lib/generators'
+  add_filter '/spec/'
+  add_filter '/vendor/'
+end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -11,4 +11,9 @@ SimpleCov.start 'rails' do
   add_filter '/lib/generators'
   add_filter '/spec/'
   add_filter '/vendor/'
+  add_filter '/public'
+  add_filter '/swagger'
+  add_filter '/script'
+  add_filter '/log'
+  add_filter '/db'
 end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -2,7 +2,7 @@
 
 require 'simplecov'
 
-SimpleCov.minimum_coverage 94
+SimpleCov.minimum_coverage 54
 SimpleCov.start 'rails' do
   add_filter '/bin/'
   add_filter '/config/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'rspec/rails'
 require 'capybara'
 require 'database_cleaner'
 require 'rspec/retry'
+require 'coverage_helper'
 require 'paper_trail/frameworks/rspec'
 
 require 'webdrivers'


### PR DESCRIPTION
#### What? Why?

This PR makes sure there is a minimum level of tests covered by the developers. I have set the threshold at 54 for now but can be re-adjusted manually using SimpleCov coverage helper.

I initially set the threshold to 94% but since the lack of specs, the CI build fails. Hence reduced to 54% now as that is the current test coverage of the project. Anyone can add more specs to increase the test coverage.
<img width="1163" alt="Screenshot 2020-10-11 at 19 17 04" src="https://user-images.githubusercontent.com/4223130/95686615-dcd8fb00-0bf6-11eb-8020-6831999715a8.png">




#### What should we test?
This creates test coverage report for test and dev env, which gives more idea of the coverage of specs needed or the specs that have covered various part of the codebase.

