### PR TITLE
Update the base Ubuntu Docker image from 18.04 to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+ENV TZ Europe/London
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" >> /etc/apt/sources.list
 
 # Install all the requirements
 RUN apt-get update && apt-get install -y curl git build-essential software-properties-common wget zlib1g-dev libssl1.0-dev libreadline-dev libyaml-dev libffi-dev libxml2-dev libxslt1-dev wait-for-it imagemagick unzip


### PR DESCRIPTION
#### What? Why?

Closes #6152 

Update the base Ubuntu Docker image to version 20.04

<!-- Please assign one category to your PR and delete the others. 
The categories are based on https://keepachangelog.com/en/1.0.0/. -->

Changelog Category: Changed

#### what to test
This is a dev test, someone needs to try this locally and verify it works for them: the local server runs successfully as before.