### PR TITLE
Fix display issue in product image edit page

### DIFF
--- a/app/assets/stylesheets/admin/products.scss
+++ b/app/assets/stylesheets/admin/products.scss
@@ -121,3 +121,10 @@ form#image_upload {
   }
 }
 
+form.edit_image {
+  .field {
+    img {
+      max-width: 150px;
+    }
+  }
+}


### PR DESCRIPTION
#### What? Why?

Fixes a minor display regression with new image sizes in admin product edit page.

#### What should we test?
<!-- List which features should be tested and how. -->

In admin product edit, when uploading an image the thumbnail isn't so big it breaks the layout.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->


<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

Fixed image layout regression in product edit image page.
