### PR TITLE
Send emails when subscription payments require SCA auth

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -157,7 +157,7 @@ module Spree
 
         raise Spree::Core::GatewayError, I18n.t('authorization_failure') unless @payment.pending?
 
-        return unless @payment.cvv_response_message.present?
+        return unless @payment.authorization_action_required?
 
         PaymentMailer.authorize_payment(@payment).deliver_later
         raise Spree::Core::GatewayError, I18n.t('action_required')

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -25,8 +25,8 @@ module Spree
     before_action :check_at_least_one_line_item, only: :update
 
     def show
-      ProcessPaymentIntent.new(params["payment_intent"], params[:id]).call!
       @order = Spree::Order.find_by!(number: params[:id])
+      ProcessPaymentIntent.new(params["payment_intent"], @order).call!
     end
 
     def empty

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -25,7 +25,7 @@ module Spree
     before_action :check_at_least_one_line_item, only: :update
 
     def show
-      process_payment_intent!(params["payment_intent"])
+      ProcessPaymentIntent.new(params["payment_intent"], params[:id]).call!
       @order = Spree::Order.find_by!(number: params[:id])
     end
 
@@ -215,18 +215,6 @@ module Spree
         :distributor_id, :order_cycle_id,
         line_items_attributes: [:id, :quantity]
       )
-    end
-
-    def process_payment_intent!(payment_intent)
-      return unless payment_intent&.starts_with?("pi_")
-      return unless order = Spree::Order.find_by!(number: params[:id])
-
-      last_payment = OrderPaymentFinder.new(order).last_payment
-      return unless last_payment&.state == "pending" &&
-                    last_payment&.response_code == payment_intent
-
-      last_payment.update_attribute(:cvv_response_message, nil)
-      last_payment.complete!
     end
   end
 end

--- a/app/helpers/full_url_helper.rb
+++ b/app/helpers/full_url_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module FullUrlHelper
+  def url_helpers
+    # This is how we can get the helpers with a usable root_url outside the controllers
+    Rails.application.routes.default_url_options = ActionMailer::Base.default_url_options
+    Rails.application.routes.url_helpers
+  end
+
+  def full_checkout_path
+    URI.join(url_helpers.root_url, url_helpers.checkout_path).to_s
+  end
+
+  def full_order_path(order)
+    URI.join(url_helpers.root_url, url_helpers.order_path(order)).to_s
+  end
+end

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -84,7 +84,9 @@ class SubscriptionConfirmJob < ActiveJob::Base
   def authorize_payment!(order)
     return if order.subscription.payment_method.class != Spree::Gateway::StripeSCA
 
-    OrderManagement::Order::StripeScaPaymentAuthorize.new(order).call!
+    OrderManagement::Order::StripeScaPaymentAuthorize.new(order).
+      extend(OrderManagement::Order::SendAuthorizationEmails).
+      call!
   end
 
   def send_confirmation_email(order)

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -47,7 +47,6 @@ class SubscriptionConfirmJob < ActiveJob::Base
 
     process_payment!(order)
     send_confirmation_email(order)
-    send_payment_authorization_emails(order)
   rescue StandardError => e
     if order.errors.any?
       send_failed_payment_email(order)
@@ -92,14 +91,6 @@ class SubscriptionConfirmJob < ActiveJob::Base
     order.update!
     record_success(order)
     SubscriptionMailer.confirmation_email(order).deliver_now
-  end
-
-  def send_payment_authorization_emails(order)
-    order.payments.each do |payment|
-      if payment.cvv_response_message.present?
-        PaymentMailer.authorize_payment(payment).deliver_now
-      end
-    end
   end
 
   def send_failed_payment_email(order, error_message = nil)

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -84,7 +84,7 @@ class SubscriptionConfirmJob < ActiveJob::Base
   def authorize_payment!(order)
     return if order.subscription.payment_method.class != Spree::Gateway::StripeSCA
 
