### PR TITLE
Install any missing gems when booting docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     command: >
       bash -c "wait-for-it -t 30 db:5432 &&
                rm -f tmp/pids/server.pid &&
+               (bundle check || bundle install)
                yarn install &&
                bundle exec rails s -p 3000 -b '0.0.0.0'"
   worker:
@@ -47,6 +48,7 @@ services:
       OFN_DB_HOST: db
     command: >
       bash -c "wait-for-it -t 30 db:5432 &&
+               (bundle check || bundle install)
                bundle exec rake jobs:work"
 volumes:
   gems:


### PR DESCRIPTION
#### What? Why?

This runs `bundle install` if there are any missing gems when booting the containers. `bundle check` ensures we don't unnecessarily run `bundle install`, which is rather slow.

This avoids having to build the entire image (painfully slow) or having to bring up a container just to install the gems. I used to do this with `docker-compose run --rm web bundle install`.

#### What should we test?

It'd worth having someone else check it although it's fairly simple.
#### Release notes

Install missing gems when booting dev env with docker compose.
Changelog Category: Technical changes