### PR TITLE
Corrected RuboCop offenses in spec/support/request/shop_workflow.rb

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -845,6 +845,7 @@ Metrics/ModuleLength:
   - spec/models/spree/variant_spec.rb
   - spec/services/permissions/order_spec.rb
   - spec/services/variant_units/option_value_namer_spec.rb
+  - spec/support/request/shop_workflow.rb
 
 Metrics/ParameterLists:
   Max: 5

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -71,7 +71,7 @@ module ShopWorkflow
     wait_for_cart
   end
 
-  def click_add_bulk_max_to_cart(variant = nil, quantity = 1)
+  def click_add_bulk_max_to_cart(_variant = nil, quantity = 1)
     within(".reveal-modal") do
       quantity.times do
         page.all("button", text: increase_quantity_symbol).last.click


### PR DESCRIPTION
This pull request corrects the following RuboCop offenses:
```bash
spec/support/request/shop_workflow.rb:1:1: C: Metrics/ModuleLength: Module has too many lines. [101/100]
module ShopWorkflow ...
^^^^^^^^^^^^^^^^^^^
spec/support/request/shop_workflow.rb:74:34: W: Lint/UnusedMethodArgument: Unused method argument - variant. If it's necessary, use _ or _variant as an argument name to indicate that it won't be used.
  def click_add_bulk_max_to_cart(variant = nil, quantity = 1)
```

This pull request reduces the number of offenses from 117 to 115.