### PR TITLE
Paypal stock clashes

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -25,7 +25,7 @@ class CheckoutController < Spree::StoreController
 
   before_action :ensure_order_not_completed
   before_action :ensure_checkout_allowed
-  before_action :ensure_sufficient_stock_lines
+  before_action :handle_insufficient_stock
 
   before_action :associate_user
   before_action :check_authorization

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -5,6 +5,7 @@ require 'open_food_network/address_finder'
 class CheckoutController < Spree::StoreController
   layout 'darkswarm'
 
+  include OrderStockCheck
   include CheckoutHelper
   include OrderCyclesHelper
   include EnterprisesHelper
@@ -75,13 +76,6 @@ class CheckoutController < Spree::StoreController
 
   def ensure_order_not_completed
     redirect_to main_app.cart_path if @order.completed?
-  end
-
-  def ensure_sufficient_stock_lines
-    if @order.insufficient_stock_lines.present?
-      flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity)
-      redirect_to main_app.cart_path
-    end
   end
 
   def load_order

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -4,9 +4,9 @@ module OrderStockCheck
   extend ActiveSupport::Concern
 
   def ensure_sufficient_stock_lines
-    if @order.insufficient_stock_lines.present?
-      flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity)
-      redirect_to main_app.cart_path
-    end
+    return true if @order.insufficient_stock_lines.blank?
+
+    flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity)
+    redirect_to main_app.cart_path
   end
 end

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module OrderStockCheck
+  extend ActiveSupport::Concern
+
+  def ensure_sufficient_stock_lines
+    if @order.insufficient_stock_lines.present?
+      flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity)
+      redirect_to main_app.cart_path
+    end
+  end
+end

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -3,10 +3,16 @@
 module OrderStockCheck
   extend ActiveSupport::Concern
 
-  def ensure_sufficient_stock_lines
-    return true if @order.insufficient_stock_lines.blank?
+  def handle_insufficient_stock
+    return if sufficient_stock?
 
     flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity)
     redirect_to main_app.cart_path
+  end
+
+  private
+
+  def sufficient_stock?
+    @sufficient_stock ||= @order.insufficient_stock_lines.blank?
   end
 end

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -58,9 +58,10 @@ Spree::PaypalController.class_eval do
 
   def confirm
     @order = current_order || raise(ActiveRecord::RecordNotFound)
+
     # At this point the user has come back from the Paypal form, and we get one
     # last chance to interact with the payment process before the money moves...
