### PR TITLE
Setup Github Actions as CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   push:
 
+env:
+  DISABLE_KNAPSACK: true
+
 jobs:
   test-models:
     runs-on: ubuntu-18.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ env:
   DISABLE_KNAPSACK: true
 
 jobs:
-  test-models:
+  test-non-spree-models:
     runs-on: ubuntu-18.04
     services:
       postgres:
@@ -47,7 +47,48 @@ jobs:
           bundle exec rake db:schema:load RAILS_ENV=test
 
       - name: Run tests
-        run: bundle exec rspec spec/models
+        run: bundle exec rspec spec/models --exclude-pattern "spec/models/spree/*"
+
+  test-spree-models:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run tests
+        run: bundle exec rspec spec/models/spree
 
   test-admin-features:
     runs-on: ubuntu-18.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
           bundle exec rake db:schema:load RAILS_ENV=test
 
       - name: Run admin feature tests
-        run: bundle exec rspec spec/features/admin/*_spec.rb
+        run: bundle exec rspec --profile -- spec/features/admin/*_spec.rb
 
   test-admin-features-folders:
     runs-on: ubuntu-18.04
@@ -170,7 +170,7 @@ jobs:
           bundle exec rake db:schema:load RAILS_ENV=test
 
       - name: Run admin feature tests
-        run: bundle exec rspec --pattern "spec/features/admin/*/*_spec.rb"
+        run: bundle exec rspec --profile --pattern "spec/features/admin/*/*_spec.rb"
 
   test-consumer-features:
     runs-on: ubuntu-18.04
@@ -211,7 +211,7 @@ jobs:
           bundle exec rake db:schema:load RAILS_ENV=test
 
       - name: Run consumer feature tests
-        run: bundle exec rspec spec/features/consumer
+        run: bundle exec rspec --profile -- spec/features/consumer
 
   test-controllers:
     runs-on: ubuntu-18.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,270 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: Build
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
 
 jobs:
-  test:
-
+  test-models:
     runs-on: ubuntu-18.04
-
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
-      run: bundle exec rspec spec/queries
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run tests
+        run: bundle exec rspec spec/models
+
+  test-admin-features:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run admin feature tests
+        run: bundle exec rspec spec/features/admin/*_spec.rb
+
+  test-admin-features-folders:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run admin feature tests
+        run: bundle exec rspec --pattern "spec/features/admin/*/*_spec.rb"
+
+  test-consumer-features:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run consumer feature tests
+        run: bundle exec rspec spec/features/consumer
+
+  test-controllers:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run tests
+        run: bundle exec rspec spec/controllers
+
+  test-other:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run JS tests
+        run: RAILS_ENV=test bundle exec rake karma:run
+
+      - name: Run all other tests
+        run: |
+          bundle exec rspec \
+            spec/helpers/ \
+            spec/initializers/ \
+            spec/jobs/ \
+            spec/lib/ \
+            spec/mailers/ \
+            spec/queries/ \
+            spec/requests/ \
+            spec/serializers/ \
+            spec/services/ \
+            spec/validators/ \
+            spec/views
+
+      - name: Run engines tests
+        run: bundle exec rake ofn:specs:engines:rspec

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---colour
---format Fuubar

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://semaphoreci.com/api/v1/openfoodfoundation/openfoodnetwork-2/branches/master/badge.svg)](https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2)
 [![Code Climate](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork.png)](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork)