-    OrderManagement::Subscriptions::StripeScaPaymentAuthorize.new(order).call!
+    OrderManagement::Order::StripeScaPaymentAuthorize.new(order).call!
   end
 
   def send_confirmation_email(order)

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -97,7 +97,7 @@ class SubscriptionConfirmJob < ActiveJob::Base
   def send_payment_authorization_emails(order)
     order.payments.each do |payment|
       if payment.cvv_response_message.present?
-        PaymentMailer.authorize_payment(payment).deliver
+        PaymentMailer.authorize_payment(payment).deliver_now
       end
     end
   end

--- a/app/jobs/subscription_confirm_job.rb
+++ b/app/jobs/subscription_confirm_job.rb
@@ -97,7 +97,7 @@ class SubscriptionConfirmJob < ActiveJob::Base
   def send_payment_authorization_emails(order)
     order.payments.each do |payment|
       if payment.cvv_response_message.present?
-        Spree::PaymentMailer.authorize_payment(payment).deliver
+        PaymentMailer.authorize_payment(payment).deliver
       end
     end
   end

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -7,8 +7,22 @@ class PaymentMailer < Spree::BaseMailer
     @payment = payment
     subject = I18n.t('spree.payment_mailer.authorize_payment.subject',
                      distributor: @payment.order.distributor.name)
-    mail(to: payment.order.user.email,
-         from: from_address,
-         subject: subject)
+    I18n.with_locale valid_locale(@payment.order.user) do
+      mail(to: payment.order.user.email,
+           from: from_address,
+           subject: subject)
+    end
+  end
+
+  def authorization_required(payment)
+    @payment = payment
+    shop_owner = @payment.order.distributor.owner
+    subject = I18n.t('spree.payment_mailer.authorization_required.subject',
+                     order: @payment.order)
+    I18n.with_locale valid_locale(shop_owner) do
+      mail(to: shop_owner.email,
+           from: from_address,
+           subject: subject)
+    end
   end
 end

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -83,12 +83,12 @@ module Spree
     end
 
     def can_resend_authorization_email?(payment)
-      payment.pending? && payment.cvv_response_message.present?
+      payment.pending? && payment.authorization_action_required?
     end
 
     # Indicates whether its possible to capture the payment
     def can_capture?(payment)
-      return false if payment.cvv_response_message.present?
+      return false if payment.authorization_action_required?
 
       payment.pending? || payment.checkout?
     end

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -10,6 +10,8 @@ require 'active_merchant/billing/gateways/stripe_decorator'
 module Spree
   class Gateway
     class StripeSCA < Gateway
+      include FullUrlHelper
+
       preference :enterprise_id, :integer
 
       validate :ensure_enterprise_selected
@@ -144,16 +146,6 @@ module Spree
         return if preferred_enterprise_id.andand.positive?
 
         errors.add(:stripe_account_owner, I18n.t(:error_required))
-      end
-
-      def full_checkout_path
-        URI.join(url_helpers.root_url, url_helpers.checkout_path).to_s
-      end
-
-      def url_helpers
-        # This is how we can get the helpers with a usable root_url outside the controllers
-        Rails.application.routes.default_url_options = ActionMailer::Base.default_url_options
-        Rails.application.routes.url_helpers
       end
     end
   end

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -122,7 +122,7 @@ module Spree
     end
 
     def resend_authorization_email!
-      return unless cvv_response_message.present?
+      return unless authorization_action_required?
 
       PaymentMailer.authorize_payment(self).deliver_later
     end

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -15,6 +15,7 @@ module Spree
 
       def process_offline!
         return unless validate!
+        return if cvv_response_message.present?
 
         if payment_method.auto_capture?
           charge_offline!

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -15,7 +15,7 @@ module Spree
 
       def process_offline!
         return unless validate!
-        return if cvv_response_message.present?
+        return if authorization_action_required?
 
         if payment_method.auto_capture?
           charge_offline!
