### PR TITLE
New Product Form: Fill all space available

### DIFF
--- a/app/views/spree/admin/products/_display_as.html.haml
+++ b/app/views/spree/admin/products/_display_as.html.haml
@@ -1,4 +1,4 @@
-.three.columns.omega{ "ng-if" => "product.variant_unit_with_scale != 'items'" }
+.six.columns.omega{ "ng-if" => "product.variant_unit_with_scale != 'items'" }
   = f.field_container :display_as do
     = f.label :product_display_as, t('.display_as')
     %input#product_display_as.fullwidth{name: "product[display_as]", placeholder: "{{ placeholder_text }}", type: "text"}

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -37,7 +37,7 @@
             %input{ type: 'hidden', 'ng-value' => 'product.master.unit_value', name: 'product[unit_value]' }
             %input{ type: 'hidden', 'ng-value' => 'product.master.unit_description', name: 'product[unit_description]' }
         = render 'display_as', f: f
-        .three.columns.omega{ 'ng-show' => "product.variant_unit_with_scale == 'items'" }
+        .six.columns.omega{ 'ng-show' => "product.variant_unit_with_scale == 'items'" }
           = f.field_container :unit_name do
             = f.label :product_variant_unit_name, t(".unit_name")
             %span.required *


### PR DESCRIPTION
#### What? Why?
Closes #6798 
Use all available space to display these two fields as they are mutually exclusive.

#### What should we test?
1. Go to `/admin/products/new`
2. Select `Items` value for `UNIT SIZE` field: there is no unused space on this line
3. Select whatever value for `UNIT SIZE` field: there is no unused space on this line

<img width="982" alt="Capture d’écran 2021-02-03 à 21 41 30" src="https://user-images.githubusercontent.com/296452/106807800-de2ca880-6669-11eb-9f92-832a28c75d53.png">
<img width="1002" alt="Capture d’écran 2021-02-03 à 21 41 35" src="https://user-images.githubusercontent.com/296452/106807810-e08f0280-6669-11eb-9fbc-07f7a0aa0c89.png">


#### Release notes
Fix a margin issue on new product form.


Changelog Category: User facing changes
