### PR TITLE
update template path for cookies banner, fix #6284

### DIFF
--- a/engines/web/app/assets/javascripts/web/cookies_banner/cookies_banner_service.js.coffee
+++ b/engines/web/app/assets/javascripts/web/cookies_banner/cookies_banner_service.js.coffee
@@ -4,7 +4,7 @@ Darkswarm.factory "CookiesBannerService", (Navigation, $modal, $location, Redire
     modalMessage: null
     isEnabled: false
 
-    open: (path, template = 'angular-templates/cookies_banner.html') =>
+    open: (path, template = '/angular-templates/cookies_banner.html') =>
       return unless @isEnabled
       @modalInstance = $modal.open
         templateUrl: template

--- a/engines/web/app/assets/javascripts/web/cookies_policy/cookies_policy_modal_service.js.coffee
+++ b/engines/web/app/assets/javascripts/web/cookies_policy/cookies_policy_modal_service.js.coffee
@@ -8,7 +8,7 @@ Darkswarm.factory "CookiesPolicyModalService", (Navigation, $modal, $location, C
       if @isEnabled()
         @open ''
 
-    open: (path = false, template = 'angular-templates/cookies_policy.html') =>
+    open: (path = false, template = '/angular-templates/cookies_policy.html') =>
       @modalInstance = $modal.open
         templateUrl: template
         windowClass: "cookies-policy-modal medium"


### PR DESCRIPTION
#### What? Why?

Closes #6284


#### What should we test?
Directly visiting a shop page in private mode should display the cookies banner


#### Release notes
Fixed a bug where the cookies banner did not display on pages other than the homepage. 

Changelog Category: User facing changes


#### Dependencies


#### Documentation updates