### PR TITLE
Updated spec/factories/calculator_factory.rb for RuboCop

### DIFF
--- a/spec/factories/calculator_factory.rb
+++ b/spec/factories/calculator_factory.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
   end
 
   factory :weight_calculator, class: Calculator::Weight do
-    after(:build)  { |c|
+    after(:build) { |c|
       c.set_preference(:per_unit, 0.5)
       c.set_preference(:unit_from_list, "kg")
     }


### PR DESCRIPTION
This pull request removes an unnecessary space from spec/factories/calculator_factory.rb.  This reduces the number of RuboCop offenses from 91 to 90.