### PR TITLE
[Deprecation] Replace ActionMailer#deliver with ActionMailer#deliver_now

### DIFF
--- a/app/controllers/admin/manager_invitations_controller.rb
+++ b/app/controllers/admin/manager_invitations_controller.rb
@@ -35,7 +35,7 @@ module Admin
       new_user.save!
 
       @enterprise.users << new_user
-      Delayed::Job.enqueue ManagerInvitationJob.new(@enterprise.id, new_user.id)
+      ManagerInvitationJob.perform_later(@enterprise.id, new_user.id)
 
       new_user
     end

--- a/app/controllers/spree/admin/mail_methods_controller.rb
+++ b/app/controllers/spree/admin/mail_methods_controller.rb
@@ -15,7 +15,7 @@ module Spree
       end
 
       def testmail
-        if TestMailer.test_email(spree_current_user).deliver
+        if TestMailer.test_email(spree_current_user).deliver_now
           flash[:success] = Spree.t('admin.mail_methods.testmail.delivery_success')
         else
           flash[:error] = Spree.t('admin.mail_methods.testmail.delivery_error')

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -78,7 +78,7 @@ module Spree
       end
 
       def resend
-        Spree::OrderMailer.confirm_email_for_customer(@order.id, true).deliver_now
+        Spree::OrderMailer.confirm_email_for_customer(@order.id, true).deliver_later
         flash[:success] = t('admin.orders.order_email_resent')
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
@@ -87,7 +87,7 @@ module Spree
       def invoice
         pdf = InvoiceRenderer.new.render_to_string(@order)
 
-        Spree::OrderMailer.invoice_email(@order.id, pdf).deliver_now
+        Spree::OrderMailer.invoice_email(@order.id, pdf).deliver_later
         flash[:success] = t('admin.orders.invoice_email_sent')
 
         respond_with(@order) { |format|

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -78,7 +78,7 @@ module Spree
       end
 
       def resend
-        Spree::OrderMailer.confirm_email_for_customer(@order.id, true).deliver
+        Spree::OrderMailer.confirm_email_for_customer(@order.id, true).deliver_now
         flash[:success] = t('admin.orders.order_email_resent')
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
@@ -87,7 +87,7 @@ module Spree
       def invoice
         pdf = InvoiceRenderer.new.render_to_string(@order)
 
-        Spree::OrderMailer.invoice_email(@order.id, pdf).deliver
+        Spree::OrderMailer.invoice_email(@order.id, pdf).deliver_now
         flash[:success] = t('admin.orders.invoice_email_sent')
 
         respond_with(@order) { |format|

--- a/app/jobs/confirm_order_job.rb
+++ b/app/jobs/confirm_order_job.rb
@@ -2,7 +2,7 @@
 
 class ConfirmOrderJob < ActiveJob::Base
   def perform(order_id)
-    Spree::OrderMailer.confirm_email_for_customer(order_id).deliver
-    Spree::OrderMailer.confirm_email_for_shop(order_id).deliver
+    Spree::OrderMailer.confirm_email_for_customer(order_id).deliver_now
+    Spree::OrderMailer.confirm_email_for_shop(order_id).deliver_now
   end
 end

--- a/app/jobs/confirm_signup_job.rb
+++ b/app/jobs/confirm_signup_job.rb
@@ -3,6 +3,6 @@
 class ConfirmSignupJob < ActiveJob::Base
   def perform(user_id)
     user = Spree::User.find user_id
-    Spree::UserMailer.signup_confirmation(user).deliver
+    Spree::UserMailer.signup_confirmation(user).deliver_now
   end
 end

--- a/app/jobs/heartbeat_job.rb
+++ b/app/jobs/heartbeat_job.rb
@@ -1,4 +1,6 @@
-class HeartbeatJob
+# frozen_string_literal: true
+
+class HeartbeatJob < ActiveJob::Base
   def perform
     Spree::Config.last_job_queue_heartbeat_at = Time.now.in_time_zone
   end

--- a/app/jobs/manager_invitation_job.rb
+++ b/app/jobs/manager_invitation_job.rb
@@ -1,5 +1,7 @@
-ManagerInvitationJob = Struct.new(:enterprise_id, :user_id) do
-  def perform
+# frozen_string_literal: true
+
+class ManagerInvitationJob < ActiveJob::Base
+  def perform(enterprise_id, user_id)
     enterprise = Enterprise.find enterprise_id
     user = Spree::User.find user_id
     EnterpriseMailer.manager_invitation(enterprise, user).deliver_now

--- a/app/jobs/manager_invitation_job.rb
+++ b/app/jobs/manager_invitation_job.rb
@@ -2,6 +2,6 @@ ManagerInvitationJob = Struct.new(:enterprise_id, :user_id) do
   def perform
     enterprise = Enterprise.find enterprise_id
     user = Spree::User.find user_id
-    EnterpriseMailer.manager_invitation(enterprise, user).deliver
+    EnterpriseMailer.manager_invitation(enterprise, user).deliver_now
   end
 end

--- a/app/jobs/order_cycle_notification_job.rb
+++ b/app/jobs/order_cycle_notification_job.rb
@@ -5,7 +5,7 @@ class OrderCycleNotificationJob < ActiveJob::Base
   def perform(order_cycle_id)
     order_cycle = OrderCycle.find(order_cycle_id)
     order_cycle.suppliers.each do |supplier|
-      ProducerMailer.order_cycle_report(supplier, order_cycle).deliver
+      ProducerMailer.order_cycle_report(supplier, order_cycle).deliver_now
     end
   end
 end

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -90,13 +90,13 @@ class SubscriptionConfirmJob
   def send_confirmation_email(order)
     order.update!
     record_success(order)
-    SubscriptionMailer.confirmation_email(order).deliver
+    SubscriptionMailer.confirmation_email(order).deliver_now
   end
 
   def send_failed_payment_email(order, error_message = nil)
     order.update!
     record_and_log_error(:failed_payment, order, error_message)
-    SubscriptionMailer.failed_payment_email(order).deliver
+    SubscriptionMailer.failed_payment_email(order).deliver_now
   rescue StandardError => e
     Bugsnag.notify(e, order: order, error_message: error_message)
   end

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -1,7 +1,7 @@
 require 'order_management/subscriptions/summarizer'
 
 # Confirms orders of unconfirmed proxy orders in recently closed Order Cycles
-class SubscriptionConfirmJob
+class SubscriptionConfirmJob < ActiveJob::Base
   def perform
     confirm_proxy_orders!
   end

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -87,11 +87,11 @@ class SubscriptionPlacementJob
   def send_placement_email(order, changes)
     record_issue(:changes, order) if changes.present?
     record_success(order) if changes.blank?
-    SubscriptionMailer.placement_email(order, changes).deliver
+    SubscriptionMailer.placement_email(order, changes).deliver_now
   end
 
   def send_empty_email(order, changes)
     record_issue(:empty, order)
-    SubscriptionMailer.empty_email(order, changes).deliver
+    SubscriptionMailer.empty_email(order, changes).deliver_now
   end
 end

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -1,6 +1,6 @@
 require 'order_management/subscriptions/summarizer'
 
-class SubscriptionPlacementJob
+class SubscriptionPlacementJob < ActiveJob::Base
   def perform
     ids = proxy_orders.pluck(:id)
     proxy_orders.update_all(placed_at: Time.zone.now)

--- a/app/jobs/welcome_enterprise_job.rb
+++ b/app/jobs/welcome_enterprise_job.rb
@@ -3,6 +3,6 @@
 class WelcomeEnterpriseJob < ActiveJob::Base
   def perform(enterprise_id)
     enterprise = Enterprise.find enterprise_id
-    EnterpriseMailer.welcome(enterprise).deliver
+    EnterpriseMailer.welcome(enterprise).deliver_now
   end
 end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -824,7 +824,7 @@ module Spree
     def after_cancel
       shipments.each(&:cancel!)
 
-      OrderMailer.cancel_email(id).deliver
+      OrderMailer.cancel_email(id).deliver_now
       self.payment_state = 'credit_owed' unless shipped?
     end
 

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -824,7 +824,7 @@ module Spree
     def after_cancel
       shipments.each(&:cancel!)
 
-      OrderMailer.cancel_email(id).deliver_now
+      OrderMailer.cancel_email(id).deliver_later
       self.payment_state = 'credit_owed' unless shipped?
     end
 

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -319,7 +319,7 @@ module Spree
     end
 
     def send_shipped_email
-      ShipmentMailer.shipped_email(id).deliver_now
+      ShipmentMailer.shipped_email(id).deliver_later
     end
 
     def update_adjustment_included_tax

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -319,7 +319,7 @@ module Spree
     end
 
     def send_shipped_email
-      ShipmentMailer.shipped_email(id).deliver
+      ShipmentMailer.shipped_email(id).deliver_now
     end
 
     def update_adjustment_included_tax

--- a/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
@@ -37,13 +37,13 @@ module OrderManagement
 
       def send_placement_summary_emails
         @summaries.values.each do |summary|
-          SubscriptionMailer.placement_summary_email(summary).deliver
+          SubscriptionMailer.placement_summary_email(summary).deliver_now
         end
       end
 
       def send_confirmation_summary_emails
         @summaries.values.each do |summary|
-          SubscriptionMailer.confirmation_summary_email(summary).deliver
+          SubscriptionMailer.confirmation_summary_email(summary).deliver_now
         end
       end
 

--- a/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
@@ -37,13 +37,13 @@ module OrderManagement
 
       def send_placement_summary_emails
         @summaries.values.each do |summary|
-          SubscriptionMailer.placement_summary_email(summary).deliver_now
+          SubscriptionMailer.placement_summary_email(summary).deliver_later
         end
       end
 
       def send_confirmation_summary_emails
         @summaries.values.each do |summary|
-          SubscriptionMailer.confirmation_summary_email(summary).deliver_now
+          SubscriptionMailer.confirmation_summary_email(summary).deliver_later
         end
       end
 

--- a/engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb
@@ -100,7 +100,7 @@ module OrderManagement
         let(:summary1) { double(:summary) }
         let(:summary2) { double(:summary) }
         let(:summaries) { { 1 => summary1, 2 => summary2 } }
-        let(:mail_mock) { double(:mail, deliver: true) }
+        let(:mail_mock) { double(:mail, deliver_now: true) }
 
         before do
           summarizer.instance_variable_set(:@summaries, summaries)
@@ -116,7 +116,7 @@ module OrderManagement
         let(:summary1) { double(:summary) }
         let(:summary2) { double(:summary) }
         let(:summaries) { { 1 => summary1, 2 => summary2 } }
-        let(:mail_mock) { double(:mail, deliver: true) }
+        let(:mail_mock) { double(:mail, deliver_now: true) }
 
         before do
           summarizer.instance_variable_set(:@summaries, summaries)

--- a/engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/summarizer_spec.rb
@@ -100,7 +100,7 @@ module OrderManagement
         let(:summary1) { double(:summary) }
         let(:summary2) { double(:summary) }
         let(:summaries) { { 1 => summary1, 2 => summary2 } }
-        let(:mail_mock) { double(:mail, deliver_now: true) }
+        let(:mail_mock) { double(:mail, deliver_later: true) }
 
         before do
           summarizer.instance_variable_set(:@summaries, summaries)
@@ -116,7 +116,7 @@ module OrderManagement
         let(:summary1) { double(:summary) }
         let(:summary2) { double(:summary) }
         let(:summaries) { { 1 => summary1, 2 => summary2 } }
-        let(:mail_mock) { double(:mail, deliver_now: true) }
+        let(:mail_mock) { double(:mail, deliver_later: true) }
 
         before do
           summarizer.instance_variable_set(:@summaries, summaries)

--- a/lib/tasks/subscriptions/test.rake
+++ b/lib/tasks/subscriptions/test.rake
@@ -25,7 +25,7 @@ namespace :ofn do
           placed_at: nil)
 
         # Run placement job to create orders
-        SubscriptionPlacementJob.new.perform
+        SubscriptionPlacementJob.perform_now
       end
 
       desc "Force confirmation job for a specific Order Cycle"
@@ -43,7 +43,7 @@ namespace :ofn do
         )
 
         # Run Confirm Job to process payments
