### PR TITLE
Remove spree_i18n dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,6 @@ gem 'ransack', '~> 1.8.10'
 gem 'state_machine', '1.2.0'
 gem 'stringex', '~> 1.5.1'
 
-gem 'spree_i18n', github: 'openfoodfoundation/spree_i18n', branch: '1-3-stable'
-
 # Our branch contains the following changes:
 # - Pass customer email and phone number to PayPal (merged to upstream master)
 # - Change type of password from string to password to hide it in the form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,15 +19,6 @@ GIT
   specs:
     ofn-qz (0.1.0)
 
-GIT
-  remote: https://github.com/openfoodfoundation/spree_i18n.git
-  revision: 12f18312232f0ce70270d47859d2951d12f7791c
-  branch: 1-3-stable
-  specs:
-    spree_i18n (1.0.0)
-      i18n (~> 0.5)
-      rails-i18n
-
 PATH
   remote: engines/catalog
   specs:
@@ -767,7 +758,6 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   simplecov
-  spree_i18n!
   spree_paypal_express!
   spring
   spring-commands-rspec


### PR DESCRIPTION
#### What? Why?

Closes #6426 

#### What should we test?
We need to verify translations are available and that there are no missing translations in the app.


#### Release notes
Changelog Category: Technical changes
Removed dependency spree_i18n, it's not used. 