@@ -184,6 +184,10 @@ module Spree
                          shipping_address: order.ship_address.try(:active_merchant_hash) })
 
         options
+      end
+
+      def authorization_action_required?
+        cvv_response_message.present?
       end
 
       private

--- a/app/services/checkout/stripe_redirect.rb
+++ b/app/services/checkout/stripe_redirect.rb
@@ -15,7 +15,7 @@ module Checkout
       return unless stripe_payment_method?
 
       payment = OrderManagement::Order::StripeScaPaymentAuthorize.new(@order).
-        call!(full_checkout_path, false)
+        call!(full_checkout_path)
       raise if @order.errors.any?
 
       field_with_url(payment)

--- a/app/services/checkout/stripe_redirect.rb
+++ b/app/services/checkout/stripe_redirect.rb
@@ -14,7 +14,8 @@ module Checkout
     def path
       return unless stripe_payment_method?
 
-      payment = OrderManagement::Order::StripeScaPaymentAuthorize.new(@order).call!(full_checkout_path)
+      payment = OrderManagement::Order::StripeScaPaymentAuthorize.new(@order).
+        call!(full_checkout_path, false)
       raise if @order.errors.any?
 
       field_with_url(payment)

--- a/app/services/checkout/stripe_redirect.rb
+++ b/app/services/checkout/stripe_redirect.rb
@@ -14,7 +14,7 @@ module Checkout
     def path
       return unless stripe_payment_method?
 
-      payment = OrderManagement::Subscriptions::StripeScaPaymentAuthorize.new(@order).call!(full_checkout_path)
+      payment = OrderManagement::Order::StripeScaPaymentAuthorize.new(@order).call!(full_checkout_path)
       raise if @order.errors.any?
 
       field_with_url(payment)

--- a/app/services/checkout/stripe_redirect.rb
+++ b/app/services/checkout/stripe_redirect.rb
@@ -3,6 +3,8 @@
 # Provides the redirect path if a redirect to the payment gateway is needed
 module Checkout
   class StripeRedirect
+    include FullUrlHelper
+
     def initialize(params, order)
       @params = params
       @order = order
@@ -12,7 +14,7 @@ module Checkout
     def path
       return unless stripe_payment_method?
 
-      payment = OrderManagement::Subscriptions::StripeScaPaymentAuthorize.new(@order).call!
+      payment = OrderManagement::Subscriptions::StripeScaPaymentAuthorize.new(@order).call!(full_checkout_path)
       raise if @order.errors.any?
 
       field_with_url(payment)

--- a/app/services/checkout/stripe_redirect.rb
+++ b/app/services/checkout/stripe_redirect.rb
@@ -15,7 +15,7 @@ module Checkout
       payment = OrderManagement::Subscriptions::StripeScaPaymentAuthorize.new(@order).call!
       raise if @order.errors.any?
 
-      field_with_url(payment) if url?(field_with_url(payment))
+      field_with_url(payment)
     end
 
     private
@@ -28,14 +28,8 @@ module Checkout
       payment_method.is_a?(Spree::Gateway::StripeSCA)
     end
 
-    def url?(string)
-      return false if string.blank?
-
-      string.starts_with?("http")
-    end
-
     # Stripe::AuthorizeResponsePatcher patches the Stripe authorization response
-    #   so that this field stores the redirect URL
+    #   so that this field stores the redirect URL. It also verifies that it is a Stripe URL.
     def field_with_url(payment)
       payment.cvv_response_message
     end

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class ProcessPaymentIntent
-  def initialize(payment_intent, order_number)
+  def initialize(payment_intent, order)
     @payment_intent = payment_intent
-    @order = Spree::Order.find_by!(number: order_number)
-    @last_payment = OrderPaymentFinder.new(@order).last_payment
+    @order = order
+    @last_payment = OrderPaymentFinder.new(order).last_payment
   end
 
   def call!
@@ -16,8 +16,10 @@ class ProcessPaymentIntent
 
   private
 
