### PR TITLE
Improve performance on summing adjustments and payment

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -19,7 +19,7 @@ module CheckoutHelper
     adjustments.reject! { |a| a.originator_type == 'EnterpriseFee' && a.source_type != 'Spree::LineItem' }
     unless exclude.include? :admin_and_handling
       adjustments << Spree::Adjustment.new(
-        label: I18n.t(:orders_form_admin), amount: enterprise_fee_adjustments.sum(:amount)
+        label: I18n.t(:orders_form_admin), amount: enterprise_fee_adjustments.sum(&:amount)
       )
     end
 

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -19,7 +19,7 @@ module CheckoutHelper
     adjustments.reject! { |a| a.originator_type == 'EnterpriseFee' && a.source_type != 'Spree::LineItem' }
     unless exclude.include? :admin_and_handling
       adjustments << Spree::Adjustment.new(
-        label: I18n.t(:orders_form_admin), amount: enterprise_fee_adjustments.map(&:amount).sum
+        label: I18n.t(:orders_form_admin), amount: enterprise_fee_adjustments.sum(:amount)
       )
     end
 
@@ -28,7 +28,7 @@ module CheckoutHelper
 
   def display_checkout_admin_and_handling_adjustments_total_for(order)
     adjustments = order.adjustments.eligible.where('originator_type = ? AND source_type != ? ', 'EnterpriseFee', 'Spree::LineItem')
-    Spree::Money.new adjustments.map(&:amount).sum, currency: order.currency
+    Spree::Money.new adjustments.sum(:amount), currency: order.currency
   end
 
   def checkout_line_item_adjustments(order)
@@ -36,7 +36,7 @@ module CheckoutHelper
   end
 
   def checkout_subtotal(order)
-    order.item_total + checkout_line_item_adjustments(order).map(&:amount).sum
+    order.item_total + checkout_line_item_adjustments(order).sum(:amount)
   end
 
   def display_checkout_subtotal(order)

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -397,11 +397,11 @@ module Spree
     end
 
     def ship_total
-      adjustments.shipping.map(&:amount).sum
+      adjustments.shipping.sum(:amount)
     end
 
     def tax_total
-      adjustments.tax.map(&:amount).sum
+      adjustments.tax.sum(:amount)
     end
 
     # Creates new tax charges if there are any applicable rates. If prices already

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -55,9 +55,9 @@ module OrderManagement
       # - adjustment_total - total value of all adjustments
       # - total - order total, it's the equivalent to item_total plus adjustment_total
       def update_totals
-        order.payment_total = payments.completed.map(&:amount).sum
+        order.payment_total = payments.completed.sum(:amount)
         order.item_total = line_items.map(&:amount).sum
-        order.adjustment_total = adjustments.eligible.map(&:amount).sum
+        order.adjustment_total = adjustments.eligible.sum(:amount)
         order.total = order.item_total + order.adjustment_total
       end
 

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -11,14 +11,12 @@ module OrderManagement
       before { allow(order).to receive(:backordered?) { false } }
 
       it "updates totals" do
-        payments = [double(amount: 5), double(amount: 5)]
-        allow(order).to receive_message_chain(:payments, :completed).and_return(payments)
+        allow(order).to receive_message_chain(:payments, :completed, :sum).and_return(10)
 
         line_items = [double(amount: 10), double(amount: 20)]
         allow(order).to receive_messages line_items: line_items
 
-        adjustments = [double(amount: 10), double(amount: -20)]
-        allow(order).to receive_message_chain(:adjustments, :eligible).and_return(adjustments)
+        allow(order).to receive_message_chain(:adjustments, :eligible, :sum).and_return(-10)
 
         updater.update_totals
         expect(order.payment_total).to eq 10

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -31,4 +31,29 @@ describe CheckoutHelper, type: :helper do
     order.distributor.allow_guest_orders = false
     expect(helper.guest_checkout_allowed?).to be false
   end
+
+  describe "#checkout_adjustments_for" do
+    let(:order) { create(:order_with_totals_and_distribution) }
+    let(:enterprise_fee) { create(:enterprise_fee, amount: 123) }
+    let!(:fee_adjustment) {
+      create(:adjustment, originator: enterprise_fee, adjustable: order, source: order)
+    }
+
+    before do
+      # Sanity check initial adjustments state
+      expect(order.adjustments.shipping.count).to eq 1
+      expect(order.adjustments.enterprise_fee.count).to eq 1
+    end
+
+    it "collects adjustments on the order" do
+      adjustments = helper.checkout_adjustments_for(order)
+
+      shipping_adjustment = order.adjustments.shipping.first
+      expect(adjustments).to include shipping_adjustment
+
+      admin_fee_summary = adjustments.last
+      expect(admin_fee_summary.label).to eq I18n.t(:orders_form_admin)
+      expect(admin_fee_summary.amount).to eq 123
+    end
+  end
 end

--- a/spec/models/spree/order/adjustments_spec.rb
+++ b/spec/models/spree/order/adjustments_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+
 describe Spree::Order do
   let(:order) { Spree::Order.new }
 
@@ -21,19 +22,20 @@ describe Spree::Order do
   end
 
   context "totaling adjustments" do
-    let(:adjustment1) { build(:adjustment, amount: 5) }
-    let(:adjustment2) { build(:adjustment, amount: 10) }
+    let!(:adjustment1) { create(:adjustment, amount: 5) }
+    let!(:adjustment2) { create(:adjustment, amount: 10) }
+    let(:adjustments) { Spree::Adjustment.where(id: [adjustment1, adjustment2]) }
 
     context "#ship_total" do
       it "should return the correct amount" do
-        allow(order).to receive_message_chain :adjustments, shipping: [adjustment1, adjustment2]
+        allow(order).to receive_message_chain :adjustments, shipping: adjustments
         expect(order.ship_total).to eq 15
       end
     end
 
     context "#tax_total" do
       it "should return the correct amount" do
-        allow(order).to receive_message_chain :adjustments, tax: [adjustment1, adjustment2]
+        allow(order).to receive_message_chain :adjustments, tax: adjustments
         expect(order.tax_total).to eq 15
       end
     end


### PR DESCRIPTION
#### What? Why?

`:amount` is a database field in these cases, as opposed to a method that returns a computed result. Calling `.sum(:amount)` is much more efficient as it computes the sum at database level, as opposed to `.map(&:amount).sum`, which would fetch and instanciate all the objects first, and then sum the amounts after.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved performance on summing payment and adjustment amounts.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes