### PR TITLE
Fix customer balance n+1

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -66,7 +66,12 @@ module Admin
       return Customer.where("1=0") unless json_request? && params[:enterprise_id].present?
 
       Customer.of(managed_enterprise_id).
-        includes(:bill_address, :ship_address, user: :credit_cards)
+        includes(:bill_address, :ship_address, user: :credit_cards).
+        joins(:orders).
+        merge(Spree::Order.complete.not_state(:canceled)).
+        group("customers.id").
+        select("customers.*").
+        select("SUM(total - payment_total) AS balance_value")
     end
 
     def managed_enterprise_id

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -65,13 +65,7 @@ module Admin
     def collection
       return Customer.where("1=0") unless json_request? && params[:enterprise_id].present?
 
-      Customer.of(managed_enterprise_id).
-        includes(:bill_address, :ship_address, user: :credit_cards).
-        joins(:orders).
-        merge(Spree::Order.complete.not_state(:canceled)).
-        group("customers.id").
-        select("customers.*").
-        select("SUM(total - payment_total) AS balance_value")
+      CustomersWithBalance.new(managed_enterprise_id).query
     end
 
     def managed_enterprise_id

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -17,9 +17,10 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render_as_json @collection,
-                         tag_rule_mapping: tag_rule_mapping,
-                         customer_tags: customer_tags_by_id
+          render json: @collection,
+                 each_serializer: ::Api::Admin::CustomerWithBalanceSerializer,
+                 tag_rule_mapping: tag_rule_mapping,
+                 customer_tags: customer_tags_by_id
         end
       end
     end
@@ -63,9 +64,11 @@ module Admin
     private
 
     def collection
-      return Customer.where("1=0") unless json_request? && params[:enterprise_id].present?
-
-      CustomersWithBalance.new(managed_enterprise_id).query
+      if json_request? && params[:enterprise_id].present?
+        CustomersWithBalance.new(managed_enterprise_id).query
+      else
+        Customer.where('1=0')
+      end
     end
 
     def managed_enterprise_id

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -65,7 +65,8 @@ module Admin
 
     def collection
       if json_request? && params[:enterprise_id].present?
-        CustomersWithBalance.new(managed_enterprise_id).query
+        CustomersWithBalance.new(managed_enterprise_id).query.
+          includes(:bill_address, :ship_address, user: :credit_cards)
       else
         Customer.where('1=0')
       end

--- a/app/serializers/api/admin/customer_serializer.rb
+++ b/app/serializers/api/admin/customer_serializer.rb
@@ -9,6 +9,8 @@ module Api
       has_one :ship_address, serializer: Api::AddressSerializer
       has_one :bill_address, serializer: Api::AddressSerializer
 
+      delegate :balance_value, to: :object
+
       def name
         object.name.presence || object.bill_address.andand.full_name
       end
@@ -50,11 +52,6 @@ module Api
         return object.tag_list unless options[:customer_tags]
 
         options[:customer_tags].andand[object.id] || []
-      end
-
-      def balance_value
-        @balance_value ||=
-          OpenFoodNetwork::UserBalanceCalculator.new(object.email, object.enterprise).balance
       end
     end
   end

--- a/app/serializers/api/admin/customer_serializer.rb
+++ b/app/serializers/api/admin/customer_serializer.rb
@@ -4,12 +4,10 @@ module Api
   module Admin
     class CustomerSerializer < ActiveModel::Serializer
       attributes :id, :email, :enterprise_id, :user_id, :code, :tags, :tag_list, :name,
-                 :allow_charges, :default_card_present?, :balance, :balance_status
+                 :allow_charges, :default_card_present?
 
       has_one :ship_address, serializer: Api::AddressSerializer
       has_one :bill_address, serializer: Api::AddressSerializer
-
-      delegate :balance_value, to: :object
 
       def name
         object.name.presence || object.bill_address.andand.full_name
@@ -17,20 +15,6 @@ module Api
 
       def tag_list
         customer_tag_list.join(",")
-      end
-
-      def balance
-        Spree::Money.new(balance_value, currency: Spree::Config[:currency]).to_s
-      end
-
-      def balance_status
-        if balance_value.positive?
-          "credit_owed"
-        elsif balance_value.negative?
-          "balance_due"
-        else
-          ""
-        end
       end
 
       def tags

