### PR TITLE
Update default card/authorized shops UI

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
@@ -1,7 +1,7 @@
 Darkswarm.controller "CreditCardsCtrl", ($scope, CreditCard, CreditCards) ->
   angular.extend(this, new FieldsetMixin($scope))
   $scope.savedCreditCards = CreditCards.saved
-  $scope.setDefault = CreditCards.setDefault
+  $scope.confirmSetDefault = CreditCards.confirmSetDefault
   $scope.CreditCard = CreditCard
   $scope.secrets = CreditCard.secrets
   $scope.showForm = CreditCard.show

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -5,17 +5,20 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages, Cu
     add: (card) ->
       @saved.push card
 
+    setDefault: (card) =>
+      card.is_default = true
+      for othercard in @saved when othercard != card
+        othercard.is_default = false
+      $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
+        Messages.success(t('js.default_card_updated'))
+        for customer in Customers.index()
+          customer.allow_charges = false
+      , (response) ->
+        Messages.flash(response.data.flash)
+
     confirmSetDefault: (card, event) =>
       if confirm t("js.default_card_voids_auth")
-        card.is_default = true
-        for othercard in @saved when othercard != card
-          othercard.is_default = false
-        $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
-          Messages.success(t('js.default_card_updated'))
-          for customer in Customers.index()
-            customer.allow_charges = false
-        , (response) ->
-          Messages.flash(response.data.flash)
+        @setDefault(card)
       else
         event.preventDefault()
         return false

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -11,8 +11,7 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages, Cu
         othercard.is_default = false
       $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
         Messages.success(t('js.default_card_updated'))
-        for customer in Customers.index()
-          customer.allow_charges = false
+        Customers.clearAllAllowCharges()
       , (response) ->
         Messages.flash(response.data.flash)
 

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -5,11 +5,15 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages)->
     add: (card) ->
       @saved.push card
 
-    setDefault: (card) =>
-      card.is_default = true
-      for othercard in @saved when othercard != card
-        othercard.is_default = false
-      $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
-        Messages.success(t('js.default_card_updated'))
-      , (response) ->
-        Messages.flash(response.data.flash)
+    confirmSetDefault: (card, event) =>
+      if confirm t("js.default_card_voids_auth")
+        card.is_default = true
+        for othercard in @saved when othercard != card
+          othercard.is_default = false
+        $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
+          Messages.success(t('js.default_card_updated'))
+        , (response) ->
+          Messages.flash(response.data.flash)
+      else
+        event.preventDefault()
+        return false

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages)->
+Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages, Customers)->
   new class CreditCard
     saved: $filter('orderBy')(savedCreditCards,'-is_default')
 
@@ -12,6 +12,8 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages)->
           othercard.is_default = false
         $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
           Messages.success(t('js.default_card_updated'))
+          for customer in Customers.index()
+            customer.allow_charges = false
         , (response) ->
           Messages.flash(response.data.flash)
       else

--- a/app/assets/javascripts/darkswarm/services/customer.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/customer.js.coffee
@@ -12,9 +12,12 @@ angular.module("Darkswarm").factory 'Customer', ($resource, $injector, Messages)
   })
 
   Customer.prototype.update = ->
+    if @allow_charges
+      Messages.loading(t('js.authorising'))
     @$update().then (response) =>
-      if response.gateway_recurring_payment_client_secret && $injector.has('stripeObject')
-        stripe = $injector.get('stripeObject')
+      if response.gateway_recurring_payment_client_secret && $injector.has('stripePublishableKey')
+        Messages.clear()
+        stripe = Stripe($injector.get('stripePublishableKey'), { stripeAccount: response.gateway_shop_id })
         stripe.confirmCardSetup(response.gateway_recurring_payment_client_secret).then (result) =>
           if result.error
             @allow_charges = false

