### PR TITLE
Add retry handling for flaky spec timeouts

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,6 +101,10 @@ RSpec.configure do |config|
 
   # Retry
   config.verbose_retry = true
+  # Try twice (retry once)
+  config.default_retry_count = 2
+  # Only retry when Selenium raises Net::ReadTimeout
+  config.exceptions_to_retry = [Net::ReadTimeout]
 
   # Force use of expect (over should)
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
#### What? Why?

We've had this flaky build error appearing recently across various feature specs. Unlike the usual suspects, it can seemingly appear randomly in almost any part of the build:

![Screenshot from 2021-02-08 12-39-59](https://user-images.githubusercontent.com/9029026/107221045-649f0c80-6a13-11eb-80f5-00d24d62586e.png)

I've read various anecdotal references to this, apparently it can be caused by asset compiling not finishing when a feature spec is loaded in the suite (it seems to occur only in feature tests that use JS). There are some references to this being improved by Capybara updates or changing Chromedriver versions, but it's not clear.

This PR adds a simple retry (once) when the build encounters this specific error. It seems to work pretty well.

#### What should we test?
<!-- List which features should be tested and how. -->

Build should be less flaky...?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added mitigation for Net::ReadTimeout issues in the test suite.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
