### PR TITLE
Add quantity input to shop front

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
@@ -8,6 +8,16 @@ Darkswarm.controller "ShopVariantCtrl", ($scope, $modal, Cart) ->
 
   $scope.variant.line_item.quantity ||= 0
 
+  $scope.$watch "variant.line_item.quantity", ->
+    item = $scope.variant.line_item
+    if item.quantity > $scope.available()
+      item.quantity = $scope.available()
+
+  $scope.$watch "variant.line_item.max_quantity", ->
+    item = $scope.variant.line_item
+    if item.max_quantity > $scope.available()
+      item.max_quantity = $scope.available()
+
   if $scope.variant.product.group_buy
     $scope.$watch "variant.line_item.quantity", ->
       item = $scope.variant.line_item

--- a/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
@@ -34,6 +34,10 @@ Darkswarm.controller "ShopVariantCtrl", ($scope, $modal, Cart) ->
     wantedQuantity = variant.line_item.max_quantity + quantity
     $scope.quantityValid(wantedQuantity) && variant.line_item.quantity > 0
 
+  $scope.available = ->
+    variant = $scope.variant
+    variant.on_demand && Infinity || variant.on_hand
+
   $scope.quantityValid = (quantity) ->
     variant = $scope.variant
     minimum = 0

--- a/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
@@ -6,18 +6,24 @@ Darkswarm.controller "ShopVariantCtrl", ($scope, $modal, Cart) ->
     return if old_value[0] == null && new_value[0] == null
     Cart.adjust($scope.variant.line_item)
 
+  if $scope.variant.product.group_buy
+    $scope.$watch "variant.line_item.quantity", ->
+      item = $scope.variant.line_item
+      if item.quantity < 1 || item.max_quantity < item.quantity
+        item.max_quantity = item.quantity
+
+    $scope.$watch "variant.line_item.max_quantity", ->
+      item = $scope.variant.line_item
+      if item.max_quantity < item.quantity
+        item.quantity = item.max_quantity
+
   $scope.add = (quantity) ->
     item = $scope.variant.line_item
     item.quantity += quantity
-    if $scope.variant.product.group_buy
-      if item.quantity < 1 || item.max_quantity < item.quantity
-        item.max_quantity = item.quantity
 
   $scope.addMax = (quantity) ->
     item = $scope.variant.line_item
     item.max_quantity += quantity
-    if item.max_quantity < item.quantity
-      item.quantity = item.max_quantity
 
   $scope.canAdd = (quantity) ->
     wantedQuantity = $scope.variant.line_item.quantity + quantity

--- a/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
@@ -6,6 +6,8 @@ Darkswarm.controller "ShopVariantCtrl", ($scope, $modal, Cart) ->
     return if old_value[0] == null && new_value[0] == null
     Cart.adjust($scope.variant.line_item)
 
+  $scope.variant.line_item.quantity ||= 0
+
   if $scope.variant.product.group_buy
     $scope.$watch "variant.line_item.quantity", ->
       item = $scope.variant.line_item

--- a/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/shop_variant_controller.js.coffee
@@ -17,21 +17,33 @@ Darkswarm.controller "ShopVariantCtrl", ($scope, $modal, Cart) ->
       if item.max_quantity < item.quantity
         item.quantity = item.max_quantity
 
+  $scope.quantity = ->
+    $scope.variant.line_item.quantity || 0
+
+  $scope.maxQuantity = ->
+    $scope.variant.line_item.max_quantity || $scope.sanitizedQuantity()
+
+  $scope.sanitizedQuantity = ->
+    Math.max(0, Math.min($scope.quantity(), $scope.available()))
+
+  $scope.sanitizedMaxQuantity = ->
+    Math.max($scope.sanitizedQuantity(), Math.min($scope.maxQuantity(), $scope.available()))
+
   $scope.add = (quantity) ->
     item = $scope.variant.line_item
