### PR TITLE
Optimise Shipment#to_package

### DIFF
--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -249,8 +249,11 @@ module Spree
 
     def to_package
       package = OrderManagement::Stock::Package.new(stock_location, order)
-      inventory_units.includes(:variant).each do |inventory_unit|
-        package.add inventory_unit.variant, 1, inventory_unit.state_name
+      grouped_inventory_units = inventory_units.includes(:variant).group_by do |iu|
+        [iu.variant, iu.state_name]
+      end
+      grouped_inventory_units.each do |(variant, state_name), inventory_units|
+        package.add variant, inventory_units.count, state_name
       end
       package
     end


### PR DESCRIPTION
#### What? Why?

This performance improvement is added in a Spree 2.2 commit to reduce the amount of processing done in larger orders. Spotted when looking at adjustments changes in `2-2-stable`.

See: https://github.com/spree/spree/commit/ab01b1ec1e2b08068b3bfcca99c7886c0747514f for details.

#### What should we test?
<!-- List which features should be tested and how. -->

The `#to_package` method is used when checking different shipping rates for an order, and when calculating some adjustments. Maybe sanity check switching shipping methods at checkout and placing an order (with lots of items in the order, not just one)?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Backported a performance improvement for Shipment#to_package
