### PR TITLE
specify Spree routes for pagination, fix 500 on admin/users

### DIFF
--- a/app/views/spree/admin/users/index.html.haml
+++ b/app/views/spree/admin/users/index.html.haml
@@ -26,7 +26,9 @@
         %td.user_enterprise_limit= user.enterprise_limit
         %td.actions
           = link_to_delete user, no_text: true
-= paginate @users
+- _with_routes Spree::Core::Engine.routes do
+  = paginate @users
+
 - content_for :sidebar_title do
   = t(".search")
 - content_for :sidebar do

--- a/app/views/spree/admin/zones/index.html.haml
+++ b/app/views/spree/admin/zones/index.html.haml
@@ -7,7 +7,8 @@
   %li
     = button_link_to t("spree.new_zone"), new_object_url, icon: 'icon-plus', id: 'admin_new_zone_link'
 
-= paginate @zones
+- _with_routes Spree::Core::Engine.routes do
+  = paginate @zones
 
 - if @zones.empty?
   .no-objects-found
@@ -38,4 +39,5 @@
           %td.actions
             = link_to_edit zone, no_text: true
             = link_to_delete zone, no_text: true
-= paginate @zones
+- _with_routes Spree::Core::Engine.routes do
+  = paginate @zones


### PR DESCRIPTION
#### What? Why?

Closes #6348

This might not be the solution we want (I'm still reading up on some threads) but it does get rid of the 500 error on admin/users.

This is the megathread that I looked through: https://github.com/kaminari/kaminari/pull/322

The solution from the maintainers of Kaminari is the one I implemented in this PR. There's also a few other suggestions on how to monkeypatch Kaminari, or use the `kaminari_route_prefix` gem, as done here: 

https://github.com/denny/ShinyCMS-ruby/pull/666/files

The two files I changed were the only places I saw in the code that call `paginate` but I just did a simple grep for that string... we could do a more thorough check for any other places that might use pagination and be impacted. 

#### What should we test?
Go to /admin/users on an instance with lots of users

#### Release notes
None, bug is still not deployed (except to FR)


#### Dependencies



#### Documentation updates
