### PR TITLE
[Rails 5] Update Angular CSRF handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,7 @@ gem 'mini_racer', '0.2.15'
 
 gem 'uglifier', '>= 1.0.3'
 
+gem 'angular_rails_csrf'
 gem 'foundation-icons-sass-rails'
 
 gem 'foundation-rails', '= 5.5.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
       railties (>= 3.1)
       sprockets (~> 2.0)
       tilt
+    angular_rails_csrf (4.2.0)
+      railties (>= 3, < 7)
     angularjs-file-upload-rails (2.4.1)
     angularjs-rails (1.5.5)
     arel (6.0.4)
@@ -732,6 +734,7 @@ DEPENDENCIES
   acts_as_list (= 0.9.19)
   andand
   angular-rails-templates (~> 0.3.0)
+  angular_rails_csrf
   angularjs-file-upload-rails (~> 2.4.1)
   angularjs-rails (= 1.5.5)
   atomic

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -104,6 +104,8 @@ GEM
       railties (>= 4.2, < 7)
       sprockets (>= 3.0, < 5)
       tilt
+    angular_rails_csrf (4.2.0)
+      railties (>= 3, < 7)
     angularjs-file-upload-rails (2.4.1)
     angularjs-rails (1.5.5)
     arel (7.1.4)
@@ -556,6 +558,7 @@ DEPENDENCIES
   acts_as_list (= 0.9.19)
   andand
   angular-rails-templates (>= 0.3.0)
+  angular_rails_csrf
   angularjs-file-upload-rails (~> 2.4.1)
   angularjs-rails (= 1.5.5)
   atomic

--- a/app/assets/javascripts/admin/admin_ofn.js.coffee
+++ b/app/assets/javascripts/admin/admin_ofn.js.coffee
@@ -10,5 +10,4 @@ angular.module("ofn.admin", [
   "admin.taxons",
   "infinite-scroll"
 ]).config ($httpProvider) ->
-  $httpProvider.defaults.headers.common["X-CSRF-Token"] = $("meta[name=csrf-token]").attr("content")
   $httpProvider.defaults.headers.common["Accept"] = "application/json, text/javascript, */*"

--- a/app/assets/javascripts/admin/index_utils/index_utils.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/index_utils.js.coffee
@@ -1,2 +1,2 @@
 angular.module("admin.indexUtils", ['admin.resources', 'ngSanitize', 'templates', 'admin.utils']).config ($httpProvider) ->
-  $httpProvider.defaults.headers.common["X-CSRF-Token"] = $("meta[name=csrf-token]").attr("content"); $httpProvider.defaults.headers.common["Accept"] = "application/json, text/javascript, */*";
+  $httpProvider.defaults.headers.common["Accept"] = "application/json, text/javascript, */*"

--- a/app/assets/javascripts/admin/order_cycles/order_cycles.js.erb.coffee
+++ b/app/assets/javascripts/admin/order_cycles/order_cycles.js.erb.coffee
@@ -1,8 +1,4 @@
 angular.module('admin.orderCycles', ['ngTagsInput', 'admin.indexUtils', 'admin.enterprises'])
-
-  .config ($httpProvider) ->
-    $httpProvider.defaults.headers.common['X-CSRF-Token'] = $('meta[name=csrf-token]').attr('content')
-
   .directive 'datetimepicker', ($timeout, $parse) ->
     require: "ngModel"
     link: (scope, element, attrs, ngModel) ->

--- a/app/assets/javascripts/admin/product_import/product_import.js.coffee
+++ b/app/assets/javascripts/admin/product_import/product_import.js.coffee
@@ -1,3 +1,2 @@
 angular.module("admin.productImport", ["ngResource"]).config ($httpProvider) ->
-  $httpProvider.defaults.headers.common["X-CSRF-Token"] = $("meta[name=csrf-token]").attr("content")
   $httpProvider.defaults.headers.common["Accept"] = "application/json, text/javascript, */*"

--- a/app/assets/javascripts/admin/utils/utils.js.coffee
+++ b/app/assets/javascripts/admin/utils/utils.js.coffee
@@ -1,1 +1,2 @@
-angular.module("admin.utils", ["templates", "ngSanitize"]).config ($httpProvider) -> $httpProvider.defaults.headers.common["X-CSRF-Token"] = $("meta[name=csrf-token]").attr("content"); $httpProvider.defaults.headers.common["Accept"] = "application/json, text/javascript, */*";
+angular.module("admin.utils", ["templates", "ngSanitize"]).config ($httpProvider) ->
+ $httpProvider.defaults.headers.common["Accept"] = "application/json, text/javascript, */*"

--- a/app/assets/javascripts/darkswarm/darkswarm.js.coffee
+++ b/app/assets/javascripts/darkswarm/darkswarm.js.coffee
@@ -12,7 +12,6 @@ window.Darkswarm = angular.module("Darkswarm", [
   'angularFileUpload',
   'angularSlideables'
 ]).config ($httpProvider, $tooltipProvider, $locationProvider, $anchorScrollProvider) ->
-  $httpProvider.defaults.headers['common']['X-CSRF-Token'] = $('meta[name="csrf-token"]').attr('content')
   $httpProvider.defaults.headers['common']['X-Requested-With'] = 'XMLHttpRequest'
   $httpProvider.defaults.headers.common.Accept = "application/json, text/javascript, */*"
 


### PR DESCRIPTION
#### What? Why?

Pulls in another piece from the Rails 5 upgrade #6635. Should be compatible with master.

Changes Angular CSRF token handling from the current (slightly hacky) method which pulls the token out of a tag in the DOM via jQuery, to a well-used gem made for handling CSRF tokens in Angular.

#### What should we test?
<!-- List which features should be tested and how. -->

Form submissions that submit data asynchronously (without doing a full page reload). Admin bulk products is a good example.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated Angular CSRF token handling for Rails 5

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes