### PR TITLE
Remove anchor in URL so avoid browser scrolling to the top of the page when editing order

### DIFF
--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -54,9 +54,8 @@
 
           %td.actions
             - if can? :update, shipment
-              = link_to '', '#', :class => 'save-method icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, title: I18n.t('actions.save')
-              = link_to '', '#', :class => 'cancel-method icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
-
+              = link_to '', '', :class => 'save-method icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, title: I18n.t('actions.save')
+              = link_to '', '', :class => 'cancel-method icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
       %tr.show-method.total
         %td{ :colspan => "4" }
           - if shipment.adjustment.present?
@@ -73,7 +72,7 @@
         - if shipment.adjustment.present? && !shipment.shipped?
           %td.actions
             - if can? :update, shipment
-              = link_to '', '#', :class => 'edit-method icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
+              = link_to '', '', :class => 'edit-method icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
 
       %tr.edit-tracking.hidden.total
         %td{ :colspan => "5" }
@@ -83,8 +82,8 @@
 
         %td.actions
           - if can? :update, shipment
-            = link_to '', '#', :class => 'save-tracking icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, :title => I18n.t('actions.save')
-            = link_to '', '#', :class => 'cancel-tracking icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
+            = link_to '', '', :class => 'save-tracking icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, :title => I18n.t('actions.save')
+            = link_to '', '', :class => 'cancel-tracking icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
 
       %tr.show-tracking.total
         %td{ :colspan => "5" }
@@ -97,4 +96,4 @@
 
         %td.actions
           - if can? :update, shipment
-            = link_to '', '#', :class => 'edit-tracking icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
+            = link_to '', '', :class => 'edit-tracking icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')


### PR DESCRIPTION
#### What? Why?
Closes #6707 
Do not add '#' in URL so the browser will not scroll to the top of the page.

#### What should we test?
 - As an admin, edit order
 - Try to edit the shipping method or tracking info of that order
 - URL must be the same and no jump into the top of the page should happen



#### Release notes
Avoid unintentional scroll to top when editing an order.
Changelog Category: User facing changes

