### PR TITLE
Use deliver_now in Jobs

### DIFF
--- a/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
@@ -37,13 +37,13 @@ module OrderManagement
 
       def send_placement_summary_emails
         @summaries.values.each do |summary|
-          SubscriptionMailer.placement_summary_email(summary).deliver_later
+          SubscriptionMailer.placement_summary_email(summary).deliver_now
         end
       end
 
       def send_confirmation_summary_emails
         @summaries.values.each do |summary|
-          SubscriptionMailer.confirmation_summary_email(summary).deliver_later
+          SubscriptionMailer.confirmation_summary_email(summary).deliver_now
         end
       end
 


### PR DESCRIPTION
#### What? Why?

Closes #6682

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Emails delivered from jobs use `#deliver_now` instead of `#deliver_later`.

#### What should we test?
<!-- List which features should be tested and how. -->

Subscription emails are delivered correctly

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated mail delivery for Subscription Jobs

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes


