### PR TITLE
fix #6252 ([mobile UX] Eur symbol displayed below the price of the item)

### DIFF
--- a/app/assets/javascripts/darkswarm/filters/localize_currency.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/localize_currency.js.coffee
@@ -6,7 +6,7 @@ Darkswarm.filter "localizeCurrency", (currencyConfig)->
     # Set decimal points, 2 or 0 if hide_cents.
     decimals = if currencyConfig.hide_cents == "true" then 0 else 2
     # Set format if the currency symbol should come after the number, otherwise (default) use the locale setting.
-    format = if currencyConfig.symbol_position == "after" then "%n %u" else undefined
+    format = if currencyConfig.symbol_position == "after" then "%n%u" else undefined
     # We need to use parseFloat as the amount should come in as a string.
     amount = parseFloat(amount)
 

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -59,10 +59,10 @@
 
         // Variant price
         .variant-price {
+          white-space: nowrap;
           @include breakpoint(phablet) {
             padding-left: 1rem;
           }
-          white-space: nowrap;
         }
 
         // Total price

--- a/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-product-rows.scss
@@ -62,6 +62,7 @@
           @include breakpoint(phablet) {
             padding-left: 1rem;
           }
+          white-space: nowrap;
         }
 
         // Total price

--- a/spec/javascripts/unit/darkswarm/filters/localize_currency_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/filters/localize_currency_spec.js.coffee
@@ -26,7 +26,7 @@ describe 'convert number to localised currency ', ->
 
   it "can place symbols after the amount", ->
     currencyconfig.symbol_position = "after"
-    expect(filter(333.3)).toEqual "333.30 $"
+    expect(filter(333.3)).toEqual "333.30$"
 
   it "can add a currency string", ->
     currencyconfig.display_currency = "true"


### PR DESCRIPTION
#### What? Why?

Closes #6252 

The formatting string for the currency display put an extra space in between the amount and the currency symbol, which resulted in it wrapping onto a second line. 


#### What should we test?
See the issue; you can change the instance config to put the currency symbol after the amount and a price with four digits should remain all on one line. 


#### Release notes
Fixed a visual bug where the price for an item would split across two lines on mobile devices. 

Changelog Category: User facing changes 

#### Dependencies


#### Documentation updates
