### PR TITLE
Add new translation for shipping method

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3104,6 +3104,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     back_to_taxonomies_list: "Back to Taxonomies List"
 
     shipping_methods: "Shipping Methods"
+    shipping_method: "Shipping Method"
 
     shipping_categories: "Shipping Categories"
     new_shipping_category: "New Shipping Category"


### PR DESCRIPTION
What? Why?
Closes #5993

I am adding `spree.shipping_method` translation. The issue was caused by missing the translation key on the locales. 

What should we test?
Test the edit shipping method on order details on admin dashboard.

How to do:

1. Login as an admin.
2. Go to orders.
3. Select one of the orders and edit shipping method.

Changelog Category: Fixed