### PR TITLE
Upgrade aws-sdk and switch to S3 virtual host style URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'kaminari', '~> 0.14.1'
 
 gem 'andand'
 gem 'angularjs-rails', '1.5.5'
-gem 'aws-sdk', '1.11.1' # temporarily locked down due to https://github.com/aws/aws-sdk-ruby/issues/273
+gem 'aws-sdk', '1.67.0'
 gem 'bugsnag'
 gem 'db2fog'
 gem 'haml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,10 +117,11 @@ GEM
     awesome_nested_set (3.0.3)
       activerecord (>= 4.0.0, < 5)
     awesome_print (1.8.0)
-    aws-sdk (1.11.1)
+    aws-sdk (1.67.0)
+      aws-sdk-v1 (= 1.67.0)
+    aws-sdk-v1 (1.67.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4)
-      uuidtools (~> 2.1)
+      nokogiri (~> 1)
     bcrypt (3.1.13)
     bugsnag (6.18.0)
       concurrent-ruby (~> 1.0)
@@ -648,7 +649,6 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
-    uuidtools (2.1.5)
     warden (1.2.7)
       rack (>= 1.0)
     webdrivers (4.2.0)
@@ -688,7 +688,7 @@ DEPENDENCIES
   atomic
   awesome_nested_set (~> 3.0.0.rc.1)
   awesome_print
-  aws-sdk (= 1.11.1)
+  aws-sdk (= 1.67.0)
   bugsnag
   byebug (~> 11.0.0)
   cancan (~> 1.6.10)

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -50,30 +50,36 @@ module Spree
       false
     end
 
-    def self.set_attachment_attributes(attribute_name, attribute_value)
+    def self.set_attachment_attribute(attribute_name, attribute_value)
       attachment_definitions[:attachment][attribute_name] = attribute_value
     end
 
-    def self.set_s3_attachment_definitions
+    def self.set_storage_attachment_attributes
       if Spree::Config[:use_s3]
-        set_attachment_attributes(:storage, :s3)
-        set_attachment_attributes(:s3_credentials, s3_credentials)
-        set_attachment_attributes(:s3_headers,
-                                  ActiveSupport::JSON.decode(Spree::Config[:s3_headers]))
-        set_attachment_attributes(:bucket, Spree::Config[:s3_bucket])
-
-        # We use :s3_alias_url (virtual host url style) and set the URL on property s3_host_alias
-        set_attachment_attributes(:s3_host_alias, attachment_definitions[:attachment][:url])
-        set_attachment_attributes(:url, ":s3_alias_url")
+        set_s3_attachment_attributes
       else
-        attachment_definitions[:attachment].delete :storage
+        attachment_definitions[:attachment].delete(:storage)
       end
     end
+
+    def self.set_s3_attachment_attributes
+      set_attachment_attribute(:storage, :s3)
+      set_attachment_attribute(:s3_credentials, s3_credentials)
+      set_attachment_attribute(:s3_headers,
+                               ActiveSupport::JSON.decode(Spree::Config[:s3_headers]))
+      set_attachment_attribute(:bucket, Spree::Config[:s3_bucket])
+
+      # We use :s3_alias_url (virtual host url style) and set the URL on property s3_host_alias
+      set_attachment_attribute(:s3_host_alias, attachment_definitions[:attachment][:url])
+      set_attachment_attribute(:url, ":s3_alias_url")
+    end
+    private_class_method :set_s3_attachment_attributes
 
     def self.s3_credentials
       { access_key_id: Spree::Config[:s3_access_key],
         secret_access_key: Spree::Config[:s3_secret],
         bucket: Spree::Config[:s3_bucket] }
     end
+    private_class_method :s3_credentials
   end
 end

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -61,6 +61,11 @@ module Spree
         set_attachment_attributes(:s3_headers,
                                   ActiveSupport::JSON.decode(Spree::Config[:s3_headers]))
         set_attachment_attributes(:bucket, Spree::Config[:s3_bucket])
+
+        # When using S3, we set the URL on property s3_host_name
+        set_attachment_attributes(:s3_host_name, attachment_definitions[:attachment][:url])
+        set_attachment_attributes(:url, ":s3_domain_url")
+        # :s3_alias_url
       else
         attachment_definitions[:attachment].delete :storage
       end

--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -62,10 +62,9 @@ module Spree
                                   ActiveSupport::JSON.decode(Spree::Config[:s3_headers]))
         set_attachment_attributes(:bucket, Spree::Config[:s3_bucket])
 
-        # When using S3, we set the URL on property s3_host_name
-        set_attachment_attributes(:s3_host_name, attachment_definitions[:attachment][:url])
-        set_attachment_attributes(:url, ":s3_domain_url")
-        # :s3_alias_url
+        # We use :s3_alias_url (virtual host url style) and set the URL on property s3_host_alias
+        set_attachment_attributes(:s3_host_alias, attachment_definitions[:attachment][:url])
+        set_attachment_attributes(:url, ":s3_alias_url")
       else
         attachment_definitions[:attachment].delete :storage
       end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -37,8 +37,8 @@ Spree.config do |config|
 end
 
 # Attachments settings
-Spree::Image.set_attachment_attributes(:path, ENV['ATTACHMENT_PATH']) if ENV['ATTACHMENT_PATH']
-Spree::Image.set_attachment_attributes(:url, ENV['ATTACHMENT_URL']) if ENV['ATTACHMENT_URL']
+Spree::Image.set_attachment_attribute(:path, ENV['ATTACHMENT_PATH']) if ENV['ATTACHMENT_PATH']
+Spree::Image.set_attachment_attribute(:url, ENV['ATTACHMENT_URL']) if ENV['ATTACHMENT_URL']
 Spree::Image.set_storage_attachment_attributes
 
 # Spree 2.0 recommends explicitly setting this here when using spree_auth_devise

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -39,7 +39,7 @@ end
 # Attachments settings
 Spree::Image.set_attachment_attributes(:path, ENV['ATTACHMENT_PATH']) if ENV['ATTACHMENT_PATH']
 Spree::Image.set_attachment_attributes(:url, ENV['ATTACHMENT_URL']) if ENV['ATTACHMENT_URL']
-Spree::Image.set_s3_attachment_definitions
+Spree::Image.set_storage_attachment_attributes
 
 # Spree 2.0 recommends explicitly setting this here when using spree_auth_devise
 Spree.user_class = 'Spree::User'


### PR DESCRIPTION
#### What? Why?

Closes #511 
Closes #4177 

Here I re-use the existing attachment URL variable. **I dont think attachment_url is used right now, only attachment_path is taken into account as far as I understand**, at least with images on S3.
Have a look at the config change PR to see how it will look like:
https://github.com/openfoodfoundation/ofn-install/pull/667

#### What should we test?
We need to deploy this and verify the existing images are still working as well as verify new uploads.
There's very little risk this will affect non-s3 images setup.
We should test that this will work with images stored in a region outside the USA, I have tested locally with eu-west-3 and it worked well.

We need to verify that this version of aws-sdk keeps db backups to S3 working. We need to setup backups to S3 in staging before we stage this PR and then see if backups are still correctly taken after this PR is staged.

#### Release notes
Changelog Category: Technical changes
Upgraded AWS SDK used to interac with AWS S3 and backups.
We can now use all S3 buckets to store images.

#### Dependencies
Before the release with this PR is deployed, this PR with new URLs for all servers needs to be merged https://github.com/openfoodfoundation/ofn-install/pull/667 and the servers provisioned.