### PR TITLE
Update cache store naming

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Openfoodnetwork::Application.configure do
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i
   memcached_value_max_bytes = memcached_value_max_megabytes * 1024 * 1024
-  config.cache_store = :dalli_store, { value_max_bytes: memcached_value_max_bytes }
+  config.cache_store = :mem_cache_store, { value_max_bytes: memcached_value_max_bytes }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -44,7 +44,7 @@ Openfoodnetwork::Application.configure do
   # Use a different cache store in production
   memcached_value_max_megabytes = ENV.fetch("MEMCACHED_VALUE_MAX_MEGABYTES", 1).to_i
   memcached_value_max_bytes = memcached_value_max_megabytes * 1024 * 1024
-  config.cache_store = :dalli_store, { value_max_bytes: memcached_value_max_bytes }
+  config.cache_store = :mem_cache_store, { value_max_bytes: memcached_value_max_bytes }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"


### PR DESCRIPTION
#### What? Why?

Updates cache config in line with this deprecation message:

```
DEPRECATION: :dalli_store will be removed in Dalli 3.0. 
Please use Rails' official :mem_cache_store instead. 
https://guides.rubyonrails.org/caching_with_rails.html
```

Memcached should still be used either way, so there shouldn't be any change functionally.

This Rails issue gives some good background if anyone is interested: https://github.com/rails/rails/issues/21595

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough, we have caching specs in place.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Fixed minor deprecation warning in cache store naming.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