--- a/app/assets/javascripts/darkswarm/services/customer.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/customer.js.coffee
@@ -1,4 +1,4 @@
-angular.module("Darkswarm").factory 'Customer', ($resource, Messages) ->
+angular.module("Darkswarm").factory 'Customer', ($resource, $injector, Messages) ->
   Customer = $resource('/api/customers/:id/:action.json', {}, {
     'index':
       method: 'GET'
@@ -13,7 +13,17 @@ angular.module("Darkswarm").factory 'Customer', ($resource, Messages) ->
 
   Customer.prototype.update = ->
     @$update().then (response) =>
-      Messages.success(t('js.changes_saved'))
+      if response.gateway_recurring_payment_client_secret && $injector.has('stripeObject')
+        stripe = $injector.get('stripeObject')
+        stripe.confirmCardSetup(response.gateway_recurring_payment_client_secret).then (result) =>
+          if result.error
+            @allow_charges = false
+            @$update(allow_charges: false)
+            Messages.error(result.error.message)
+          else
+            Messages.success(t('js.changes_saved'))
+      else
+        Messages.success(t('js.changes_saved'))
     , (response) =>
       Messages.error(response.data.error)
 

--- a/app/assets/javascripts/darkswarm/services/customers.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/customers.js.coffee
@@ -12,3 +12,7 @@ angular.module("Darkswarm").factory 'Customers', (Customer) ->
       for customer in customers
         @all.push customer
         @byID[customer.id] = customer
+
+    clearAllAllowCharges: () ->
+      for customer in @index()
+        customer.allow_charges = false

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -13,9 +13,8 @@ module Api
 
       client_secret = RecurringPayments.setup_for(@customer) if params[:customer][:allow_charges]
 
-      if @customer.update(params[:customer])
-        @customer.gateway_recurring_payment_client_secret = client_secret
-        @customer.gateway_shop_id = @customer.enterprise.stripe_account&.stripe_user_id
+      if @customer.update(customer_params)
+        add_recurring_payment_info(@customer, client_secret)
         render json: @customer, serializer: CustomerSerializer, status: :ok
       else
         invalid_resource!(@customer)
@@ -24,6 +23,15 @@ module Api
 
     def customer_params
       params.require(:customer).permit(:code, :email, :enterprise_id, :allow_charges)
+    end
+
+    private
+
+    def add_recurring_payment_info(customer, client_secret)
+      return unless client_secret
+
+      customer.gateway_recurring_payment_client_secret = client_secret
+      customer.gateway_shop_id = customer.enterprise.stripe_account&.stripe_user_id
     end
   end
 end

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -21,10 +21,6 @@ module Api
       end
     end
 
-    def customer_params
-      params.require(:customer).permit(:code, :email, :enterprise_id, :allow_charges)
-    end
-
     private
 
     def add_recurring_payment_info(client_secret)

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -11,7 +11,10 @@ module Api
       @customer = Customer.find(params[:id])
       authorize! :update, @customer
 
+      client_secret = RecurringPayments.setup_for(@customer) if params[:customer][:allow_charges]
+
       if @customer.update(customer_params)
+        @customer.gateway_recurring_payment_client_secret = client_secret if client_secret
         render json: @customer, serializer: CustomerSerializer, status: :ok
       else
         invalid_resource!(@customer)

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -13,8 +13,9 @@ module Api
 
       client_secret = RecurringPayments.setup_for(@customer) if params[:customer][:allow_charges]
 
-      if @customer.update(customer_params)
-        @customer.gateway_recurring_payment_client_secret = client_secret if client_secret
+      if @customer.update(params[:customer])
+        @customer.gateway_recurring_payment_client_secret = client_secret
+        @customer.gateway_shop_id = @customer.enterprise.stripe_account&.stripe_user_id
         render json: @customer, serializer: CustomerSerializer, status: :ok
       else
         invalid_resource!(@customer)

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -33,5 +33,9 @@ module Api
       customer.gateway_recurring_payment_client_secret = client_secret
       customer.gateway_shop_id = customer.enterprise.stripe_account&.stripe_user_id
     end
+
+    def customer_params
+      params.require(:customer).permit(:code, :email, :enterprise_id, :allow_charges)
+    end
   end
 end

--- a/app/controllers/api/customers_controller.rb
+++ b/app/controllers/api/customers_controller.rb
@@ -14,7 +14,7 @@ module Api
       client_secret = RecurringPayments.setup_for(@customer) if params[:customer][:allow_charges]
 
       if @customer.update(customer_params)
-        add_recurring_payment_info(@customer, client_secret)
+        add_recurring_payment_info(client_secret)
         render json: @customer, serializer: CustomerSerializer, status: :ok
       else
         invalid_resource!(@customer)
@@ -27,11 +27,11 @@ module Api
 
     private
 
-    def add_recurring_payment_info(customer, client_secret)
+    def add_recurring_payment_info(client_secret)
       return unless client_secret
 
-      customer.gateway_recurring_payment_client_secret = client_secret
-      customer.gateway_shop_id = customer.enterprise.stripe_account&.stripe_user_id
+      @customer.gateway_recurring_payment_client_secret = client_secret
+      @customer.gateway_shop_id = @customer.enterprise.stripe_account&.stripe_user_id
     end
 
     def customer_params

--- a/app/controllers/spree/credit_cards_controller.rb
+++ b/app/controllers/spree/credit_cards_controller.rb
@@ -60,7 +60,7 @@ module Spree
     def destroy_at_stripe
       stripe_customer = Stripe::Customer.retrieve(@credit_card.gateway_customer_profile_id, {})
 
-      stripe_customer&.delete
+      stripe_customer&.delete unless stripe_customer.deleted?
     end
 
     def stripe_account_id

--- a/app/controllers/spree/credit_cards_controller.rb
+++ b/app/controllers/spree/credit_cards_controller.rb
@@ -63,13 +63,6 @@ module Spree
       stripe_customer&.delete unless stripe_customer.deleted?
     end
 
-    def stripe_account_id
-      StripeAccount.
-        find_by(enterprise_id: @credit_card.payment_method.preferred_enterprise_id).
-        andand.
-        stripe_user_id
-    end
-
     def create_customer(token)
       Stripe::Customer.create(email: spree_current_user.email, source: token)
     end

--- a/app/controllers/spree/credit_cards_controller.rb
+++ b/app/controllers/spree/credit_cards_controller.rb
@@ -58,8 +58,9 @@ module Spree
 
     # It destroys the whole customer object
     def destroy_at_stripe
-      stripe_customer = Stripe::Customer.retrieve(@credit_card.gateway_customer_profile_id, {})
+      Stripe::CreditCardCloner.new.destroy_clones(@credit_card)
 
+      stripe_customer = Stripe::Customer.retrieve(@credit_card.gateway_customer_profile_id, {})
       stripe_customer&.delete unless stripe_customer.deleted?
     end
 

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -62,7 +62,7 @@ class SubscriptionConfirmJob
     return unless order.payment_required?
 
     prepare_for_payment!(order)
-    order.process_payments!(true)
+    order.process_payments!(offline: true)
     raise if order.errors.any?
   end
 

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -62,7 +62,7 @@ class SubscriptionConfirmJob
     return unless order.payment_required?
 
     prepare_for_payment!(order)
-    order.process_payments!
+    order.process_payments!(true)
     raise if order.errors.any?
   end
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -25,6 +25,8 @@ class Customer < ActiveRecord::Base
 
   before_create :associate_user
 
+  attr_accessor :gateway_recurring_payment_client_secret
+
   private
 
   def downcase_email

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -26,6 +26,7 @@ class Customer < ActiveRecord::Base
   before_create :associate_user
 
   attr_accessor :gateway_recurring_payment_client_secret
+  attr_accessor :gateway_shop_id
 
   private
 

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -20,6 +20,7 @@ module Spree
 
     after_create :ensure_single_default_card
     after_save :ensure_single_default_card, if: :default_card_needs_updating?
+    after_save :remove_shop_authorizations, if: :default_card_needs_updating?
 
     scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
 
@@ -150,6 +151,10 @@ module Spree
 
       user.credit_cards.update_all(['is_default=(id=?)', id])
       self.is_default = true
+    end
+
+    def remove_shop_authorizations
+      user.customers.update_all(allow_charges: false)
     end
   end
 end

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -22,7 +22,7 @@ module Spree
     after_save :ensure_single_default_card, if: :default_card_needs_updating?
     after_save :remove_shop_authorizations, if: :default_card_needs_updating?
     after_destroy :remove_shop_authorizations, if: :is_default
-    
+
     scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
 
     # needed for some of the ActiveMerchant gateways (eg. SagePay)
@@ -155,6 +155,8 @@ module Spree
     end
 
     def remove_shop_authorizations
+      return unless user
+
       user.customers.update_all(allow_charges: false)
     end
   end

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -21,7 +21,8 @@ module Spree
     after_create :ensure_single_default_card
     after_save :ensure_single_default_card, if: :default_card_needs_updating?
     after_save :remove_shop_authorizations, if: :default_card_needs_updating?
-
+    after_destroy :remove_shop_authorizations, if: :is_default
+    
     scope :with_payment_profile, -> { where('gateway_customer_profile_id IS NOT NULL') }
 
     # needed for some of the ActiveMerchant gateways (eg. SagePay)

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -46,6 +46,19 @@ module Spree
       end
 
       # NOTE: the name of this method is determined by Spree::Payment::Processing
+      def charge_offline(money, creditcard, gateway_options)
+        options = basic_options(gateway_options)
+        customer_id, payment_method_id = Stripe::CreditCardCloner.new.clone(creditcard,
+                                                                            stripe_account_id)
+
+        options[:customer] = customer_id
+        options[:off_session] = true
+        provider.purchase(money, payment_method_id, options)
+      rescue Stripe::StripeError => e
+        failed_activemerchant_billing_response(e.message)
+      end
+
+      # NOTE: the name of this method is determined by Spree::Payment::Processing
       def authorize(money, creditcard, gateway_options)
         authorize_response = provider.authorize(*options_for_authorize(money,
                                                                        creditcard,

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -48,8 +48,8 @@ module Spree
       # NOTE: the name of this method is determined by Spree::Payment::Processing
       def charge_offline(money, creditcard, gateway_options)
         options = basic_options(gateway_options)
-        customer_id, payment_method_id = Stripe::CreditCardCloner.new.clone(creditcard,
-                                                                            stripe_account_id)
+        customer_id, payment_method_id =
+          Stripe::CreditCardCloner.new.find_or_clone(creditcard, stripe_account_id)
 
         options[:customer] = customer_id
         options[:off_session] = true
@@ -110,8 +110,8 @@ module Spree
         options = basic_options(gateway_options)
         options[:return_url] = full_checkout_path
 
-        customer_id, payment_method_id = Stripe::CreditCardCloner.new.clone(creditcard,
-                                                                            stripe_account_id)
+        customer_id, payment_method_id =
+          Stripe::CreditCardCloner.new.find_or_clone(creditcard, stripe_account_id)
         options[:customer] = customer_id
         [money, payment_method_id, options]
       end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -499,13 +499,13 @@ module Spree
     #   which gets rescued and converted to FALSE when
     #   :allow_checkout_on_gateway_error is set to false
     #
-    def process_payments!
+    def process_payments!(offline = false)
       raise Core::GatewayError, Spree.t(:no_pending_payments) if pending_payments.empty?
 
       pending_payments.each do |payment|
         break if payment_total >= total
 
-        payment.process!
+        payment.process!(offline)
 
         if payment.completed?
           self.payment_total += payment.amount

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -499,7 +499,7 @@ module Spree
     #   which gets rescued and converted to FALSE when
     #   :allow_checkout_on_gateway_error is set to false
     #
-    def process_payments!(offline = false)
+    def process_payments!(offline: false)
       raise Core::GatewayError, Spree.t(:no_pending_payments) if pending_payments.empty?
 
       pending_payments.each do |payment|

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -15,10 +15,8 @@ module Spree
           raise Core::GatewayError, Spree.t(:payment_method_not_supported)
         end
 
-        if offline
-          charge_offline!
-        elsif payment_method.auto_capture?
-          purchase!
+        if payment_method.auto_capture?
+          purchase!(offline)
         else
           authorize!
         end
@@ -29,14 +27,9 @@ module Spree
         gateway_action(source, :authorize, :pend)
       end
 
-      def purchase!
+      def purchase!(offline = false)
         started_processing!
-        gateway_action(source, :purchase, :complete)
-      end
-
-      def charge_offline!
-        started_processing!
-        gateway_action(source, :charge_offline, :complete)
+        gateway_action(source, offline ? :charge_offline : :purchase, :complete)
       end
 
       def capture!

--- a/app/serializers/api/customer_serializer.rb
+++ b/app/serializers/api/customer_serializer.rb
@@ -1,6 +1,6 @@
 module Api
   class CustomerSerializer < ActiveModel::Serializer
     attributes :id, :enterprise_id, :name, :code, :email, :allow_charges,
-               :gateway_recurring_payment_client_secret
+               :gateway_recurring_payment_client_secret, :gateway_shop_id
   end
 end

--- a/app/serializers/api/customer_serializer.rb
+++ b/app/serializers/api/customer_serializer.rb
@@ -1,5 +1,6 @@
 module Api
   class CustomerSerializer < ActiveModel::Serializer
-    attributes :id, :enterprise_id, :name, :code, :email, :allow_charges
+    attributes :id, :enterprise_id, :name, :code, :email, :allow_charges,
+               :gateway_recurring_payment_client_secret
   end
 end

--- a/app/services/recurring_payments.rb
+++ b/app/services/recurring_payments.rb
@@ -10,7 +10,7 @@ class RecurringPayments
       Stripe::CreditCardCloner.new.find_or_clone(card, stripe_account)
     setup_intent = Stripe::SetupIntent.create(
       { payment_method: payment_method_id, customer: customer_id },
-      { stripe_account: stripe_account }
+      stripe_account: stripe_account
     )
     setup_intent.client_secret
   end

--- a/app/services/recurring_payments.rb
+++ b/app/services/recurring_payments.rb
@@ -3,12 +3,15 @@
 class RecurringPayments
   def self.setup_for(customer)
     return unless card = customer.user.default_card
-    return unless payment_method = card.gateway_payment_profile_id
-    return unless customer_profile_id = card.gateway_customer_profile_id
 
     stripe_account = customer.enterprise.stripe_account&.stripe_user_id
-    setup_intent = Stripe::SetupIntent.create(
-      payment_method: payment_method, customer: customer_profile_id, on_behalf_of: stripe_account
+
+    customer_id, payment_method_id = Stripe::CreditCardCloner.new.clone(card,
+                                                                        stripe_account)
+    setup_intent = Stripe::SetupIntent.create({
+      payment_method: payment_method_id, customer: customer_id }, {
+        stripe_account: stripe_account
+      }
     )
     setup_intent.client_secret
   end

--- a/app/services/recurring_payments.rb
+++ b/app/services/recurring_payments.rb
@@ -3,8 +3,7 @@
 class RecurringPayments
   def self.setup_for(customer)
     return unless card = customer.user.default_card
-
-    stripe_account = customer.enterprise.stripe_account&.stripe_user_id
+    return unless stripe_account = customer.enterprise.stripe_account&.stripe_user_id
 
     customer_id, payment_method_id =
       Stripe::CreditCardCloner.new.find_or_clone(card, stripe_account)

--- a/app/services/recurring_payments.rb
+++ b/app/services/recurring_payments.rb
@@ -6,12 +6,11 @@ class RecurringPayments
 
     stripe_account = customer.enterprise.stripe_account&.stripe_user_id
 
-    customer_id, payment_method_id = Stripe::CreditCardCloner.new.clone(card,
-                                                                        stripe_account)
-    setup_intent = Stripe::SetupIntent.create({
-      payment_method: payment_method_id, customer: customer_id }, {
-        stripe_account: stripe_account
-      }
+    customer_id, payment_method_id =
+      Stripe::CreditCardCloner.new.find_or_clone(card, stripe_account)
+    setup_intent = Stripe::SetupIntent.create(
+      { payment_method: payment_method_id, customer: customer_id },
+      { stripe_account: stripe_account }
     )
     setup_intent.client_secret
   end

--- a/app/services/recurring_payments.rb
+++ b/app/services/recurring_payments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RecurringPayments
+  def self.setup_for(customer)
+    return unless card = customer.user.default_card
+    return unless payment_method = card.gateway_payment_profile_id
+    return unless customer_profile_id = card.gateway_customer_profile_id
+
+    stripe_account = customer.enterprise.stripe_account&.stripe_user_id
+    setup_intent = Stripe::SetupIntent.create(
+      payment_method: payment_method, customer: customer_profile_id, on_behalf_of: stripe_account
+    )
+    setup_intent.client_secret
+  end
+end

--- a/app/views/spree/users/_authorised_shops.html.haml
+++ b/app/views/spree/users/_authorised_shops.html.haml
@@ -1,5 +1,8 @@
 %table
   %tr
+    %td{ colspan: 2 }
+      = t('spree.users.cards.authorised_shops_agreement')
+  %tr
     %th= t(".shop_name")
     %th= t(".allow_charges?")
   %tr.customer{ id: "customer{{ customer.id }}", ng: { repeat: "customer in customers" } }

--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -18,7 +18,7 @@
         .new_card{ ng: { show: 'CreditCard.visible', class: '{visible: CreditCard.visible}' } }
           %h3= t(:add_new_credit_card)
           = render 'new_card_form'
-        .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible' } }
+        .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible || savedCreditCards.length == 0' } }
           %h3
             = t('.authorised_shops')
             %button.button.secondary.tiny.help-btn.ng-scope{ "help-modal" => t('.authorised_shops_popover') }

--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -21,6 +21,4 @@
         .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible || savedCreditCards.length == 0' } }
           %h3
             = t('.authorised_shops')
-            %button.button.secondary.tiny.help-btn.ng-scope{ "help-modal" => t('.authorised_shops_popover') }
-              %i.ofn-i_013-help
           = render 'authorised_shops'

--- a/app/views/spree/users/_saved_cards.html.haml
+++ b/app/views/spree/users/_saved_cards.html.haml
@@ -10,7 +10,7 @@
     %td.number{ ng: { bind: '::card.number' } }
     %td.expiry{ ng: { bind: '::card.expiry' } }
     %td.is-default
-      %input{ type: 'radio', name: 'default_card', ng: { model: 'card.is_default', change: 'setDefault(card)', value: "true"} }
+      %input{ type: 'radio', name: 'default_card', ng: { model: 'card.is_default', click: 'confirmSetDefault(card, $event)', value: "true"} }
     %td.actions
       %a{"rel" => "nofollow", "data-method" => "delete", "ng-href" => "{{card.delete_link}}" }
         = t(:delete)

--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -5,6 +5,7 @@
   - if Stripe.publishable_key
     :javascript
       angular.module('Darkswarm').value("stripeObject", Stripe("#{Stripe.publishable_key}"))
+      angular.module('Darkswarm').value("stripePublishableKey", "#{Stripe.publishable_key}")
 
 .darkswarm
   .row.pad-top

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2509,6 +2509,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   js:
     saving: 'Saving...'
     changes_saved: 'Changes saved.'
+    authorising: "Authorising..."
     save_changes_first: Save changes first.
     all_changes_saved: All changes saved
     unsaved_changes: You have unsaved changes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3700,7 +3700,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         delete?: Delete?
       cards:
         authorised_shops: Authorised Shops
-        authorised_shops_popover: This is the list of shops which are permitted to charge your default credit card for any subscriptions (ie. repeating orders) you may have. Your card details will be kept secure and will not be shared with shop owners. You will always be notified when you are charged.
+        authorised_shops_agreement: This is the list of shops which are permitted to charge your default credit card for any subscriptions (ie. repeating orders) you may have. Your card details will be kept secure and will not be shared with shop owners. You will always be notified when you are charged. By checking the box for a shop, you are agreeing to authorise that shop to send instructions to the financial institution that issued your card to take payments in accordance with the terms of any subscription you create with that shop.
         saved_cards_popover: This is the list of cards you have opted to save for later use. Your 'default' will be selected automatically when you checkout an order, and can be charged by any shops you have allowed to do so (see right).
       authorised_shops:
         shop_name: "Shop Name"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2524,6 +2524,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     resolve_errors: Please resolve the following errors
     more_items: "+ %{count} More"
     default_card_updated: Default Card Updated
+    default_card_voids_auth: Changing your default card will remove shops' existing authorizations to charge it. You can re-authorize shops after updating the default card. Do you wish to change the default card?"
     cart:
       add_to_cart_failed: >
         There was a problem adding this product to the cart.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3703,7 +3703,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         saved_cards_popover: This is the list of cards you have opted to save for later use. Your 'default' will be selected automatically when you checkout an order, and can be charged by any shops you have allowed to do so (see right).
       authorised_shops:
         shop_name: "Shop Name"
-        allow_charges?: "Allow Charges?"
+        allow_charges?: "Allow Charges to Default Card?"
     localized_number:
       invalid_format: has an invalid format. Please enter a number.
     api:

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -73,7 +73,7 @@ module Stripe
 
       loop do
         response = Stripe::Customer.list({ email: email, starting_after: starting_after },
-                                         { stripe_account: connected_account_id })
+                                         stripe_account: connected_account_id)
         customers += response.data
         break unless response.has_more
 
@@ -88,7 +88,7 @@ module Stripe
 
       loop do
         options = { customer: customer_id, type: 'card', starting_after: starting_after }
-        response = Stripe::PaymentMethod.list(options, { stripe_account: connected_account_id })
+        response = Stripe::PaymentMethod.list(options, stripe_account: connected_account_id)
         payment_methods += response.data
         break unless response.has_more
 

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -32,7 +32,7 @@ module Stripe
         customer_id, _payment_method_id = find_cloned_card(card, stripe_account)
         next unless customer_id
 
-        customer = Stripe::Customer.retrieve(customer_id, { stripe_account: stripe_account })
+        customer = Stripe::Customer.retrieve(customer_id, stripe_account: stripe_account)
         customer&.delete unless customer.deleted?
       end
     end
@@ -80,31 +80,31 @@ module Stripe
     end
 
     def find_customers(email, connected_account_id)
-      starting_after = nil
+      start_after = nil
       customers = []
 
       loop do
-        response = Stripe::Customer.list({ email: email, starting_after: starting_after },
+        response = Stripe::Customer.list({ email: email, starting_after: start_after, limit: 100 },
                                          stripe_account: connected_account_id)
         customers += response.data
         break unless response.has_more
 
-        starting_after = response.data.last.id
+        start_after = response.data.last.id
       end
       customers
     end
 
     def find_payment_methods(customer_id, connected_account_id)
-      starting_after = nil
+      start_after = nil
       payment_methods = []
 
       loop do
-        options = { customer: customer_id, type: 'card', starting_after: starting_after }
+        options = { customer: customer_id, type: 'card', starting_after: start_after, limit: 100 }
         response = Stripe::PaymentMethod.list(options, stripe_account: connected_account_id)
         payment_methods += response.data
         break unless response.has_more
 
-        starting_after = response.data.last.id
+        start_after = response.data.last.id
       end
       payment_methods
     end

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -1,27 +1,37 @@
 # frozen_string_literal: true
 
-# Here we clone
-#   - a card (card_*) or payment_method (pm_*) stored (in a customer) in a platform account
-# into
+# Here we clone (or find a clone of)
+#   - a card (card_*) or payment_method (pm_*) stored (in a customer) in a platform account into
 #   - a payment method (pm_*) (in a new customer) in a connected account
 #
 # This is required when using the Stripe Payment Intents API:
 #   - the customer and payment methods are stored in the platform account
 #       so that they can be re-used across multiple sellers
-#   - when a card needs to be charged, we need to create it in the seller's stripe account
+#   - when a card needs to be charged, we need to clone (or find the clone)
+#       in the seller's stripe account
 #
-# We are doing this process every time the card is charged:
-#   - this means that, if the customer uses the same card on the same seller multiple times,
-#       the card will be created multiple times on the seller's account
-#   - to avoid this, we would have to store the IDs of every card on each seller's stripe account
-#       in our database (this way we only have to store the platform account ID)
+# To avoid creating a new clone of the card/customer each time the card is charged or
+# authorized (e.g. for SCA), we attach metadata { clone: true } to the card the first time we
+# clone it and look for a card with the same fingerprint (hash of the card number) and
+# that metadata key to avoid cloning it multiple times.
+
 module Stripe
   class CreditCardCloner
+    def find_or_clone(credit_card, connected_account_id)
+      if card = find_cloned_card(credit_card, connected_account_id)
+        card
+      else
+        clone(credit_card, connected_account_id)
+      end
+    end
+
+    private
+
     def clone(credit_card, connected_account_id)
       new_payment_method = clone_payment_method(credit_card, connected_account_id)
 
       # If no customer is given, it will clone the payment method only
-      return nil, new_payment_method.id if credit_card.gateway_customer_profile_id.blank?
+      return [nil, new_payment_method.id] if credit_card.gateway_customer_profile_id.blank?
 
       new_customer = Stripe::Customer.create({ email: credit_card.user.email },
                                              stripe_account: connected_account_id)
@@ -29,10 +39,63 @@ module Stripe
                                         new_customer.id,
                                         connected_account_id)
 
+      add_metadata_to_payment_method(new_payment_method.id, connected_account_id)
+
       [new_customer.id, new_payment_method.id]
     end
 
-    private
+    def find_cloned_card(card, connected_account_id)
+      matches = []
+      return matches unless fingerprint = fingerprint_for_card(card)
+
+      find_customers(card.user.email, connected_account_id).each do |customer|
+        find_payment_methods(customer.id, connected_account_id).each do |payment_method|
+          if payment_method_is_clone?(payment_method, fingerprint)
+            matches << [customer.id, payment_method.id]
+          end
+        end
+      end
+
+      matches.first
+    end
+
+    def payment_method_is_clone?(payment_method, fingerprint)
+      payment_method.card.fingerprint == fingerprint && payment_method.metadata["ofn-clone"]
+    end
+
+    def fingerprint_for_card(card)
+      Stripe::PaymentMethod.retrieve(card.gateway_payment_profile_id).card.fingerprint
+    end
+
+    def find_customers(email, connected_account_id)
+      starting_after = nil
+      customers = []
+
+      loop do
+        response = Stripe::Customer.list({ email: email, starting_after: starting_after },
+                                         { stripe_account: connected_account_id })
+        customers += response.data
+        break unless response.has_more
+
+        starting_after = response.data.last.id
+      end
+      customers
+    end
+
+    def find_payment_methods(customer_id, connected_account_id)
+      starting_after = nil
+      payment_methods = []
+
+      loop do
+        options = { customer: customer_id, type: 'card', starting_after: starting_after }
+        response = Stripe::PaymentMethod.list(options, { stripe_account: connected_account_id })
+        payment_methods += response.data
+        break unless response.has_more
+
+        starting_after = response.data.last.id
+      end
+      payment_methods
+    end
 
     def clone_payment_method(credit_card, connected_account_id)
       platform_acct_payment_method_id = credit_card.gateway_payment_profile_id
@@ -46,6 +109,12 @@ module Stripe
     def attach_payment_method_to_customer(payment_method_id, customer_id, connected_account_id)
       Stripe::PaymentMethod.attach(payment_method_id,
                                    { customer: customer_id },
+                                   stripe_account: connected_account_id)
+    end
+
+    def add_metadata_to_payment_method(payment_method_id, connected_account_id)
+      Stripe::PaymentMethod.update(payment_method_id,
+                                   { metadata: { "ofn-clone": true } },
                                    stripe_account: connected_account_id)
     end
   end

--- a/lib/stripe/credit_card_cloner.rb
+++ b/lib/stripe/credit_card_cloner.rb
@@ -18,7 +18,7 @@
 module Stripe
   class CreditCardCloner
     def find_or_clone(card, connected_account_id)
-      if cloned_card = find_cloned_card(card, connected_account_id)
+      if card.user && cloned_card = find_cloned_card(card, connected_account_id)
         cloned_card
       else
         clone(card, connected_account_id)
@@ -57,9 +57,9 @@ module Stripe
     end
 
     def find_cloned_card(card, connected_account_id)
-      matches = []
-      return matches unless fingerprint = fingerprint_for_card(card)
+      return nil unless fingerprint = fingerprint_for_card(card)
 
+      matches = []
       find_customers(card.user.email, connected_account_id).each do |customer|
         find_payment_methods(customer.id, connected_account_id).each do |payment_method|
           if payment_method_is_clone?(payment_method, fingerprint)

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -24,6 +24,9 @@ feature '
     before do
       stub_payment_methods_post_request
       stub_payment_intent_get_request
+      stub_retrieve_payment_method_request("pm_123")
+      stub_list_customers_request(email: order.user.email, response: {})
+      stub_get_customer_payment_methods_request(customer: "cus_A456", response: {})
     end
 
     context "for a complete order" do

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -431,7 +431,7 @@ feature 'Subscriptions' do
     end
 
     describe "allowed variants" do
-      let!(:customer) { create(:customer, enterprise: shop, allow_charges: true) }
+      let!(:customer) { create(:customer, enterprise: shop) }
       let!(:credit_card) { create(:stored_credit_card, user: customer.user) }
       let!(:shop_product) { create(:product, supplier: shop) }
       let!(:shop_variant) { create(:variant, product: shop_product, unit_value: "2000") }
@@ -468,6 +468,7 @@ feature 'Subscriptions' do
       end
 
       it "permit creating and editing of the subscription" do
+        customer.update_attributes(allow_charges: true)
         # Fill in other details
         fill_in_subscription_basic_details
         click_button "Next"

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -51,6 +51,7 @@ feature "Credit Cards", js: true do
       # Allows switching of default card
       within(".card#card#{non_default_card.id}") do
         find_field('default_card').click
+        accept_alert
         expect(find_field('default_card')).to be_checked
       end
 

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -2,11 +2,14 @@ require 'spec_helper'
 
 feature "Credit Cards", js: true do
   include AuthenticationHelper
+  include StripeHelper
+  include StripeStubs
+
   describe "as a logged in user" do
     let(:user) { create(:user) }
     let!(:customer) { create(:customer, user: user) }
-    let!(:default_card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ', is_default: true) }
-    let!(:non_default_card) { create(:credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_FDTG') }
+    let!(:default_card) { create(:stored_credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_AZNMJ', is_default: true) }
+    let!(:non_default_card) { create(:stored_credit_card, user_id: user.id, gateway_customer_profile_id: 'cus_FDTG') }
 
     around do |example|
       original_stripe_connect_enabled = Spree::Config[:stripe_connect_enabled]
@@ -17,7 +20,7 @@ feature "Credit Cards", js: true do
     before do
       login_as user
 
-      allow(Stripe).to receive(:api_key) { "sk_test_xxxx" }
+      allow(Stripe).to receive(:api_key) { "sk_test_12345" }
       allow(Stripe).to receive(:publishable_key) { "some_token" }
       Spree::Config.set(stripe_connect_enabled: true)
 
@@ -26,6 +29,9 @@ feature "Credit Cards", js: true do
 
       stub_request(:delete, "https://api.stripe.com/v1/customers/cus_AZNMJ").
         to_return(status: 200, body: JSON.generate(deleted: true, id: "cus_AZNMJ"))
+      stub_retrieve_payment_method_request("card_1EY...")
+      stub_list_customers_request(email: user.email, response: {})
+      stub_get_customer_payment_methods_request(customer: "cus_AZNMJ", response: {})
     end
 
     it "passes the smoke test" do

--- a/spec/features/consumer/shopping/checkout_stripe_spec.rb
+++ b/spec/features/consumer/shopping/checkout_stripe_spec.rb
@@ -97,6 +97,12 @@ feature "Check out with Stripe", js: true do
     end
 
     context "with guest checkout" do
+      before do
+        stub_retrieve_payment_method_request("pm_123")
+        stub_list_customers_request(email: order.user.email, response: {})
+        stub_get_customer_payment_methods_request(customer: "cus_A456", response: {})
+      end
+
       context "when the card is accepted" do
         before do
           stub_payment_intents_post_request order: order
@@ -205,7 +211,12 @@ feature "Check out with Stripe", js: true do
 
       context "saving a card and re-using it" do
         before do
+          stub_retrieve_payment_method_request("pm_123")
+          stub_list_customers_request(email: order.user.email, response: {})
+          stub_get_customer_payment_methods_request(customer: "cus_A456", response: {})
+          stub_get_customer_payment_methods_request(customer: "cus_A123", response: {})
           stub_payment_methods_post_request request: { payment_method: "pm_123", customer: "cus_A123" }, response: { pm_id: "pm_123" }
+          stub_add_metadata_request(payment_method: "pm_123", response: {})
           stub_payment_intents_post_request order: order
           stub_successful_capture_request order: order
           stub_customers_post_request email: user.email

--- a/spec/javascripts/unit/darkswarm/services/credit_cards_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/credit_cards_spec.js.coffee
@@ -36,6 +36,7 @@ describe 'CreditCards service', ->
 
       it "loads a success flash", ->
         CreditCards.setDefault(card2)
+        $httpBackend.expectGET('/api/customers.json').respond 200, []
         $httpBackend.flush()
         expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({success: t('js.default_card_updated')})
 

--- a/spec/lib/stripe/credit_card_cloner_spec.rb
+++ b/spec/lib/stripe/credit_card_cloner_spec.rb
@@ -5,7 +5,7 @@ require 'stripe/credit_card_cloner'
 
 module Stripe
   describe CreditCardCloner do
-    describe "#clone" do
+    describe "#find_or_clone" do
       include StripeStubs
 
       let(:cloner) { Stripe::CreditCardCloner.new }
@@ -14,7 +14,7 @@ module Stripe
       let(:payment_method_id) { "pm_1234" }
       let(:new_customer_id) { "cus_A456" }
       let(:new_payment_method_id) { "pm_456" }
-      let(:stripe_account_id) { "acct_456" }
+      let(:stripe_account_id) { "abc123" }
       let(:payment_method_response_mock) { { status: 200, body: payment_method_response_body } }
 
       let(:credit_card) { create(:credit_card, user: create(:user)) }
@@ -29,6 +29,12 @@ module Stripe
         stub_customers_post_request email: credit_card.user.email,
                                     response: { customer_id: new_customer_id },
                                     stripe_account_header: true
+
+        stub_retrieve_payment_method_request(payment_method_id)
+        stub_list_customers_request(email: credit_card.user.email, response: {})
+        stub_get_customer_payment_methods_request(customer: "cus_A456", response: {})
+        stub_add_metadata_request(payment_method: "pm_456", response: {})
+
         stub_request(:post,
                      "https://api.stripe.com/v1/payment_methods/#{new_payment_method_id}/attach")
           .with(body: { customer: new_customer_id },
@@ -47,7 +53,7 @@ module Stripe
         end
 
         it "clones the payment method only" do
-          customer_id, payment_method_id = cloner.clone(credit_card, stripe_account_id)
+          customer_id, payment_method_id = cloner.find_or_clone(credit_card, stripe_account_id)
 
           expect(payment_method_id).to eq new_payment_method_id
           expect(customer_id).to eq nil
@@ -65,7 +71,7 @@ module Stripe
         end
 
         it "clones both the payment method and the customer" do
-          customer_id, payment_method_id = cloner.clone(credit_card, stripe_account_id)
+          customer_id, payment_method_id = cloner.find_or_clone(credit_card, stripe_account_id)
 
           expect(payment_method_id).to eq new_payment_method_id
           expect(customer_id).to eq new_customer_id

--- a/spec/lib/stripe/payment_intent_validator_spec.rb
+++ b/spec/lib/stripe/payment_intent_validator_spec.rb
@@ -8,7 +8,7 @@ module Stripe
     describe "#call" do
       let(:validator) { Stripe::PaymentIntentValidator.new }
       let(:payment_intent_id) { "pi_123" }
-      let(:stripe_account_id) { "acct_456" }
+      let(:stripe_account_id) { "abc123" }
       let(:payment_intent_response_mock) { { status: 200, body: payment_intent_response_body } }
 
       before do

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -6,6 +6,8 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
   include ShopWorkflow
   include AuthenticationHelper
   include OpenFoodNetwork::ApiHelper
+  include StripeHelper
+  include StripeStubs
 
   let!(:order_cycle) { create(:simple_order_cycle) }
   let!(:enterprise) { create(:distributor_enterprise) }
@@ -104,6 +106,11 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
     stub_request(:post, "https://api.stripe.com/v1/payment_intents/#{payment_intent_id}/capture")
       .with(basic_auth: ["sk_test_12345", ""], body: { amount_to_capture: "1234" })
       .to_return(payment_intent_response_mock)
+
+    stub_retrieve_payment_method_request("pm_123")
+    stub_list_customers_request(email: order.user.email, response: {})
+    stub_get_customer_payment_methods_request(customer: "cus_A456", response: {})
+    stub_add_metadata_request(payment_method: "pm_456", response: {})
   end
 
   context "when the user submits a new card and doesn't request that the card is saved for later" do

--- a/spec/support/request/stripe_stubs.rb
+++ b/spec/support/request/stripe_stubs.rb
@@ -35,12 +35,45 @@ module StripeStubs
       .to_return(hub_payment_method_response_mock({ pm_id: "pm_123" }))
   end
 
+  def stub_retrieve_payment_method_request(payment_method_id = "pm_1234")
+    stub_request(:get, "https://api.stripe.com/v1/payment_methods/#{payment_method_id}")
+      .with(headers: { 'Authorization' => 'Bearer sk_test_12345' })
+      .to_return(retrieve_payment_method_response_mock({}))
+  end
+
   # Stubs the customers call to both the main stripe account and the connected account
   def stub_customers_post_request(email:, response: {}, stripe_account_header: false)
     stub = stub_request(:post, "https://api.stripe.com/v1/customers")
       .with(body: { email: email })
-    stub = stub.with(headers: { 'Stripe-Account' => 'acct_456' }) if stripe_account_header
+    stub = stub.with(headers: { 'Stripe-Account' => 'abc123' }) if stripe_account_header
     stub.to_return(customers_response_mock(response))
+  end
+
+  def stub_list_customers_request(email:, response: {})
+    stub = stub_request(:get, "https://api.stripe.com/v1/customers?email=#{email}&limit=100")
+    stub = stub.with(
+      headers: { 'Authorization' => 'Bearer sk_test_12345', 'Stripe-Account' => 'abc123' }
+    )
+    stub.to_return(list_customers_response_mock(response))
+  end
+
+  def stub_get_customer_payment_methods_request(customer: "cus_A456", response: {})
+    stub = stub_request(
+      :get, "https://api.stripe.com/v1/payment_methods?customer=#{customer}&limit=100&type=card"
+    )
+    stub = stub.with(
+      headers: { 'Authorization' => 'Bearer sk_test_12345', 'Stripe-Account' => 'abc123' }
+    )
+    stub.to_return(get_customer_payment_methods_response_mock(response))
+  end
+
+  def stub_add_metadata_request(payment_method: "pm_456", response: {})
+    stub = stub_request(:post, "https://api.stripe.com/v1/payment_methods/#{payment_method}")
+    stub = stub.with(body: { metadata: { "ofn-clone": true } })
+    stub = stub.with(
+      headers: { 'Authorization' => 'Bearer sk_test_12345', 'Stripe-Account' => 'abc123' }
+    )
+    stub.to_return(add_metadata_response_mock(response))
   end
 
   def stub_successful_capture_request(order:, response: {})
@@ -118,5 +151,31 @@ module StripeStubs
       body: JSON.generate(object: "refund",
                           amount: 2000,
                           charge: "ch_1234") }
+  end
+
+  def retrieve_payment_method_response_mock(options)
+    { status: options[:code] || 200,
+      body: JSON.generate(
+        id: options[:pm_id] || "pm_456", customer: "cus_A123", card: { fingerprint: "12345" }
+      ) }
+  end
+
+  def list_customers_response_mock(options)
+    { status: options[:code] || 200,
+      body: JSON.generate(has_more: false, data: [{ id: "cus_A456" }]) }
+  end
+
+  def get_customer_payment_methods_response_mock(options)
+    payment_method = options[:payment_method] || "pm_456"
+    fingerprint = options[:fingerprint] || "7890"
+    { status: options[:code] || 200,
+      body: JSON.generate(
+        has_more: false, data: [{ id: payment_method, card: { fingerprint: fingerprint } }]
+      ) }
+  end
+
+  def add_metadata_response_mock(options)
+    { status: options[:code] || 200,
+      body: JSON.generate({}) }
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #4723
Closes #4175 

This performs the extra SCA auth step if necessary when a user authorizes a shop to charge their default card. Cards authorized in this way can be charged offline for subscriptions.

Cards are no longer cloned to the connected account each time we use/authorize them.

We now show updated language on the account page to let customers know about what it means to authorize the card. 

#### What should we test?
Stripe provides card numbers that require SCA authentication: https://stripe.com/docs/testing

Adding an SCA card as the default card on the account page and then authorizing a shop to charge the default card should show the SCA modal. 

Charging that card for a subscription offline should work. 

#### Release notes
Added support for SCA

Changelog Category: User facing changes 

#### Dependencies

#### Documentation updates
