### PR TITLE
Upgrade Ruby and Ubuntu to latest in GH action

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   brakeman-scan:
     name: Brakeman Scan
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: '2.4'
+        ruby-version: '2.7'
 
     - name: Setup Brakeman
       env:


### PR DESCRIPTION
#### What? Why?

It was asked for in https://github.com/openfoodfoundation/openfoodnetwork/pull/6163/ to use the latest stable Ruby version. It's also better to use Ubuntu's latest as well.



#### What should we test?

Brakeman should keep working.

#### Release notes

Upgrade Ruby and Ubuntu versions in Brakeman's Github workflow to their latest stable.
Changelog Category: Technical changes