-    item.quantity += quantity
+    item.quantity = $scope.sanitizedQuantity() + quantity
 
   $scope.addMax = (quantity) ->
     item = $scope.variant.line_item
-    item.max_quantity += quantity
+    item.max_quantity = $scope.sanitizedMaxQuantity() + quantity
 
   $scope.canAdd = (quantity) ->
-    wantedQuantity = $scope.variant.line_item.quantity + quantity
+    wantedQuantity = $scope.sanitizedQuantity() + quantity
     $scope.quantityValid(wantedQuantity)
 
   $scope.canAddMax = (quantity) ->
     variant = $scope.variant
-    wantedQuantity = variant.line_item.max_quantity + quantity
+    wantedQuantity = $scope.sanitizedMaxQuantity() + quantity
     $scope.quantityValid(wantedQuantity) && variant.line_item.quantity > 0
 
   $scope.available = ->

--- a/app/assets/javascripts/darkswarm/services/variants.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/variants.js.coffee
@@ -23,5 +23,5 @@ Darkswarm.factory 'Variants', ->
 
     lineItemFor: (variant) ->
       variant: variant
-      quantity: null
-      max_quantity: null
+      quantity: 0
+      max_quantity: 0

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -9,7 +9,7 @@
     {{ variant.line_item.total_price | localizeCurrency }}
 
 .row
-  .columns.small-6
+  .columns.small-12.medium-6
     .variant-bulk-buy-quantity-label
       {{ "js.shopfront.bulk_buy_modal.min_quantity" | t }}
     %div
@@ -24,7 +24,7 @@
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
         -# U+FF0B Fullwidth Plus Sign
         ＋
-  .columns.small-6
+  .columns.small-12.medium-6
     .variant-bulk-buy-quantity-label
       {{ "js.shopfront.bulk_buy_modal.max_quantity" | t }}
     %div

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -16,7 +16,11 @@
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
         -# U+FF0D Fullwidth Hyphen-Minus
         －
-      %input.bulk-buy.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.quantity"}}>
+      %input.bulk-buy.variant-quantity{
+        type: "number",
+        min: "0",
+        max: "{{ available() }}",
+        ng: {model: "variant.line_item.quantity", max: "Infinity"}}>
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
         -# U+FF0B Fullwidth Plus Sign
         ＋
@@ -27,7 +31,11 @@
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(-1)", disabled: "!canAddMax(-1)"}}>
         -# U+FF0D Fullwidth Hyphen-Minus
         －
-      %input.bulk-buy.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.max_quantity"}}>
+      %input.bulk-buy.variant-quantity{
+        type: "number",
+        min: "0",
+        max: "{{ available() }}",
+        ng: {model: "variant.line_item.max_quantity", max: "Infinity"}}>
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(1)", disabled: "!canAddMax(1)"}}
         -# U+FF0B Fullwidth Plus Sign
         ＋

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -16,8 +16,7 @@
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
         -# U+FF0D Fullwidth Hyphen-Minus
         －
-      %span.bulk-buy.variant-quantity>
-        {{ variant.line_item.quantity }}
+      %input.bulk-buy.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.quantity"}}>
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
         -# U+FF0B Fullwidth Plus Sign
         ＋
@@ -28,8 +27,7 @@
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(-1)", disabled: "!canAddMax(-1)"}}>
         -# U+FF0D Fullwidth Hyphen-Minus
         －
-      %span.bulk-buy.variant-quantity>
-        {{ variant.line_item.max_quantity }}
+      %input.bulk-buy.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.max_quantity"}}>
       %button.bulk-buy-add.variant-quantity{type: "button", ng: {click: "addMax(1)", disabled: "!canAddMax(1)"}}
         -# U+FF0B Fullwidth Plus Sign
         ＋

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -8,7 +8,12 @@
     %button.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
       -# U+FF0D Fullwidth Hyphen-Minus
       －
