### PR TITLE
Include sort direction parameter during bulk product update to prevent JS error causing 'Saving' text to hang

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -21,6 +21,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     sorting: ""
   }
 
+  $scope.sorting = "name asc"
   $scope.producers = producers
   $scope.taxons = Taxons.all
   $scope.tax_categories = tax_categories
@@ -48,7 +49,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
       'q[name_cont]': $scope.q.query,
       'q[supplier_id_eq]': $scope.q.producerFilter,
       'q[primary_taxon_id_eq]': $scope.q.categoryFilter,
-      'q[s]': $scope.q.sorting,
+      'q[s]': $scope.sorting,
       import_date: $scope.q.importDateFilter,
       page: $scope.page,
       per_page: $scope.per_page
@@ -104,7 +105,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
   $scope.$watch 'sortOptions', (sort) ->
     return unless sort && sort.predicate != ""
 
-    $scope.q.sorting = sort.getSortingExpr()
+    $scope.sorting = sort.getSortingExpr(defaultDirection: "asc")
     $scope.fetchProducts()
   , true
 
@@ -216,6 +217,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
           'q[name_cont]': $scope.q.query
           'q[supplier_id_eq]': $scope.q.producerFilter
           'q[primary_taxon_id_eq]': $scope.q.categoryFilter
+          'q[s]': $scope.sorting
           import_date: $scope.q.importDateFilter
         page: $scope.page
         per_page: $scope.per_page

--- a/app/assets/javascripts/admin/index_utils/services/sort_options.js.coffee
+++ b/app/assets/javascripts/admin/index_utils/services/sort_options.js.coffee
@@ -3,9 +3,11 @@ angular.module("admin.indexUtils").factory 'SortOptions', ->
     predicate: ""
     reverse: true
 
-    getSortingExpr: () ->
-      sortingExpr = this.predicate + ' desc' if this.reverse
-      sortingExpr = this.predicate + ' asc' if !this.reverse
+    getSortingExpr: (options) ->
+      defaultDirection = if (options && options.defaultDirection) then options.defaultDirection else "desc"
+      reverseDirection = if defaultDirection == "desc" then "asc" else "desc"
+      sortingExpr = this.predicate + ' ' + defaultDirection if this.reverse
+      sortingExpr = this.predicate + ' ' + reverseDirection if !this.reverse
       sortingExpr
 
     toggle: (predicate) ->

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -368,7 +368,7 @@ describe "AdminProductEditCtrl", ->
       $scope.sortOptions.toggle('name')
       $scope.$apply()
 
-      expect($scope.q.sorting).toEqual 'name asc'
+      expect($scope.sorting).toEqual 'name desc'
       expect($scope.fetchProducts).toHaveBeenCalled()
 
   describe "updating the product on hand count", ->

--- a/spec/javascripts/unit/admin/index_utils/services/sort_options_spec.js.coffee
+++ b/spec/javascripts/unit/admin/index_utils/services/sort_options_spec.js.coffee
@@ -42,3 +42,19 @@ describe "SortOptions service", ->
         SortOptions.toggle("column.b")
         expect(SortOptions.predicate).toEqual "column.b"
         expect(SortOptions.reverse).toBe false
+
+    describe "getting the sorting expression", ->
+      describe "when not specifying the default sort direction", ->
+        it "sets the direction to 'asc' after the first toggle because the default direction is 'desc'", ->
+          SortOptions.toggle("column.a")
+          expect(SortOptions.getSortingExpr()).toEqual "column.a asc"
+
+      describe "when specifying the default sorting direction as 'desc'", ->
+        it "sets the direction to 'asc' after the first toggle", ->
+          SortOptions.toggle("column.a")
+          expect(SortOptions.getSortingExpr(defaultDirection: "desc")).toEqual "column.a asc"
+
+      describe "when specifying the default sorting direction as 'asc'", ->
+        it "sets the direction to 'desc' after the first toggle", ->
+          SortOptions.toggle("column.a")
+          expect(SortOptions.getSortingExpr(defaultDirection: "asc")).toEqual "column.a desc"


### PR DESCRIPTION
#### What? Why?

Before if you did a bulk product update there was a Javascript error:

> TypeError: Cannot set property 'variants' of null

The update would be saved correctly in the background but the 'Saving...' text would hang.

It only seemed to happen if pagination was required i.e. more than 15 products. It seemed to be happening because the default sort order on the products API endpoint which handles the bulk update is 'created desc' but 'name asc' on the /admin/products controller.

Another fix included here is for the sorting direction arrows which were not displaying on the admin products page. The sorting arrows require the sorting expression to be on the :sorting var instead of :q.sorting.

Fixes #6399

#### What should we test?

1. Go to products page in the admin area.
2. Make sure there is enough products to require pagination (at least 16)
3. Do a bulk update, for example by changing one product name.
4. Check the 'Saving' text doesn't hang and there is no JS error in the console.

Additional: Check sort products by name arrows appear, and change direction when you toggle the sort direction.

#### Release notes

Prevent JS error causing hanging 'Saving' text during bulk product update and get sort by name arrows working.

Changelog Category: User facing changes