### PR TITLE
Update delayed_job script environment loading

### DIFF
--- a/script/delayed_job
+++ b/script/delayed_job
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require_relative '../config/environment'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'delayed/command'
 Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
#### What? Why?

Deployment of #5978 failed at the `restart delayed_job` task. The stack trace shows `script/delayed_job` as the source, and specifically the environment loading line.

I think this startup script is slightly old. Our current version of the delayed_job gem generates an updated version of the same file when running the delayed_job setup via `rails generate delayed_job`.

#### What should we test?
<!-- List which features should be tested and how. -->

.
