### PR TITLE
Fix payment identifier generation

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -23,7 +23,7 @@ module Spree
     has_one :adjustment, as: :source, dependent: :destroy
 
     validate :validate_source
-    before_save :set_unique_identifier
+    before_create :set_unique_identifier
 
     after_save :create_payment_profile, if: :profiles_supported?
 


### PR DESCRIPTION
#### What? Why?

Upstream bugfix from Spree 2.2. The unique identifier should be set once on creation, not regenerated on each save.

See: https://github.com/spree/spree/commit/4e747187d75a11b3fe86e1718f76843c2d108dd3

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed payment unique identifier generation

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
