### PR TITLE
Allow Geocoder to be configured to use different APIs

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,7 +1,9 @@
 # Google requires an API key with a billing account to use their API.
 # The key is stored in config/application.yml.
+
 Geocoder.configure(
-  lookup: :google,
+  timeout: ENV.fetch('GEOCODER_TIMEOUT', 3).to_i,
+  lookup: ENV.fetch('GEOCODER_SERVICE', :google).to_sym,
   use_https: true,
-  api_key: ENV.fetch('GOOGLE_MAPS_API_KEY', nil)
+  api_key: ENV.fetch('GEOCODER_API_KEY', ENV["GOOGLE_MAPS_API_KEY"])
 )


### PR DESCRIPTION
#### What? Why?

This gives instances the option to use [other geocoding services](https://github.com/alexreisner/geocoder/blob/master/README_API_GUIDE.md), for example MapBox, because instances may not have a Google Maps API key if they are using Open Street Map for their map instead of Google Maps. This means instances could use a single service like MapBox for both Maps and Geocoding rather than needing to use/pay for two different services. No problem if the timing isn't right for this or if it needs discussion.

#### What should we test?

1. To test geocoding via MapBox setup the following environment variables on an instance:

```
GEOCODER_SERVICE=mapbox
GEOCODER_TIMEOUT=6
GEOCODER_API_KEY=*****
```
2. Go to enterprise and change the address.
3. Check the map to make sure the enterprise icon has moved to the new address.

(I can send an MapBox API key if needed)

#### Release notes

Allow Geocoder to be configured to use different APIs

Changelog Category: Technical changes

#### Documentation updates

Update ofn-install documentation with instructions on how to configure different Geocoder services.