### PR TITLE
Fix #6543

### DIFF
--- a/lib/stripe/credit_card_clone_finder.rb
+++ b/lib/stripe/credit_card_clone_finder.rb
@@ -8,7 +8,8 @@ module Stripe
     end
 
     def find_cloned_card
-      return nil unless fingerprint = fingerprint_for_card(@card) && email = @card.user&.email
+      return nil unless fingerprint = fingerprint_for_card(@card)
+      return nil unless email = @card.user&.email
 
       customers = Stripe::Customer.list({ email: email, limit: 100 }, stripe_account: @stripe_account)
 


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/6543

In refactoring to a CreditCardCloneFinder, I combined two conditionals in order to appease Rubocop's desire for <=10 lines per method: https://github.com/openfoodfoundation/openfoodnetwork/pull/6469/commits/4c25edd91c395a22d592ad6ae7e0506e2879ca13

Combining the two conditionals meant that `fingerprint` was getting set to the result of `email = @card.user&.email` instead of the result of `fingerprint_for_card(@card)`.

This separates the two conditionals to fix it. 


#### What should we test?
The x-3155 credit card should now be able to be set up and charged offline for subscriptions. 


#### Release notes
n/a


#### Dependencies



#### Documentation updates
