### PR TITLE
Separate date format used for server communication from user-readable date

### DIFF
--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -39,6 +39,7 @@
 //= require flatpickr/dist/l10n/sv
 //= require flatpickr/dist/l10n/tr
 //= require shortcut-buttons-flatpickr/dist/shortcut-buttons-flatpickr.min
+//= require flatpickr/dist/plugins/labelPlugin/labelPlugin
 
 // spree
 //= require admin/spree/spree

--- a/app/assets/javascripts/admin/order_cycles/order_cycles.js.erb.coffee
+++ b/app/assets/javascripts/admin/order_cycles/order_cycles.js.erb.coffee
@@ -7,6 +7,7 @@ angular.module('admin.orderCycles', ['ngTagsInput', 'admin.indexUtils', 'admin.e
                             window.FLATPICKR_DATETIME_DEFAULT, {
                             onOpen: (selectedDates, dateStr, instance) ->
                               instance.setDate(ngModel.$modelValue)
+                              instance.input.dispatchEvent(new Event('focus', { bubbles: true }));
                             }));
 
   .directive 'ofnOnChange', ->

--- a/app/assets/javascripts/admin/util.js.erb
+++ b/app/assets/javascripts/admin/util.js.erb
@@ -9,7 +9,9 @@ $(document).ready(function() {
     fp.setDate(date, true);
   }
   window.FLATPICKR_DATE_DEFAULT = {
-    dateFormat: Spree.translations.flatpickr_date_format,
+    altInput: true,
+    altFormat: Spree.translations.flatpickr_date_format,
+    dateFormat: "Y-m-d",
     locale: I18n.locale,
     plugins: [
         ShortcutButtonsPlugin({
@@ -25,7 +27,9 @@ $(document).ready(function() {
     {},
     window.FLATPICKR_DATE_DEFAULT,
     {
-      dateFormat: Spree.translations.flatpickr_datetime_format,
+      altInput: true,
+      altFormat: Spree.translations.flatpickr_datetime_format,
+      dateFormat: "Y-m-d H:i",
       enableTime: true,
       time_24hr: true,
       plugins: [

--- a/app/assets/javascripts/admin/util.js.erb
+++ b/app/assets/javascripts/admin/util.js.erb
@@ -20,7 +20,8 @@ $(document).ready(function() {
           }],
           label: "or",
           onClick: onClickButtons
-        })
+        }),
+        labelPlugin({})
       ]
   }
   window.FLATPICKR_DATETIME_DEFAULT = Object.assign(
@@ -39,7 +40,8 @@ $(document).ready(function() {
           }],
           label: "or",
           onClick: onClickButtons
-        })
+        }),
+        labelPlugin({})
       ]
     }
   );

--- a/app/assets/stylesheets/admin/components/date-picker.scss
+++ b/app/assets/stylesheets/admin/components/date-picker.scss
@@ -17,7 +17,9 @@ input.datetimepicker {
   min-width: 12.9em;
 }
 
