### PR TITLE
Remove old abandoned carts

### DIFF
--- a/app/models/spree/option_values_line_item.rb
+++ b/app/models/spree/option_values_line_item.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Spree
+  class OptionValuesLineItem < ActiveRecord::Base
+    belongs_to :line_item, class_name: 'Spree::LineItem'
+    belongs_to :option_value, class_name: 'Spree::OptionValue'
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,7 +11,7 @@ env "MAILTO", app_config["SCHEDULE_NOTIFICATIONS"] if app_config["SCHEDULE_NOTIF
 job_type :run_file, "cd :path; :environment_variable=:environment bundle exec script/rails runner :task :output"
 job_type :enqueue_job,  "cd :path; :environment_variable=:environment bundle exec script/enqueue :task :priority :output"
 
-every 1.month do
+every 1.month, at: '4:30am' do
   rake 'ofn:data:remove_transient_data'
 end
 

--- a/db/migrate/20210127174120_add_cascading_deletes.rb
+++ b/db/migrate/20210127174120_add_cascading_deletes.rb
@@ -1,0 +1,20 @@
+class AddCascadingDeletes < ActiveRecord::Migration
+  def change
+    # Updates foreign key definitions between orders, shipments, and inventory_units
+    # to allow for cascading deletes at database level. If an order is intentionally
+    # deleted *without callbacks*, it's shipments and inventory units will be removed
+    # cleanly without throwing foreign key errors.
+
+    remove_foreign_key :spree_shipments, name: "spree_shipments_order_id_fk"
+    add_foreign_key :spree_shipments, :spree_orders, column: 'order_id',
+                    name: 'spree_shipments_order_id_fk', on_delete: :cascade
+
+    remove_foreign_key :spree_inventory_units, name: 'spree_inventory_units_shipment_id_fk'
+    add_foreign_key :spree_inventory_units, :spree_shipments, column: 'shipment_id',
+                    name: 'spree_inventory_units_shipment_id_fk', on_delete: :cascade
+
+    remove_foreign_key :spree_inventory_units, name: 'spree_inventory_units_order_id_fk'
+    add_foreign_key :spree_inventory_units, :spree_orders, column: 'order_id',
+                    name: 'spree_inventory_units_order_id_fk', on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210125123000) do
+ActiveRecord::Schema.define(version: 20210127174120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1252,9 +1252,9 @@ ActiveRecord::Schema.define(version: 20210125123000) do
   add_foreign_key "proxy_orders", "subscriptions", name: "proxy_orders_subscription_id_fk"
   add_foreign_key "spree_addresses", "spree_countries", column: "country_id", name: "spree_addresses_country_id_fk"
   add_foreign_key "spree_addresses", "spree_states", column: "state_id", name: "spree_addresses_state_id_fk"
-  add_foreign_key "spree_inventory_units", "spree_orders", column: "order_id", name: "spree_inventory_units_order_id_fk"
+  add_foreign_key "spree_inventory_units", "spree_orders", column: "order_id", on_delete: :cascade
   add_foreign_key "spree_inventory_units", "spree_return_authorizations", column: "return_authorization_id", name: "spree_inventory_units_return_authorization_id_fk"
-  add_foreign_key "spree_inventory_units", "spree_shipments", column: "shipment_id", name: "spree_inventory_units_shipment_id_fk"
+  add_foreign_key "spree_inventory_units", "spree_shipments", column: "shipment_id", on_delete: :cascade
   add_foreign_key "spree_inventory_units", "spree_variants", column: "variant_id", name: "spree_inventory_units_variant_id_fk"
   add_foreign_key "spree_line_items", "spree_orders", column: "order_id", name: "spree_line_items_order_id_fk"
   add_foreign_key "spree_line_items", "spree_variants", column: "variant_id", name: "spree_line_items_variant_id_fk"
@@ -1290,7 +1290,7 @@ ActiveRecord::Schema.define(version: 20210125123000) do
   add_foreign_key "spree_roles_users", "spree_roles", column: "role_id", name: "spree_roles_users_role_id_fk"
   add_foreign_key "spree_roles_users", "spree_users", column: "user_id", name: "spree_roles_users_user_id_fk"
   add_foreign_key "spree_shipments", "spree_addresses", column: "address_id", name: "spree_shipments_address_id_fk"
-  add_foreign_key "spree_shipments", "spree_orders", column: "order_id", name: "spree_shipments_order_id_fk"
+  add_foreign_key "spree_shipments", "spree_orders", column: "order_id", on_delete: :cascade
   add_foreign_key "spree_state_changes", "spree_users", column: "user_id", name: "spree_state_changes_user_id_fk"
   add_foreign_key "spree_states", "spree_countries", column: "country_id", name: "spree_states_country_id_fk"
   add_foreign_key "spree_tax_rates", "spree_tax_categories", column: "tax_category_id", name: "spree_tax_rates_tax_category_id_fk"

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -15,5 +15,14 @@ class RemoveTransientData
     Spree::StateChange.where("created_at < ?", RETENTION_PERIOD).delete_all
     Spree::LogEntry.where("created_at < ?", RETENTION_PERIOD).delete_all
     Session.where("updated_at < ?", RETENTION_PERIOD).delete_all
+
+    # Clear old carts and associated records
+    old_carts = Spree::Order.where("state = 'cart' AND updated_at < ?", RETENTION_PERIOD)
+    old_cart_line_items = Spree::LineItem.where(order_id: old_carts)
+    old_cart_adjustments = Spree::Adjustment.where(order_id: old_carts)
+
+    old_cart_adjustments.delete_all
+    old_cart_line_items.delete_all
+    old_carts.delete_all
   end
 end

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -24,5 +24,16 @@ class RemoveTransientData
     old_cart_adjustments.delete_all
     old_cart_line_items.delete_all
     old_carts.delete_all
+
+    # Clear option values for deleted line items
+    ActiveRecord::Base.connection.execute <<-SQL
+      DELETE FROM spree_option_values_line_items
+      WHERE line_item_id IN (
+        SELECT line_item_id FROM spree_option_values_line_items
+        LEFT OUTER JOIN spree_line_items
+        ON spree_option_values_line_items.line_item_id = spree_line_items.id
+        WHERE spree_line_items.id IS NULL
+      );
+    SQL
   end
 end

--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class RemoveTransientData
-  RETENTION_PERIOD = 6.months.ago.to_date
+  MEDIUM_RETENTION = 6.months.ago.to_date
+  SHORT_RETENTION = 3.months.ago.to_date
 
   # This model lets us operate on the sessions DB table using ActiveRecord's
   # methods within the scope of this service. This relies on the AR's
@@ -12,9 +13,9 @@ class RemoveTransientData
   def call
     Rails.logger.info("#{self.class.name}: processing")
 
-    Spree::StateChange.where("created_at < ?", RETENTION_PERIOD).delete_all
-    Spree::LogEntry.where("created_at < ?", RETENTION_PERIOD).delete_all
-    Session.where("updated_at < ?", RETENTION_PERIOD).delete_all
+    Spree::StateChange.where("created_at < ?", MEDIUM_RETENTION).delete_all
+    Spree::LogEntry.where("created_at < ?", MEDIUM_RETENTION).delete_all
+    Session.where("updated_at < ?", SHORT_RETENTION).delete_all
 
     clear_old_cart_data!
     clear_line_item_option_values!
@@ -23,7 +24,7 @@ class RemoveTransientData
   private
 
   def clear_old_cart_data!
-    old_carts = Spree::Order.where("state = 'cart' AND updated_at < ?", RETENTION_PERIOD)
+    old_carts = Spree::Order.where("state = 'cart' AND updated_at < ?", SHORT_RETENTION)
     old_cart_line_items = Spree::LineItem.where(order_id: old_carts)
     old_cart_adjustments = Spree::Adjustment.where(order_id: old_carts)
 

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -61,23 +61,11 @@ describe RemoveTransientData do
         expect{ old_adjustment.reload }.to raise_error ActiveRecord::RecordNotFound
       end
 
-      context "removing defunct line item option value records" do
-        let(:connection) { ActiveRecord::Base.connection }
-        let(:query) {
-          <<-SQL
-            SELECT * FROM spree_option_values_line_items
-            LEFT OUTER JOIN spree_line_items
-            ON spree_option_values_line_items.line_item_id = spree_line_items.id
-            WHERE spree_line_items.id IS NULL;
-          SQL
-        }
+      it "removes any defunct line item option value records" do
+        line_item.delete
 
-        it "removes the records" do
-          line_item.delete
-
-          expect{ RemoveTransientData.new.call }.
-            to change{ connection.execute(query).count }.by(-1)
-        end
+        expect{ RemoveTransientData.new.call }.
+          to change{ Spree::OptionValuesLineItem.count }.by(-1)
       end
     end
   end

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -35,5 +35,30 @@ describe RemoveTransientData do
 
       expect(RemoveTransientData::Session.all).to be_empty
     end
+
+    describe "deleting old carts" do
+      let(:product) { create(:product) }
+      let(:variant) { product.variants.first }
+
+      let!(:cart) { create(:order, state: 'cart') }
+      let!(:line_item) { create(:line_item, order: cart, variant: variant) }
+      let!(:adjustment) { create(:adjustment, order: cart) }
+
+      let!(:old_cart) { create(:order, state: 'cart', updated_at: retention_period - 1.day) }
+      let!(:old_line_item) { create(:line_item, order: old_cart, variant: variant) }
+      let!(:old_adjustment) { create(:adjustment, order: old_cart) }
+
+      it 'deletes cart orders and related objects older than retention_period' do
+        RemoveTransientData.new.call
+
+        expect{ cart.reload }.to_not raise_error
+        expect{ line_item.reload }.to_not raise_error
+        expect{ adjustment.reload }.to_not raise_error
+
+        expect{ old_cart.reload }.to raise_error ActiveRecord::RecordNotFound
+        expect{ old_line_item.reload }.to raise_error ActiveRecord::RecordNotFound
+        expect{ old_adjustment.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 end

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -5,7 +5,8 @@ require 'tasks/data/remove_transient_data'
 
 describe RemoveTransientData do
   describe '#call' do
-    let(:retention_period) { RemoveTransientData::RETENTION_PERIOD }
+    let(:medium_retention) { RemoveTransientData::MEDIUM_RETENTION }
+    let(:short_retention) { RemoveTransientData::SHORT_RETENTION }
 
     before do
       allow(Spree::StateChange).to receive(:delete_all)
@@ -15,21 +16,21 @@ describe RemoveTransientData do
     end
 
     it 'deletes state changes older than rentention_period' do
-      Spree::StateChange.create(created_at: retention_period - 1.day)
+      Spree::StateChange.create(created_at: medium_retention - 1.day)
 
       RemoveTransientData.new.call
       expect(Spree::StateChange.all).to be_empty
     end
 
     it 'deletes log entries older than retention_period' do
-      Spree::LogEntry.create(created_at: retention_period - 1.day)
+      Spree::LogEntry.create(created_at: medium_retention - 1.day)
 
       expect { RemoveTransientData.new.call }
         .to change(Spree::LogEntry, :count).by(-1)
     end
 
     it 'deletes sessions older than retention_period' do
-      RemoveTransientData::Session.create(session_id: 1, updated_at: retention_period - 1.day)
+      RemoveTransientData::Session.create(session_id: 1, updated_at: short_retention - 1.day)
 
       RemoveTransientData.new.call
 
@@ -44,7 +45,7 @@ describe RemoveTransientData do
       let!(:line_item) { create(:line_item, order: cart, variant: variant) }
       let!(:adjustment) { create(:adjustment, order: cart) }
 
-      let!(:old_cart) { create(:order, state: 'cart', updated_at: retention_period - 1.day) }
+      let!(:old_cart) { create(:order, state: 'cart', updated_at: short_retention - 1.day) }
       let!(:old_line_item) { create(:line_item, order: old_cart, variant: variant) }
       let!(:old_adjustment) { create(:adjustment, order: old_cart) }
 


### PR DESCRIPTION
#### What? Why?

Removes cart orders (and associated records) that have not been touched for more than 3 months.

On UK prod, the number of stale carts (not touched in > 3 months) is currently **1,041,785**. And that's not including all the related line items and adjustments...

For reference, the total number of _all_ orders on UK prod is **1,354,292**, so ~77% of them are stale carts.

:fire::fire:

Context: we'll need to do some big migrations at some points around orders/line_items/adjustments, and it'll be a lot smoother if we can clear lots of junk out of our databases first...

#### What should we test?
<!-- List which features should be tested and how. -->

Note: requires use of the Rails console.

1. In the Rails console, check the number of stale carts with: `Spree::Order.where("state = 'cart' AND updated_at < '2020-10-01'").count`
2. Exit the console and do `bundle exec rake ofn:data:remove_transient_data`
3. Go back to the Rails console and check the new count: `Spree::Order.where("state = 'cart' AND updated_at < '2020-10-01'").count`

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added data cleanup job for removing old cart orders.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
