### PR TITLE
Align items on shipping and payment methods forms

### DIFF
--- a/app/views/spree/admin/payment_methods/_form.html.haml
+++ b/app/views/spree/admin/payment_methods/_form.html.haml
@@ -4,28 +4,28 @@
   .row
     = t '.deactivation_warning'
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = label_tag nil, t('.name')
-    .omega.eight.columns
+    .omega.twelve.columns
       = text_field :payment_method, :name, class: 'fullwidth'
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = label_tag nil, t('.description')
-    .omega.eight.columns
+    .omega.twelve.columns
       = text_area :payment_method, :description, {cols: 60, rows: 6, class: 'fullwidth'}
   - if spree_current_user.admin?
     .row
-      .alpha.three.columns
+      .alpha.four.columns
         = label_tag nil, t('.environment')
-      .omega.eight.columns
+      .omega.twelve.columns
         = collection_select(:payment_method, :environment, Rails.configuration.database_configuration.keys.sort, :to_s, :titleize, {}, {id: 'gtwy-env', class: 'select2 fullwidth'})
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = label_tag nil, t('.display')
-    .omega.eight.columns
+    .omega.twelve.columns
       = select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [t('.' + display.to_s), display == :both ? nil : display.to_s] }, {}, {class: 'select2 fullwidth'})
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = label_tag nil, t('.active')
     .two.columns
       = radio_button :payment_method, :active, true
@@ -37,14 +37,12 @@
       = label_tag nil, t('.active_no')
 
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = label(:payment_method, :tags, t('.tags'))
-    .omega.eight.columns
+    .omega.twelve.columns
       = hidden_field(:payment_method, :tag_list, "ng-value" => "paymentMethod.tag_list")
       %tags-with-translation#something{ object: "paymentMethod" }
 
   = render 'providers'
 
-  .row
-    .omega.eleven.columns
-      = render partial: 'spree/admin/shared/calculator_fields', locals: { f: f }
+  = render partial: 'spree/admin/shared/calculator_fields', locals: { f: f }

--- a/app/views/spree/admin/payment_methods/_provider_settings.html.haml
+++ b/app/views/spree/admin/payment_methods/_provider_settings.html.haml
@@ -5,13 +5,14 @@
   = render 'stripe_connect'
 - else
   - if @payment_method.preferences.present?
-    %fieldset.alpha.eleven.columns.no-border-bottom#gateway_fields
+    %fieldset.no-border-bottom#gateway_fields
       %legend{ align: "center"}
         = t(:provider_settings)
       .preference-settings
         = fields_for :payment_method, @payment_method do |payment_method_form|
           - preference_fields(@payment_method, payment_method_form).each do |field|
-            .field.alpha.three.columns
-              = field[:label]
-            .field.omega.eight.columns
-              = field[:field]
+            .row
+              .alpha.four.columns
+                = field[:label]
+              .omega.twelve.columns
+                = field[:field]

--- a/app/views/spree/admin/payment_methods/_providers.html.haml
+++ b/app/views/spree/admin/payment_methods/_providers.html.haml
@@ -1,8 +1,8 @@
 #provider-settings{ ng: { controller: "ProvidersCtrl" } }
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = label :payment_method, :type, t('.provider')
-    .omega.eight.columns
+    .omega.twelve.columns
       = collection_select(:payment_method, :type, @providers, :to_s, :clean_name, (!@object.persisted? ? { :selected => "Spree::PaymentMethod::Check"} : {}), { class: 'select2 fullwidth', 'provider-prefs-for' => "#{@object.id}"})
 
   %div{"ng-include" => "include_html" }

--- a/app/views/spree/admin/payment_methods/_stripe_connect.html.haml
+++ b/app/views/spree/admin/payment_methods/_stripe_connect.html.haml
@@ -3,16 +3,17 @@
     = t(:provider_settings)
   .preference-settings{ ng: { controller: "StripeController" } }
     = fields_for :payment_method, @payment_method do |payment_method_form|
