### PR TITLE
Fix data integrity issues with data migration

### DIFF
--- a/app/services/variant_units/option_value_namer.rb
+++ b/app/services/variant_units/option_value_namer.rb
@@ -78,7 +78,7 @@ module VariantUnits
       }
 
       scales = units[@variant.product.variant_unit]
-      product_scale = @variant.product.variant_unit_scale
+      product_scale = @variant.product.try(:variant_unit_scale) || 1.0
       product_scale_system = scales[product_scale.to_f]['system']
 
       largest_unit = find_largest_unit(scales, product_scale_system)

--- a/spec/services/variant_units/option_value_namer_spec.rb
+++ b/spec/services/variant_units/option_value_namer_spec.rb
@@ -4,6 +4,30 @@ require 'spec_helper'
 
 module VariantUnits
   describe OptionValueNamer do
+    describe '#name' do
+      subject { described_class.new(variant) }
+
+      context 'when variant_unit_scale is nil' do
+        context 'when variant_unit is weight' do
+          let(:product) { build(:product, variant_unit: 'weight', variant_unit_scale: nil) }
+          let(:variant) { build(:variant, product: product) }
+
+          it 'defaults to variant_unit_scale 1.0' do
+            expect(subject.name).to eq('1 g')
+          end
+        end
+
+        context 'when variant_unit is volume' do
+          let(:product) { build(:product, variant_unit: 'volume', variant_unit_scale: nil) }
+          let(:variant) { build(:variant, product: product) }
+
+          it 'defaults to variant_unit_scale 1.0' do
+            expect(subject.name).to eq('1 L')
+          end
+        end
+      end
+    end
+
     describe "generating option value name" do
       let(:v) { Spree::Variant.new }
       let(:subject) { OptionValueNamer.new }


### PR DESCRIPTION
#### What? Why?

Related to #6818

This adds the necessary defensive coding for 20210202052337_migrate_variant_unit_values.rb to work.

#### What should we test?

The mentioned data migration needs to work locally using a dump from AU.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes