### PR TITLE
Adding inverse_of

### DIFF
--- a/app/models/spree/inventory_unit.rb
+++ b/app/models/spree/inventory_unit.rb
@@ -5,7 +5,8 @@ module Spree
     belongs_to :variant, class_name: "Spree::Variant"
     belongs_to :order, class_name: "Spree::Order"
     belongs_to :shipment, class_name: "Spree::Shipment"
-    belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization"
+    belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization",
+                                      inverse_of: :inventory_units
 
     scope :backordered, -> { where state: 'backordered' }
     scope :shipped, -> { where state: 'shipped' }

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -41,7 +41,7 @@ module Spree
     has_many :state_changes, as: :stateful
     has_many :line_items, -> { order('created_at ASC') }, dependent: :destroy
     has_many :payments, dependent: :destroy
-    has_many :return_authorizations, dependent: :destroy
+    has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :adjustments, -> { order "#{Spree::Adjustment.table_name}.created_at ASC" },
              as: :adjustable,
              dependent: :destroy

--- a/app/models/spree/return_authorization.rb
+++ b/app/models/spree/return_authorization.rb
@@ -2,9 +2,9 @@
 
 module Spree
   class ReturnAuthorization < ActiveRecord::Base
-    belongs_to :order, class_name: 'Spree::Order'
+    belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations
 
-    has_many :inventory_units
+    has_many :inventory_units, inverse_of: :return_authorization
     has_one :stock_location
     before_create :generate_number
     before_save :force_positive_amount

--- a/app/models/spree/shipping_category.rb
+++ b/app/models/spree/shipping_category.rb
@@ -4,7 +4,7 @@ module Spree
   class ShippingCategory < ActiveRecord::Base
     validates :name, presence: true
     has_many :products
-    has_many :shipping_method_categories
+    has_many :shipping_method_categories, inverse_of: :shipping_method
     has_many :shipping_methods, through: :shipping_method_categories
   end
 end

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -12,7 +12,7 @@ module Spree
     has_many :shipments
     has_many :shipping_method_categories
     has_many :shipping_categories, through: :shipping_method_categories
-    has_many :shipping_rates
+    has_many :shipping_rates, inverse_of: :shipping_method
     has_many :distributor_shipping_methods
     has_many :distributors, through: :distributor_shipping_methods,
                             class_name: 'Enterprise',

--- a/app/models/spree/shipping_method_category.rb
+++ b/app/models/spree/shipping_method_category.rb
@@ -3,6 +3,7 @@
 module Spree
   class ShippingMethodCategory < ActiveRecord::Base
     belongs_to :shipping_method, class_name: 'Spree::ShippingMethod'
-    belongs_to :shipping_category, class_name: 'Spree::ShippingCategory'
+    belongs_to :shipping_category, class_name: 'Spree::ShippingCategory',
+                                   inverse_of: :shipping_method_categories
   end
 end

--- a/app/models/spree/shipping_rate.rb
+++ b/app/models/spree/shipping_rate.rb
@@ -3,7 +3,7 @@
 module Spree
   class ShippingRate < ActiveRecord::Base
     belongs_to :shipment, class_name: 'Spree::Shipment'
-    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod'
+    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
 
     scope :frontend,
           -> {

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -4,7 +4,7 @@ module Spree
   class StockItem < ActiveRecord::Base
     acts_as_paranoid
 
-    belongs_to :stock_location, class_name: 'Spree::StockLocation'
+    belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items
     belongs_to :variant, class_name: 'Spree::Variant'
     has_many :stock_movements, dependent: :destroy
 

--- a/app/models/spree/stock_location.rb
+++ b/app/models/spree/stock_location.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class StockLocation < ActiveRecord::Base
-    has_many :stock_items, dependent: :delete_all
+    has_many :stock_items, dependent: :delete_all, inverse_of: :stock_location
     has_many :stock_movements, through: :stock_items
 
     belongs_to :state, class_name: 'Spree::State'

--- a/app/models/spree/tax_category.rb
+++ b/app/models/spree/tax_category.rb
@@ -5,7 +5,7 @@ module Spree
     acts_as_paranoid
     validates :name, presence: true, uniqueness: { scope: :deleted_at }
 
-    has_many :tax_rates, dependent: :destroy
+    has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
 
     before_save :set_default_category
 

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -16,8 +16,8 @@ module Spree
   class TaxRate < ActiveRecord::Base
     acts_as_paranoid
     include Spree::Core::CalculatedAdjustments
-    belongs_to :zone, class_name: "Spree::Zone"
-    belongs_to :tax_category, class_name: "Spree::TaxCategory"
+    belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates
+    belongs_to :tax_category, class_name: "Spree::TaxCategory", inverse_of: :tax_rates
 
     validates :amount, presence: true, numericality: true
     validates :tax_category_id, presence: true

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -18,10 +18,10 @@ module Spree
                         :tax_category_id, :shipping_category_id, :meta_description,
                         :meta_keywords, :tax_category, :shipping_category
 
-    has_many :inventory_units
-    has_many :line_items
+    has_many :inventory_units, inverse_of: :variant
+    has_many :line_items, inverse_of: :variant
 
-    has_many :stock_items, dependent: :destroy
+    has_many :stock_items, dependent: :destroy, inverse_of: :variant
     has_many :stock_locations, through: :stock_items
     has_many :stock_movements
 

--- a/app/models/spree/zone.rb
+++ b/app/models/spree/zone.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class Zone < ActiveRecord::Base
-    has_many :zone_members, dependent: :destroy, class_name: "Spree::ZoneMember"
-    has_many :tax_rates, dependent: :destroy
+    has_many :zone_members, dependent: :destroy, class_name: "Spree::ZoneMember", inverse_of: :zone
+    has_many :tax_rates, dependent: :destroy, inverse_of: :zone
     has_and_belongs_to_many :shipping_methods, join_table: 'spree_shipping_methods_zones'
 
     validates :name, presence: true, uniqueness: true

--- a/app/models/spree/zone_member.rb
+++ b/app/models/spree/zone_member.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class ZoneMember < ActiveRecord::Base
-    belongs_to :zone, class_name: 'Spree::Zone', counter_cache: true
+    belongs_to :zone, class_name: 'Spree::Zone', counter_cache: true, inverse_of: :zone_members
     belongs_to :zoneable, polymorphic: true
 
     def name


### PR DESCRIPTION
#### What? Why?

Brings in some improvements to the definitions on associations from Spree `2-2-stable`. Explicitly defining the `inverse_of` on associations helps `ActiveRecord` figure out what it's supposed to be doing, especially across join tables.

See commit messages for links to the original Spree commits (with links to issues they fix and related discussions).

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Added missing `inverse_of` declarations on various associations.