### PR TITLE
Ensure unit_value is a number

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -64,8 +64,8 @@ module Spree
     }
 
     before_validation :set_cost_currency
-    before_validation :update_weight_from_unit_value, if: ->(v) { v.product.present? }
     before_validation :ensure_unit_value
+    before_validation :update_weight_from_unit_value, if: ->(v) { v.product.present? }
 
     after_save :save_default_price
     after_save :update_units
@@ -300,7 +300,7 @@ module Spree
     end
 
     def ensure_unit_value
-      return unless product&.variant_unit == "items" && unit_value.nil?
+      return unless (product&.variant_unit == "items" && unit_value.nil?) || unit_value&.nan?
 
       self.unit_value = 1.0
     end

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -300,6 +300,7 @@ module Spree
     end
 
     def ensure_unit_value
+      Bugsnag.notify("Trying to set unit_value to NaN") if unit_value&.nan?
       return unless (product&.variant_unit == "items" && unit_value.nil?) || unit_value&.nan?
 
       self.unit_value = 1.0

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -799,5 +799,13 @@ module Spree
         expect(variant.unit_value).to eq 1
       end
     end
+
+    context "trying to set an invalid unit_value" do
+      it "does not allow NaN" do
+        variant.update(unit_value: Float::NAN)
+
+        expect(variant.reload.unit_value).to eq(1.0)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #6527 
Closes #6737 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This is a lighter weight approach than https://github.com/openfoodfoundation/openfoodnetwork/pull/6872; it's less guaranteed to work 100%, but I'm fairly confident that the way these variants are getting corrupted is that we're setting `unit_value` to `Float::NAN` and then the weight is getting set in the other `before_validation` method. Unless I'm missing something, this should prevent that from happening. 

#### What should we test?
<!-- List which features should be tested and how. -->
More of a prod-test to keep an eye out for that bug recurring. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug that would cause the shopfront to not completely load.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
