### PR TITLE
FullWidth admin layout quick wins

### DIFF
--- a/app/views/admin/enterprises/form/_address.html.haml
+++ b/app/views/admin/enterprises/form/_address.html.haml
@@ -31,8 +31,7 @@
     \/
     = af.label :country_id, t(:country)
     %span.required *
-  %div{ "ng-controller" => "countryCtrl" }
-    .four.columns
-      %input.ofn-select2.fullwidth#enterprise_address_attributes_state_id{ name: 'enterprise[address_attributes][state_id]', type: 'number', data: 'countriesById[Enterprise.address.country_id].states', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.state_id' } }
-    .four.columns.omega
-      %input.ofn-select2.fullwidth#enterprise_address_attributes_country_id{ name: 'enterprise[address_attributes][country_id]', type: 'number', data: 'countries', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.country_id' } }
+  .four.columns{ "ng-controller" => "countryCtrl" }
+    %input.ofn-select2.fullwidth#enterprise_address_attributes_state_id{ name: 'enterprise[address_attributes][state_id]', type: 'number', data: 'countriesById[Enterprise.address.country_id].states', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.state_id' } }
+  .four.columns.omega{ "ng-controller" => "countryCtrl" }
+    %input.ofn-select2.fullwidth#enterprise_address_attributes_country_id{ name: 'enterprise[address_attributes][country_id]', type: 'number', data: 'countries', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.country_id' } }

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -1,19 +1,17 @@
 .row
-  .alpha.eleven.columns
-    .three.columns.alpha
-      = f.label :name, t('.name')
-      %span.required *
-    .eight.columns.omega
-      = f.text_field :name, { placeholder: t('.name_placeholder') }
+  .three.columns.alpha
+    = f.label :name, t('.name')
+    %span.required *
+  .eight.columns.omega
+    = f.text_field :name, { placeholder: t('.name_placeholder') }
 - if @groups.present?
   .row
-    .alpha.eleven.columns
-      .three.columns.alpha
-        = f.label :group_ids, t('.groups')
-        %div{'ofn-with-tip' => t('.groups_tip')}
-          %a= t('admin.whats_this')
-      .eight.columns.omega
-        = f.collection_select :group_ids, @groups, :id, :name, {}, class: "select2 fullwidth", multiple: true, placeholder: t('.groups_placeholder')
+    .three.columns.alpha
+      = f.label :group_ids, t('.groups')
+      %div{'ofn-with-tip' => t('.groups_tip')}
+        %a= t('admin.whats_this')
+    .eight.columns.omega
+      = f.collection_select :group_ids, @groups, :id, :name, {}, class: "select2 fullwidth", multiple: true, placeholder: t('.groups_placeholder')
 
 .row
   .three.columns.alpha
@@ -25,20 +23,19 @@
     = f.label :is_primary_producer, t('.producer')
 - if spree_current_user.admin?
   .row
-    .alpha.eleven.columns
-      .three.columns.alpha
-        = f.label :sells, t('.sells')
-        %div{'ofn-with-tip' => t('.sells_tip')}
-          %a= t('admin.whats_this')
-      .two.columns
-        = f.radio_button :sells, "none", 'ng-model' => 'Enterprise.sells'
-        = f.label :sells, t('.none'), value: "none"
-      .two.columns
-        = f.radio_button :sells, "own", 'ng-model' => 'Enterprise.sells'
-        = f.label :sells, t('.own'), value: "own"
-      .four.columns.omega
-        = f.radio_button :sells, "any", 'ng-model' => 'Enterprise.sells'
-        = f.label :sells, t('.any'), value: "any"
+    .three.columns.alpha
+      = f.label :sells, t('.sells')
+      %div{'ofn-with-tip' => t('.sells_tip')}
+        %a= t('admin.whats_this')
+    .two.columns
+      = f.radio_button :sells, "none", 'ng-model' => 'Enterprise.sells'
+      = f.label :sells, t('.none'), value: "none"
+    .two.columns
+      = f.radio_button :sells, "own", 'ng-model' => 'Enterprise.sells'
+      = f.label :sells, t('.own'), value: "own"
+    .four.columns.omega
+      = f.radio_button :sells, "any", 'ng-model' => 'Enterprise.sells'
+      = f.label :sells, t('.any'), value: "any"
 .row
   .three.columns.alpha
     %label= t('.visible_in_search')
@@ -56,7 +53,7 @@
       = f.label :permalink, t('.permalink')
       %div{'ofn-with-tip' => t('.permalink_tip', link: main_app.root_url)}
         %a= t('admin.whats_this')
-    .six.columns
+    .eight.columns
       = f.text_field :permalink, { 'ng-model' => "Enterprise.permalink", placeholder: "eg. your-shop-name", 'ng-model-options' => "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }" }
     .two.columns.omega
       %div{ng: {show: "checking", cloak: true}, style: "width: 30px; height: 30px;"}

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -98,9 +98,10 @@
   .controls.sixteen.columns.alpha.omega{ ng: { hide: 'RequestMonitor.loading || line_items.length == 0' } }
     %div.three.columns.alpha
       %input.fullwidth{ :type => "text", :id => 'quick_search', 'ng-model' => 'quickSearch', :placeholder => 'Quick Search' }
-    = render 'admin/shared/bulk_actions_dropdown'
-    %div.seven.columns &nbsp;
-    %columns-dropdown{ action: "#{controller_name}_#{action_name}" }
+    %div.three.columns
+      = render 'admin/shared/bulk_actions_dropdown'
+    %div.ten.columns
+      %columns-dropdown{ action: "#{controller_name}_#{action_name}" }
 
   %div.sixteen.columns.alpha#loading{ 'ng-if' => 'RequestMonitor.loading' }
     = render partial: "components/spinner"


### PR DESCRIPTION
#### What? Why?
Closes epic #6746 (both #6745 and #6747)



#### What should we test?

1. On `/admin/orders/bulk_management`, you must see margin between the quick search and the action button as the screenshot:
<img width="415" alt="Capture d’écran 2021-01-27 à 15 09 11" src="https://user-images.githubusercontent.com/296452/106002894-edcc5000-60b1-11eb-8993-6d97fd4646d3.png">

2. On page `admin/enterprises/[ENTREPRISE-SLUG]/edit#/primary_details`, you must see the aligned form as the screenshot:
<img width="270" alt="Capture d’écran 2021-01-27 à 15 08 49" src="https://user-images.githubusercontent.com/296452/106003026-15bbb380-60b2-11eb-8a0c-c0bbeb127187.png">

3.  On page `admin/enterprises/[ENTREPRISE-SLUG]/edit#/adress`, you must see the aligned form as the screenshot:
<img width="282" alt="Capture d’écran 2021-01-27 à 15 08 54" src="https://user-images.githubusercontent.com/296452/106003078-21a77580-60b2-11eb-9652-865711c9dea0.png">



#### Release notes
Fix alignment on admin pages.


Changelog Category: User facing changes
