### PR TITLE
Touch updated_at column when updating records via #update_column

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -36,7 +36,10 @@ module Spree
         invoke_callbacks(:update, :before)
         payment_method_type = params[:payment_method].delete(:type)
         if @payment_method['type'].to_s != payment_method_type
-          @payment_method.update_column(:type, payment_method_type)
+          @payment_method.update_columns(
+            type: payment_method_type,
+            updated_at: Time.zone.now
+          )
           @payment_method = PaymentMethod.find(params[:id])
         end
 
@@ -81,7 +84,10 @@ module Spree
           authorize! :show_provider_preferences, @payment_method
           payment_method_type = params[:provider_type]
           if @payment_method['type'].to_s != payment_method_type
-            @payment_method.update_column(:type, payment_method_type)
+            @payment_method.update_columns(
+              type: payment_method_type,
+              updated_at: Time.zone.now
+            )
             @payment_method = PaymentMethod.find(params[:pm_id])
           end
         else

--- a/app/controllers/spree/admin/taxons_controller.rb
+++ b/app/controllers/spree/admin/taxons_controller.rb
@@ -61,7 +61,12 @@ module Spree
             @taxon.move_to_right_of(new_siblings[new_position - 1]) # we move down
           end
           # Reset legacy position, if any extensions still rely on it
-          new_parent.children.reload.each{ |t| t.update_column(:position, t.position) }
+          new_parent.children.reload.each do |t|
+            t.update_columns(
+              position: t.position,
+              updated_at: Time.zone.now
+            )
+          end
 
           if parent_id
             @taxon.reload

--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -89,7 +89,10 @@ module Spree
     # count towards the order's adjustment_total.
     def set_eligibility
       result = mandatory || amount != 0
-      update_column(:eligible, result)
+      update_columns(
+        eligible: result,
+        updated_at: Time.zone.now
+      )
     end
 
     # Update both the eligibility and amount of the adjustment. Adjustments

--- a/app/models/spree/inventory_unit.rb
+++ b/app/models/spree/inventory_unit.rb
@@ -46,7 +46,12 @@ module Spree
     end
 
     def self.finalize_units!(inventory_units)
-      inventory_units.map { |iu| iu.update_column(:pending, false) }
+      inventory_units.map do |iu|
+        iu.update_columns(
+          pending: false,
+          updated_at: Time.zone.now
+        )
+      end
     end
 
     def find_stock_item

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -604,7 +604,10 @@ module Spree
       return unless shipments.any?
 
       shipments.destroy_all
-      update_column(:state, "address")
+      update_columns(
+        state: "address",
+        updated_at: Time.zone.now
+      )
     end
 
     def refresh_shipment_rates

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -196,7 +196,10 @@ module Spree
       order.payments.with_state('checkout').where.not(id: id).each do |payment|
         # Using update_column skips validations and so it skips validate_source. As we are just
         # invalidating past payments here, we don't want to validate all of them at this stage.
-        payment.update_column(:state, 'invalid')
+        payment.update_columns(
+          state: 'invalid',
+          updated_at: Time.zone.now
+        )
         payment.ensure_correct_adjustment
       end
     end

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -217,7 +217,10 @@ module Spree
     def update!(order)
       old_state = state
       new_state = determine_state(order)
-      update_column :state, new_state
+      update_columns(
+        state: new_state,
+        updated_at: Time.zone.now
+      )
       after_ship if new_state == 'shipped' && old_state != 'shipped'
     end
 

--- a/app/models/spree/tax_category.rb
+++ b/app/models/spree/tax_category.rb
@@ -13,8 +13,12 @@ module Spree
       # set existing default tax category to false if this one has been marked as default
 
       return unless is_default && tax_category = self.class.find_by(is_default: true)
+      return if tax_category == self
 
-      tax_category.update_column(:is_default, false) unless tax_category == self
+      tax_category.update_columns(
+        is_default: false,
+        updated_at: Time.zone.now
+      )
     end
   end
 end

--- a/app/models/spree/taxonomy.rb
+++ b/app/models/spree/taxonomy.rb
@@ -15,7 +15,10 @@ module Spree
 
     def set_name
       if root
-        root.update_column(:name, name)
+        root.update_columns(
+          name: name,
+          updated_at: Time.zone.now
+        )
       else
         self.root = Taxon.create!(taxonomy_id: id, name: name)
       end

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -39,7 +39,8 @@ module OrderManagement
           item_total: order.item_total,
           adjustment_total: order.adjustment_total,
           payment_total: order.payment_total,
