### PR TITLE
Transifex Updater

### DIFF
--- a/lib/tasks/translations/transifex_updater.rb
+++ b/lib/tasks/translations/transifex_updater.rb
@@ -3,7 +3,7 @@
 require 'yaml'
 
 class TransifexUpdater
-  def initialize
+  def update
     return unless updatable_locales.present? && tx_client_present?
 
     fetch_translations

--- a/lib/tasks/translations/transifex_updater.rb
+++ b/lib/tasks/translations/transifex_updater.rb
@@ -31,19 +31,69 @@ class TransifexUpdater
 
   # Processes each new translation file (if any) and applies updates to original
   def update_translations
-    new_translations = Dir.glob(Rails.root.join("config/locales/*.new"))
+    return unless new_translation_files.any?
 
-    new_translations.each do |new_file|
-      existing_file = new_file.chomp('.new')
+    new_translation_files.each do |new_file|
+      current_file = new_file.chomp('.new')
+      updated_translations = apply_updates(current_file, new_file)
 
-      merged_data = deep_diff_merge(YAML.load_file(existing_file), YAML.load_file(new_file))
-
-      File.open(existing_file, "w") do |file|
-        file.write merged_data.to_yaml(line_width: -1)
+      File.open(current_file, "w") do |file|
+        file.write updated_translations.to_yaml(line_width: -1)
       end
 
       File.delete(new_file)
     end
+  end
+
+  def apply_updates(current_file, new_file)
+    current_translations = YAML.load_file(current_file)
+    upstream_translations = YAML.load_file(new_file)
+
+    puts "\n####### Locale: #{root_key(current_translations)} #######\n\n"
+
+    puts "####### New compatible keys in basefile:\n\n"
+    updated_structure = { root_key(current_translations) =>
+                              merge_keys(keys(current_translations), keys(base_translations)) }
+
+    puts "\n####### New/updated compatible translations:\n\n"
+    merge_values(updated_structure, upstream_translations)
+  end
+
+  # The root key in any locale, eg: "fr"
+  def root_key(translations)
+    translations.first[0]
+  end
+
+  # Everything else underneath the root_key
+  def keys(translations)
+    translations.first[1]
+  end
+
+  def new_translation_files
+    Dir.glob(Rails.root.join("config/locales/*.new"))
+  end
+
+  def base_translations
+    YAML.load_file(Rails.root.join("config/locales/en.yml"))
+  end
+
+  # Recursively diffs and reverse-merges keys from second_hash into first_hash, where both
+  # hashes are deeply-nested datasets of unknown depth (eg converted from complex YAML).
+  # - Keys missing in second_hash are not removed from first_hash
+  # - Keys present in second_hash that are not present in first_hash are added to first_hash
+  def merge_keys(first_hash, second_hash)
+    second_hash.each_pair do |second_key, second_value|
+      first_value = first_hash[second_key]
+
+      if second_value.is_a?(Hash) && first_value.is_a?(Hash)
+        first_hash[second_key] = merge_keys(first_value, second_value)
+      elsif !first_hash.key? second_key
+        puts JSON.pretty_generate({second_key => second_value})
+        first_hash[second_key] = second_value
+      end
+    end
+
+    first_hash
   end
 
   # Recursively diffs and reverse-merges values from second_hash into first_hash, where both
@@ -52,15 +102,16 @@ class TransifexUpdater
   # - Keys present in second_hash that are not present in first_hash are not added
   # - Values in second_hash overwrite values in first_hash, if the keys are present
   #   in both hashes, and a value is present (non-blank) in second_hash
-  def deep_diff_merge(first_hash, second_hash)
+  def merge_values(first_hash, second_hash)
     first_hash.each_pair do |current_key, current_value|
       new_value = second_hash[current_key]
 
-      first_hash[current_key] = if current_value.is_a?(Hash) && new_value.is_a?(Hash)
-                                  deep_diff_merge current_value, new_value
-                                else
-                                  new_value.present? ? new_value : current_value
-                                end
+      if current_value.is_a?(Hash) && new_value.is_a?(Hash)
+        first_hash[current_key] = merge_values(current_value, new_value)
+      elsif new_value.present? && new_value != current_value
+        puts "#{current_key}: #{new_value}"
+        first_hash[current_key] = new_value
+      end
     end
 
     first_hash

