### PR TITLE
Add dependabot config to increase limit to 10 PRs

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
#### What? Why?

This adds a config file to increase dependabot temporarily to 10 PRs (after rails 4.2 we will need it).
It also adds yarn, I think this will make dependabot try to upgrade yarn dependencies as well :+1: 

#### What should we test?
Merge and verify is dependabot can open 10 PRs.

