### PR TITLE
Customer balance bulk coop report

### DIFF
--- a/app/models/concerns/balance.rb
+++ b/app/models/concerns/balance.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+# Contains the methods to compute an order balance form the point of view of the enterprise and not
+# the individual shopper.
+module Balance
+  FINALIZED_NON_SUCCESSFUL_STATES = %w(canceled returned).freeze
+
+  # Returns the order balance by considering the total as money owed to the order distributor aka.
+  # the shop, and as a positive balance of said enterprise. If the customer pays it all, they
+  # distributor and customer are even.
+  #
+  # Note however, this is meant to be used only in the context of a single order object. When
+  # working with a collection of orders, such an index controller action, please consider using
+  # `app/queries/oustanding_balance.rb` instead so we avoid potential N+1s.
+  def outstanding_balance
+    if state.in?(FINALIZED_NON_SUCCESSFUL_STATES)
+      -payment_total
+    else
+      total - payment_total
+    end
+  end
+
+  def outstanding_balance?
+    !outstanding_balance.zero?
+  end
+
+  def display_outstanding_balance
+    Spree::Money.new(outstanding_balance, currency: currency)
+  end
+end

--- a/app/models/concerns/balance.rb
+++ b/app/models/concerns/balance.rb
@@ -14,12 +14,23 @@ module Balance
   # Note however, this is meant to be used only in the context of a single order object. When
   # working with a collection of orders, such an index controller action, please consider using
   # `app/queries/oustanding_balance.rb` instead so we avoid potential N+1s.
-  def outstanding_balance
+  def new_outstanding_balance
     if state.in?(FINALIZED_NON_SUCCESSFUL_STATES)
       -payment_total
     else
       total - payment_total
     end
+  end
+
+  # This method is the one we're gradually replacing with `#new_outstanding_balance`. Having them
+  # separate enables us to choose which implementation we want depending on the context using
+  # a feature toggle. This avoids incosistent behavior across the app during that incremental
+  # refactoring.
+  #
+  # It is meant to be removed as soon as we get product approval that the new implementation has
+  # been working correctly in production.
+  def outstanding_balance
+    total - payment_total
   end
 
   def outstanding_balance?

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -131,7 +131,7 @@ module Spree
     }
 
     scope :not_state, lambda { |state|
-      where("state != ?", state)
+      where.not(state: state)
     }
 
     # All the states an order can be in after completing the checkout

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -136,6 +136,7 @@ module Spree
 
     # All the states an order can be in after completing the checkout
     FINALIZED_STATES = %w(complete canceled resumed awaiting_return returned).freeze
+    FINALIZED_NON_SUCCESSFUL_STATES = %w(canceled returned).freeze
 
     scope :finalized, -> { where(state: FINALIZED_STATES) }
 
@@ -394,7 +395,11 @@ module Spree
     end
 
     def outstanding_balance
-      total - payment_total
+      if state.in?(FINALIZED_NON_SUCCESSFUL_STATES)
+        -payment_total
+      else
+        total - payment_total
+      end
     end
 
     def outstanding_balance?

--- a/app/queries/complete_visible_orders.rb
+++ b/app/queries/complete_visible_orders.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CompleteVisibleOrders
+  def initialize(order_permissions)
+    @order_permissions = order_permissions
+  end
+
+  def query
+    order_permissions.visible_orders.complete
+  end
+
+  private
+
+  attr_reader :order_permissions
+end

--- a/app/queries/outstanding_balance.rb
+++ b/app/queries/outstanding_balance.rb
@@ -8,6 +8,9 @@
 # cases.
 #
 # See CompleteOrdersWithBalance or CustomersWithBalance as examples.
+#
+# Note this query object and `app/models/concerns/balance.rb` should implement the same behavior
+# until we find a better way. If you change one, please, change the other too.
 class OutstandingBalance
   # All the states of a finished order but that shouldn't count towards the balance (the customer
   # didn't get the order for whatever reason). Note it does not include complete

--- a/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
+++ b/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
@@ -22,6 +22,7 @@ module OrderManagement
 
           @supplier_report = BulkCoopSupplierReport.new
           @allocation_report = BulkCoopAllocationReport.new
+          @filter_canceled = false
         end
 
         def header
@@ -138,6 +139,8 @@ module OrderManagement
 
         private
 
