### PR TITLE
Remove Paperclip URL handlers

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,3 +1,14 @@
 Paperclip::Attachment.default_options[:source_file_options] = {
   all: "-auto-orient"
 }
+
+url_adapters = [
+  "Paperclip::UriAdapter",
+  "Paperclip::HttpUrlProxyAdapter",
+  "Paperclip::DataUriAdapter"
+]
+
+# Remove Paperclip URL adapters from registered handlers
+Paperclip.io_adapters.registered_handlers.delete_if do |_proc, adapter_class|
+  url_adapters.include? adapter_class.to_s
+end


### PR DESCRIPTION
#### What? Why?

Removes unused Paperclip URL handlers.

#### What should we test?
<!-- List which features should be tested and how. -->

Manual test: image uploads (in bulk products, edit product, and edit enterprise pages) and the new PDF uploads for T&Cs should all be working normally (not broken).

Dev test: in the Rails console, do: `Paperclip.io_adapters.registered_handlers.map(&:second)`. The output should list a number of classes. The list of classes should _not contain_: `Paperclip::UriAdapter`.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Removed unused Paperclip handlers.