### PR TITLE
[Flaky Spec] Complex OC spec

### DIFF
--- a/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-xfeature '
+feature '
     As an administrator
     I want to create/update complex order cycles with a specific time
 ', js: true do
@@ -90,9 +90,10 @@ xfeature '
     expect(page).to have_content 'Your order cycle has been updated.'
 
     # And I add a distributor and some products
+    expect(page).to_not have_content "Loading..."
     select 'My distributor', from: 'new_distributor_id'
     click_button 'Add distributor'
-    expect(page).to have_field("order_cycle_outgoing_exchange_2_pickup_time")
+    expect(page).to have_selector "tr.distributor-#{distributor.id}"
 
     fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'New time 0'
     fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'New instructions 0'


### PR DESCRIPTION
#### What? Why?

Closes #6586 

Re-enables OC updating spec and add an expectation to improve waiting  between page load and UI interactions

#### What should we test?
<!-- List which features should be tested and how. -->

Green build. No flaky spec on `spec/features/admin/order_cycles/complex_updating_specific_time_spec.rb` relating to lines 16 or 95.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Re-enabled and fixed a flaky order cycles updating spec

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

