### PR TITLE
Adding a tax_rates key to en.yml to match the key used everywhere.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3117,6 +3117,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     tax rate: "Tax Rates"
     new_tax_rate: "New Tax Rate"
     tax_category: "Tax Category"
+    tax_rates: "Tax Rates"
     rate: "Rate"
     tax_rate_amount_explanation: "Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)"
     included_in_price: "Included in Price"


### PR DESCRIPTION
#### What? Why?

Closes #6387

On the General Settings page at /admin/general_settings/edit the text "Tax Rates" in the right hand column was not being translated. This was because the spree translation key didn't have a tax_rates key. The key exists elsewhere in en.yml and is, I believe, being used for reports.

Fixing this was a matter of adding a tax_rates key under the spree key.



#### What should we test?
Generate the new translation file for a language and confirm that the "Tax Rates" text is translated.



#### Release notes
Add a tax_rates key to en.yml


Changelog Category: User facing changes