### PR TITLE
[Adjustments] Associate all adjustments with an order

### DIFF
--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -39,6 +39,8 @@ module Spree
     belongs_to :adjustable, polymorphic: true
     belongs_to :source, polymorphic: true
     belongs_to :originator, polymorphic: true
+    belongs_to :order, class_name: "Spree::Order"
+
     belongs_to :tax_rate, -> { where spree_adjustments: { originator_type: 'Spree::TaxRate' } },
                foreign_key: 'originator_id'
 

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -71,6 +71,7 @@ module Spree
             amount: amount,
             source: order,
             originator: self,
+            order: order,
             state: "closed",
             label: label
           )

--- a/db/migrate/20201219120055_add_order_to_adjustments.rb
+++ b/db/migrate/20201219120055_add_order_to_adjustments.rb
@@ -1,5 +1,13 @@
 class AddOrderToAdjustments < ActiveRecord::Migration
   def up
+    class Spree::Adjustment < ActiveRecord::Base
+      belongs_to :adjustable, polymorphic: true
+      belongs_to :order, class_name: "Spree::Order"
+    end
+    class Spree::LineItem < ActiveRecord::Base
+      belongs_to :order, class_name: "Spree::Order"
+    end
+
     add_column :spree_adjustments, :order_id, :integer
 
     # Ensure migration can use the new column

--- a/db/migrate/20201219120055_add_order_to_adjustments.rb
+++ b/db/migrate/20201219120055_add_order_to_adjustments.rb
@@ -1,0 +1,18 @@
+class AddOrderToAdjustments < ActiveRecord::Migration
+  def up
+    add_column :spree_adjustments, :order_id, :integer
+
+    # Ensure migration can use the new column
+    Spree::Adjustment.reset_column_information
+
+    # Migrate adjustments on orders
+    Spree::Adjustment.where(order_id: nil, adjustable_type: "Spree::Order").find_each do |adjustment|
+      adjustment.update_column(:order_id, adjustment.adjustable_id)
+    end
+
+    # Migrate adjustments on line_items
+    Spree::Adjustment.where(order_id: nil, adjustable_type: "Spree::LineItem").includes(:adjustable).find_each do |adjustment|
+      adjustment.update_column(:order_id, adjustment.adjustable.order_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201113163227) do
+ActiveRecord::Schema.define(version: 20201219120055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -393,6 +393,7 @@ ActiveRecord::Schema.define(version: 20201113163227) do
     t.string   "adjustable_type", limit: 255
     t.decimal  "included_tax",                precision: 10, scale: 2, default: 0.0,  null: false
     t.string   "state",           limit: 255
+    t.integer  "order_id"
   end
 
   add_index "spree_adjustments", ["adjustable_id"], name: "index_adjustments_on_order_id", using: :btree

--- a/lib/spree/core/calculated_adjustments.rb
+++ b/lib/spree/core/calculated_adjustments.rb
@@ -40,6 +40,7 @@ module Spree
               amount: amount,
               source: old_calculable,
               originator: self,
+              order: order_object_for(target),
               label: label,
               mandatory: mandatory,
               state: state
@@ -74,6 +75,17 @@ module Spree
             Rails.application.config.spree.calculators
           end
           private_class_method :spree_calculators
+
+          private
+
+          def order_object_for(target)
+            # Temporary method for adjustments transition.
+            if target.is_a? Spree::Order
+              target
+            elsif target.respond_to?(:order)
+              target.order
+            end
+          end
         end
       end
     end

--- a/spec/lib/spree/core/calculated_adjustments_spec.rb
+++ b/spec/lib/spree/core/calculated_adjustments_spec.rb
@@ -28,6 +28,11 @@ describe Spree::Core::CalculatedAdjustments do
       tax_rate.create_adjustment("foo", target, order)
     end
 
+    it "should be associated with the order" do
+      tax_rate.create_adjustment("foo", target, order)
+      expect(target.adjustments.first.order_id).to eq order.id
+    end
+
     it "should have the correct originator and an amount derived from the calculator and supplied calculable" do
       adjustment = tax_rate.create_adjustment("foo", target, order)
       expect(adjustment).not_to be_nil


### PR DESCRIPTION
#### What? Why?

This change is introduced in the adjustments updates from Spree 2.2 and used heavily in new scopes and methods (which are not included here). For example, in the future we'll be able to call `order.all_adjustments` to access all adjustments on the order, the order's line items, and the order's shipments.

We can make this initial change now and migrate the data.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Adjustments: all adjustments are now associated with an order

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
