### PR TITLE
Dead code: superfluous argument in CartService#populate

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -11,7 +11,7 @@ class CartController < BaseController
     Spree::Adjustment.without_callbacks do
       cart_service = CartService.new(order)
 
-      cart_service.populate(params.slice(:products, :variants, :quantity), true)
+      cart_service.populate(params.slice(:variants, :quantity), true)
       if cart_service.valid?
         order.update_distribution_charge!
         order.cap_quantity_at_stock!

--- a/app/services/cart_service.rb
+++ b/app/services/cart_service.rb
@@ -1,5 +1,7 @@
 require 'open_food_network/scope_variant_to_hub'
 
+# Previously Spree::OrderPopulator. Modified to work with max_quantity and variant overrides.
+
 class CartService
   attr_accessor :order, :currency
   attr_reader :variants_h


### PR DESCRIPTION
#### What? Why?

`CartService#populate` doesn't use `:products` anywhere, so it doesn't need to be passed in as part of the argument.

Also added a small comment to clarify that `CartService` is actually `Spree::OrderPopulator`. There are some upstream changes to the original class that will need to be brought in to this class soon as part of adjustments updates.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Clarified arguments passed to CartService in order populate

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
