### PR TITLE
Redirect api/enterprises/:id/shopfront to new url

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -31,6 +31,7 @@ Openfoodnetwork::Application.routes.draw do
     resources :enterprises do
       post :update_image, on: :member
 
+      get :shopfront, to: redirect('/api/shops/%{enterprise_id}')
       resource :logo, only: [:destroy]
       resource :promo_image, only: [:destroy]
       resource :terms_and_conditions, only: [:destroy]


### PR DESCRIPTION
#### What? Why?

Closes #6040 

I originally did this by adding a method to the API Enterprises controller and putting the redirect there, but this seems simpler. It does have the small downside of not using the named route (i.e. having the `/api/shops` prefix hardcoded). 


#### What should we test?
Visit the url https://openfoodnetwork.org.au/api/enterprises/871/shopfront for example; no snail. 


#### Release notes
Added a redirect for a previously published URL to its new location.

Changelog Category: Technical


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