+        attr_reader :filter_canceled
+
         def line_item_includes
           [
             {
@@ -149,7 +152,7 @@ module OrderManagement
         end
 
         def order_permissions
-          @order_permissions ||= ::Permissions::Order.new(@user, @params[:q])
+          @order_permissions ||= ::Permissions::Order.new(@user, filter_canceled)
         end
 
         def report_line_items

--- a/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
+++ b/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
@@ -14,6 +14,7 @@ module OrderManagement
         ].freeze
 
         attr_reader :params
+
         def initialize(user, params = {}, render_table = false)
           @params = params
           @user = user

--- a/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
+++ b/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
@@ -163,7 +163,11 @@ module OrderManagement
         end
 
         def customer_payments_amount_owed(line_items)
-          unique_orders(line_items).sum(&:outstanding_balance)
+          if OpenFoodNetwork::FeatureToggle.enabled?(:customer_balance, @user)
+            unique_orders(line_items).sum(&:new_outstanding_balance)
+          else
+            unique_orders(line_items).sum(&:outstanding_balance)
+          end
         end
 
         def customer_payments_amount_paid(line_items)

--- a/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
+++ b/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
@@ -159,15 +159,19 @@ module OrderManagement
         end
 
         def customer_payments_total_cost(line_items)
-          line_items.map(&:order).uniq.sum(&:total)
+          unique_orders(line_items).sum(&:total)
         end
 
         def customer_payments_amount_owed(line_items)
-          line_items.map(&:order).uniq.sum(&:outstanding_balance)
+          unique_orders(line_items).sum(&:outstanding_balance)
         end
 
         def customer_payments_amount_paid(line_items)
-          line_items.map(&:order).uniq.sum(&:payment_total)
+          unique_orders(line_items).sum(&:payment_total)
+        end
+
+        def unique_orders(line_items)
+          line_items.map(&:order).uniq
         end
 
         def empty_cell(_line_items)

--- a/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
+++ b/engines/order_management/app/services/order_management/reports/bulk_coop/bulk_coop_report.rb
@@ -149,13 +149,15 @@ module OrderManagement
         end
 
         def order_permissions
-          return @order_permissions unless @order_permissions.nil?
-
-          @order_permissions = ::Permissions::Order.new(@user, @params[:q])
+          @order_permissions ||= ::Permissions::Order.new(@user, @params[:q])
         end
 
         def report_line_items
-          @report_line_items ||= OpenFoodNetwork::Reports::LineItems.new(order_permissions, @params)
+          @report_line_items ||= OpenFoodNetwork::Reports::LineItems.new(
+            order_permissions,
+            @params,
+            CompleteVisibleOrders.new(order_permissions).query
+          )
         end
 
         def customer_payments_total_cost(line_items)

--- a/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
@@ -18,15 +18,16 @@ describe OrderManagement::Reports::BulkCoop::BulkCoopReport do
 
     context "as a site admin" do
       it "fetches completed orders" do
-        o2 = create(:order)
+        o2 = create(:order, state: 'cart')
         o2.line_items << build(:line_item)
         expect(subject.table_items).to eq([li1])
       end
 
-      it "does not show cancelled orders" do
-        o2 = create(:order, state: "canceled", completed_at: 1.day.ago)
-        o2.line_items << build(:line_item_with_shipment)
-        expect(subject.table_items).to eq([li1])
+      it "shows cancelled orders" do
+        o2 = create(:order, state: 'canceled', completed_at: 1.day.ago, order_cycle: oc1, distributor: d1) 
+        line_item = build(:line_item_with_shipment)
+        o2.line_items << line_item
+        expect(subject.table_items).to include(line_item)
       end
     end
 

--- a/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
+++ b/engines/order_management/spec/services/order_management/reports/bulk_coop/bulk_coop_report_spec.rb
@@ -3,7 +3,12 @@
 require 'spec_helper'
 
 describe OrderManagement::Reports::BulkCoop::BulkCoopReport do
+  subject { OrderManagement::Reports::BulkCoop::BulkCoopReport.new user, params, true }
+  let(:user) { create(:admin_user) }
+
   describe "fetching orders" do
+    let(:params) { {} }
+
     let(:d1) { create(:distributor_enterprise) }
     let(:oc1) { create(:simple_order_cycle) }
     let(:o1) { create(:order, completed_at: 1.day.ago, order_cycle: oc1, distributor: d1) }
@@ -12,9 +17,6 @@ describe OrderManagement::Reports::BulkCoop::BulkCoopReport do
     before { o1.line_items << li1 }
 
     context "as a site admin" do
-      let(:user) { create(:admin_user) }
-      subject { OrderManagement::Reports::BulkCoop::BulkCoopReport.new user, {}, true }
-
       it "fetches completed orders" do
         o2 = create(:order)
         o2.line_items << build(:line_item)
@@ -121,6 +123,24 @@ describe OrderManagement::Reports::BulkCoop::BulkCoopReport do
         it "does not show line items supplied by my producers" do
           expect(subject.table_items).to eq([])
         end
+      end
+    end
+  end
+
+  describe '#columns' do
+    context 'when report type is bulk_coop_customer_payments' do
+      let(:params) { { report_type: 'bulk_coop_customer_payments' } }
+
+      it 'returns' do
+        expect(subject.columns).to eq(
+          [
+            :order_billing_address_name,
+            :order_completed_at,
+            :customer_payments_total_cost,
+            :customer_payments_amount_owed,
+            :customer_payments_amount_paid,
+          ]
+        )
       end
     end
   end

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -49,7 +49,7 @@ module OpenFoodNetwork
       if FeatureToggle.enabled?(:customer_balance, @user)
         Spree::Order.
           finalized.
-          where.not(spree_orders: { state: :canceled }).
+          not_state(:canceled).
           distributed_by_user(@user).
           managed_by(@user).
           search(params[:q])

--- a/lib/open_food_network/reports/line_items.rb
+++ b/lib/open_food_network/reports/line_items.rb
@@ -23,10 +23,9 @@ module OpenFoodNetwork
         end
 
         editable_line_items = editable_line_items(line_items)
+        without_editable_line_items = line_items.reject { |li| editable_line_items.include? li }
 
-        line_items.reject{ |li|
-          editable_line_items.include? li
-        }.each do |line_item|
+        without_editable_line_items.each do |line_item|
           OrderDataMasker.new(line_item.order).call
         end
 

--- a/lib/open_food_network/reports/line_items.rb
+++ b/lib/open_food_network/reports/line_items.rb
@@ -2,9 +2,10 @@ module OpenFoodNetwork
   module Reports
     # shared code to search and list line items
     class LineItems
-      def initialize(order_permissions, params)
+      def initialize(order_permissions, params, orders_relation = nil)
         @order_permissions = order_permissions
         @params = params
+        @orders_relation = orders_relation || complete_not_canceled_visible_orders
       end
 
       def orders
@@ -33,8 +34,14 @@ module OpenFoodNetwork
 
       private
 
+      attr_reader :orders_relation
+
+      def complete_not_canceled_visible_orders
+        @order_permissions.visible_orders.complete.not_state(:canceled)
+      end
+
       def search_orders
-        @order_permissions.visible_orders.complete.not_state(:canceled).search(@params[:q])
+        orders_relation.search(@params[:q])
       end
 
       # From the line_items given, returns the ones that are editable by the user

--- a/lib/open_food_network/reports/line_items.rb
+++ b/lib/open_food_network/reports/line_items.rb
@@ -22,8 +22,7 @@ module OpenFoodNetwork
           line_items = line_items.includes(*line_item_includes).references(:line_items)
         end
 
-        editable_line_items = editable_line_items(line_items)
-        without_editable_line_items = line_items.reject { |li| editable_line_items.include? li }
+        without_editable_line_items = line_items - editable_line_items(line_items)
 
         without_editable_line_items.each do |line_item|
           OrderDataMasker.new(line_item.order).call

--- a/spec/lib/open_food_network/reports/line_items_spec.rb
+++ b/spec/lib/open_food_network/reports/line_items_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'open_food_network/reports/line_items'
+
+describe OpenFoodNetwork::Reports::LineItems do
+  subject(:reports_line_items) { described_class.new(order_permissions, params) }
+
+  # This object lets us add some test coverage despite the very deep coupling between the class
+  # under test and the various objects it depends on. Other more common moking strategies where very
+  # hard.
+  class FakeOrderPermissions
+    def initialize(line_item)
+      @relation = Spree::LineItem.where(id: line_item.id)
+    end
+
+    def visible_line_items
+      relation
+    end
+
+    def editable_line_items
+      line_item = FactoryBot.create(:line_item)
+      Spree::LineItem.where(id: line_item.id)
+    end
+
+    private
+
+    attr_reader :relation
+  end
+
+  class FakeRansackResult
+    attr_reader :result
+
+    def initialize(result)
+      @result = result
+    end
+  end
+
+  describe '#list' do
+    let!(:order) { create(:order, distributor: create(:enterprise)) }
+    let!(:line_item) { create(:line_item, order: order) }
+
+    let(:order_permissions) { FakeOrderPermissions.new(line_item) }
+    let(:params) { {} }
+
+    before do
+      orders_relation = Spree::Order.where(id: order.id)
+      allow(reports_line_items).to receive(:search_orders) { FakeRansackResult.new(orders_relation) }
+    end
+
+    it 'returns masked data' do
+      line_items = reports_line_items.list
+      expect(line_items.first.order.email).to eq(I18n.t('admin.reports.hidden'))
+    end
+  end
+end

--- a/spec/models/concerns/balance_spec.rb
+++ b/spec/models/concerns/balance_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Order do
-
+describe Balance do
   context "#outstanding_balance" do
     context 'when orders are in cart state' do
       let(:order) { build(:order, total: 100, payment_total: 10, state: 'cart') }

--- a/spec/models/concerns/balance_spec.rb
+++ b/spec/models/concerns/balance_spec.rb
@@ -1,6 +1,138 @@
 require 'spec_helper'
 
 describe Balance do
+  context "#new_outstanding_balance" do
+    context 'when orders are in cart state' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'cart') }
+
+      it 'returns the order balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when orders are in address state' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'address') }
+
+      it 'returns the order balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when orders are in delivery state' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'delivery') }
+
+      it 'returns the order balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when orders are in payment state' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'payment') }
+
+      it 'returns the order balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when no orders where paid' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'complete') }
+
+      it 'returns the customer balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when an order was paid' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'complete') }
+
+      it 'returns the customer balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when an order is canceled' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'canceled') }
+
+      it 'returns the customer balance' do
+        expect(order.new_outstanding_balance).to eq(-10)
+      end
+    end
+
+    context 'when an order is resumed' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'resumed') }
+
+      it 'returns the customer balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when an order is in payment' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'payment') }
+
+      it 'returns the customer balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when an order is awaiting_return' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'awaiting_return') }
+
+      it 'returns the customer balance' do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when an order is returned' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'returned') }
+
+      it 'returns the balance' do
+        expect(order.new_outstanding_balance).to eq(-10)
+      end
+    end
+
+    context 'when payment_total is less than total' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'complete') }
+
+      it "returns positive" do
+        expect(order.new_outstanding_balance).to eq(100 - 10)
+      end
+    end
+
+    context 'when payment_total is greater than total' do
+      let(:order) { create(:order, total: 8.20, payment_total: 10.20, state: 'complete') }
+
+      it "returns negative amount" do
+        expect(order.new_outstanding_balance).to eq(-2.00)
+      end
+    end
+  end
+
+  context '#outstanding_balance?' do
+    context 'when total is greater than payment_total' do
+      let(:order) { build(:order, total: 10.10, payment_total: 9.50) }
+
+      it 'returns true' do
+        expect(order.outstanding_balance?).to eq(true)
+      end
+    end
+
+    context 'when total is less than payment_total' do
+      let(:order) { build(:order, total: 8.25, payment_total: 10.44) }
+
+      it 'returns true' do
+        expect(order.outstanding_balance?).to eq(true)
+      end
+    end
+
+    context "when total equals payment_total" do
+      let(:order) { build(:order, total: 10.10, payment_total: 10.10) }
+
+      it 'returns false' do
+        expect(order.outstanding_balance?).to eq(false)
+      end
+    end
+  end
+
   context "#outstanding_balance" do
     context 'when orders are in cart state' do
       let(:order) { build(:order, total: 100, payment_total: 10, state: 'cart') }
