### PR TITLE
Delete dead code Spree::Order#price_adjustments

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -723,15 +723,7 @@ module Spree
     end
 
     def total_tax
-      (adjustments.to_a + price_adjustments.to_a).sum(&:included_tax)
-    end
-
-    def price_adjustments
-      adjustments = []
-
-      line_items.each { |line_item| adjustments.concat line_item.adjustments }
-
-      adjustments
+      (adjustments.to_a + line_item_adjustments.to_a).sum(&:included_tax)
     end
 
     def price_adjustment_totals

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -83,8 +83,8 @@ module Spree
       order.adjustments(:reload)
       order.line_items(:reload)
       # TaxRate adjustments (order.adjustments.tax)
-      #   and price adjustments (tax included on line items) consist of 100% tax
-      (order.adjustments.tax + order.price_adjustments).each do |adjustment|
+      #   and line item adjustments (tax included on line items) consist of 100% tax
+      (order.adjustments.tax + order.line_item_adjustments.reload).each do |adjustment|
         adjustment.set_absolute_included_tax! adjustment.amount
       end
     end

--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -4,7 +4,7 @@
 
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
 
-  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.price_adjustments, :title => t(".line_item_adjustments")}
+  = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.line_item_adjustments, :title => t(".line_item_adjustments")}
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => order_adjustments_for_display(@order), :title => t(".order_adjustments")}
 
   - if order.line_items.exists?

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -221,7 +221,7 @@ module Spree
         end
 
         it "does not crash when order data has been updated previously" do
-          order.price_adjustments.first.destroy
+          order.line_item_adjustments.first.destroy
           tax_rate.adjust(order)
         end
       end


### PR DESCRIPTION
#### What? Why?

The `Spree::Order#price_adjustments` method returns the same thing as the `Spree::Order#line_items_adjustments` scope, but in a slightly less useful format (an array instead of a relation).

This method's name is also very misleading. At the time of this PR, the only adjustments that ever appear on line_items are tax adjustments for _inclusive_ tax rates, which by definition have no effect on the price... so "price adjustments" is a ridiculuous method name.

:fire::fire::fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Quick sanity check; place an order that has included tax on line items and see if it looks ok.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed dead code: Spree::Order#price_adjustments

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