-    return unless ensure_sufficient_stock_lines
+    return handle_insufficient_stock unless sufficient_stock?
 
     @order.payments.create!({
       source: Spree::PaypalExpressCheckout.create({

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -67,7 +67,7 @@ Spree::PaypalController.class_eval do
   private
 
   def payment_method
-    Spree::PaymentMethod.find(params[:payment_method_id])
+    @payment_method ||= Spree::PaymentMethod.find(params[:payment_method_id])
   end
 
   def permit_parameters!

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -61,7 +61,7 @@ Spree::PaypalController.class_eval do
 
     # At this point the user has come back from the Paypal form, and we get one
     # last chance to interact with the payment process before the money moves...
-    return handle_insufficient_stock unless sufficient_stock?
+    return reset_to_cart unless sufficient_stock?
 
     @order.payments.create!({
       source: Spree::PaypalExpressCheckout.create({
@@ -112,6 +112,11 @@ Spree::PaypalController.class_eval do
       OrderCompletionReset.new(self, current_order).call
       session[:access_token] = current_order.token
     end
+  end
+
+  def reset_to_cart
+    OrderCheckoutRestart.new(@order).call
+    handle_insufficient_stock
   end
 
   # See #1074 and #1837 for more detail on why we need this

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -40,6 +40,9 @@ Spree::PaypalController.class_eval do
     begin
       pp_response = provider.set_express_checkout(pp_request)
       if pp_response.success?
+        # At this point Paypal has *provisionally* accepted that the payment can now be placed,
+        # and the user will be redirected to a Paypal payment page. On completion, the user is
+        # sent back and the response is handled in the #confirm action in this controller.
         redirect_to provider.express_checkout_url(pp_response, useraction: 'commit')
       else
         flash[:error] = Spree.t('flash.generic_error', scope: 'paypal', reasons: pp_response.errors.map(&:long_message).join(" "))

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -66,6 +66,10 @@ Spree::PaypalController.class_eval do
 
   private
 
+  def payment_method
+    Spree::PaymentMethod.find(params[:payment_method_id])
+  end
+
   def permit_parameters!
     params.permit(:token, :payment_method_id, :PayerID)
   end

--- a/app/controllers/spree/paypal_controller_decorator.rb
+++ b/app/controllers/spree/paypal_controller_decorator.rb
@@ -60,7 +60,8 @@ Spree::PaypalController.class_eval do
     @order = current_order || raise(ActiveRecord::RecordNotFound)
     # At this point the user has come back from the Paypal form, and we get one
     # last chance to interact with the payment process before the money moves...
-    ensure_sufficient_stock_lines
+    return unless ensure_sufficient_stock_lines
+
     @order.payments.create!({
       source: Spree::PaypalExpressCheckout.create({
         token: params[:token],

--- a/spec/controllers/spree/paypal_controller_spec.rb
+++ b/spec/controllers/spree/paypal_controller_spec.rb
@@ -27,6 +27,20 @@ module Spree
         spree_post :confirm, payment_method_id: payment_method.id
         expect(session[:access_token]).to eq(controller.current_order.token)
       end
+
+      context "if the stock ran out whilst the payment was being placed" do
+        before do
+          allow(controller.current_order).to receive(:insufficient_stock_lines).and_return(true)
+        end
+
+        it "redirects to the cart with out of stock error" do
+          expect(spree_post(:confirm, payment_method_id: payment_method.id)).
+            to redirect_to cart_path
+
+          # And does not complete processing of the payment
+          expect(controller.current_order.reload.payments.count).to eq 0
+        end
+      end
     end
 
     describe '#expire_current_order' do

--- a/spec/controllers/spree/paypal_controller_spec.rb
+++ b/spec/controllers/spree/paypal_controller_spec.rb
@@ -37,8 +37,11 @@ module Spree
           expect(spree_post(:confirm, payment_method_id: payment_method.id)).
             to redirect_to cart_path
 
-          # And does not complete processing of the payment
-          expect(controller.current_order.reload.payments.count).to eq 0
+          order = controller.current_order.reload
+
+          # Order is in "cart" state and did not complete processing of the payment
+          expect(order.state).to eq "cart"
+          expect(order.payments.count).to eq 0
         end
       end
     end

--- a/spec/features/consumer/shopping/checkout_paypal_spec.rb
+++ b/spec/features/consumer/shopping/checkout_paypal_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 feature "Check out with Paypal", js: true do
   include ShopWorkflow
   include CheckoutHelper
+  include PaypalHelper
 
   let(:distributor) { create(:distributor_enterprise) }
   let(:supplier) { create(:supplier_enterprise) }
@@ -41,20 +42,13 @@ feature "Check out with Paypal", js: true do
     add_product_to_cart order, product
   end
 
-  describe "as a guest" do
+  context "as a guest" do
     it "fails with an error message" do
       visit checkout_path
       checkout_as_guest
       fill_out_form(free_shipping.name, paypal.name, save_default_addresses: false)
 
-      paypal_response = double(:response, success?: false, errors: [])
-      paypal_provider = double(
-        :provider,
-        build_set_express_checkout: nil,
-        set_express_checkout: paypal_response
-      )
-      allow_any_instance_of(Spree::PaypalController).to receive(:provider).
-        and_return(paypal_provider)
+      stub_paypal_response success: false
 
       place_order
       expect(page).to have_content "PayPal failed."

--- a/spec/requests/checkout/paypal_spec.rb
+++ b/spec/requests/checkout/paypal_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe "checking out an order with a paypal express payment method", type: :request do
   include ShopWorkflow
+  include PaypalHelper
 
   let!(:address) { create(:address) }
   let!(:shop) { create(:enterprise) }
@@ -25,18 +26,6 @@ describe "checking out an order with a paypal express payment method", type: :re
     )
   end
   let(:params) { { token: 'lalalala', PayerID: 'payer1', payment_method_id: payment_method.id } }
-  let(:mocked_xml_response) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <Envelope><Body>
-      <GetExpressCheckoutDetailsResponse>
-        <Ack>Success</Ack>
-        <PaymentDetails>Something</PaymentDetails>
-        <DoExpressCheckoutPaymentResponseDetails>
-          <PaymentInfo><TransactionID>s0metran$act10n</TransactionID></PaymentInfo>
-        </DoExpressCheckoutPaymentResponseDetails>
-      </GetExpressCheckoutDetailsResponse>
-    </Body></Envelope>"
-  }
 
   before do
     order.reload.update_totals
@@ -45,8 +34,7 @@ describe "checking out an order with a paypal express payment method", type: :re
     expect(order.next).to be true # => payment
     set_order order
 
-    stub_request(:post, "https://api-3t.sandbox.paypal.com/2.0/")
-      .to_return(status: 200, body: mocked_xml_response )
+    stub_paypal_confirm
   end
 
   context "with a flat percent calculator" do

--- a/spec/support/request/paypal_helper.rb
+++ b/spec/support/request/paypal_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaypalHelper
+  def stub_paypal_response(options)
+    paypal_response = double(:response, success?: options[:success], errors: [])
+    paypal_provider = double(
+      :provider,
+      build_set_express_checkout: nil,
+      set_express_checkout: paypal_response
+    )
+    allow_any_instance_of(Spree::PaypalController).to receive(:provider).
+      and_return(paypal_provider)
+  end
+end

--- a/spec/support/request/paypal_helper.rb
+++ b/spec/support/request/paypal_helper.rb
@@ -1,14 +1,37 @@
 # frozen_string_literal: true
 
 module PaypalHelper
+  # Initial request to confirm the payment can be placed (before redirecting to paypal)
   def stub_paypal_response(options)
     paypal_response = double(:response, success?: options[:success], errors: [])
     paypal_provider = double(
       :provider,
       build_set_express_checkout: nil,
-      set_express_checkout: paypal_response
+      set_express_checkout: paypal_response,
+      express_checkout_url: options[:redirect]
     )
     allow_any_instance_of(Spree::PaypalController).to receive(:provider).
       and_return(paypal_provider)
+  end
+
+  # Additional request to re-confirm the payment, when the order is finalised.
+  def stub_paypal_confirm
+    stub_request(:post, "https://api-3t.sandbox.paypal.com/2.0/")
+      .to_return(status: 200, body: mocked_xml_response )
+  end
+
+  private
+
+  def mocked_xml_response
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <Envelope><Body>
+      <GetExpressCheckoutDetailsResponse>
+        <Ack>Success</Ack>
+        <PaymentDetails>Something</PaymentDetails>
+        <DoExpressCheckoutPaymentResponseDetails>
+          <PaymentInfo><TransactionID>s0metran$act10n</TransactionID></PaymentInfo>
+        </DoExpressCheckoutPaymentResponseDetails>
+      </GetExpressCheckoutDetailsResponse>
+    </Body></Envelope>"
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5953

Fixes an issue where stock could be reduced to zero between the point a paypal payment was started and when it was finished. The result was that the order was no longer valid, so it would not be saved (and would disappear from the system) but the payment would come out of the user's account :grimacing: 

#### What should we test?

This will be an interesting one. Requires a Paypal test account. I'd say:

- Open up the edit page for a variant with low stock in one tab
- Add that variant to a cart in another tab
- Check out and use Paypal
- After submitting and going to the paypal form, but before submitting, switch to the other tab and set the stock to zero on the item
- Submit the Paypal form
- You should be redirected to the cart with the usual "out of stock" message
- The payment should not have been finalised

#### Release notes

Fixed an issue with paypal payments where items had gone out of stock at the point of payment processing

Changelog Category: Technical changes

