### PR TITLE
Add steps for syncing releases with Transifex

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,6 +9,9 @@ assignees: ''
 
 Steps: 
 
+- [ ] Remove Transifex' [auto update] if present.
+- [ ] Upload source to Transifex: `tx push -s`
+- [ ] Merge [transifex pull request].
 - [ ] Include translations: `tx pull --force`
 - [ ] [Draft new release]
 - [ ] Notify #instance-managers of user-facing changes.
@@ -20,4 +23,6 @@ Steps:
 
 The full process is described at https://github.com/openfoodfoundation/openfoodnetwork/wiki/Releasing.
 
+[auto update]: https://www.transifex.com/open-food-foundation/open-food-network/content/
+[transifex pull request]: https://github.com/openfoodfoundation/openfoodnetwork/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+head%3Atransifex
 [Draft new release]: https://github.com/openfoodfoundation/openfoodnetwork/releases/new?tag=v&title=v+Code+Name&body=Congrats%0A%0ADescription%0A%0A%23%23+User+facing+changes+:eyes:%0A%0A%0A%0A%23%23+Technical+changes+:wrench:%0A%0A


### PR DESCRIPTION
#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We have been experimenting with new ways to sync translations with the current release. The main problems were:

* Translations are often not ready by Thursday, when the release is drafted. Last minute merges can make this impossible.
* Merges to master after the release has been drafted can throw the translations out of sync with the release. Translation updates after Thursday can't always be included in the release because they relate to master, not the release.
* And sometimes we would like the option to fix translations in the current release after it has been deployed on Tuesdays.

So we said that we don't want Transifex to update the source file automatically while a release is drafted and deployed. Maybe not even after the deploy.

Here I'm documenting my proposed solution of uploading the source file to Transifex manually when drafting the release.


#### What should we test?
<!-- List which features should be tested and how. -->

No tests needed.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Updated our release process.



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

If this is accepted, we should also update https://github.com/openfoodfoundation/openfoodnetwork/wiki/Releasing.