### PR TITLE
[Adjustments] Delete dead code #eligible_for_originator?

### DIFF
--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -86,16 +86,8 @@ module Spree
     # Update the boolean _eligible_ attribute which determines which adjustments
     # count towards the order's adjustment_total.
     def set_eligibility
-      result = mandatory || (amount != 0 && eligible_for_originator?)
+      result = mandatory || amount != 0
       update_column(:eligible, result)
-    end
-
-    # Allow originator of the adjustment to perform an additional eligibility of the adjustment
-    # Should return _true_ if originator is absent or doesn't implement _eligible?_
-    def eligible_for_originator?
-      return true if originator.nil?
-
-      !originator.respond_to?(:eligible?) || originator.eligible?(source)
     end
 
     # Update both the eligibility and amount of the adjustment. Adjustments

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -76,20 +76,6 @@ module Spree
           adjustment.set_eligibility
           expect(adjustment).to be_eligible
         end
-
-        it "should be eligible if not mandatory and eligible for the originator" do
-          adjustment.mandatory = false
-          allow(adjustment).to receive_messages(eligible_for_originator?: true)
-          adjustment.set_eligibility
-          expect(adjustment).to be_eligible
-        end
-
-        it "should not be eligible if not mandatory not eligible for the originator" do
-          adjustment.mandatory = false
-          allow(adjustment).to receive_messages(eligible_for_originator?: false)
-          adjustment.set_eligibility
-          expect(adjustment).to_not be_eligible
-        end
       end
     end
 
@@ -133,32 +119,6 @@ module Spree
           expect(adjustment).to_not be_finalized
           adjustment.state = "open"
           expect(adjustment).to_not be_finalized
-        end
-      end
-    end
-
-    context "#eligible_for_originator?" do
-      context "with no originator" do
-        specify { expect(adjustment).to be_eligible_for_originator }
-      end
-
-      context "with originator that doesn't have 'eligible?'" do
-        before { adjustment.originator = build(:tax_rate) }
-        specify { expect(adjustment).to be_eligible_for_originator }
-      end
-
-      context "with originator that has 'eligible?'" do
-        let(:originator) { Spree::TaxRate.new }
-        before { adjustment.originator = originator }
-
-        context "and originator is eligible for order" do
-          before { allow(originator).to receive_messages(eligible?: true) }
-          specify { expect(adjustment).to be_eligible_for_originator }
-        end
-
-        context "and originator is not eligible for order" do
-          before { allow(originator).to receive_messages(eligible?: false) }
-          specify { expect(adjustment).to_not be_eligible_for_originator }
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

This check is used only by `Spree::Promotion` objects, which are not present in OFN. There are no objects which can be originators of an adjustment that also respond to `#eligible?` in this way, so the method always returns `true`.

:fire::fire::fire:


#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed dead code `Spree::Adjustment#eligible_for_originator?`

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