--- a/app/serializers/api/admin/customer_with_balance_serializer.rb
+++ b/app/serializers/api/admin/customer_with_balance_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  module Admin
+    class CustomerWithBalanceSerializer < CustomerSerializer
+      attributes :balance, :balance_status
+
+      delegate :balance_value, to: :object
+
+      def balance
+        Spree::Money.new(balance_value, currency: Spree::Config[:currency]).to_s
+      end
+
+      def balance_status
+        if balance_value.positive?
+          "credit_owed"
+        elsif balance_value.negative?
+          "balance_due"
+        else
+          ""
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/customer_with_calculated_balance_serializer.rb
+++ b/app/serializers/api/admin/customer_with_calculated_balance_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Api
+  module Admin
+    class CustomerWithCalculatedBalanceSerializer < CustomerSerializer
+      attributes :balance, :balance_status
+
+      def balance
+        Spree::Money.new(balance_value, currency: Spree::Config[:currency]).to_s
+      end
+
+      def balance_status
+        if balance_value.positive?
+          "credit_owed"
+        elsif balance_value.negative?
+          "balance_due"
+        else
+          ""
+        end
+      end
+
+      def balance_value
+        @balance_value ||=
+          OpenFoodNetwork::UserBalanceCalculator.new(object.email, object.enterprise).balance
+      end
+    end
+  end
+end

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CustomersWithBalance
   def initialize(enterprise_id)
     @enterprise_id = enterprise_id
@@ -6,14 +8,22 @@ class CustomersWithBalance
   def query
     Customer.of(enterprise_id).
       includes(:bill_address, :ship_address, user: :credit_cards).
-      joins(:orders).
-      merge(Spree::Order.complete.not_state(:canceled)).
+      joins("LEFT JOIN spree_orders ON spree_orders.customer_id = customers.id").
       group("customers.id").
       select("customers.*").
-      select("SUM(total - payment_total) AS balance_value")
+      select(outstanding_balance)
   end
 
   private
 
   attr_reader :enterprise_id
+
+  def outstanding_balance
+    <<-SQL.strip_heredoc
+       SUM(
+         CASE WHEN state = 'canceled' THEN payment_total
+         ELSE payment_total - total END
+       ) AS balance_value
+    SQL
+  end
 end

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -18,6 +18,8 @@ class CustomersWithBalance
 
   attr_reader :enterprise_id
 
+  # Arel doesn't support CASE statements until v7.1.0 so we'll have to wait with SQL literals
+  # a little longer. See https://github.com/rails/arel/pull/400 for details.
   def outstanding_balance
     <<-SQL.strip_heredoc
        SUM(

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class CustomersWithBalance
-  def initialize(enterprise_id)
-    @enterprise_id = enterprise_id
+  def initialize(enterprise)
+    @enterprise = enterprise
   end
 
   def query
-    Customer.of(enterprise_id).
+    Customer.of(enterprise).
       joins(left_join_non_cart_orders).
       group("customers.id").
       select("customers.*").
@@ -15,7 +15,7 @@ class CustomersWithBalance
 
   private
 
-  attr_reader :enterprise_id
+  attr_reader :enterprise
 
   # Arel doesn't support CASE statements until v7.1.0 so we'll have to wait with SQL literals
   # a little longer. See https://github.com/rails/arel/pull/400 for details.

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -8,7 +8,7 @@ class CustomersWithBalance
   def query
     Customer.of(enterprise_id).
       includes(:bill_address, :ship_address, user: :credit_cards).
-      joins("LEFT JOIN spree_orders ON spree_orders.customer_id = customers.id").
+      joins(left_join_non_cart_orders).
       group("customers.id").
       select("customers.*").
       select(outstanding_balance)
@@ -27,6 +27,13 @@ class CustomersWithBalance
               WHEN state IS NOT NULL THEN payment_total - total
          ELSE 0 END
        ) AS balance_value
+    SQL
+  end
+
+  def left_join_non_cart_orders
+    <<-SQL.strip_heredoc
+      LEFT JOIN spree_orders ON spree_orders.customer_id = customers.id
+        AND spree_orders.state != 'cart'
     SQL
   end
 end

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -7,7 +7,6 @@ class CustomersWithBalance
 
   def query
     Customer.of(enterprise_id).
-      includes(:bill_address, :ship_address, user: :credit_cards).
       joins(left_join_non_cart_orders).
       group("customers.id").
       select("customers.*").

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -1,0 +1,19 @@
+class CustomersWithBalance
+  def initialize(enterprise_id)
+    @enterprise_id = enterprise_id
+  end
+
+  def query
+    Customer.of(enterprise_id).
+      includes(:bill_address, :ship_address, user: :credit_cards).
+      joins(:orders).
+      merge(Spree::Order.complete.not_state(:canceled)).
+      group("customers.id").
+      select("customers.*").
+      select("SUM(total - payment_total) AS balance_value")
+  end
+
+  private
+
+  attr_reader :enterprise_id
+end

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -29,6 +29,8 @@ class CustomersWithBalance
     SQL
   end
 
+  # The resulting orders are in states that belong after the checkout. Only these can be considered
+  # for a customer's balance.
   def left_join_complete_orders
     <<-SQL.strip_heredoc
       LEFT JOIN spree_orders ON spree_orders.customer_id = customers.id