-        SubscriptionConfirmJob.new.perform
+        SubscriptionConfirmJob.perform_now
       end
 
       def exit_in_production

--- a/spec/controllers/admin/manager_invitations_controller_spec.rb
+++ b/spec/controllers/admin/manager_invitations_controller_spec.rb
@@ -36,10 +36,8 @@ module Admin
         end
 
         it 'enqueues an invitation email' do
-          allow(ManagerInvitationJob)
-            .to receive(:new).with(enterprise.id, kind_of(Integer)) { manager_invitation }
-
-          expect(Delayed::Job).to receive(:enqueue).with(manager_invitation)
+          expect(ManagerInvitationJob)
+            .to receive(:perform_later).with(enterprise.id, kind_of(Integer))
 
           spree_post :create, email: 'un.registered@email.com', enterprise_id: enterprise.id
         end

--- a/spec/controllers/admin/proxy_orders_controller_spec.rb
+++ b/spec/controllers/admin/proxy_orders_controller_spec.rb
@@ -78,7 +78,7 @@ describe Admin::ProxyOrdersController, type: :controller do
 
     before do
       # Processing order to completion
-      allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver: true) }
+      allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
       OrderWorkflow.new(order).complete!
       proxy_order.reload
       proxy_order.cancel

--- a/spec/controllers/admin/proxy_orders_controller_spec.rb
+++ b/spec/controllers/admin/proxy_orders_controller_spec.rb
@@ -78,7 +78,7 @@ describe Admin::ProxyOrdersController, type: :controller do
 
     before do
       # Processing order to completion
-      allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
+      allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_later: true) }
       OrderWorkflow.new(order).complete!
       proxy_order.reload
       proxy_order.cancel

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -446,7 +446,7 @@ describe Admin::SubscriptionsController, type: :controller do
               before do
                 params[:open_orders] = 'cancel'
                 allow(Spree::OrderMailer).to receive(:cancel_email) { mail_mock }
-                allow(mail_mock).to receive(:deliver)
+                allow(mail_mock).to receive(:deliver_now)
               end
 
               it 'renders the cancelled subscription as json, and cancels the open order' do
