### PR TITLE
Customer balance reports

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -65,7 +65,7 @@ module OpenFoodNetwork
 
     def orders
       if FeatureToggle.enabled?(:customer_balance, @user)
-        search_result = search.result.order(:id)
+        search_result = search.result.order(:completed_at)
         orders_with_balance = OutstandingBalance.new(search_result).
           query.
           select('spree_orders.*')

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -3,7 +3,9 @@ require 'open_food_network/user_balance_calculator'
 module OpenFoodNetwork
   class OrderCycleManagementReport
     DEFAULT_DATE_INTERVAL = { from: -1.month, to: 1.day }.freeze
+
     attr_reader :params
+
     def initialize(user, params = {}, render_table = false)
       @params = sanitize_params(params)
       @user = user

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -48,7 +48,7 @@ module OpenFoodNetwork
     end
 
     def orders
-      filter search.result
+      filter(search.result.order(:id))
     end
 
     def table_items

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -47,8 +47,8 @@ module OpenFoodNetwork
 
     def search
       Spree::Order.
-        complete.
-        where("spree_orders.state != ?", :canceled).
+        finalized.
+        where.not(spree_orders: { state: :canceled }).
         distributed_by_user(@user).
         managed_by(@user).
         search(params[:q])

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -26,6 +26,14 @@ module OpenFoodNetwork
           expect(subject.orders).to eq([o2])
         end
 
+        it 'orders them by id' do
+          result = instance_double(ActiveRecord::Relation)
+          allow_any_instance_of(Ransack::Search).to receive(:result).and_return(result)
+          expect(result).to receive(:order).with(:id) { Spree::Order.none }
+
+          subject.orders
+        end
+
         context "default date range" do
           it "fetches orders completed in the past month" do
             o1 = create(:order, completed_at: 1.month.ago - 1.day)

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -43,11 +43,10 @@ module OpenFoodNetwork
           end
 
           it 'orders them by id' do
-            result = instance_double(ActiveRecord::Relation)
-            allow_any_instance_of(Ransack::Search).to receive(:result).and_return(result)
-            expect(result).to receive(:order).with(:id) { Spree::Order.none }
+            order1 = create(:order, completed_at: 1.day.ago, state: 'complete')
+            order2 = create(:order, completed_at: 2.days.ago, state: 'complete')
 
-            subject.orders
+            expect(subject.orders.pluck(:id)).to eq([order2.id, order1.id])
           end
         end
 


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/6698.

This only fixes the OC management report by making it show the balance of each order instead of the customer's balance and using the new implementation, under a feature toggle as usual.

#### What should we test?

See _Acceptance Criteria & Tests_ at #6698

#### Release notes
Use new order balance calculation in order cycle management report but hidden under a feature toggle.

Changelog Category: User facing changes