--- a/app/services/customers_with_balance.rb
+++ b/app/services/customers_with_balance.rb
@@ -24,7 +24,8 @@ class CustomersWithBalance
     <<-SQL.strip_heredoc
        SUM(
          CASE WHEN state = 'canceled' THEN payment_total
-         ELSE payment_total - total END
+              WHEN state IS NOT NULL THEN payment_total - total
+         ELSE 0 END
        ) AS balance_value
     SQL
   end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -31,6 +31,8 @@ module OpenFoodNetwork
     end
 
     def self.enable(feature_name, user_emails)
+      return unless user_emails.present?
+
       Thread.current[:features] ||= {}
       Thread.current[:features][feature_name] = Feature.new(user_emails)
     end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -36,12 +36,12 @@ module OpenFoodNetwork
     end
 
     def initialize
-      @features = Thread.current[:features]
+      @features = Thread.current[:features] || {}
     end
 
     def enabled?(feature_name, user)
       if user.present?
-        feature = features[feature_name]
+        feature = features.fetch(feature_name, NullFeature.new)
         feature.enabled?(user)
       else
         true?(env_variable_value(feature_name))
@@ -77,5 +77,11 @@ module OpenFoodNetwork
     private
 
     attr_reader :users
+  end
+
+  class NullFeature
+    def enabled?(_user)
+      false
+    end
   end
 end

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'open_food_network/user_balance_calculator'
 
 module Admin
   describe CustomersController, type: :controller do
@@ -42,6 +43,49 @@ module Admin
               spree_get :index, params
             end
 
+            context 'when the customer_balance feature is enabled' do
+              let(:customers_with_balance) { instance_double(CustomersWithBalance) }
+
+              before do
+                allow(OpenFoodNetwork::FeatureToggle)
+                  .to receive(:enabled?).with(:customer_balance, enterprise.owner) { true }
+              end
+
+              it 'calls CustomersWithBalance' do
+                allow(CustomersWithBalance)
+                  .to receive(:new).with(enterprise) { customers_with_balance }
+
+                expect(customers_with_balance).to receive(:query) { Customer.none }
+
+                spree_get :index, params
+              end
+
+              it 'serializes using CustomerWithBalanceSerializer' do
+                expect(Api::Admin::CustomerWithBalanceSerializer).to receive(:new)
+
+                spree_get :index, params
+              end
+            end
+
+            context 'when the customer_balance feature is not enabled' do
+              let(:calculator) do
+                instance_double(OpenFoodNetwork::UserBalanceCalculator, balance: 0)
+              end
+
+              it 'calls Customer.of' do
+                expect(Customer).to receive(:of).twice.with(enterprise) { Customer.none }
+
+                spree_get :index, params
+              end
+
+              it 'serializes calling the UserBalanceCalculator' do
+                expect(OpenFoodNetwork::UserBalanceCalculator)
+                  .to receive(:new).with(customer.email, customer.enterprise) { calculator }
+
+                spree_get :index, params
+              end
+            end
+
             context 'when the customer has no orders' do
               it 'includes the customer balance in the response' do
                 spree_get :index, params
@@ -52,6 +96,11 @@ module Admin
             context 'when the customer has complete orders' do
               let(:order) { create(:order, customer: customer, state: 'complete') }
               let!(:line_item) { create(:line_item, order: order, price: 10.0) }
+
+              before do
+                allow(OpenFoodNetwork::FeatureToggle)
+                  .to receive(:enabled?).with(:customer_balance, enterprise.owner) { true }
+              end
 
               it 'includes the customer balance in the response' do
                 spree_get :index, params
@@ -65,6 +114,9 @@ module Admin
               let!(:payment) { create(:payment, order: order, amount: order.total) }
 
               before do
+                allow(OpenFoodNetwork::FeatureToggle)
+                  .to receive(:enabled?).with(:customer_balance, enterprise.owner) { true }
+
                 allow_any_instance_of(Spree::Payment).to receive(:completed?).and_return(true)
                 order.process_payments!
 
@@ -93,6 +145,9 @@ module Admin
               let!(:payment) { create(:payment, order: order, amount: order.total) }
 
               before do
+                allow(OpenFoodNetwork::FeatureToggle)
+                  .to receive(:enabled?).with(:customer_balance, enterprise.owner) { true }
+
                 allow_any_instance_of(Spree::Payment).to receive(:completed?).and_return(true)
                 order.process_payments!
 

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -42,9 +42,68 @@ module Admin
               spree_get :index, params
             end
 