-          total: order.total
+          total: order.total,
+          updated_at: Time.zone.now
         )
       end
 

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -49,6 +49,10 @@ describe RemoveTransientData do
       let!(:old_line_item) { create(:line_item, order: old_cart, variant: variant) }
       let!(:old_adjustment) { create(:adjustment, order: old_cart) }
 
+      before do
+        old_cart.update_columns(updated_at: short_retention - 1.day)
+      end
+
       it 'deletes cart orders and related objects older than retention_period' do
         RemoveTransientData.new.call
 

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -191,7 +191,8 @@ describe Spree::Shipment do
     shared_examples_for "immutable once shipped" do
       it "should remain in shipped state once shipped" do
         shipment.state = 'shipped'
-        expect(shipment).to receive(:update_column).with(:state, 'shipped')
+        expect(shipment).to receive(:update_columns).
+          with(state: 'shipped', updated_at: kind_of(Time))
         shipment.update!(order)
       end
     end
@@ -201,7 +202,8 @@ describe Spree::Shipment do
         unit = create(:inventory_unit)
         allow(unit).to receive(:backordered?) { true }
         allow(shipment).to receive_messages(inventory_units: [unit])
-        expect(shipment).to receive(:update_column).with(:state, 'pending')
+        expect(shipment).to receive(:update_columns).
+          with(state: 'pending', updated_at: kind_of(Time))
         shipment.update!(order)
       end
     end
@@ -210,7 +212,8 @@ describe Spree::Shipment do
       it "should result in a 'pending' state" do
         allow(order).to receive(:canceled?) { true }
 
-        expect(shipment).to receive(:update_column).with(:state, 'canceled')
+        expect(shipment).to receive(:update_columns).
+          with(state: 'canceled', updated_at: kind_of(Time))
         shipment.update!(order)
       end
     end
@@ -219,7 +222,8 @@ describe Spree::Shipment do
       it "should result in a 'pending' state" do
         allow(order).to receive(:can_ship?) { false }
 
-        expect(shipment).to receive(:update_column).with(:state, 'pending')
+        expect(shipment).to receive(:update_columns).
+          with(state: 'pending', updated_at: kind_of(Time))
         shipment.update!(order)
       end
     end
@@ -231,7 +235,8 @@ describe Spree::Shipment do
         before { allow(order).to receive(:paid?) { true } }
 
         it "should result in a 'ready' state" do
-          expect(shipment).to receive(:update_column).with(:state, 'ready')
+          expect(shipment).to receive(:update_columns).
+            with(state: 'ready', updated_at: kind_of(Time))
           shipment.update!(order)
         end
 
@@ -244,7 +249,8 @@ describe Spree::Shipment do
 
           it "should result in a 'ready' state" do
             shipment.state = 'pending'
-            expect(shipment).to receive(:update_column).with(:state, 'ready')
+            expect(shipment).to receive(:update_columns).
+              with(state: 'ready', updated_at: kind_of(Time))
             shipment.update!(order)
           end
 
@@ -259,7 +265,8 @@ describe Spree::Shipment do
 
         it "should result in a 'pending' state" do
           shipment.state = 'ready'
-          expect(shipment).to receive(:update_column).with(:state, 'pending')
+          expect(shipment).to receive(:update_columns).
+            with(state: 'pending', updated_at: kind_of(Time))
           shipment.update!(order)
         end
 
@@ -274,7 +281,8 @@ describe Spree::Shipment do
         shipment.state = 'pending'
         expect(shipment).to receive :after_ship
         allow(shipment).to receive_messages determine_state: 'shipped'
-        expect(shipment).to receive(:update_column).with(:state, 'shipped')
+        expect(shipment).to receive(:update_columns).
+          with(state: 'shipped', updated_at: kind_of(Time))
         shipment.update!(order)
       end
     end


### PR DESCRIPTION
#### What? Why?

The `#update_column` and `#update_columns` methods skip callbacks (which is really useful sometimes), but they don't set the `updated_at` field on the record (which we _should_ be doing in these cases).

This is an upstream fix introduced in Spree 2.2 here: https://github.com/spree/spree/commit/b367c629ceafc199ca16d763797a06c237c5fe21

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Ensure updated_at is set when using #update_columns

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
