### PR TITLE
Upgrade pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,10 +153,10 @@ group :test do
 end
 
 group :development do
-  gem 'byebug', '~> 11.1.3' # 11.1 requires ruby 2.4
+  gem 'byebug'
   gem 'debugger-linecache'
-  gem "pry", "~> 0.12.0" # pry 0.13 is not compatible with pry-byebug 3.7
-  gem 'pry-byebug', '~> 3.8.0' # 3.8 requires ruby 2.4
+  gem 'pry'
+  gem 'pry-byebug'
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
@@ -488,12 +488,12 @@ GEM
       paypal-sdk-core (~> 0.2.3)
     pg (0.21.0)
     power_assert (1.2.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.8.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     rack (1.6.13)
     rack-mini-profiler (2.3.0)
@@ -737,7 +737,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk (= 1.67.0)
   bugsnag
-  byebug (~> 11.1.3)
+  byebug
   cancan (~> 1.6.10)
   capybara
   catalog!
@@ -790,8 +790,8 @@ DEPENDENCIES
   paperclip (~> 3.4.1)
   paranoia (~> 2.4)
   pg (~> 0.21.0)
-  pry (~> 0.12.0)
-  pry-byebug (~> 3.8.0)
+  pry
+  pry-byebug
   rack-mini-profiler (< 3.0.0)
   rack-rewrite
   rack-ssl


### PR DESCRIPTION
#### What? Why?
Ruby 2.3 was blocking this upgrade. 

#### What should we test?
dev test - make sure it's still working in dev.


#### Release notes

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Update pry and pry-byebug.
