### PR TITLE
Removed variant argument from click_add_bulk_max_to_cart

### DIFF
--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -251,7 +251,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
           # -- Max quantity
           open_bulk_quantity_modal(variant)
-          click_add_bulk_max_to_cart variant, 1
+          click_add_bulk_max_to_cart 1
 
           expect(order.reload.line_items.first.max_quantity).to eq(7)
 
@@ -406,7 +406,7 @@ feature "As a consumer I want to shop with a distributor", js: true do
 
             it "does not update max_quantity" do
               click_add_bulk_to_cart variant, 2
-              click_add_bulk_max_to_cart variant, 1
+              click_add_bulk_max_to_cart 1
               close_modal
 
               variant.update! on_hand: 1

--- a/spec/support/request/shop_workflow.rb
+++ b/spec/support/request/shop_workflow.rb
@@ -71,7 +71,7 @@ module ShopWorkflow
     wait_for_cart
   end
 
-  def click_add_bulk_max_to_cart(variant = nil, quantity = 1)
+  def click_add_bulk_max_to_cart(quantity = 1)
     within(".reveal-modal") do
       quantity.times do
         page.all("button", text: increase_quantity_symbol).last.click


### PR DESCRIPTION
This pull request addresses the following RuboCop offense:
```bash
spec/support/request/shop_workflow.rb:74:34: W: Lint/UnusedMethodArgument: Unused method argument - variant. If it's necessary, use _ or _variant as an argument name to indicate that it won't be used.
  def click_add_bulk_max_to_cart(variant = nil, quantity = 1)
```

The number of offenses is reduced from 122 to 121.