### PR TITLE
Update image default styles

### DIFF
--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -11,7 +11,7 @@ module Spree
                       default_style: :product,
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
-                      convert_options: { all: '-strip -auto-orient -colorspace RGB' }
+                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
 
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -6,8 +6,8 @@ module Spree
     validate :no_attachment_errors
 
     has_attached_file :attachment,
-                      styles: { mini: ["48x48#", :jpg], small: ["227x227#", :jpg],
-                                product: ["240x240>", :jpg], large: ["600x600>", :jpg] },
+                      styles: { mini: "48x48#", small: "227x227#",
+                                product: "240x240>", large: "600x600>" },
                       default_style: :product,
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -6,8 +6,8 @@ module Spree
     validate :no_attachment_errors
 
     has_attached_file :attachment,
-                      styles: { mini: '48x48>', small: '100x100>',
-                                product: '240x240>', large: '600x600>' },
+                      styles: { mini: ["48x48#", :jpg], small: ["227x227#", :jpg],
+                                product: ["240x240>", :jpg], large: ["600x600>", :jpg] },
                       default_style: :product,
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',


### PR DESCRIPTION
#### What? Why?
Extracted from https://github.com/openfoodfoundation/openfoodnetwork/pull/5729
This is where we update to new default image styles.

#### What should we test?
This is a dev test: verify that new images uploaded to the server will have the new default styles.

We can do this as a regular test: upload a product image that is **not square** after staging this PR and check both the super-small thumbnail in admin/products and the image shown in the shopfront are a nice square shape that fills the whole space.

#### Release notes
Updated to new default image styles.
