### PR TITLE
fixed capture payment

### DIFF
--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -40,7 +40,7 @@ module Api
 
       def ready_to_capture
         pending_payment = object.pending_payments.first
-        object.payment_required? && pending_payment
+        object.payment_required? && pending_payment && (order.state != "canceled")
       end
 
       def ready_to_ship


### PR DESCRIPTION
#### Listing Orders UX Improvement: Payment state of canceled cash/EFFs order
This fix will get rid of the capture payment button presented in the listing orders table when the state of an order is cancelled. This is important because no money is due when an order is cancelled.

Closes #5268 

Customer opts to pay for an order by cash/EFFs payment method. This order is then cancelled- either by the food enterprise or the customer- prior to payment being captured. If an order is then cancelled, the capture payment should disappear from the listing orders table. The current behavior has the capture payment button as still present.

One can test if when an order is made by cash and is cancelled before a payment is captured, does the "capture payment" button still exist for that order. This involves many functional tests and more rigorous testing may be required for the UI.

#### Release notes
For cancelled orders by cash/EFF's payment method before payment is captured, capture payment button is deleted 

User facing changes