### PR TITLE
Fix Javascript date format for some languages like :it or :pt.

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3336,8 +3336,8 @@ ca:
           or_enter_new_card: "O bé introdueix els detalls d'una nova targeta:"
           remember_this_card: Recordar aquesta targeta?
     date_picker:
-      format: '%d-% m-% Y'
-      js_format: 'dd-mm-yy'
+      format: ! '%Y/%m/%d'
+      js_format: 'yy/mm/dd'
     orders:
       error_flash_for_unavailable_items: "Un ítem del teu carret ja no està disponible. Sis plau actualitza les quantitats seleccionades."
       edit:

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -3237,8 +3237,8 @@ de_DE:
           or_enter_new_card: "Oder geben Sie Details für eine neue Karte ein:"
           remember_this_card: Diese Karte speichern?
     date_picker:
-      format: '% Y-% m-%d'
-      js_format: 'JJ-MM-TT'
+      format: ! '%d.%m.%Y'
+      js_format: 'dd.mm.yy'
     orders:
       edit:
         login_to_view_order: "Bitte loggen Sie sich ein, um Ihre Bestellung anzuzeigen."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3337,7 +3337,7 @@ es:
           remember_this_card: ¿Recordar esta tarjeta?
     date_picker:
       format: '%Y-%m-%d'
-      js_format: 'yy-mm-dd'
+      js_format: 'yy/mm/dd'
     orders:
       error_flash_for_unavailable_items: "Un artículo de tu carrito ahora no está disponible. Por favor actualiza las cantidades seleccionadas"
       edit:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -3319,7 +3319,7 @@ it:
           remember_this_card: Ricordare questa Carta?
     date_picker:
       format: '%Y-%m-%d'
-      js_format: 'aa-mm-gg'
+      js_format: 'yy/mm/dd'
     orders:
       error_flash_for_unavailable_items: "Un oggetto nel tuo carrello è diventato non disponibile, Per favore aggiorna le quantità selezionate."
       edit:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -3019,8 +3019,8 @@ pt:
           or_enter_new_card: "Ou, introduza detalhes para um novo cartão:"
           remember_this_card: Lembra-se deste cartão?
     date_picker:
-      format: '%Y-%m-%d'
-      js_format: 'aa-mm-dd'
+      format: ! '%Y/%m/%d'
+      js_format: 'yy/mm/dd'
     orders:
       edit:
         login_to_view_order: "Por favor faça login para ver a sua encomenda."

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -3321,8 +3321,8 @@ pt_BR:
           or_enter_new_card: "Ou, adicione os dados para um novo cartão:"
           remember_this_card: Lembrar deste cartão?
     date_picker:
-      format: '%A-%m-'
-      js_format: 'aa-mm-dd'
+      format: ! '%Y/%m/%d'
+      js_format: 'yy/mm/dd'
     orders:
       error_flash_for_unavailable_items: "Um item no seu carrinho ficou indisponível. Por favor atualize as quantidades selecionadas. "
       edit:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -2086,8 +2086,8 @@ sv:
           enterprises_require_tos: "Företag måste acceptera servicevillkoren"
           footer_tos_url: "Användarvillkor URL"
     date_picker:
-      format: '%Y-%m-%d'
-      js_format: 'åå-mm-dd'
+      format: ! '%Y/%m/%d'
+      js_format: 'yy/mm/dd'
     orders:
       bought:
         item: "Redan beställd i denna beställningsomgång"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -3324,8 +3324,8 @@ tr:
           or_enter_new_card: "Veya yeni bir kart için bilgileri girin:"
           remember_this_card: Bu kart hatırlansın mı?
     date_picker:
-      format: '% Y-% A-%d'
-      js_format: 'yy-aa-gg'
+      format: ! '%Y-%m-%d'
+      js_format: 'yy-mm-dd'
     orders:
       error_flash_for_unavailable_items: "Sepetinizdeki ürünlerden biri bitti veya azaldı. Lütfen seçili miktarı güncelleyin."
       edit:


### PR DESCRIPTION
#### What? Why?
I think our translators or automatic translations has miss-translated these formats. I copy the formats on spree_i18n gem from here: https://github.com/spree-contrib/spree_i18n/tree/1-3-stable/config/locales

Closes #6170

## Before
![image](https://user-images.githubusercontent.com/49499/96375765-3ef7aa00-117b-11eb-80a0-036e06a2705c.png)

## After
![image](https://user-images.githubusercontent.com/49499/96375756-2be4da00-117b-11eb-8de6-cf7dd0468ebb.png)


#### What should we test?
Check the software in all available locales and check that dates on date pickers looks ok. I didn't check all cases. 
Please QA 🙏 
