### PR TITLE
When resetting stock to 0 on absent products in inventory import also reset the on demand setting

### DIFF
--- a/app/models/product_import/inventory_reset_strategy.rb
+++ b/app/models/product_import/inventory_reset_strategy.rb
@@ -8,7 +8,7 @@ module ProductImport
       @enterprise_ids = enterprise_ids
 
       if enterprise_ids.present?
-        relation.update_all(count_on_hand: 0)
+        relation.update_all(count_on_hand: 0, on_demand: false)
       else
         0
       end


### PR DESCRIPTION
Before when you imported inventory and clicked the 'Set stock to zero for all existing products not present in the file' option it would set the on hand stock to 0 but if the variant override was also set to be on demand the inventory would still be available for sale. This change makes sure the on demand setting is turned off too.

Fixes #6289

#### What should we test?

See 'Steps to Reproduce' in #6289

#### Release notes

When resetting stock to 0 on absent products during an inventory import also turn off the on demand setting.

Changelog Category: User facing changes