### PR TITLE
Flaky tag spec: use send_keys instead of set; only find the element once

### DIFF
--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -141,7 +141,10 @@ module WebHelper
   def fill_in_tag(tag_name, selector = "tags-input .tags input")
     expect(page).to have_selector selector
     find(:css, selector).send_keys(tag_name, :return)
-    expect(page).to have_selector ".tag-list .tag-item span", text: tag_name
+    tag_selector = ".tag-list .tag-item span"
+    expect(page).to have_selector tag_selector
+    tag = find(:css, tag_selector)
+    expect(tag.text(:all)).to eq(tag_name)
   end
 
   private

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -140,8 +140,7 @@ module WebHelper
 
   def fill_in_tag(tag_name, selector = "tags-input .tags input")
     expect(page).to have_selector selector
-    find(:css, selector).send_keys ""
-    find(:css, selector).set "#{tag_name}\n"
+    find(:css, selector).send_keys(tag_name, :return)
     expect(page).to have_selector ".tag-list .tag-item span", text: tag_name
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #6165 


#### What should we test?
Green build



#### Release notes
Fixed a flaky spec

Changelog Category: Technical changes


#### Dependencies

#### Documentation updates
