### PR TITLE
Enable new customer balance for the beta testers

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -60,4 +60,11 @@ SMTP_PASSWORD: 'f00d'
 # STRIPE_CLIENT_ID: "ca_xxxx" # This can be a development ID or a production ID
 # STRIPE_ENDPOINT_SECRET: "whsec_xxxx"
 
+# Feature toggles
+#
+# Adding user emails separated by commas will enable them the use of certain features. See
+# config/initializers/feature_toggles.rb for details.
+#
+# BETA_TESTERS: ofn@example.com,superadmin@example.com
+
 MEMCACHED_VALUE_MAX_MEGABYTES: '4'

--- a/config/initializers/feature_toggles.rb
+++ b/config/initializers/feature_toggles.rb
@@ -1,0 +1,5 @@
+require 'open_food_network/feature_toggle'
+
+beta_testers = ENV['BETA_TESTERS']&.split(/[\s,]+/)
+
+OpenFoodNetwork::FeatureToggle.enable(:customer_balance, beta_testers)


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/pull/6366/

This enables the use of the new customer balance implementation to whatever users we specify in the BETA_TESTERS env var with https://github.com/openfoodfoundation/ofn-install/pull/684/

This var is meant to contain the user emails that will log in such as personal accounts (I have an account with admin access to my hub) or superadmin accounts used by the core team. This way can gather early feedback ourselves while not releasing the new logic to users.

#### What should we test?

A dev can do a quick test that the value from the env var is successfully picked up.

#### Release notes

Enable the new customer balance implementation to the core team only by means of a feature toggle.
Changelog Category: Technical changes
