### PR TITLE
Fix docker local environment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,11 @@ RUN sh -c "echo 'deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main'
     apt-get update && \
     apt-get install -yqq --no-install-recommends postgresql-client-9.5 libpq-dev
 
-# Install node
-RUN apt-get install -y nodejs
+# Install node & yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install -y nodejs yarn
 
 # Install Chrome
 RUN wget --quiet -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -43,5 +46,9 @@ RUN wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.z
 
 # Copy code and install app dependencies
 COPY . /usr/src/app/
+
+# Install front-end dependencies
+RUN yarn install
+
 # Run bundler install in parallel with the amount of available CPUs
 RUN bundle install --jobs="$(nproc)"


### PR DESCRIPTION
#### What? Why?

After setting up the local environment using docker, when visiting http://localhost:3000, I'm getting `couldn't find file ...moment.min.js` error (See https://github.com/openfoodfoundation/openfoodnetwork/pull/6049#issuecomment-704848918)

Right now `moment.js` should be installed using yarn, so this PR installs front-end dependencies like moment.js during the docker build. This is a requirement added by https://github.com/openfoodfoundation/openfoodnetwork/pull/6049. 

Changes:
- Added yarn dependency in the `web` container.
- Install node dependencies before executing bundler.

#### What should we test?

We should test that, after recreating the local docker environment, the home http://localhost:3000 works as expected.