### PR TITLE
Fix issue with orphaned adjustments in migration

### DIFF
--- a/db/migrate/20201219120055_add_order_to_adjustments.rb
+++ b/db/migrate/20201219120055_add_order_to_adjustments.rb
@@ -34,4 +34,8 @@ class AddOrderToAdjustments < ActiveRecord::Migration
       adjustment.update_column(:order_id, line_item.order_id)
     end
   end
+
+  def down
+    remove_column :spree_adjustments, :order_id
+  end
 end

--- a/db/migrate/20201219120055_add_order_to_adjustments.rb
+++ b/db/migrate/20201219120055_add_order_to_adjustments.rb
@@ -21,7 +21,17 @@ class AddOrderToAdjustments < ActiveRecord::Migration
 
     # Migrate adjustments on line_items
     Spree::Adjustment.where(order_id: nil, adjustable_type: "Spree::LineItem").includes(:adjustable).find_each do |adjustment|
-      adjustment.update_column(:order_id, adjustment.adjustable.order_id)
+      line_item = adjustment.adjustable
+
+      # In some cases a line item has been deleted but an orphaned adjustment remains in the
+      # database. There is no way for this orphan to ever be returned or accessed via any scopes,
+      # and no way to know what order it related to. In this case we can remove the record.
+      if line_item.nil?
+        adjustment.delete
+        next
+      end
+
+      adjustment.update_column(:order_id, line_item.order_id)
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Unblocks deployment of draft release #6704.

Deals with a rare case where orphaned line item adjustments can exist where the associated line item has been deleted.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated a migration to resolve issues with deleted line items.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

