### PR TITLE
[Flaky Specs] Fix tag_rules and select2 issues

### DIFF
--- a/spec/features/admin/tag_rules_spec.rb
+++ b/spec/features/admin/tag_rules_spec.rb
@@ -16,7 +16,7 @@ feature 'Tag Rules', js: true do
       expect(page).to have_content 'No tags apply to this enterprise yet'
       expect(page).to have_no_selector '.customer_tag'
       click_button '+ Add A New Tag'
-      find(:css, "tags-input .tags input").set "volunteer\n"
+      fill_in_tag "volunteer"
 
       # New FilterShippingMethods Rule
       expect(page).to have_content 'No rules apply to this tag yet'
@@ -24,7 +24,7 @@ feature 'Tag Rules', js: true do
       select2_select 'Show or Hide shipping methods at checkout', from: 'rule_type_selector'
       click_button "Add Rule"
       within(".customer_tag #tr_0") do
-        find(:css, "tags-input .tags input").set "volunteers-only\n"
+        fill_in_tag "volunteers-only"
         select2_select "NOT VISIBLE", from: "enterprise_tag_rules_attributes_0_preferred_matched_shipping_methods_visibility"
       end
 
@@ -33,7 +33,7 @@ feature 'Tag Rules', js: true do
       select2_select 'Show or Hide variants in my shop', from: 'rule_type_selector'
       click_button "Add Rule"
       within(".customer_tag #tr_1") do
-        find(:css, "tags-input .tags input").set "volunteers-only1\n"
+        fill_in_tag "volunteers-only1"
         select2_select "VISIBLE", from: "enterprise_tag_rules_attributes_1_preferred_matched_variants_visibility"
       end
 
@@ -42,7 +42,7 @@ feature 'Tag Rules', js: true do
       select2_select 'Show or Hide payment methods at checkout', from: 'rule_type_selector'
       click_button "Add Rule"
       within(".customer_tag #tr_2") do
-        find(:css, "tags-input .tags input").set "volunteers-only2\n"
+        fill_in_tag "volunteers-only2"
         select2_select "VISIBLE", from: "enterprise_tag_rules_attributes_2_preferred_matched_payment_methods_visibility"
       end
 
@@ -51,7 +51,7 @@ feature 'Tag Rules', js: true do
       select2_select 'Show or Hide order cycles in my shopfront', from: 'rule_type_selector'
       click_button "Add Rule"
       within(".customer_tag #tr_3") do
-        find(:css, "tags-input .tags input").set "volunteers-only3\n"
+        fill_in_tag "volunteers-only3"
         select2_select "NOT VISIBLE", from: "enterprise_tag_rules_attributes_3_preferred_matched_order_cycles_visibility"
       end
 
@@ -60,7 +60,7 @@ feature 'Tag Rules', js: true do
       select2_select 'Show or Hide order cycles in my shopfront', from: 'rule_type_selector'
       click_button "Add Rule"
       within(".default_rules #tr_0") do
-        find(:css, "tags-input .tags input").set "wholesale\n"
+        fill_in_tag "wholesale"
         expect(page).to have_content "not visible"
       end
 
@@ -124,20 +124,20 @@ feature 'Tag Rules', js: true do
       expect(page).to have_selector '.customer_tag .header tags-input .tag-list ti-tag-item', text: "trusted", count: 1
       all(:css, ".customer_tag .header tags-input").each do |node|
         node.find("li.tag-item a.remove-button").click
-        node.find(".tags input").set "volunteer\n"
+        within(:xpath, node.path) { fill_in_tag "volunteer", ".tags input" }
       end
 
       # DEFAULT FilterShippingMethods rule
       within ".default_rules #tr_0" do
         within "li.tag-item", text: "local ✖" do find("a.remove-button").click end
-        find(:css, "tags-input .tags input").set "volunteers-only\n"
+        fill_in_tag "volunteers-only"
         expect(page).to have_content "not visible"
       end
 
       # FilterProducts rule
       within ".customer_tag #tr_1" do
         within "li.tag-item", text: "member ✖" do find("a.remove-button").click end