-            it 'includes the customer balance in the response' do
-              spree_get :index, params
-              expect(json_response.first["balance"]).to eq("$0.00")
+            context 'when the customer has no orders' do
+              it 'includes the customer balance in the response' do
+                spree_get :index, params
+                expect(json_response.first["balance"]).to eq("$0.00")
+              end
+            end
+
+            context 'when the customer has complete orders' do
+              let(:order) { create(:order, customer: customer, state: 'complete') }
+              let!(:line_item) { create(:line_item, order: order, price: 10.0) }
+
+              it 'includes the customer balance in the response' do
+                spree_get :index, params
+                expect(json_response.first["balance"]).to eq("$-10.00")
+              end
+            end
+
+            context 'when the customer has canceled orders' do
+              let(:order) { create(:order, customer: customer) }
+              let!(:line_item) { create(:line_item, order: order, price: 10.0) }
+              let!(:payment) { create(:payment, order: order, amount: order.total) }
+
+              before do
+                allow_any_instance_of(Spree::Payment).to receive(:completed?).and_return(true)
+                order.process_payments!
+
+                order.update_attribute(:state, 'canceled')
+              end
+
+              it 'includes the customer balance in the response' do
+                spree_get :index, params
+                expect(json_response.first["balance"]).to eq("$10.00")
+              end
+            end
+
+            context 'when the customer has cart orders' do
+              let(:order) { create(:order, customer: customer, state: 'cart') }
+              let!(:line_item) { create(:line_item, order: order, price: 10.0) }
+
+              it 'includes the customer balance in the response' do
+                spree_get :index, params
+                expect(json_response.first["balance"]).to eq("$-10.00")
+              end
+            end
+
+            context 'when the customer has an order with a void payment' do
+              let(:order) { create(:order, customer: customer) }
+              let!(:line_item) { create(:line_item, order: order, price: 10.0) }
+              let!(:payment) { create(:payment, order: order, amount: order.total) }
+
+              before do
+                allow_any_instance_of(Spree::Payment).to receive(:completed?).and_return(true)
+                order.process_payments!
+
+                payment.void_transaction!
+              end
+
+              it 'includes the customer balance in the response' do
+                expect(order.payment_total).to eq(0)
+                spree_get :index, params
+                expect(json_response.first["balance"]).to eq('$-10.00')
+              end
             end
           end
 

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -83,12 +83,12 @@ module Admin
 
               it 'includes the customer balance in the response' do
                 spree_get :index, params
-                expect(json_response.first["balance"]).to eq("$-10.00")
+                expect(json_response.first["balance"]).to eq("$0.00")
               end
             end
 
             context 'when the customer has an order with a void payment' do
-              let(:order) { create(:order, customer: customer) }
+              let(:order) { create(:order, customer: customer, state: 'complete') }
               let!(:line_item) { create(:line_item, order: order, price: 10.0) }
               let!(:payment) { create(:payment, order: order, amount: order.total) }
 

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -41,6 +41,11 @@ module Admin
               expect(ActiveModel::ArraySerializer).to receive(:new)
               spree_get :index, params
             end
+
+            it 'includes the customer balance in the response' do
+              spree_get :index, params
+              expect(json_response.first["balance"]).to eq("$0.00")
+            end
           end
 
           context "and enterprise_id is not given in params" do

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     user
     bill_address
     completed_at { nil }
-    email { user.email }
+    email { user&.email || customer.email }
 
     factory :order_with_totals do
       after(:create) do |order|

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -97,9 +97,9 @@ feature 'Customers' do
 
       describe "for a shop with multiple customers" do
         before do
-          mock_balance(customer1.email, managed_distributor1, 88)
-          mock_balance(customer2.email, managed_distributor1, -99)
-          mock_balance(customer4.email, managed_distributor1, 0)
+          build_balance(customer1, managed_distributor1, 88)
+          build_balance(customer2, managed_distributor1, -99)
+          build_balance(customer4, managed_distributor1, 0)
 
           customer4.update enterprise: managed_distributor1
         end
@@ -122,11 +122,12 @@ feature 'Customers' do
           end
         end
 
-        def mock_balance(email, enterprise, balance)
-          user_balance_calculator = instance_double(OpenFoodNetwork::UserBalanceCalculator)
-          expect(OpenFoodNetwork::UserBalanceCalculator).to receive(:new).
-            with(email, enterprise).and_return(user_balance_calculator)
-          expect(user_balance_calculator).to receive(:balance).and_return(balance)
+        def build_balance(customer, enterprise, balance)
+          order = build(:order, total: balance, payment_total: 0, distributor: enterprise)
+          order.email = customer.email
+          order.customer_id = customer.id
+          order.completed_at = Time.zone.now
+          order.save!
         end
       end
 

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -97,9 +97,33 @@ feature 'Customers' do
 
       describe "for a shop with multiple customers" do
         before do
-          build_balance(customer1, managed_distributor1, 88)
-          build_balance(customer2, managed_distributor1, -99)
-          build_balance(customer4, managed_distributor1, 0)
+          create(
+            :order,
+            total: 0,
+            payment_total: 88,
+            distributor: managed_distributor1,
+            user: nil,
+            completed_at: Time.zone.now,
+            customer: customer1
+          )
+          create(
+            :order,
+            total: 99,
+            payment_total: 0,
+            distributor: managed_distributor1,
+            user: nil,
+            completed_at: Time.zone.now,
+            customer: customer2
+          )
+          create(
+            :order,
+            total: 0,
+            payment_total: 0,
+            distributor: managed_distributor1,
+            user: nil,
+            completed_at: Time.zone.now,
+            customer: customer4
+          )
 
           customer4.update enterprise: managed_distributor1
         end
