### PR TITLE
Remove cost price field field from product variant form

### DIFF
--- a/app/services/permitted_attributes/variant.rb
+++ b/app/services/permitted_attributes/variant.rb
@@ -5,7 +5,7 @@ module PermittedAttributes
     def self.attributes
       [
         :id, :sku, :on_hand, :on_demand,
-        :cost_price, :price, :unit_value, :unit_description,
+        :price, :unit_value, :unit_description,
         :display_name, :display_as,
         :weight, :height, :width, :depth
       ]

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -34,9 +34,6 @@
     .field
       = f.label :price, t('.price')
       = f.text_field :price, value: number_to_currency(@variant.price, unit: ''), class: 'fullwidth'
-    .field
-      = f.label :cost_price, t('.cost_price')
-      = f.text_field :cost_price, value: number_to_currency(@variant.cost_price, unit: ''), class: 'fullwidth'
 
     %div{ 'set-on-demand' => '' }
       .field.checkbox


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/6741

#### What should we test?
<!-- List which features should be tested and how. -->

1. Log in as an admin
1. Go to /products. Click on the pencil icon to edit a product
1. Click on Variants on the sidebar and edit or add a new variant
1. The cost price field should no longer exist

![image](https://user-images.githubusercontent.com/7039523/107132358-35ba5680-68ac-11eb-8aa1-ca6d7ffb8f15.png)


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Remove cost price field from product variant form
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
