### PR TITLE
Exempted spec/support/request/web_helper.rb from Metrics/AbcSize

### DIFF
--- a/.rubocop_manual_todo.yml
+++ b/.rubocop_manual_todo.yml
@@ -452,6 +452,7 @@ Metrics/AbcSize:
   - spec/services/order_checkout_restart_spec.rb
   - spec/support/i18n_translations_checker.rb
   - spec/support/performance_helper.rb
+  - spec/support/request/web_helper.rb
 
 Metrics/BlockLength:
   Max: 25


### PR DESCRIPTION
This reduces the number of offenses from 122 to 121.