### PR TITLE
Package selection: use "columns" system to display 3 items on same line

### DIFF
--- a/app/views/admin/enterprises/_change_type_form.html.haml
+++ b/app/views/admin/enterprises/_change_type_form.html.haml
@@ -6,9 +6,9 @@
   %input{ hidden: "true", name: "sells", ng: { required: true, pattern: "/^(none|own|any)$/", model: 'sells', value: "sells"} }
 
   .row
-    .options.sixteen.columns.alpha
+    .options.container
       - if @enterprise.is_primary_producer
-        .basic_producer.option.one-third.column.alpha
+        .basic_producer.option.six.columns.alpha
           %a.full-width.button.selector{ ng: { click: "sells='none'", class: "{selected: sells=='none'}" } }
             .top
               %h3= t('.producer_profile')
@@ -17,7 +17,7 @@
           %p.description
             = t('.producer_description_text')
 
-        .producer_shop.option.one-third.column
+        .producer_shop.option.six.columns
           %a.full-width.button.selector{ ng: { click: "sells='own'", class: "{selected: sells=='own'}" } }
             .top
               %h3= t('.producer_shop')
@@ -28,7 +28,7 @@
             %br
             = t('.producer_shop_description_text2')
 
-        .full_hub.option.one-third.column.omega
+        .full_hub.option.six.columns.omega
           %a.full-width.button.selector{ ng: { click: "sells='any'", class: "{selected: sells=='any'}" } }
             .top
               %h3= t('.producer_hub')


### PR DESCRIPTION


#### What? Why?
Use our "columns" (`grid.scss`) system to display 3 packages on the same line.
Closes #6781
_Note_: as it's impossible to divide 16 (finest size on our columns system)  by 3 (# items to display), use `.six` class. 
_Note_: This view is not so responsive: displaying 3 items on small width size screen can be painful. Maybe items should be displayed on columns.
```css
.flex-container {
  display: flex;
  flex-direction: row;
}

/* Responsive layout - makes a one column layout instead of a two-column layout */
@media (max-width: 800px) {
  .flex-container {
    flex-direction: column;
  }
}
```

#### What should we test?
##### Scenario 1
1. Register on the platform
2. Complete all the steps until landing on the admin interface at admin/enterprises/NAME/welcome
3. Check the boxes are aligned on the same line

<img width="762" alt="Capture d’écran 2021-02-01 à 14 16 15" src="https://user-images.githubusercontent.com/296452/106463821-2c8a4d80-6498-11eb-8ce8-93d9d7bca7d9.png">

##### Scenario 2
1. Login as admin
2. go to dashboard
3. Select "change package"
<img width="916" alt="Capture d’écran 2021-02-01 à 14 35 25" src="https://user-images.githubusercontent.com/296452/106465796-c05d1900-649a-11eb-9823-0f42d79518e0.png">

#### Release notes
Fix display issue on package selection when creating enterprise

Changelog Category: User facing changes

