### PR TITLE
Update default card/authorized shops UI (v2.0)

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
@@ -1,7 +1,7 @@
 Darkswarm.controller "CreditCardsCtrl", ($scope, CreditCard, CreditCards) ->
   angular.extend(this, new FieldsetMixin($scope))
   $scope.savedCreditCards = CreditCards.saved
-  $scope.setDefault = CreditCards.setDefault
+  $scope.confirmSetDefault = CreditCards.confirmSetDefault
   $scope.CreditCard = CreditCard
   $scope.secrets = CreditCard.secrets
   $scope.showForm = CreditCard.show

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -5,17 +5,20 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages, Cu
     add: (card) ->
       @saved.push card
 
+    setDefault: (card) =>
+      card.is_default = true
+      for othercard in @saved when othercard != card
+        othercard.is_default = false
+      $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
+        Messages.success(t('js.default_card_updated'))
+        for customer in Customers.index()
+          customer.allow_charges = false
+      , (response) ->
+        Messages.flash(response.data.flash)
+
     confirmSetDefault: (card, event) =>
       if confirm t("js.default_card_voids_auth")
-        card.is_default = true
-        for othercard in @saved when othercard != card
-          othercard.is_default = false
-        $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
-          Messages.success(t('js.default_card_updated'))
-          for customer in Customers.index()
-            customer.allow_charges = false
-        , (response) ->
-          Messages.flash(response.data.flash)
+        @setDefault(card)
       else
         event.preventDefault()
         return false

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -5,11 +5,15 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages)->
     add: (card) ->
       @saved.push card
 
-    setDefault: (card) =>
-      card.is_default = true
-      for othercard in @saved when othercard != card
-        othercard.is_default = false
-      $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
-        Messages.success(t('js.default_card_updated'))
-      , (response) ->
-        Messages.flash(response.data.flash)
+    confirmSetDefault: (card, event) =>
+      if confirm t("js.default_card_voids_auth")
+        card.is_default = true
+        for othercard in @saved when othercard != card
+          othercard.is_default = false
+        $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
+          Messages.success(t('js.default_card_updated'))
+        , (response) ->
+          Messages.flash(response.data.flash)
+      else
+        event.preventDefault()
+        return false

--- a/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/credit_cards.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages)->
+Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages, Customers)->
   new class CreditCard
     saved: $filter('orderBy')(savedCreditCards,'-is_default')
 
@@ -12,6 +12,8 @@ Darkswarm.factory 'CreditCards', ($http, $filter, savedCreditCards, Messages)->
           othercard.is_default = false
         $http.put("/credit_cards/#{card.id}", is_default: true).then (data) ->
           Messages.success(t('js.default_card_updated'))
+          for customer in Customers.index()
+            customer.allow_charges = false
         , (response) ->
           Messages.flash(response.data.flash)
       else

--- a/app/controllers/spree/credit_cards_controller.rb
+++ b/app/controllers/spree/credit_cards_controller.rb
@@ -27,6 +27,7 @@ module Spree
       authorize! :update, @credit_card
 
       if @credit_card.update(credit_card_params)
+        remove_shop_authorizations if credit_card_params["is_default"]
         render json: @credit_card, serializer: ::Api::CreditCardSerializer, status: :ok
       else
         update_failed
@@ -55,6 +56,10 @@ module Spree
     end
 
     private
+
+    def remove_shop_authorizations
+      @credit_card.user.customers.update_all(allow_charges: false)
+    end
 
     # It destroys the whole customer object
     def destroy_at_stripe

--- a/app/views/spree/users/_authorised_shops.html.haml
+++ b/app/views/spree/users/_authorised_shops.html.haml
@@ -1,5 +1,8 @@
 %table
   %tr
+    %td{ colspan: 2 }
+      = t('spree.users.cards.authorised_shops_agreement')
+  %tr
     %th= t(".shop_name")
     %th= t(".allow_charges?")
   %tr.customer{ id: "customer{{ customer.id }}", ng: { repeat: "customer in customers" } }

--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -18,7 +18,7 @@
         .new_card{ ng: { show: 'CreditCard.visible', class: '{visible: CreditCard.visible}' } }
           %h3= t(:add_new_credit_card)
           = render 'new_card_form'
-        .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible' } }
+        .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible || savedCreditCards.length == 0' } }
           %h3
             = t('.authorised_shops')
             %button.button.secondary.tiny.help-btn.ng-scope{ "help-modal" => t('.authorised_shops_popover') }

--- a/app/views/spree/users/_cards.html.haml
+++ b/app/views/spree/users/_cards.html.haml
@@ -21,6 +21,4 @@
         .authorised_shops{ ng: { controller: 'AuthorisedShopsCtrl', hide: 'CreditCard.visible || savedCreditCards.length == 0' } }
           %h3
             = t('.authorised_shops')
-            %button.button.secondary.tiny.help-btn.ng-scope{ "help-modal" => t('.authorised_shops_popover') }
-              %i.ofn-i_013-help
           = render 'authorised_shops'

--- a/app/views/spree/users/_saved_cards.html.haml
+++ b/app/views/spree/users/_saved_cards.html.haml
@@ -10,7 +10,7 @@
     %td.number{ ng: { bind: '::card.number' } }
     %td.expiry{ ng: { bind: '::card.expiry' } }
     %td.is-default
-      %input{ type: 'radio', name: 'default_card', ng: { model: 'card.is_default', change: 'setDefault(card)', value: "true"} }
+      %input{ type: 'radio', name: 'default_card', ng: { model: 'card.is_default', click: 'confirmSetDefault(card, $event)', value: "true"} }
     %td.actions
       %a{"rel" => "nofollow", "data-method" => "delete", "ng-href" => "{{card.delete_link}}" }
         = t(:delete)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3700,7 +3700,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         delete?: Delete?
       cards:
         authorised_shops: Authorised Shops
