### PR TITLE
Patch #6469: use `purchase` to charge offline for Stripe Connect

### DIFF
--- a/app/models/spree/gateway/stripe_connect.rb
+++ b/app/models/spree/gateway/stripe_connect.rb
@@ -31,6 +31,10 @@ module Spree
         failed_activemerchant_billing_response(e.message)
       end
 
+      def charge_offline(money, creditcard, gateway_options)
+        purchase(money, creditcard, gateway_options)
+      end
+
       # NOTE: the name of this method is determined by Spree::Payment::Processing
       def void(response_code, _creditcard, gateway_options)
         gateway_options[:stripe_account] = stripe_account_id

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -134,6 +134,48 @@ describe SubscriptionConfirmJob do
       expect(job).to receive(:record_order)
     end
 
+    context "when Stripe payments need to be processed" do
+      let(:charge_response_mock) do
+        { status: 200, body: JSON.generate(id: "ch_1234", object: "charge", amount: 2000) }
+      end
+
+      before do
+        allow(order).to receive(:payment_required?) { true }
+        expect(job).to receive(:setup_payment!) { true }
+        stub_request(:post, "https://api.stripe.com/v1/charges")
+          .with(body: /amount/)
+          .to_return(charge_response_mock)
+      end
+
+      context "Stripe SCA" do
+        let(:stripe_sca_payment_method) { create(:stripe_sca_payment_method) }
+        let(:stripe_sca_payment) { create(:payment, amount: 10, payment_method: stripe_sca_payment_method) }
+
+        before do
+          allow(order).to receive(:pending_payments) { [stripe_sca_payment] }
+          expect(stripe_sca_payment_method).to receive(:charge_offline)
+        end
+
+        it "runs the charges in offline mode" do
+          job.send(:confirm_order!, order)
+        end
+      end
+
+      context "Stripe Connect" do
+        let(:stripe_connect_payment_method) { create(:stripe_connect_payment_method) }
+        let(:stripe_connect_payment) { create(:payment, amount: 10, payment_method: stripe_connect_payment_method) }
+
+        before do
+          allow(order).to receive(:pending_payments) { [stripe_connect_payment] }
+          expect(stripe_connect_payment_method).to receive(:charge_offline)
+        end
+
+        it "runs the charges in offline mode" do
+          job.send(:confirm_order!, order)
+        end
+      end
+    end
+
     context "when payments need to be processed" do
       let(:payment_method) { create(:payment_method) }
       let(:payment) { create(:payment, amount: 10) }

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -150,14 +150,18 @@ describe SubscriptionConfirmJob do
       context "Stripe SCA" do
         let(:stripe_sca_payment_method) { create(:stripe_sca_payment_method) }
         let(:stripe_sca_payment) { create(:payment, amount: 10, payment_method: stripe_sca_payment_method) }
+        let(:provider) { double }
 
         before do
+          allow_any_instance_of(Stripe::CreditCardCloner).to receive(:find_or_clone) { ["cus_123", "pm_1234"] }
           allow(order).to receive(:pending_payments) { [stripe_sca_payment] }
-          expect(stripe_sca_payment_method).to receive(:charge_offline)
+          allow(stripe_sca_payment_method).to receive(:provider) { provider }
+          allow(stripe_sca_payment_method.provider).to receive(:purchase) { true }
         end
 
         it "runs the charges in offline mode" do
           job.send(:confirm_order!, order)
+          expect(stripe_sca_payment_method.provider).to have_received(:purchase)
         end
       end
 
@@ -167,11 +171,12 @@ describe SubscriptionConfirmJob do
 
         before do
           allow(order).to receive(:pending_payments) { [stripe_connect_payment] }
-          expect(stripe_connect_payment_method).to receive(:charge_offline)
+          allow(stripe_connect_payment_method).to receive(:purchase) { true }
         end
 
         it "runs the charges in offline mode" do
           job.send(:confirm_order!, order)
+          expect(stripe_connect_payment_method).to have_received(:purchase)
         end
       end
     end

--- a/spec/models/spree/gateway/stripe_connect_spec.rb
+++ b/spec/models/spree/gateway/stripe_connect_spec.rb
@@ -91,4 +91,15 @@ describe Spree::Gateway::StripeConnect, type: :model do
       expect(provider).to have_received(:refund).with(money, response_code, hash_including(stripe_account: stripe_account_id))
     end
   end
+
+  describe "#charging offline" do
+    let(:gateway_options) { { some: 'option' } }
+    let(:money) { double(:money) }
+    let(:card) { double(:creditcard) }
+
+    it "uses #purchase to charge offline" do
+      subject.charge_offline(money, card, gateway_options)
+      expect(provider).to have_received(:purchase).with('money', 'cc', 'opts')
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Fixes a regression discovered in #6469 where subscriptions were not working for Stripe Connect

Closes #6543 

#### What should we test?
Charging a subscription that is set up with Stripe Connect.


#### Release notes
n/a


#### Dependencies


#### Documentation updates
