### PR TITLE
remove asterisk on 'display as' field unit value for a product

### DIFF
--- a/app/views/spree/admin/products/_display_as.html.haml
+++ b/app/views/spree/admin/products/_display_as.html.haml
@@ -1,5 +1,4 @@
 .three.columns.omega{ "ng-if" => "product.variant_unit_with_scale != 'items'" }
   = f.field_container :display_as do
     = f.label :product_display_as, t('.display_as')
-    %span.required *
     %input#product_display_as.fullwidth{name: "product[display_as]", placeholder: "{{ placeholder_text }}", type: "text"}


### PR DESCRIPTION
#### What? Why?
Closes #6651
"Display as" field for a unit value (on a product) is not a mandatory field. Remove trailing asterisk.



#### What should we test?
 - Log in as admin and visit admin/product/new
 - Choose a Unit Size * which is not items.
 - "Display as" should not have an asterisk

<img width="372" alt="Capture d’écran 2021-01-13 à 11 32 29" src="https://user-images.githubusercontent.com/296452/104440787-1113dd00-5593-11eb-9e82-16b9e8e587c6.png">


#### Release notes
Remove trailing asterisk on a no mandatory field when adding a new product.

Changelog Category: User facing changes