-.container input[readonly].flatpickr-input {
+.container input[readonly].flatpickr-input,
+.container input[readonly].datepicker,
+.container input[readonly].datetimepicker {
   background-color: $white;
   cursor: pointer;
 }

--- a/app/views/admin/order_cycles/_name_and_timing_form.html.haml
+++ b/app/views/admin/order_cycles/_name_and_timing_form.html.haml
@@ -11,7 +11,7 @@
     = f.label :orders_open_at, t('.orders_open')
   .omega.six.columns.fullwidth_inputs
     - if viewing_as_coordinator_of?(@order_cycle)
-      = f.text_field :orders_open_at, 'datetimepicker' => 'order_cycle.orders_open_at', 'ng-model' => 'order_cycle.orders_open_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'
+      = f.text_field :orders_open_at, 'datetimepicker' => 'order_cycle.orders_open_at', 'ng-model' => 'order_cycle.orders_open_at', 'ng-if' => 'loaded()', 'change-warning' => 'order_cycle', class: "datetimepicker"
     - else
       {{ order_cycle.orders_open_at }}
 
@@ -24,7 +24,7 @@
     = f.label :orders_close, t('.orders_close')
   .six.columns.omega.fullwidth_inputs
     - if viewing_as_coordinator_of?(@order_cycle)
-      = f.text_field :orders_close_at, 'datetimepicker' => 'order_cycle.orders_close_at', 'ng-model' => 'order_cycle.orders_close_at', 'ng-disabled' => '!loaded()', 'change-warning' => 'order_cycle'
+      = f.text_field :orders_close_at, 'datetimepicker' => 'order_cycle.orders_close_at', 'ng-model' => 'order_cycle.orders_close_at', 'ng-if' => 'loaded()', 'change-warning' => 'order_cycle', class: "datetimepicker"
     - else
       {{ order_cycle.orders_close_at }}
 

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -21,12 +21,12 @@
       %label{ :for => 'start_date_filter' }
         = t("admin.start_date")
       %br
-      %input.fullwidth{ :type => "text", :id => 'start_date_filter', 'ng-model' => 'startDate', 'datepicker' => "startDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()', 'ng-model-options' => '{ debounce: 1000 }' }
+      %input.fullwidth.datepicker{ :type => "text", :id => 'start_date_filter', 'ng-model' => 'startDate', 'datepicker' => "startDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()', 'ng-model-options' => '{ debounce: 1000 }' }
     .date_filter{ :class => "two columns" }
       %label{ :for => 'end_date_filter' }
         = t("admin.end_date")
       %br
-      %input.fullwidth{ :type => "text", :id => 'end_date_filter', 'ng-model' => 'endDate', 'datepicker' => "endDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()', 'ng-model-options' => '{ debounce: 1000 }' }
+      %input.fullwidth.datepicker{ :type => "text", :id => 'end_date_filter', 'ng-model' => 'endDate', 'datepicker' => "endDate", 'confirm-change' => "confirmRefresh()", 'ng-change' => 'refreshData()', 'ng-model-options' => '{ debounce: 1000 }' }
     .one.column &nbsp;
     .filter_select{ :class => "three columns" }
       %label{ :for => 'supplier_filter' }

--- a/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
@@ -128,8 +128,8 @@ feature '
     toggle_columns "Producers", "Shops"
 
     expect(page).to have_input "oc#{oc.id}[name]", value: "Plums & Avos"
-    expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: order_cycle_opening_time.strftime("%F %T %z")
-    expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: order_cycle_closing_time.strftime("%F %T %z")
+    expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: Time.at(order_cycle_opening_time), visible: false
+    expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: Time.at(order_cycle_closing_time), visible: false
     expect(page).to have_content "My coordinator"
 
     expect(page).to have_selector 'td.producers', text: 'My supplier'

--- a/spec/features/admin/order_cycles/complex_editing_spec.rb
+++ b/spec/features/admin/order_cycles/complex_editing_spec.rb
@@ -25,8 +25,8 @@ feature '
 
     # Then I should see the basic settings
     expect(page.find('#order_cycle_name').value).to eq(oc.name)
-    expect(page.find('#order_cycle_orders_open_at').value).to eq(oc.orders_open_at.to_s)
-    expect(page.find('#order_cycle_orders_close_at').value).to eq(oc.orders_close_at.to_s)
+    expect(page.find('#order_cycle_orders_open_at').value).to eq(oc.orders_open_at.strftime("%Y-%m-%d %H:%M"))
+    expect(page.find('#order_cycle_orders_close_at').value).to eq(oc.orders_close_at.strftime("%Y-%m-%d %H:%M"))
     expect(page).to have_content "COORDINATOR\n#{oc.coordinator.name}"
 
     click_button 'Next'

--- a/spec/features/admin/order_cycles/list_spec.rb
+++ b/spec/features/admin/order_cycles/list_spec.rb
@@ -53,8 +53,8 @@ feature '
     within('table#listing_order_cycles tbody tr:nth-child(2)') do
       # Then I should see the basic fields
       expect(page).to have_input "oc#{oc1.id}[name]", value: oc1.name
-      expect(page).to have_input "oc#{oc1.id}[orders_open_at]", value: oc1.orders_open_at
-      expect(page).to have_input "oc#{oc1.id}[orders_close_at]", value: oc1.orders_close_at
+      expect(page).to have_input "oc#{oc1.id}[orders_open_at]", value: oc1.orders_open_at, visible: false
+      expect(page).to have_input "oc#{oc1.id}[orders_close_at]", value: oc1.orders_close_at, visible: false
       expect(page).to have_content oc1.coordinator.name
 
       # And I should see the suppliers and distributors

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -496,8 +496,8 @@ feature '
       oc = OrderCycle.last
 
       expect(page).to have_input "oc#{oc.id}[name]", value: "Plums & Avos"
-      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0).strftime("%F %T %z")
-      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 0o0, 0o0).strftime("%F %T %z")
+      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0).strftime("%F %T %z"), visible: false
+      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 0o0, 0o0).strftime("%F %T %z"), visible: false
 
       # And it should have some variants selected
       expect(oc.exchanges.incoming.first.variants.count).to eq(2)
@@ -529,8 +529,8 @@ feature '
 
       # Then I should see the basic settings
       expect(page).to have_field 'order_cycle_name', with: oc.name
-      expect(page).to have_field 'order_cycle_orders_open_at', with: oc.orders_open_at.to_s
-      expect(page).to have_field 'order_cycle_orders_close_at', with: oc.orders_close_at.to_s
+      expect(page).to have_field 'order_cycle_orders_open_at', with: oc.orders_open_at.strftime("%Y-%m-%d %H:%M")
+      expect(page).to have_field 'order_cycle_orders_close_at', with: oc.orders_close_at.strftime("%Y-%m-%d %H:%M")
       expect(page).to have_field 'order_cycle_outgoing_exchange_0_pickup_time', with: 'pickup time'
       expect(page).to have_field 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
 