+  attr_reader :order
+
   def valid?
-    @order.present? && valid_intent_string? && matches_last_payment?
+    order.present? && valid_intent_string? && matches_last_payment?
   end
 
   def valid_intent_string?

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -10,23 +10,23 @@ class ProcessPaymentIntent
   def call!
     return unless valid?
 
-    @last_payment.update_attribute(:cvv_response_message, nil)
-    @last_payment.complete!
+    last_payment.update_attribute(:cvv_response_message, nil)
+    last_payment.complete!
   end
 
   private
 
-  attr_reader :order
+  attr_reader :order, :payment_intent, :last_payment
 
   def valid?
     order.present? && valid_intent_string? && matches_last_payment?
   end
 
   def valid_intent_string?
-    @payment_intent&.starts_with?("pi_")
+    payment_intent&.starts_with?("pi_")
   end
 
   def matches_last_payment?
-    @last_payment&.state == "pending" && @last_payment&.response_code == @payment_intent
+    last_payment&.state == "pending" && last_payment&.response_code == payment_intent
   end
 end

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class ProcessPaymentIntent
+  def initialize(payment_intent, order_number)
+    @payment_intent = payment_intent
+    @order = Spree::Order.find_by!(number: order_number)
+    @last_payment = OrderPaymentFinder.new(@order).last_payment
+  end
+
+  def call!
+    return unless valid?
+
+    @last_payment.update_attribute(:cvv_response_message, nil)
+    @last_payment.complete!
+  end
+
+  private
+
+  def valid?
+    @order.present? && valid_intent_string? && matches_last_payment?
+  end
+
+  def valid_intent_string?
+    @payment_intent&.starts_with?("pi_")
+  end
+
+  def matches_last_payment?
+    @last_payment&.state == "pending" && @last_payment&.response_code == @payment_intent
+  end
+end

--- a/app/views/payment_mailer/authorization_required.html.haml
+++ b/app/views/payment_mailer/authorization_required.html.haml
@@ -1,0 +1,2 @@
+= t('spree.payment_mailer.authorization_required.message', order_number: @payment.order.number)
+= link_to spree.edit_admin_order_url(@payment.order), spree.edit_admin_order_url(@payment.order)

--- a/app/views/payment_mailer/authorization_required.text.haml
+++ b/app/views/payment_mailer/authorization_required.text.haml
@@ -1,0 +1,3 @@
+= t('spree.payment_mailer.authorization_required.message', order_number: @payment.order.number)
+
+= link_to spree.edit_admin_order_url(@payment.order), spree.edit_admin_order_url(@payment.order)

--- a/app/views/payment_mailer/authorize_payment.html.haml
+++ b/app/views/payment_mailer/authorize_payment.html.haml
@@ -1,2 +1,2 @@
-= t('.instructions', distributor: @payment.order.distributor.name, amount: @payment.display_amount)
-= main_app.authorize_payment_url(@payment)
+= t('spree.payment_mailer.authorize_payment.instructions', distributor: @payment.order.distributor.name, amount: @payment.display_amount)
+= link_to main_app.authorize_payment_url(@payment), main_app.authorize_payment_url(@payment)

--- a/app/views/payment_mailer/authorize_payment.text.haml
+++ b/app/views/payment_mailer/authorize_payment.text.haml
@@ -1,3 +1,3 @@
-= t('.instructions', distributor: @payment.order.distributor.name, amount: @payment.display_amount)
+= t('spree.payment_mailer.authorize_payment.instructions', distributor: @payment.order.distributor.name, amount: @payment.display_amount)
 
-= main_app.authorize_payment_url(@payment)
+= link_to main_app.authorize_payment_url(@payment), main_app.authorize_payment_url(@payment)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3658,6 +3658,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       authorize_payment:
         subject: "Please authorize your payment to %{distributor} on OFN"
         instructions: "Your payment of %{amount} to %{distributor} requires additional authentication. Please visit the following URL to authorize your payment:"
