### PR TITLE
Temporarily skip very flaky specs

### DIFF
--- a/spec/features/admin/enterprise_roles_spec.rb
+++ b/spec/features/admin/enterprise_roles_spec.rb
@@ -117,7 +117,7 @@ feature '
         end
       end
 
-      it "allows adding new managers" do
+      xit "allows adding new managers" do
         within 'table.managers' do
           select2_select user3.email, from: 'ignored', search: true
 
@@ -129,7 +129,7 @@ feature '
         end
       end
 
-      it "shows changes to enterprise contact or owner" do
+      xit "shows changes to enterprise contact or owner" do
         select2_select user2.email, from: 'receives_notifications_dropdown'
         within('#save-bar') { click_button 'Update' }
         navigate_to_enterprise_users
@@ -146,7 +146,7 @@ feature '
         end
       end
 
-      it "can invite unregistered users to be managers" do
+      xit "can invite unregistered users to be managers" do
         setup_email
         find('a.button.help-modal').click
         expect(page).to have_css '#invite-manager-modal'


### PR DESCRIPTION
#### What? Why?

These are the tests that are failing a lot across all builds, slowing down everything in the pipe. It's better to skip these rather than paying this huge toll. They can be restored once we spike a new CI service.

https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/branches/transifex/builds/1 is a great example.

#### What should we test?

Green build

#### Release notes

Skip very flaky specs
Changelog Category: Technical changes
