### PR TITLE
Fix #s3_credentials

### DIFF
--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -64,7 +64,7 @@ module Spree
       end
     end
 
-    def s3_credentials
+    def self.s3_credentials
       { access_key_id: Spree::Config[:s3_access_key],
         secret_access_key: Spree::Config[:s3_secret],
         bucket: Spree::Config[:s3_bucket] }


### PR DESCRIPTION
#### What? Why?

Fixes broken deployments caused by: an initializer that calls a class method, but the class method calls an instance method :boom:

Only occurs on servers that use S3 for images, so I assume we staged the PR that introduced it in Katuma? 

:warning: This is blocking testing/deployment of the current release. :warning: 

#### What should we test?
<!-- List which features should be tested and how. -->

This PR can be deployed to staging servers that use S3. Already tested :heavy_check_mark: 

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Fixed s3 config initialization.