+      authorization_required:
+        subject: "A payment requires authorization from the customer"
+        message: "A payment for order %{order_number} requires additional authorization from the customer. The customer has been notified via email and the payment will appear as pending until it is authorized."
     shipment_mailer:
       shipped_email:
         dear_customer: "Dear Customer,"

--- a/engines/order_management/app/services/order_management/order/send_authorization_emails.rb
+++ b/engines/order_management/app/services/order_management/order/send_authorization_emails.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OrderManagement
+  module Order
+    module SendAuthorizationEmails
+      def call!(redirect_url = full_order_path(@order))
+        super(redirect_url)
+
+        return unless @payment.authorization_action_required?
+
+        PaymentMailer.authorize_payment(@payment).deliver_now
+        PaymentMailer.authorization_required(@payment).deliver_now
+      end
+    end
+  end
+end

--- a/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
@@ -17,7 +17,7 @@ module OrderManagement
 
         @order.errors.add(:base, I18n.t('authorization_failure')) unless @payment.pending?
 
-        if send_emails && @payment.cvv_response_message.present?
+        if send_emails && @payment.authorization_action_required?
           PaymentMailer.authorize_payment(@payment).deliver_now
           PaymentMailer.authorization_required(@payment).deliver_now
         end

--- a/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
@@ -10,14 +10,14 @@ module OrderManagement
         @payment = OrderPaymentFinder.new(@order).last_pending_payment
       end
 
-      def call!(redirect_url = full_order_path(@order))
+      def call!(redirect_url = full_order_path(@order), send_emails = true)
         return unless @payment&.checkout?
 
         @payment.authorize!(redirect_url)
 
         @order.errors.add(:base, I18n.t('authorization_failure')) unless @payment.pending?
 
-        if @payment.cvv_response_message.present?
+        if send_emails && @payment.cvv_response_message.present?
           PaymentMailer.authorize_payment(@payment).deliver_now
           PaymentMailer.authorization_required(@payment).deliver_now
         end

--- a/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module OrderManagement
-  module Subscriptions
+  module Order
     class StripeScaPaymentAuthorize
       include FullUrlHelper
 

--- a/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb
@@ -10,17 +10,12 @@ module OrderManagement
         @payment = OrderPaymentFinder.new(@order).last_pending_payment
       end
 
-      def call!(redirect_url = full_order_path(@order), send_emails = true)
+      def call!(redirect_url = full_order_path(@order))
         return unless @payment&.checkout?
 
         @payment.authorize!(redirect_url)
 
         @order.errors.add(:base, I18n.t('authorization_failure')) unless @payment.pending?
-
-        if send_emails && @payment.authorization_action_required?
-          PaymentMailer.authorize_payment(@payment).deliver_now
-          PaymentMailer.authorization_required(@payment).deliver_now
-        end
 
         @payment
       end

--- a/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
@@ -3,15 +3,17 @@
 module OrderManagement
   module Subscriptions
     class StripeScaPaymentAuthorize
+      include FullUrlHelper
+
       def initialize(order)
         @order = order
         @payment = OrderPaymentFinder.new(@order).last_pending_payment
       end
 
-      def call!
+      def call!(redirect_url = full_order_path(@order))
         return unless @payment&.checkout?
 
-        @payment.authorize!
+        @payment.authorize!(redirect_url)
 
         @order.errors.add(:base, I18n.t('authorization_failure')) unless @payment.pending?
 

--- a/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
@@ -15,6 +15,10 @@ module OrderManagement
 
         @order.errors.add(:base, I18n.t('authorization_failure')) unless @payment.pending?
 
+        if @payment.cvv_response_message.present?
+          PaymentMailer.authorize_payment(@payment).deliver_now
+        end
+
         @payment
       end
     end

