### PR TITLE
Fix invalid unit value (rebase of #6250)

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -96,6 +96,7 @@ module Spree
 
     validates :variant_unit, presence: true
     validates :unit_value, presence: true
+    validates :unit_value, numericality: true
     validates :variant_unit_scale,
               presence: { if: ->(p) { %w(weight volume).include? p.variant_unit } }
     validates :variant_unit_name,

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -95,8 +95,7 @@ module Spree
     validates :tax_category_id, presence: true, if: "Spree::Config.products_require_tax_category"
 
     validates :variant_unit, presence: true
-    validates :unit_value, presence: true
-    validates :unit_value, numericality: true
+    validates :unit_value, presence: { if: ->(p) { %w(weight volume).include? p.variant_unit } }
     validates :variant_unit_scale,
               presence: { if: ->(p) { %w(weight volume).include? p.variant_unit } }
     validates :variant_unit_name,

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -95,6 +95,7 @@ module Spree
     validates :tax_category_id, presence: true, if: "Spree::Config.products_require_tax_category"
 
     validates :variant_unit, presence: true
+    validates :unit_value, presence: true
     validates :variant_unit_scale,
               presence: { if: ->(p) { %w(weight volume).include? p.variant_unit } }
     validates :variant_unit_name,

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -112,6 +112,27 @@ feature '
       variant = product.variants.first
       expect(variant.on_demand).to be true
     end
+
+    scenario "creating product with empty unit value", js: true do
+      login_as_admin_and_visit spree.admin_products_path
+
+      click_link 'New Product'
+
+      fill_in 'product_name', with: 'Hot Cakes'
+      select 'New supplier', from: 'product_supplier_id'
+      select "Weight (kg)", from: 'product_variant_unit_with_scale'
+      select taxon.name, from: "product_primary_taxon_id"
+      fill_in 'product_price', with: '1.99'
+      fill_in 'product_on_hand', with: 0
+      check 'product_on_demand'
+      select 'Test Tax Category', from: 'product_tax_category_id'
+      page.find("div[id^='taTextElement']").native.send_keys('In demand, and on_demand! The hottest cakes in town.')
+
+      click_button 'Create'
+
+      expect(current_path).to eq spree.admin_products_path
+      expect(page).to have_content "Unit value can't be blank"
+    end
   end
 
   context "as an enterprise user" do

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -126,7 +126,7 @@ feature '
       fill_in 'product_on_hand', with: 0
       check 'product_on_demand'
       select 'Test Tax Category', from: 'product_tax_category_id'
-      page.find("div[id^='taTextElement']").native.send_keys('In demand, and on_demand! The hottest cakes in town.')
+      find("div[id^='taTextElement']").native.send_keys('In demand, and on_demand! The hottest cakes in town.')
 
       click_button 'Create'
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -247,6 +247,10 @@ module Spree
         expect(build(:simple_product, taxons: [], primary_taxon: nil)).not_to be_valid
       end
 
+      it "requires a unit value" do
+        expect(build(:simple_product, unit_value: nil)).not_to be_valid
+      end
+
       it "requires a supplier" do
         expect(build(:simple_product, supplier: nil)).not_to be_valid
       end


### PR DESCRIPTION
#### What? Why?

Closes #6117
Closes #3912
Closes #4959 

See the original PR (#6250) for details; I tried to rebase it after the spree updates and couldn't untangle things... sorry @tsara27 !

There is still a lot left to be desired in this UI; as @Erioldoesdesign [noted](https://github.com/openfoodfoundation/openfoodnetwork/issues/4959#issuecomment-721177819), it isn't very clear what this field is for. Moreover the error now says "unit value can't be blank" but the label on the field itself is "value"; and even moreover, if you do fill in the field but with something that's not a number, because it's confusing what should go in there, you get the same "unit value can't be blank" error. 

So yes, lots of potential for further improvement here...but this gets rid of the 500 slug. And closes three issues for the price of one!


#### What should we test?
Login as an admin.
Go to products.
Create a new product.
Fill other required details, leave the unit value empty.
Should see an error and not a slug. 

#### Release notes
Fixed a bug where entering an empty or invalid value on the product creation page would show a slug instead of an error message. 
Changelog Category: User facing changes 

#### Dependencies



#### Documentation updates
