### PR TITLE
Changed '.sum(&block)' to 'to_a.sum(&block)' in app/models/calculator files only

### DIFF
--- a/app/models/calculator/default_tax.rb
+++ b/app/models/calculator/default_tax.rb
@@ -33,7 +33,7 @@ module Calculator
         line_items_total(order),
         per_item_fees_total(order, calculator),
         per_order_fees_total(order, calculator)
-      ].sum do |total|
+      ].to_a.sum do |total|
         round_to_two_places(total * rate.amount)
       end
     end
@@ -43,16 +43,16 @@ module Calculator
         line_item.product.tax_category == rate.tax_category
       end
 
-      matched_line_items.sum(&:total)
+      matched_line_items.to_a.sum(&:total)
     end
 
     # Finds relevant fees for each line_item,
     #   calculates the tax on them, and returns the total tax
     def per_item_fees_total(order, calculator)
-      order.line_items.sum do |line_item|
+      order.line_items.to_a.sum do |line_item|
         calculator.per_item_enterprise_fee_applicators_for(line_item.variant)
           .select { |applicator| applicable_rate?(applicator, line_item) }
-          .sum { |applicator| applicator.enterprise_fee.compute_amount(line_item) }
+          .to_a.sum { |applicator| applicator.enterprise_fee.compute_amount(line_item) }
       end
     end
 
@@ -67,7 +67,7 @@ module Calculator
     def per_order_fees_total(order, calculator)
       calculator.per_order_enterprise_fee_applicators_for(order)
         .select { |applicator| applicator.enterprise_fee.tax_category == rate.tax_category }
-        .sum { |applicator| applicator.enterprise_fee.compute_amount(order) }
+        .to_a.sum { |applicator| applicator.enterprise_fee.compute_amount(order) }
     end
 
     def compute_line_item(line_item)

--- a/app/models/calculator/flexi_rate.rb
+++ b/app/models/calculator/flexi_rate.rb
@@ -25,7 +25,7 @@ module Calculator
 
     def compute(object)
       max = preferred_max_items.to_i
-      items_count = line_items_for(object).map(&:quantity).sum
+      items_count = line_items_for(object).map(&:quantity).to_a.sum
 
       # check max value to avoid divide by 0 errors
       return 0 if max.zero?

--- a/app/models/calculator/price_sack.rb
+++ b/app/models/calculator/price_sack.rb
@@ -24,7 +24,7 @@ module Calculator
 
     def compute(object)
       min = preferred_minimal_amount.to_f
-      order_amount = line_items_for(object).map { |x| x.price * x.quantity }.sum
+      order_amount = line_items_for(object).map { |x| x.price * x.quantity }.to_a.sum
 
       if order_amount < min
         cost = preferred_normal_amount.to_f


### PR DESCRIPTION
For the files within the app/models/calculator directory, this pull request addresses the following deprecation message:
```
DEPRECATION WARNING: Calling #sum with a block is deprecated and will be removed in Rails 4.1. If you want to perform sum calculation over the array of elements, use `to_a.sum(&block)`.
```
There are numerous instances of these deprecation messages.  I will be making a series of small pull requests like this one to address them.