### PR TITLE
show specific error message when add-to-cart fails

### DIFF
--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -50,7 +50,7 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
         @popQueue() if @update_enqueued
 
       .error (response, status)=>
-        Messages.flash({error: t('js.cart.add_to_cart_failed')})
+        Messages.flash({error: response.error})
         @update_running = false
 
     compareAndNotifyStockLevels: (stockLevels) =>

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -25,7 +25,8 @@ class CartController < BaseController
                        stock_levels: VariantsStockLevels.new.call(order, variant_ids) },
                status: :ok
       else
-        render json: { error: cart_service.errors.full_messages.join(",") }, status: :precondition_failed
+        render json: { error: cart_service.errors.full_messages.join(",") },
+               status: :precondition_failed
       end
     end
     populate_variant_attributes

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -14,7 +14,7 @@ class CartController < BaseController
       cart_service = CartService.new(order)
 
       errors = cart_service.populate(params.slice(:products, :variants, :quantity), true)[:errors]
-      if errors.blank?
+      if errors.empty?
         order.update_distribution_charge!
         order.cap_quantity_at_stock!
         order.update!

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -13,7 +13,8 @@ class CartController < BaseController
     Spree::Adjustment.without_callbacks do
       cart_service = CartService.new(order)
 
-      if cart_service.populate(params.slice(:products, :variants, :quantity), true)
+      errors = cart_service.populate(params.slice(:products, :variants, :quantity), true)[:errors]
+      if errors.blank?
         order.update_distribution_charge!
         order.cap_quantity_at_stock!
         order.update!
@@ -24,7 +25,7 @@ class CartController < BaseController
                        stock_levels: VariantsStockLevels.new.call(order, variant_ids) },
                status: :ok
       else
-        render json: { error: true }, status: :precondition_failed
+        render json: { error: errors.full_messages.join(",") }, status: :precondition_failed
       end
     end
     populate_variant_attributes

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -13,8 +13,8 @@ class CartController < BaseController
     Spree::Adjustment.without_callbacks do
       cart_service = CartService.new(order)
 
-      errors = cart_service.populate(params.slice(:products, :variants, :quantity), true)[:errors]
-      if errors.empty?
+      cart_service.populate(params.slice(:products, :variants, :quantity), true)
+      if cart_service.valid?
         order.update_distribution_charge!
         order.cap_quantity_at_stock!
         order.update!
@@ -25,7 +25,7 @@ class CartController < BaseController
                        stock_levels: VariantsStockLevels.new.call(order, variant_ids) },
                status: :ok
       else
-        render json: { error: errors.full_messages.join(",") }, status: :precondition_failed
+        render json: { error: cart_service.errors.full_messages.join(",") }, status: :precondition_failed
       end
     end
     populate_variant_attributes

--- a/app/services/cart_service.rb
+++ b/app/services/cart_service.rb
@@ -19,7 +19,11 @@ class CartService
       attempt_cart_add_variants variants_data
       overwrite_variants variants_data if overwrite
     end
-    { errors: errors }
+    valid?
+  end
+
+  def valid?
+    errors.empty?
   end
 
   private

--- a/app/services/cart_service.rb
+++ b/app/services/cart_service.rb
@@ -19,7 +19,7 @@ class CartService
       attempt_cart_add_variants variants_data
       overwrite_variants variants_data if overwrite
     end
-    valid?
+    { errors: errors }
   end
 
   private
@@ -109,10 +109,6 @@ class CartService
     end
   end
 
-  def valid?
-    errors.empty?
-  end
-
   def cart_remove(variant_id)
     variant = Spree::Variant.find(variant_id)
     @order.remove_variant(variant)
@@ -145,7 +141,7 @@ class CartService
 
   def check_order_cycle_provided
     order_cycle_provided = @order_cycle.present?
-    errors.add(:base, "Please choose an order cycle for this order.") unless order_cycle_provided
+    errors.add(:base, I18n.t(:spree_order_cycle_error)) unless order_cycle_provided
     order_cycle_provided
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2213,6 +2213,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   spree_classification_primary_taxon_error: "Taxon %{taxon} is the primary taxon of %{product} and cannot be deleted"
   spree_order_availability_error: "Distributor or order cycle cannot supply the products in your cart"
   spree_order_populator_error: "That distributor or order cycle can't supply all the products in your cart. Please choose another."
+  spree_order_cycle_error: "Please choose an order cycle for this order."
   spree_order_populator_availability_error: "That product is not available from the chosen distributor or order cycle."
   spree_distributors_error: "At least one hub must be selected"
   spree_user_enterprise_limit_error: "^%{email} is not permitted to own any more enterprises (limit is %{enterprise_limit})."

--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -5,33 +5,37 @@ describe CartController, type: :controller do
 
   describe "basic behaviour" do
     let(:cart_service) { double }
