### PR TITLE
Rails 5 upgrade with dualboot

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -46,6 +46,9 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Bundler/DuplicatedGem:
+  Enabled: false
+
 ## TEMPORARY/CONTESTED SETTINGS
 #
 # These are still to be decided upon, but recommended for inclusion by

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,16 @@ source 'https://rubygems.org'
 ruby "2.4.4"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
+plugin 'bootboot', '~> 0.1.1' unless Bundler.settings[:frozen]
+Plugin.send(:load_plugin, 'bootboot') if Plugin.installed?('bootboot')
+
+if ENV['DEPENDENCIES_NEXT']
+  enable_dual_booting if Plugin.installed?('bootboot')
+
+  # This will only be loaded when running
+  # bundler command prefixed with `DEPENDENCIES_NEXT=1
+end
+
 gem 'i18n'
 gem 'i18n-js', '~> 3.8.0'
 gem 'rails', '~> 4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -5,23 +5,43 @@ ruby "2.4.4"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 plugin 'bootboot', '~> 0.1.1' unless Bundler.settings[:frozen]
-Plugin.send(:load_plugin, 'bootboot') if Plugin.installed?('bootboot')
+Plugin.__send__(:load_plugin, 'bootboot') if Plugin.installed?('bootboot')
 
 if ENV['DEPENDENCIES_NEXT']
   enable_dual_booting if Plugin.installed?('bootboot')
 
   # This will only be loaded when running
   # bundler command prefixed with `DEPENDENCIES_NEXT=1
+  gem 'rails', '> 5.0', '< 5.1'
+
+  gem 'activemerchant', '>= 1.78.0'
+  gem 'angular-rails-templates', '>= 0.3.0'
+  gem 'awesome_nested_set'
+  gem 'ransack', '2.3.0'
+  gem 'responders'
+  gem 'sass', '<= 4.7.1'
+  gem 'sass-rails', '< 6.0.0'
+else
+  gem 'rails', '~> 4.2'
+
+  gem 'activemerchant', '~> 1.78.0'
+  gem 'angular-rails-templates', '~> 0.3.0'
+  gem 'awesome_nested_set', '~> 3.3.1'
+  gem 'ransack', '~> 1.8.10'
+  gem 'responders', '~> 2.0'
+  gem 'sass'
+  gem 'sass-rails'
+
+  gem 'db2fog'
+  gem 'unicorn'
 end
 
 gem 'i18n'
 gem 'i18n-js', '~> 3.8.0'
-gem 'rails', '~> 4.2'
 gem 'rails-i18n'
 gem 'rails_safe_tasks', '~> 1.0'
 
 gem "activerecord-import"
-gem 'responders', '~> 2.0'
 
 gem "catalog", path: "./engines/catalog"
 gem 'dfc_provider', path: './engines/dfc_provider'
@@ -32,14 +52,12 @@ gem 'activerecord-postgresql-adapter'
 gem 'pg', '~> 0.21.0'
 
 gem 'acts_as_list', '0.9.19'
-gem 'awesome_nested_set', '~> 3.3.1'
 gem 'cancancan', '~> 1.7.0'
 gem 'ffaker'
 gem 'highline', '2.0.3' # Necessary for the install generator
 gem 'json'
 gem 'monetize', '~> 1.1'
 gem 'paranoia', '~> 2.4'
-gem 'ransack', '~> 1.8.10'
 gem 'state_machines-activerecord'
 gem 'stringex', '~> 2.8.5'
 
@@ -50,10 +68,6 @@ gem 'stringex', '~> 2.8.5'
 gem 'spree_paypal_express', github: 'openfoodfoundation/better_spree_paypal_express', branch: '2-1-0-stable'
 
 gem 'stripe'
-
-# We need at least this version to have Digicert's root certificate
-# which is needed for Pin Payments (and possibly others).
-gem 'activemerchant', '~> 1.78.0'
 
 gem 'devise'
 gem 'devise-encryptable'
@@ -71,12 +85,8 @@ gem 'andand'
 gem 'angularjs-rails', '1.5.5'
 gem 'aws-sdk', '1.67.0'
 gem 'bugsnag'
-gem 'db2fog'
 gem 'haml'
 gem 'redcarpet'
-gem 'sass'
-gem 'sass-rails'
-gem 'unicorn'
 
 gem 'actionpack-action_caching'
 # AMS 0.9.x and 0.10.x are very different from 0.8.4 and the upgrade is not straight forward
@@ -114,7 +124,6 @@ gem 'mini_racer', '0.2.15'
 
 gem 'uglifier', '>= 1.0.3'
 
