### PR TITLE
Added yarn install to docker-compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     command: >
       bash -c "wait-for-it -t 30 db:5432 &&
                rm -f tmp/pids/server.pid &&
+               yarn install &&
                bundle exec rails s -p 3000 -b '0.0.0.0'"
   worker:
     tty: true


### PR DESCRIPTION
Adding "yarn install" to the "docker-compose up" process makes it possible to see the app (instead of an error message) at http://localhost:3000/.  This pull request addresses Issue #6254 .