### PR TITLE
User profile tabs: specify :hover rule only for devices that can effectively handle it

### DIFF
--- a/app/assets/stylesheets/darkswarm/tabset.scss
+++ b/app/assets/stylesheets/darkswarm/tabset.scss
@@ -32,22 +32,24 @@
 
     border-bottom: 4px solid transparent;
 
-    &:hover, &:focus, &:active {
-      transition: all 0.4s ease-in-out;
-      border-bottom: 4px solid $clr-brick-bright;
-      cursor: pointer;
-
-      @include breakpoint(phablet) {
-        transition: none;
-        color: white;
-        background-color: $clr-brick-bright;
-      }
-
-      a {
-        color: $clr-brick-bright;
+    @media (hover: hover) {
+      &:hover {
+        transition: all 0.4s ease-in-out;
+        border-bottom: 4px solid $clr-brick-bright;
+        cursor: pointer;
 
         @include breakpoint(phablet) {
-          color: #ffffff;
+          transition: none;
+          color: white;
+          background-color: $clr-brick-bright;
+        }
+
+        a {
+          color: $clr-brick-bright;
+
+          @include breakpoint(phablet) {
+            color: #ffffff;
+          }
         }
       }
     }


### PR DESCRIPTION
#### What? Why?

Closes #6766 

Since mobile device cannot handle `:hover` rule (hover is non sense for touch devices), specify css for only devices that effectively handle it (with media query `@media (hover: hover)`).
see https://css-tricks.com/solving-sticky-hover-states-with-media-hover-hover/
and https://caniuse.com/mdn-css_at-rules_media_hover for compatibility (quite good)


#### What should we test?
On both mobile device and desktop browser (with small screen size and another one with normal screen one) : 
1, Log in and go to the account section.
2. Click thorough the tabs.
3. Now, click on the back button
4. Visited tabs should not be filled with red background. On desktop browser with small size, hovered tabs with pointer must be filled with red background.

![2021-02-01 11 13 30](https://user-images.githubusercontent.com/296452/106445120-ebd20a80-647e-11eb-99ca-f1a57a32401a.gif)
![2021-02-01 11 17 34](https://user-images.githubusercontent.com/296452/106445961-f8a32e00-647f-11eb-8388-cd1176c5cb55.gif)



#### Release notes
Fix hovered and visited user profile tabs background color issue

Changelog Category: User facing changes
