### PR TITLE
Bugfix/Instagram links validation and migration to update the current db

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -5,6 +5,7 @@ require 'spree/core/s3_support'
 class Enterprise < ActiveRecord::Base
   SELLS = %w(unspecified none own any).freeze
   ENTERPRISE_SEARCH_RADIUS = 100
+  INSTAGRAM_REGEX = %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
 
   preference :shopfront_message, :text, default: ""
   preference :shopfront_closed_message, :text, default: ""
@@ -379,11 +380,7 @@ class Enterprise < ActiveRecord::Base
   end
 
   def instagram=(value)
-    self[:instagram] = value.downcase.try(:gsub, instagram_regex, '\1').delete('@')
-  end
-
-  def instagram_regex
-    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
+    self[:instagram] = value.downcase.try(:gsub, INSTAGRAM_REGEX, '\1').delete('@')
   end
 
   protected
@@ -393,8 +390,6 @@ class Enterprise < ActiveRecord::Base
   end
 
   private
-
-
 
   def current_exchange_variants
     ExchangeVariant.joins(exchange: :order_cycle)

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -379,7 +379,11 @@ class Enterprise < ActiveRecord::Base
   end
 
   def instagram=(value)
-    self[:instagram] = value.downcase.try(:gsub, instagram_regex, '\1').gsub('@', '')
+    self[:instagram] = value.downcase.try(:gsub, instagram_regex, '\1').delete('@')
+  end
+
+  def instagram_regex
+    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
   end
 
   protected
@@ -390,9 +394,7 @@ class Enterprise < ActiveRecord::Base
 
   private
 
-  def instagram_regex
-    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
-  end
+
 
   def current_exchange_variants
     ExchangeVariant.joins(exchange: :order_cycle)

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -103,6 +103,8 @@ class Enterprise < ActiveRecord::Base
   after_validation :geocode_address
   after_validation :ensure_owner_is_manager, if: lambda { owner_id_changed? && !owner_id.nil? }
 
+  validates :instagram, format: /\A[a-zA-Z0-9._-]{1,30}\z/, allow_blank: true
+
   after_touch :touch_distributors
   after_create :set_default_contact
   after_create :relate_to_owners_enterprises
@@ -376,6 +378,10 @@ class Enterprise < ActiveRecord::Base
     abn.present?
   end
 
+  def instagram=(value)
+    self[:instagram] = value.downcase.try(:gsub, instagram_regex, '\1').gsub('@', '')
+  end
+
   protected
 
   def devise_mailer
@@ -383,6 +389,10 @@ class Enterprise < ActiveRecord::Base
   end
 
   private
+
+  def instagram_regex
+    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
+  end
 
   def current_exchange_variants
     ExchangeVariant.joins(exchange: :order_cycle)

--- a/db/migrate/20201217163340_update_enterprise_socia_links.rb
+++ b/db/migrate/20201217163340_update_enterprise_socia_links.rb
@@ -1,14 +1,11 @@
 class UpdateEnterpriseSociaLinks < ActiveRecord::Migration
-  def instagram_regex
-    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
-  end
   def change
     say_with_time "Updating enterprises..." do
       count = 0
       Enterprise.find_each do |enterprise|
         unless enterprise.instagram.nil?
           say "Update enterprise: #{enterprise.id}"
-          enterprise.update(instagram: enterprise.instagram.downcase.try(:gsub, instagram_regex, '\1').gsub('@', ''))
+          enterprise.update(instagram: enterprise.instagram.downcase.try(:gsub, enterprise.instagram_regex, '\1').delete('@'))
           count += 1
         end
       end

--- a/db/migrate/20201217163340_update_enterprise_socia_links.rb
+++ b/db/migrate/20201217163340_update_enterprise_socia_links.rb
@@ -1,0 +1,18 @@
+class UpdateEnterpriseSociaLinks < ActiveRecord::Migration
+  def instagram_regex
+    %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}
+  end
+  def change
+    say_with_time "Updating enterprises..." do
+      count = 0
+      Enterprise.find_each do |enterprise|
+        unless enterprise.instagram.nil?
+          say "Update enterprise: #{enterprise.id}"
+          enterprise.update(instagram: enterprise.instagram.downcase.try(:gsub, instagram_regex, '\1').gsub('@', ''))
+          count += 1
+        end
+      end
+      count
+    end
+  end
+end

--- a/db/migrate/20201217163340_update_enterprise_social_links.rb
+++ b/db/migrate/20201217163340_update_enterprise_social_links.rb
@@ -1,11 +1,11 @@
-class UpdateEnterpriseSociaLinks < ActiveRecord::Migration
-  def change
+class UpdateEnterpriseSocialLinks < ActiveRecord::Migration
+  def up
     say_with_time "Updating enterprises..." do
       count = 0
       Enterprise.find_each do |enterprise|
         unless enterprise.instagram.nil?
           say "Update enterprise: #{enterprise.id}"
-          enterprise.update(instagram: enterprise.instagram.downcase.try(:gsub, enterprise.instagram_regex, '\1').delete('@'))
+          enterprise.update(instagram: enterprise.instagram)
           count += 1
         end
       end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -149,6 +149,96 @@ describe Enterprise do
       it "sets the enterprise contact to the owner by default" do
         expect(enterprise.contact).to eq enterprise.owner
       end
+
+      context "prevent a wrong instagram link pattern" do
+        it "invalidates the instagram attribute https://facebook.com/user" do
+          e = build(:enterprise, instagram: 'https://facebook.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "invalidates the instagram attribute tagram.com/user" do
+          e = build(:enterprise, instagram: 'tagram.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "invalidates the instagram attribute https://instagram.com/user/preferences" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/preferences')
+          expect(e).to_not be_valid
+        end
+      end
+
+      context "accepted pattern" do
+        it "validates empty instagram attribute" do
+          e = build(:enterprise, instagram: '')
+          expect(e).to be_valid
+          expect(e.instagram).to eq ""
+        end
+
+        it "validates the instagram attribute @my-user" do
+          e = build(:enterprise, instagram: '@my-user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "my-user"
+        end
+
+        it "validates the instagram attribute user" do
+          e = build(:enterprise, instagram: 'user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute my_www5.example" do
+          e = build(:enterprise, instagram: 'my_www5.example')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "my_www5.example"
+        end
+
+        it "validates the instagram attribute http://instagram.com/user" do
+          e = build(:enterprise, instagram: 'http://instagram.com/user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute https://instagram.com/user/" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute https://www.instagram.com/user" do
+          e = build(:enterprise, instagram: 'https://www.instagram.com/user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute https://www.instagram.com/@user" do
+          e = build(:enterprise, instagram: 'https://www.instagram.com/@user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute instagram.com/@user" do
+          e = build(:enterprise, instagram: 'instagram.com/@user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute Https://www.Instagram.com/@User" do
+          e = build(:enterprise, instagram: 'Https://www.Instagram.com/@User')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute instagram.com/user" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "renders the expected pattern" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e.instagram).to eq "user"
+        end
+      end
     end
 
     describe "preferred_shopfront_taxon_order" do


### PR DESCRIPTION
#### What? Why?

Closes #1760

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This PR fix the issue with instagram links incorporating the last approach on this [PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/5052), it validates the instagram link added for the user, so it stores just the instagram username.
Also, I added a new migration `20201217163340_update_enterprise_socia_links.rb` to update the instagram links in the current database.

#### What should we test?
<!-- List which features should be tested and how. -->
In the enterprise_spec.rb file, I've added the validation tests proposed in the last [PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/5052).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes


