### PR TITLE
Emphasise ways to get help in user emails

### DIFF
--- a/app/assets/stylesheets/mail/email.scss
+++ b/app/assets/stylesheets/mail/email.scss
@@ -63,6 +63,12 @@ p.notice {
   margin-top: 20px;
 }
 
+.powered-by-ofn {
+  background-color: #ebebeb;
+  padding: .5em;
+  text-align: center;
+}
+
 table.social {
   background-color: #ebebeb;
 

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MailerHelper
+  def footer_ofn_link
+    ofn = I18n.t("shared.mailers.powered_by.open_food_network")
+
+    if ContentConfig.footer_email.present?
+      mail_to ContentConfig.footer_email, ofn
+    else
+      link_to ofn, "https://www.openfoodnetwork.org"
+    end
+  end
+end

--- a/app/mailers/spree/order_mailer.rb
+++ b/app/mailers/spree/order_mailer.rb
@@ -6,6 +6,7 @@ module Spree
     helper SpreeCurrencyHelper
     helper Spree::Admin::PaymentsHelper
     helper OrderHelper
+    helper MailerHelper
     include I18nHelper
 
     def cancel_email(order_or_order_id, resend = false)

--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -4,6 +4,8 @@ module Spree
   class UserMailer < BaseMailer
     include I18nHelper
 
+    helper MailerHelper
+
     # Overrides `Devise::Mailer.reset_password_instructions`
     def reset_password_instructions(user, token, _opts = {})
       @edit_password_reset_url = spree.

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,5 +1,6 @@
 class SubscriptionMailer < Spree::BaseMailer
   helper CheckoutHelper
+  helper MailerHelper
   helper ShopMailHelper
   helper OrderHelper
   helper Spree::Admin::PaymentsHelper

--- a/app/views/shared/mailers/_powered_by.html.haml
+++ b/app/views/shared/mailers/_powered_by.html.haml
@@ -1,0 +1,2 @@
+%p.powered-by-ofn
+  = t(".powered_html", open_food_network: footer_ofn_link)

--- a/app/views/spree/order_mailer/cancel_email.html.haml
+++ b/app/views/spree/order_mailer/cancel_email.html.haml
@@ -26,4 +26,4 @@
     = t(".unpaid_order")
 
 = render 'signoff'
-= render 'shared/mailers/social_and_contact'
+= render 'shared/mailers/powered_by'

--- a/app/views/spree/order_mailer/confirm_email_for_customer.html.haml
+++ b/app/views/spree/order_mailer/confirm_email_for_customer.html.haml
@@ -25,4 +25,4 @@
 = render 'shipping'
 = render 'special_instructions'
 = render 'signoff'
-= render 'shared/mailers/social_and_contact'
+= render 'shared/mailers/powered_by'

--- a/app/views/spree/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/spree/user_mailer/confirmation_instructions.html.haml
@@ -12,7 +12,7 @@
 
 = render 'shared/mailers/signoff'
 
-= render 'shared/mailers/social_and_contact'
+= render 'shared/mailers/powered_by'
 
 %p.notice
   = t :email_confirmation_notice_unexpected, sitename: @instance, contact: @contact

--- a/app/views/subscription_mailer/confirmation_summary_email.html.haml
+++ b/app/views/subscription_mailer/confirmation_summary_email.html.haml
@@ -19,4 +19,4 @@
 
 %p &nbsp;
 = render 'shared/mailers/signoff'
-= render 'shared/mailers/social_and_contact'
+= render 'shared/mailers/powered_by'

--- a/app/views/subscription_mailer/placement_summary_email.html.haml
+++ b/app/views/subscription_mailer/placement_summary_email.html.haml
@@ -19,4 +19,4 @@
 
 %p &nbsp;
 = render 'shared/mailers/signoff'
-= render 'shared/mailers/social_and_contact'
+= render 'shared/mailers/powered_by'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1252,6 +1252,10 @@ en:
       hide_closed_shops: "Hide closed shops"
       show_on_map: "Show all on the map"
   shared:
+    mailers:
+      powered_by:
+        open_food_network: "Open Food Network"
+        powered_html: "Your shopping experience is powered by the %{open_food_network}."
     menu:
       cart:
         cart: "Cart"

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -132,6 +132,19 @@ describe Spree::OrderMailer do
         Spree::OrderMailer.confirm_email_for_customer(order.id).deliver_now
         expect(ActionMailer::Base.deliveries.first.reply_to).to eq([distributor.contact.email])
       end
+
+      it "includes a link to the configured instance email address" do
+        mail = Spree::OrderMailer.confirm_email_for_customer(order.id)
+
+        expect(mail.body.encoded).to include "mailto:hello@openfoodnetwork.org"
+      end
+
+      it "includes a link to the OFN global website if no email address is available" do
+        expect(ContentConfig).to receive(:footer_email).and_return("")
+        mail = Spree::OrderMailer.confirm_email_for_customer(order.id)
+
+        expect(mail.body.encoded).to include "https://www.openfoodnetwork.org"
+      end
     end
 
     describe "for shops" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -47,6 +47,19 @@ describe Spree::UserMailer do
     end
   end
 
+  describe "#confirmation_instructions" do
+    it "sends an email" do
+      token = "random"
+      email = Spree::UserMailer.confirmation_instructions(user, token)
+
+      expect {
+        email.deliver_now
+      }.to change {
+        ActionMailer::Base.deliveries.count
+      }.by(1)
+    end
+  end
+
   # adapted from https://github.com/spree/spree_auth_devise/blob/70737af/spec/mailers/user_mailer_spec.rb
   describe '#reset_password_instructions' do
     describe 'message contents' do


### PR DESCRIPTION
#### What? Why?

Closes #6102

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We had a very prominent footer showing how to get in contact with the
local instance people but most users need to get in contact with the
enterprise they are buying from. So removing all those details and
replacing them by a simple "powered by" line will hopefully direct
attention to the shop's contact details.


#### What should we test?
<!-- List which features should be tested and how. -->

Trigger the following emails and confirm that they still look good:


-   spree/order_mailer/cancel_email
-   spree/order_mailer/confirm_email_for_customer
-   spree/user_mailer/confirmation_instructions
-   subscription_mailer/confirmation_summary_email
-   subscription_mailer/placement_summary_email

Remove the email configuration as super admin (/admin/contents/edit) and re-send an order confirmation.
The link should now point to the global website.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Simplified the order confirmation email amongst some others to direct more attention to shops instead of the Open Food Network instance.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



