### PR TITLE
Toggle customer balance to entire instance

### DIFF
--- a/config/initializers/feature_toggles.rb
+++ b/config/initializers/feature_toggles.rb
@@ -1,5 +1,11 @@
 require 'open_food_network/feature_toggle'
 
-beta_testers = ENV['BETA_TESTERS']&.split(/[\s,]+/)
+beta_testers = ENV['BETA_TESTERS']&.split(/[\s,]+/) || []
 
-OpenFoodNetwork::FeatureToggle.enable(:customer_balance, beta_testers)
+OpenFoodNetwork::FeatureToggle.enable(:customer_balance) do |user|
+  if beta_testers == ['all']
+    true
+  else
+    beta_testers.include?(user.email)
+  end
+end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -30,11 +30,14 @@ module OpenFoodNetwork
       new.enabled?(feature_name, user)
     end
 
-    def self.enable(feature_name, user_emails)
-      return unless user_emails.present?
-
+    def self.enable(feature_name, user_emails = nil, &block)
       Thread.current[:features] ||= {}
-      Thread.current[:features][feature_name] = Feature.new(user_emails)
+
+      if user_emails.nil?
+        Thread.current[:features][feature_name] = BlockFeature.new(block)
+      else
+        Thread.current[:features][feature_name] = Feature.new(user_emails)
+      end
     end
 
     def initialize
@@ -85,5 +88,19 @@ module OpenFoodNetwork
     def enabled?(_user)
       false
     end
+  end
+
+  class BlockFeature
+    def initialize(block)
+      @block = block
+    end
+
+    def enabled?(user)
+      block.call(user)
+    end
+
+    private
+
+    attr_reader :block
   end
 end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -30,14 +30,9 @@ module OpenFoodNetwork
       new.enabled?(feature_name, user)
     end
 
-    def self.enable(feature_name, user_emails = nil, &block)
+    def self.enable(feature_name, &block)
       Thread.current[:features] ||= {}
-
-      if user_emails.nil?
-        Thread.current[:features][feature_name] = BlockFeature.new(block)
-      else
-        Thread.current[:features][feature_name] = Feature.new(user_emails)
-      end
+      Thread.current[:features][feature_name] = Feature.new(block)
     end
 
     def initialize
@@ -71,26 +66,6 @@ module OpenFoodNetwork
   end
 
   class Feature
-    def initialize(users = [])
-      @users = users
-    end
-
-    def enabled?(user)
-      users.include?(user.email)
-    end
-
-    private
-
-    attr_reader :users
-  end
-
-  class NullFeature
-    def enabled?(_user)
-      false
-    end
-  end
-
-  class BlockFeature
     def initialize(block)
       @block = block
     end
@@ -102,5 +77,11 @@ module OpenFoodNetwork
     private
 
     attr_reader :block
+  end
+
+  class NullFeature
+    def enabled?(_user)
+      false
+    end
   end
 end

--- a/spec/initializers/feature_toggles_spec.rb
+++ b/spec/initializers/feature_toggles_spec.rb
@@ -27,8 +27,9 @@ describe 'config/initializers/feature_toggles.rb' do
   end
 
   context 'when beta_testers is a list of emails' do
+    let(:other_user) { build(:user) }
+
     context 'and the user is in the list' do
-      let(:other_user) { build(:user) }
       before { ENV['BETA_TESTERS'] = "#{user.email}, #{other_user.email}" }
 
       it 'enables the feature' do
@@ -40,6 +41,17 @@ describe 'config/initializers/feature_toggles.rb' do
     end
 
     context 'and the user is not in the list' do
+      before { ENV['BETA_TESTERS'] = "#{other_user.email}" }
+
+      it 'disables the feature' do
+        execute_initializer
+
+        enabled = OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, user)
+        expect(enabled).to eq(false)
+      end
+    end
+
+    context 'and the list is empty' do
       before { ENV['BETA_TESTERS'] = '' }
 
       it 'disables the feature' do

--- a/spec/initializers/feature_toggles_spec.rb
+++ b/spec/initializers/feature_toggles_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'config/initializers/feature_toggles.rb' do
+  let(:user) { build(:user) }
+
+  around do |example|
+    original = ENV['BETA_TESTERS']
+    example.run
+    ENV['BETA_TESTERS'] = original
+  end
+
+  context 'when beta_testers is ["all"]' do
+    before { ENV['BETA_TESTERS'] = 'all' }
+
+    it 'returns true' do
+      require './config/initializers/feature_toggles' # execute the initializer's code block
+
+      enabled = OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, user)
+      expect(enabled).to eq(true)
+    end
+  end
+
+  context 'when beta_testers is a list of emails' do
+    context 'and the user is in the list' do
+      let(:other_user) { build(:user) }
+      before { ENV['BETA_TESTERS'] = "#{user.email}, #{other_user.email}" }
+
+      it 'enables the feature' do
+        require './config/initializers/feature_toggles' # execute the initializer's code block
+
+        enabled = OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, user)
+        expect(enabled).to eq(true)
+      end
+    end
+
+    context 'and the user is not in the list' do
+      before { ENV['BETA_TESTERS'] = '' }
+
+      it 'disables the feature' do
+        require './config/initializers/feature_toggles' # execute the initializer's code block
+
+        enabled = OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, user)
+        expect(enabled).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/initializers/feature_toggles_spec.rb
+++ b/spec/initializers/feature_toggles_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe 'config/initializers/feature_toggles.rb' do
+  # Executes the initializer's code block by reading the Ruby file. Note that `Kernel#require` would
+  # prevent this from happening twice.
+  subject(:execute_initializer) do
+    load Rails.root.join('config/initializers/feature_toggles.rb')
+  end
+
   let(:user) { build(:user) }
 
   around do |example|
@@ -13,7 +19,7 @@ describe 'config/initializers/feature_toggles.rb' do
     before { ENV['BETA_TESTERS'] = 'all' }
 
     it 'returns true' do
-      require './config/initializers/feature_toggles' # execute the initializer's code block
+      execute_initializer
 
       enabled = OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, user)
       expect(enabled).to eq(true)
@@ -26,7 +32,7 @@ describe 'config/initializers/feature_toggles.rb' do
       before { ENV['BETA_TESTERS'] = "#{user.email}, #{other_user.email}" }
 
       it 'enables the feature' do
-        require './config/initializers/feature_toggles' # execute the initializer's code block
+        execute_initializer
 
         enabled = OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, user)
         expect(enabled).to eq(true)
@@ -37,7 +43,7 @@ describe 'config/initializers/feature_toggles.rb' do
       before { ENV['BETA_TESTERS'] = '' }
 
       it 'disables the feature' do
-        require './config/initializers/feature_toggles' # execute the initializer's code block
+        execute_initializer
 
         enabled = OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, user)
         expect(enabled).to eq(false)

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -48,5 +48,31 @@ module OpenFoodNetwork
         end
       end
     end
+
+    context 'when passing in a block' do
+      let(:user) { build(:user) }
+
+      context 'and the block does not specify arguments' do
+        before do
+          FeatureToggle.enable(:foo) { 'return value' }
+        end
+
+        it "returns the block's return value" do
+          expect(FeatureToggle.enabled?(:foo, user)).to eq('return value')
+        end
+      end
+
+      context 'and the block specifies arguments' do
+        let(:users) { [user.email] }
+
+        before do
+          FeatureToggle.enable(:foo) { |user| users.include?(user.email) }
+        end
+
+        it "returns the block's return value" do
+          expect(FeatureToggle.enabled?(:foo, user)).to eq(true)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -32,26 +32,6 @@ module OpenFoodNetwork
     context 'when specifying users' do
       let(:user) { build(:user) }
 
-      context 'and the feature is enabled for them' do
-        before { FeatureToggle.enable(:foo, [user.email]) }
-
-        it 'returns true' do
-          expect(FeatureToggle.enabled?(:foo, user)).to eq(true)
-        end
-      end
-
-      context 'and the feature is disabled for them' do
-        before { FeatureToggle.enable(:foo, []) }
-
-        it 'returns false' do
-          expect(FeatureToggle.enabled?(:foo, user)).to eq(false)
-        end
-      end
-    end
-
-    context 'when passing in a block' do
-      let(:user) { build(:user) }
-
       context 'and the block does not specify arguments' do
         before do
           FeatureToggle.enable(:foo) { 'return value' }


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/6804

This refactors the feature toggles implementation to make it flexible enough to fit more complex toggling strategies such as enabling a feature for an entire OFN instance.

For reviewers, going commit by commit might be easier to understand.

#### What should we test?

`spec/initializers/feature_toggles_spec.rb` covers this (yes, it's the first time I test an initializer but it's proven enough) but I'd like you @filipefurtad0 to give it a try so you get acquainted with it and can give me feedback. I guess this can ease testing toggled features.

#### Release notes

Enabled toggling a feature to an entire instance.
Changelog Category: Technical changes