### PR TITLE
Pass request_queuing setting to Rack middleware

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -3,7 +3,10 @@ if ENV['DATADOG_RAILS_APM']
     c.use :rails, service_name: 'rails'
     c.use :delayed_job, service_name: 'delayed_job'
     c.use :dalli, service_name: 'memcached'
+
     c.analytics_enabled = true
     c.runtime_metrics_enabled = true
+
+    c[:rack].request_queuing = true
   end
 end


### PR DESCRIPTION
#### What? Why?

Fixes https://github.com/openfoodfoundation/openfoodnetwork/pull/6551, which got reverted in https://github.com/openfoodfoundation/openfoodnetwork/pull/6703.

It turns out that this setting belongs to the Rack middleware Datadog
comes with to track requests (See https://github.com/DataDog/dd-trace-rb/blob/e4c430a1748acc04cc28c2cdf2a11f491e86cee9/docs/GettingStarted.md#rack).

The way to pass this option to it is through `configuration[:rack]` where the `TraceMiddleware` will read it from. See
[lib/ddtrace/contrib/rack/middlewares.rb#L215-L217](https://github.com/DataDog/dd-trace-rb/blob/f57aefe60a18d1f1e00ee5b1829e893de4db4269/lib/ddtrace/contrib/rack/middlewares.rb#L215-L217)
and [lib/ddtrace/contrib/rack/middlewares.rb#L30-L43](https://github.com/DataDog/dd-trace-rb/blob/f57aefe60a18d1f1e00ee5b1829e893de4db4269/lib/ddtrace/contrib/rack/middlewares.rb#L30-L43).

#### What should we test?

We need to deploy this to a server with Datadog enabled. I plan to do so by branching off the latest tag, cherry-picking this commit and deploying it to Katuma production.

#### Release notes
Reenable and fix request queuing tracking in Datadog
Changelog Category: Technical changes