-gem 'angular-rails-templates', '~> 0.3.0'
 gem 'foundation-icons-sass-rails'
 
 gem 'foundation-rails', '= 5.5.2.1'

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -1,0 +1,848 @@
+GIT
+  remote: https://github.com/jeremydurham/custom-err-msg.git
+  revision: 3a8ec9dddc7a5b0aab7c69a6060596de300c68f4
+  specs:
+    custom_error_message (1.1.1)
+
+GIT
+  remote: https://github.com/openfoodfoundation/better_spree_paypal_express.git
+  revision: 1a477e9f7763297944cc99b6f4dd3d962aa963e9
+  branch: 2-1-0-stable
+  specs:
+    spree_paypal_express (2.0.3)
+      paypal-sdk-merchant (= 1.106.1)
+
+GIT
+  remote: https://github.com/openfoodfoundation/ofn-qz.git
+  revision: 467f6ea1c44529c7c91cac4c8211bbd863588c0b
+  branch: ofn-rails-4
+  specs:
+    ofn-qz (0.1.0)
+
+GIT
+  remote: https://github.com/openfoodfoundation/spree_i18n.git
+  revision: 12f18312232f0ce70270d47859d2951d12f7791c
+  branch: 1-3-stable
+  specs:
+    spree_i18n (1.0.0)
+      i18n (~> 0.5)
+      rails-i18n
+
+PATH
+  remote: engines/catalog
+  specs:
+    catalog (0.0.1)
+
+PATH
+  remote: engines/dfc_provider
+  specs:
+    dfc_provider (0.0.1)
+      active_model_serializers (~> 0.8.4)
+      jwt (~> 2.2)
+      rspec (~> 3.9)
+
+PATH
+  remote: engines/order_management
+  specs:
+    order_management (0.0.1)
+
+PATH
+  remote: engines/web
+  specs:
+    web (0.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.6)
+    actionmailer (4.2.11.3)
+      actionpack (= 4.2.11.3)
+      actionview (= 4.2.11.3)
+      activejob (= 4.2.11.3)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (4.2.11.3)
+      actionview (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
+      rack (~> 1.6)
+      rack-test (~> 0.6.2)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.2.1)
+      actionpack (>= 4.0.0)
+    actionview (4.2.11.3)
+      activesupport (= 4.2.11.3)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.8.4)
+      activemodel (>= 3.0)
+    activejob (4.2.11.3)
+      activesupport (= 4.2.11.3)
+      globalid (>= 0.3.0)
+    activemerchant (1.78.0)
+      activesupport (>= 3.2.14, < 6.x)
+      builder (>= 2.1.2, < 4.0.0)
+      i18n (>= 0.6.9)
+      nokogiri (~> 1.4)
+    activemodel (4.2.11.3)
+      activesupport (= 4.2.11.3)
+      builder (~> 3.1)
+    activerecord (4.2.11.3)
+      activemodel (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
+      arel (~> 6.0)
+    activerecord-import (1.0.7)
+      activerecord (>= 3.2)
+    activerecord-postgresql-adapter (0.0.1)
+      pg
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
+    activesupport (4.2.11.3)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    acts-as-taggable-on (4.0.0)
+      activerecord (>= 4.0)
+    acts_as_list (0.3.0)
+      activerecord (>= 3.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    aliyun-sdk (0.8.0)
+      nokogiri (~> 1.6)
+      rest-client (~> 2.0)
+    andand (1.3.3)
+    angular-rails-templates (0.3.0)
+      railties (>= 3.1)
+      sprockets (~> 2.0)
+      tilt
+    angularjs-file-upload-rails (2.4.1)
+    angularjs-rails (1.5.5)
+    arel (6.0.4)
+    ast (2.4.0)
+    atomic (1.1.101)
+    awesome_nested_set (3.2.1)
+      activerecord (>= 4.0.0, < 7.0)
+    awesome_print (1.8.0)
+    aws-sdk (1.67.0)
+      aws-sdk-v1 (= 1.67.0)
+    aws-sdk-v1 (1.67.0)
+      json (~> 1.4)
+      nokogiri (~> 1)
+    bcrypt (3.1.16)
+    bugsnag (6.18.0)
+      concurrent-ruby (~> 1.0)
+    builder (3.2.4)
+    byebug (11.0.1)
+    cancan (1.6.10)
+    capybara (2.18.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (>= 2.0, < 4.0)
+    childprocess (3.0.0)
+    chronic (0.10.2)
+    chunky_png (1.3.14)
+    climate_control (0.2.0)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
+    coderay (1.1.2)
+    coffee-rails (4.2.2)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
+    combine_pdf (1.0.16)
+      ruby-rc4 (>= 0.1.5)
+    compass (1.0.3)
+      chunky_png (~> 1.2)
+      compass-core (~> 1.0.2)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.3)
+      multi_json (~> 1.0)
+      sass (>= 3.3.0, < 3.5)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    compass-rails (4.0.0)
+      compass (~> 1.0.0)
+      sass-rails (< 5.1)
+      sprockets (< 4.0)
+    concurrent-ruby (1.1.7)
+    crack (0.4.4)
+    crass (1.0.6)
+    css_parser (1.7.1)
+      addressable
+    daemons (1.3.1)
+    dalli (2.7.11)
+    database_cleaner (1.8.5)
+    db2fog (0.9.0)
+      activerecord (>= 3.2.0, < 5.0)
+      fog (~> 1.0)
+      rails (>= 3.2.0, < 5.0)
+    ddtrace (0.42.0)
+      msgpack
+    debugger-linecache (1.2.0)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
+    delayed_job_web (1.4.3)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      rack-protection (>= 1.5.5)
+      sinatra (>= 1.4.4)
+    devise (3.5.10)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 3.2.6, < 5)
+      responders
+      thread_safe (~> 0.1)
+      warden (~> 1.2.3)
+    devise-encryptable (0.2.0)
+      devise (>= 2.1.0)
+    devise-token_authenticatable (0.4.10)
+      devise (>= 3.5.2, < 4.0.0)
+    diff-lcs (1.4.4)
+    docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dry-inflector (0.1.2)
+    erubis (2.7.0)
+    eventmachine (1.2.7)
+    excon (0.78.0)
+    execjs (2.7.0)
+    factory_bot (4.10.0)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.10.0)
+      factory_bot (~> 4.10.0)
+      railties (>= 3.0.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    ffaker (1.32.1)
+    ffi (1.13.1)
+    figaro (1.2.0)
+      thor (>= 0.14.0, < 2)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.41.0)
+      fog-aliyun (>= 0.1.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-cloudatcost (~> 0.1.0)
+      fog-core (~> 1.45)
+      fog-digitalocean (>= 0.3.0)
+      fog-dnsimple (~> 1.0)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
+      fog-internet-archive
+      fog-joyent
+      fog-json
+      fog-local
+      fog-openstack
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-rackspace
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      json (>= 1.8, < 2.0)
+    fog-aliyun (0.3.19)
+      aliyun-sdk (~> 0.8.0)
+      fog-core
+      fog-json
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (2.0.1)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.16.1)
+      dry-inflector
+      fog-core
+      fog-json
+      mime-types
+    fog-cloudatcost (0.1.2)
+      fog-core (~> 1.36)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.45.0)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+    fog-digitalocean (0.4.0)
+      fog-core
+      fog-json
+      fog-xml
+      ipaddress (>= 0.5)
+    fog-dnsimple (1.0.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-internet-archive (0.0.2)
+      fog-core
+      fog-json
+      fog-xml
+    fog-joyent (0.0.1)
+      fog-core (~> 1.42)
+      fog-json (>= 1.0)
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-local (0.6.0)
+      fog-core (>= 1.27, < 3.0)
+    fog-openstack (0.3.10)
+      fog-core (>= 1.45, <= 2.1.0)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
+    fog-powerdns (0.2.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-profitbricks (4.1.1)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-rackspace (0.1.6)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-vsphere (3.4.0)
+      fog-core
+      rbvmomi (>= 1.9, < 3)
+    fog-xenserver (1.0.0)
+      fog-core
+      fog-xml
+      xmlrpc
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
+    foundation-icons-sass-rails (3.0.0)
+      railties (>= 3.1.1)
+      sass-rails (>= 3.1.1)
+    foundation-rails (5.5.2.1)
+      railties (>= 3.1.0)
+      sass (>= 3.3.0, < 3.5)
+    fuubar (2.5.0)
+      rspec-core (~> 3.0)
+      ruby-progressbar (~> 1.4)
+    geocoder (1.6.4)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
+    globalid (0.4.2)
+      activesupport (>= 4.2.0)
+    gmaps4rails (2.1.2)
+    haml (5.2.0)
+      temple (>= 0.8.0)
+      tilt
+    hashdiff (1.0.1)
+    highline (2.0.3)
+    hike (1.2.3)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    i18n-js (3.8.0)
+      i18n (>= 0.6.6)
+    immigrant (0.3.6)
+      activerecord (>= 3.0)
+    ipaddress (0.8.3)
+    jaro_winkler (1.5.4)
+    jquery-migrate-rails (1.2.1)
+    jquery-rails (3.1.5)
+      railties (>= 3.0, < 5.0)
+      thor (>= 0.14, < 2.0)
+    jquery-ui-rails (4.2.1)
+      railties (>= 3.2.16)
+    json (1.8.6)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    json_spec (1.1.5)
+      multi_json (~> 1.0)
+      rspec (>= 2.0, < 4.0)
+    jwt (2.2.2)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
+    kgio (2.11.3)
+    knapsack (1.19.0)
+      rake
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    libv8 (7.3.492.27.1)
+    loofah (2.7.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
+    mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
+    mini_racer (0.2.15)
+      libv8 (> 7.3)
+    minitest (5.14.2)
+    money (5.0.0)
+      i18n (~> 0.4)
+      json
+    msgpack (1.3.3)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    netrc (0.11.0)
+    newrelic_rpm (3.18.1.330)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    oj (3.10.8)
+    optimist (3.0.1)
+    orm_adapter (0.5.0)
+    paper_trail (7.1.3)
+      activerecord (>= 4.0, < 5.2)
+      request_store (~> 1.1)
+    paperclip (3.4.2)
+      activemodel (>= 3.0.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      cocaine (~> 0.5.0)
+      mime-types
+    parallel (1.19.1)
+    paranoia (2.4.2)
+      activerecord (>= 4.0, < 6.1)
+    parser (2.7.1.0)
+      ast (~> 2.4.0)
+    paypal-sdk-core (0.2.10)
+      multi_json (~> 1.0)
+      xml-simple
+    paypal-sdk-merchant (1.106.1)
+      paypal-sdk-core (~> 0.2.3)
+    pg (0.21.0)
+    power_assert (1.2.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    public_suffix (4.0.6)
+    rack (1.6.13)
+    rack-mini-profiler (2.0.2)
+      rack (>= 1.2.0)
+    rack-protection (1.5.5)
+      rack
+    rack-rewrite (1.5.1)
+    rack-ssl (1.4.1)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails (4.2.11.3)
+      actionmailer (= 4.2.11.3)
+      actionpack (= 4.2.11.3)
+      actionview (= 4.2.11.3)
+      activejob (= 4.2.11.3)
+      activemodel (= 4.2.11.3)
+      activerecord (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 4.2.11.3)
+      sprockets-rails
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.9)
+      activesupport (>= 4.2.0, < 5.0)
+      nokogiri (~> 1.6)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
+    rails-i18n (4.0.9)
+      i18n (~> 0.7)
+      railties (~> 4.0)
+    rails_safe_tasks (1.0.0)
+    railties (4.2.11.3)
+      actionpack (= 4.2.11.3)
+      activesupport (= 4.2.11.3)
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
+    raindrops (0.19.1)
+    rake (13.0.1)
+    ransack (1.8.10)
+      actionpack (>= 3.0, < 5.2)
+      activerecord (>= 3.0, < 5.2)
+      activesupport (>= 3.0, < 5.2)
+      i18n
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rbvmomi (2.4.1)
+      builder (~> 3.0)
+      json (>= 1.8)
+      nokogiri (~> 1.5)
+      optimist (~> 3.0)
+    redcarpet (3.5.0)
+    request_store (1.5.0)
+      rack (>= 1.4)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rexml (3.2.4)
+    roadie (3.5.1)
+      css_parser (~> 1.4)
+      nokogiri (~> 1.8)
+    roadie-rails (1.3.0)
+      railties (>= 3.0, < 5.3)
+      roadie (~> 3.1)
+    roo (2.8.3)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-rails (4.0.1)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.9)
+      rspec-expectations (~> 3.9)
+      rspec-mocks (~> 3.9)
+      rspec-support (~> 3.9)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+    rspec-support (3.10.0)
+    rswag (2.3.1)
+      rswag-api (= 2.3.1)
+      rswag-specs (= 2.3.1)
+      rswag-ui (= 2.3.1)
+    rswag-api (2.3.1)
+      railties (>= 3.1, < 7.0)
+    rswag-specs (2.3.1)
+      activesupport (>= 3.1, < 7.0)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.0)
+    rswag-ui (2.3.1)
+      actionpack (>= 3.1, < 7.0)
+      railties (>= 3.1, < 7.0)
+    rubocop (0.81.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-rails (2.5.2)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    ruby-progressbar (1.10.1)
+    ruby-rc4 (0.1.5)
+    rubyzip (1.3.0)
+    sass (3.4.25)
+    sass-rails (5.0.7)
+      railties (>= 4.0.0, < 6)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
+    select2-rails (3.4.9)
+      sass-rails
+      thor (~> 0.14)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    shoulda-matchers (4.0.1)
+      activesupport (>= 4.2.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    spring (1.7.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
+    sprockets (2.12.5)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    sprockets-rails (2.3.3)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      sprockets (>= 2.8, < 4.0)
+    state_machines (0.5.0)
+    state_machines-activemodel (0.7.1)
+      activemodel (>= 4.1)
+      state_machines (>= 0.5.0)
+    state_machines-activerecord (0.6.0)
+      activerecord (>= 4.1)
+      state_machines-activemodel (>= 0.5.0)
+    stringex (1.5.1)
+    stripe (5.28.0)
+    temple (0.8.2)
+    test-prof (0.7.5)
+    test-unit (3.3.6)
+      power_assert
+    thor (0.20.3)
+    thread_safe (0.3.6)
+    tilt (1.4.1)
+    timecop (0.9.2)
+    tzinfo (1.2.8)
+      thread_safe (~> 0.1)
+    uglifier (4.2.0)
+      execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+    unicode-display_width (1.7.0)
+    unicorn (5.7.0)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
+    unicorn-rails (2.2.1)
+      rack
+      unicorn
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
+    warden (1.2.7)
+      rack (>= 1.0)
+    webdrivers (4.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.10.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
+    wicked_pdf (2.1.0)
+      activesupport
+    wkhtmltopdf-binary (0.12.5)
+    xml-simple (1.1.5)
+    xmlrpc (0.3.0)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack-action_caching
+  active_model_serializers (= 0.8.4)
+  activemerchant (~> 1.78.0)
+  activerecord-import
+  activerecord-postgresql-adapter
+  activerecord-session_store
+  acts-as-taggable-on (~> 4.0)
+  acts_as_list (= 0.3.0)
+  andand
+  angular-rails-templates (~> 0.3.0)
+  angularjs-file-upload-rails (~> 2.4.1)
+  angularjs-rails (= 1.5.5)
+  atomic
+  awesome_nested_set (~> 3.2.1)
+  awesome_print
+  aws-sdk (= 1.67.0)
+  bugsnag
+  byebug (~> 11.0.0)
+  cancan (~> 1.6.10)
+  capybara (>= 2.18.0)
+  catalog!
+  coffee-rails (~> 4.2.2)
+  combine_pdf
+  compass-rails
+  custom_error_message!
+  daemons
+  dalli
+  database_cleaner
+  db2fog
+  ddtrace
+  debugger-linecache
+  delayed_job_active_record
+  delayed_job_web
+  devise (~> 3.5.10)
+  devise-encryptable
+  devise-token_authenticatable (~> 0.4.10)
+  dfc_provider!
+  eventmachine (>= 1.2.3)
+  factory_bot_rails (= 4.10.0)
+  ffaker (~> 1.16)
+  figaro
+  foundation-icons-sass-rails
+  foundation-rails (= 5.5.2.1)
+  fuubar (~> 2.5.0)
+  geocoder
+  gmaps4rails
+  haml
+  highline (= 2.0.3)
+  i18n
+  i18n-js (~> 3.8.0)
+  immigrant
+  jquery-migrate-rails
+  jquery-rails (= 3.1.5)
+  jquery-ui-rails (~> 4.2)
+  json
+  json_spec (~> 1.1.4)
+  jwt (~> 2.2)
+  kaminari (~> 0.17.0)
+  knapsack
+  letter_opener (>= 1.4.1)
+  mini_racer (= 0.2.15)
+  money (< 6.1.0)
+  newrelic_rpm (~> 3.0)
+  oauth2 (~> 1.4.4)
+  ofn-qz!
+  oj
+  order_management!
+  paper_trail (~> 7.1.3)
+  paperclip (~> 3.4.1)
+  paranoia (~> 2.0)
+  pg (~> 0.21.0)
+  pry (~> 0.12.0)
+  pry-byebug (~> 3.7.0)
+  rack-mini-profiler (< 3.0.0)
+  rack-rewrite
+  rack-ssl
+  rails (~> 4.2)
+  rails-i18n
+  rails_safe_tasks (~> 1.0)
+  ransack (~> 1.8.10)
+  redcarpet
+  responders (~> 2.0)
+  roadie-rails (~> 1.3.0)
+  roo (~> 2.8.3)
+  rspec-rails (>= 3.5.2)
+  rspec-retry
+  rswag
+  rubocop
+  rubocop-rails
+  sass
+  sass-rails
+  select2-rails (~> 3.4.7)
+  selenium-webdriver
+  shoulda-matchers
+  simplecov
+  spree_i18n!
+  spree_paypal_express!
+  spring
+  spring-commands-rspec
+  state_machines-activerecord
+  stringex (~> 1.5.1)
+  stripe
+  test-prof
+  test-unit (~> 3.3)
+  timecop
+  uglifier (>= 1.0.3)
+  unicorn
+  unicorn-rails
+  unicorn-worker-killer
+  web!
+  webdrivers
+  webmock
+  whenever
+  wicked_pdf
+  wkhtmltopdf-binary
+
+RUBY VERSION
+   ruby 2.3.7p456
+
+BUNDLED WITH
+   1.17.3

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -19,15 +19,6 @@ GIT
   specs:
     ofn-qz (0.1.0)
 
-GIT
-  remote: https://github.com/openfoodfoundation/spree_i18n.git
-  revision: 12f18312232f0ce70270d47859d2951d12f7791c
-  branch: 1-3-stable
-  specs:
-    spree_i18n (1.0.0)
-      i18n (~> 0.5)
-      rails-i18n
-
 PATH
   remote: engines/catalog
   specs:
@@ -54,45 +45,47 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
-    actionmailer (4.2.11.3)
-      actionpack (= 4.2.11.3)
-      actionview (= 4.2.11.3)
-      activejob (= 4.2.11.3)
+    actioncable (5.0.7.2)
+      actionpack (= 5.0.7.2)
+      nio4r (>= 1.2, < 3.0)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.0.7.2)
+      actionpack (= 5.0.7.2)
+      actionview (= 5.0.7.2)
+      activejob (= 5.0.7.2)
       mail (~> 2.5, >= 2.5.4)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (4.2.11.3)
-      actionview (= 4.2.11.3)
-      activesupport (= 4.2.11.3)
-      rack (~> 1.6)
-      rack-test (~> 0.6.2)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.0.7.2)
+      actionview (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      rack (~> 2.0)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
     actionpack-action_caching (1.2.1)
       actionpack (>= 4.0.0)
-    actionview (4.2.11.3)
-      activesupport (= 4.2.11.3)
+    actionview (5.0.7.2)
+      activesupport (= 5.0.7.2)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
-    activejob (4.2.11.3)
-      activesupport (= 4.2.11.3)
-      globalid (>= 0.3.0)
-    activemerchant (1.78.0)
-      activesupport (>= 3.2.14, < 6.x)
+    activejob (5.0.7.2)
+      activesupport (= 5.0.7.2)
+      globalid (>= 0.3.6)
+    activemerchant (1.107.4)
+      activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
       nokogiri (~> 1.4)
-    activemodel (4.2.11.3)
-      activesupport (= 4.2.11.3)
-      builder (~> 3.1)
-    activerecord (4.2.11.3)
-      activemodel (= 4.2.11.3)
-      activesupport (= 4.2.11.3)
-      arel (~> 6.0)
+    activemodel (5.0.7.2)
+      activesupport (= 5.0.7.2)
+    activerecord (5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      arel (~> 7.0)
     activerecord-import (1.0.7)
       activerecord (>= 3.2)
     activerecord-postgresql-adapter (0.0.1)
@@ -103,29 +96,26 @@ GEM
       multi_json (~> 1.11, >= 1.11.2)
       rack (>= 1.5.2, < 3)
       railties (>= 4.0)
-    activesupport (4.2.11.3)
-      i18n (~> 0.7)
+    activesupport (5.0.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     acts-as-taggable-on (4.0.0)
       activerecord (>= 4.0)
-    acts_as_list (0.3.0)
+    acts_as_list (0.9.19)
       activerecord (>= 3.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    aliyun-sdk (0.8.0)
-      nokogiri (~> 1.6)
-      rest-client (~> 2.0)
     andand (1.3.3)
-    angular-rails-templates (0.3.0)
-      railties (>= 3.1)
-      sprockets (~> 2.0)
+    angular-rails-templates (1.1.0)
+      railties (>= 4.2, < 7)
+      sprockets (>= 3.0, < 5)
       tilt
     angularjs-file-upload-rails (2.4.1)
     angularjs-rails (1.5.5)
-    arel (6.0.4)
-    ast (2.4.0)
+    arel (7.1.4)
+    ast (2.4.1)
     atomic (1.1.101)
     awesome_nested_set (3.2.1)
       activerecord (>= 4.0.0, < 7.0)
@@ -141,20 +131,21 @@ GEM
     builder (3.2.4)
     byebug (11.0.1)
     cancan (1.6.10)
-    capybara (2.18.0)
+    capybara (3.15.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     childprocess (3.0.0)
     chronic (0.10.2)
     chunky_png (1.3.14)
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    coderay (1.1.2)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -162,7 +153,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    combine_pdf (1.0.16)
+    combine_pdf (1.0.19)
       ruby-rc4 (>= 0.1.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -176,10 +167,8 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    compass-rails (4.0.0)
+    compass-rails (2.0.1)
       compass (~> 1.0.0)
-      sass-rails (< 5.1)
-      sprockets (< 4.0)
     concurrent-ruby (1.1.7)
     crack (0.4.4)
     crass (1.0.6)
@@ -188,11 +177,7 @@ GEM
     daemons (1.3.1)
     dalli (2.7.11)
     database_cleaner (1.8.5)
-    db2fog (0.9.0)
-      activerecord (>= 3.2.0, < 5.0)
-      fog (~> 1.0)
-      rails (>= 3.2.0, < 5.0)
-    ddtrace (0.42.0)
+    ddtrace (0.43.0)
       msgpack
     debugger-linecache (1.2.0)
     delayed_job (4.1.8)
@@ -205,25 +190,20 @@ GEM
       delayed_job (> 2.0.3)
       rack-protection (>= 1.5.5)
       sinatra (>= 1.4.4)
-    devise (3.5.10)
+    devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
-    devise-token_authenticatable (0.4.10)
-      devise (>= 3.5.2, < 4.0.0)
+    devise-token_authenticatable (1.1.0)
+      devise (>= 4.0.0, < 5.0.0)
     diff-lcs (1.4.4)
     docile (1.3.2)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    dry-inflector (0.1.2)
     erubis (2.7.0)
     eventmachine (1.2.7)
-    excon (0.78.0)
     execjs (2.7.0)
     factory_bot (4.10.0)
       activesupport (>= 3.0.0)
@@ -232,161 +212,10 @@ GEM
       railties (>= 3.0.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffaker (1.32.1)
+    ffaker (2.11.0)
     ffi (1.13.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.41.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.45)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 1.0)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (<= 0.1.0)
-      fog-internet-archive
-      fog-joyent
-      fog-json
-      fog-local
-      fog-openstack
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (>= 1.8, < 2.0)
-    fog-aliyun (0.3.19)
-      aliyun-sdk (~> 0.8.0)
-      fog-core
-      fog-json
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (2.0.1)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.16.1)
-      dry-inflector
-      fog-core
-      fog-json
-      mime-types
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.45.0)
-      builder
-      excon (~> 0.58)
-      formatador (~> 0.2)
-    fog-digitalocean (0.4.0)
-      fog-core
-      fog-json
-      fog-xml
-      ipaddress (>= 0.5)
-    fog-dnsimple (1.0.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-internet-archive (0.0.2)
-      fog-core
-      fog-json
-      fog-xml
-    fog-joyent (0.0.1)
-      fog-core (~> 1.42)
-      fog-json (>= 1.0)
-    fog-json (1.2.0)
-      fog-core
-      multi_json (~> 1.10)
-    fog-local (0.6.0)
-      fog-core (>= 1.27, < 3.0)
-    fog-openstack (0.3.10)
-      fog-core (>= 1.45, <= 2.1.0)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    fog-powerdns (0.2.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-profitbricks (4.1.1)
-      fog-core (~> 1.42)
-      fog-json (~> 1.0)
-    fog-rackspace (0.1.6)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (3.4.0)
-      fog-core
-      rbvmomi (>= 1.9, < 3)
-    fog-xenserver (1.0.0)
-      fog-core
-      fog-xml
-      xmlrpc
-    fog-xml (0.1.3)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
-    formatador (0.2.5)
     foundation-icons-sass-rails (3.0.0)
       railties (>= 3.1.1)
       sass-rails (>= 3.1.1)
@@ -407,21 +236,17 @@ GEM
       tilt
     hashdiff (1.0.1)
     highline (2.0.3)
-    hike (1.2.3)
-    http-accept (1.7.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    i18n (0.9.5)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n-js (3.8.0)
       i18n (>= 0.6.6)
     immigrant (0.3.6)
       activerecord (>= 3.0)
-    ipaddress (0.8.3)
     jaro_winkler (1.5.4)
     jquery-migrate-rails (1.2.1)
-    jquery-rails (3.1.5)
-      railties (>= 3.0, < 5.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (4.2.1)
       railties (>= 3.2.16)
@@ -432,40 +257,48 @@ GEM
       multi_json (~> 1.0)
       rspec (>= 2.0, < 4.0)
     jwt (2.2.2)
-    kaminari (0.17.0)
-      actionpack (>= 3.0.0)
-      activesupport (>= 3.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kgio (2.11.3)
-    knapsack (1.19.0)
+    knapsack (1.20.0)
       rake
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libv8 (7.3.492.27.1)
+    libv8 (8.4.255.0)
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types-data (3.2020.1104)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     mini_racer (0.2.15)
       libv8 (> 7.3)
     minitest (5.14.2)
-    money (5.0.0)
-      i18n (~> 0.4)
-      json
+    money (3.1.5)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    netrc (0.11.0)
-    newrelic_rpm (3.18.1.330)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.4)
@@ -475,7 +308,6 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     oj (3.10.8)
-    optimist (3.0.1)
     orm_adapter (0.5.0)
     paper_trail (7.1.3)
       activerecord (>= 4.0, < 5.2)
@@ -486,90 +318,80 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.0)
       mime-types
-    parallel (1.19.1)
+    parallel (1.19.2)
     paranoia (2.4.2)
       activerecord (>= 4.0, < 6.1)
-    parser (2.7.1.0)
-      ast (~> 2.4.0)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
     paypal-sdk-core (0.2.10)
       multi_json (~> 1.0)
       xml-simple
     paypal-sdk-merchant (1.106.1)
       paypal-sdk-core (~> 0.2.3)
     pg (0.21.0)
+    polyamorous (2.3.0)
+      activerecord (>= 5.0)
     power_assert (1.2.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.7.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
-    rack (1.6.13)
+    rack (2.2.3)
     rack-mini-profiler (2.0.2)
       rack (>= 1.2.0)
-    rack-protection (1.5.5)
+    rack-protection (2.1.0)
       rack
     rack-rewrite (1.5.1)
     rack-ssl (1.4.1)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.2.11.3)
-      actionmailer (= 4.2.11.3)
-      actionpack (= 4.2.11.3)
-      actionview (= 4.2.11.3)
-      activejob (= 4.2.11.3)
-      activemodel (= 4.2.11.3)
-      activerecord (= 4.2.11.3)
-      activesupport (= 4.2.11.3)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.11.3)
-      sprockets-rails
-    rails-deprecated_sanitizer (1.0.3)
-      activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.9)
-      activesupport (>= 4.2.0, < 5.0)
-      nokogiri (~> 1.6)
-      rails-deprecated_sanitizer (>= 1.0.1)
+    rails (5.0.7.2)
+      actioncable (= 5.0.7.2)
+      actionmailer (= 5.0.7.2)
+      actionpack (= 5.0.7.2)
+      actionview (= 5.0.7.2)
+      activejob (= 5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activerecord (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      bundler (>= 1.3.0)
+      railties (= 5.0.7.2)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails-i18n (4.0.9)
-      i18n (~> 0.7)
-      railties (~> 4.0)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     rails_safe_tasks (1.0.0)
-    railties (4.2.11.3)
-      actionpack (= 4.2.11.3)
-      activesupport (= 4.2.11.3)
+    railties (5.0.7.2)
+      actionpack (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
-    ransack (1.8.10)
-      actionpack (>= 3.0, < 5.2)
-      activerecord (>= 3.0, < 5.2)
-      activesupport (>= 3.0, < 5.2)
+    ransack (2.3.0)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
       i18n
+      polyamorous (= 2.3.0)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbvmomi (2.4.1)
-      builder (~> 3.0)
-      json (>= 1.8)
-      nokogiri (~> 1.5)
-      optimist (~> 3.0)
     redcarpet (3.5.0)
+    regexp_parser (1.8.2)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.2.4)
     roadie (3.5.1)
       css_parser (~> 1.4)
@@ -630,6 +452,7 @@ GEM
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
+    ruby2_keywords (0.0.2)
     rubyzip (1.3.0)
     sass (3.4.25)
     sass-rails (5.0.7)
@@ -651,22 +474,22 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    spring (1.7.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    spring (2.0.2)
+      activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (2.12.5)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.2.2)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     state_machines (0.5.0)
     state_machines-activemodel (0.7.1)
       activemodel (>= 4.1)
@@ -674,23 +497,22 @@ GEM
     state_machines-activerecord (0.6.0)
       activerecord (>= 4.1)
       state_machines-activemodel (>= 0.5.0)
-    stringex (1.5.1)
+    stringex (2.8.5)
     stripe (5.28.0)
     temple (0.8.2)
     test-prof (0.7.5)
-    test-unit (3.3.6)
+    test-unit (3.3.7)
       power_assert
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (1.4.1)
+    tilt (2.0.10)
     timecop (0.9.2)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     unicorn (5.7.0)
       kgio (~> 2.6)
@@ -701,8 +523,8 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
-    warden (1.2.7)
-      rack (>= 1.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     webdrivers (4.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -711,13 +533,15 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.6.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     whenever (1.0.0)
       chronic (>= 0.6.3)
     wicked_pdf (2.1.0)
       activesupport
-    wkhtmltopdf-binary (0.12.5)
+    wkhtmltopdf-binary (0.12.6.5)
     xml-simple (1.1.5)
-    xmlrpc (0.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -727,24 +551,24 @@ PLATFORMS
 DEPENDENCIES
   actionpack-action_caching
   active_model_serializers (= 0.8.4)
-  activemerchant (~> 1.78.0)
+  activemerchant (>= 1.78.0)
   activerecord-import
   activerecord-postgresql-adapter
   activerecord-session_store
   acts-as-taggable-on (~> 4.0)
-  acts_as_list (= 0.3.0)
+  acts_as_list (= 0.9.19)
   andand
-  angular-rails-templates (~> 0.3.0)
+  angular-rails-templates (>= 0.3.0)
   angularjs-file-upload-rails (~> 2.4.1)
   angularjs-rails (= 1.5.5)
   atomic
-  awesome_nested_set (~> 3.2.1)
+  awesome_nested_set
   awesome_print
   aws-sdk (= 1.67.0)
   bugsnag
   byebug (~> 11.0.0)
   cancan (~> 1.6.10)
-  capybara (>= 2.18.0)
+  capybara (= 3.15)
   catalog!
   coffee-rails (~> 4.2.2)
   combine_pdf
@@ -753,18 +577,17 @@ DEPENDENCIES
   daemons
   dalli
   database_cleaner
-  db2fog
   ddtrace
   debugger-linecache
   delayed_job_active_record
   delayed_job_web
-  devise (~> 3.5.10)
+  devise
   devise-encryptable
-  devise-token_authenticatable (~> 0.4.10)
+  devise-token_authenticatable
   dfc_provider!
   eventmachine (>= 1.2.3)
   factory_bot_rails (= 4.10.0)
-  ffaker (~> 1.16)
+  ffaker
   figaro
   foundation-icons-sass-rails
   foundation-rails (= 5.5.2.1)
@@ -777,17 +600,16 @@ DEPENDENCIES
   i18n-js (~> 3.8.0)
   immigrant
   jquery-migrate-rails
-  jquery-rails (= 3.1.5)
+  jquery-rails (= 4.4.0)
   jquery-ui-rails (~> 4.2)
   json
   json_spec (~> 1.1.4)
   jwt (~> 2.2)
-  kaminari (~> 0.17.0)
+  kaminari (= 1.2.1)
   knapsack
   letter_opener (>= 1.4.1)
   mini_racer (= 0.2.15)
   money (< 6.1.0)
-  newrelic_rpm (~> 3.0)
   oauth2 (~> 1.4.4)
   ofn-qz!
   oj
@@ -796,17 +618,16 @@ DEPENDENCIES
   paperclip (~> 3.4.1)
   paranoia (~> 2.0)
   pg (~> 0.21.0)
-  pry (~> 0.12.0)
-  pry-byebug (~> 3.7.0)
+  pry (>= 0.12.0)
   rack-mini-profiler (< 3.0.0)
   rack-rewrite
   rack-ssl
-  rails (~> 4.2)
+  rails (> 5.0, < 5.1)
   rails-i18n
   rails_safe_tasks (~> 1.0)
-  ransack (~> 1.8.10)
+  ransack (= 2.3.0)
   redcarpet
-  responders (~> 2.0)
+  responders
   roadie-rails (~> 1.3.0)
   roo (~> 2.8.3)
   rspec-rails (>= 3.5.2)
@@ -814,24 +635,23 @@ DEPENDENCIES
   rswag
   rubocop
   rubocop-rails
-  sass
-  sass-rails
+  sass (<= 4.7.1)
+  sass-rails (< 6.0.0)
   select2-rails (~> 3.4.7)
   selenium-webdriver
   shoulda-matchers
   simplecov
-  spree_i18n!
   spree_paypal_express!
   spring
   spring-commands-rspec
   state_machines-activerecord
-  stringex (~> 1.5.1)
+  stringex (~> 2.8.5)
   stripe
   test-prof
   test-unit (~> 3.3)
+  test_after_commit
   timecop
   uglifier (>= 1.0.3)
-  unicorn
   unicorn-rails
   unicorn-worker-killer
   web!


### PR DESCRIPTION
#### What? Why?

This starts with https://github.com/openfoodfoundation/openfoodnetwork/issues/6346 and closes https://github.com/openfoodfoundation/openfoodnetwork/issues/4800

All credit for making the gemfile dependencies work in rails 5 is for @Matt-Yorkley (I coudlnt make it work!) :clap: :clap:
https://github.com/Matt-Yorkley/openfoodnetwork/commits/rails-5-0
 
All I did was to make it dual bootable. The beauty is that this PR **can be merged to master** and you can run BOTH green:
bundle install      (rails 4.2)
and 
DEPENDENCIES_NEXT=1 bundle install       (rails 5)

NOTE: I think we can make the Gemfile simpler than this, I dont think we need so many gems inside the first if ENV['DEPENDENCIES_NEXT'], we can move some to the shared space.

#### What should we test?
I am not sure we even need a sanity check on the app running on rails 4.2...
We can then start looking at the rails 5 build and fix problems **in master**!!!

#### Release notes
Changelog Category: Technical changes
Setup dual boot for rails 5 upgrade.