### PR TITLE
Patch Rails :deep_munge issue so empty array parameters don't get converted to nil

### DIFF
--- a/config/initializers/action_dispatch_request_deep_munge_patch.rb
+++ b/config/initializers/action_dispatch_request_deep_munge_patch.rb
@@ -1,0 +1,1 @@
+require "action_dispatch/request"

--- a/lib/action_dispatch/request.rb
+++ b/lib/action_dispatch/request.rb
@@ -1,0 +1,47 @@
+# This patch fixes the Rails issue where ActionDispatch::Request#deep_munge was converting empty
+# array paramters into nils, see https://github.com/rails/rails/issues/13420
+#
+# Before this patch:
+#
+# | JSON                             | Hash                    |
+# |----------------------------------|-------------------------|
+# | { "person": [] }                 | { 'person' => nil }     |
+#
+# After patch:
+#
+# | JSON                             | Hash                    |
+# |----------------------------------|-------------------------|
+# | { "person": [] }                 | { 'person' => [] }      |
+#
+# The issue started in Rails v4.0.0.beta1:
+#
+# https://github.com/rails/rails/commit/8e577fe560d5756fcc67840ba304d79ada6804e4
+#
+# This patch can be removed on or after Rails v5.0.0.beta1 when the issue was fixed:
+#
+# https://github.com/rails/rails/commit/8f8ccb9901cab457c6e1d52bdb25acf658fd5777
+#
+# Credit:
+#
+# https://gist.github.com/victorblasco/f675b4cbaf9c0bc19f81
+
+module ActionDispatch
+  class Request
+    def deep_munge(hash)
+      hash.each do |k, v|
+        case v
+        when Array
+          v.grep(Hash) { |x| deep_munge(x) }
+          v.compact!
+
+          # This patch removes the next line
+          # hash[k] = nil if v.empty?
+        when Hash
+          deep_munge(v)
+        end
+      end
+
+      hash
+    end
+  end
+end

--- a/lib/action_dispatch/request.rb
+++ b/lib/action_dispatch/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This patch fixes the Rails issue where ActionDispatch::Request#deep_munge was converting empty
 # array paramters into nils, see https://github.com/rails/rails/issues/13420
 #
@@ -28,7 +30,7 @@
 module ActionDispatch
   class Request
     def deep_munge(hash)
-      hash.each do |k, v|
+      hash.each do |_k, v|
         case v
         when Array
           v.grep(Hash) { |x| deep_munge(x) }

--- a/spec/lib/action_dispatch/request_spec.rb
+++ b/spec/lib/action_dispatch/request_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe ActionDispatch::Request do
+  it "strips nils from arrays" do
+    assert_parses({ "key" => ["value"] }, 'key[]=value&key[]')
+    assert_parses({ "key1" => { "key2" => ["value"] } }, 'key1[key2][]=value&key1[key2][]')
+  end
+
+  it "doesn't convert an empty array to nil" do
+    assert_parses({ "key" => [] }, 'key[]')
+  end
+
+  private
+
+  def assert_parses(expected, actual)
+    assert_equal expected, ActionDispatch::Request.new('QUERY_STRING' => actual).query_parameters
+  end
+end

--- a/spec/lib/action_dispatch/request_spec.rb
+++ b/spec/lib/action_dispatch/request_spec.rb
@@ -1,18 +1,25 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe ActionDispatch::Request do
   it "strips nils from arrays" do
-    assert_parses({ "key" => ["value"] }, 'key[]=value&key[]')
-    assert_parses({ "key1" => { "key2" => ["value"] } }, 'key1[key2][]=value&key1[key2][]')
+    expect(parse_query_parameters('key[]=value&key[]')).to eq({ "key" => ["value"] })
+  end
+
+  it "strips nils from nested arrays" do
+    expect(
+      parse_query_parameters('key1[key2][]=value&key1[key2][]')
+    ).to eq({ "key1" => { "key2" => ["value"] } })
   end
 
   it "doesn't convert an empty array to nil" do
-    assert_parses({ "key" => [] }, 'key[]')
+    expect(parse_query_parameters('key[]')).to eq({ "key" => [] })
   end
 
   private
 
-  def assert_parses(expected, actual)
-    assert_equal expected, ActionDispatch::Request.new('QUERY_STRING' => actual).query_parameters
+  def parse_query_parameters(query_parameters)
+    ActionDispatch::Request.new("QUERY_STRING" => query_parameters).query_parameters
   end
 end


### PR DESCRIPTION
#### What? Why?

Before people were unable to remove coordinator fees from an order cycle because [Rails was converting the empty :coordinator_fee_ids array parameter into nil](https://github.com/rails/rails/issues/13420). This issue was introduced to Rails in v4.0.0.beta1 and isn't fixed [until v5.0.0.beta1](https://github.com/rails/rails/commit/8f8ccb9901cab457c6e1d52bdb25acf658fd5777)

We could avoid the monkey patch :see_no_evil: by do something like `params[:coordinator_fee_ids] ||= []` but it seems like this issue could cause problems in other parts of the app so perhaps a general fix might be better until Rails v5.

Closes #6224

#### What should we test?

See _Steps to reproduce_ in #6224 

#### Release notes

Fix removing of coordinator fees from order cycles.

Changelog Category: User facing changes 