### PR TITLE
6199 adjust alignment on the Order Cycle component on ipad

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -154,21 +154,23 @@ shop ordercycle {
     }
   }
 
+  .select-and-closing-container {
+    @include breakpoint(desktop) {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+  }
+
   closing {
     color: $white;
     padding: 0 0 12px;
 
     @include breakpoint(desktop) {
-      float: none;
-      display: inline-block;
-      padding: 0.2em 0 0;
+      padding: 0;
       font-size: 1.2em;
       margin-right: 1em;
-    }
-
-    @include breakpoint(tablet) {
-      float: none;
-      padding: 0;
     }
   }
 

--- a/app/views/enterprises/_change_order_cycle.html.haml
+++ b/app/views/enterprises/_change_order_cycle.html.haml
@@ -1,27 +1,28 @@
 %div{"ng-controller" => "OrderCycleChangeCtrl", "ng-cloak" => true}
-  %closing
-    %div{"ng-if" => "OrderCycle.selected()"}
-      %div{"ng-if" => "closesInLessThan3Months()"}
-        = t :enterprises_next_closing
-        %strong {{ OrderCycle.orders_close_at() | date_in_words }}
-      %div{"ng-if" => "!closesInLessThan3Months()"}
-        = t :enterprises_currently_open
-    %div{"ng-if" => "!OrderCycle.selected()"}
-      = t :enterprises_choose
+  .select-and-closing-container
+    %closing
+      %div{"ng-if" => "OrderCycle.selected()"}
+        %div{"ng-if" => "closesInLessThan3Months()"}
+          = t :enterprises_next_closing
+          %strong {{ OrderCycle.orders_close_at() | date_in_words }}
+        %div{"ng-if" => "!closesInLessThan3Months()"}
+          = t :enterprises_currently_open
+      %div{"ng-if" => "!OrderCycle.selected()"}
+        = t :enterprises_choose
 
-  .order-cycle-select
-    .select-label
-      %span= t :enterprises_ready_for
+    .order-cycle-select
+      .select-label
+        %span= t :enterprises_ready_for
 
-    - if oc_select_options.count == 1
-      %p
-        = oc_select_options.first[:time]
+      - if oc_select_options.count == 1
+        %p
+          = oc_select_options.first[:time]
 
-    - else
-      %select.select2.avenir#order_cycle_id{"ng-model" => "order_cycle.order_cycle_id",
-        "ofn-change-order-cycle" => true,
-        "disabled" => require_customer?,
-        "ng-options" => "oc.id as oc.time for oc in #{oc_select_options.to_json}"}
+      - else
+        %select.select2.avenir#order_cycle_id{"ng-model" => "order_cycle.order_cycle_id",
+          "ofn-change-order-cycle" => true,
+          "disabled" => require_customer?,
+          "ng-options" => "oc.id as oc.time for oc in #{oc_select_options.to_json}"}
 
-        - if oc_select_options.count > 1
-          %option{value: "", disabled: "", selected: ""}= t :shopping_oc_select
+          - if oc_select_options.count > 1
+            %option{value: "", disabled: "", selected: ""}= t :shopping_oc_select


### PR DESCRIPTION
#### What? Why?
Closes #6199 
Adjust vertical alignment of the component "Order Cycle" (and specially the "Ready for" field) on a shop on iPad device.

#### What should we test?
On an iPad (and other devices, depending on screen width), the ready for field must be vertically centered.

#### Release notes
Fix vertical alignment issue on order cycle on a shop.


Changelog Category: User facing changes
