### PR TITLE
docker-compose run --rm web -> docker-compose run web

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 ## What's the point?
 * Setting up the Open Food Network app on your local machine is quick and easy with the aid of Docker and Docker Compose.
 * Docker provides a common virtual environment available to all developers and resolves the infamous "but it works on my machine" problem.
-* Use the scripts in this directory to execute tasks in Docker.  Please note that these scripts are intended to be executed from this app's root directory.  These scripts allow you to bypass the need to keep typing "docker-compose run --rm web".
+* Use the scripts in this directory to execute tasks in Docker.  Please note that these scripts are intended to be executed from this app's root directory.  These scripts allow you to bypass the need to keep typing "docker-compose run web".
 
 ## Installing Docker
 * You should have at least 2 GB free on your local machine to download Docker images and create Docker containers for this app.

--- a/docker/cop
+++ b/docker/cop
@@ -2,10 +2,10 @@
 
 # This script runs RuboCop.
 
-echo '------------------------------------------------------'
-echo 'BEGIN: docker-compose run --rm web bundle exec rubocop'
-echo '------------------------------------------------------'
-docker-compose run --rm web bundle exec rubocop
-echo '----------------------------------------------------'
-echo 'END: docker-compose run --rm web bundle exec rubocop'
-echo '----------------------------------------------------'
+echo '-------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rubocop'
+echo '-------------------------------------------------'
+docker-compose run web bundle exec rubocop
+echo '-----------------------------------------------'
+echo 'END: docker-compose run web bundle exec rubocop'
+echo '-----------------------------------------------'

--- a/docker/run
+++ b/docker/run
@@ -19,4 +19,4 @@ function cleanup {
 
 trap cleanup EXIT
 
-docker-compose run --rm web $@
+docker-compose run web $@

--- a/docker/seed
+++ b/docker/seed
@@ -2,26 +2,26 @@
 
 # This is the data seeding script.
 
-echo '------------------------------------------------------------'
-echo 'BEGIN: docker-compose run --rm web bundle exec rake db:reset'
-echo '------------------------------------------------------------'
-docker-compose run --rm web bundle exec rake db:reset
-echo '----------------------------------------------------------'
-echo 'END: docker-compose run --rm web bundle exec rake db:reset'
-echo '----------------------------------------------------------'
+echo '-------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:reset'
+echo '-------------------------------------------------------'
+docker-compose run web bundle exec rake db:reset
+echo '-----------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:reset'
+echo '-----------------------------------------------------'
 
-echo '-------------------------------------------------------------------'
-echo 'BEGIN: docker-compose run --rm web bundle exec rake db:test:prepare'
-echo '-------------------------------------------------------------------'
-docker-compose run --rm web bundle exec rake db:test:prepare
-echo '-----------------------------------------------------------------'
-echo 'END: docker-compose run --rm web bundle exec rake db:test:prepare'
-echo '-----------------------------------------------------------------'
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake db:test:prepare
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo '------------------------------------------------------------'
 
-echo '-------------------------------------------------------------------'
-echo 'BEGIN: docker-compose run --rm web bundle exec rake ofn:sample_data'
-echo '-------------------------------------------------------------------'
-docker-compose run --rm web bundle exec rake ofn:sample_data
-echo '-----------------------------------------------------------------'
-echo 'END: docker-compose run --rm web bundle exec rake ofn:sample_data'
-echo '-----------------------------------------------------------------'
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake ofn:sample_data'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake ofn:sample_data
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake ofn:sample_data'
+echo '------------------------------------------------------------'

--- a/docker/test-log
+++ b/docker/test-log
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-echo '-------------------------------------------------------------------'
-echo 'BEGIN: docker-compose run --rm web bundle exec rake db:test:prepare'
-echo '-------------------------------------------------------------------'
-docker-compose run --rm web bundle exec rake db:test:prepare
-echo '-----------------------------------------------------------------'
-echo 'END: docker-compose run --rm web bundle exec rake db:test:prepare'
-echo '-----------------------------------------------------------------'
+echo '--------------------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo '--------------------------------------------------------------'
+docker-compose run web bundle exec rake db:test:prepare
+echo '------------------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo '------------------------------------------------------------'
 
-echo '---------------------------------------------------------'
-echo 'BEGIN: docker-compose run --rm web bundle exec rspec spec'
-echo '---------------------------------------------------------'
-docker-compose run --rm web bundle exec rspec spec
-echo '-------------------------------------------------------'
-echo 'END: docker-compose run --rm web bundle exec rspec spec'
-echo '-------------------------------------------------------'
+echo '----------------------------------------------------'
+echo 'BEGIN: docker-compose run web bundle exec rspec spec'
+echo '----------------------------------------------------'
+docker-compose run web bundle exec rspec spec
+echo '--------------------------------------------------'
+echo 'END: docker-compose run web bundle exec rspec spec'
+echo '--------------------------------------------------'


### PR DESCRIPTION
#### What? Why?

Executing Docker commands with "docker-compose run --rm web" (the current setup in the scripts in the docker directory) does NOT save the changes in the Docker container, because the Docker container is destroyed after the action is completed.

The changes in this pull request save the results of actions performed in the Docker container.