### PR TITLE
Make loading spinner visible

### DIFF
--- a/app/assets/javascripts/templates/admin/modals/bulk_invoice.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/bulk_invoice.html.haml
@@ -6,7 +6,7 @@
 %p.error{ ng: { show: 'error' } }
   {{error}}
 
-%img.spinner{ src: "/assets/spinning-circles.svg", ng: { show: "loading" } }
+%img.spinner{ src: image_path("spinning-circles.svg"), ng: { show: "loading" } }
 %p{ ng: { show: "loading" } }
   = t('js.admin.orders.index.please_wait')
 

--- a/app/assets/javascripts/templates/admin/modals/image_upload.html.haml
+++ b/app/assets/javascripts/templates/admin/modals/image_upload.html.haml
@@ -3,7 +3,7 @@
 
 %form#image_upload{ name: 'form', novalidate: true, enctype: 'multipart/form-data', multipart: true, ng: { controller: "ProductImageCtrl" } }
   %div.image-preview
-    %img.spinner{ src: "/assets/spinning-circles.svg", ng: { hide: "!imageUploader.isUploading" }}
+    %img.spinner{ src: image_path("spinning-circles.svg"), ng: { hide: "!imageUploader.isUploading" }}
     %img.preview{ng: {src: "{{imagePreview}}", class: "{'faded': imageUploader.isUploading}"}}
 
   %label{for: 'image-upload', class: 'button'} {{ 'admin.products.index.upload_an_image' | t }}

--- a/app/assets/javascripts/templates/admin/panels/exchange_products_panel_footer.html.haml
+++ b/app/assets/javascripts/templates/admin/panels/exchange_products_panel_footer.html.haml
@@ -6,6 +6,6 @@
 
 .sixteen.columns.alpha#loading{ 'ng-show' => 'productsLoading()' }
   %br
-  %img.spinner{ src: "/assets/spinning-circles.svg" }
+  %img.spinner{ src: image_path("spinning-circles.svg")}
   %h1
     {{ 'js.admin.panels.exchange_products.loading_variants' | t }}

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -81,7 +81,7 @@
         %span{'ng-bind-html' => 'order.display_total'}
       %td.actions
         %div.row-loading-icons
-          %span{ng: {show: 'rowStatus[order.id] == "loading"', cloak: true}}
+          %div{ng: {show: 'rowStatus[order.id] == "loading"', cloak: true}, style: "width: 30px; height: 30px;"}
             = render partial: "components/spinner"
           %i.success.icon-ok-sign{ng: {show: 'rowStatus[order.id] == "success"'} }
           %i.error.icon-remove-sign.with-tip{ng: {show: 'rowStatus[order.id] == "error"'}, 'ofn-with-tip' => t('.order_not_updated')}


### PR DESCRIPTION
#### What? Why?
Closes #6795
In 4 different cases, the loading spinner was invisible, due to two different reasons:
 - Because the svg was to small to see it (1 particular case)
 - Because the path to the svg asset wasn't correctly set up

The aim of this PR is to:
 - Specify width and height for this particular case.
 - Specify the right path to the svg asset.

#### What should we test?
##### Scenario 1: Bulk invoice printing
1. Go to `/admin/orders?q[s]=completed_at+desc`
2. Select orders and hit print invoices button
3. You must see a loading spinner.
<img width="357" alt="Capture d’écran 2021-02-04 à 11 55 03" src="https://user-images.githubusercontent.com/296452/106883123-d90a4080-66df-11eb-9557-5acfddd099a6.png">


##### Scenario 2: Capturing or Shipping an order from orders page.
1. Go to `/admin/orders?q[s]=completed_at+desc`
Press on
![106493945-18574800-64ba-11eb-9d10-21b85517dc06](https://user-images.githubusercontent.com/296452/106572505-c6a1d280-6538-11eb-9beb-eb1170c1702b.png)
2. Before the green check is displayed you must the spinner.

##### Scenario 3: Use the image upload modal
1. Go to the product list page: `admin/products`
2. By clicking on image of a product, image upload modal opens
3. Upload a new image. During the upload, there must be a loading spinner.
<img width="404" alt="Capture d’écran 2021-02-04 à 11 58 09" src="https://user-images.githubusercontent.com/296452/106883462-4918c680-66e0-11eb-8d49-dfc5d6c2392b.png">


##### Scenario 4: Load all variants for incoming or outgoing product in a order cycle edition
1. Go to `/admin/order_cycles/[ORDER_CYCLE_ID]/incoming`
2. Click on a product that had a lot of variants
3. Click on "Load all variants" to see the spinner


#### Release notes
Fix display issue on loading spinner: some cases the loading spinner wasn't visible.


Changelog Category: User facing changes