@@ -457,7 +457,7 @@ describe Admin::SubscriptionsController, type: :controller do
                 expect(subscription.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'canceled'
                 expect(proxy_order.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
-                expect(mail_mock).to have_received(:deliver)
+                expect(mail_mock).to have_received(:deliver_now)
               end
             end
           end
@@ -545,7 +545,7 @@ describe Admin::SubscriptionsController, type: :controller do
               before do
                 params[:open_orders] = 'cancel'
                 allow(Spree::OrderMailer).to receive(:cancel_email) { mail_mock }
-                allow(mail_mock).to receive(:deliver)
+                allow(mail_mock).to receive(:deliver_now)
               end
 
               it 'renders the paused subscription as json, and cancels the open order' do
@@ -556,7 +556,7 @@ describe Admin::SubscriptionsController, type: :controller do
                 expect(subscription.reload.paused_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'canceled'
                 expect(proxy_order.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
-                expect(mail_mock).to have_received(:deliver)
+                expect(mail_mock).to have_received(:deliver_now)
               end
             end
           end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -446,7 +446,7 @@ describe Admin::SubscriptionsController, type: :controller do
               before do
                 params[:open_orders] = 'cancel'
                 allow(Spree::OrderMailer).to receive(:cancel_email) { mail_mock }
-                allow(mail_mock).to receive(:deliver_now)
+                allow(mail_mock).to receive(:deliver_later)
               end
 
               it 'renders the cancelled subscription as json, and cancels the open order' do
@@ -457,7 +457,7 @@ describe Admin::SubscriptionsController, type: :controller do
                 expect(subscription.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'canceled'
                 expect(proxy_order.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
-                expect(mail_mock).to have_received(:deliver_now)
+                expect(mail_mock).to have_received(:deliver_later)
               end
             end
           end
@@ -545,7 +545,7 @@ describe Admin::SubscriptionsController, type: :controller do
               before do
                 params[:open_orders] = 'cancel'
                 allow(Spree::OrderMailer).to receive(:cancel_email) { mail_mock }
-                allow(mail_mock).to receive(:deliver_now)
+                allow(mail_mock).to receive(:deliver_later)
               end
 
               it 'renders the paused subscription as json, and cancels the open order' do
@@ -556,7 +556,7 @@ describe Admin::SubscriptionsController, type: :controller do
                 expect(subscription.reload.paused_at).to be_within(5.seconds).of Time.zone.now
                 expect(order.reload.state).to eq 'canceled'
                 expect(proxy_order.reload.canceled_at).to be_within(5.seconds).of Time.zone.now
-                expect(mail_mock).to have_received(:deliver_now)
+                expect(mail_mock).to have_received(:deliver_later)
               end
             end
           end

--- a/spec/jobs/confirm_order_job_spec.rb
+++ b/spec/jobs/confirm_order_job_spec.rb
@@ -10,8 +10,8 @@ describe ConfirmOrderJob do
     shop_confirm_fake = double(:confirm_email_for_shop)
     expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return customer_confirm_fake
     expect(Spree::OrderMailer).to receive(:confirm_email_for_shop).and_return shop_confirm_fake
-    expect(customer_confirm_fake).to receive :deliver
-    expect(shop_confirm_fake).to receive :deliver
+    expect(customer_confirm_fake).to receive :deliver_now
+    expect(shop_confirm_fake).to receive :deliver_now
 
     ConfirmOrderJob.perform_now order.id
   end

--- a/spec/jobs/confirm_signup_job_spec.rb
+++ b/spec/jobs/confirm_signup_job_spec.rb
@@ -8,7 +8,7 @@ describe ConfirmSignupJob do
   it "sends a confirmation email to the user" do
     mail = double(:mail)
     expect(Spree::UserMailer).to receive(:signup_confirmation).with(user).and_return(mail)
-    expect(mail).to receive(:deliver)
+    expect(mail).to receive(:deliver_now)
 
     ConfirmSignupJob.perform_now(user.id)
   end

--- a/spec/jobs/heartbeat_job_spec.rb
+++ b/spec/jobs/heartbeat_job_spec.rb
@@ -22,7 +22,7 @@ describe HeartbeatJob do
 
   def run_job
     clear_jobs
-    Delayed::Job.enqueue HeartbeatJob.new
+    HeartbeatJob.perform_now
     flush_jobs ignore_exceptions: false
   end
 end

--- a/spec/jobs/order_cycle_notification_job_spec.rb
+++ b/spec/jobs/order_cycle_notification_job_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe OrderCycleNotificationJob do
   let(:order_cycle) { create(:order_cycle) }
-  let(:mail) { double(:mail, deliver: true) }
+  let(:mail) { double(:mail, deliver_now: true) }
 
   before do
     allow(ProducerMailer).to receive(:order_cycle_report).twice.and_return(mail)

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -240,7 +240,7 @@ describe SubscriptionConfirmJob do
 
   describe "#send_confirmation_email" do
     let(:order) { instance_double(Spree::Order) }
-    let(:mail_mock) { double(:mailer_mock, deliver: true) }
+    let(:mail_mock) { double(:mailer_mock, deliver_now: true) }
 
     before do
       allow(SubscriptionMailer).to receive(:confirmation_email) { mail_mock }
@@ -251,13 +251,13 @@ describe SubscriptionConfirmJob do
       expect(job).to receive(:record_success).with(order).once
       job.send(:send_confirmation_email, order)
       expect(SubscriptionMailer).to have_received(:confirmation_email).with(order)
-      expect(mail_mock).to have_received(:deliver)
+      expect(mail_mock).to have_received(:deliver_now)
     end
   end
 
   describe "#send_failed_payment_email" do
     let(:order) { instance_double(Spree::Order) }
-    let(:mail_mock) { double(:mailer_mock, deliver: true) }
+    let(:mail_mock) { double(:mailer_mock, deliver_now: true) }
 
     before do
       allow(SubscriptionMailer).to receive(:failed_payment_email) { mail_mock }
@@ -268,7 +268,7 @@ describe SubscriptionConfirmJob do
       expect(job).to receive(:record_and_log_error).with(:failed_payment, order, nil).once
       job.send(:send_failed_payment_email, order)
       expect(SubscriptionMailer).to have_received(:failed_payment_email).with(order)
-      expect(mail_mock).to have_received(:deliver)
+      expect(mail_mock).to have_received(:deliver_now)
     end
   end
 end

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -209,7 +209,7 @@ describe SubscriptionPlacementJob do
 
   describe "#send_placement_email" do
     let!(:order) { double(:order) }
-    let(:mail_mock) { double(:mailer_mock, deliver: true) }
+    let(:mail_mock) { double(:mailer_mock, deliver_now: true) }
 
     before do
       allow(SubscriptionMailer).to receive(:placement_email) { mail_mock }
@@ -222,7 +222,7 @@ describe SubscriptionPlacementJob do
         expect(job).to receive(:record_issue).with(:changes, order).once
         job.send(:send_placement_email, order, changes)
         expect(SubscriptionMailer).to have_received(:placement_email).with(order, changes)
-        expect(mail_mock).to have_received(:deliver)
+        expect(mail_mock).to have_received(:deliver_now)
       end
     end
 
@@ -233,7 +233,7 @@ describe SubscriptionPlacementJob do
         expect(job).to receive(:record_success).with(order).once
         job.send(:send_placement_email, order, changes)
         expect(SubscriptionMailer).to have_received(:placement_email)
-        expect(mail_mock).to have_received(:deliver)
+        expect(mail_mock).to have_received(:deliver_now)
       end
     end
   end
@@ -241,7 +241,7 @@ describe SubscriptionPlacementJob do
   describe "#send_empty_email" do
     let!(:order) { double(:order) }
     let(:changes) { double(:changes) }
-    let(:mail_mock) { double(:mailer_mock, deliver: true) }
+    let(:mail_mock) { double(:mailer_mock, deliver_now: true) }
 
     before do
       allow(SubscriptionMailer).to receive(:empty_email) { mail_mock }
@@ -251,7 +251,7 @@ describe SubscriptionPlacementJob do
       expect(job).to receive(:record_issue).with(:empty, order).once
       job.send(:send_empty_email, order, changes)
       expect(SubscriptionMailer).to have_received(:empty_email).with(order, changes)
-      expect(mail_mock).to have_received(:deliver)
+      expect(mail_mock).to have_received(:deliver_now)
     end
   end
 end

--- a/spec/jobs/welcome_enterprise_job_spec.rb
+++ b/spec/jobs/welcome_enterprise_job_spec.rb
@@ -8,7 +8,7 @@ describe WelcomeEnterpriseJob do
   it "sends a welcome email to the enterprise" do
     mail = double(:mail)
     expect(EnterpriseMailer).to receive(:welcome).with(enterprise).and_return(mail)
-    expect(mail).to receive(:deliver)
+    expect(mail).to receive(:deliver_now)
 
     WelcomeEnterpriseJob.perform_now(enterprise.id)
   end

--- a/spec/lib/spree/core/mail_interceptor_spec.rb
+++ b/spec/lib/spree/core/mail_interceptor_spec.rb
@@ -24,7 +24,7 @@ describe Spree::OrderMailer do
 
     it "should use the from address specified in the preference" do
       Spree::Config[:mails_from] = "no-reply@foobar.com"
-      message.deliver
+      message.deliver_now
       @email = ActionMailer::Base.deliveries.first
       expect(@email.from).to eq ["no-reply@foobar.com"]
     end
@@ -33,7 +33,7 @@ describe Spree::OrderMailer do
       Spree::Config[:mails_from] = "preference@foobar.com"
       message.from = "override@foobar.com"
       message.to = "test@test.com"
-      message.deliver
+      message.deliver_now
       email = ActionMailer::Base.deliveries.first
       expect(email.from).to eq ["override@foobar.com"]
       expect(email.to).to eq ["test@test.com"]
@@ -41,7 +41,7 @@ describe Spree::OrderMailer do
 
     it "should add the bcc email when provided" do
       Spree::Config[:mail_bcc] = "bcc-foo@foobar.com"
-      message.deliver
+      message.deliver_now
       @email = ActionMailer::Base.deliveries.first
       expect(@email.bcc).to eq ["bcc-foo@foobar.com"]
     end
@@ -57,14 +57,14 @@ describe Spree::OrderMailer do
 
       it "should replace the receipient with the specified address" do
         Spree::Config[:intercept_email] = "intercept@foobar.com"
-        message.deliver
+        message.deliver_now
         @email = ActionMailer::Base.deliveries.first
         expect(@email.to).to eq ["intercept@foobar.com"]
       end
 
       it "should modify the subject to include the original email" do
         Spree::Config[:intercept_email] = "intercept@foobar.com"
-        message.deliver
+        message.deliver_now
         @email = ActionMailer::Base.deliveries.first
         expect(@email.subject).to include order.distributor.contact.email
       end
@@ -73,7 +73,7 @@ describe Spree::OrderMailer do
     context "when intercept_mode is not provided" do
       it "should not modify the recipient" do
         Spree::Config[:intercept_email] = ""
-        message.deliver
+        message.deliver_now
         @email = ActionMailer::Base.deliveries.first
         expect(@email.to).to eq [order.distributor.contact.email]
       end

--- a/spec/mailers/enterprise_mailer_spec.rb
+++ b/spec/mailers/enterprise_mailer_spec.rb
@@ -15,7 +15,7 @@ describe EnterpriseMailer do
 
   describe "#welcome" do
     it "sends a welcome email when given an enterprise" do
-      EnterpriseMailer.welcome(enterprise).deliver
+      EnterpriseMailer.welcome(enterprise).deliver_now
 
       mail = ActionMailer::Base.deliveries.first
       expect(mail.subject)
@@ -25,7 +25,7 @@ describe EnterpriseMailer do
 
   describe "#manager_invitation" do
     it "should send a manager invitation email when given an enterprise and user" do
-      EnterpriseMailer.manager_invitation(enterprise, user).deliver
+      EnterpriseMailer.manager_invitation(enterprise, user).deliver_now
       expect(ActionMailer::Base.deliveries.count).to eq 1
       mail = ActionMailer::Base.deliveries.first
       expect(mail.subject).to eq "#{enterprise.name} has invited you to be a manager"

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -23,14 +23,14 @@ describe Spree::OrderMailer do
     it "confirm_email_for_customer accepts an order id as an alternative to an Order object" do
       expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
       expect {
-        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver
+        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver_now
       }.to_not raise_error
     end
 
     it "cancel_email accepts an order id as an alternative to an Order object" do
       expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
       expect {
-        Spree::OrderMailer.cancel_email(order.id).deliver
+        Spree::OrderMailer.cancel_email(order.id).deliver_now
       }.to_not raise_error
     end
   end
@@ -101,7 +101,7 @@ describe Spree::OrderMailer do
 
     describe "for customers" do
       it "should send an email to the customer when given an order" do
-        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver
+        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver_now
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first.to).to eq([order.email])
       end
@@ -114,14 +114,14 @@ describe Spree::OrderMailer do
       end
 
       it "sets a reply-to of the enterprise email" do
-        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver
+        Spree::OrderMailer.confirm_email_for_customer(order.id).deliver_now
         expect(ActionMailer::Base.deliveries.first.reply_to).to eq([distributor.contact.email])
       end
     end
 
     describe "for shops" do
       it "sends an email to the shop owner when given an order" do
-        Spree::OrderMailer.confirm_email_for_shop(order.id).deliver
+        Spree::OrderMailer.confirm_email_for_shop(order.id).deliver_now
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first.to).to eq([distributor.contact.email])
       end
@@ -129,7 +129,7 @@ describe Spree::OrderMailer do
       it "sends an email even if a footer_email is given" do
         # Testing bug introduced by a9c37c162e1956028704fbdf74ce1c56c5b3ce7d
         ContentConfig.footer_email = "email@example.com"
-        Spree::OrderMailer.confirm_email_for_shop(order.id).deliver
+        Spree::OrderMailer.confirm_email_for_shop(order.id).deliver_now
         expect(ActionMailer::Base.deliveries.count).to eq(1)
       end
     end

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -99,7 +99,7 @@ describe ProducerMailer, type: :mailer do
 
   it "sends no mail when the producer has no orders" do
     expect do
-      ProducerMailer.order_cycle_report(s3, order_cycle).deliver
+      ProducerMailer.order_cycle_report(s3, order_cycle).deliver_now
     end.to change(ActionMailer::Base.deliveries, :count).by(0)
   end
 

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -51,10 +51,6 @@ describe ProducerMailer, type: :mailer do
 
   let(:mail) { ProducerMailer.order_cycle_report(s1, order_cycle) }
 
-  it "should send an email when an order cycle is closed" do
-    expect(ActionMailer::Base.deliveries.count).to eq(1)
-  end
-
   it "sets a reply-to of the oc coordinator's email" do
     expect(mail.reply_to).to eq [order_cycle.coordinator.contact.email]
   end

--- a/spec/mailers/shipment_mailer_spec.rb
+++ b/spec/mailers/shipment_mailer_spec.rb
@@ -30,7 +30,7 @@ describe Spree::ShipmentMailer do
   it "shipment_email accepts an shipment id as an alternative to an Shipment object" do
     expect(Spree::Shipment).to receive(:find).with(shipment.id).and_return(shipment)
     expect {
-      Spree::ShipmentMailer.shipped_email(shipment.id).deliver
+      Spree::ShipmentMailer.shipped_email(shipment.id).deliver_now
     }.to_not raise_error
   end
 end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -21,7 +21,7 @@ describe SubscriptionMailer, type: :mailer do
       before do
         changes[order.line_items.first.id] = 2
         expect do
-          SubscriptionMailer.placement_email(order, changes).deliver
+          SubscriptionMailer.placement_email(order, changes).deliver_now
         end.to change{ SubscriptionMailer.deliveries.count }.by(1)
       end
 
@@ -35,7 +35,7 @@ describe SubscriptionMailer, type: :mailer do
     context "and changes have not been made to the order" do
       before do
         expect do
-          SubscriptionMailer.placement_email(order, {}).deliver
+          SubscriptionMailer.placement_email(order, {}).deliver_now
         end.to change{ SubscriptionMailer.deliveries.count }.by(1)
       end
 
@@ -56,7 +56,7 @@ describe SubscriptionMailer, type: :mailer do
       let(:body) { email.body.encoded }
 
       before do
-        SubscriptionMailer.placement_email(order, {}).deliver
+        SubscriptionMailer.placement_email(order, {}).deliver_now
       end
 
       context "when the customer has a user account" do
@@ -103,7 +103,7 @@ describe SubscriptionMailer, type: :mailer do
 
     before do
       expect do
-        SubscriptionMailer.confirmation_email(order).deliver
+        SubscriptionMailer.confirmation_email(order).deliver_now
       end.to change{ SubscriptionMailer.deliveries.count }.by(1)
     end
 
@@ -143,7 +143,7 @@ describe SubscriptionMailer, type: :mailer do
 
     before do
       expect do
-        SubscriptionMailer.empty_email(order, {}).deliver
+        SubscriptionMailer.empty_email(order, {}).deliver_now
       end.to change{ SubscriptionMailer.deliveries.count }.by(1)
     end
 
@@ -164,7 +164,7 @@ describe SubscriptionMailer, type: :mailer do
       order.errors.add(:base, "This is a payment failure error")
 
       expect do
-        SubscriptionMailer.failed_payment_email(order).deliver
+        SubscriptionMailer.failed_payment_email(order).deliver_now
       end.to change{ SubscriptionMailer.deliveries.count }.by(1)
     end
 
@@ -215,7 +215,7 @@ describe SubscriptionMailer, type: :mailer do
         allow(summary).to receive(:order_count) { 37 }
         allow(summary).to receive(:issue_count) { 0 }
         allow(summary).to receive(:issues) { {} }
-        SubscriptionMailer.placement_summary_email(summary).deliver
+        SubscriptionMailer.placement_summary_email(summary).deliver_now
       end
 
       it "sends the email, which notifies the enterprise that all orders were successfully processed" do
@@ -240,7 +240,7 @@ describe SubscriptionMailer, type: :mailer do
 
       context "when no unrecorded issues are present" do
         it "sends the email, which notifies the enterprise that some issues were encountered" do
-          SubscriptionMailer.placement_summary_email(summary).deliver
+          SubscriptionMailer.placement_summary_email(summary).deliver_now
           expect(body).to include I18n.t("#{scope}.placement_summary_email.intro", shop: shop.name)
           expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 37)
           expect(body).to include I18n.t("#{scope}.summary_overview.success_some", count: 35)
@@ -268,7 +268,7 @@ describe SubscriptionMailer, type: :mailer do
 
         it "sends the email, which notifies the enterprise that some issues were encountered" do
           expect(summary).to receive(:orders_affected_by).with(:other) { [order3, order4] }
-          SubscriptionMailer.placement_summary_email(summary).deliver
+          SubscriptionMailer.placement_summary_email(summary).deliver_now
           expect(body).to include I18n.t("#{scope}.summary_detail.processing.title", count: 2)
           expect(body).to include I18n.t("#{scope}.summary_detail.processing.explainer")
           expect(body).to include I18n.t("#{scope}.summary_detail.other.title", count: 2)
@@ -291,7 +291,7 @@ describe SubscriptionMailer, type: :mailer do
         allow(summary).to receive(:issue_count) { 2 }
         allow(summary).to receive(:issues) { { changes: { 1 => nil, 2 => nil } } }
         allow(summary).to receive(:orders_affected_by) { [order1, order2] }
-        SubscriptionMailer.placement_summary_email(summary).deliver
+        SubscriptionMailer.placement_summary_email(summary).deliver_now
       end
 
       it "sends the email, which notifies the enterprise that some issues were encountered" do
@@ -325,7 +325,7 @@ describe SubscriptionMailer, type: :mailer do
         allow(summary).to receive(:order_count) { 37 }
         allow(summary).to receive(:issue_count) { 0 }
         allow(summary).to receive(:issues) { {} }
-        SubscriptionMailer.confirmation_summary_email(summary).deliver
+        SubscriptionMailer.confirmation_summary_email(summary).deliver_now
       end
 
       it "sends the email, which notifies the enterprise that all orders were successfully processed" do
@@ -350,7 +350,7 @@ describe SubscriptionMailer, type: :mailer do
 
       context "when no unrecorded issues are present" do
         it "sends the email, which notifies the enterprise that some issues were encountered" do
-          SubscriptionMailer.confirmation_summary_email(summary).deliver
+          SubscriptionMailer.confirmation_summary_email(summary).deliver_now
           expect(body).to include I18n.t("#{scope}.confirmation_summary_email.intro", shop: shop.name)
           expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 37)
           expect(body).to include I18n.t("#{scope}.summary_overview.success_some", count: 35)
@@ -378,7 +378,7 @@ describe SubscriptionMailer, type: :mailer do
 
         it "sends the email, which notifies the enterprise that some issues were encountered" do
           expect(summary).to receive(:orders_affected_by).with(:other) { [order3, order4] }
-          SubscriptionMailer.confirmation_summary_email(summary).deliver
+          SubscriptionMailer.confirmation_summary_email(summary).deliver_now
           expect(body).to include I18n.t("#{scope}.summary_detail.failed_payment.title", count: 2)
           expect(body).to include I18n.t("#{scope}.summary_detail.failed_payment.explainer")
           expect(body).to include I18n.t("#{scope}.summary_detail.other.title", count: 2)
@@ -401,7 +401,7 @@ describe SubscriptionMailer, type: :mailer do
         allow(summary).to receive(:issue_count) { 2 }
         allow(summary).to receive(:issues) { { changes: { 1 => nil, 2 => nil } } }
         allow(summary).to receive(:orders_affected_by) { [order1, order2] }
-        SubscriptionMailer.confirmation_summary_email(summary).deliver
+        SubscriptionMailer.confirmation_summary_email(summary).deliver_now
       end
 
       it "sends the email, which notifies the enterprise that some issues were encountered" do

--- a/spec/mailers/test_mailer_spec.rb
+++ b/spec/mailers/test_mailer_spec.rb
@@ -15,7 +15,7 @@ describe Spree::TestMailer do
   it "confirm_email accepts a user id as an alternative to a User object" do
     expect(Spree.user_class).to receive(:find).with(user.id).and_return(user)
     expect {
-      Spree::TestMailer.test_email(user.id).deliver
+      Spree::TestMailer.test_email(user.id).deliver_now
     }.to_not raise_error
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -21,7 +21,7 @@ describe Spree::UserMailer do
 
   describe '#signup_confirmation' do
     it "sends email when given a user" do
-      Spree::UserMailer.signup_confirmation(user).deliver
+      Spree::UserMailer.signup_confirmation(user).deliver_now
       expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
 
@@ -35,13 +35,13 @@ describe Spree::UserMailer do
 
       it "sends email in user locale when user locale is defined" do
         user.locale = 'es'
-        Spree::UserMailer.signup_confirmation(user).deliver
+        Spree::UserMailer.signup_confirmation(user).deliver_now
         expect(ActionMailer::Base.deliveries.first.body).to include "Gracias por unirte"
       end
 
       it "sends email in default locale when user locale is not available" do
         user.locale = 'cn'
-        Spree::UserMailer.signup_confirmation(user).deliver
+        Spree::UserMailer.signup_confirmation(user).deliver_now
         expect(ActionMailer::Base.deliveries.first.body).to include "Obrigada por juntar-se"
       end
     end
@@ -50,7 +50,7 @@ describe Spree::UserMailer do
   # adapted from https://github.com/spree/spree_auth_devise/blob/70737af/spec/mailers/user_mailer_spec.rb
   describe '#reset_password_instructions' do
     describe 'message contents' do
-      let(:message) { described_class.reset_password_instructions(user, nil).deliver }
+      let(:message) { described_class.reset_password_instructions(user, nil).deliver_now }
 
       context 'subject includes' do
         it 'translated devise instructions' do
@@ -86,7 +86,7 @@ describe Spree::UserMailer do
     describe 'legacy support for User object' do
       it 'sends an email' do
         expect do
-          Spree::UserMailer.reset_password_instructions(user, nil).deliver
+          Spree::UserMailer.reset_password_instructions(user, nil).deliver_now
         end.to change(ActionMailer::Base.deliveries, :size).by(1)
       end
     end

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -30,7 +30,7 @@ describe ProxyOrder, type: :model do
         let(:order) { create(:completed_order_with_totals) }
 
         it "returns true and sets canceled_at to the current time, and cancels the order" do
-          expect(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
+          expect(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_later: true) }
           expect(proxy_order.cancel).to be true
           expect_cancelled_now proxy_order
           expect(order.reload.state).to eq 'canceled'
@@ -107,7 +107,7 @@ describe ProxyOrder, type: :model do
 
       context "and the order has already been cancelled" do
         before do
-          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
+          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_later: true) }
           while !order.completed? do break unless order.next! end
           order.cancel
         end
