### PR TITLE
[Rails 5] Make app startup in rails 5 and update Gemfile_next.lock

### DIFF
--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -5,14 +5,6 @@ GIT
     custom_error_message (1.1.1)
 
 GIT
-  remote: https://github.com/openfoodfoundation/better_spree_paypal_express.git
-  revision: 1a477e9f7763297944cc99b6f4dd3d962aa963e9
-  branch: 2-1-0-stable
-  specs:
-    spree_paypal_express (2.0.3)
-      paypal-sdk-merchant (= 1.106.1)
-
-GIT
   remote: https://github.com/openfoodfoundation/ofn-qz.git
   revision: 467f6ea1c44529c7c91cac4c8211bbd863588c0b
   branch: ofn-rails-4
@@ -130,7 +122,7 @@ GEM
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.0.1)
-    cancan (1.6.10)
+    cancancan (1.7.1)
     capybara (3.15.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -205,11 +197,11 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    factory_bot (4.10.0)
-      activesupport (>= 3.0.0)
-    factory_bot_rails (4.10.0)
-      factory_bot (~> 4.10.0)
-      railties (>= 3.0.0)
+    factory_bot (5.2.0)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.2.0)
+      factory_bot (~> 5.2.0)
+      railties (>= 4.2.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffaker (2.11.0)
@@ -222,7 +214,7 @@ GEM
     foundation-rails (5.5.2.1)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
-    fuubar (2.5.0)
+    fuubar (2.5.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     geocoder (1.6.4)
@@ -291,7 +283,10 @@ GEM
     mini_racer (0.2.15)
       libv8 (> 7.3)
     minitest (5.14.2)
-    money (3.1.5)
+    monetize (1.9.4)
+      money (~> 6.12)
+    money (6.13.8)
+      i18n (>= 0.6.4, <= 2)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -307,10 +302,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (3.10.8)
     orm_adapter (0.5.0)
-    paper_trail (7.1.3)
-      activerecord (>= 4.0, < 5.2)
+    paper_trail (10.3.1)
+      activerecord (>= 4.2)
       request_store (~> 1.1)
     paperclip (3.4.2)
       activemodel (>= 3.0.0)
@@ -335,6 +329,9 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     rack (2.2.3)
     rack-mini-profiler (2.0.2)
@@ -566,9 +563,9 @@ DEPENDENCIES
   awesome_print
   aws-sdk (= 1.67.0)
   bugsnag
-  byebug (~> 11.0.0)
-  cancan (~> 1.6.10)
-  capybara (= 3.15)
+  byebug
+  cancancan (~> 1.7.0)
+  capybara
   catalog!
   coffee-rails (~> 4.2.2)
   combine_pdf
@@ -586,12 +583,12 @@ DEPENDENCIES
   devise-token_authenticatable
   dfc_provider!
   eventmachine (>= 1.2.3)
-  factory_bot_rails (= 4.10.0)
+  factory_bot_rails (= 5.2.0)
   ffaker
   figaro
   foundation-icons-sass-rails
   foundation-rails (= 5.5.2.1)
-  fuubar (~> 2.5.0)
+  fuubar (~> 2.5.1)
   geocoder
   gmaps4rails
   haml
@@ -605,20 +602,21 @@ DEPENDENCIES
   json
   json_spec (~> 1.1.4)
   jwt (~> 2.2)
-  kaminari (= 1.2.1)
+  kaminari (~> 1.2.1)
   knapsack
   letter_opener (>= 1.4.1)
   mini_racer (= 0.2.15)
-  money (< 6.1.0)
+  monetize (~> 1.1)
   oauth2 (~> 1.4.4)
   ofn-qz!
-  oj
   order_management!
-  paper_trail (~> 7.1.3)
+  paper_trail (~> 10.3.1)
   paperclip (~> 3.4.1)
-  paranoia (~> 2.0)
+  paranoia (~> 2.4)
+  paypal-sdk-merchant (= 1.106.1)
   pg (~> 0.21.0)
-  pry (>= 0.12.0)
+  pry
+  pry-byebug
   rack-mini-profiler (< 3.0.0)
   rack-rewrite
   rack-ssl
@@ -641,7 +639,6 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   simplecov
-  spree_paypal_express!
   spring
   spring-commands-rspec
   state_machines-activerecord
@@ -662,7 +659,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 RUBY VERSION
-   ruby 2.3.7p456
+   ruby 2.4.4p296
 
 BUNDLED WITH
    1.17.3

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,7 +1,4 @@
 unless Rails.env.production?
-  # Enable cache instrumentation, which is disabled by default
-  ActiveSupport::Cache::Store.instrument = true
-
   # Log message in the same default logger
   ActiveSupport::Cache::Store.logger = Rails.logger
 end

--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -1,15 +1,17 @@
-require_relative 'spree'
+unless ENV['DEPENDENCIES_NEXT']
+  require_relative 'spree'
 
-# See: https://github.com/itbeaver/db2fog
-DB2Fog.config = {
-    :aws_access_key_id     => Spree::Config[:s3_access_key],
-    :aws_secret_access_key => Spree::Config[:s3_secret],
-    :directory             => ENV['S3_BACKUPS_BUCKET'],
-    :provider              => 'AWS'
-}
+  # See: https://github.com/itbeaver/db2fog
+  DB2Fog.config = {
+      :aws_access_key_id     => Spree::Config[:s3_access_key],
+      :aws_secret_access_key => Spree::Config[:s3_secret],
+      :directory             => ENV['S3_BACKUPS_BUCKET'],
+      :provider              => 'AWS'
+  }
 
-region = ENV['S3_BACKUPS_REGION'] || ENV['S3_REGION']
+  region = ENV['S3_BACKUPS_REGION'] || ENV['S3_REGION']
 
-# If no region is defined we leave this config key undefined (instead of nil),
-# so that db2fog correctly applies it's default
-DB2Fog.config[:region] = region if region
+  # If no region is defined we leave this config key undefined (instead of nil),
+  # so that db2fog correctly applies it's default
+  DB2Fog.config[:region] = region if region
+end

--- a/config/initializers/js_template_helpers.rb
+++ b/config/initializers/js_template_helpers.rb
@@ -2,12 +2,5 @@
 # https://github.com/pitr/angular-rails-templates/issues/45#issuecomment-43229086
 
 Rails.application.assets.context_class.class_eval do
-  # include ApplicationHelper
-  # include ActionView::Helpers
-  # include Rails.application.routes.url_helpers
-
-  # Including all of the helpers (above) has caused some intermittent CSS include issues
-  # (not finding mixins from an @include in sass). Therefore, we're only including the
-  # bare minimum here.
   include ActionView::Helpers::TranslationHelper
 end

--- a/config/initializers/js_template_helpers.rb
+++ b/config/initializers/js_template_helpers.rb
@@ -1,6 +1,14 @@
 # Make helpers (#t in particular) available to javascript templates
 # https://github.com/pitr/angular-rails-templates/issues/45#issuecomment-43229086
 
-Rails.application.assets.context_class.class_eval do
-  include ActionView::Helpers::TranslationHelper
+if ENV['DEPENDENCIES_NEXT']
+  Rails.application.config.assets.configure do |env|
+    env.context_class.class_eval do
+      include ActionView::Helpers::TranslationHelper
+    end
+  end
+else
+  Rails.application.assets.context_class.class_eval do
+    include ActionView::Helpers::TranslationHelper
+  end
 end


### PR DESCRIPTION
#### What? Why?

This Pr updates the outdated Gemfile_next.lock and removes cache instrumentation that was enabled for staging, see commit message for more details. It also disabled db2fog in rails 5 and fixes a problem in js template helpers.
The result is that rails s will now work :+1: 

All credit to @Matt-Yorkley these fixes are copied from #6635 I just made it dual boot friendly so that it can go to master :+1: 
Matt do you want to give this style a try? In this PR there are examples for 3 options: 1. fix/remove the code from master, 2. make code run only in rails 4.2 (db2fog) and 3. if else with different versions for rails 4.2 and rails 5.

#### What should we test?
I think a green build is enough here.

#### Release notes
Changelog Category: Technical changes
Cache instrumentation in staging servers is removed now (it was not working in rails 5).