### PR TITLE
 Use JS I18n function in assets to avoid parsing error

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -45,7 +45,7 @@ $(document).ready(function() {
       if (quantity > maxQuantity) {
         quantity = maxQuantity;
         save.parents('tr').find('input.line_item_quantity').val(maxQuantity);
-        alert('<%= I18n.t("js.admin.orders.quantity_adjusted") %>');
+        alert(t("js.admin.orders.quantity_adjusted"));
       }
       toggleItemEdit();
 
@@ -84,7 +84,7 @@ adjustItems = function(shipment_number, variant_id, quantity){
     url += '.json';
 
     if (new_quantity == 0) {
-      alert('<%= I18n.t("js.admin.orders.quantity_unchanged") %>');
+      alert(t("js.admin.orders.quantity_unchanged"));
     } else {
       $.ajax({
         type: "PUT",


### PR DESCRIPTION
#### What? Why?

Closes #6749

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

I checked all assets for the same pattern and they seem fine:
```
$ git ls-files -- app/assets/**.erb* | xargs git grep -w t -- 
app/assets/javascripts/admin/spree/base.js.erb:  // Trunkate text in page_title that didn't fit
app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb:        alert(t("js.admin.orders.quantity_adjusted"));
app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb:      alert(t("js.admin.orders.quantity_unchanged"));
```

#### What should we test?
<!-- List which features should be tested and how. -->

Repeat the steps in https://github.com/openfoodfoundation/openfoodnetwork/issues/5989#issuecomment-759640598.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Use javascript translate function in all assets.


