### PR TITLE
Don't serialize all variant override objects where they are not needed

### DIFF
--- a/app/serializers/api/admin/variant_serializer.rb
+++ b/app/serializers/api/admin/variant_serializer.rb
@@ -5,10 +5,8 @@ module Api
     class VariantSerializer < ActiveModel::Serializer
       attributes :id, :name, :producer_name, :image, :sku, :import_date,
                  :options_text, :unit_value, :unit_description, :unit_to_display,
-                 :display_as, :display_name, :name_to_display,
+                 :display_as, :display_name, :name_to_display, :variant_overrides_count,
                  :price, :on_demand, :on_hand, :in_stock, :stock_location_id, :stock_location_name
-
-      has_many :variant_overrides
 
       def name
         if object.full_name.present?
@@ -54,6 +52,10 @@ module Api
         return if object.stock_items.empty?
 
         object.stock_items.first.stock_location.name
+      end
+
+      def variant_overrides_count
+        object.variant_overrides.count
       end
     end
   end

--- a/app/views/spree/admin/products/index/_products_variant.html.haml
+++ b/app/views/spree/admin/products/index/_products_variant.html.haml
@@ -29,6 +29,6 @@
   %td.actions
     %a{ 'ng-click' => 'editWarn(product,variant)', :class => "edit-variant icon-edit no-text", 'ng-show' => "variantSaved(variant)", 'ofn-with-tip' => t(:edit)  }
   %td.actions
-    %span.icon-warning-sign{ 'ng-if' => 'variant.variant_overrides', 'ofn-with-tip' => "{{ 'spree.admin.products.index.products_variant.variant_has_n_overrides' | t:{n: variant.variant_overrides.length} }}" }
+    %span.icon-warning-sign{ 'ng-if' => 'variant.variant_overrides_count > 0', 'ofn-with-tip' => "{{ 'spree.admin.products.index.products_variant.variant_has_n_overrides' | t:{n: variant.variant_overrides_count} }}" }
   %td.actions
     %a{ 'ng-click' => 'deleteVariant(product,variant)', "ng-class" => '{disabled: product.variants.length < 2}', :class => "delete-variant icon-trash no-text", 'ofn-with-tip' => t(:remove)  }

--- a/spec/features/admin/bulk_product_update_spec.rb
+++ b/spec/features/admin/bulk_product_update_spec.rb
@@ -168,6 +168,28 @@ feature '
       expect(page).to have_field "variant_display_as", with: "bag"
       expect(page).to have_field "variant_display_as", with: "bin"
     end
+
+    context "with variant overrides" do
+      let!(:product) { create(:product) }
+      let(:variant) { product.variants.first }
+      let(:hub) { create(:distributor_enterprise) }
+      let!(:override) { create(:variant_override, variant: variant, hub: hub ) }
+      let(:variant_overrides_tip) {
+        I18n.t('spree.admin.products.index.products_variant.variant_has_n_overrides', n: 1)
+      }
+
+      it "displays an icon indicating a variant has overrides" do
+        visit spree.admin_products_path
+
+        find("a.view-variants").click
+
+        within "tr#v_#{variant.id}" do
+          expect(page).to have_selector(
+            "span.icon-warning-sign[data-powertip='#{variant_overrides_tip}']"
+          )
+        end
+      end
+    end
   end
 
   scenario "creating a new product" do


### PR DESCRIPTION
#### What? Why?

This bit of data is only needed in one place, and only as a count (not all the objects), and can cause huge amounts of superfluous data to be fetched and serialized, for example in the admin products index page (where variant override data is not used at all). So for example, a variant could have 20 different overrides (from different distributors), and every override would be serialized in full, for every variant, for every product. And they're not even used... :boom:

Noticed whilst investigating #6608

#### What should we test?
<!-- List which features should be tested and how. -->

Affects admin bulk products page and admin product edit pages. Shouldn't have any noticeable effect on behavior. Should improve performance where lots of products have lots of overrides.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