@@ -54,7 +186,7 @@ describe Balance do
       let(:order) { build(:order, total: 100, payment_total: 10, state: 'canceled') }
 
       it 'returns the customer balance' do
-        expect(order.outstanding_balance).to eq(-10)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
@@ -86,7 +218,7 @@ describe Balance do
       let(:order) { build(:order, total: 100, payment_total: 10, state: 'returned') }
 
       it 'returns the balance' do
-        expect(order.outstanding_balance).to eq(-10)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
@@ -103,32 +235,6 @@ describe Balance do
 
       it "returns negative amount" do
         expect(order.outstanding_balance).to eq(-2.00)
-      end
-    end
-  end
-
-  context '#outstanding_balance?' do
-    context 'when total is greater than payment_total' do
-      let(:order) { build(:order, total: 10.10, payment_total: 9.50) }
-
-      it 'returns true' do
-        expect(order.outstanding_balance?).to eq(true)
-      end
-    end
-
-    context 'when total is less than payment_total' do
-      let(:order) { build(:order, total: 8.25, payment_total: 10.44) }
-
-      it 'returns true' do
-        expect(order.outstanding_balance?).to eq(true)
-      end
-    end
-
-    context "when total equals payment_total" do
-      let(:order) { build(:order, total: 10.10, payment_total: 10.10) }
-
-      it 'returns false' do
-        expect(order.outstanding_balance?).to eq(false)
       end
     end
   end

