### PR TITLE
Remove #update_attributes_without_callbacks

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -766,13 +766,6 @@ module Spree
       address
     end
 
-    # Update attributes of a record in the database without callbacks, validations etc.
-    #   This was originally an extension to ActiveRecord in Spree but only used for Spree::Order
-    def update_attributes_without_callbacks(attributes)
-      assign_attributes(attributes)
-      Spree::Order.where(id: id).update_all(attributes)
-    end
-
     private
 
     def process_each_payment

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -32,7 +32,7 @@ module OrderManagement
         # update totals a second time in case updated adjustments have an effect on the total
         update_totals
 
-        order.update_attributes_without_callbacks(
+        order.update_columns(
           payment_state: order.payment_state,
           shipment_state: order.shipment_state,
           item_total: order.item_total,

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module OrderManagement
   module Order
     describe Updater do
-      let(:order) { build(:order) }
+      let(:order) { create(:order) }
       let(:updater) { OrderManagement::Order::Updater.new(order) }
 
       before { allow(order).to receive(:backordered?) { false } }

--- a/spec/models/spree/order/updating_spec.rb
+++ b/spec/models/spree/order/updating_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Spree::Order do
-  let(:order) { build(:order) }
+  let(:order) { create(:order) }
 
   context "#update!" do
     let(:line_items) { [build(:line_item, amount: 5)] }


### PR DESCRIPTION
#### What? Why?

This is a slightly hacky Spree method that's removed in Spree 2.2

See: https://github.com/spree/spree/commit/7deba6a152fd63258941a5ca89f06205a5b62cfd

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed unnecessary method #update_attributes_without_callbacks

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
