### PR TITLE
Remove unused truncate_html gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ gem 'haml'
 gem 'redcarpet'
 gem 'sass'
 gem 'sass-rails'
-gem 'truncate_html', '0.9.2'
 gem 'unicorn'
 
 gem 'actionpack-action_caching'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -634,7 +634,6 @@ GEM
     thread_safe (0.3.6)
     tilt (1.4.1)
     timecop (0.9.2)
-    truncate_html (0.9.2)
     tzinfo (0.3.57)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -778,7 +777,6 @@ DEPENDENCIES
   test-prof
   test-unit (~> 3.3)
   timecop
-  truncate_html (= 0.9.2)
   uglifier (>= 1.0.3)
   unicorn
   unicorn-rails


### PR DESCRIPTION
#### What? Why?

It seems that we don't use this gem in OFN. It was used in Spree in https://github.com/openfoodfoundation/spree/blob/2-1-0-stable/core/app/helpers/spree/orders_helper.rb to truncate the product description. We don't because we show it in the product modal, and there's no trace of that helper method in our codebase nor I see the gem used at all.

#### What should we test?

It's worth checking the places where we should the product description both front and backoffice.

#### Release notes

Remove unused truncate_html gem.
Changelog Category: Technical changes