-        find(:css, "tags-input .tags input").set "volunteers-only1\n"
+        fill_in_tag "volunteers-only1"
         expect(page).to have_select2 "enterprise_tag_rules_attributes_1_preferred_matched_variants_visibility", selected: 'VISIBLE'
         select2_select 'NOT VISIBLE', from: "enterprise_tag_rules_attributes_1_preferred_matched_variants_visibility"
       end
@@ -145,7 +145,7 @@ feature 'Tag Rules', js: true do
       # FilterPaymentMethods rule
       within ".customer_tag #tr_2" do
         within "li.tag-item", text: "trusted ✖" do find("a.remove-button").click end
-        find(:css, "tags-input .tags input").set "volunteers-only2\n"
+        fill_in_tag "volunteers-only2"
         expect(page).to have_select2 "enterprise_tag_rules_attributes_2_preferred_matched_payment_methods_visibility", selected: 'NOT VISIBLE'
         select2_select 'VISIBLE', from: "enterprise_tag_rules_attributes_2_preferred_matched_payment_methods_visibility"
       end
@@ -153,7 +153,7 @@ feature 'Tag Rules', js: true do
       # FilterOrderCycles rule
       within ".customer_tag #tr_3" do
         within "li.tag-item", text: "wholesale ✖" do find("a.remove-button").click end
-        find(:css, "tags-input .tags input").set "volunteers-only3\n"
+        fill_in_tag "volunteers-only3"
         expect(page).to have_select2 "enterprise_tag_rules_attributes_3_preferred_matched_order_cycles_visibility", selected: 'VISIBLE'
         select2_select 'NOT VISIBLE', from: "enterprise_tag_rules_attributes_3_preferred_matched_order_cycles_visibility"
       end
@@ -161,7 +161,7 @@ feature 'Tag Rules', js: true do
       # FilterShippingMethods rule
       within ".customer_tag #tr_4" do
         within "li.tag-item", text: "local ✖" do find("a.remove-button").click end
-        find(:css, "tags-input .tags input").set "volunteers-only4\n"
+        fill_in_tag "volunteers-only4"
         expect(page).to have_select2 "enterprise_tag_rules_attributes_4_preferred_matched_shipping_methods_visibility", selected: 'NOT VISIBLE'
         select2_select 'VISIBLE', from: "enterprise_tag_rules_attributes_4_preferred_matched_shipping_methods_visibility"
       end

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -111,6 +111,8 @@ module WebHelper
     page.find(:xpath, '//body')
       .find(:css, '.select2-drop-active .select2-result-label', text: options[:select_text] || value)
       .click
+
+    expect(page).to have_select2 options[:from], selected: options[:select_text] || value
   end
 
   def open_select2(selector)

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -136,6 +136,10 @@ module WebHelper
     page.evaluate_script("#{angular_scope(controller)}.scope().RequestMonitor.loading == false")
   end
 
+  def fill_in_tag(tag_name, selector = "tags-input .tags input")
+    find(:css, selector).set "#{tag_name}\n"
+  end
+
   private
 
   # Takes an optional angular controller name eg: "LineItemsCtrl",

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -137,7 +137,10 @@ module WebHelper
   end
 
   def fill_in_tag(tag_name, selector = "tags-input .tags input")
+    expect(page).to have_selector selector
+    find(:css, selector).send_keys ""
     find(:css, selector).set "#{tag_name}\n"
+    expect(page).to have_selector ".tag-list .tag-item span", text: tag_name
   end
 
   private


### PR DESCRIPTION
#### What? Why?

Closes #6165 

Flaky specs: for some reason the select2 dropdown does not always close properly. The dropdown is still open when capybara moves on to the next step in the spec, which means it obscures other elements on the page, which can't be clicked. :boom:

The `tag_rules` feature spec currently has flaky failures on _multiple_ different lines, with two different underlying causes. I'm pretty sure this PR now fixes both of them, and should reduce general select2-related flakyness in all specs. 

#### What should we test?
<!-- List which features should be tested and how. -->

Green specs

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed a flaky spec in the test suite

Changelog Category: Technical changes
