### PR TITLE
move gateway_error require to lib/spree/core.rb

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open_food_network/address_finder'
-require 'spree/core/gateway_error'
 
 class CheckoutController < Spree::StoreController
   layout 'darkswarm'

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -3,7 +3,6 @@ require 'open_food_network/spree_api_key_loader'
 module Spree
   module Admin
     class OrdersController < Spree::Admin::BaseController
-      require 'spree/core/gateway_error'
       include OpenFoodNetwork::SpreeApiKeyLoader
       helper CheckoutHelper
 

--- a/lib/spree/core.rb
+++ b/lib/spree/core.rb
@@ -50,6 +50,7 @@ require 'spree/core/permalinks'
 require 'spree/core/token_resource'
 require 'spree/core/calculated_adjustments'
 require 'spree/core/product_duplicator'
+require 'spree/core/gateway_error'
 
 ActiveRecord::Base.class_eval do
   include CollectiveIdea::Acts::NestedSet

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'spree/core/gateway_error'
 
 describe Spree::Admin::PaymentsController, type: :controller do
   include StripeHelper

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'spree/core/gateway_error'
 
 describe Spree::Admin::PaymentsController, type: :controller do
   let!(:shop) { create(:enterprise) }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'spree/core/gateway_error'
 
 describe Spree::Order do
   include OpenFoodNetwork::EmailHelper

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'spree/core/gateway_error'
 
 describe Spree::Payment do
   context 'original specs from Spree' do


### PR DESCRIPTION
#### What? Why?

Closes #6360 

We could alternatively keep adding the `require` line to any files that need it, but it seems like it's already in quite a few so I put it in lib/spree/core.rb and removed it elsewhere. 

#### What should we test?
An error encountered when trying to process a payment that fails (bad/wrong customer in Stripe, for example). 

#### Release notes
Bug fix: we no longer show an error slug (500 error) when there is a problem processing your payment. 

Changelog Category: User facing changes 


#### Dependencies


#### Documentation updates