--- a/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/stripe_sca_payment_authorize.rb
@@ -17,6 +17,7 @@ module OrderManagement
 
         if @payment.cvv_response_message.present?
           PaymentMailer.authorize_payment(@payment).deliver_now
+          PaymentMailer.authorization_required(@payment).deliver_now
         end
 
         @payment

--- a/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/summarizer.rb
@@ -35,12 +35,14 @@ module OrderManagement
         record_issue(type, order, line2)
       end
 
+      # This uses `deliver_now` since it's called from inside a job
       def send_placement_summary_emails
         @summaries.values.each do |summary|
           SubscriptionMailer.placement_summary_email(summary).deliver_now
         end
       end
 
+      # This uses `deliver_now` since it's called from inside a job
       def send_confirmation_summary_emails
         @summaries.values.each do |summary|
           SubscriptionMailer.confirmation_summary_email(summary).deliver_now

--- a/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
@@ -78,6 +78,15 @@ module OrderManagement
                 expect(PaymentMailer).to have_received(:authorization_required)
                 expect(mail_mock).to have_received(:deliver_now).twice
               end
+
+              it "doesn't send emails if param is set to false" do
+                payment_authorize.call!(nil, false)
+
+                expect(order.errors.size).to eq 0
+                expect(PaymentMailer).to_not have_received(:authorize_payment)
+                expect(PaymentMailer).to_not have_received(:authorization_required)
+                expect(mail_mock).to_not have_received(:deliver_now)
+              end
             end
           end
         end

--- a/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
@@ -3,11 +3,11 @@
 require 'spec_helper'
 
 module OrderManagement
-  module Subscriptions
+  module Order
     describe StripeScaPaymentAuthorize do
       let(:order) { create(:order) }
       let(:payment_authorize) {
-        OrderManagement::Subscriptions::StripeScaPaymentAuthorize.new(order)
+        OrderManagement::Order::StripeScaPaymentAuthorize.new(order)
       }
 
       describe "#call!" do

--- a/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/stripe_sca_payment_authorize_spec.rb
@@ -70,8 +70,8 @@ module OrderManagement
                 }
               end
 
-              it "sends an email requesting authorization and an email notifying the shop owner" do
-                payment_authorize.call!
+              it "sends an email requesting authorization and an email notifying the shop owner when requested" do
+                payment_authorize.extend(OrderManagement::Order::SendAuthorizationEmails).call!
 
                 expect(order.errors.size).to eq 0
                 expect(PaymentMailer).to have_received(:authorize_payment)
@@ -79,8 +79,8 @@ module OrderManagement
                 expect(mail_mock).to have_received(:deliver_now).twice
               end
 
-              it "doesn't send emails if param is set to false" do
-                payment_authorize.call!(nil, false)
+              it "doesn't send emails by default" do
+                payment_authorize.call!
 
                 expect(order.errors.size).to eq 0
                 expect(PaymentMailer).to_not have_received(:authorize_payment)

--- a/engines/order_management/spec/services/order_management/subscriptions/stripe_sca_payment_authorize_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/stripe_sca_payment_authorize_spec.rb
@@ -63,18 +63,20 @@ module OrderManagement
 
               before do
                 allow(PaymentMailer).to receive(:authorize_payment) { mail_mock }
+                allow(PaymentMailer).to receive(:authorization_required) { mail_mock }
                 allow(payment).to receive(:authorize!) {
                   payment.state = "pending"
                   payment.cvv_response_message = "https://stripe.com/redirect"
                 }
               end
 
-              it "adds sends an email requesting authorization" do
+              it "sends an email requesting authorization and an email notifying the shop owner" do
                 payment_authorize.call!
 
                 expect(order.errors.size).to eq 0
                 expect(PaymentMailer).to have_received(:authorize_payment)
-                expect(mail_mock).to have_received(:deliver_now)
+                expect(PaymentMailer).to have_received(:authorization_required)
+                expect(mail_mock).to have_received(:deliver_now).twice
               end
             end
           end

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -230,11 +230,9 @@ describe SubscriptionConfirmJob do
           end
 
           it "sends only a subscription confirm email, no regular confirmation emails" do