-        authorised_shops_popover: This is the list of shops which are permitted to charge your default credit card for any subscriptions (ie. repeating orders) you may have. Your card details will be kept secure and will not be shared with shop owners. You will always be notified when you are charged.
+        authorised_shops_agreement: This is the list of shops which are permitted to charge your default credit card for any subscriptions (ie. repeating orders) you may have. Your card details will be kept secure and will not be shared with shop owners. You will always be notified when you are charged. By checking the box for a shop, you are agreeing to authorise that shop to send instructions to the financial institution that issued your card to take payments in accordance with the terms of any subscription you create with that shop.
         saved_cards_popover: This is the list of cards you have opted to save for later use. Your 'default' will be selected automatically when you checkout an order, and can be charged by any shops you have allowed to do so (see right).
       authorised_shops:
         shop_name: "Shop Name"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2524,6 +2524,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     resolve_errors: Please resolve the following errors
     more_items: "+ %{count} More"
     default_card_updated: Default Card Updated
+    default_card_voids_auth: Changing your default card will remove shops' existing authorizations to charge it. You can re-authorize shops after updating the default card. Do you wish to change the default card?"
     cart:
       add_to_cart_failed: >
         There was a problem adding this product to the cart.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3703,7 +3703,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         saved_cards_popover: This is the list of cards you have opted to save for later use. Your 'default' will be selected automatically when you checkout an order, and can be charged by any shops you have allowed to do so (see right).
       authorised_shops:
         shop_name: "Shop Name"
-        allow_charges?: "Allow Charges?"
+        allow_charges?: "Allow Charges to Default Card?"
     localized_number:
       invalid_format: has an invalid format. Please enter a number.
     api:

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -67,7 +67,7 @@ describe Spree::CreditCardsController, type: :controller do
     end
   end
 
-  describe "#update" do
+  describe "#update card to be the default card" do
     let(:params) { { format: :json, credit_card: { is_default: true } } }
     context "when the specified credit card is not found" do
       before { params[:id] = 123 }
@@ -108,6 +108,23 @@ describe Spree::CreditCardsController, type: :controller do
             spree_put :update, params
             json_response = JSON.parse(response.body)
             expect(json_response['flash']['error']).to eq I18n.t(:card_could_not_be_updated)
+          end
+        end
+
+        context "and there are existing authorizations for the user" do
+          let!(:customer1) { create(:customer, allow_charges: true) }
+          let!(:customer2) { create(:customer, allow_charges: true) }
+
+          it "removes the authorizations" do
+            customer1.user = card.user
+            customer2.user = card.user
+            customer1.save
+            customer2.save
+            expect(customer1.reload.allow_charges).to be true
+            expect(customer2.reload.allow_charges).to be true
+            spree_put :update, params
+            expect(customer1.reload.allow_charges).to be false
+            expect(customer2.reload.allow_charges).to be false
           end
         end
       end

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -431,7 +431,7 @@ feature 'Subscriptions' do
     end
 
     describe "allowed variants" do
-      let!(:customer) { create(:customer, enterprise: shop, allow_charges: true) }
+      let!(:customer) { create(:customer, enterprise: shop) }
       let!(:credit_card) { create(:stored_credit_card, user: customer.user) }
       let!(:shop_product) { create(:product, supplier: shop) }
       let!(:shop_variant) { create(:variant, product: shop_product, unit_value: "2000") }
@@ -468,6 +468,7 @@ feature 'Subscriptions' do
       end
 
       it "permit creating and editing of the subscription" do
+        customer.update_attributes(allow_charges: true)
         # Fill in other details
         fill_in_subscription_basic_details
         click_button "Next"

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -51,6 +51,7 @@ feature "Credit Cards", js: true do
       # Allows switching of default card
       within(".card#card#{non_default_card.id}") do
         find_field('default_card').click
+        accept_alert
         expect(find_field('default_card')).to be_checked
       end
 

--- a/spec/javascripts/unit/darkswarm/services/credit_cards_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/credit_cards_spec.js.coffee
@@ -36,6 +36,7 @@ describe 'CreditCards service', ->
 
       it "loads a success flash", ->
         CreditCards.setDefault(card2)
+        $httpBackend.expectGET('/api/customers.json').respond 200, []
         $httpBackend.flush()
         expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({success: t('js.default_card_updated')})
 


### PR DESCRIPTION
#### What? Why?

Closes #4175. Pared down version of https://github.com/openfoodfoundation/openfoodnetwork/pull/6241
This is a precursor to additional SCA work. Here we just update the UI to explain how cards are used, and clear authorizations if the default card is changed. 

Bringing over two points from @mkllnk's initial review:
- As @mkllnk points out [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/6241#discussion_r535752706), we could consider altering the data model so that authorizations are not lost if the default card is toggled. This would also simplify the Stripe cloning/retrieval code, but comes at the cost of an increase in complexity of our data models. **I'd recommend we wait on this and consider it as an improvement after the deadline.** 

<s>- This adds some logic to the `Spree::CreditCard` model. We may want to consider moving that somewhere else.</s> This is now addressed in e90b22b914d23889c09f9d98aec71571b4581aba


#### What should we test?
Changing a default card should clear authorizations for all shops. 
The user should see a warning when changing the default card.
The text above the authorized cards table should adequately explain how cards are charged for subscriptions.


#### Release notes
Updated the saved credit cards UI

Changelog Category: User facing changes

#### Dependencies


#### Documentation updates
