### PR TITLE
[Rails 4.1] Update deep_munge patch to rails 4.1, the code is now in Request::Utils

### DIFF
--- a/lib/action_dispatch/request.rb
+++ b/lib/action_dispatch/request.rb
@@ -30,7 +30,6 @@
 module ActionDispatch
   class Request < Rack::Request
     class Utils # :nodoc:
-
       mattr_accessor :perform_deep_munge
       self.perform_deep_munge = true
 
@@ -47,10 +46,11 @@ module ActionDispatch
               v.compact!
 
               # This patch removes the following lines
-              #if v.empty?
-              #  hash[k] = nil
-              #  ActiveSupport::Notifications.instrument("deep_munge.action_controller", keys: keys)
-              #end
+              # if v.empty?
+              #   hash[k] = nil
+              # ActiveSupport::Notifications.instrument("deep_munge.action_controller",
+              #                                         keys: keys)
+              # end
             when Hash
               deep_munge(v, keys)
             end

--- a/lib/action_dispatch/request.rb
+++ b/lib/action_dispatch/request.rb
@@ -38,26 +38,30 @@ module ActionDispatch
         def deep_munge(hash, keys = [])
           return hash unless perform_deep_munge
 
-          hash.each do |k, v|
-            keys << k
-            case v
-            when Array
-              v.grep(Hash) { |x| deep_munge(x, keys) }
-              v.compact!
-
-              # This patch removes the following lines
-              # if v.empty?
-              #   hash[k] = nil
-              # ActiveSupport::Notifications.instrument("deep_munge.action_controller",
-              #                                         keys: keys)
-              # end
-            when Hash
-              deep_munge(v, keys)
-            end
-            keys.pop
+          hash.each do |key, value|
+            deep_munge_value(key, value, keys)
           end
 
           hash
+        end
+
+        def deep_munge_value(key, value, keys)
+          keys << key
+          case value
+          when Array
+            value.grep(Hash) { |x| deep_munge(x, keys) }
+            value.compact!
+
+            # This patch removes the following lines
+            # if v.empty?
+            #   hash[k] = nil
+            # ActiveSupport::Notifications.instrument("deep_munge.action_controller",
+            #                                         keys: keys)
+            # end
+          when Hash
+            deep_munge(value, keys)
+          end
+          keys.pop
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Apparently this patch https://github.com/openfoodfoundation/openfoodnetwork/pull/6247 is not working in rails 4.1 broken spec.

I adapted the code to the ActionDispatch::Request code in Rails 4.1

#### What should we test?
A green spec indicates the patch is in place but we should proabably validate #6224 is still fixed :+1: 


#### Release notes
Changelog Category: Technical changes
Adapt rails patch to rails 4.1. 