### PR TITLE
Add internationalization to payment method clean name

### DIFF
--- a/app/models/spree/payment_method.rb
+++ b/app/models/spree/payment_method.rb
@@ -110,8 +110,8 @@ module Spree
     end
 
     def self.clean_name
-      I18n_key = "spree.admin.payment_methods.providers." + name.demodulize.downcase
-      I18n.t(I18n_key)
+      i18n_key = "spree.admin.payment_methods.providers." + name.demodulize.downcase
+      I18n.t(i18n_key)
     end
 
     private

--- a/app/models/spree/payment_method.rb
+++ b/app/models/spree/payment_method.rb
@@ -110,23 +110,9 @@ module Spree
     end
 
     def self.clean_name
-      case name
-      when "Spree::PaymentMethod::Check"
-        "Cash/EFT/etc. (payments for which automatic validation is not required)"
-      when "Spree::Gateway::Migs"
-        "MasterCard Internet Gateway Service (MIGS)"
-      when "Spree::Gateway::Pin"
-        "Pin Payments"
-      when "Spree::Gateway::StripeConnect"
-        "Stripe"
-      when "Spree::Gateway::StripeSCA"
-        "Stripe SCA"
-      when "Spree::Gateway::PayPalExpress"
-        "PayPal Express"
-      else
-        i = name.rindex('::') + 2
-        name[i..-1]
-      end
+      i = name.rindex('::') + 2
+      i18n_name = "spree.admin.payment_methods.providers." + name[i..-1].downcase
+      I18n.t(i18n_name)
     end
 
     private

--- a/app/models/spree/payment_method.rb
+++ b/app/models/spree/payment_method.rb
@@ -110,9 +110,8 @@ module Spree
     end
 
     def self.clean_name
-      i = name.rindex('::') + 2
-      i18n_name = "spree.admin.payment_methods.providers." + name[i..-1].downcase
-      I18n.t(i18n_name)
+      I18n_key = "spree.admin.payment_methods.providers." + name.demodulize.downcase
+      I18n.t(I18n_key)
     end
 
     private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3431,6 +3431,14 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           deactivation_warning: "De-activating a payment method can make the payment method disappear from your list. Alternatively, you can hide a payment method from the checkout page by setting the option 'Display' to 'back office only'."
         providers:
           provider: "Provider"
+          check: "Cash/EFT/etc. (payments for which automatic validation is not required)"
+          migs: "MasterCard Internet Gateway Service (MIGS)"
+          pin: "Pin Payments"
+          paypalexpress: "PayPal Express"
+          stripeconnect: "Stripe"
+          stripesca: "Stripe SCA"
+          bogus: "Bogus"
+          bogussimple: "BogusSimple"
       payments:
         source_forms:
           stripe:

--- a/spec/models/spree/payment_method_spec.rb
+++ b/spec/models/spree/payment_method_spec.rb
@@ -58,14 +58,14 @@ module Spree
     end
 
     it "generates a clean name for known Payment Method types" do
-      expect(Spree::PaymentMethod::Check.clean_name).to eq("Cash/EFT/etc. (payments for which automatic validation is not required)")
-      expect(Spree::Gateway::Migs.clean_name).to eq("MasterCard Internet Gateway Service (MIGS)")
-      expect(Spree::Gateway::Pin.clean_name).to eq("Pin Payments")
-      expect(Spree::Gateway::PayPalExpress.clean_name).to eq("PayPal Express")
-      expect(Spree::Gateway::StripeConnect.clean_name).to eq("Stripe")
-
-      # Testing else condition
-      expect(Spree::Gateway::BogusSimple.clean_name).to eq("BogusSimple")
+      expect(Spree::PaymentMethod::Check.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.check"))
+      expect(Spree::Gateway::Migs.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.migs"))
+      expect(Spree::Gateway::Pin.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.pin"))
+      expect(Spree::Gateway::PayPalExpress.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.paypalexpress"))
+      expect(Spree::Gateway::StripeConnect.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.stripeconnect"))
+      expect(Spree::Gateway::StripeSCA.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.stripesca"))
+      expect(Spree::Gateway::BogusSimple.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.bogussimple"))
+      expect(Spree::Gateway::Bogus.clean_name).to eq(I18n.t("spree.admin.payment_methods.providers.bogus"))
     end
 
     it "computes the amount of fees" do


### PR DESCRIPTION
#### What? Why?

Closes #6535 

This adds internationalization to the payment method model clean name method, fixing the internationalzation of the new payment method at the admin panel

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Test create new payment method at admin panel


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Internationalization added at creating new payment method at admin panel for the payment method type
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 

