### PR TITLE
remove choose currency from admin general settings

### DIFF
--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -60,10 +60,6 @@
                 = preference_field_tag(key, Spree::Config[key], :type => type)
                 = label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean
             .field
-              = label_tag :currency, Spree.t(:choose_currency)
-              %br/
-              = select_tag :currency, currency_options, :class => 'fullwidth'
-            .field
               = label_tag Spree.t(:currency_symbol_position)
               %br/
               .choices


### PR DESCRIPTION
#### What? Why?

Closes #6569 and #6568 

#### What should we test?
See general setting at admin, the choose currency field is no longer there



#### Release notes
User facing changes




