### PR TITLE
enhances customers_spec.rb to check customer balance, after additional payments were added to an order

### DIFF
--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -13,6 +13,14 @@ feature 'Customers' do
     let(:managed_distributor2) { create(:distributor_enterprise, owner: user) }
     let(:unmanaged_distributor) { create(:distributor_enterprise) }
 
+    let(:order1) { create(:order, total: 0, payment_total: 88, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer1) }
+    let(:order2) { create(:order, total: 99, payment_total: 0, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer2) }
+    let(:order3) { create(:order, total: 0,  payment_total: 0, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer4) }
+
+    let(:payment_method) { create(:stripe_sca_payment_method, distributors: [managed_distributor1]) }
+    let(:payment1) { create(:payment, order: order1, state: 'completed', payment_method: payment_method, response_code: 'pi_123', amount: 88.00) }
+    let(:payment2) { create(:payment, order: order1, state: 'completed', payment_method: payment_method, response_code: 'pi_123', amount: -25.00) }
+
     describe "using the customers index", js: true do
       let!(:customer1) { create(:customer, enterprise: managed_distributor1, code: nil) }
       let!(:customer2) { create(:customer, enterprise: managed_distributor1, code: nil) }
@@ -100,33 +108,13 @@ feature 'Customers' do
           allow(OpenFoodNetwork::FeatureToggle)
             .to receive(:enabled?).with(:customer_balance, user) { true }
 
-          create(
-            :order,
-            total: 0,
-            payment_total: 88,
-            distributor: managed_distributor1,
-            user: nil,
-            state: 'complete',
-            customer: customer1
-          )
-          create(
-            :order,
-            total: 99,
-            payment_total: 0,
-            distributor: managed_distributor1,
-            user: nil,
-            state: 'complete',
-            customer: customer2
-          )
-          create(
-            :order,
-            total: 0,
-            payment_total: 0,
-            distributor: managed_distributor1,
-            user: nil,
-            state: 'complete',
-            customer: customer4
-          )
+          # calling the variables necessary for this testcase here;
+          # 'paymen_method' and 'payment1' are necessary to add additional payments to an order, as in a test case below (see payment2)
+          payment_method
+          payment1
+          order1
+          order2
+          order3
 
           customer4.update enterprise: managed_distributor1
         end

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -133,7 +133,7 @@ feature 'Customers' do
         context "with an additional negative payment (or refund)" do
           let!(:payment2) { create(:payment, order: order1, state: 'completed', payment_method: payment_method, response_code: 'pi_123', amount: -25.00) }
 
-          it "it displays an updated customer balance" do
+          it "displays an updated customer balance" do
             visit spree.admin_order_payments_path order1
             expect(page).to have_content "$#{payment2.amount}"
 

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -13,14 +13,6 @@ feature 'Customers' do
     let(:managed_distributor2) { create(:distributor_enterprise, owner: user) }
     let(:unmanaged_distributor) { create(:distributor_enterprise) }
 
-    let(:order1) { create(:order, total: 0, payment_total: 88, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer1) }
-    let(:order2) { create(:order, total: 99, payment_total: 0, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer2) }
-    let(:order3) { create(:order, total: 0,  payment_total: 0, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer4) }
-
-    let(:payment_method) { create(:stripe_sca_payment_method, distributors: [managed_distributor1]) }
-    let(:payment1) { create(:payment, order: order1, state: 'completed', payment_method: payment_method, response_code: 'pi_123', amount: 88.00) }
-    let(:payment2) { create(:payment, order: order1, state: 'completed', payment_method: payment_method, response_code: 'pi_123', amount: -25.00) }
-
     describe "using the customers index", js: true do
       let!(:customer1) { create(:customer, enterprise: managed_distributor1, code: nil) }
       let!(:customer2) { create(:customer, enterprise: managed_distributor1, code: nil) }
@@ -104,17 +96,17 @@ feature 'Customers' do
       end
 
       describe "for a shop with multiple customers" do
+        let!(:order1) { create(:order, total: 0, payment_total: 88, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer1) }
+        let!(:order2) { create(:order, total: 99, payment_total: 0, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer2) }
+        let!(:order3) { create(:order, total: 0,  payment_total: 0, distributor: managed_distributor1, user: nil, state: 'complete', customer: customer4) }
+
+        let!(:payment_method) { create(:stripe_sca_payment_method, distributors: [managed_distributor1]) }
+        let!(:payment1) { create(:payment, order: order1, state: 'completed', payment_method: payment_method, response_code: 'pi_123', amount: 88.00) }
+        let(:payment2) { create(:payment, order: order1, state: 'completed', payment_method: payment_method, response_code: 'pi_123', amount: -25.00) }
+
         before do
           allow(OpenFoodNetwork::FeatureToggle)
             .to receive(:enabled?).with(:customer_balance, user) { true }
-
-          # calling the variables necessary for this testcase here;
-          # 'paymen_method' and 'payment1' are necessary to add additional payments to an order, as in a test case below (see payment2)
-          payment_method
-          payment1
-          order1
-          order2
-          order3
 
           customer4.update enterprise: managed_distributor1
         end
@@ -139,11 +131,11 @@ feature 'Customers' do
 
         # this adds the additional payments to an order, and checks for customer balance
         it "updates customer balance with additional negative payments, on an order" do
+          # payment2 needs to be lazily defined to be called here, as way to add a payment to order1
           payment2
 
-          # verifies the payment2 was correctly added to the order
           visit spree.admin_order_payments_path order1
-          expect(page).to have_content "$-25.00"
+          expect(page).to have_content "$#{payment2.amount}"
 
           visit admin_customers_path
           select2_select managed_distributor1.name, from: "shop_id"

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -137,17 +137,22 @@ feature 'Customers' do
           end
         end
 
-        # this adds the additional payments to an order, and checks for customer balance 
+        # this adds the additional payments to an order, and checks for customer balance
         it "updates customer balance with additional negative payments, on an order" do
-          
           payment2
 
+          # verifies the payment2 was correctly added to the order
+          visit spree.admin_order_payments_path order1
+          expect(page).to have_content "$-25.00"
+
+          visit admin_customers_path
           select2_select managed_distributor1.name, from: "shop_id"
 
+          # checks customer balance, after payment2 was added
           within "tr#c_#{customer1.id}" do
-          expect(page).to have_content "CREDIT OWED"
-          expect(page).to have_content "$63.00"
-          end        
+            expect(page).to have_content "CREDIT OWED"
+            expect(page).to have_content "$63.00"
+          end
         end
       end
 

--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -136,6 +136,19 @@ feature 'Customers' do
             expect(page).to have_content "$0.00"
           end
         end
+
+        # this adds the additional payments to an order, and checks for customer balance 
+        it "updates customer balance with additional negative payments, on an order" do
+          
+          payment2
+
+          select2_select managed_distributor1.name, from: "shop_id"
+
+          within "tr#c_#{customer1.id}" do
+          expect(page).to have_content "CREDIT OWED"
+          expect(page).to have_content "$63.00"
+          end        
+        end
       end
 
       it "allows updating of attributes" do


### PR DESCRIPTION
#### What? Why?

Closes #6732

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This relates to PR #6366, and adds a test case to cover for a manually performed test, namely the case in which additional payments are added to an order.

The approach here was to create a new (negative) payment, which is to be added to a given order, by calling the variable from which it was defined. After that, an assertion regarding customer balance was added.

This differs from the initially discussed approach in that the UI is not used to click and insert data.  


#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

- declared variables using let; called the variables when needed which allowed to set up an additional test case
- added an additional payment to an order, by calling a previously declared variable

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes

Technical changes.