### PR TITLE
Fix sorting of admin products by name

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -104,7 +104,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
   $scope.$watch 'sortOptions', (sort) ->
     return unless sort && sort.predicate != ""
 
-    $scope.sorting = sort.getSortingExpr()
+    $scope.q.sorting = sort.getSortingExpr()
     $scope.fetchProducts()
   , true
 

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -357,6 +357,15 @@ describe "AdminProductEditCtrl", ->
     it "resets dirtyProducts", ->
       expect(DirtyProducts.clear).toHaveBeenCalled()
 
+  describe "sorting products", ->
+    it "sorts products", ->
+      spyOn $scope, "fetchProducts"
+
+      $scope.sortOptions.toggle('name')
+      $scope.$apply()
+
+      expect($scope.q.sorting).toEqual 'name asc'
+      expect($scope.fetchProducts).toHaveBeenCalled()
 
   describe "updating the product on hand count", ->
     it "updates when product is not available on demand", ->


### PR DESCRIPTION
#### What? Why?

The API expects the `sorting` parameter to be nested inside the `q` paramter.

Closes #6105
#### What should we test?

See _Steps to Reproduce_ in #6105 

#### Release notes

Fix sorting of products by name in admin.

Changelog Category: Fixed 