### PR TITLE
Fixed Translation for DatePicker

### DIFF
--- a/app/assets/javascripts/admin/spree/base.js.erb
+++ b/app/assets/javascripts/admin/spree/base.js.erb
@@ -127,7 +127,16 @@ $(document).ready(function() {
         nextText: Spree.translations.next,
         showOn: "focus"
       });
-
+      
+       $.datepicker.regional[I18n.locale] = {
+          prevText: Spree.translations.previous,
+          nextText: Spree.translations.next,
+          monthNames: Spree.translations.month_names,
+          dayNames: Spree.translations.abbr_day_names,
+          dayNamesMin: Spree.translations.abbr_day_names,
+          dateFormat: Spree.translations.date_picker
+      };
+      $.datepicker.setDefaults( $.datepicker.regional[I18n.locale]);
       // Correctly display range dates
       $('.date-range-filter .datepicker-from').datepicker('option', 'onSelect', function(selectedDate) {
         $(".date-range-filter .datepicker-to" ).datepicker( "option", "minDate", selectedDate );


### PR DESCRIPTION
#### What? Why?

Closes #6226
We have included a way to translate the datepicker months and weeks within the Orders page when logged in as an administrator. This change was needed because when the language of the website was something other than English, the months and days in the datepicker would still appear to be in English.

We found our fix by browsing the Datepicker widget opensource Code in the JQuery UI documentation. From here, we were able to understand how to properly translate the Datepicker.


#### What should we test?

More rigorous tests for datepicker might be needed in order to ensure the functionality of the translation.

#### Release notes

Translation for Datepicker has been fixed to support languages other than English.

Changelog Category: User facing changes