### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
 
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION


#### What? Why?
I found the dependabot config problem here: https://github.com/openfoodfoundation/openfoodnetwork/network/updates
yarn is not a valid value, here I change it to npm.

#### What should we test?
This is just a github config file.
