### PR TITLE
[Rails 4.1] Change Rails ActiveRelation mutator methods because they're not valid on

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -88,7 +88,7 @@ module Admin
         redirect_to main_app.admin_enterprises_path
       else
         touched_enterprises = @enterprise_set.collection.select(&:changed?)
-        @enterprise_set.collection.select! { |e| touched_enterprises.include? e }
+        @enterprise_set.collection.to_a.select! { |e| touched_enterprises.include? e }
         flash[:error] = I18n.t(:enterprise_bulk_update_error)
         render :index
       end

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -4,21 +4,29 @@ module CheckoutHelper
   end
 
   def checkout_adjustments_for(order, opts = {})
-    adjustments = order.adjustments.eligible
     exclude = opts[:exclude] || {}
 
     adjustments = adjustments.to_a
 
     # Remove empty tax adjustments and (optionally) shipping fees
-    adjustments.reject! { |a| a.originator_type == 'Spree::TaxRate' && a.amount == 0 }
-    adjustments.reject! { |a| a.originator_type == 'Spree::ShippingMethod' } if exclude.include? :shipping
-    adjustments.reject! { |a| a.originator_type == 'Spree::PaymentMethod' } if exclude.include? :payment
-    adjustments.reject! { |a| a.source_type == 'Spree::LineItem' } if exclude.include? :line_item
+    adjustments = order
+      .adjustments
+      .eligible
+      .reject do |adjustment|
+        (adjustment.originator_type == 'Spree::TaxRate' && adjustment.amount.zero?) ||
+          (adjustment.originator_type == 'Spree::ShippingMethod' && exclude.include?(:shipping)) ||
+          (adjustment.originator_type == 'Spree::PaymentMethod' && exclude.include?(:payment)) ||
+          (adjustment.source_type == 'Spree::LineItem' && exclude.include?(:line_item))
+      end
 
     enterprise_fee_adjustments = adjustments.select { |a| a.originator_type == 'EnterpriseFee' && a.source_type != 'Spree::LineItem' }
     adjustments.reject! { |a| a.originator_type == 'EnterpriseFee' && a.source_type != 'Spree::LineItem' }
+
     unless exclude.include? :admin_and_handling
-      adjustments << Spree::Adjustment.new(label: I18n.t(:orders_form_admin), amount: enterprise_fee_adjustments.sum(:amount))
+      adjustments << Spree::Adjustment.new(
+        label: I18n.t(:orders_form_admin),
+        amount: enterprise_fee_adjustments.sum(&:amount)
+      )
     end
 
     adjustments

--- a/app/models/model_set.rb
+++ b/app/models/model_set.rb
@@ -43,23 +43,22 @@ class ModelSet
 
   def save
     collection_to_delete.each(&:destroy)
-    collection_to_keep.all?(&:save)
-  end
-
-  def collection_to_delete
-    # Remove all elements to be deleted from collection and return them
-    # Allows us to render @model_set.collection without deleted elements
-    deleted = []
-    @collection = collection.to_a
-    collection.delete_if { |e| deleted << e if @delete_if.andand.call(e.attributes) }
-    deleted
-  end
-
-  def collection_to_keep
-    collection.reject { |e| @delete_if.andand.call(e.attributes) }
+    (collection - collection_to_delete).each(&:save)
   end
 
   def persisted?
     false
+  end
+
+  private
+
+  attr_accessor :delete_if, :reject_if, :klass
+
+  # Remove all elements to be deleted from collection and return them
+  # Allows us to render @model_set.collection without deleted elements
+  def collection_to_delete
+    return [] if delete_if.nil?
+
+    collection.select { |model| delete_if.call(model.attributes) }
   end
 end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -67,14 +67,14 @@ module Spree
     end
 
     def known_users
-      if admin?
-        Spree::User.where(nil)
-      else
-        Spree::User
-          .includes(:enterprises)
-          .where("enterprises.id IN (SELECT enterprise_id FROM enterprise_roles WHERE user_id = ?)",
-                 id)
-      end
+      return Spree::User.where(nil) if admin?
+
+      Spree::User
+        .joins(:enterprises)
+        .where(
+          'enterprises.id IN (SELECT enterprise_id FROM enterprise_roles WHERE user_id = ?)',
+          id
+        )
     end
 
     def build_enterprise_roles
