### PR TITLE
Ensure ShippingMethod is correctly using soft-deletion

### DIFF
--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -5,6 +5,7 @@ module Spree
     include Spree::Core::CalculatedAdjustments
     DISPLAY = [:both, :front_end, :back_end].freeze
 
+    acts_as_paranoid
     acts_as_taggable
 
     default_scope -> { where(deleted_at: nil) }

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -159,6 +159,16 @@ module Spree
       end
     end
 
+    # Regression test for Spree #4320
+    context "soft deletion" do
+      let(:shipping_method) { create(:shipping_method) }
+
+      it "soft-deletes when destroy is called" do
+        shipping_method.destroy
+        expect(shipping_method.deleted_at).to_not be_blank
+      end
+    end
+
     context 'factory' do
       let(:shipping_method){ create :shipping_method }
 


### PR DESCRIPTION
#### What? Why?

Pulls in some minor upstream fixes to soft-deletion on `ShippingMethod`.

We've already applied some of the changes in this commit during previous Spree upgrade work, but there were a couple of bits missing. Basically the transition to soft-deletion was started but left unfinished.

See: https://github.com/spree/spree/commit/25f5c2daf82d64d04fb77dd99e63aa941eae52f8

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Updated soft-deletion of shipping methods.