### PR TITLE
Fix the issue #6892

### DIFF
--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -57,7 +57,9 @@
       %span
         = t("admin.orders.bulk_management.shared")
     .eight.columns
-      %h6.text-center{ 'ng-show' => 'sharedResource' } {{ selectedUnitsProduct.name + ": ALL" }}
+      %h6.text-center{ 'ng-show' => 'sharedResource' } 
+        {{ selectedUnitsProduct.name + ": " }}
+        = t('admin.orders.bulk_management.all')
       %h6.text-center{ 'ng-hide' => 'sharedResource' } {{ selectedUnitsVariant.full_name }}
     .three.columns
       %h6.text-right

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -684,6 +684,7 @@ en:
         max_fulfilled_units: "Max Fulfilled Units"
         order_error: "Some errors must be resolved before you can update orders.\nAny fields with red borders contain errors."
         variants_without_unit_value: "WARNING: Some variants do not have a unit value"
+        all: "All"
       select_variant: "Select a variant"
     enterprise:
       select_outgoing_oc_products_from: Select outgoing OC products from


### PR DESCRIPTION
#### What? Why?

Closes #6892

There is a translation missing in Orders Bulk Management. The "ALL" text in the page was a plain text and not a translation.
The solution I propose is to add the translation in the place where the text was and create a key in `config/locales/en.yml` to correctly place a translation for the text so Transifex can do his magic.



#### What should we test?
Test if Transifex call correctly the translation for the word in the right place.



#### Release notes
Fix missing translation in Bulk Management



#### Dependencies
No dependencies



#### Documentation updates
I don't think so.
