### PR TITLE
fix #5829 (Voiding an initial payment (i.e. a full refund) after partially refunding the order is not possible with Stripe-SCA)

### DIFF
--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -61,7 +61,7 @@ module Spree
         payment_intent_response = Stripe::PaymentIntent.retrieve(payment_intent_id,
                                                                  stripe_account: stripe_account_id)
         gateway_options[:stripe_account] = stripe_account_id
-        provider.refund(payment_intent_response.amount_received, response_code, gateway_options)
+        provider.refund(refundable_amount(payment_intent_response), response_code, gateway_options)
       end
 
       # NOTE: the name of this method is determined by Spree::Payment::Processing
@@ -78,6 +78,11 @@ module Spree
       end
 
       private
+
+      def refundable_amount(payment_intent_response)
+        payment_intent_response.amount_received -
+          payment_intent_response.charges.data.map(&:amount_refunded).sum
+      end
 
       # In this gateway, what we call 'secret_key' is the 'login'
       def options

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
@@ -154,12 +154,11 @@ describe Spree::Admin::PaymentsController, type: :controller do
         before do
           allow(Stripe).to receive(:api_key) { "sk_test_12345" }
           allow(StripeAccount).to receive(:find_by) { stripe_account }
-
-          stub_payment_intent_get_request
         end
 
         context "where the request succeeds" do
           before do
+            stub_payment_intent_get_request
             # Issues the refund
             stub_request(:post, "https://api.stripe.com/v1/charges/ch_1234/refunds").
               with(basic_auth: ["sk_test_12345", ""]).
@@ -181,6 +180,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
         context "where the request fails" do
           before do
+            stub_payment_intent_get_request
             stub_request(:post, "https://api.stripe.com/v1/charges/ch_1234/refunds").
               with(basic_auth: ["sk_test_12345", ""]).
               to_return(status: 200, body: JSON.generate(error: { message: "Bup-bow!" }) )
@@ -196,6 +196,27 @@ describe Spree::Admin::PaymentsController, type: :controller do
             expect(order.payment_total).to_not eq 0
             expect(order.outstanding_balance).to eq 0
             expect(flash[:error]).to eq "Bup-bow!"
+          end
+        end
+
+        context "when a partial refund has already been issued" do
+          before do
+            stub_payment_intent_get_request(response: { amount_refunded: 200 })
+            stub_request(:post, "https://api.stripe.com/v1/charges/ch_1234/refunds").
+              with(basic_auth: ["sk_test_12345", ""]).
+              to_return(status: 200,
+                        body: JSON.generate(id: 're_123', object: 'refund', status: 'succeeded') )
+          end
+
+          it "can still void the payment" do
+            order.reload
+            expect(order.payment_total).to_not eq 0
+            expect(order.outstanding_balance).to eq 0
+            spree_put :fire, params
+            expect(payment.reload.state).to eq 'void'
+            order.reload
+            expect(order.payment_total).to eq 0
+            expect(order.outstanding_balance).to_not eq 0
           end
         end
       end

--- a/spec/support/request/stripe_stubs.rb
+++ b/spec/support/request/stripe_stubs.rb
@@ -68,6 +68,7 @@ module StripeStubs
   private
 
   def payment_intent_authorize_response_mock(options)
+    chargedata = [{ id: "ch_1234", amount: 2000, amount_refunded: options[:amount_refunded] || 0 }]
     { status: options[:code] || 200,
       body: JSON.generate(id: "pi_123",
                           object: "payment_intent",
@@ -75,9 +76,7 @@ module StripeStubs
                           amount_received: 2000,
                           status: options[:intent_status] || "requires_capture",
                           last_payment_error: nil,
-                          charges: {
-                            data: [{ id: "ch_1234", amount: 2000, amount_refunded: 0 }] })
-                          }
+                          charges: { data: chargedata }) }
   end
 
   def payment_intent_redirect_response_mock(redirect_url)

--- a/spec/support/request/stripe_stubs.rb
+++ b/spec/support/request/stripe_stubs.rb
@@ -75,7 +75,9 @@ module StripeStubs
                           amount_received: 2000,
                           status: options[:intent_status] || "requires_capture",
                           last_payment_error: nil,
-                          charges: { data: [{ id: "ch_1234", amount: 2000 }] }) }
+                          charges: {
+                            data: [{ id: "ch_1234", amount: 2000, amount_refunded: 0 }] })
+                          }
   end
 
   def payment_intent_redirect_response_mock(redirect_url)


### PR DESCRIPTION
#### What? Why?

Closes #5829 

This adds a method to calculate the refundable amount by looking at the `charges` property of the returned `PaymentIntent` from Stripe. A charge is created when a partial refund is issued. If there are no partial refunds issued, the full amount will still be refunded. 


#### What should we test?
See issue's Steps to Reproduce

#### Release notes
Fixed a bug that prevented payments from being refunded if a partial refund had already been issued. 

Changelog Category: User facing changes

#### Dependencies

#### Documentation updates
