### PR TITLE
Also soft-delete tax rates when changing `included_in_price`

### DIFF
--- a/app/controllers/spree/admin/tax_rates_controller.rb
+++ b/app/controllers/spree/admin/tax_rates_controller.rb
@@ -6,12 +6,22 @@ module Spree
       delegate :transition_rate!, :updated_rate, to: :updater
 
       def update
-        return super unless amount_changed? && associated_adjustments?
+        return super unless requires_transition?
 
         transition_tax_rate
       end
 
       private
+
+      def requires_transition?
+        (included_changed? || amount_changed?) && associated_adjustments?
+      end
+
+      def included_changed?
+        ActiveRecord::Type::Boolean.new.type_cast_from_user(
+          permitted_resource_params[:included_in_price]
+        ) != @tax_rate.included_in_price
+      end
 
       def amount_changed?
         BigDecimal(permitted_resource_params[:amount]) != @tax_rate.amount

--- a/spec/controllers/spree/admin/tax_rates_controller_spec.rb
+++ b/spec/controllers/spree/admin/tax_rates_controller_spec.rb
@@ -7,9 +7,10 @@ module Spree
     describe TaxRatesController, type: :controller do
       include AuthenticationHelper
 
+      let!(:default_tax_zone) { create(:zone, default_tax: true) }
       let!(:tax_rate) {
         create(:tax_rate, name: "Original Rate", amount: 0.1, included_in_price: false,
-                          calculator: build(:calculator))
+                          calculator: build(:calculator), zone: default_tax_zone)
       }
 
       describe "#update" do
@@ -34,7 +35,7 @@ module Spree
             end
           end
 
-          context "when the amount or included flag are changed" do
+          context "when the amount is changed" do
             it "duplicates the record and soft-deletes the duplicate" do
               expect {
                 spree_put :update, id: tax_rate.id, tax_rate: { name: "Changed Rate", amount: "0.5" }
@@ -50,6 +51,29 @@ module Spree
               updated_rate = Spree::TaxRate.last
               expect(updated_rate.name).to eq "Changed Rate"
               expect(updated_rate.amount).to eq 0.5
+              expect(updated_rate.deleted?).to be false
+            end
+          end
+
+          context "when included_in_price is changed" do
+            it "duplicates the record and soft-deletes the duplicate" do
+              expect {
+                spree_put :update, id: tax_rate.id, tax_rate: { name: "Changed Rate", included_in_price: "1" }
+              }.to change{ Spree::TaxRate.with_deleted.count }.by(1)
+
+              expect(response).to redirect_to spree.admin_tax_rates_url
+
+              deprecated_rate = tax_rate.reload
+              expect(deprecated_rate.name).to eq "Original Rate"
+              expect(deprecated_rate.amount).to eq 0.1
+              expect(deprecated_rate.included_in_price).to be false
+              expect(deprecated_rate.deleted?).to be true
+
+              updated_rate = Spree::TaxRate.last
+              expect(updated_rate.name).to eq "Changed Rate"
+              expect(updated_rate.amount).to eq 0.1
+              expect(updated_rate.included_in_price).to be true
+              expect(updated_rate.deleted?).to be false
             end
           end
         end


### PR DESCRIPTION
#### What? Why?

Following previous changes in https://github.com/openfoodfoundation/openfoodnetwork/pull/6678

Uses the TaxRate soft-deletion transition process when the `included_in_price` boolean changes as well as the `amount`, for the same reasons.

#### What should we test?
<!-- List which features should be tested and how. -->

If the `included_in_price` checkbox is changed on a TaxRate, it is cloned and soft-deleted so that the old version is still applied to existing adjustments on old orders and the new version will be applied to new orders.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

