### PR TITLE
[Rails 4.1] Fix stubbing of stock totals

### DIFF
--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -234,7 +234,7 @@ module Spree
         context 'when stock_items out of stock' do
           before do
             allow_any_instance_of(Spree::StockItem).to receive_messages(backorderable: false)
-            allow_any_instance_of(Spree::StockItem).to receive_messages(count_on_hand: 0)
+            allow_any_instance_of(Spree::Stock::Quantifier).to receive_messages(total_on_hand: 0)
           end
 
           it 'return false if stock_items out of stock' do


### PR DESCRIPTION
#### What? Why?

Fixes first error in #6193

Recent changes to the way count_on_hand is summed in `Spree::Stock::Quantifier` mean the old method stubbing used here will not work. `stock_items.sum(&:count_on_hand)` changed to `stock_items.sum(:count_on_hand)`, which means `#count_on_hand` is not called directly on `StockItem`.

Fixes error:
```
  2) Spree::Variant#in_stock? when stock_items are not backorderable when stock_items out of stock return false if stock_items out of stock
     Failure/Error: expect(variant.in_stock?).to be_falsy

       expected: falsey value
            got: true
     # ./spec/models/spree/variant_spec.rb:241:in `block (5 levels) in <module:Spree>'
  ```


#### What should we test?
<!-- List which features should be tested and how. -->

Green spec
