### PR TITLE
Remove required field asterisk from on_hand's field on new products form

### DIFF
--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -55,7 +55,6 @@
         .three.columns
           = f.field_container :on_hand do
             = f.label :on_hand, t(".on_hand")
-            %span.required *
             %br/
             = f.text_field :on_hand, class: 'fullwidth'
             = f.error_message_on :on_hand

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -57,7 +57,7 @@
             = f.label :on_hand, t(".on_hand")
             %span.required *
             %br/
-            = f.text_field :on_hand, class: 'fullwidth'
+            = f.number_field :on_hand, class: 'fullwidth', min: '0', required: true
             = f.error_message_on :on_hand
         .two.columns.omega
           = f.field_container :on_demand do

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -57,7 +57,7 @@
             = f.label :on_hand, t(".on_hand")
             %span.required *
             %br/
-            = f.number_field :on_hand, class: 'fullwidth', min: '0', required: true
+            = f.text_field :on_hand, class: 'fullwidth'
             = f.error_message_on :on_hand
         .two.columns.omega
           = f.field_container :on_demand do


### PR DESCRIPTION
#### What? Why?

Closes [#6159 ](https://github.com/openfoodfoundation/openfoodnetwork/issues/6159)

Even though original issue suggests showing "on hand is a mandatory field" errors using model validations, I believe this would add more complexity, when same trouble can be solved with more simple way.

Default value of `count_on_hand` is defined as `0` in database level, therefore `StockItem` with nil `count_on_hand` will be build as `0`. In order to detect the violence of presence validation,  we would need to add another migration(which removes default value of `count_on_hand` on `StockItem`), and add custom associated validation to `Product` model for checking validity of the `StockItem`. And also maybe some changes would be needed regarding `concerns/variant_stock#save_stock`.

This PR suggests adding html required attribute to 'on hand' field, and changing it is type from `text_field` to `number_field`, since it is an integer column.

#### What should we test?
* Adding new product on `admin/products/new` with deleting 'on hand' field value. HTML required attribute should point that box can not be left blank. 
* On hand value can be increased and decreased by clicking its up/down arrows on the field box.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
~Change on_hand's field to number_field and add required attribute on new products form~
Remove required field asterisk from on_hand's field on new products form

<!-- Please select one for your PR and delete the other. -->
User facing changes

