### PR TITLE
[Rails 4.1] API exception response

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -72,7 +72,7 @@ module Api
     end
 
     def error_during_processing(exception)
-      render(text: { exception: exception.message }.to_json,
+      render(json: { exception: exception.message },
              status: :unprocessable_entity) && return
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #6173

For some reason when using `render text:` instead of `render json:` for this response, the status code being returned was `200` instead of the clearly explicitly defined `422` (:unprocessable_entity). I absolutely have no idea why! Anyway, this fixes it.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how. -->

Green spec for any tests expecting a 422 and getting a 200 in `spec/controllers/api/shipments_controller_spec.rb`:
```
  0) Api::ShipmentsController as an admin for a completed order with shipment #add returns error code when adding to order contents fails
     Failure/Error: expect(response.status).to eq 422

       expected: 422
            got: 200

       (compared using ==)
     # ./spec/controllers/api/shipments_controller_spec.rb:230:in `expect_error_response'
     # ./spec/controllers/api/shipments_controller_spec.rb:176:in `block (5 levels) in <top (required)>'
     # -e:1:in `<main>'
```
