### PR TITLE
Dont show 'closing in' message when oc closes in more than 3 months

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/order_cycle_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/order_cycle_controller.js.coffee
@@ -25,3 +25,6 @@ Darkswarm.controller "OrderCycleChangeCtrl", ($scope, $rootScope, $timeout, Orde
     Cart.reloadFinalisedLineItems()
     ChangeableOrdersAlert.reload()
     $rootScope.$broadcast 'orderCycleSelected'
+
+  $scope.closesInLessThan3Months = () ->
+    moment().diff(moment(OrderCycle.orders_close_at(),  "YYYY-MM-DD HH:mm:SS Z"), 'days') > -75

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -170,10 +170,6 @@ shop ordercycle {
       float: none;
       padding: 0;
     }
-
-    .no-message-pad {
-      padding: 0.95rem;
-    }
   }
 
   form.custom {

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -170,6 +170,10 @@ shop ordercycle {
       float: none;
       padding: 0;
     }
+
+    .no-message-pad {
+      padding: 0.95rem;
+    }
   }
 
   form.custom {

--- a/app/views/enterprises/_change_order_cycle.html.haml
+++ b/app/views/enterprises/_change_order_cycle.html.haml
@@ -1,8 +1,10 @@
 %div{"ng-controller" => "OrderCycleChangeCtrl", "ng-cloak" => true}
   %closing
     %div{"ng-if" => "OrderCycle.selected()"}
-      = t :enterprises_next_closing
-      %strong {{ OrderCycle.orders_close_at() | date_in_words }}
+      %div{"ng-if" => "closesInLessThan3Months()"}
+        = t :enterprises_next_closing
+        %strong {{ OrderCycle.orders_close_at() | date_in_words }}
+      %div.no-message-pad{"ng-if" => "!closesInLessThan3Months()"}
     %div{"ng-if" => "!OrderCycle.selected()"}
       = t :enterprises_choose
 

--- a/app/views/enterprises/_change_order_cycle.html.haml
+++ b/app/views/enterprises/_change_order_cycle.html.haml
@@ -4,7 +4,8 @@
       %div{"ng-if" => "closesInLessThan3Months()"}
         = t :enterprises_next_closing
         %strong {{ OrderCycle.orders_close_at() | date_in_words }}
-      %div.no-message-pad{"ng-if" => "!closesInLessThan3Months()"}
+      %div{"ng-if" => "!closesInLessThan3Months()"}
+        = t :enterprises_currently_open
     %div{"ng-if" => "!OrderCycle.selected()"}
       = t :enterprises_choose
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1659,6 +1659,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   shopping_producers_of_hub: "%{hub}'s producers:"
 
   enterprises_next_closing: "Next order closing"
+  enterprises_currently_open: "Orders are currently open"
   enterprises_ready_for: "Ready for"
   enterprises_choose: "Choose when you want your order:"
 

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -60,9 +60,9 @@ feature "As a consumer I want to shop with a distributor", js: true do
         describe "when order cycle closes in more than 3 months" do
           before { oc1.update orders_close_at: 5.months.from_now }
 
-          it "does not show 'closing in' message" do
+          it "shows alternative to 'closing in' message" do
             visit shop_path
-            expect(page).not_to have_content "Next order closing in 2 days"
+            expect(page).to have_content "Orders are currently open"
           end
         end
       end

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -47,11 +47,24 @@ feature "As a consumer I want to shop with a distributor", js: true do
     describe "selecting an order cycle" do
       let(:exchange1) { oc1.exchanges.to_enterprises(distributor).outgoing.first }
 
-      it "selects an order cycle if only one is open" do
-        exchange1.update_attribute :pickup_time, "turtles"
-        visit shop_path
-        expect(page).to have_selector "p", text: 'turtles'
-        expect(page).not_to have_content "choose when you want your order"
+      describe "with only one open order cycle" do
+        before { exchange1.update_attribute :pickup_time, "turtles" }
+
+        it "selects an order cycle" do
+          visit shop_path
+          expect(page).to have_selector "p", text: 'turtles'
+          expect(page).not_to have_content "choose when you want your order"
+          expect(page).to have_content "Next order closing in 2 days"
+        end
+
+        describe "when order cycle closes in more than 3 months" do
+          before { oc1.update orders_close_at: 5.months.from_now }
+
+          it "does not show 'closing in' message" do
+            visit shop_path
+            expect(page).not_to have_content "Next order closing in 2 days"
+          end
+        end
       end
 
       describe "with multiple order cycles" do


### PR DESCRIPTION
#### What? Why?

Closes #5305

#### What should we test?
We need to verify the message disappears if OC closes in more than 75 days from now and shows "closing in 2 months" up to that date.

#### Release notes
Changelog Category: User facing changes
Order Cycle "closing in" message is not shown now if the Order Cycle closses in more than 3 months.