-      .alpha.four.columns
-        = payment_method_form.label :stripe_account_owner
-      .omega.twelve.columns
-        - if @stripe_account_holder.nil? || spree_current_user.enterprises.include?(@stripe_account_holder)
-          %input.ofn-select2.fullwidth#payment_method_preferred_enterprise_id{ type: 'number',
-            name: 'payment_method[preferred_enterprise_id]',
-            placeholder: t(".enterprise_select_placeholder"),
-            data: 'shops', ng: { model: 'paymentMethod.preferred_enterprise_id' } }
-        - else
-          %strong= Enterprise.find_by(id: @payment_method).andand.name
+      .row
+        .alpha.four.columns
+          = payment_method_form.label :stripe_account_owner
+        .omega.twelve.columns
+          - if @stripe_account_holder.nil? || spree_current_user.enterprises.include?(@stripe_account_holder)
+            %input.ofn-select2.fullwidth#payment_method_preferred_enterprise_id{ type: 'number',
+              name: 'payment_method[preferred_enterprise_id]',
+              placeholder: t(".enterprise_select_placeholder"),
+              data: 'shops', ng: { model: 'paymentMethod.preferred_enterprise_id' } }
+          - else
+            %strong= Enterprise.find_by(id: @payment_method).andand.name
 
     #stripe-account-status{ ng: { show: "paymentMethod.preferred_enterprise_id" } }
       .alert-box.warning{ ng: { hide: "stripe_account.status" } }

--- a/app/views/spree/admin/payment_methods/_stripe_connect.html.haml
+++ b/app/views/spree/admin/payment_methods/_stripe_connect.html.haml
@@ -1,17 +1,18 @@
-%fieldset.alpha.eleven.columns.no-border-bottom#gateway_fields
+%fieldset.no-border-bottom#gateway_fields
   %legend{ align: "center"}
     = t(:provider_settings)
   .preference-settings{ ng: { controller: "StripeController" } }
     = fields_for :payment_method, @payment_method do |payment_method_form|
-      = payment_method_form.label :stripe_account_owner
-      %br
-      - if @stripe_account_holder.nil? || spree_current_user.enterprises.include?(@stripe_account_holder)
-        %input.ofn-select2.fullwidth#payment_method_preferred_enterprise_id{ type: 'number',
-          name: 'payment_method[preferred_enterprise_id]',
-          placeholder: t(".enterprise_select_placeholder"),
-          data: 'shops', ng: { model: 'paymentMethod.preferred_enterprise_id' } }
-      - else
-        %strong= Enterprise.find_by(id: @payment_method).andand.name
+      .alpha.four.columns
+        = payment_method_form.label :stripe_account_owner
+      .omega.twelve.columns
+        - if @stripe_account_holder.nil? || spree_current_user.enterprises.include?(@stripe_account_holder)
+          %input.ofn-select2.fullwidth#payment_method_preferred_enterprise_id{ type: 'number',
+            name: 'payment_method[preferred_enterprise_id]',
+            placeholder: t(".enterprise_select_placeholder"),
+            data: 'shops', ng: { model: 'paymentMethod.preferred_enterprise_id' } }
+        - else
+          %strong= Enterprise.find_by(id: @payment_method).andand.name
 
     #stripe-account-status{ ng: { show: "paymentMethod.preferred_enterprise_id" } }
       .alert-box.warning{ ng: { hide: "stripe_account.status" } }

--- a/app/views/spree/admin/shared/_calculator_fields.html.haml
+++ b/app/views/spree/admin/shared/_calculator_fields.html.haml
@@ -1,19 +1,19 @@
 %fieldset#calculator_fields.no-border-bottom
   %legend{align: "center"}= t(:calculator)
   #preference-settings
-    .field
-      .alpha.three.columns
+    .row
+      .alpha.four.columns
         = f.label(:calculator_type, t(:calculator), for: 'calc_type')
-      .omega.eight.columns
+      .omega.twelve.columns
         = f.select(:calculator_type, @calculators.map { |c| [c.description, c.name] }, {}, {id: 'calc_type', class: 'select2 fullwidth'})
     - if !@object.new_record?
-      .field
+      .row
         .calculator-settings
           = f.fields_for :calculator do |calculator_form|
             - preference_fields(@object.calculator, calculator_form).each do |field|
-              .field.alpha.three.columns
+              .alpha.four.columns
                 = field[:label]
-              .field.omega.eight.columns
+              .field.twelve.eight.columns
                 = field[:field]
         - if @object.calculator.respond_to?(:preferences)
           %span.calculator-settings-warning.info.warning= t(:calculator_settings_warning)