@@ -120,14 +144,6 @@ feature 'Customers' do
             expect(page).to_not have_content "BALANCE DUE"
             expect(page).to have_content "$0.00"
           end
-        end
-
-        def build_balance(customer, enterprise, balance)
-          order = build(:order, total: balance, payment_total: 0, distributor: enterprise)
-          order.email = customer.email
-          order.customer_id = customer.id
-          order.completed_at = Time.zone.now
-          order.save!
         end
       end
 

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -97,6 +97,9 @@ feature 'Customers' do
 
       describe "for a shop with multiple customers" do
         before do
+          allow(OpenFoodNetwork::FeatureToggle)
+            .to receive(:enabled?).with(:customer_balance, user) { true }
+
           create(
             :order,
             total: 0,

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -103,7 +103,7 @@ feature 'Customers' do
             payment_total: 88,
             distributor: managed_distributor1,
             user: nil,
-            completed_at: Time.zone.now,
+            state: 'complete',
             customer: customer1
           )
           create(
@@ -112,7 +112,7 @@ feature 'Customers' do
             payment_total: 0,
             distributor: managed_distributor1,
             user: nil,
-            completed_at: Time.zone.now,
+            state: 'complete',
             customer: customer2
           )
           create(
@@ -121,7 +121,7 @@ feature 'Customers' do
             payment_total: 0,
             distributor: managed_distributor1,
             user: nil,
-            completed_at: Time.zone.now,
+            state: 'complete',
             customer: customer4
           )
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -201,14 +201,25 @@ describe Spree::Order do
     let(:payment) { build(:payment) }
     before { allow(order).to receive_messages pending_payments: [payment], total: 10 }
 
-    it "should process the payments" do
-      expect(payment).to receive(:process!)
-      expect(order.process_payments!).to be_truthy
-    end
-
     it "should return false if no pending_payments available" do
       allow(order).to receive_messages pending_payments: []
       expect(order.process_payments!).to be_falsy
+    end
+
+    context "when the processing is sucessful" do
+      it "should process the payments" do
+        expect(payment).to receive(:process!)
+        expect(order.process_payments!).to be_truthy
+      end
+
+      it "stores the payment total on the order" do
+        allow(payment).to receive(:process!)
+        allow(payment).to receive(:completed?).and_return(true)
+
+        order.process_payments!
+
+        expect(order.payment_total).to eq(payment.amount)
+      end
     end
 
     context "when a payment raises a GatewayError" do

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -584,6 +584,15 @@ describe Spree::Payment do
           )
         end
       end
+
+      context 'when the payment was completed but now void' do
+        let(:payment) { create(:payment, amount: 100, order: order, state: 'completed') }
+
+        it 'updates order payment total' do
+          payment.void
+          expect(order.payment_total).to eq 0
+        end
+      end
     end
 
     context "#build_source" do

--- a/spec/serializers/api/admin/customer_with_balance_serializer_spec.rb
+++ b/spec/serializers/api/admin/customer_with_balance_serializer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Api::Admin::CustomerWithBalanceSerializer do
+  let(:serialized_customer) { described_class.new(customer) }
+
+  describe '#balance' do
+    let(:customer) { double(Customer, balance_value: 1.2) }
+    let(:money) { instance_double(Spree::Money, to_s: "$1.20") }
+
+    before do
+      allow(Spree::Money).to receive(:new).with(1.2, currency: "AUD") { money }
+    end
+
+    it 'returns the balance_value as a money amount' do
+      expect(serialized_customer.balance).to eq("$1.20")
+    end
+  end
+
+  describe '#balance_status' do
+    context 'when the balance_value is positive' do
+      let(:customer) { double(Customer, balance_value: 1) }
+
+      it 'returns credit_owed' do
+        expect(serialized_customer.balance_status).to eq("credit_owed")
+      end
+    end
+
+    context 'when the balance_value is negative' do
+      let(:customer) { double(Customer, balance_value: -1) }
+
+      it 'returns credit_owed' do
+        expect(serialized_customer.balance_status).to eq("balance_due")
+      end
+    end
+
+    context 'when the balance_value is zero' do
+      let(:customer) { double(Customer, balance_value: 0) }
+
+      it 'returns credit_owed' do
+        expect(serialized_customer.balance_status).to eq("")
+      end
+    end
+  end
+end

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -12,14 +12,28 @@ describe CustomersWithBalance do
       let(:total) { 200.00 }
       let(:order_total) { 100.00 }
 
-      before do
-        create(:order, customer: customer, total: order_total, payment_total: 0)
-        create(:order, customer: customer, total: order_total, payment_total: 0)
+      context 'when non-guest order' do
+        before do
+          create(:order, customer: customer, total: order_total, payment_total: 0)
+          create(:order, customer: customer, total: order_total, payment_total: 0)
+        end
+
+        it 'returns the customer balance' do
+          customer = customers_with_balance.query.first
+          expect(customer.balance_value).to eq(-total)
+        end
       end
 
