### PR TITLE
Open PostgreSQL port in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_PASSWORD: f00d
       POSTGRES_USER: ofn
       POSTGRES_DB: open_food_network_dev
+    ports:
+      - 5432:5432
     volumes:
       - 'postgres:/var/lib/postgresql/data'
   web:


### PR DESCRIPTION
#### What? Why?

After setting up the environment with docker, we can't access PostgreSQL DB from the host machine. This PR opens the default db port.

We talked about this need in https://github.com/openfoodfoundation/openfoodnetwork/pull/6200 