### PR TITLE
Allow mail_auth_type to be set

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ def set_mail_configuration
     mail_host: ENV.fetch('MAIL_HOST'),
     mail_domain: ENV.fetch('MAIL_DOMAIN'),
     mail_port: ENV.fetch('MAIL_PORT'),
-    mail_auth_type: 'login',
+    mail_auth_type: ENV.fetch('MAIL_AUTH_TYPE', 'login'),
     smtp_username: ENV.fetch('SMTP_USERNAME'),
     smtp_password: ENV.fetch('SMTP_PASSWORD'),
     secure_connection_type: ENV.fetch('MAIL_SECURE_CONNECTION', 'None'),


### PR DESCRIPTION
#### What? Why?

Allows setting `mail_auth_type`. This is a standard mail config setting, but was previously not configurable via ofn-install and was just set to a hard-coded default.

Needed for Sendgrid API authentication. Tested and working in UK Staging :heavy_check_mark: 

Twinned with: https://github.com/openfoodfoundation/ofn-install/issues/668

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

I think this is dev-test. Requires provisioning updated configs with corresponding PR in ofn-install before deploying.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Made mail_auth_type setting configurable via provisioning

