### PR TITLE
Fixes issue #6262.

### DIFF
--- a/app/views/spree/shared/_user_form.html.haml
+++ b/app/views/spree/shared/_user_form.html.haml
@@ -14,6 +14,6 @@
     = f.password_field :password, class: 'title'
 
   %p
-    = f.label :password_confirmation, Spree.t(:confirm_password)
+    = f.label :password_confirmation, t(:password_confirmation)
     %br
     = f.password_field :password_confirmation, class: 'title'


### PR DESCRIPTION
#### What? Why?

Closes #6262 
Without this the label will not show in many languages. With the change I propose it's working.



#### Release notes
Fixed missing label for "Password Confirmation".
![Captura de tela_2020-11-04_13-13-27](https://user-images.githubusercontent.com/61836657/98137626-f7725d00-1ea0-11eb-82df-8302661a71e0.png)