--- a/spec/models/spree/order/outstanding_balance_spec.rb
+++ b/spec/models/spree/order/outstanding_balance_spec.rb
@@ -1,216 +1,132 @@
 require 'spec_helper'
 
 describe Spree::Order do
-  let(:order) { build(:order) }
 
   context "#outstanding_balance" do
     context 'when orders are in cart state' do
-      before do
-        create(:order, total: order_total, payment_total: 0, state: 'cart')
-        create(:order, total: order_total, payment_total: 0, state: 'cart')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'cart') }
 
       it 'returns the order balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(-order_total)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when orders are in address state' do
-      before do
-        create(:order, total: order_total, payment_total: 0, state: 'address')
-        create(:order, total: order_total, payment_total: 50, state: 'address')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'address') }
 
       it 'returns the order balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(-order_total)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when orders are in delivery state' do
-      before do
-        create(:order, total: order_total, payment_total: 0, state: 'delivery')
-        create(:order, total: order_total, payment_total: 50, state: 'delivery')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'delivery') }
 
       it 'returns the order balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(-order_total)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when orders are in payment state' do
-      before do
-        create(:order, total: order_total, payment_total: 0, state: 'payment')
-        create(:order, total: order_total, payment_total: 50, state: 'payment')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'payment') }
 
       it 'returns the order balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(-order_total)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when no orders where paid' do