-            ActionMailer::Base.deliveries.clear
             expect{ job.send(:confirm_order!, order) }.to_not enqueue_job ConfirmOrderJob
             expect(job).to have_received(:send_confirmation_email).once
             expect(job).to have_received(:send_payment_authorization_emails).once
-            expect(ActionMailer::Base.deliveries.count).to be 1
           end
         end
       end
@@ -277,7 +275,7 @@ describe SubscriptionConfirmJob do
 
   describe "#send_payment_authorization_emails" do
     let(:order) { instance_double(Spree::Order) }
-    let(:mail_mock) { double(:mailer_mock, deliver: true) }
+    let(:mail_mock) { double(:mailer_mock, deliver_now: true) }
     let(:payment) { create(:payment, amount: 10) }
 
     before do
@@ -289,14 +287,14 @@ describe SubscriptionConfirmJob do
       allow(payment).to receive(:cvv_response_message) { "http://redirect_url" }
       job.send(:send_payment_authorization_emails, order)
       expect(PaymentMailer).to have_received(:authorize_payment)
-      expect(mail_mock).to have_received(:deliver)
+      expect(mail_mock).to have_received(:deliver_now)
     end
 
     it "does not send authorization email if no payment requires it" do
       allow(payment).to receive(:cvv_response_message) { nil }
       job.send(:send_payment_authorization_emails, order)
       expect(PaymentMailer).not_to have_received(:authorize_payment)
-      expect(mail_mock).not_to have_received(:deliver)
+      expect(mail_mock).not_to have_received(:deliver_now)
     end
   end
 end

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -282,20 +282,20 @@ describe SubscriptionConfirmJob do
 
     before do
       allow(order).to receive(:payments) { [payment] }
-      allow(Spree::PaymentMailer).to receive(:authorize_payment) { mail_mock }
+      allow(PaymentMailer).to receive(:authorize_payment) { mail_mock }
     end
 
     it "sends authorization email if a payment requires it" do
       allow(payment).to receive(:cvv_response_message) { "http://redirect_url" }
       job.send(:send_payment_authorization_emails, order)
-      expect(Spree::PaymentMailer).to have_received(:authorize_payment)
+      expect(PaymentMailer).to have_received(:authorize_payment)
       expect(mail_mock).to have_received(:deliver)
     end
 
     it "does not send authorization email if no payment requires it" do
       allow(payment).to receive(:cvv_response_message) { nil }
       job.send(:send_payment_authorization_emails, order)
-      expect(Spree::PaymentMailer).not_to have_received(:authorize_payment)
+      expect(PaymentMailer).not_to have_received(:authorize_payment)
       expect(mail_mock).not_to have_received(:deliver)
     end
   end

--- a/spec/services/checkout/stripe_redirect_spec.rb
+++ b/spec/services/checkout/stripe_redirect_spec.rb
@@ -43,6 +43,7 @@ describe Checkout::StripeRedirect do
               stripe_payment.state = 'pending'
               true
             end
+            allow(stripe_payment.order).to receive(:distributor) { distributor }
             test_redirect_url = "http://stripe_auth_url/"
             allow(stripe_payment).to receive(:cvv_response_message).and_return(test_redirect_url)
 


### PR DESCRIPTION
#### What? Why?

Closes #4179

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This sends an email to each customer if an admin creates a payment that requires additional authorization because of SCA. The email contains a link to an OFN URL which redirects them to the appropriate URL to authorize the payment. 


#### What should we test?
<!-- List which features should be tested and how. -->
Using a default card that always requires SCA authorization (https://stripe.com/docs/testing), set up a subscription and run the SubscriptionConfirmJob. The email should be sent to the customer with the link to authorize the payment. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Subscription payments that require extra authorization because of SCA can now be completed by the customer by following the link in the automatically generated email.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
