### PR TITLE
deleting only OFN related Docker containers and images

### DIFF
--- a/docker/nuke
+++ b/docker/nuke
@@ -11,10 +11,18 @@ docker network prune -f
 
 echo '--------------------------------------'
 echo 'Killing and removing all Docker images'
+
 for i in $(docker images -a -q)
 do
-  docker kill $i; wait;
-  docker rmi -f $i; wait;
+  echo "Evaluating $(docker image inspect --format='{{ .RepoTags }}' $i)"
+  if [[ $(docker image inspect --format='{{ .RepoTags }}' $i) =~ "openfoodnetwork" ]]
+  then
+    echo "Deleting $i"
+    docker kill $i; wait;
+    docker rmi -f $i; wait;
+  else
+    echo 'Ignoring container not related to OFN'
+  fi
 done;
 
 echo '------------'

--- a/docker/nukec
+++ b/docker/nukec
@@ -4,10 +4,18 @@
 
 echo '------------------------------------------'
 echo 'Killing and removing all Docker containers'
+ 
 for i in $(docker ps -a -q)
 do
-  docker kill $i; wait;
-  docker rm -f $i; wait;
+  echo "Evaluating $(docker inspect --format='{{ .Name }}' $i)"
+  if [[ $(docker inspect --format='{{ .Name }}' $i) =~ "openfoodnetwork" ]]
+  then
+    echo "Deleting OFN container: $i"
+    docker kill $i; wait;
+    docker rm -f $i; wait;
+  else
+    echo 'Ignoring container not related to OFN'
+  fi
 done;
 
 echo '------------'


### PR DESCRIPTION
Developers can host several different `images` and `containers` even not related to openfoodnetwork. This PR will fix any issue related to the use of `docker/nuke` so any developer can easily run this script without removing any other container/image.