### PR TITLE
GA toggle

### DIFF
--- a/lib/open_food_network/feature.rb
+++ b/lib/open_food_network/feature.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module OpenFoodNetwork
+  class Feature
+    def initialize(users = [])
+      @users = users
+    end
+
+    def enabled?(user)
+      users.include?(user.email)
+    end
+
+    private
+
+    attr_reader :users
+  end
+end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -1,3 +1,7 @@
+require 'open_food_network/feature'
+require 'open_food_network/null_feature'
+require 'open_food_network/ga_feature'
+
 module OpenFoodNetwork
   # This feature toggles implementation provides two mechanisms to conditionally enable features.
   #
@@ -67,35 +71,6 @@ module OpenFoodNetwork
 
     def true?(value)
       value.to_s.casecmp("true").zero?
-    end
-  end
-
-  class Feature
-    def initialize(users = [])
-      @users = users
-    end
-
-    def enabled?(user)
-      users.include?(user.email)
-    end
-
-    private
-
-    attr_reader :users
-  end
-
-  class NullFeature
-    def enabled?(_user)
-      false
-    end
-  end
-
-  class GAFeature
-    def initialize(_users)
-    end
-
-    def enabled?(_user)
-      true
     end
   end
 end

--- a/lib/open_food_network/ga_feature.rb
+++ b/lib/open_food_network/ga_feature.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module OpenFoodNetwork
+  class GAFeature
+    def initialize(_users); end
+
+    def enabled?(_user)
+      true
+    end
+  end
+end

--- a/lib/open_food_network/null_feature.rb
+++ b/lib/open_food_network/null_feature.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module OpenFoodNetwork
+  class NullFeature
+    def enabled?(_user)
+      false
+    end
+  end
+end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -40,11 +40,19 @@ module OpenFoodNetwork
         end
       end
 
+      context 'and the feature is enabled for "all"' do
+        before { FeatureToggle.enable(:foo, ["all"]) }
+
+        it 'returns true' do
+          expect(FeatureToggle.enabled?(:foo, user)).to eq(true)
+        end
+      end
+
       context 'and the feature is disabled for them' do
         before { FeatureToggle.enable(:foo, []) }
 
         it 'returns false' do
-          expect(FeatureToggle.enabled?(:foo, user)).to eq(false)
+          expect(FeatureToggle.enabled?(:foo, user)).to eq(true)
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

I implemented this while working on https://github.com/openfoodfoundation/openfoodnetwork/pull/6643

Allows toggling a feature to all users. This comes in handy while in development and you don't want to check which user logged in. Simply run the app with `BETA_TESTERS=all` and solved.
    
It also gives us the flexibility to toggle it for all users in production without needing a deployment. Just change the ENV var and restart (reload won't be enough).

#### What should we test?

This shouldn't need manual testing. It's already thoroughly covered by automated tests.

#### Release notes

Allow toggling a feature to all users
Changelog Category: Technical changes