### PR TITLE
Update secret key base

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -3,11 +3,5 @@
 # Your secret key for verifying the integrity of signed cookies.
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks. 
-Openfoodnetwork::Application.config.secret_token = if Rails.env.development? or Rails.env.test?
-  ('x' * 30) # Meets basic minimum of 30 chars.
-else
-  ENV["SECRET_TOKEN"]
-end
-
-Openfoodnetwork::Application.config.secret_key_base = 'ceb1eb86c50285e696f899b2e7ea306d1ec1e81fe5c7af0e5cbc238bebe3fd60f19df7b9076fab836182821ebe14e41b64bdcdb4370520dc5bb711c1bc0ae616'
+# no regular words or you'll be exposed to dictionary attacks.
+Openfoodnetwork::Application.config.secret_key_base = ENV["SECRET_TOKEN"]

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,15 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Openfoodnetwork::Application.config.secret_key_base = ENV["SECRET_TOKEN"]
+
+secret_key = if Rails.env.development? or Rails.env.test?
+  ('x' * 30) # Meets basic minimum of 30 chars.
+else
+  ENV["SECRET_TOKEN"]
+end
+
+# Rails 4+ key for signing and encrypting cookies.
+Openfoodnetwork::Application.config.secret_key_base = secret_key
+
+# Legacy secret_token variable. This is still used directly for encryption.
+Openfoodnetwork::Application.config.secret_token = secret_key


### PR DESCRIPTION
#### What? Why?

`secret_token` has been replaced by `secret_key_base` in Rails 4+ for encrypting cookies (which we don't actually use). We still use the `secret_token` config directly in some places.

#### What should we test?
<!-- List which features should be tested and how. -->

- Basic cookies still work.
- User sessions are not affected (current user not logged out and basket not emptied when deployed).
- User can log in and out.
- Stripe works. 

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
