### PR TITLE
Update haml lint config

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,70 @@
+# Whether to ignore frontmatter at the beginning of HAML documents for
+# frameworks such as Jekyll/Middleman
+skip_frontmatter: false
+
+linters:
+  AltText:
+    enabled: false
+
+  ClassAttributeWithStaticValue:
+    enabled: true
+
+  ClassesBeforeIds:
+    enabled: true
+
+  ConsecutiveComments:
+    enabled: true
+
+  ConsecutiveSilentScripts:
+    enabled: true
+    max_consecutive: 2
+
+  EmptyScript:
+    enabled: true
+
+  HtmlAttributes:
+    enabled: true
+
+  ImplicitDiv:
+    enabled: true
+
+  LeadingCommentSpace:
+    enabled: true
+
+  LineLength:
+    enabled: true
+    max: 80
+
+  MultilinePipe:
+    enabled: true
+
+  MultilineScript:
+    enabled: true
+
+  ObjectReferenceAttributes:
+    enabled: true
+
+  RuboCop:
+    enabled: false
+
+  RubyComments:
+    enabled: true
+
+  SpaceBeforeScript:
+    enabled: true
+
+  SpaceInsideHashAttributes:
+    enabled: true
+    style: space
+
+  TagName:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  UnnecessaryInterpolation:
+    enabled: true
+
+  UnnecessaryStringOutput:
+    enabled: true

--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -55,7 +55,7 @@ linters:
 
   SpaceInsideHashAttributes:
     enabled: true
-    style: space
+    style: no_space
 
   TagName:
     enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -2,3 +2,5 @@ rubocop:
   config_file: .rubocop_styleguide.yml
 scss:
   config_file: .scss-lint.yml
+haml:
+  config_file: .haml-lint.yml


### PR DESCRIPTION
#### What? Why?

This shuts the annoying lint error

```
Hash attribute should start with one space after the opening brace
Hash attribute should end with one space before the closing brace
```

and it aligns with our existing style. See #6629 as an example.


#### What should we test?

Green build.

#### Release notes

Set `SpaceInsideHashAttributes` haml lint check to no_space
Changelog Category: Technical changes