-      before do
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'complete') }
 
       it 'returns the customer balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(-order_total)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when an order was paid' do
-      let(:payment_total) { order_total }
-
-      before do
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-        order = create(:order, total: order_total, payment_total: payment_total)
-        order.update_attribute(:state, 'complete')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'complete') }
 
       it 'returns the customer balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(payment_total - 200.0)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when an order is canceled' do
-      let(:payment_total) { order_total }
-      let(:non_canceled_orders_total) { order_total }
-
-      before do
-        create(:order, total: order_total, payment_total: order_total, state: 'canceled')
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'canceled') }
 
       it 'returns the customer balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(payment_total)
+        expect(order.outstanding_balance).to eq(-10)
       end
     end
 
     context 'when an order is resumed' do
-      let(:payment_total) { order_total }
-
-      before do
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-        order = create(:order, total: order_total, payment_total: payment_total)
-        order.update_attribute(:state, 'resumed')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'resumed') }
 
       it 'returns the customer balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(payment_total - 200.0)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when an order is in payment' do
-      let(:payment_total) { order_total }
-
-      before do
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-        order = create(:order, total: order_total, payment_total: payment_total)
-        order.update_attribute(:state, 'payment')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'payment') }
 
       it 'returns the customer balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(payment_total - 200.0)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when an order is awaiting_return' do
-      let(:payment_total) { order_total }
-
-      before do
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-        order = create(:order, total: order_total, payment_total: payment_total)
-        order.update_attribute(:state, 'awaiting_return')
-      end
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'awaiting_return') }
 
       it 'returns the customer balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(payment_total - 200.0)
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
     context 'when an order is returned' do
-      let(:payment_total) { order_total }
-      let(:non_returned_orders_total) { order_total }
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'returned') }
 
-      before do
-        order = create(:order, total: order_total, payment_total: payment_total)
-        order.update_attribute(:state, 'returned')
-        order = create(:order, total: order_total, payment_total: 0)
-        order.update_attribute(:state, 'complete')
-      end
-
-      it 'returns the customer balance' do
-        order = outstanding_balance.query.first
-        expect(order.balance_value).to eq(payment_total)
+      it 'returns the balance' do
+        expect(order.outstanding_balance).to eq(-10)
       end
     end
 
