### PR TITLE
Explicitly render json to fix missing template error

### DIFF
--- a/app/controllers/api/order_cycles_controller.rb
+++ b/app/controllers/api/order_cycles_controller.rb
@@ -45,7 +45,7 @@ module Api
     private
 
     def render_no_products
-      render status: :not_found, json: ''
+      render status: :not_found, plain: {}.to_json, content_type: "application/json"
     end
 
     def product_properties


### PR DESCRIPTION
#### What? Why?

Closes #6491 

It looks like this was happening when the order cycle is closed; we could go further and render a more informative message instead. 


#### What should we test?
Green build; Once it's merged and deployed, we could verify by visiting one of the URL's in the bugsnag report. Should see no more slug. 

#### Release notes
Fixed an error where closed order cycles were showing 
Changelog Category: User facing changes | Technical changes


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
