### PR TITLE
Align center order adjustment and order total title

### DIFF
--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -9,7 +9,7 @@
 
   - if order.line_items.exists?
     %fieldset#order-total.no-border-bottom{"data-hook" => "order_details_total"}
-      %legend= t(".order_total")
+      %legend{ align: 'center' }= t(".order_total")
       %span.order-total= order.display_total
 
   = form_for @order, url: admin_order_url(@order), method: :put do |f|

--- a/app/views/spree/admin/orders/_form/_adjustments.html.haml
+++ b/app/views/spree/admin/orders/_form/_adjustments.html.haml
@@ -1,6 +1,6 @@
 - if adjustments.present?
   %fieldset.no-border-bottom
-    %legend= title
+    %legend{ align: 'center' }= title
     %table>
       %thead
         %tr


### PR DESCRIPTION
#### What? Why?
Closes #5955 

I am adding html attributes to the align html element so the alignment will work on firefox browser.

#### What should we test?
Test the edit order details on admin dashboard.

How to do:

Login as an admin.
Go to orders.
Select one of the orders.
You will be able to see the order adjustment and order total title center aligned.

Screenshot: 
![image](https://user-images.githubusercontent.com/3486644/97660302-b561a980-1aa3-11eb-9b4a-d6393ffe72bd.png)


Changelog Category: Fixed