### PR TITLE
Make user's profile tabs aware of location change event

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/tabset_ctrl.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/tabset_ctrl.js.coffee
@@ -1,4 +1,4 @@
-Darkswarm.directive "tabsetCtrl", (Tabsets, $location) ->
+Darkswarm.directive "tabsetCtrl", (Tabsets, $location, $rootScope) ->
   restrict: "C"
   scope:
     id: "@"
@@ -9,7 +9,13 @@ Darkswarm.directive "tabsetCtrl", (Tabsets, $location) ->
     if $scope.navigate
       path = $location.path()?.match(/^\/\w+$/)?[0]
       $scope.selected = path[1..] if path
-
+    
+    # Watch location change success event to operate back/forward buttons
+    $rootScope.$on "$locationChangeSuccess", ->
+      if $scope.navigate
+        path = $location.path()?.match(/^\/\w+$/)?[0]
+        Tabsets.toggle($scope.id, path[1..] if path)
+     
     this.toggle = (name) ->
       Tabsets.toggle($scope.id, name)
 

--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -22,14 +22,14 @@
 
   .row.tabset-ctrl#account-tabs{ style: 'margin-bottom: 100px', navigate: 'true', selected: 'orders', prefix: 'account' }
     .small.12.medium-3.columns.tab{ name: "orders" }
-      %a{ }=t('.tabs.orders')
+      %a=t('.tabs.orders')
     - if Spree::Config.stripe_connect_enabled && Stripe.publishable_key
       .small.12.medium-3.columns.tab{ name: "cards" }
-        %a{ }=t('.tabs.cards')
+        %a=t('.tabs.cards')
     .small.12.medium-3.columns.tab{ name: "transactions" }
-      %a{ }=t('.tabs.transactions')
+      %a=t('.tabs.transactions')
     .small.12.medium-3.columns.tab{ name: "settings" }
-      %a{ }=t('.tabs.settings')
+      %a=t('.tabs.settings')
     .small-12.columns.tab-view
 
   = render partial: "shared/footer"

--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -22,14 +22,14 @@
 
   .row.tabset-ctrl#account-tabs{ style: 'margin-bottom: 100px', navigate: 'true', selected: 'orders', prefix: 'account' }
     .small.12.medium-3.columns.tab{ name: "orders" }
-      %a{ href: 'javascript:void(0)' }=t('.tabs.orders')
+      %a{ }=t('.tabs.orders')
     - if Spree::Config.stripe_connect_enabled && Stripe.publishable_key
       .small.12.medium-3.columns.tab{ name: "cards" }
-        %a{ href: 'javascript:void(0)' }=t('.tabs.cards')
+        %a{ }=t('.tabs.cards')
     .small.12.medium-3.columns.tab{ name: "transactions" }
-      %a{ href: 'javascript:void(0)' }=t('.tabs.transactions')
+      %a{ }=t('.tabs.transactions')
     .small.12.medium-3.columns.tab{ name: "settings" }
-      %a{ href: 'javascript:void(0)' }=t('.tabs.settings')
+      %a{ }=t('.tabs.settings')
     .small-12.columns.tab-view
 
   = render partial: "shared/footer"

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -39,7 +39,7 @@ feature "Credit Cards", js: true do
     it "passes the smoke test" do
       visit "/account"
 
-      click_link I18n.t('spree.users.show.tabs.cards')
+      find("a", :text => %r{#{I18n.t('spree.users.show.tabs.cards')}}i).click
 
       expect(page).to have_content I18n.t(:saved_cards)
 

--- a/spec/features/consumer/account/settings_spec.rb
+++ b/spec/features/consumer/account/settings_spec.rb
@@ -18,7 +18,7 @@ feature "Account Settings", js: true do
       setup_email
       login_as user
       visit "/account"
-      click_link I18n.t('spree.users.show.tabs.settings')
+      find("a", :text => %r{#{I18n.t('spree.users.show.tabs.settings')}}i).click
       expect(page).to have_content I18n.t('spree.users.form.account_settings')
     end
 
@@ -37,7 +37,7 @@ feature "Account Settings", js: true do
       user.reload
       expect(user.email).to eq 'old@email.com'
       expect(user.unconfirmed_email).to eq 'new@email.com'
-      click_link I18n.t('spree.users.show.tabs.settings')
+      find("a", :text => %r{#{I18n.t('spree.users.show.tabs.settings')}}i).click
       expect(page).to have_content I18n.t('spree.users.show.unconfirmed_email',
                                           unconfirmed_email: 'new@email.com')
     end

--- a/spec/features/consumer/account_spec.rb
+++ b/spec/features/consumer/account_spec.rb
@@ -54,7 +54,7 @@ feature '
                                   href: "#{distributor_credit.permalink}/shop", count: 1)
 
         # Viewing transaction history
-        click_link I18n.t('spree.users.show.tabs.transactions')
+        find("a", :text => %r{#{I18n.t('spree.users.show.tabs.transactions')}}i).click
 
         # It shows all hubs that have been ordered from with balance or credit
         expect(page).to have_content distributor1.name


### PR DESCRIPTION
#### What? Why?
Closes #4971 
Forward and back buttons were unusable since the 'tab system' wasn't aware of the location change event. This PR make it aware of this event.

#### What should we test?
1. Log in.
2. Go to your profile.
3. Click on the title of different tabs in the order you wish
4. Back and forward buttons must work and show the appropriate selected tab and its content


#### Release notes
Operate browser's back and forward buttons on the user's profile tabs.

Changelog Category: User facing changes


#### What it looks like?
![2021-01-27 10 42 06](https://user-images.githubusercontent.com/296452/105972942-72a47300-608c-11eb-86c2-580956959006.gif)



