### PR TITLE
Disable mail methods form so no one can edit

### DIFF
--- a/app/assets/stylesheets/admin/components/messages.scss
+++ b/app/assets/stylesheets/admin/components/messages.scss
@@ -43,3 +43,14 @@
   &.success { background-color: rgba($color-success, 0.8) }
   &.error   { background-color: rgba($color-error,   0.8) }
 }
+
+.notice {
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  background-color: $spree-light-blue;
+  border-radius: $border-radius;
+
+  a {
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/admin/variables.scss
+++ b/app/assets/stylesheets/admin/variables.scss
@@ -16,3 +16,5 @@ $admin-table-border: $pale-blue;
 $modal-close-button-color: #de6060;
 $modal-close-button-hover-color: #bf4545;
 $disabled-button: $light-grey;
+
+$border-radius: 3px;

--- a/app/controllers/spree/admin/mail_methods_controller.rb
+++ b/app/controllers/spree/admin/mail_methods_controller.rb
@@ -10,7 +10,7 @@ module Spree
           Spree::Config[name] = value
         end
 
-        flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:mail_methods))
+        flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:mail_method_settings))
         render :edit
       end
 

--- a/app/views/spree/admin/mail_methods/_form.html.haml
+++ b/app/views/spree/admin/mail_methods/_form.html.haml
@@ -1,6 +1,8 @@
 %div
   .row
     %fieldset.no-border-bottom
+      %div.notice
+        = t('spree.mail_settings_notice_html')
       %legend{align: "center"}= t("spree.general")
       .field
         = label_tag :mails_from, t("spree.send_mails_as")
@@ -12,14 +14,14 @@
       .field
         = label_tag :mail_bcc, t("spree.send_copy_of_all_mails_to")
         %br/
-        = text_field_tag :mail_bcc, Spree::Config[:mail_bcc], maxlength: 256, class: 'fullwidth'
+        = text_field_tag :mail_bcc, Spree::Config[:mail_bcc], disabled: true, class: 'fullwidth'
         %br/
         %span.info
           = t("spree.smtp_send_copy_to_this_addresses")
       .field
         = label_tag :intercept_email, t("spree.intercept_email_address")
         %br/
-        = text_field_tag :intercept_email, Spree::Config[:intercept_email], maxlength: 256, class: 'fullwidth'
+        = text_field_tag :intercept_email, Spree::Config[:intercept_email], disabled: true, class: 'fullwidth'
         %br/
         %span.info
           = t("spree.intercept_email_instructions")

--- a/app/views/spree/admin/mail_methods/_form.html.haml
+++ b/app/views/spree/admin/mail_methods/_form.html.haml
@@ -14,7 +14,7 @@
       .field
         = label_tag :mail_bcc, t("spree.send_copy_of_all_mails_to")
         %br/
-        = text_field_tag :mail_bcc, Spree::Config[:mail_bcc], disabled: true, class: 'fullwidth'
+        = text_field_tag :mail_bcc, Spree::Config[:mail_bcc], maxlength: 256, class: 'fullwidth'
         %br/
         %span.info
           = t("spree.smtp_send_copy_to_this_addresses")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3101,6 +3101,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     choose_currency: "Choose Currency"
 
     mail_method_settings: "Mail Method Settings"
+    mail_settings_notice_html: "Some of the following settings can't be edited and are listed here just for debugging purposes. Changes can be made by updating the instance's secrets and provisioning them using <a href='https://github.com/openfoodfoundation/ofn-install'>ofn-install</a>. Reach out to the OFN global team for further details."
     general: "General"
     enable_mail_delivery: "Enable Mail Delivery"
     send_mails_as: "Send Mails As"

--- a/spec/features/admin/configuration/mail_methods_spec.rb
+++ b/spec/features/admin/configuration/mail_methods_spec.rb
@@ -5,19 +5,18 @@ require 'spec_helper'
 describe "Mail Methods" do
   include AuthenticationHelper
 
-  before(:each) do
-    login_as_admin_and_visit spree.edit_admin_general_settings_path
-  end
+  before { login_as_admin_and_visit spree.edit_admin_general_settings_path }
 
   context "edit" do
-    before(:each) do
-      click_link "Mail Method Settings"
-    end
+    before { click_link "Mail Method Settings" }
 
-    it "should be able to edit mail method settings" do
-      fill_in "mail_bcc", with: "ofn@example.com"
-      click_button "Update"
-      expect(page).to have_content("successfully updated!")
+    it "only allows changing the mails_from setting" do
+      fill_in 'mails_from', with: 'ofn@example.com'
+      expect(page).to have_field('mail_bcc', disabled: true)
+      expect(page).to have_field('intercept_email', disabled: true)
+
+      click_button 'Update'
+      expect(page).to have_content('successfully updated!')
     end
   end
 end

--- a/spec/features/admin/configuration/mail_methods_spec.rb
+++ b/spec/features/admin/configuration/mail_methods_spec.rb
@@ -12,7 +12,7 @@ describe "Mail Methods" do
 
     it "only allows changing the mails_from setting" do
       fill_in 'mails_from', with: 'ofn@example.com'
-      expect(page).to have_field('mail_bcc', disabled: true)
+      fill_in 'mail_bcc', with: 'bcc@example.com'
       expect(page).to have_field('intercept_email', disabled: true)
 
       click_button 'Update'


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/pull/6537

This moves a step closer to having a simple and straightforward way to configure the app's mail delivery which doesn't require to be a nuclear engineer to troubleshoot mail issues.

It happens way too often that servers have mail config broken when restarted or redeployed and it takes too much brain power to fix it. No doubt; it's way too complex.

#### :camera_flash: Screenshot

![Screenshot from 2021-02-02 12-18-46](https://user-images.githubusercontent.com/762088/106593850-99ade980-6551-11eb-8177-4d1409b92acd.png)

#### What should we test?

Green build.

#### Release notes

Disable all mail method configuration fields but "Send mails as"
Changelog Category: User facing changes
