### PR TITLE
6196 fix text wrapping on oc

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -41,15 +41,16 @@ ordercycle {
 
   .order-cycle-select {
     border: 1px solid $teal-300;
-    display: inline-block;
+    display: flex;
     font-size: 1em;
     border-radius: $radius-small;
 
     .select-label {
       background-color: rgba($teal-300, 0.5);
-      display: inline-block;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       border-radius: $radius-small 0 0 $radius-small;
-      float: left;
       font-size: 1em;
       line-height: 1.3em;
       padding: 0.5em 0.75em;

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -44,6 +44,8 @@ ordercycle {
     display: flex;
     font-size: 1em;
     border-radius: $radius-small;
+    margin-right: 10px;
+    margin-left: 10px;
 
     .select-label {
       background-color: rgba($teal-300, 0.5);

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -67,14 +67,11 @@ ordercycle {
       background-image: image-url('white-caret.svg');
       background-size: 30px auto;
       background-position-x: 102%;
+      height: 2.35em;
     }
 
     p {
       text-align: left;
-    }
-
-    select {
-      height: 2.35em;
     }
 
     select,

--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -53,7 +53,6 @@ ordercycle {
       font-size: 1em;
       line-height: 1.3em;
       padding: 0.5em 0.75em;
-      height: 2.35em;
 
       span {
         width: max-content;
@@ -71,6 +70,10 @@ ordercycle {
       text-align: left;
     }
 
+    select {
+      height: 2.35em;
+    }
+
     select,
     p {
       display: inline-block;
@@ -82,7 +85,6 @@ ordercycle {
       padding: 0.5em 1.25em 0.5em 0.75em;
       font-size: 1em;
       line-height: 1.3em;
-      height: 2.35em;
       min-width: 13em;
       width: 200px;
 


### PR DESCRIPTION
#### What? Why?

Closes #6196 

Resolve a text wrapping issue on the open cycle displayer on a shop (when there is only 1 option, ie. with no `<select />`). 

#### What should we test?

When visiting a shop that has only 1 ready for option, if the ready for field has a long text (requires wrapping onto 2 lines), the box does not wrap up like it should. We should wrap the text on the 2 lines. 


#### Release notes
Fix text wrapping issue on order cycle on a shop.

Changelog Category: User facing changes