-      it 'returns the customer balance' do
-        customer = customers_with_balance.query.first
-        expect(customer.balance_value).to eq(-total)
+      context 'when guest order' do
+        before do
+          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
+          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
+        end
+
+        it 'returns the customer balance' do
+          customer = customers_with_balance.query.first
+          expect(customer.balance_value).to eq(-total)
+        end
       end
     end
 
@@ -28,14 +42,34 @@ describe CustomersWithBalance do
       let(:order_total) { 100.00 }
       let(:payment_total) { order_total }
 
-      before do
-        create(:order, customer: customer, total: order_total, payment_total: 0)
-        create(:order, customer: customer, total: order_total, payment_total: payment_total)
+      context 'when non-guest order' do
+        before do
+          create(:order, customer: customer, total: order_total, payment_total: 0)
+          create(:order, customer: customer, total: order_total, payment_total: payment_total)
+        end
+
+        it 'returns the customer balance' do
+          customer = customers_with_balance.query.first
+          expect(customer.balance_value).to eq(payment_total - total)
+        end
       end
 
-      it 'returns the customer balance' do
-        customer = customers_with_balance.query.first
-        expect(customer.balance_value).to eq(payment_total - total)
+      context 'when guest order' do
+        before do
+          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
+          create(
+            :order,
+            customer: customer,
+            user: nil,
+            total: order_total,
+            payment_total: payment_total
+          )
+        end
+
+        it 'returns the customer balance' do
+          customer = customers_with_balance.query.first
+          expect(customer.balance_value).to eq(payment_total - total)
+        end
       end
     end
 
@@ -45,16 +79,43 @@ describe CustomersWithBalance do
       let(:payment_total) { 100.00 }
       let(:complete_orders_total) { order_total }
 
-      before do
-        create(:order, customer: customer, total: order_total, payment_total: 0)
-        create(
-          :order,
-          customer: customer,
-          total: order_total,
-          payment_total: order_total,
-          state: 'canceled'
-        )
+      context 'when non-guest order' do
+        before do
+          create(:order, customer: customer, total: order_total, payment_total: 0)
+          create(
+            :order,
+            customer: customer,
+            total: order_total,
+            payment_total: order_total,
+            state: 'canceled'
+          )
+        end
+
+        it 'returns the customer balance' do
+          customer = customers_with_balance.query.first
+          expect(customer.balance_value).to eq(payment_total - complete_orders_total)
+        end
       end
+
+      context 'when guest order' do
+        before do
+          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
+          create(
+            :order,
+            customer: customer,
+            user: nil,
+            total: order_total,
+            payment_total: order_total,
+            state: 'canceled'
+          )
+        end
+
+        it 'returns the customer balance' do
+          customer = customers_with_balance.query.first
+          expect(customer.balance_value).to eq(payment_total - complete_orders_total)
+        end
+      end
+    end
 
       it 'returns the customer balance' do
         customer = customers_with_balance.query.first

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -12,28 +12,14 @@ describe CustomersWithBalance do
       let(:total) { 200.00 }
       let(:order_total) { 100.00 }
 
-      context 'when non-guest order' do
-        before do
-          create(:order, customer: customer, total: order_total, payment_total: 0)
-          create(:order, customer: customer, total: order_total, payment_total: 0)
-        end
-
-        it 'returns the customer balance' do
-          customer = customers_with_balance.query.first
-          expect(customer.balance_value).to eq(-total)
-        end
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0)
+        create(:order, customer: customer, total: order_total, payment_total: 0)
       end
 
-      context 'when guest order' do
-        before do
-          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
-          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
-        end
-
-        it 'returns the customer balance' do
-          customer = customers_with_balance.query.first
-          expect(customer.balance_value).to eq(-total)
-        end
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(-total)
       end
     end
 
@@ -42,34 +28,14 @@ describe CustomersWithBalance do
       let(:order_total) { 100.00 }
       let(:payment_total) { order_total }
 
-      context 'when non-guest order' do
-        before do
-          create(:order, customer: customer, total: order_total, payment_total: 0)
-          create(:order, customer: customer, total: order_total, payment_total: payment_total)
-        end
-
-        it 'returns the customer balance' do
-          customer = customers_with_balance.query.first
-          expect(customer.balance_value).to eq(payment_total - total)
-        end
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0)
+        create(:order, customer: customer, total: order_total, payment_total: payment_total)
       end
 
-      context 'when guest order' do
-        before do
-          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
-          create(
-            :order,
-            customer: customer,
-            user: nil,
-            total: order_total,
-            payment_total: payment_total
-          )
-        end
-
-        it 'returns the customer balance' do
-          customer = customers_with_balance.query.first
-          expect(customer.balance_value).to eq(payment_total - total)
-        end
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - total)
       end
     end
 
