### PR TITLE
Allow docker-compose configuration customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ coverage
 /reports/
 !/reports/README.md
 bin/
+docker-compose.override.yml


### PR DESCRIPTION
#### What? Why?

Allow developers to customize *docker-compose* configuration by using an unversioned `docker-compose.override.yml` file.

That way, we can expose for example the DB port without changing the configuration in the versioned `docker-compose.yml` file.

```yaml
# docker-compose.override.yml

version: '3'

services:
  db:
    ports:
    - 5432:5432
```
