### PR TITLE
Use full width for "new product" form

### DIFF
--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -6,22 +6,22 @@
   .twelve.columns.alpha
     %fieldset.no-border-bottom{ id: "new_product" }
       %legend{align: "center"}= t(".new_product")
-      .twelve.columns.alpha
-        .six.columns.alpha
+      .sixteen.columns.alpha
+        .eight.columns.alpha
           = f.field_container :supplier do
             = f.label :supplier_id, t(".supplier")
             %span.required *
             = f.collection_select(:supplier_id, @producers, :id, :name, {:include_blank => true}, {:class => "select2 fullwidth"})
             = f.error_message_on :supplier
-        .six.columns.omega
+        .eight.columns.omega
           = f.field_container :name do
             = f.label :name, t(".product_name")
             %span.required *
             %br/
             = f.text_field :name, :class => 'fullwidth title'
             = f.error_message_on :name
-      .twelve.columns.alpha{ 'ng-controller' => 'unitsCtrl' }
-        .six.columns.alpha
+      .sixteen.columns.alpha{ 'ng-controller' => 'unitsCtrl' }
+        .eight.columns.alpha
           = f.field_container :units do
             = f.label :variant_unit_with_scale, t(".units")
             %span.required *
@@ -29,7 +29,7 @@
               %option{'value' => '', 'ng-hide' => "hasUnit(product)"}
             %input{ type: 'hidden', 'ng-value' => 'product.variant_unit', name: 'product[variant_unit]' }
             %input{ type: 'hidden', 'ng-value' => 'product.variant_unit_scale', name: 'product[variant_unit_scale]' }
-        .three.columns
+        .two.columns
           = f.field_container :unit_value do
             = f.label :product_unit_value_with_description, t(".value"), 'ng-disabled' => "!hasUnit(product)"
             %span.required *
@@ -42,17 +42,17 @@
             = f.label :product_variant_unit_name, t(".unit_name")
             %span.required *
             %input.fullwidth{ id: 'product_variant_unit_name','ng-model' => 'product.variant_unit_name', :name => 'product[variant_unit_name]', :placeholder => t('admin.products.unit_name_placeholder'), :type => 'text' }
-      .twelve.columns.alpha
-        .six.columns.alpha
+      .sixteen.columns.alpha
+        .eight.columns.alpha
           = render 'spree/admin/products/primary_taxon_form', f: f
-        .two.columns
+        .three.columns
           = f.field_container :price do
             = f.label :price, t(".price")
             %span.required *
             %br/
             = f.text_field :price, class: 'fullwidth'
             = f.error_message_on :price
-        .two.columns
+        .three.columns
           = f.field_container :on_hand do
             = f.label :on_hand, t(".on_hand")
             %span.required *
@@ -65,17 +65,16 @@
             %br/
             = f.check_box :on_demand
             = f.error_message_on :on_demand
-      .twelve.columns.alpha
-        .six.columns.alpha &nbsp;
-        .three.columns
+      .sixteen.columns.alpha
+        .four.columns
           - if Spree::TaxCategory.any?
             = render 'spree/admin/products/tax_category_form', f: f
           - else
             &nbsp;
-        .three.columns.omega
+        .four.columns.omega
           = render 'spree/admin/products/shipping_category_form', f: f
 
-      .twelve.columns.alpha
+      .sixteen.columns.alpha
         = f.field_container :description do
           = f.label :product_description, t(".product_description")
           %br/


### PR DESCRIPTION
#### What? Why?
Closes #6783 
Use the full available width to display the form.


#### What should we test?
1. Got to `admin/products/new`
2. The form should be displayed aligned and should use all the available space.
<img width="1057" alt="Capture d’écran 2021-02-01 à 16 33 59" src="https://user-images.githubusercontent.com/296452/106480508-c7405780-64ab-11eb-887c-9385d3cfd351.png">

NB: there's a space after "Display as" to let the space available for "Unit Name" field:
<img width="442" alt="Capture d’écran 2021-02-01 à 16 39 32" src="https://user-images.githubusercontent.com/296452/106480833-1ab2a580-64ac-11eb-9120-9a37445b1b2e.png">

#### Release notes
Fix display issues on "New Product" form.

Changelog Category: User facing changes


