### PR TITLE
[Flaky Spec] Improve simple OC spec

### DIFF
--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -204,11 +204,14 @@ feature '
         click_button 'Add supplier'
         select 'Permitted supplier', from: 'new_supplier_id'
         click_button 'Add supplier'
+        expect(page).to have_content "Permitted supplier"
 
         select_incoming_variant supplier_managed, 0, variant_managed
         select_incoming_variant supplier_permitted, 1, variant_permitted
 
         click_button 'Save and Next'
+        expect(page).to have_content 'Your order cycle has been updated.'
+        expect(page).to_not have_content "Loading..."
 
         expect(page).to have_select 'new_distributor_id'
         expect(page).not_to have_select 'new_distributor_id', with_options: [distributor_unmanaged.name]
@@ -216,6 +219,7 @@ feature '
         click_button 'Add distributor'
         select 'Permitted distributor', from: 'new_distributor_id'
         click_button 'Add distributor'
+        expect(page).to have_content "Permitted distributor"
 
         expect(page).to have_input 'order_cycle_outgoing_exchange_0_pickup_time'
         fill_in 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
@@ -612,6 +616,7 @@ feature '
   end
 
   def select_incoming_variant(supplier, exchange_no, variant)
+    expect(page).to have_selector "table.exchanges tr.supplier-#{supplier.id} td.products"
     page.find("table.exchanges tr.supplier-#{supplier.id} td.products").click
     check "order_cycle_incoming_exchange_#{exchange_no}_variants_#{variant.id}"
   end


### PR DESCRIPTION

#### What? Why?

Closes #6624 

Add some improvements to help ensure UI elements are actually loaded by Angular before they are clicked on by Capybara.


#### What should we test?
<!-- List which features should be tested and how. -->

Green build for `spec/features/admin/order_cycles/simple_spec.rb`

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved flaky simple OC spec

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