@@ -159,17 +159,14 @@ module Spree
     def limit_owned_enterprises
       return unless owned_enterprises.size > enterprise_limit
 
-      errors.add(:owned_enterprises, I18n.t(:spree_user_enterprise_limit_error,
-                                            email: email,
-                                            enterprise_limit: enterprise_limit))
-    end
-
-    def remove_payments_in_checkout(enterprises)
-      enterprises.each do |enterprise|
-        enterprise.distributed_orders.each do |order|
-          order.payments.keep_if { |payment| payment.state != "checkout" }
-        end
-      end
+      errors.add(
+        :owned_enterprises,
+        I18n.t(
+          :spree_user_enterprise_limit_error,
+          email: email,
+          enterprise_limit: enterprise_limit
+        )
+      )
     end
   end
 end

--- a/app/models/variant_override_set.rb
+++ b/app/models/variant_override_set.rb
@@ -19,12 +19,6 @@ class VariantOverrideSet < ModelSet
   # This method will delete VariantOverrides that have no values (see deletable? above)
   #   If the user sets all values to nil in the UI the VO will be deleted from the DB
   def collection_to_delete
-    deleted = []
-    collection.delete_if { |e| deleted << e if @delete_if.andand.call(e.attributes, e.tag_list) }
-    deleted
-  end
-
-  def collection_to_keep
-    collection.reject { |e| @delete_if.andand.call(e.attributes, e.tag_list) }
+    collection.select { |model| delete_if.call(model.attributes, model.tag_list) }
   end
 end

--- a/app/services/shop/order_cycles_list.rb
+++ b/app/services/shop/order_cycles_list.rb
@@ -20,11 +20,13 @@ module Shop
     # order_cycles is a ActiveRecord::Relation that is modified with reject in the TagRuleApplicator
     # If this relation is reloaded (for example by calling count on it), the modifications are lost
     def apply_tag_rules!(order_cycles)
-      applicator = OpenFoodNetwork::TagRuleApplicator.new(@distributor,
-                                                          "FilterOrderCycles",
-                                                          @customer.andand.tag_list)
-      applicator.filter!(order_cycles)
+      applicator = OpenFoodNetwork::TagRuleApplicator.new(
+        @distributor,
+        "FilterOrderCycles",
+        @customer.andand.tag_list
+      )
 
+      applicator.filter!(order_cycles)
       order_cycles
     end
   end

--- a/engines/order_management/app/services/order_management/stock/package.rb
+++ b/engines/order_management/app/services/order_management/stock/package.rb
@@ -92,11 +92,12 @@ module OrderManagement
       #
       # @return [Array<Spree::ShippingMethod>]
       def shipping_methods
-        available_shipping_methods = shipping_categories.flat_map(&:shipping_methods).uniq.to_a
-
-        available_shipping_methods.keep_if do |shipping_method|
-          ships_with?(order.distributor.shipping_methods.to_a, shipping_method)
-        end
+        shipping_categories
+          .flat_map(&:shipping_methods)
+          .uniq
+          .select do |shipping_method|
+            ships_with?(order.distributor.shipping_methods.to_a, shipping_method)
+          end
       end
 
       def inspect

--- a/engines/order_management/app/services/order_management/stock/prioritizer.rb
+++ b/engines/order_management/app/services/order_management/stock/prioritizer.rb
@@ -13,8 +13,7 @@ module OrderManagement
 
       def prioritized_packages
         adjust_packages
-        prune_packages
-        packages
+        packages.reject(&:empty?)
       end
 
       private
@@ -35,10 +34,6 @@ module OrderManagement
           item = package.find_item adjuster.variant, adjuster.status
           adjuster.adjust(item) if item
         end
-      end
-
-      def prune_packages
-        packages.reject!(&:empty?)
       end
     end
   end

