### PR TITLE
Use `render json` in all json API endpoints

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -72,7 +72,7 @@ module Api
     end
 
     def error_during_processing(exception)
-      render(text: { exception: exception.message }.to_json,
+      render(json: { exception: exception.message },
              status: :unprocessable_entity) && return
     end
 

--- a/app/controllers/api/enterprise_fees_controller.rb
+++ b/app/controllers/api/enterprise_fees_controller.rb
@@ -6,9 +6,9 @@ module Api
       authorize! :destroy, enterprise_fee
 
       if enterprise_fee.destroy
-        render text: I18n.t(:successfully_removed), status: :no_content
+        render json: I18n.t(:successfully_removed), status: :no_content
       else
-        render text: enterprise_fee.errors.full_messages.first, status: :forbidden
+        render json: enterprise_fee.errors.full_messages.first, status: :forbidden
       end
     end
 

--- a/app/controllers/api/enterprises_controller.rb
+++ b/app/controllers/api/enterprises_controller.rb
@@ -15,7 +15,7 @@ module Api
       @enterprise = Enterprise.new(params[:enterprise])
       if @enterprise.save
         @enterprise.user_ids = user_ids
-        render text: @enterprise.id, status: :created
+        render json: @enterprise.id, status: :created
       else
         invalid_resource!(@enterprise)
       end
@@ -26,7 +26,7 @@ module Api
       authorize! :update, @enterprise
 
       if @enterprise.update(params[:enterprise])
-        render text: @enterprise.id, status: :ok
+        render json: @enterprise.id, status: :ok
       else
         invalid_resource!(@enterprise)
       end
@@ -37,9 +37,9 @@ module Api
       authorize! :update, @enterprise
 
       if params[:logo] && @enterprise.update( logo: params[:logo] )
-        render text: @enterprise.logo.url(:medium), status: :ok
+        render json: @enterprise.logo.url(:medium), status: :ok
       elsif params[:promo] && @enterprise.update( promo_image: params[:promo] )
-        render text: @enterprise.promo_image.url(:medium), status: :ok
+        render json: @enterprise.promo_image.url(:medium), status: :ok
       else
         invalid_resource!(@enterprise)
       end

--- a/app/controllers/api/exchange_products_controller.rb
+++ b/app/controllers/api/exchange_products_controller.rb
@@ -31,9 +31,7 @@ module Api
     private
 
     def render_variant_count
-      render text: {
-        count: variants.count
-      }.to_json
+      render json: { count: variants.count }
     end
 
     def variants
@@ -86,7 +84,7 @@ module Api
       result = { products: serializer }
       result = result.merge(pagination: pagination_data(paginated_products)) if pagination_required?
 
-      render text: result.to_json
+      render json: result
     end
 
     def pagination_data(paginated_products)

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -135,13 +135,13 @@ module Api
         each_serializer: product_serializer
       )
 
-      render text: {
+      render json: {
         products: serializer,
         # This line is used by the PagedFetcher JS service (inventory).
         pages: products.num_pages,
         # This hash is used by the BulkProducts JS service.
         pagination: pagination_data(products)
-      }.to_json
+      }
     end
 
     def query_params_with_defaults

--- a/app/controllers/api/shops_controller.rb
+++ b/app/controllers/api/shops_controller.rb
@@ -8,7 +8,7 @@ module Api
     def show
       enterprise = Enterprise.find_by(id: params[:id])
 
-      render text: Api::EnterpriseShopfrontSerializer.new(enterprise).to_json, status: :ok
+      render json: Api::EnterpriseShopfrontSerializer.new(enterprise), status: :ok
     end
 
     def closed_shops


### PR DESCRIPTION
#### What? Why?

Closes #6294

Replaces all uses of `render text:` with `render json:` in API endpoints. 

In some cases in Rails 4.1, `render text:` was returning characters in Unicode, so for example `3` would be rendered as `\u0033`.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Removed use of "render text" in json API endpoints
