### PR TITLE
Emphasize disabled Add button when out of stock

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -29,9 +29,12 @@ button.add-variant, button.variant-quantity {
   &:hover {
     background-color: $orange-600;
   }
+
   &[disabled] {
+    background-color: $grey-400;
+
     &:hover, &:focus {
-      background-color: $orange-500;
+      background-color: $grey-400;
     }
   }
   &:nth-of-type(1) {
@@ -84,14 +87,6 @@ button.bulk-buy.variant-quantity {
 
 button.bulk-buy-add.variant-quantity {
   width: 2.5rem;
-
-  &[disabled] {
-    background-color: $grey-400;
-
-    &:hover, &:focus {
-      background-color: $grey-400;
-    }
-  }
 }
 
 span.bulk-buy.variant-quantity {


### PR DESCRIPTION

#### What? Why?

Closes #6616

Using the same grey as was used in the bulk modal already. This makes it more consistent and hopefully more clear.
![Screenshot from 2021-01-07 10-36-29](https://user-images.githubusercontent.com/3524483/103833113-3fe20d00-50d4-11eb-9448-389653078a03.png)

With the new input field in PR #6606, it will look like this:
![Screenshot from 2021-01-07 10-33-15](https://user-images.githubusercontent.com/3524483/103832968-ccd89680-50d3-11eb-807c-be36f2ee1eed.png)



#### What should we test?
<!-- List which features should be tested and how. -->

* Go to a shopfront with limited stock.
* Add an item to the cart until you reach the stock level.
* Verify that the button color is clearer.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

Emphasize that you can't use the Add button in the shopfront when an item is out of stock.



