### PR TITLE
Track request queuing in Datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -3,7 +3,9 @@ if ENV['DATADOG_RAILS_APM']
     c.use :rails, service_name: 'rails'
     c.use :delayed_job, service_name: 'delayed_job'
     c.use :dalli, service_name: 'memcached'
+
     c.analytics_enabled = true
     c.runtime_metrics_enabled = true
+    c.request_queuing = true
   end
 end


### PR DESCRIPTION
#### What? Why?

Request queuing is critical to understand whether our app servers are able to cope with all the traffic or requests pile up in Nginx queues. I find the article https://www.speedshop.co/2015/07/29/scaling-ruby-apps-to-1000-rpm.html and https://mailchi.mp/railsspeed/scaling-is-almost-entirely-about-queue-latency?e=7eb32a02d1 incredibly enlightening on this topic. Thanks @nateberkopec :heart:.

This requires https://github.com/openfoodfoundation/ofn-install/pull/689.

#### What should we test?

Nothing

#### Release notes
Track request queuing in Datadog
Changelog Category: Technical changes