### PR TITLE
Close unit price tooltip when user click outside the tooltip

### DIFF
--- a/app/assets/stylesheets/darkswarm/question-mark-icon.scss
+++ b/app/assets/stylesheets/darkswarm/question-mark-icon.scss
@@ -38,6 +38,15 @@
   margin-top: 0.1rem;
   background-color: transparent;
 
+  .background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+  }
+
   .joyride-content-wrapper {
     background-color: $dynamic-blue;
     padding: $padding-small;


### PR DESCRIPTION
#### What? Why?
This PR is for enabled the possibility to close the unit price tooltip when user click outside the tooltip (anywhere else)
Closes #6895 


#### What should we test?
1. Visit a shopfront, and click on the question mark icon to display unit price tooltip
2. Tooltip should appear
3. Click inside the tooltip: tooltip should always been displayed.
4. Click outside the tooltip: tooltip must be closed.


#### Release notes
Close unit price tooltip on click outside the tooltip.

Changelog Category: User facing changes

