### PR TITLE
IGNORE: I'm just trying to find out what version of Linux is used in SemaphoreCI.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+system('cat /etc/os-release')
+
 require 'simplecov'
 SimpleCov.start 'rails'
 


### PR DESCRIPTION
This pull request is not intended for review or merging.  I'm just seeking the output of "cat /etc/os-release" in the SemaphoreCI environment.