### PR TITLE
[Rails 4.1] indexed variants

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -136,7 +136,7 @@ module Spree
     end
 
     def self.indexed
-      scoped.index_by(&:id)
+      where(nil).index_by(&:id)
     end
 
     def self.active(currency = nil)


### PR DESCRIPTION
#### What? Why?

Fixes second error in #6193

`#scoped` is deprecated and removed. See: https://github.com/rails/rails/issues/12756

#### What should we test?
<!-- List which features should be tested and how. -->

Green spec:
```
 3) Spree::Variant indexing variants by id indexes variants by id
     Failure/Error: scoped.index_by(&:id)
     
     NameError:
       undefined local variable or method `scoped' for #<Class:0x0000563a51169c20>
     # ./app/models/spree/variant.rb:139:in `indexed'
     # ./spec/models/spree/variant_spec.rb:442:in `block (3 levels) in <module:Spree>'
```
