### PR TITLE
Enable "back" and "forward" buttons into enterprise side menu

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/side_menu_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/side_menu_controller.js.coffee
@@ -1,5 +1,5 @@
 angular.module("admin.enterprises")
-  .controller "sideMenuCtrl", ($scope, $parse, enterprise, SideMenu, enterprisePermissions) ->
+  .controller "sideMenuCtrl", ($scope, $parse, enterprise, SideMenu, enterprisePermissions, $rootScope, $location) ->
     $scope.Enterprise = enterprise
     $scope.menu = SideMenu
     $scope.select = SideMenu.select
@@ -23,6 +23,9 @@ angular.module("admin.enterprises")
     ]
 
     SideMenu.init()
+
+    $rootScope.$on "$locationChangeSuccess", ->
+      SideMenu.locationDidChange($location.path()?.match(/^\/\w+$/)?[0])
 
     $scope.showItem = (item) ->
       if item.show?

--- a/app/assets/javascripts/admin/side_menu/services/side_menu.js.coffee
+++ b/app/assets/javascripts/admin/side_menu/services/side_menu.js.coffee
@@ -3,17 +3,22 @@ angular.module("admin.side_menu")
     new class SideMenu
       items: []
       selected: null
+      didSelect: false
 
       # Checks for path and uses it to set the view
       # If no path, loads first view
       init: =>
         path = $location.path()?.match(/^\/\w+$/)?[0]
-        index = if path
-          name = path[1..]
-          @items.indexOf(@find_by_name(name))
-        else
-          0
+        index = @getIndexFromPath(path)
         @select(index)
+
+      locationDidChange: (path) =>
+        if !@didSelect # do not reselect if it has been already done
+          index = @getIndexFromPath(path)
+          @select(index)
+          # reset the focus on active element to avoid links on side menu to be focused
+          document.activeElement.blur()
+        @didSelect = false
 
       setItems: (items) =>
         @items = items
@@ -24,7 +29,15 @@ angular.module("admin.side_menu")
           @selected.selected = false if @selected
           @selected = @items[index]
           @selected.selected = true
-          $location.path(@selected.name)
+          @didSelect = true
+          $location.path(@selected.name)          
+
+      getIndexFromPath: (path) =>
+        index = if path
+          name = path[1..]
+          @items.indexOf(@find_by_name(name))
+        else
+          0
 
       find_by_name: (name) =>
         for item in @items when item.name is name


### PR DESCRIPTION
#### What? Why?
Closes #6754
Make back and forward browser's button to be functional into the Enterprise side menu. 

Similar to #6751


#### What should we test?
 1. As an admin, go to an enterprise edit settings page (`admin/enterprises/[ENTERPRISE-SLUG]/edit#/primary_details`).
 2. Navigate with the left panel, and see content on the right is changing
 3. Using the browser's back and forward buttons change the url path and the content of the page. 

![2021-02-05 16 23 12](https://user-images.githubusercontent.com/296452/107053784-87d97a00-67cf-11eb-8116-2b52789fce68.gif)

#### Release notes
Enable browser's back and forward buttons on the enterprise settings page.
Changelog Category: User facing changes


