### PR TITLE
First rails 5 upgrade PR with dual boot: remove action_dispatch/request if on rails 5 so we can boot the app in rails 5

### DIFF
--- a/config/initializers/action_dispatch_request_deep_munge_patch.rb
+++ b/config/initializers/action_dispatch_request_deep_munge_patch.rb
@@ -1,1 +1,1 @@
-require "action_dispatch/request"
+require "action_dispatch/request" unless ENV['DEPENDENCIES_NEXT']


### PR DESCRIPTION
#### What? Why?

I took the fix from #6635
With this Pr you can boot the app locally in both rails 4.2 and rails 5 :tada: dual boot magic.

#### What should we test?
dev test.
boot the app in rails 4.2
rails s

boot the app in rails 5
DEPENDENCIES_NEXT=1 rails s

both should work

#### Release notes
Changelog Category: Technical changes
App is not bootable in rails 5.
