### PR TITLE
Extends spec coverage of Tax Rates settings - CRUD operations

### DIFF
--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -52,7 +52,7 @@ describe "Tax Rates" do
       uncheck("tax_rate[show_rate_in_label]")
       check("tax_rate[included_in_price]")
       click_button "Update"
-      expect(page).to have_content("Included Price Validation")
+      expect(page).to have_content("cannot be selected unless you have set a Default Tax Zone")
     end
 
     it "can be deleted", js: true do

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe "Tax Rates" do

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -1,12 +1,12 @@
-# frozen_string_literal: true
-
 require 'spec_helper'
 
 describe "Tax Rates" do
   include AuthenticationHelper
 
   let!(:calculator) { create(:calculator_per_item, calculable: create(:order)) }
-  let!(:tax_rate) { create(:tax_rate, calculator: calculator) }
+  let!(:tax_rate) { create(:tax_rate, name: "IVA", calculator: calculator) }
+  let!(:zone_id) { create(:zone, name: "Ilhas") }
+  let!(:tax_category_id) { create(:tax_category, name: "Full") }
 
   before do
     login_as_admin_and_visit spree.edit_admin_general_settings_path
@@ -28,5 +28,38 @@ describe "Tax Rates" do
     fill_in "Rate", with: "0.05"
     click_button "Create"
     expect(page).to have_content("Tax rate has been successfully created!")
+  end
+
+  # Adds further CRUD operations: editing, deleting
+  context "while editing" do
+    it "fields can be filled in and dropfdowns retains changes" do
+      visit spree.edit_admin_tax_rate_path(tax_rate.id)
+      fill_in "Rate", with: "0.23"
+      fill_in "Name", with: "GST"
+
+      find(:id, "tax_rate_zone_id").select "Ilhas"
+      find(:id, "tax_rate_tax_category_id").select "Full"
+      click_button "Update"
+      expect(page).to have_content('Tax rate "GST" has been successfully updated!')
+      expect(page).to have_content("0.23")
+    end
+
+    # See #6554: in order to set a Tax Rate as included in the price,
+    # there must be at least one Zone set the "Default Tax Zone"
+    it "checkboxes can be ticked" do
+      visit spree.edit_admin_tax_rate_path(tax_rate.id)
+      uncheck("tax_rate[show_rate_in_label]")
+      check("tax_rate[included_in_price]")
+      click_button "Update"
+      expect(page).to have_content("Included Price Validation")
+    end
+
+    it "can be deleted", js: true do
+      click_link "Tax Rates"
+      accept_alert do
+        find(:xpath, "/html/body/div[1]/div[3]/div/div/div/table/tbody/tr[1]/td[8]/a[2]").click
+      end
+      expect(page).not_to have_content("IVA")
+    end
   end
 end

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -6,8 +6,8 @@ describe "Tax Rates" do
 
   let!(:calculator) { create(:calculator_per_item, calculable: create(:order)) }
   let!(:tax_rate) { create(:tax_rate, name: "IVA", calculator: calculator) }
-  let!(:zone_id) { create(:zone, name: "Ilhas") }
-  let!(:tax_category_id) { create(:tax_category, name: "Full") }
+  let!(:zone) { create(:zone, name: "Ilhas") }
+  let!(:tax_category) { create(:tax_category, name: "Full") }
 
   before do
     login_as_admin_and_visit spree.edit_admin_general_settings_path

--- a/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/spec/features/admin/configuration/tax_rates_spec.rb
@@ -58,7 +58,7 @@ describe "Tax Rates" do
     it "can be deleted", js: true do
       click_link "Tax Rates"
       accept_alert do
-        find(:xpath, "/html/body/div[1]/div[3]/div/div/div/table/tbody/tr[1]/td[8]/a[2]").click
+        find(".delete-resource").click
       end
       expect(page).not_to have_content("IVA")
     end


### PR DESCRIPTION
#### What? Why?

Related to #6016 and #6554.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Some CRUD operations were missing in the existing spec. This PR adds further test cases, like editing, deleting and verifying the "Included Price Validation".

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added tests regarding editing fields, drop-downs and check-boxes and deleting a Tax Rate.
Added an assertion regarding the "Included Price Validation" for Tax Rates.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

No user facing changes.