-    %input.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.quantity"}}>
+    %input.variant-quantity{
+      type: "number",
+      min: "0",
+      max: "{{ available() }}",
+      ng: {model: "variant.line_item.quantity", max: "Infinity"}
+      }>
     %button.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
       -# U+FF0B Fullwidth Plus Sign
       ＋

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -1,4 +1,4 @@
-.small-5.medium-3.large-3.columns.text-right{"ng-if" => "::!variant.product.group_buy"}
+.small-5.medium-3.large-3.columns.variant-quantity-column.text-right{"ng-if" => "::!variant.product.group_buy"}
 
   %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
     {{ "js.shopfront.variant.add_to_cart" | t }}

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -5,6 +5,7 @@
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(-1)"}}>
     -# U+FF0D Fullwidth Hyphen-Minus
     －
+  %input.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.quantity", if: "variant.line_item.quantity"}}>
   %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
     -# U+FF0B Fullwidth Plus Sign
     ＋

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -1,11 +1,11 @@
 .small-5.medium-3.large-3.columns.variant-quantity-column.text-right{"ng-if" => "::!variant.product.group_buy"}
 
-  .variant-quantity-inputs{ng: {if: "!variant.line_item.quantity"}}
+  .variant-quantity-inputs{ng: {if: "variant.line_item.quantity == 0"}}
     %button.add-variant{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
       {{ "js.shopfront.variant.add_to_cart" | t }}
 
-  .variant-quantity-inputs{ng: {if: "variant.line_item.quantity"}}
-    %button.variant-quantity{type: "button", ng: {click: "add(-1)"}}>
+  .variant-quantity-inputs{ng: {if: "variant.line_item.quantity != 0"}}
+    %button.variant-quantity{type: "button", ng: {click: "add(-1)", disabled: "!canAdd(-1)"}}>
       -# U+FF0D Fullwidth Hyphen-Minus
       －
     %input.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.quantity"}}>

--- a/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_no_group_buy.html.haml
@@ -1,15 +1,17 @@
 .small-5.medium-3.large-3.columns.variant-quantity-column.text-right{"ng-if" => "::!variant.product.group_buy"}
 
-  %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
-    {{ "js.shopfront.variant.add_to_cart" | t }}
-  %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(-1)"}}>
-    -# U+FF0D Fullwidth Hyphen-Minus
-    －
-  %input.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.quantity", if: "variant.line_item.quantity"}}>
-  %button.variant-quantity{type: "button", ng: {if: "variant.line_item.quantity", click: "add(1)", disabled: "!canAdd(1)"}}
-    -# U+FF0B Fullwidth Plus Sign
-    ＋
-  %br
+  .variant-quantity-inputs{ng: {if: "!variant.line_item.quantity"}}
+    %button.add-variant{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
+      {{ "js.shopfront.variant.add_to_cart" | t }}
+
+  .variant-quantity-inputs{ng: {if: "variant.line_item.quantity"}}
+    %button.variant-quantity{type: "button", ng: {click: "add(-1)"}}>
+      -# U+FF0D Fullwidth Hyphen-Minus
+      －
+    %input.variant-quantity{type: "number", min: "0", max: "{{ available() }}", ng: {model: "variant.line_item.quantity"}}>
+    %button.variant-quantity{type: "button", ng: {click: "add(1)", disabled: "!canAdd(1)"}}
+      -# U+FF0B Fullwidth Plus Sign
+      ＋
   .variant-quantity-display{ng: {class: "{visible: variant.line_item.quantity}"}}
     {{ "js.shopfront.variant.quantity_in_cart" | t:{quantity: variant.line_item.quantity || 0} }}
   %input{type: :hidden,

--- a/app/assets/javascripts/templates/partials/shop_variant_with_group_buy.html.haml
+++ b/app/assets/javascripts/templates/partials/shop_variant_with_group_buy.html.haml
@@ -1,4 +1,4 @@
-.small-5.medium-3.large-3.columns.text-right{"ng-if" => "::variant.product.group_buy"}
+.small-5.medium-3.large-3.columns.variant-quantity-column.text-right{"ng-if" => "::variant.product.group_buy"}
 
   %button.add-variant{type: "button", ng: {if: "!variant.line_item.quantity", click: "addBulk(1)", disabled: "!canAdd(1)"}}
     {{ "js.shopfront.variant.add_to_cart" | t }}

--- a/app/assets/javascripts/templates/shop_variant.html.haml
+++ b/app/assets/javascripts/templates/shop_variant.html.haml
@@ -1,5 +1,5 @@
 .variants.row
-  .small-4.medium-4.large-6.columns.variant-name
+  .small-4.medium-4.large-5.columns.variant-name
     .inline{"ng-if" => "::variant.display_name"} {{ ::variant.display_name }}
     .variant-unit {{ ::variant.unit_to_display }}
   .small-3.medium-3.large-2.columns.variant-price
@@ -8,7 +8,7 @@
       "price-breakdown-placement" => "bottom",
       "price-breakdown-animation" => true}
     {{ variant.price_with_fees | localizeCurrency }}
-  .medium-2.large-1.columns.total-price
+  .medium-2.large-2.columns.total-price
     %span{"ng-class" => "{filled: variant.line_item.total_price}"}
       {{ variant.line_item.total_price | localizeCurrency }}
 

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -6,6 +6,10 @@
 .darkswarm {
   // #search
   @include placeholder(rgba(0, 0, 0, 0.4), #777);
+
+  .row .columns.variant-quantity-column {
+    padding-left: 0;
+  }
 }
 
 .reveal-modal.product-bulk-modal {

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -19,6 +19,12 @@
 // Components to add variants to cart and change quantities
 //
 // They are not nested so that they can be used in modals.
+
+.variant-quantity-inputs {
+  height: 2.5rem;
+  white-space: nowrap;
+}
+
 button.add-variant, button.variant-quantity {
   height: 2.5rem;
   border-radius: 0;

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -9,7 +9,7 @@
 }
 
 .reveal-modal.product-bulk-modal {
-  width: 26em;
+  width: 27em;
 }
 
 // Components to add variants to cart and change quantities
@@ -89,14 +89,17 @@ button.bulk-buy-add.variant-quantity {
   width: 2.5rem;
 }
 
-span.bulk-buy.variant-quantity {
+input[type="number"].bulk-buy.variant-quantity {
   border: .1em solid $grey-200;
   height: 2.5rem;
   display: inline-block;
-  min-width: 3em;
+  width: 5em;
   padding: .5em;
   text-align: center;
   vertical-align: top;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: textfield;
 }
 
 .variant-bulk-buy-price-summary {

--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -48,7 +48,7 @@ button.add-variant, button.variant-quantity {
 }
 
 button.add-variant {
-  min-width: 6rem;
+  min-width: 7rem;
   padding: 0 1em;
 
   &[disabled] {
@@ -59,7 +59,7 @@ button.add-variant {
 }
 
 button.variant-quantity {
-  width: 3rem;
+  width: 2.25rem;
 
   &:nth-of-type(1):not(.bulk-buy):not(.bulk-buy-add) {
     border-right: .1em solid $orange-400;
@@ -71,7 +71,7 @@ button.variant-quantity {
   font-size: 0.875em;
   margin-top: 0.25em;
   text-align: center;
-  width: 6rem;
+  width: 7rem;
   visibility: hidden;
 
   &.visible {
@@ -83,23 +83,28 @@ button.bulk-buy.variant-quantity {
   background-color: transparent;
   border: .1em solid $grey-200;
   color: inherit;
+  width: 3.5rem;
 }
 
 button.bulk-buy-add.variant-quantity {
   width: 2.5rem;
 }
 
-input[type="number"].bulk-buy.variant-quantity {
+[type="number"].variant-quantity {
   border: .1em solid $grey-200;
   height: 2.5rem;
   display: inline-block;
-  width: 5em;
-  padding: .5em;
+  width: 2.5rem;
+  padding: 0;
   text-align: center;
   vertical-align: top;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: textfield;
+
+  &.bulk-buy {
+    width: 5rem;
+  }
 }
 
 .variant-bulk-buy-price-summary {

--- a/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
@@ -4,18 +4,18 @@ describe "ShopVariantCtrl", ->
 
   beforeEach ->
     module 'Darkswarm'
-    scope =
-      $watchGroup: ->
-      variant: {
+
+    inject ($rootScope, $controller, $modal)->
+      scope = $rootScope.$new()
+      scope.$watchGroup = ->
+      scope.variant = {
         on_demand: true
-        product: {group_buy: false}
+        product: {group_buy: true}
         line_item: {
           quantity: 0
           max_quantity: 0
         }
       }
-
-    inject ($controller, $modal)->
       ctrl = $controller 'ShopVariantCtrl', {$scope: scope, $modal: $modal, Cart: null}
 
   it "adds an item to the cart", ->
@@ -33,20 +33,22 @@ describe "ShopVariantCtrl", ->
     expect(scope.variant.line_item.max_quantity).toEqual 5
 
   it "adds to the max quantity to be at least min quantity", ->
-    scope.variant.product.group_buy = true
-    scope.variant.line_item.max_quantity = 2
+    scope.$apply ->
+      scope.variant.line_item.max_quantity = 2
 
-    scope.add 3
+    scope.$apply ->
+      scope.add 3
 
     expect(scope.variant.line_item.quantity).toEqual 3
     expect(scope.variant.line_item.max_quantity).toEqual 3
 
   it "decreases the min quantity to not exceed max quantity", ->
-    scope.variant.product.group_buy = true
-    scope.variant.line_item.quantity = 3
-    scope.variant.line_item.max_quantity = 5
+    scope.$apply ->
+      scope.variant.line_item.quantity = 3
+      scope.variant.line_item.max_quantity = 5
 
-    scope.addMax -3
+    scope.$apply ->
+      scope.addMax -3
 
     expect(scope.variant.line_item.quantity).toEqual 2
     expect(scope.variant.line_item.max_quantity).toEqual 2

--- a/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
@@ -27,10 +27,28 @@ describe "ShopVariantCtrl", ->
     scope.add 5
     expect(scope.variant.line_item.quantity).toEqual 6
 
+  it "adds to an invalid quantity", ->
+    scope.$apply ->
+      scope.variant.line_item.quantity = -5
+    scope.add 1
+    expect(scope.variant.line_item.quantity).toEqual 1
+
+  it "adds to an undefined quantity", ->
+    scope.$apply ->
+      scope.variant.line_item.quantity = undefined
+    scope.add 1
+    expect(scope.variant.line_item.quantity).toEqual 1
+
   it "adds to the max quantity", ->
     scope.addMax 5
     expect(scope.variant.line_item.quantity).toEqual 0
     expect(scope.variant.line_item.max_quantity).toEqual 5
+
+  it "adds to an undefined max quantity", ->
+    scope.variant.line_item.quantity = 3
+    scope.variant.line_item.max_quantity = undefined
+    scope.addMax 1
+    expect(scope.variant.line_item.max_quantity).toEqual 4
 
   it "adds to the max quantity to be at least min quantity", ->
     scope.$apply ->
@@ -73,6 +91,42 @@ describe "ShopVariantCtrl", ->
     scope.add 3
     expect(scope.canAdd(2)).toEqual true
     expect(scope.canAdd(3)).toEqual false
+
+  it "denies adding if quantity is too high", ->
+    scope.variant.on_demand = false
+    scope.variant.on_hand = 5
+    scope.variant.line_item.quantity = 7
+    scope.variant.line_item.max_quantity = 7
+
+    expect(scope.canAdd(1)).toEqual false
+    expect(scope.canAddMax(1)).toEqual false
+
+  it "allows decrease when quantity is too high", ->
+    scope.variant.on_demand = false
+    scope.variant.on_hand = 5
+    scope.variant.line_item.quantity = 7
+    scope.variant.line_item.max_quantity = 7
+    expect(scope.canAdd(-1)).toEqual true
+    expect(scope.canAddMax(-1)).toEqual true
+
+  it "allows increase when quantity is negative", ->
+    scope.variant.on_demand = false
+    scope.variant.on_hand = 5
+    scope.variant.line_item.quantity = -3
+    scope.variant.line_item.max_quantity = -3
+    expect(scope.canAdd(1)).toEqual true
+    expect(scope.canAddMax(1)).toEqual false
+
+    scope.variant.line_item.quantity = 1
+    expect(scope.canAddMax(1)).toEqual true
+
+  it "denies decrease when quantity is negative", ->
+    scope.variant.on_demand = false
+    scope.variant.on_hand = 5
+    scope.variant.line_item.quantity = -3
+    scope.variant.line_item.max_quantity = -3
+    expect(scope.canAdd(-1)).toEqual false
+    expect(scope.canAddMax(-1)).toEqual false
 
   it "denies declaring max quantity before item is in cart", ->
     expect(scope.canAddMax(1)).toEqual false

--- a/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
@@ -12,11 +12,14 @@ describe "ShopVariantCtrl", ->
         on_demand: true
         product: {group_buy: true}
         line_item: {
-          quantity: 0
-          max_quantity: 0
+          quantity: undefined
+          max_quantity: undefined
         }
       }
       ctrl = $controller 'ShopVariantCtrl', {$scope: scope, $modal: $modal, Cart: null}
+
+  it "initializes the quantity for shop display", ->
+    expect(scope.variant.line_item.quantity).toEqual 0
 
   it "adds an item to the cart", ->
     scope.add 1

--- a/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/controllers/checkout/shop_variant_controller_spec.js.coffee
@@ -74,6 +74,16 @@ describe "ShopVariantCtrl", ->
     expect(scope.variant.line_item.quantity).toEqual 2
     expect(scope.variant.line_item.max_quantity).toEqual 2
 
+  it "caps at the available quantity", ->
+    scope.$apply ->
+      scope.variant.on_demand = false
+      scope.variant.on_hand = 3
+      scope.variant.line_item.quantity = 5
+      scope.variant.line_item.max_quantity = 7
+
+    expect(scope.variant.line_item.quantity).toEqual 3
+    expect(scope.variant.line_item.max_quantity).toEqual 3
+
   it "allows adding when variant is on demand", ->
     expect(scope.canAdd(5000)).toEqual true
 


### PR DESCRIPTION
#### What? Why?

Closes #6081

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Since we replaced the old quantity fields in the shopfront with Add buttons, you needed to click a thousand times to add a thousand items to your cart. The workaround is to go to the edit cart page which still has an editable quantity field. This pull request adds such a quantity field back to the shopfront as well, in addition to the easy buttons.

Old vs new:
![Screenshot from 2021-01-06 16-41-41](https://user-images.githubusercontent.com/3524483/103733561-21313700-503e-11eb-98bc-063cd0fbe195.png) ![Screenshot from 2021-01-06 17-16-34](https://user-images.githubusercontent.com/3524483/103735809-f8f80700-5042-11eb-92e5-710500ea6ae1.png)



#### What should we test?
<!-- List which features should be tested and how. -->

* Add an item to the cart.
* Change the quantity with the buttons.
* Change the quantity with the input field
* Do the same for bulk items with bulk quantities.
* Repeat on mobile and desktop.
* Test the feedback when the wanted quantity isn't available any more (reduce stock level in the backend and then add another item). 

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

Quantities can now be entered directly in the shop front which makes it easier to add large quantities.





#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

The user guide contains a recording which could be updated:
https://guide.openfoodnetwork.org/basic-features/shopfront