### PR TITLE
Add script to draft release notes

### DIFF
--- a/script/release-notes-template
+++ b/script/release-notes-template
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Lists all PRs for the next release in a neat list to copy into the release
+# template. It also opens all PRs in Firefox so that you can find the release
+# notes.
+
+git fetch upstream
+latest="$(git tag --sort="-v:refname" | head -1)"
+
+echo "Changes since last release $latest:"
+
+pr_numbers() {
+	git log "$latest.." --merges --oneline |\
+        grep -oP 'Merge pull request #\K[0-9]+(?= from)'
+}
+
+pr_numbers |\
+       while read n; do echo "https://github.com/openfoodfoundation/openfoodnetwork/pull/$n"; done |\
+       xargs firefox
+
+pr_numbers |\
+       while read n; do echo "- #$n "; done


### PR DESCRIPTION
#### What? Why?

When I draft a new release, I run the script from this PR to copy and paste all the release notes. I prefer the formatting with the PR number first because it aligns all the numbers and list items can be distinguished easier.

![release-notes](https://user-images.githubusercontent.com/3524483/96215865-cf42bd00-0fca-11eb-997d-d34c6b2f6625.png)
Left: unformatted list of changes. Right: formatted list.

This script could be way more general and it could try to parse the release notes for us but that may not be worth the effort. Future pull requests can improve this script. I mainly wanted to share this in case you find it useful as well.

#### Release notes
<!-- Write a line or two to be included in the release notes.
Everything is worth mentioning, because you did it for a reason. -->

Added script to help draft release notes.

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Added

