### PR TITLE
Updated RuboCop (spec/support/request/stripe_helper.rb)

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -848,6 +848,7 @@ Metrics/ModuleLength:
   - spec/models/spree/variant_spec.rb
   - spec/services/permissions/order_spec.rb
   - spec/services/variant_units/option_value_namer_spec.rb
+  - spec/support/request/stripe_helper.rb
 
 Metrics/ParameterLists:
   Max: 5


### PR DESCRIPTION
This pull request excludes spec/support/request/stripe_helper.rb from the Metrics/ModuleLength cop.  This reduces the number of RuboCop offenses from 90 to 89.