@@ -587,8 +587,8 @@ feature '
       oc = OrderCycle.last
 
       expect(page).to have_input "oc#{oc.id}[name]", value: "Plums & Avos"
-      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0).strftime("%F %T %z")
-      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 0o0, 0o0).strftime("%F %T %z")
+      expect(page).to have_input "oc#{oc.id}[orders_open_at]", value: Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0).strftime("%F %T %z"), visible: false
+      expect(page).to have_input "oc#{oc.id}[orders_close_at]", value: Time.zone.local(2040, 10, 24, 17, 0o0, 0o0).strftime("%F %T %z"), visible: false
 
       # And it should have a variant selected
       expect(oc.exchanges.incoming.first.variants).to eq([v2])

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -462,8 +462,14 @@ feature '
       expect(page).to have_button('Create', disabled: false)
 
       # If I fill in the basic fields
-      fill_in 'order_cycle_orders_open_at', with: '2040-10-17 06:00:00'
-      fill_in 'order_cycle_orders_close_at', with: '2040-10-24 17:00:00'
+      find('#order_cycle_orders_open_at').click
+      select_datetime_from_datepicker Time.at(Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0))
+      # hide the datetimepicker
+      find("body").send_keys(:escape)
+      find('#order_cycle_orders_close_at').click
+      select_datetime_from_datepicker Time.at(Time.zone.local(2040, 10, 24, 17, 0o0, 0o0))
+      # hide the datetimepicker
+      find("body").send_keys(:escape)
       fill_in 'order_cycle_outgoing_exchange_0_pickup_instructions', with: 'pickup instructions'
 
       # Then my products / variants should already be selected

--- a/spec/support/features/datepicker_helper.rb
+++ b/spec/support/features/datepicker_helper.rb
@@ -12,7 +12,15 @@ module Features
       navigate_datepicker_to_month date
       find('.flatpickr-calendar.open .flatpickr-days .flatpickr-day:not(.prevMonthDay)', text: date.strftime("%e").to_s.strip, exact_text: true, match: :first).click
     end
-    
+
+    def select_datetime_from_datepicker(datetime)
+      ## First of all select date
+      select_date_from_datepicker(datetime)
+      # Then select time
+      find(".flatpickr-calendar.open .flatpickr-hour").set datetime.strftime("%H").to_s.strip
+      find(".flatpickr-calendar.open .flatpickr-minute").set datetime.strftime("%M").to_s.strip
+    end
+
     def navigate_datepicker_to_month(date, reference_date = Time.zone.today)
       month_and_year = date.strftime("%-m %Y")
       

--- a/spec/support/request/web_helper.rb
+++ b/spec/support/request/web_helper.rb
@@ -22,10 +22,12 @@ module WebHelper
     selector  = "[name='#{name}']"
     selector += "[placeholder='#{opts[:placeholder]}']" if opts.key? :placeholder
 
-    element = page.all(selector).first
+    visible = opts.key?(:visible) ? opts[:visible] : true
+    
+    element = page.all(selector, visible: visible).first
     expect(element.value).to eq(opts[:with]) if element && opts.key?(:with)
 
-    have_selector selector
+    have_selector selector, visible: visible
   end
 
   def fill_in_fields(field_values)


### PR DESCRIPTION
#### What? Why?
Closes #6917

This aim of this PR is to separate date format used for communication between backend and frontend and date format visible in the input for the end user.
 - Date format used by both back and front end is fixed.
 - Date format visible by end user is i18nized (and named `altFormat` by flatpickr)


#### What should we test?
The issue has been found by using another language than english (a language that doesn't use the date format : `Y-m-d` or `Y-m-d H:i` for its date(time)picker) on pre-filled form. I do recommend to test all the date(time)picker of the platform with another language than english (such as `FR`), and have a special attention to whom pre-filled (as far as i know: `/admin/reports/orders_and_fulfillment` and `/admin/orders/bulk_management`).


##### List of date(time)picker: 

 - `/admin/order_cycles/`
 - `/admin/order_cycles/[ORDER_ID]/edit`
 - `/admin/reports` such as `/order_management/reports/bulk_coop/new` or `admin/reports/orders_and_fulfillment? report_type=order_cycle_customer_totals`
 - 
 - `/admin/orders/bulk_management`
 - `/admin/orders?q[s]=completed_at+desc#`
 - `/admin/order_cycles/new` (create new order cycle)
 
for reference, the PR which introduce the new datepicker: #6691


#### Release notes
Fix display issue from datepicker when language wasn't english.

Changelog Category: User facing changes