@@ -147,7 +147,7 @@ describe ProxyOrder, type: :model do
 
       context "and the order has been cancelled" do
         before do
-          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
+          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_later: true) }
           while !order.completed? do break unless order.next! end
           order.cancel
         end

--- a/spec/models/proxy_order_spec.rb
+++ b/spec/models/proxy_order_spec.rb
@@ -30,7 +30,7 @@ describe ProxyOrder, type: :model do
         let(:order) { create(:completed_order_with_totals) }
 
         it "returns true and sets canceled_at to the current time, and cancels the order" do
-          expect(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver: true) }
+          expect(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
           expect(proxy_order.cancel).to be true
           expect_cancelled_now proxy_order
           expect(order.reload.state).to eq 'canceled'
@@ -107,7 +107,7 @@ describe ProxyOrder, type: :model do
 
       context "and the order has already been cancelled" do
         before do
-          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver: true) }
+          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
           while !order.completed? do break unless order.next! end
           order.cancel
         end
@@ -147,7 +147,7 @@ describe ProxyOrder, type: :model do
 
       context "and the order has been cancelled" do
         before do
-          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver: true) }
+          allow(Spree::OrderMailer).to receive(:cancel_email) { double(:email, deliver_now: true) }
           while !order.completed? do break unless order.next! end
           order.cancel
         end