--- a/lib/tasks/translations/transifex_updater.rb
+++ b/lib/tasks/translations/transifex_updater.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+class TransifexUpdater
+  def initialize
+    return unless updatable_locales.present? && tx_client_present?
+
+    fetch_translations
+    update_translations
+  end
+
+  private
+
+  def updatable_locales
+    locales = ENV.fetch("AVAILABLE_LOCALES", "").split(",").collect(&:strip)
+    locales.delete("en")
+    locales
+  end
+
+  def tx_client_present?
+    system("tx --version")
+  end
+
+  # Fetches translations for available locales that have changed since the local git version.
+  # Any updated translations are saved in a separate file (eg `fr.yml.new`) and the original
+  # file (eg `fr.yml`) is left untouched.
+  def fetch_translations
+    system("tx pull --use-git-timestamps --disable-overwrite -l #{updatable_locales.join(',')}")
+  end
+
+  # Processes each new translation file (if any) and applies updates to original
+  def update_translations
+    new_translations = Dir.glob(Rails.root.join("config/locales/*.new"))
+
+    new_translations.each do |new_file|
+      existing_file = new_file.chomp('.new')
+
+      merged_data = deep_diff_merge(YAML.load_file(existing_file), YAML.load_file(new_file))
+
+      File.open(existing_file, "w") do |file|
+        file.write merged_data.to_yaml(line_width: -1)
+      end
+
+      File.delete(new_file)
+    end
+  end
+
+  # Recursively diffs and reverse-merges values from second_hash into first_hash, where both
+  # hashes are deeply-nested datasets of unknown depth (eg converted from complex YAML).
+  # - Keys missing in second_hash are not removed from first_hash
+  # - Keys present in second_hash that are not present in first_hash are not added
+  # - Values in second_hash overwrite values in first_hash, if the keys are present
+  #   in both hashes, and a value is present (non-blank) in second_hash
+  def deep_diff_merge(first_hash, second_hash)
+    first_hash.each_pair do |current_key, current_value|
+      new_value = second_hash[current_key]
+
+      first_hash[current_key] = if current_value.is_a?(Hash) && new_value.is_a?(Hash)
+                                  deep_diff_merge current_value, new_value
+                                else
+                                  new_value.present? ? new_value : current_value
+                                end
+    end
+
+    first_hash
+  end
+end

--- a/lib/tasks/translations/update_translations.rake
+++ b/lib/tasks/translations/update_translations.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "tasks/translations/transifex_updater"
+
+namespace :ofn do
+  namespace :translations do
+    desc "Pull new translations from Transifex"
+
+    task update: :environment do
+      TransifexUpdater.new
+    end
+  end
+end

--- a/lib/tasks/translations/update_translations.rake
+++ b/lib/tasks/translations/update_translations.rake
@@ -7,7 +7,7 @@ namespace :ofn do
     desc "Pull new translations from Transifex"
 
     task update: :environment do
-      TransifexUpdater.new
+      TransifexUpdater.new.update
     end
   end
 end

--- a/spec/lib/tasks/translations/transifex_updater_spec.rb
+++ b/spec/lib/tasks/translations/transifex_updater_spec.rb
@@ -4,8 +4,21 @@ require 'spec_helper'
 require 'tasks/translations/transifex_updater'
 
 describe TransifexUpdater do
+  let(:subject) { TransifexUpdater.new }
+
+  describe "#updatable_locales" do
+    before do
+      allow(ENV).to receive(:fetch).with("AVAILABLE_LOCALES", "") { "en,fr,es" }
+    end
+
+    it "returns an array of available locales excluding `en`" do
+      updatable_locales = subject.__send__(:updatable_locales)
+
+      expect(updatable_locales).to eq ["fr", "es"]
+    end
+  end
+
   describe "#deep_diff_merge" do
