### PR TITLE
Remove old deprecation warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -206,16 +206,6 @@ RSpec.configure do |config|
 
   config.include JsonSpec::Helpers
 
-  # Suppress Selenium deprecation warnings. Stops a flood of pointless warnings filling the
-  # test output. We can remove this in the future after upgrading Rails, Rack, and Capybara.
-  if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR == 0
-    Selenium::WebDriver.logger.level = :error
-  else
-    ActiveSupport::Deprecation.warn(
-      "Suppressing Selenium deprecation warnings is not needed any more."
-    )
-  end
-
   # Profiling
   #
   # This code shouldn't be run in normal circumstances. But if you want to know


### PR DESCRIPTION
#### What? Why?

We're in Rails 4.2 so we can remove it. This gets rid of the following message when running tests:

```
DEPRECATION WARNING: Suppressing Selenium deprecation warnings is not needed any more. (called from block in <top (required)> at /usr/src/app/spec/spec_helper.rb:214)
```

#### What should we test?

Nothing

#### Release notes

Remove old Rails-4.0-related deprecation warning
Changelog Category: Technical changes