### PR TITLE
Update reference to OFN Handbook in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We're part of global movement - get involved!
 
 ## Contributing
 
-If you are interested in contributing to the OFN in any capacity, please introduce yourself [on Slack][slack-invite], and have a look through our [Contributor Guide][contributor-guide].
+If you are interested in contributing to the OFN in any capacity, please introduce yourself [on Slack][slack-invite], and have a look through the [OFN Handbook][ofn-handbook].
 
 Our [GETTING_STARTED](GETTING_STARTED.md) and [CONTRIBUTING](CONTRIBUTING.md) guides are the best place to start for developers looking to set up a development environment and make contributions to the codebase.
 
@@ -41,7 +41,7 @@ Copyright (c) 2012 - 2020 Open Food Foundation, released under the AGPL licence.
 
 [survey]: https://docs.google.com/a/eaterprises.com.au/forms/d/1zxR5vSiU9CigJ9cEaC8-eJLgYid8CR8er7PPH9Mc-30/edit#
 [slack-invite]: https://join.slack.com/t/openfoodnetwork/shared_invite/zt-9sjkjdlu-r02kUMP1zbrTgUhZhYPF~A
-[contributor-guide]: https://ofn-user-guide.gitbook.io/ofn-contributor-guide/who-are-we
+[ofn-handbook]: https://ofn-user-guide.gitbook.io/ofn-handbook/
 [ofn-install]: https://github.com/openfoodfoundation/ofn-install
 [super-admin-guide]: https://ofn-user-guide.gitbook.io/ofn-super-admin-guide
 [welcome-dev]: https://github.com/openfoodfoundation/openfoodnetwork/projects/27


### PR DESCRIPTION
#### What? Why?

Changed README.md's references from Contribution Guide to OFN Handbook to match current links, since the contributor-guide would just send you to the handbook.


#### Release notes

Changelog Category: User facing changes

Updated references to OFN Handbook in README.md
