### PR TITLE
Fix users removing last item of confirmed order on /cart page

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
@@ -1,12 +1,19 @@
-Darkswarm.controller "EditBoughtOrderController", ($scope, $resource, Cart) ->
+Darkswarm.controller "EditBoughtOrderController", ($scope, $resource, $timeout, Cart) ->
   $scope.showBought = false
+  $scope.removeEnabled = true
 
   $scope.deleteLineItem = (id) ->
-    params = {id: id}
-    success = (response) ->
-      $(".line-item-" + id).remove()
-      Cart.removeFinalisedLineItem(id)
-    fail = (error) ->
-      console.log error
+    if Cart.check_last_finalised_item()
+      $scope.removeEnabled = false
+      $timeout (->
+        $scope.removeEnabled = true
+      ), 10000
+    else
+      params = {id: id}
+      success = (response) ->
+        $(".line-item-" + id).remove()
+        Cart.removeFinalisedLineItem(id)
+      fail = (error) ->
+        console.log error
 
-    $resource("/line_items/:id").delete(params, success, fail)
+      $resource("/line_items/:id").delete(params, success, fail)

--- a/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.controller "EditBoughtOrderController", ($scope, $resource, $timeout, Cart) ->
+Darkswarm.controller "EditBoughtOrderController", ($scope, $resource, $timeout, Cart, Messages) ->
   $scope.showBought = false
   $scope.removeEnabled = true
 

--- a/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
@@ -4,8 +4,8 @@ Darkswarm.controller "EditBoughtOrderController", ($scope, $resource, $timeout, 
 
   $scope.deleteLineItem = (id) ->
     if Cart.has_one_line_item()
-        Messages.error(t 'orders_cannot_remove_the_final_item')
-        $scope.removeEnabled = false
+      Messages.error(t 'orders_cannot_remove_the_final_item')
+      $scope.removeEnabled = false
       $timeout (->
         $scope.removeEnabled = true
       ), 10000

--- a/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
@@ -3,8 +3,9 @@ Darkswarm.controller "EditBoughtOrderController", ($scope, $resource, $timeout, 
   $scope.removeEnabled = true
 
   $scope.deleteLineItem = (id) ->
-    if Cart.check_last_finalised_item()
-      $scope.removeEnabled = false
+    if Cart.has_one_line_item()
+        Messages.error(t 'orders_cannot_remove_the_final_item')
+        $scope.removeEnabled = false
       $timeout (->
         $scope.removeEnabled = true
       ), 10000

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -115,6 +115,12 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       @line_items = []
       localStorageService.clearAll() # One day this will have to be moar GRANULAR
 
+    check_last_finalised_item: =>
+      if @line_items_finalised.length == 1
+        Messages.error(t 'orders_cannot_remove_the_final_item')
+
+      @line_items_finalised.length == 1
+
     removeFinalisedLineItem: (id) =>
       @line_items_finalised = @line_items_finalised.filter (item) ->
         item.id != id

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -116,7 +116,8 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       localStorageService.clearAll() # One day this will have to be moar GRANULAR
 
     has_one_line_item: =>
-        @line_items_finalised.length == 1
+      @line_items_finalised.length == 1
+
     removeFinalisedLineItem: (id) =>
       @line_items_finalised = @line_items_finalised.filter (item) ->
         item.id != id

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -115,12 +115,8 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       @line_items = []
       localStorageService.clearAll() # One day this will have to be moar GRANULAR
 
-    check_last_finalised_item: =>
-      if @line_items_finalised.length == 1
-        Messages.error(t 'orders_cannot_remove_the_final_item')
-
-      @line_items_finalised.length == 1
-
+    has_one_line_item: =>
+        @line_items_finalised.length == 1
     removeFinalisedLineItem: (id) =>
       @line_items_finalised = @line_items_finalised.filter (item) ->
         item.id != id

--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -28,5 +28,5 @@
         = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
 
       %td.bought-item-delete.text-center
-        %a{ng: {click: "deleteLineItem(#{line_item.id})"}}
+        %a{ng: {click: "removeEnabled && deleteLineItem(#{line_item.id})"}}
           %i.ofn-i_026-trash

--- a/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
@@ -227,10 +227,7 @@ describe 'Cart service', ->
       spyOn(RailsFlashLoader, 'loadFlash')
       li = {variant: {id: 1}, quantity: 3}
       Cart.line_items_finalised = [li]
-      Cart.check_last_finalised_item()
-      expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith(
-        {error: t 'orders_cannot_remove_the_final_item'}
-      )
+      expect(Cart.has_one_line_item()).toBe(true)
 
   it "pops the queue", ->
     Cart.update_enqueued = true

--- a/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
@@ -222,6 +222,16 @@ describe 'Cart service', ->
         expect(li.quantity).toEqual 1
         expect(li.max_quantity).toEqual 1
 
+  describe "when modifying a confirmed order", ->
+    it "displays flash error when attempting to remove final item", ->
+      spyOn(RailsFlashLoader, 'loadFlash')
+      li = {variant: {id: 1}, quantity: 3}
+      Cart.line_items_finalised = [li]
+      Cart.check_last_finalised_item()
+      expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith(
+        {error: t 'orders_cannot_remove_the_final_item'}
+      )
+
   it "pops the queue", ->
     Cart.update_enqueued = true
     spyOn(Cart, 'scheduleUpdate')


### PR DESCRIPTION
#### What? Why?

Closes #5546

This change prevents users from removing the last item of a confirmed order on the /cart page. This was allowed when shops had the option to edit confirmed orders for the same OC. 

The functionality is similar to what happens when an order is edited from the /orders page. The main difference is that it displays the error without a page reload. The remove button is disabled when a user presses it for 10s (the time the flash error message is displayed for) to prevent multiple error messages appearing with each button press.

#### What should we test?
When a shop allows edits to confirmed orders, ensure that user cannot remove last item of a confirmed order in the /cart page.
Confirm that attempting to remove an item multiple times displays at most one error message.

#### Release notes
Customers can no longer remove the last item of a confirmed order on the /cart page.

Changelog Category: User facing changes

#### Dependencies
This fix is related to #5505 and should prevent one possible cause for this bug of getting a 500 error when viewing an order from which all items were removed.