### PR TITLE
Avoid loading variant overrides for no reason

### DIFF
--- a/lib/spree/core/controller_helpers/order.rb
+++ b/lib/spree/core/controller_helpers/order.rb
@@ -17,7 +17,7 @@ module Spree
         def current_order(create_order_if_necessary = false)
           order = spree_current_order(create_order_if_necessary)
 
-          if order
+          if order&.line_items.present?
             scoper = OpenFoodNetwork::ScopeVariantToHub.new(order.distributor)
             order.line_items.each do |li|
               scoper.scope(li.variant)

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -91,6 +91,11 @@ describe BaseController, type: :controller do
       expect(session[:order_id]).to_not eq last_cart.id
       expect(controller.current_order.line_items.count).to eq 0
     end
+
+    it "doesn't load variant overrides without line items" do
+      expect(VariantOverride).to_not receive(:indexed)
+      controller.current_order(true)
+    end
   end
 
   it "redirects to home with message if order cycle is expired" do


### PR DESCRIPTION
#### What? Why?

Related to #5905 and replacing #5927.

If a user visits a shop but doesn't have any items in the cart, we currently query and index all VariantOverrides of that shop without needing or using that data. A simple guard clause prevents this from happening.

#### What should we test?
<!-- List which features should be tested and how. -->

- Set up a shop which overrides prices.
- Visit the shop front and check that the prices are correct.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Optimised page load times for visitors with empty carts.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