--- a/engines/order_management/spec/services/order_management/stock/estimator_spec.rb
+++ b/engines/order_management/spec/services/order_management/stock/estimator_spec.rb
@@ -8,7 +8,7 @@ module OrderManagement
       let!(:shipping_method) { create(:shipping_method, zones: [create(:zone)] ) }
       let(:package) { build(:stock_package_fulfilled) }
       let(:order) { package.order }
-      subject { Estimator.new(order) }
+      subject { described_class.new(order) }
 
       context "#shipping rates" do
         before(:each) do
@@ -23,7 +23,8 @@ module OrderManagement
           allow_any_instance_of(Spree::ShippingMethod).
             to receive_message_chain(:calculator, :marked_for_destruction?)
 
-          allow(package).to receive_messages(shipping_methods: [shipping_method])
+          # FIXME: DO NOT mock private methods
+          allow(package).to receive_messages(select_shipping_methods: [shipping_method])
         end
 
         context "the order's ship address is in the same zone" do
@@ -74,7 +75,8 @@ module OrderManagement
           allow(shipping_methods[2]).
             to receive_message_chain(:calculator, :compute).and_return(4.00)
 
-          allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
+          # FIXME: DO NOT mock private methods
+          allow(subject).to receive(:select_shipping_methods).and_return(shipping_methods)
 
           expected_costs = %w[3.00 4.00 5.00].map(&BigDecimal.method(:new))
           expect(subject.shipping_rates(package).map(&:cost)).to eq expected_costs
@@ -89,7 +91,8 @@ module OrderManagement
             allow(shipping_methods[1]).
               to receive_message_chain(:calculator, :compute).and_return(3.00)
 
-            allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
+            # FIXME: DO NOT mock private methods
+            allow(subject).to receive(:select_shipping_methods).and_return(shipping_methods)
 
             shipping_rates = subject.shipping_rates(package)
             expect(shipping_rates.sort_by(&:cost).map(&:selected)).to eq [true, false]
@@ -101,7 +104,8 @@ module OrderManagement
             allow(shipping_methods[1]).
               to receive_message_chain(:calculator, :compute).and_return(nil)
 
-            allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
+            # FIXME: DO NOT mock private methods
+            allow(subject).to receive(:select_shipping_methods).and_return(shipping_methods)
 
             subject.shipping_rates(package)
           end
@@ -116,8 +120,9 @@ module OrderManagement
             allow(backend_method).to receive_message_chain(:calculator, :compute).and_return(0.00)
             allow(generic_method).to receive_message_chain(:calculator, :compute).and_return(5.00)
 
+            # FIXME: DO NOT mock private methods
             allow(subject).
-              to receive(:shipping_methods).and_return([backend_method, generic_method])
+              to receive(:select_shipping_methods).and_return([backend_method, generic_method])
 
             expect(subject.shipping_rates(package).map(&:selected)).to eq [false, true]
           end

--- a/lib/open_food_network/available_payment_method_filter.rb
+++ b/lib/open_food_network/available_payment_method_filter.rb
@@ -3,12 +3,12 @@ module OpenFoodNetwork
     def filter!(payment_methods)
       if stripe_enabled?
         payment_methods.to_a.reject! do |payment_method|
-          payment_method.type.ends_with?("StripeConnect") &&
+          stripe_connect?(payment_method) &&
             stripe_configuration_incomplete?(payment_method)
         end
       else
         payment_methods.to_a.reject! do |payment_method|
-          payment_method.type.ends_with?("StripeConnect")
+          stripe_connect?(payment_method)
         end
       end
     end
@@ -17,6 +17,10 @@ module OpenFoodNetwork
 
     def stripe_enabled?
       Spree::Config.stripe_connect_enabled && Stripe.publishable_key
+    end
+
+    def stripe_connect?(payment_method)
+      payment_method.type.ends_with?("StripeConnect")
     end
 
     def stripe_configuration_incomplete?(payment_method)

--- a/lib/spree/core/controller_helpers/auth.rb
+++ b/lib/spree/core/controller_helpers/auth.rb
@@ -35,7 +35,7 @@ module Spree
 
         def store_location
           # disallow return to login, logout, signup pages