--- a/spec/models/spree/order/state_machine_spec.rb
+++ b/spec/models/spree/order/state_machine_spec.rb
@@ -123,7 +123,7 @@ describe Spree::Order do
         order_id = args[0]
         mail_message
       }
-      expect(mail_message).to receive :deliver_now
+      expect(mail_message).to receive :deliver_later
       order.cancel!
       expect(order_id).to eq order.id
     end
@@ -133,7 +133,7 @@ describe Spree::Order do
         allow(shipment).to receive(:ensure_correct_adjustment)
         allow(shipment).to receive(:update_order)
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
-        allow(mail_message).to receive :deliver_now
+        allow(mail_message).to receive :deliver_later
 
         allow(order).to receive :has_available_shipment
       end
@@ -143,7 +143,7 @@ describe Spree::Order do
       before do
         # Stubs methods that cause unwanted side effects in this test
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
-        allow(mail_message).to receive :deliver_now
+        allow(mail_message).to receive :deliver_later
         allow(order).to receive :has_available_shipment
         allow(order).to receive :restock_items!
         allow(shipment).to receive(:cancel!)

--- a/spec/models/spree/order/state_machine_spec.rb
+++ b/spec/models/spree/order/state_machine_spec.rb
@@ -123,7 +123,7 @@ describe Spree::Order do
         order_id = args[0]
         mail_message
       }