-    context 'when there are no orders' do
-      it 'returns the order balance' do
-        orders = outstanding_balance.query
-        expect(orders).to be_empty
+    context 'when payment_total is less than total' do
+      let(:order) { build(:order, total: 100, payment_total: 10, state: 'complete') }
+
+      it "returns positive" do
+        expect(order.outstanding_balance).to eq(100 - 10)
       end
     end
 
-    it "should return positive amount when payment_total is less than total" do
-      order.payment_total = 20.20
-      order.total = 30.30
-      expect(order.outstanding_balance).to eq 10.10
-    end
+    context 'when payment_total is greater than total' do
+      let(:order) { create(:order, total: 8.20, payment_total: 10.20, state: 'complete') }
 
-    it "should return negative amount when payment_total is greater than total" do
-      order.total = 8.20
-      order.payment_total = 10.20
-      expect(order.outstanding_balance).to be_within(0.001).of(-2.00)
+      it "returns negative amount" do
+        expect(order.outstanding_balance).to eq(-2.00)
+      end
     end
   end
 
-  context "#outstanding_balance?" do
+  context '#outstanding_balance?' do
     context 'when total is greater than payment_total' do
-      before do
-        order.total = 10.10
-        order.payment_total = 9.50
-      end
+      let(:order) { build(:order, total: 10.10, payment_total: 9.50) }
 
-      it "returns true" do
+      it 'returns true' do
         expect(order.outstanding_balance?).to eq(true)
       end
     end
 
-    context "when total is less than payment_total" do
-      before do
-        order.total = 8.25
-        order.payment_total = 10.44
-      end
+    context 'when total is less than payment_total' do
+      let(:order) { build(:order, total: 8.25, payment_total: 10.44) }
 
-      it "returns true" do
+      it 'returns true' do
         expect(order.outstanding_balance?).to eq(true)
       end
     end
 
     context "when total equals payment_total" do
-      before do
-        order.total = 10.10
-        order.payment_total = 10.10
-      end
+      let(:order) { build(:order, total: 10.10, payment_total: 10.10) }
 
       it 'returns false' do
         expect(order.outstanding_balance?).to eq(false)

