### PR TITLE
Soft-deleted products should not be "available"

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -274,7 +274,7 @@ module Spree
     end
 
     def available?
-      !(available_on.nil? || available_on.future?)
+      !(available_on.nil? || available_on.future?) && !deleted?
     end
 
     # split variants list into hash which shows mapping of opt value onto matching variants

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -96,6 +96,11 @@ module Spree
           product.available_on = 1.day.from_now
           expect(product).to_not be_available
         end
+
+        it "should not be available if destroyed" do
+          product.destroy
+          expect(product).to_not be_available
+        end
       end
 
       describe 'Variants sorting' do


### PR DESCRIPTION
#### What? Why?

Adds an upstream commit which apparently fixes a couple of Spree issues. Soft-deleted products should not respond to `available?` with `true`.

See: https://github.com/spree/spree/commit/6896870d7fc18f269e68f598c340db75789803d8

#### What should we test?
<!-- List which features should be tested and how. -->


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