-      expect(mail_message).to receive :deliver
+      expect(mail_message).to receive :deliver_now
       order.cancel!
       expect(order_id).to eq order.id
     end
@@ -133,7 +133,7 @@ describe Spree::Order do
         allow(shipment).to receive(:ensure_correct_adjustment)
         allow(shipment).to receive(:update_order)
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
-        allow(mail_message).to receive :deliver
+        allow(mail_message).to receive :deliver_now
 
         allow(order).to receive :has_available_shipment
       end
@@ -143,7 +143,7 @@ describe Spree::Order do
       before do
         # Stubs methods that cause unwanted side effects in this test
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
-        allow(mail_message).to receive :deliver
+        allow(mail_message).to receive :deliver_now
         allow(order).to receive :has_available_shipment
         allow(order).to receive :restock_items!
         allow(shipment).to receive(:cancel!)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -179,7 +179,7 @@ describe Spree::Order do
       # Stub this method as it's called due to a callback
       # and it's irrelevant to this test
       allow(order).to receive :has_available_shipment
-      allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver
+      allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_now
       adjustments = double
       allow(order).to receive_messages adjustments: adjustments
       expect(adjustments).to receive(:update_all).with(state: 'closed')

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -179,7 +179,7 @@ describe Spree::Order do
       # Stub this method as it's called due to a callback
       # and it's irrelevant to this test
       allow(order).to receive :has_available_shipment