@@ -77,43 +43,22 @@ describe CustomersWithBalance do
       let(:total) { 200.00 }
       let(:order_total) { 100.00 }
       let(:payment_total) { 100.00 }
-      let(:complete_orders_total) { order_total }
+      let(:non_canceled_orders_total) { order_total }
 
-      context 'when non-guest order' do
-        before do
-          create(:order, customer: customer, total: order_total, payment_total: 0)
-          create(
-            :order,
-            customer: customer,
-            total: order_total,
-            payment_total: order_total,
-            state: 'canceled'
-          )
-        end
-
-        it 'returns the customer balance' do
-          customer = customers_with_balance.query.first
-          expect(customer.balance_value).to eq(payment_total - complete_orders_total)
-        end
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0)
+        create(
+          :order,
+          customer: customer,
+          total: order_total,
+          payment_total: order_total,
+          state: 'canceled'
+        )
       end
 
-      context 'when guest order' do
-        before do
-          create(:order, customer: customer, user: nil, total: order_total, payment_total: 0)
-          create(
-            :order,
-            customer: customer,
-            user: nil,
-            total: order_total,
-            payment_total: order_total,
-            state: 'canceled'
-          )
-        end
-
-        it 'returns the customer balance' do
-          customer = customers_with_balance.query.first
-          expect(customer.balance_value).to eq(payment_total - complete_orders_total)
-        end
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - non_canceled_orders_total)
       end
     end
 

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -142,6 +142,39 @@ describe CustomersWithBalance do
       end
     end
 
+    context 'when an order is awaiting_return' do
+      let(:payment_total) { order_total }
+
+      before do
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
+        order = create(:order, customer: customer, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'awaiting_return')
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - total)
+      end
+    end
+
+    context 'when an order is returned' do
+      let(:payment_total) { order_total }
+      let(:non_returned_orders_total) { order_total }
+
+      before do
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
+        order = create(:order, customer: customer, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'returned')
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - non_returned_orders_total)
+      end
+    end
+
     context 'when there are no orders' do
       it 'returns the customer balance' do
         customer = customers_with_balance.query.first

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -8,13 +8,30 @@ describe CustomersWithBalance do
   describe '#query' do
     let(:customer) { create(:customer) }
 
+    context 'when orders are in cart state' do
+      let(:total) { 200.00 }
+      let(:order_total) { 100.00 }
+
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0, state: 'cart')
+        create(:order, customer: customer, total: order_total, payment_total: 0, state: 'cart')
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(0)
+      end
+    end
+
     context 'when no orders where paid' do
       let(:total) { 200.00 }
       let(:order_total) { 100.00 }
 
       before do
-        create(:order, customer: customer, total: order_total, payment_total: 0)
-        create(:order, customer: customer, total: order_total, payment_total: 0)
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
       end
 
       it 'returns the customer balance' do
@@ -29,8 +46,10 @@ describe CustomersWithBalance do
       let(:payment_total) { order_total }
 
       before do
-        create(:order, customer: customer, total: order_total, payment_total: 0)
-        create(:order, customer: customer, total: order_total, payment_total: payment_total)
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
+        order = create(:order, customer: customer, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'checkout')
       end
 
       it 'returns the customer balance' do
@@ -46,7 +65,8 @@ describe CustomersWithBalance do
       let(:non_canceled_orders_total) { order_total }
 
       before do
-        create(:order, customer: customer, total: order_total, payment_total: 0)
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
         create(
           :order,
           customer: customer,

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CustomersWithBalance do
+  subject(:customers_with_balance) { described_class.new(customer.enterprise.id) }
+
+  describe '#query' do
+    let(:customer) { create(:customer) }
+
+    context 'when no orders where paid' do
+      let(:total) { 200.00 }
+      let(:order_total) { 100.00 }
+
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0)
+        create(:order, customer: customer, total: order_total, payment_total: 0)
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(-total)
+      end
+    end
+
+    context 'when an order was paid' do
+      let(:total) { 200.00 }
+      let(:order_total) { 100.00 }
+      let(:payment_total) { order_total }
+
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0)
+        create(:order, customer: customer, total: order_total, payment_total: payment_total)
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - total)
+      end
+    end
+
+    context 'when an order is canceled' do
+      let(:total) { 200.00 }
+      let(:order_total) { 100.00 }
+      let(:payment_total) { 100.00 }
+      let(:complete_orders_total) { order_total }
+
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0)
+        create(
+          :order,
+          customer: customer,
+          total: order_total,
+          payment_total: order_total,
+          state: 'canceled'
+        )
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - complete_orders_total)
+      end
+    end
+  end
+end

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -7,11 +7,10 @@ describe CustomersWithBalance do
 
   describe '#query' do
     let(:customer) { create(:customer) }
+    let(:total) { 200.00 }
+    let(:order_total) { 100.00 }
 
     context 'when orders are in cart state' do
