### PR TITLE
Switch from cancan to cancancan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg', '~> 0.21.0'
 
 gem 'acts_as_list', '0.9.19'
 gem 'awesome_nested_set', '~> 3.3.1'
-gem 'cancan', '~> 1.6.10'
+gem 'cancancan', '~> 1.7.0'
 gem 'ffaker'
 gem 'highline', '2.0.3' # Necessary for the install generator
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
-    cancan (1.6.10)
+    cancancan (1.7.1)
     capybara (3.32.2)
       addressable
       mini_mime (>= 0.1.3)
@@ -737,7 +737,7 @@ DEPENDENCIES
   aws-sdk (= 1.67.0)
   bugsnag
   byebug
-  cancan (~> 1.6.10)
+  cancancan (~> 1.7.0)
   capybara
   catalog!
   coffee-rails (~> 4.2.2)


### PR DESCRIPTION
#### What? Why?

Closes #6403 

Development of cancan stopped in 2013. cancancan is the active fork of the defunct original, and has been updated many times to keep up with changes in newer Rails and Ruby versions. 

Starting here with the lowest available version (1.7.0), which should be closest to the original (1.6.10). Dependabot should be able to progressively bump this gem as needed.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Switched cancan gem from defunct version to actively maintained fork

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