+    let(:errors) { double }
 
     before do
       allow(CartService).to receive(:new).and_return(cart_service)
     end
 
     it "returns HTTP success when successful" do
-      allow(cart_service).to receive(:populate) { true }
+      allow(cart_service).to receive(:populate).and_return({ errors: {} })
       allow(cart_service).to receive(:variants_h) { {} }
       xhr :post, :populate, use_route: :spree, format: :json
       expect(response.status).to eq(200)
     end
 
     it "returns failure when unsuccessful" do
-      allow(cart_service).to receive(:populate).and_return false
+      allow(errors).to receive(:empty?).and_return(false)
+      allow(errors).to receive(:full_messages).and_return(["Error: foo"])
+      allow(cart_service).to receive(:populate).and_return({ errors: errors })
       xhr :post, :populate, use_route: :spree, format: :json
       expect(response.status).to eq(412)
     end
 
     it "tells cart_service to overwrite" do
-      expect(cart_service).to receive(:populate).with({}, true)
+      allow(cart_service).to receive(:variants_h) { {} }
+      expect(cart_service).to receive(:populate).with({}, true).and_return({ errors: {} })
       xhr :post, :populate, use_route: :spree, format: :json
     end
 
     it "returns stock levels as JSON on success" do
       allow(controller).to receive(:variant_ids_in) { [123] }
       allow_any_instance_of(VariantsStockLevels).to receive(:call).and_return("my_stock_levels")
-      allow(cart_service).to receive(:populate) { true }
+      allow(cart_service).to receive(:populate).and_return({ errors: {} })
       allow(cart_service).to receive(:variants_h) { {} }
 
       xhr :post, :populate, use_route: :spree, format: :json

--- a/spec/controllers/cart_controller_spec.rb
+++ b/spec/controllers/cart_controller_spec.rb
@@ -12,30 +12,34 @@ describe CartController, type: :controller do
     end
 
     it "returns HTTP success when successful" do
-      allow(cart_service).to receive(:populate).and_return({ errors: {} })
+      allow(cart_service).to receive(:populate) { true }
+      allow(cart_service).to receive(:valid?) { true }
       allow(cart_service).to receive(:variants_h) { {} }
       xhr :post, :populate, use_route: :spree, format: :json
       expect(response.status).to eq(200)
     end
 
     it "returns failure when unsuccessful" do
-      allow(errors).to receive(:empty?).and_return(false)
+      allow(cart_service).to receive(:populate).and_return false
+      allow(cart_service).to receive(:valid?) { false }
+      allow(cart_service).to receive(:errors) { errors }
       allow(errors).to receive(:full_messages).and_return(["Error: foo"])
-      allow(cart_service).to receive(:populate).and_return({ errors: errors })
       xhr :post, :populate, use_route: :spree, format: :json
       expect(response.status).to eq(412)
     end
 
     it "tells cart_service to overwrite" do
       allow(cart_service).to receive(:variants_h) { {} }
-      expect(cart_service).to receive(:populate).with({}, true).and_return({ errors: {} })
+      allow(cart_service).to receive(:valid?) { true }
+      expect(cart_service).to receive(:populate).with({}, true)
       xhr :post, :populate, use_route: :spree, format: :json
     end
 
     it "returns stock levels as JSON on success" do
       allow(controller).to receive(:variant_ids_in) { [123] }
       allow_any_instance_of(VariantsStockLevels).to receive(:call).and_return("my_stock_levels")
-      allow(cart_service).to receive(:populate).and_return({ errors: {} })
+      allow(cart_service).to receive(:populate) { true }
+      allow(cart_service).to receive(:valid?) { true }
       allow(cart_service).to receive(:variants_h) { {} }
 
       xhr :post, :populate, use_route: :spree, format: :json

--- a/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
@@ -138,10 +138,10 @@ describe 'Cart service', ->
       expect(Cart.popQueue).not.toHaveBeenCalled()
 
     it "shows an error on cart update failure", ->
-      $httpBackend.expectPOST("/cart/populate", data).respond 404, {}
+      $httpBackend.expectPOST("/cart/populate", data).respond 412, {}
       Cart.update()
       $httpBackend.flush()
-      expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: t('js.cart.add_to_cart_failed')})
+      expect(RailsFlashLoader.loadFlash).toHaveBeenCalled()
 
   describe "verifying stock levels after update", ->
     describe "when an item is out of stock", ->


### PR DESCRIPTION
#### What? Why?
Related to #6422

#### What should we test?
Green test build and a double check from devs should be sufficient. If we can reproduce the issue happening in that issue, the error message should now be more specific. 

#### Release notes
Add a more specific error message if something goes wrong adding an item to the cart. 

Changelog Category: User facing changes

#### Dependencies


#### Documentation updates