### PR TITLE
[Adjustments] Order tax totals

### DIFF
--- a/db/migrate/20210123044336_add_tax_totals_to_order.rb
+++ b/db/migrate/20210123044336_add_tax_totals_to_order.rb
@@ -1,0 +1,14 @@
+class AddTaxTotalsToOrder < ActiveRecord::Migration
+  def up
+    add_column :spree_orders, :included_tax_total, :decimal,
+               precision: 10, scale: 2, null: false, default: 0.0
+
+    add_column :spree_orders, :additional_tax_total, :decimal,
+               precision: 10, scale: 2, null: false, default: 0.0
+  end
+
+  def down
+    remove_column :spree_orders, :included_tax_total
+    remove_column :spree_orders, :additional_tax_total
+  end
+end

--- a/db/migrate/20210125171611_populate_order_tax_totals.rb
+++ b/db/migrate/20210125171611_populate_order_tax_totals.rb
@@ -1,0 +1,18 @@
+class PopulateOrderTaxTotals < ActiveRecord::Migration
+  def up
+    Spree::Order.where(additional_tax_total: 0, included_tax_total: 0).
+      find_each(batch_size: 500) do |order|
+
+      additional_tax_total = order.all_adjustments.tax.additional.sum(:amount)
+
+      included_tax_total = order.line_item_adjustments.tax.sum(:included_tax) +
+        order.all_adjustments.enterprise_fee.sum(:included_tax) +
+        order.adjustments.shipping.sum(:included_tax)
+
+      order.update_columns(
+        additional_tax_total: additional_tax_total,
+        included_tax_total: included_tax_total
+      )
+    end
+  end
+end

--- a/db/migrate/20210125171611_populate_order_tax_totals.rb
+++ b/db/migrate/20210125171611_populate_order_tax_totals.rb
@@ -1,4 +1,11 @@
 class PopulateOrderTaxTotals < ActiveRecord::Migration
+  class Spree::Adjustment < ActiveRecord::Base
+    scope :tax, -> { where(originator_type: 'Spree::TaxRate') }
+    scope :additional, -> { where(included: false) }
+    scope :enterprise_fee, -> { where(originator_type: 'EnterpriseFee') }
+    scope :shipping, -> { where(originator_type: 'Spree::ShippingMethod') }
+  end
+
   def up
     Spree::Order.where(additional_tax_total: 0, included_tax_total: 0).
       find_each(batch_size: 500) do |order|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -574,6 +574,8 @@ ActiveRecord::Schema.define(version: 20210203215049) do
     t.string   "last_ip_address",      limit: 255
     t.integer  "customer_id"
     t.integer  "created_by_id"
+    t.decimal  "included_tax_total",               precision: 10, scale: 2, default: 0.0, null: false
+    t.decimal  "additional_tax_total",             precision: 10, scale: 2, default: 0.0, null: false
   end
 
   add_index "spree_orders", ["completed_at", "user_id", "created_by_id", "created_at"], name: "spree_orders_completed_at_user_id_created_by_id_created_at_idx", using: :btree

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -23,25 +23,14 @@ module OrderManagement
 
         if order.completed?
           update_payment_state
-
-          # give each of the shipments a chance to update themselves
-          shipments.each { |shipment| shipment.update!(order) }
+          update_shipments
           update_shipment_state
         end
 
         update_all_adjustments
         # update totals a second time in case updated adjustments have an effect on the total
         update_totals
-
-        order.update_columns(
-          payment_state: order.payment_state,
-          shipment_state: order.shipment_state,
-          item_total: order.item_total,
-          adjustment_total: order.adjustment_total,
-          payment_total: order.payment_total,
-          total: order.total,
-          updated_at: Time.zone.now
-        )
+        persist_totals
       end
 
       # Updates the following Order total values:
@@ -52,9 +41,39 @@ module OrderManagement
       # - total - order total, it's the equivalent to item_total plus adjustment_total
       def update_totals
         order.payment_total = payments.completed.sum(:amount)
+        update_item_total
+        update_adjustment_total
+        update_order_total
+      end
+
+      # Give each of the shipments a chance to update themselves
+      def update_shipments
+        shipments.each { |shipment| shipment.update!(order) }
+      end
+
+      def update_item_total
         order.item_total = line_items.map(&:amount).sum
+        update_order_total
+      end
+
+      def update_adjustment_total
         order.adjustment_total = adjustments.eligible.sum(:amount)
+      end
+
+      def update_order_total
         order.total = order.item_total + order.adjustment_total
+      end
+
+      def persist_totals
+        order.update_columns(
+          payment_state: order.payment_state,
+          shipment_state: order.shipment_state,
+          item_total: order.item_total,
+          adjustment_total: order.adjustment_total,
+          payment_total: order.payment_total,
+          total: order.total,
+          updated_at: Time.zone.now
+        )
       end
 
       # Updates the +shipment_state+ attribute according to the following logic:

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -5,7 +5,7 @@ module OrderManagement
     class Updater
       attr_reader :order
 
-      delegate :payments, :line_items, :adjustments, :shipments, to: :order
+      delegate :payments, :line_items, :adjustments, :all_adjustments, :shipments, to: :order
 
       def initialize(order)
         @order = order
@@ -58,6 +58,11 @@ module OrderManagement
 
       def update_adjustment_total
         order.adjustment_total = adjustments.eligible.sum(:amount)
+        order.additional_tax_total = all_adjustments.tax.additional.sum(:amount)
+        order.included_tax_total = order.line_item_adjustments.tax.sum(:included_tax) +
+                                   all_adjustments.enterprise_fee.sum(:included_tax) +
+                                   adjustments.shipping.sum(:included_tax) +
+                                   adjustments.admin.sum(:included_tax)
       end
 
       def update_order_total
@@ -70,6 +75,8 @@ module OrderManagement
           shipment_state: order.shipment_state,
           item_total: order.item_total,
           adjustment_total: order.adjustment_total,
+          included_tax_total: order.included_tax_total,
+          additional_tax_total: order.additional_tax_total,
           payment_total: order.payment_total,
           total: order.total,
           updated_at: Time.zone.now

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -52,7 +52,7 @@ module OrderManagement
       end
 
       def update_item_total
-        order.item_total = line_items.map(&:amount).sum
+        order.item_total = line_items.sum('price * quantity')
         update_order_total
       end
 


### PR DESCRIPTION
#### What? Why?

Introduces **tax totals persisted directly on order records** :tada:

This is done via the pre-existing `Order::Updater` class, which handles updating things like the order total when the order's contents change. It was previously `Spree::OrderUpdater`, but it's now `OrderManagement::Order::Updater` in OFN.

After this we'll be able to directly query and sum order tax amounts at the database level without pulling data from a dozen different places or doing any calculations. When we're doing things like querying tax data on 10,000 orders for a report this should make a big difference...

#### What should we test?
<!-- List which features should be tested and how. -->

Dev-test or Filipe-test (requires use of the Rails console).

Order records should have two new fields: `additional_tax_total` and `include_tax_total`, and they should be populated with the correct totals. New orders should have these totals present and all previous orders should have these fields populated after the deployment/migration. The fields are not currently used in the UI.

Note: taxes on shipping fees and taxes on adjustments added manually via the admin UI are currently recorded as included in the price (regardless of any relevant configs or rates).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes