### PR TITLE
fix #6415 (Shop link should close modal)

### DIFF
--- a/app/assets/javascripts/templates/partials/hub_details.html.haml
+++ b/app/assets/javascripts/templates/partials/hub_details.html.haml
@@ -14,7 +14,7 @@
             {{'hubs_delivery' | t}}
     .row
       .columns.small-12
-        %a.cta-hub{"ng-href" => "{{::enterprise.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}",
+        %a.cta-hub{"ng-href" => "{{::enterprise.path}}#/shop", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}",
         "ng-class" => "{primary: enterprise.active, secondary: !enterprise.active}",
         "ng-click" => "$close()",
         "ofn-change-hub" => "enterprise"}

--- a/app/assets/javascripts/templates/partials/hub_details.html.haml
+++ b/app/assets/javascripts/templates/partials/hub_details.html.haml
@@ -16,6 +16,7 @@
       .columns.small-12
         %a.cta-hub{"ng-href" => "{{::enterprise.path}}", "ng-attr-target" => "{{ embedded_layout ? '_blank' : undefined}}",
         "ng-class" => "{primary: enterprise.active, secondary: !enterprise.active}",
+        "ng-click" => "$close()",
         "ofn-change-hub" => "enterprise"}
           .hub-name{"ng-bind" => "::enterprise.name"}
           %span{"ng-if" => "::enterprise.active"} ({{'maps_open' | t}})

--- a/app/assets/javascripts/templates/partials/producer_details.html.haml
+++ b/app/assets/javascripts/templates/partials/producer_details.html.haml
@@ -12,7 +12,7 @@
     .row
       .columns.small-12
         %a.cta-hub{"ng-repeat" => "hub in enterprise.hubs | filter:{id: '!'+enterprise.id} | orderBy:'-active'",
-        "ng-href" => "{{::hub.path}}", "ofn-empties-cart" => "hub",
+        "ng-href" => "{{::hub.path}}#/shop", "ofn-empties-cart" => "hub",
         "ng-class" => "::{primary: hub.active, secondary: !hub.active}",
         "ng-click" => "$close()"}
           .hub-name{"ng-bind" => "::hub.name"}

--- a/app/assets/javascripts/templates/partials/producer_details.html.haml
+++ b/app/assets/javascripts/templates/partials/producer_details.html.haml
@@ -13,7 +13,8 @@
       .columns.small-12
         %a.cta-hub{"ng-repeat" => "hub in enterprise.hubs | filter:{id: '!'+enterprise.id} | orderBy:'-active'",
         "ng-href" => "{{::hub.path}}", "ofn-empties-cart" => "hub",
-        "ng-class" => "::{primary: hub.active, secondary: !hub.active}"}
+        "ng-class" => "::{primary: hub.active, secondary: !hub.active}",
+        "ng-click" => "$close()"}
           .hub-name{"ng-bind" => "::hub.name"}
           %span{"ng-if" => "::hub.active"} ({{'maps_open' | t}})
           %span{"ng-if" => "::!hub.active"} ({{'maps_closed' | t}})


### PR DESCRIPTION
#### What? Why?
Closes #6415

#### What should we test?
See issue for steps to reproduce. 

#### Release notes
Fixed a bug where clicking on a producer's name in a hub's modal profile did not close the modal.

Changelog Category: User facing changes 

#### Dependencies

#### Documentation updates