-      allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_now
+      allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_later
       adjustments = double
       allow(order).to receive_messages adjustments: adjustments
       expect(adjustments).to receive(:update_all).with(state: 'closed')

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -376,7 +376,7 @@ describe Spree::Shipment do
         shipment_id = args[0]
         mail_message
       }
-      expect(mail_message).to receive :deliver
+      expect(mail_message).to receive :deliver_now
       shipment.ship!
       expect(shipment_id).to eq shipment.id
     end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -376,7 +376,7 @@ describe Spree::Shipment do
         shipment_id = args[0]
         mail_message
       }
-      expect(mail_message).to receive :deliver_now
+      expect(mail_message).to receive :deliver_later
       shipment.ship!
       expect(shipment_id).to eq shipment.id
     end

--- a/spec/support/delayed_job_helper.rb
+++ b/spec/support/delayed_job_helper.rb
@@ -2,12 +2,6 @@
 
 module OpenFoodNetwork
   module DelayedJobHelper
-    def run_job(job)
-      clear_jobs
-      Delayed::Job.enqueue job
-      flush_jobs
-    end
-
     # Process all pending Delayed jobs, keeping in mind jobs could spawn new
     # delayed job (so things might be added to the queue while processing)
     def flush_jobs(options = {})


### PR DESCRIPTION
#### What? Why?

Fixes:
```
DEPRECATION WARNING: `#deliver` is deprecated and will be removed in Rails 5. Use `#deliver_now` to deliver
immediately or `#deliver_later` to deliver through Active Job.
```

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Updated usage of deprecated ActionMailer#deliver method