-      let(:total) { 200.00 }
-      let(:order_total) { 100.00 }
-
       before do
         create(:order, customer: customer, total: order_total, payment_total: 0, state: 'cart')
         create(:order, customer: customer, total: order_total, payment_total: 0, state: 'cart')
@@ -23,10 +22,43 @@ describe CustomersWithBalance do
       end
     end
 
-    context 'when no orders where paid' do
-      let(:total) { 200.00 }
-      let(:order_total) { 100.00 }
+    context 'when orders are in address state' do
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0, state: 'address')
+        create(:order, customer: customer, total: order_total, payment_total: 50, state: 'address')
+      end
 
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(0)
+      end
+    end
+
+    context 'when orders are in delivery state' do
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0, state: 'delivery')
+        create(:order, customer: customer, total: order_total, payment_total: 50, state: 'delivery')
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(0)
+      end
+    end
+
+    context 'when orders are in payment state' do
+      before do
+        create(:order, customer: customer, total: order_total, payment_total: 0, state: 'payment')
+        create(:order, customer: customer, total: order_total, payment_total: 50, state: 'payment')
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(0)
+      end
+    end
+
+    context 'when no orders where paid' do
       before do
         order = create(:order, customer: customer, total: order_total, payment_total: 0)
         order.update_attribute(:state, 'checkout')
@@ -41,8 +73,6 @@ describe CustomersWithBalance do
     end
 
     context 'when an order was paid' do
-      let(:total) { 200.00 }
-      let(:order_total) { 100.00 }
       let(:payment_total) { order_total }
 
       before do
@@ -59,8 +89,6 @@ describe CustomersWithBalance do
     end
 
     context 'when an order is canceled' do
-      let(:total) { 200.00 }
-      let(:order_total) { 100.00 }
       let(:payment_total) { 100.00 }
       let(:non_canceled_orders_total) { order_total }
 

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -110,6 +110,38 @@ describe CustomersWithBalance do
       end
     end
 
+    context 'when an order is resumed' do
+      let(:payment_total) { order_total }
+
+      before do
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
+        order = create(:order, customer: customer, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'resumed')
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - total)
+      end
+    end
+
+    context 'when an order is in payment' do
+      let(:payment_total) { order_total }
+
+      before do
+        order = create(:order, customer: customer, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'checkout')
+        order = create(:order, customer: customer, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'payment')
+      end
+
+      it 'returns the customer balance' do
+        customer = customers_with_balance.query.first
+        expect(customer.balance_value).to eq(payment_total - total)
+      end
+    end
+
     context 'when there are no orders' do
       it 'returns the customer balance' do
         customer = customers_with_balance.query.first

--- a/spec/services/customers_with_balance_spec.rb
+++ b/spec/services/customers_with_balance_spec.rb
@@ -117,9 +117,10 @@ describe CustomersWithBalance do
       end
     end
 
+    context 'when there are no orders' do
       it 'returns the customer balance' do
         customer = customers_with_balance.query.first
-        expect(customer.balance_value).to eq(payment_total - complete_orders_total)
+        expect(customer.balance_value).to eq(0)
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

This solves [v3.3.1](https://github.com/openfoodfoundation/openfoodnetwork/releases/tag/v3.3.1)'s performance regression when calculating the customer balance.

It's simpler and many orders of magnitude more efficient to ask the DB to aggregate the customer balance based on their orders. It removes a nasty N+1. To do that I created a query object based on the work started in https://github.com/openfoodfoundation/openfoodnetwork/pull/5031. 

This is a first attempt at solving the negative performance impact of our current approach but the best solution in the long term is to either offload the balance calculation to a background job to be performed overnight so we don't go through all customer orders every time. No doubt it'll be slow for hubs that have thousands of customers with thousands of orders.

This doesn't `close` https://github.com/openfoodfoundation/openfoodnetwork/issues/4732. That needs small and fast iterations using this new approach to each of the pages displaying the customer balance.

#### What should we test?

This involves two sets of tests. 

On one hand, we need to smoke test customer balance in /admin/customers. Just to confirm that, as the automated tests tell, we haven't changed a bit of its behavior.

On the other, we need to check how the new implementation works. For that, the user you test it with needs to have the feature enabled for them. To do that, we need to add the account's email address to the list of beta users. Then, with a shopper account create some orders and payments and check:

* As Hub manager make adjustments to the orders and payments. Including voiding payments and orders. Add multiple payments to an order and include addition payments so that the orders also have more payments than the order amount.
* Cancel an order with a payment.
* Void a payment on an active order
* As you make the changes in step 2 check the Shopper balance in /admin/customers

The figures should match with all the changes you make. It'd be good to go through all of the states of the order. If there's one broken, please, don't let this pass without a test covering that case.

#### Release notes

Remove N+1 when fetching customers' balance from /admin/customers and fix `payment_total` for void payments.
Changelog Category: Technical changes