-          authentication_routes = [:spree_signup_path, :spree_login_path, :spree_logout_path]
+          authentication_routes = %i[spree_signup_path spree_login_path spree_logout_path]
           disallowed_urls = []
           authentication_routes.each do |route|
             if respond_to?(route)
@@ -43,7 +43,7 @@ module Spree
             end
           end
 
-          disallowed_urls.map!{ |url| url[/\/\w+$/] }
+          disallowed_urls.map!{ |url| url[%r{/\/\w+$/}] }
           return if disallowed_urls.include?(request.fullpath)
 
           session['spree_user_return_to'] = request.fullpath.gsub('//', '/')

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'open_food_network/order_cycle_permissions'
 
 describe Admin::EnterprisesController, type: :controller do
+
   let(:user) { create(:user) }
   let(:admin_user) { create(:admin_user) }
   let(:distributor_manager) { create(:user, enterprise_limit: 10, enterprises: [distributor]) }

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe EnterprisesController, type: :controller do
+
   describe "shopping for a distributor" do
     let(:user) { create(:user) }
     let(:order) { controller.current_order(true) }

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -4,7 +4,6 @@ module Spree
   class GatewayWithPassword < PaymentMethod
     preference :password, :string, default: "password"
   end
-
   describe Admin::PaymentMethodsController, type: :controller do
     describe "#create and #update" do
       let!(:enterprise) { create(:distributor_enterprise, owner: user) }

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -9,9 +9,7 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
       {
         id: shipping_method.id,
         shipping_method: {
-          calculator_attributes: {
-            id: shipping_method.calculator.id
-          }
+          calculator_attributes: { id: shipping_method.calculator.id }
         }
       }
     }

--- a/spec/features/admin/order_print_ticket_spec.rb
+++ b/spec/features/admin/order_print_ticket_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-
 feature '
     As an administrator
     I want to print a ticket for an order

--- a/spec/helpers/enterprises_helper_spec.rb
+++ b/spec/helpers/enterprises_helper_spec.rb
@@ -4,7 +4,6 @@ describe EnterprisesHelper, type: :helper do
   let(:user) { create(:user) }
   let(:distributor) { create(:distributor_enterprise) }
   let(:some_other_distributor) { create(:distributor_enterprise) }
-
   before { allow(helper).to receive(:spree_current_user) { user } }
 
   describe "loading available shipping methods" do

--- a/spec/lib/open_food_network/tag_rule_applicator_spec.rb
+++ b/spec/lib/open_food_network/tag_rule_applicator_spec.rb
@@ -1,4 +1,3 @@
-require 'open_food_network/tag_rule_applicator'
 require 'spec_helper'
 
 module OpenFoodNetwork
@@ -86,7 +85,9 @@ module OpenFoodNetwork
 
     describe "filter!" do
       let(:applicator) { OpenFoodNetwork::TagRuleApplicator.new(enterprise, "FilterProducts", []) }
-
+      # FIXME: Do not check internal implementation of filter!
+      #
+      # Do not check that `reject!` is called but check that subject iis filtered
       context "when the subject is nil" do
         let(:subject) { double(:subject, reject!: false) }
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe Spree.user_class do
   include OpenFoodNetwork::EmailHelper
-
   describe "associations" do
     it { is_expected.to have_many(:owned_enterprises) }
 

--- a/spec/models/variant_override_spec.rb
+++ b/spec/models/variant_override_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe VariantOverride do
   let(:variant) { create(:variant) }
   let(:hub)     { create(:distributor_enterprise) }
-
   describe "scopes" do
     let(:hub1) { create(:distributor_enterprise) }
     let(:hub2) { create(:distributor_enterprise) }
@@ -97,7 +96,6 @@ describe VariantOverride do
           end
         end
       end
-
       context "when limited stock" do
         let(:on_demand) { false }
 


### PR DESCRIPTION
> Rails 4.1.x

#### What? Why?

Closes #[the issue number this PR is related to]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->



<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added | Changed | Deprecated | Removed | Fixed | Security



#### Discourse thread
<!-- Is there a discussion about this in Discourse?
Add the link or remove this section. -->



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
