### PR TITLE
Stock items and variant deletion

### DIFF
--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -6,7 +6,7 @@ module Spree
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
     belongs_to :variant, class_name: 'Spree::Variant'
-    has_many :stock_movements, dependent: :destroy
+    has_many :stock_movements
 
     validates :stock_location, :variant, presence: true
     validates :variant_id, uniqueness: { scope: [:stock_location_id, :deleted_at] }

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -235,6 +235,17 @@ module Spree
       end
     end
 
+    context "has stock movements" do
+      let(:product) { create(:product) }
+      let(:variant) { product.master }
+      let(:stock_item) { variant.stock_items.first }
+
+      xit "doesnt raise ReadOnlyRecord error" do
+        Spree::StockMovement.create!(stock_item: stock_item, quantity: 1)
+        expect { product.destroy }.not_to raise_error
+      end
+    end
+
     describe "associations" do
       it { is_expected.to belong_to(:supplier) }
       it { is_expected.to belong_to(:primary_taxon) }

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -240,7 +240,7 @@ module Spree
       let(:variant) { product.master }
       let(:stock_item) { variant.stock_items.first }
 
-      xit "doesnt raise ReadOnlyRecord error" do
+      it "doesnt raise ReadOnlyRecord error" do
         Spree::StockMovement.create!(stock_item: stock_item, quantity: 1)
         expect { product.destroy }.not_to raise_error
       end

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Spree::StockItem do
     context "with stock movements" do
       before { Spree::StockMovement.create(stock_item: subject, quantity: 1) }
 
-      xit "doesnt raise ReadOnlyRecord error" do
+      it "doesnt raise ReadOnlyRecord error" do
         expect { subject.destroy }.not_to raise_error
       end
     end

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -102,5 +102,13 @@ RSpec.describe Spree::StockItem do
         end
       end
     end
+
+    context "with stock movements" do
+      before { Spree::StockMovement.create(stock_item: subject, quantity: 1) }
+
+      xit "doesnt raise ReadOnlyRecord error" do
+        expect { subject.destroy }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Probably closes #5947
Probably closes #5942

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Imports a fix from Spree 2.0 (which we apparently missed) for an issue where errors occur when trying to delete products where a variant has `stock_items` and `stock_movements` (eg the variant has been sold at some point). `stock_items` are already soft-deleted (good). The missing part of the puzzle was a `dependant: destroy` call on the association with `stock_movements` (bad) which could trigger hard-deletion (very bad) except that the `stock_movements` would not allow themselves to be deleted (good) but would throw a `ReadOnlyRecord` error instead (bad).

Simple! :sweat_smile: 

Thanks to @seanbaker74 for the hot tip :ok_hand: 

#### What should we test?
<!-- List which features should be tested and how. -->

Bugs described in #5947 and #5942

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

Fixed a bug causing sold variants to become non-deletable