-    let(:subject) { TransifexUpdater.new }
     let(:current_translations) {
       { "es" =>
         { "fruits" =>

--- a/spec/lib/tasks/translations/transifex_updater_spec.rb
+++ b/spec/lib/tasks/translations/transifex_updater_spec.rb
@@ -18,7 +18,46 @@ describe TransifexUpdater do
     end
   end
 
-  describe "#deep_diff_merge" do
+  describe "#merge_keys" do
+    let(:current_translations) {
+      { "fruits" =>
+        { "apples" => "Manzanas",
+          "oranges" => "Naranjas" },
+        "vegetables" =>
+          { "tomatos" => "Tomates" },
+        "baked_goods" =>
+          { "bread" => "Pan" } }
+    }
+    let(:base_translations) {
+      { "fruits" =>
+        { "apples" => "Apples",
+          "pears" => "Pears",
+          "bags" =>
+            { "grapes" => "Grapes" } },
+        "vegetables" =>
+          { "tomatos" => "Tomatos" } }
+    }
+    let(:expected_output) {
+      { "fruits" =>
+        { "apples" => "Manzanas",
+          "pears" => "Pears",
+          "oranges" => "Naranjas",
+          "bags" =>
+            { "grapes" => "Grapes" } },
+        "vegetables" =>
+          { "tomatos" => "Tomates" },
+        "baked_goods" =>
+          { "bread" => "Pan" } }
+    }
+
+    it "merges new keys from base locale" do
+      merged_data = subject.__send__(:merge_keys, current_translations, base_translations)
+
+      expect(merged_data).to eq expected_output
+    end
+  end
+
+  describe "#merge_values" do
     let(:current_translations) {
       { "es" =>
         { "fruits" =>
@@ -51,7 +90,7 @@ describe TransifexUpdater do
     }
 
     it "merges compatible upstream translations" do
-      merged_data = subject.__send__(:deep_diff_merge, current_translations, new_translations)
+      merged_data = subject.__send__(:merge_values, current_translations, new_translations)
 
       expect(merged_data).to eq expected_output
     end

--- a/spec/lib/tasks/translations/transifex_updater_spec.rb
+++ b/spec/lib/tasks/translations/transifex_updater_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tasks/translations/transifex_updater'
+
+describe TransifexUpdater do
+  describe "#deep_diff_merge" do
+    let(:subject) { TransifexUpdater.new }
+    let(:current_translations) {
+      { "es" =>
+        { "fruits" =>
+           { "apples" => "Manzanas",
+             "oranges" => "Naranjas" },
+          "vegetables" =>
+           { "tomatos" => "Tomates" },
+          "baked_goods" =>
+           { "bread" => "Pan" } } }
+    }
+    let(:new_translations) {
+      { "es" =>
+        { "fruits" =>
+          { "apples" => "Manzanitas",
+            "pears" => "Peras",
+            "bags" =>
+             { "grapes" => "Uvas" } },
+          "vegetables" =>
+          { "tomatos" => "Tomates Grandes" } } }
+    }
+    let(:expected_output) {
+      { "es" =>
+        { "fruits" =>
+           { "apples" => "Manzanitas",
+             "oranges" => "Naranjas" },
+          "vegetables" =>
+             { "tomatos" => "Tomates Grandes" },
+          "baked_goods" =>
+             { "bread" => "Pan" } } }
+    }
+
+    it "merges compatible upstream translations" do
+      merged_data = subject.__send__(:deep_diff_merge, current_translations, new_translations)
+
+      expect(merged_data).to eq expected_output
+    end
+  end
+end


### PR DESCRIPTION
WIP/POC: experimental idea for pulling Transifex updates

#### Purpose

Moving towards **Continuous Localization** which is decoupled from both releases and deployments, effectively allowing us to live-patch updated non-English translations from Transifex both _automatically_ at the point of deployment, and manually at any time after a deployment (in production).

#### Notes

- Requires the Transifex command-line client to be installed on any machine it's used on, and a Transifex client API key to be present.
- Could be run from an Ansible task inside the build directory during each deployment.
- Could be run from an Ansible playbook to update translations at any time (in production).