### PR TITLE
Further fix #5989 (Item counter accepts values higher than the available stock)

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -40,7 +40,13 @@ $(document).ready(function() {
       var variant_id = save.data('variant-id');
 
       var quantity = parseInt(save.parents('tr').find('input.line_item_quantity').val());
+      var maxQuantity = parseInt(save.parents('tr').find('input.line_item_quantity').attr("max"));
 
+      if (quantity > maxQuantity) {
+        quantity = maxQuantity;
+        save.parents('tr').find('input.line_item_quantity').val(maxQuantity);
+        alert('<%= I18n.t("js.admin.orders.quantity_adjusted") %>');
+      }
       toggleItemEdit();
 
       adjustItems(shipment_number, variant_id, quantity);
@@ -77,7 +83,9 @@ adjustItems = function(shipment_number, variant_id, quantity){
     }
     url += '.json';
 
-    if(new_quantity!=0){
+    if (new_quantity == 0) {
+      alert('<%= I18n.t("js.admin.orders.quantity_unchanged") %>');
+    } else {
       $.ajax({
         type: "PUT",
         url: Spree.url(url),

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -14,7 +14,7 @@
           = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
       - unless shipment.shipped?
         %td.item-qty-edit.hidden
-          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5, :max => item.variant.on_hand
+          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5, :max => item.variant.on_hand + item.quantity
       %td.item-total.align-center
         = line_item_shipment_price(line_item, item.quantity)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2717,6 +2717,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           processing: "processing"
           void: "void"
           invalid: "invalid"
+        quantity_adjusted: "Insufficient stock available. Line item updated to maximum available quantity."
+        quantity_unchanged: "Quantity unchanged from previous amount."
       resend_user_email_confirmation:
         resend: "Resend"
         sending: "Resend..."

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -127,21 +127,23 @@ feature '
     login_as_admin_and_visit spree.edit_admin_order_path(order)
 
     quantity = order.line_items.first.quantity
+    max_quantity = 0
     total = order.display_total
 
     within("tr.stock-item", text: order.products.first.name) do
       find("a.edit-item").click
       expect(page).to have_input(:quantity)
-      fill_in(:quantity, with: order.line_items.first.product.on_hand + 1)
+      max_quantity = find("input[name='quantity']")["max"].to_i
+      fill_in(:quantity, with: max_quantity + 1)
       find("a.save-item").click
     end
+    accept_js_alert
 
     expect(page).to_not have_content "Loading..."
     within("tr.stock-item", text: order.products.first.name) do
-      expect(page).to have_text("#{quantity} x")
+      expect(page).to have_text("#{max_quantity} x")
     end
-    expect(order.reload.display_total).to eq(total)
-    expect(order.reload.line_items.first.quantity).to eq(quantity)
+    expect(order.reload.line_items.first.quantity).to eq(max_quantity)
   end
 
   scenario "can't change distributor or order cycle once order has been finalized" do


### PR DESCRIPTION
#### What? Why?

Closes #5989 

In [testing](https://github.com/openfoodfoundation/openfoodnetwork/issues/5989#issuecomment-759640598) that PR, @filipefurtad0 noticed that it was still possible to manually fill in the quantity field and get the undesirable behavior. This prevents that from happening. 



#### What should we test?
See https://github.com/openfoodfoundation/openfoodnetwork/issues/5989#issuecomment-759640598



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Prevent the quantity field in the admin order screen from adding more than the available stock.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
