### PR TITLE
Fixes a pending test case and improves the spec run time

### DIFF
--- a/spec/features/admin/shipping_methods_spec.rb
+++ b/spec/features/admin/shipping_methods_spec.rb
@@ -157,26 +157,35 @@ feature 'shipping methods' do
       expect(page).to have_selector 'td', text: 'Two', count: 1
     end
 
-    pending "shows me only shipping methods for the enterprise I select" do
+    it "shows me only shipping methods for the enterprise I select" do
       shipping_method1
       shipping_method2
 
       visit admin_enterprises_path
       within("#e_#{distributor1.id}") { click_link 'Settings' }
+
       within(".side_menu") do
         click_link "Shipping Methods"
       end
-      expect(page).to     have_content shipping_method1.name
-      expect(page).to     have_content shipping_method2.name
+
+      expect(page).to have_content shipping_method1.name
+      expect(page).to have_content shipping_method2.name
+
+      expect(page).to have_checked_field "enterprise_shipping_method_ids_#{shipping_method2.id}"
+      expect(page).to have_checked_field "enterprise_shipping_method_ids_#{shipping_method1.id}"
 
       click_link 'Enterprises'
       within("#e_#{distributor2.id}") { click_link 'Settings' }
+
       within(".side_menu") do
         click_link "Shipping Methods"
       end
 
-      expect(page).not_to have_content shipping_method1.name
+      expect(page).to     have_content shipping_method1.name
       expect(page).to     have_content shipping_method2.name
+
+      expect(page).to have_checked_field "enterprise_shipping_method_ids_#{shipping_method2.id}"
+      expect(page).to have_unchecked_field "enterprise_shipping_method_ids_#{shipping_method1.id}"
     end
   end
 end


### PR DESCRIPTION
	modified:   spec/features/admin/shipping_methods_spec.rb

#### What? Why?

Closes #6693

One of the test cases was marked as "pending" which delayed the build (~30 sec, locally). In this "pending" section, I was not sure it was testing what it supposed to, so I'm proposing these changes:

A hub managing different distributors should _see_ all shipping methods on the shipping methods edit page (i.e., after clicking Shipping Methods on the sidebar), but only those related to the selected distributor should be ticked.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

It tests whether the available shipping methods are active for the respective distributors, when a hub manages different distributors.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

This PR introduces assertions on the checkboxes, when editing shipping methods. 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes

Technical changes.