### PR TITLE
Remove "Bogus" payment providers from staging and production

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -103,7 +103,7 @@ module Spree
       end
 
       def load_data
-        @providers = if spree_current_user.admin? || Rails.env.test?
+        @providers = if Rails.env.dev? || Rails.env.test?
                        Gateway.providers.sort_by(&:name)
                      else
                        Gateway.providers.reject{ |p| p.name.include? "Bogus" }.sort_by(&:name)


### PR DESCRIPTION
#### What? Why?

Closes #5093

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
The payment methods were made translatable in https://github.com/openfoodfoundation/openfoodnetwork/pull/6540. This removes the Bogus and BogusSimple providers in production since we can't use them there. 


#### What should we test?
<!-- List which features should be tested and how. -->
On a staging server, logged in as an admin, the Bogus/Bogus Simple providers should not appear in the list of payment providers when creating a new payment method or editing an existing one. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Removed the Bogus and BogusSimple payment providers from the list of providers.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
