### PR TITLE
Fix some missing translations in orders edit page

### DIFF
--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -54,8 +54,8 @@
 
           %td.actions
             - if can? :update, shipment
-              = link_to '', '#', :class => 'save-method icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, title: Spree.t('actions.save')
-              = link_to '', '#', :class => 'cancel-method icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => Spree.t('actions.cancel')
+              = link_to '', '#', :class => 'save-method icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, title: I18n.t('actions.save')
+              = link_to '', '#', :class => 'cancel-method icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
 
       %tr.show-method.total
         %td{ :colspan => "4" }
@@ -83,8 +83,8 @@
 
         %td.actions
           - if can? :update, shipment
-            = link_to '', '#', :class => 'save-tracking icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, :title => Spree.t('actions.save')
-            = link_to '', '#', :class => 'cancel-tracking icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => Spree.t('actions.cancel')
+            = link_to '', '#', :class => 'save-tracking icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, :title => I18n.t('actions.save')
+            = link_to '', '#', :class => 'cancel-tracking icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
 
       %tr.show-tracking.total
         %td{ :colspan => "5" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3031,6 +3031,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     delete: "Delete"
     cannot_set_shipping_method_without_address: "Cannot set shipping method until customer details are provided."
     no_tracking_present: "No tracking details provided."
+    tracking: "Tracking"
+    tracking_number: "Tracking Number"
     order_total: "Order Total"
     customer_details: "Customer Details"
     customer_search: "Customer Search"


### PR DESCRIPTION
#### What? Why?

Fixes missing translations as raised in the end of testing of https://github.com/openfoodfoundation/openfoodnetwork/pull/5978#issuecomment-721892067

#### What should we test?
We can verify the translations are not back in the order edit page.

#### Release notes
Changelog Category: User facing changes
Fix missing translations in order edit page.
