### PR TITLE
Soft-delete Enterprise Fees

### DIFF
--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -1,6 +1,8 @@
 class EnterpriseFee < ActiveRecord::Base
   include Spree::Core::CalculatedAdjustments
 
+  acts_as_paranoid
+
   belongs_to :enterprise
   belongs_to :tax_category, class_name: 'Spree::TaxCategory', foreign_key: 'tax_category_id'
 

--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -162,6 +162,13 @@ module Spree
       result
     end
 
+    # Allow accessing soft-deleted originator objects
+    def originator
+      return if originator_type.blank?
+
+      originator_type.constantize.unscoped { super }
+    end
+
     private
 
     def update_adjustable

--- a/db/migrate/20210115143738_add_deleted_at_to_enterprise_fee.rb
+++ b/db/migrate/20210115143738_add_deleted_at_to_enterprise_fee.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToEnterpriseFee < ActiveRecord::Migration
+  def change
+    add_column :enterprise_fees, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201219120055) do
+ActiveRecord::Schema.define(version: 20210115143738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 20201219120055) do
     t.datetime "updated_at",                                        null: false
     t.integer  "tax_category_id"
     t.boolean  "inherits_tax_category",             default: false, null: false
+    t.datetime "deleted_at"
   end
 
   add_index "enterprise_fees", ["enterprise_id"], name: "index_enterprise_fees_on_enterprise_id", using: :btree

--- a/spec/models/enterprise_fee_spec.rb
+++ b/spec/models/enterprise_fee_spec.rb
@@ -139,4 +139,24 @@ describe EnterpriseFee do
       end.to change(order.adjustments, :count).by(0)
     end
   end
+
+  describe "soft-deletion" do
+    let(:tax_category) { create(:tax_category) }
+    let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_category ) }
+    let!(:adjustment) { create(:adjustment, originator: enterprise_fee) }
+
+    before do
+      enterprise_fee.destroy
+      enterprise_fee.reload
+    end
+
+    it "soft-deletes the enterprise fee" do
+      expect(enterprise_fee.deleted_at).to_not be_nil
+    end
+
+    it "can be accessed by old adjustments" do
+      expect(adjustment.reload.originator).to eq enterprise_fee
+      expect(adjustment.originator.tax_category).to eq enterprise_fee.tax_category
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

These objects hold information related to adjustments and tax categories. If they are hard-deleted we lose data that's needed to make sense of associated records.

#### What should we test?
<!-- List which features should be tested and how. -->

Enterprise Fees are now soft-deleted. They should be removed from the UI when deleted but should remain in the database. Adjustments related to fees can still access the enterprise fee's tax category after it has been deleted (test coverage added).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Added soft-deletion to Enterprise Fees.