### PR TITLE
Repeat calculator migrations to clean up existing data

### DIFF
--- a/db/migrate/20201113163155_repeat_move_all_calculators_outside_the_spree_namespace.rb
+++ b/db/migrate/20201113163155_repeat_move_all_calculators_outside_the_spree_namespace.rb
@@ -1,0 +1,39 @@
+# For some unkonwn reason, after removing Spree as a dependency, some spree calculators appeared on live DBs
+# Here we repeat the migration
+class RepeatMoveAllCalculatorsOutsideTheSpreeNamespace < ActiveRecord::Migration
+  def up
+    convert_calculator("DefaultTax")
+    convert_calculator("FlatPercentItemTotal")
+    convert_calculator("FlatRate")
+    convert_calculator("FlexiRate")
+    convert_calculator("PerItem")
+    convert_calculator("PriceSack")
+  end
+
+  def down
+    revert_calculator("DefaultTax")
+    revert_calculator("FlatPercentItemTotal")
+    revert_calculator("FlatRate")
+    revert_calculator("FlexiRate")
+    revert_calculator("PerItem")
+    revert_calculator("PriceSack")
+  end
+
+  private
+
+  def convert_calculator(calculator_base_name)
+    update_calculator("Spree::Calculator::" + calculator_base_name,
+                      "Calculator::" + calculator_base_name)
+  end
+
+  def revert_calculator(calculator_base_name)
+    update_calculator("Calculator::" + calculator_base_name,
+                      "Spree::Calculator::" + calculator_base_name)
+  end
+
+  def update_calculator(from, to)
+    Spree::Calculator.connection.execute(
+      "UPDATE spree_calculators SET type = '" + to + "' WHERE type = '" + from + "'"
+    )
+  end
+end

--- a/db/migrate/20201113163227_repeat_move_calculators_preferences_outside_spree_namespace.rb
+++ b/db/migrate/20201113163227_repeat_move_calculators_preferences_outside_spree_namespace.rb
@@ -1,0 +1,25 @@
+# For some unkonwn reason, after removing Spree as a dependency, some spree calculators appeared on live DBs
+# Here we repeat the migration
+class RepeatMoveCalculatorsPreferencesOutsideSpreeNamespace < ActiveRecord::Migration
+  def up
+    replace_preferences_key("/spree/calculator", "/calculator")
+  end
+
+  def down
+    replace_preferences_key("/calculator", "/spree/calculator")
+  end
+
+  private
+
+  def replace_preferences_key(from_pattern, to_pattern)
+    updated_pref_key = "replace( pref.key, '" + from_pattern + "', '" + to_pattern + "')"
+    Spree::Preference.connection.execute(
+      "UPDATE spree_preferences pref SET key = " + updated_pref_key + "
+        WHERE pref.key like '" + from_pattern + "%'
+          AND NOT EXISTS (SELECT 1 FROM spree_preferences existing_pref
+                           WHERE existing_pref.key = " + updated_pref_key + ")"
+    )
+
+    Rails.cache.clear
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #6358

We don't understand why but we still have some calculators in live DBs with the spree namespace. Here we repeat the migrations to rename all calculators with the spree namespace.
I think this problem will not happen again because spree is now gone and these calculators names like Spree::Calculator::FlatRate are not present anywhere in the code.

This becomes an S2 6358 only after we remove spree as dependency because Spree::Calculator::FlatRate for example is now gone.

**All this migration code is just copy pasted from two existing migrations.**

#### What should we test?
This is a dev test:
- load a live DB locally (UK for example still has this data problem)
- verify the problems are there:
```
select * from spree_preferences where key like '%calculator%' and key like '%spree%';
select * from spree_calculators where type like 'Spree%';
```
- run these migrations
- verify the queries return empty sets now

Afterwards we can also run a quick manual test in a staging server just verifying calculators are working as usual.

#### Release notes
Changelog Category: Technical changes
Fixed a problem with stale data that current versions of OFN cannot handle.
