### PR TITLE
Bump acts_as_list to 0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'web', path: './engines/web'
 gem 'activerecord-postgresql-adapter'
 gem 'pg', '~> 0.21.0'
 
-gem 'acts_as_list', '= 0.2.0'
+gem 'acts_as_list', '= 0.3.0'
 gem 'awesome_nested_set', '~> 3.0.0.rc.1'
 gem 'cancan', '~> 1.6.10'
 gem 'ffaker', '~> 1.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       tzinfo (~> 0.3.37)
     acts-as-taggable-on (4.0.0)
       activerecord (>= 4.0)
-    acts_as_list (0.2.0)
+    acts_as_list (0.3.0)
       activerecord (>= 3.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
@@ -680,7 +680,7 @@ DEPENDENCIES
   activerecord-postgresql-adapter
   activerecord-session_store
   acts-as-taggable-on (~> 4.0)
-  acts_as_list (= 0.2.0)
+  acts_as_list (= 0.3.0)
   andand
   angular-rails-templates (~> 0.3.0)
   angularjs-file-upload-rails (~> 2.4.1)


### PR DESCRIPTION
#### What? Why?

Closes #5872

#### What should we test?
Trying to delete this dependency I learned where it is used :-)
https://github.com/openfoodfoundation/openfoodnetwork/pull/6311

We need to test EnterpriseGroups in the backoffice and make sure they are manually sortable and display with the correct order in the frontoffice.
We also need to verify the sorting of product images still works in the backoffice. This order is not used anywhere so this could be potentially removed... for now we can just verify that dragging images up and down the list of images doesnt blow up the page...

#### Release notes
Changelog Category: Technical changes
Bumped acts_as_list to 0.3.0