--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -4,26 +4,26 @@
   .row
     = t '.deactivation_warning'
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = f.label :name, t(:name)
-    .omega.eight.columns
+    .omega.twelve.columns
       = f.text_field :name, class: 'fullwidth', placeholder: t(:spree_admin_eg_pickup_from_school)
       = error_message_on :shipping_method, :name
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = f.label :description, t(:description)
-    .omega.eight.columns
+    .omega.twelve.columns
       = f.text_area :description, class: 'fullwidth', rows: 2, placeholder: t(:spree_admin_eg_collect_your_order)
       = error_message_on :shipping_method, :description
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = f.label :display_on, t(:display)
-    .omega.eight.columns
+    .omega.twelve.columns
       = select(:shipping_method, :display_on, [[t(".both"), nil], [t(".back_end"), "back_end"]], {}, {class: 'select2 fullwidth'})
       = error_message_on :shipping_method, :display_on
 
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       -# The 'Category' label here is just a logical descriptor for the data we are trying to collect for 'requires_ship_address'
       -# and does not relate to shipping categories in any way.
       = f.label :require_ship_address, t(:category)
@@ -37,35 +37,33 @@
       = f.label :pick_up, t(:pick_up)
 
   .row
-    .alpha.three.columns
+    .alpha.four.columns
       = f.label :tags, t(:tags)
-    .omega.eight.columns
+    .omega.twelve.columns
       = f.hidden_field :tag_list, "ng-value" => "shippingMethod.tag_list"
       %tags-with-translation#something{ object: "shippingMethod", 'find-tags' => 'findTags(query)' }
 
-  .row
-    = render partial: 'spree/admin/shared/calculator_fields', locals: { f: f }
+  
+  = render partial: 'spree/admin/shared/calculator_fields', locals: { f: f }
 
-  .row
-    .alpha.eleven.columns
-      %fieldset.categories.no-border-bottom
-        %legend{align: "center"}= t('.categories')
-        = f.field_container :categories do
-          - Spree::ShippingCategory.all.each do |category|
-            = label_tag do
-              = check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category))
-              = category.name
-              %br/
-          = error_message_on :shipping_method, :shipping_category_id
+  %fieldset.categories.no-border-bottom
+    %legend{align: "center"}= t('.categories')
+    = f.field_container :categories do
+      - Spree::ShippingCategory.all.each do |category|
+        = label_tag do
+          = check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category))
+          = category.name
+          %br/
+      = error_message_on :shipping_method, :shipping_category_id
 
-    .alpha.eleven.columns
-      %fieldset.no-border-bottom
-        %legend{align: "center"}= t('.zones')
-        = f.field_container :zones do
-          - shipping_method_zones = @shipping_method.zones.to_a
-          - Spree::Zone.all.each do |zone|
-            = label_tag do
-              = check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone))
-              = zone.name
-            %br/
-          = error_message_on :shipping_method, :zone_id
+  
+  %fieldset.no-border-bottom
+    %legend{align: "center"}= t('.zones')
+    = f.field_container :zones do
+      - shipping_method_zones = @shipping_method.zones.to_a
+      - Spree::Zone.all.each do |zone|
+        = label_tag do
+          = check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone))
+          = zone.name
+        %br/
+      = error_message_on :shipping_method, :zone_id

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -12,8 +12,7 @@
     %fieldset.no-border-top
       = render partial: 'form', locals: { f: f }
       .one.column &nbsp;
-      .alpha.four.columns
-        = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :shipping_method }
+      = render partial: 'spree/admin/shared/hubs_sidebar', locals: { f: f, klass: :shipping_method }
       .clear
       .row
         = render partial: 'spree/admin/shared/edit_resource_links'


### PR DESCRIPTION
#### What? Why?
Closes #6784 
Align forms (on both creating and editing) for shipping methods and payment methods.

#### What should we test?
1. As an enterprise manager, test both shipping methods and payments methods forms: items must be aligned.
2. Test forms on creation and editing: items must be aligned.
<img width="968" alt="Capture d’écran 2021-02-01 à 15 20 43" src="https://user-images.githubusercontent.com/296452/106474109-da035e00-64a4-11eb-8a33-74f1d5c7f79e.png">
<img width="966" alt="Capture d’écran 2021-02-01 à 15 20 15" src="https://user-images.githubusercontent.com/296452/106474243-ff906780-64a4-11eb-8397-c360fcc32c61.png">
3. Don't forget to test each state of form. For example, on the Payments methods form, don't forget to test when "Provider" field is Stripe, Paypal, ... : 
<img width="866" alt="Capture d’écran 2021-02-01 à 15 51 06" src="https://user-images.githubusercontent.com/296452/106474558-51d18880-64a5-11eb-974e-e24e2272a4fe.png">

#### Release notes
Fix alignment issues on payment methods and shipping methods

Changelog Category: User facing changes