+[![Build](https://github.com/openfoodfoundation/openfoodnetwork/actions/workflows/build.yml/badge.svg)](https://github.com/openfoodfoundation/openfoodnetwork/actions/workflows/build.yml)
 
 # Open Food Network
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,6 @@ require_relative 'config/application'
 
 Openfoodnetwork::Application.load_tasks
 
-Knapsack.load_tasks if defined?(Knapsack)
+unless ENV['DISABLE_KNAPSACK']
+  Knapsack.load_tasks if defined?(Knapsack)
+end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -21,12 +21,6 @@ module Spree
       go_to_state :complete
     end
 
-    state_machine.after_transition to: :payment, do: :charge_shipping_and_payment_fees!
-
-    state_machine.event :restart_checkout do
-      transition to: :cart, unless: :completed?
-    end
-
     token_resource
 
     belongs_to :user, class_name: Spree.user_class.to_s

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -63,6 +63,10 @@ module Spree
                 transition to: :awaiting_return
               end
 
+              event :restart_checkout do
+                transition to: :cart, unless: :completed?
+              end
+
               if states[:payment]
                 before_transition to: :complete do |order|
                   order.process_payments! if order.payment_required?
@@ -78,6 +82,7 @@ module Spree
               after_transition to: :delivery, do: :create_tax_charge!
               after_transition to: :resumed,  do: :after_resume
               after_transition to: :canceled, do: :after_cancel
+              after_transition to: :payment, do: :charge_shipping_and_payment_fees!
             end
           end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,7 @@ Openfoodnetwork::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  config.time_zone = ENV.fetch("TIMEZONE", "Melbourne")
+  config.time_zone = "UTC"
 
   # Tests assume English text on the site.
   config.i18n.default_locale = "en"

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-require 'simplecov'
+unless !!ENV['CI']
+  require 'simplecov'
 
-SimpleCov.minimum_coverage 54
-SimpleCov.start 'rails' do
-  add_filter '/bin/'
-  add_filter '/config/'
-  add_filter '/jobs/application_job.rb'
-  add_filter '/schemas/'
-  add_filter '/lib/generators'
-  add_filter '/spec/'
-  add_filter '/vendor/'
-  add_filter '/public'
-  add_filter '/swagger'
-  add_filter '/script'
-  add_filter '/log'
-  add_filter '/db'
+  SimpleCov.minimum_coverage 54
+  SimpleCov.start 'rails' do
+    add_filter '/bin/'
+    add_filter '/config/'
+    add_filter '/jobs/application_job.rb'
+    add_filter '/schemas/'
+    add_filter '/lib/generators'
+    add_filter '/spec/'
+    add_filter '/vendor/'
+    add_filter '/public'
+    add_filter '/swagger'
+    add_filter '/script'
+    add_filter '/log'
+    add_filter '/db'
+  end
 end

--- a/spec/features/admin/enterprises/terms_and_conditions_spec.rb
+++ b/spec/features/admin/enterprises/terms_and_conditions_spec.rb
@@ -44,7 +44,8 @@ feature "Uploading Terms and Conditions PDF" do
         # Add PDF
         attach_file "enterprise[terms_and_conditions]", white_pdf_file_name
 
-        Timecop.freeze(run_time = Time.zone.local(2002, 4, 13, 0, 0, 0)) do
+        time = Time.zone.local(2002, 4, 13, 0, 0, 0)
+        Timecop.freeze(run_time = time) do
           click_button "Update"
           expect(distributor.reload.terms_and_conditions_updated_at).to eq run_time
         end
@@ -53,7 +54,7 @@ feature "Uploading Terms and Conditions PDF" do
 
         go_to_business_details
         expect(page).to have_selector "a[href*='logo-white.pdf'][target=\"_blank\"]"
-        expect(page).to have_content "2002-04-13 00:00:00 +1000"
+        expect(page).to have_content time.strftime("%F %T %Z")
 
         # Replace PDF
         attach_file "enterprise[terms_and_conditions]", black_pdf_file_name

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -26,22 +26,19 @@ feature 'Multilingual', js: true do
       visit root_path
       expect(get_i18n_locale).to eq 'en'
       expect(get_i18n_translation('label_shops')).to eq 'Shops'
-      expect(cookie_named('locale')).to be_nil
-      expect(page).to have_content 'Interested in getting on the Open Food Network?'
+      expect(cookies).to be_empty
       expect(page).to have_content 'SHOPS'
 
       visit root_path(locale: 'es')
       expect(get_i18n_locale).to eq 'es'
       expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
       expect_menu_and_cookie_in_es
-      expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
 
       # it is not in the list of available of available_locales
       visit root_path(locale: 'it')
       expect(get_i18n_locale).to eq 'es'
       expect(get_i18n_translation('label_shops')).to eq 'Tiendas'
       expect_menu_and_cookie_in_es
-      expect(page).to have_content '¿Estás interesada en entrar en Open Food Network?'
     end
 
     context 'with a product in the cart' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,11 +59,11 @@ Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new(
     args: %w[headless disable-gpu no-sandbox window-size=1280,768]
   )
-  options.add_preference(:download, default_directory: Rails.root.join("tmp", "downloads").to_s)
+  options.add_preference(:download, default_directory: DownloadsHelper.path.to_s)
 
   Capybara::Selenium::Driver
     .new(app, browser: :chrome, options: options)
-    .tap { |driver| driver.browser.download_path = Rails.root.join("tmp", "downloads").to_s }
+    .tap { |driver| driver.browser.download_path = DownloadsHelper.path.to_s }
 end
 
 Capybara.default_max_wait_time = 30

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,6 +103,9 @@ RSpec.configure do |config|
   # Only retry when Selenium raises Net::ReadTimeout
   config.exceptions_to_retry = [Net::ReadTimeout]
 
+  # Force colored output, whether or not the output is a TTY
+  config.color_mode = :on
+
   # Force use of expect (over should)
   config.expect_with :rspec do |expectations|
     expectations.syntax = :expect

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,9 +59,11 @@ Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new(
     args: %w[headless disable-gpu no-sandbox window-size=1280,768]
   )
+  options.add_preference(:download, default_directory: Rails.root.join("tmp", "downloads").to_s)
+
   Capybara::Selenium::Driver
     .new(app, browser: :chrome, options: options)
-    .tap { |driver| driver.browser.download_path = DownloadsHelper.path.to_s }
+    .tap { |driver| driver.browser.download_path = Rails.root.join("tmp", "downloads").to_s }
 end
 
 Capybara.default_max_wait_time = 30

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-SimpleCov.start 'rails'
+unless ENV['CI']
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
 
 require 'rubygems'
 

--- a/spec/support/request/cookie_helper.rb
+++ b/spec/support/request/cookie_helper.rb
@@ -4,4 +4,8 @@ module CookieHelper
   def cookie_named(name)
     Capybara.current_session.driver.browser.manage.cookie_named(name)
   end
+
+  def cookies
+    Capybara.current_session.driver.browser.manage.all_cookies
+  end
 end

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -120,7 +120,7 @@ module WebHelper
   end
 
   def open_select2(selector)
-    page.find(selector).find(:css, '.select2-choice, .select2-search-field').click
+    page.find(selector).scroll_to(page.find(selector)).find(:css, '.select2-choice, .select2-search-field').click
   end
 
   def close_select2


### PR DESCRIPTION
#### What? Why?

Related to #6752. Introduces a new [Github Actions](https://docs.github.com/en/actions) workflow that will be executed on every push to a branch, allowing us to trigger it from the UI as well.

This made it necessary to fix a few tests (weren't these running in Semaphore :thinking: ?) and simplify things a bit.

As agreed in production curation and the delivery meetings, we'll have this running alongside Semaphore CI for a week to evaluate if tests fail less frequently. However, we'll soon need to work on fixing those common flaky specs. There's no magic solution here.

**Things I didn't get to and can be done later**
* DRY up build.yml: the solution I thought of is not supported by Github.
* Speed up spec/features/admin. The longest job.

#### What should we test?

Green build.

#### Release notes
Introduced CI build using Github Actions
Changelog Category: Technical changes