--- a/spec/models/spree/order/outstanding_balance_spec.rb
+++ b/spec/models/spree/order/outstanding_balance_spec.rb
@@ -1,0 +1,220 @@
+require 'spec_helper'
+
+describe Spree::Order do
+  let(:order) { build(:order) }
+
+  context "#outstanding_balance" do
+    context 'when orders are in cart state' do
+      before do
+        create(:order, total: order_total, payment_total: 0, state: 'cart')
+        create(:order, total: order_total, payment_total: 0, state: 'cart')
+      end
+
+      it 'returns the order balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(-order_total)
+      end
+    end
+
+    context 'when orders are in address state' do
+      before do
+        create(:order, total: order_total, payment_total: 0, state: 'address')
+        create(:order, total: order_total, payment_total: 50, state: 'address')
+      end
+
+      it 'returns the order balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(-order_total)
+      end
+    end
+
+    context 'when orders are in delivery state' do
+      before do
+        create(:order, total: order_total, payment_total: 0, state: 'delivery')
+        create(:order, total: order_total, payment_total: 50, state: 'delivery')
+      end
+
+      it 'returns the order balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(-order_total)
+      end
+    end
+
+    context 'when orders are in payment state' do
+      before do
+        create(:order, total: order_total, payment_total: 0, state: 'payment')
+        create(:order, total: order_total, payment_total: 50, state: 'payment')
+      end
+
+      it 'returns the order balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(-order_total)
+      end
+    end
+
+    context 'when no orders where paid' do
+      before do
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+      end
+
+      it 'returns the customer balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(-order_total)
+      end
+    end
+
+    context 'when an order was paid' do
+      let(:payment_total) { order_total }
+
+      before do
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+        order = create(:order, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'complete')
+      end
+
+      it 'returns the customer balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(payment_total - 200.0)
+      end
+    end
+
+    context 'when an order is canceled' do
+      let(:payment_total) { order_total }
+      let(:non_canceled_orders_total) { order_total }
+
+      before do
+        create(:order, total: order_total, payment_total: order_total, state: 'canceled')
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+      end
+
+      it 'returns the customer balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(payment_total)
+      end
+    end
+
+    context 'when an order is resumed' do
+      let(:payment_total) { order_total }
+
+      before do
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+        order = create(:order, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'resumed')
+      end
+
+      it 'returns the customer balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(payment_total - 200.0)
+      end
+    end
+
+    context 'when an order is in payment' do
+      let(:payment_total) { order_total }
+
+      before do
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+        order = create(:order, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'payment')
+      end
+
+      it 'returns the customer balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(payment_total - 200.0)
+      end
+    end
+
+    context 'when an order is awaiting_return' do
+      let(:payment_total) { order_total }
+
+      before do
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+        order = create(:order, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'awaiting_return')
+      end
+
+      it 'returns the customer balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(payment_total - 200.0)
+      end
+    end
+
+    context 'when an order is returned' do
+      let(:payment_total) { order_total }
+      let(:non_returned_orders_total) { order_total }
+
+      before do
+        order = create(:order, total: order_total, payment_total: payment_total)
+        order.update_attribute(:state, 'returned')
+        order = create(:order, total: order_total, payment_total: 0)
+        order.update_attribute(:state, 'complete')
+      end
+
+      it 'returns the customer balance' do
+        order = outstanding_balance.query.first
+        expect(order.balance_value).to eq(payment_total)
+      end
+    end
+
+    context 'when there are no orders' do
+      it 'returns the order balance' do
+        orders = outstanding_balance.query
+        expect(orders).to be_empty
+      end
+    end
+
+    it "should return positive amount when payment_total is less than total" do
+      order.payment_total = 20.20
+      order.total = 30.30
+      expect(order.outstanding_balance).to eq 10.10
+    end
+
+    it "should return negative amount when payment_total is greater than total" do
+      order.total = 8.20
+      order.payment_total = 10.20
+      expect(order.outstanding_balance).to be_within(0.001).of(-2.00)
+    end
+  end
+
+  context "#outstanding_balance?" do
+    context 'when total is greater than payment_total' do
+      before do
+        order.total = 10.10
+        order.payment_total = 9.50
+      end
+
+      it "returns true" do
+        expect(order.outstanding_balance?).to eq(true)
+      end
+    end
+
+    context "when total is less than payment_total" do
+      before do
+        order.total = 8.25
+        order.payment_total = 10.44
+      end
+
+      it "returns true" do
+        expect(order.outstanding_balance?).to eq(true)
+      end
+    end
+
+    context "when total equals payment_total" do
+      before do
+        order.total = 10.10
+        order.payment_total = 10.10
+      end
+
+      it 'returns false' do
+        expect(order.outstanding_balance?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -237,37 +237,6 @@ describe Spree::Order do
     end
   end
 
-  context "#outstanding_balance" do
-    it "should return positive amount when payment_total is less than total" do
-      order.payment_total = 20.20
-      order.total = 30.30
-      expect(order.outstanding_balance).to eq 10.10
-    end
-    it "should return negative amount when payment_total is greater than total" do
-      order.total = 8.20
-      order.payment_total = 10.20
-      expect(order.outstanding_balance).to be_within(0.001).of(-2.00)
-    end
-  end
-
-  context "#outstanding_balance?" do
-    it "should be true when total greater than payment_total" do
-      order.total = 10.10
-      order.payment_total = 9.50
-      expect(order.outstanding_balance?).to be_truthy
-    end
-    it "should be true when total less than payment_total" do
-      order.total = 8.25
-      order.payment_total = 10.44
-      expect(order.outstanding_balance?).to be_truthy
-    end
-    it "should be false when total equals payment_total" do
-      order.total = 10.10
-      order.payment_total = 10.10
-      expect(order.outstanding_balance?).to be_falsy
-    end
-  end
-
   context "#completed?" do
     it "should indicate if order is completed" do
       order.completed_at = nil

--- a/spec/queries/complete_visible_orders_spec.rb
+++ b/spec/queries/complete_visible_orders_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CompleteVisibleOrders do
+  subject(:complete_visible_orders) { described_class.new(order_permissions) }
+  let(:filter_canceled) { false }
+
+  describe '#query' do
+    let(:user) { create(:user) }
+    let(:enterprise) { create(:enterprise) }
+    let(:order_permissions) { ::Permissions::Order.new(user, filter_canceled) }
+
+    before do
+      user.enterprises << enterprise
+      user.save!
+    end
+
+    context 'when an order has no completed_at' do
+      let(:cart_order) { create(:order, distributor: enterprise) }
+
+      it 'does not return it' do
+        expect(complete_visible_orders.query).not_to include(cart_order)
+      end
+    end
+
+    context 'when an order has complete_at' do
+      let(:complete_order) { create(:order, completed_at: 1.day.ago, distributor: enterprise) }
+
+      it 'does not return it' do
+        expect(complete_visible_orders.query).to include(complete_order)
+      end
+    end
+
+    it 'calls #visible_orders' do
+      expect(order_permissions).to receive(:visible_orders).and_call_original
+      complete_visible_orders.query
+    end
+  end
+end

--- a/spec/services/order_data_masker_spec.rb
+++ b/spec/services/order_data_masker_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe OrderDataMasker do
+  describe '#call' do
+    let(:distributor) { create(:enterprise) }
+    let(:order) { create(:order, distributor: distributor, ship_address: create(:address)) }
+
+    context 'when displaying customer names is allowed' do
+      before { distributor.preferences[:show_customer_names_to_suppliers] = true }
+
+      it 'masks personal addresses and email' do
+        described_class.new(order).call
+
+        expect(order.bill_address.attributes).to include(
+          'phone' => '',
+          'address1' => '',
+          'address2' => '',
+          'city' => '',
+          'zipcode' => '',
+          'state_id' => nil
+        )
+
+        expect(order.ship_address.attributes).to include(
+          'phone' => '',
+          'address1' => '',
+          'address2' => '',
+          'city' => '',
+          'zipcode' => '',
+          'state_id' => nil
+        )
+
+        expect(order.email).to eq(I18n.t('admin.reports.hidden'))
+      end
+
+      it 'does not mask the full name' do
+        described_class.new(order).call
+
+        expect(order.bill_address.attributes).not_to include(
+          firstname: I18n.t('admin.reports.hidden'),
+          lastname: ''
+        )
+        expect(order.ship_address.attributes).not_to include(
+          firstname: I18n.t('admin.reports.hidden'),
+          lastname: ''
+        )
+      end
+    end
+
+    context 'when displaying customer names is not allowed' do
+      before { distributor.preferences[:show_customer_names_to_suppliers] = false }
+
+      it 'masks personal addresses and email' do
+        described_class.new(order).call
+
+        expect(order.bill_address.attributes).to include(
+          'phone' => '',
+          'address1' => '',
+          'address2' => '',
+          'city' => '',
+          'zipcode' => '',
+          'state_id' => nil
+        )
+
+        expect(order.ship_address.attributes).to include(
+          'phone' => '',
+          'address1' => '',
+          'address2' => '',
+          'city' => '',
+          'zipcode' => '',
+          'state_id' => nil
+        )
+
+        expect(order.email).to eq(I18n.t('admin.reports.hidden'))
+      end
+
+      it 'masks the full name' do
+        described_class.new(order).call
+
+        expect(order.bill_address.attributes).to include(
+          'firstname' => I18n.t('admin.reports.hidden'),
+          'lastname' => ''
+        )
+        expect(order.ship_address.attributes).to include(
+          'firstname' => I18n.t('admin.reports.hidden'),
+          'lastname' => ''
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #6856

The fact that this report relies on `Reports::LineItems` and that one returns an Array instead of an `ActiveRecord::Relation` made it too complex to reuse the recently introduced [OutstandingBalance](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/queries/outstanding_balance.rb) query object, which would enable us to reuse the logic. Although I tried, fixing this underlying issue fell out of scope.

Because of that, I made sure the implementation this report uses conforms to that new query object and therefore, is consistent with the other pages where we show the order balance. To sum up, we left the world a bit better but still not ideal.

This implementation doesn't impact performance much. The issue is how badly we are fetching line items, their orders and how we group them in the app and not in the db. The balance calculation adds little overhead compared to that.

Finally, notice I added unit tests to the code I went through. It was very hard to foresee whether I could touch those parts or not without them and I decided to leave them anyway. It leads to a better world. That's why code without tests, IMO, is bad code. It adds a toll on future development.

#### What should we test?

We need to check that numbers do make sense in that report, but also they need to be consistent with /account and /admin/customers

#### Release notes
Use new order balance calculation in bulk coop report but hidden under a feature toggle.
Changelog Category: User facing changes
