### PR TITLE
[Adjustments] Paypal adjustments test coverage

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -150,9 +150,7 @@ module Spree
     def payment_details(order)
       items = itemized_contents(order)
       item_sum = items.sum { |i| i[:Quantity] * i[:Amount][:value] }
-
-      tax_adjustments = current_order.adjustments.tax.additional
-      tax_adjustments_total = tax_adjustments.sum(:amount)
+      tax_adjustments_total = current_order.all_adjustments.tax.additional.sum(:amount)
 
       if item_sum.zero?
         # Paypal does not support no items or a zero dollar ItemTotal

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -74,19 +74,6 @@ module Spree
 
     private
 
-    def line_item(item)
-      {
-        Name: item.product.name,
-        Number: item.variant.sku,
-        Quantity: item.quantity,
-        Amount: {
-          currencyID: item.order.currency,
-          value: item.price
-        },
-        ItemCategory: "Physical"
-      }
-    end
-
     def express_checkout_request_details(order)
       {
         SetExpressCheckoutRequestDetails: {
@@ -148,7 +135,8 @@ module Spree
     end
 
     def payment_details(order)
-      items = itemized_contents(order)
+      items = PaypalItemsBuilder.new(order).call
+
       item_sum = items.sum { |i| i[:Quantity] * i[:Amount][:value] }
       tax_adjustments_total = current_order.all_adjustments.tax.additional.sum(:amount)
 
@@ -184,33 +172,6 @@ module Spree
           ShippingMethod: "Shipping Method Name Goes Here",
           PaymentAction: "Sale"
         }
-      end
-    end
-
-    def itemized_contents(order)
-      items = order.line_items.map(&method(:line_item))
-
-      tax_adjustments = order.adjustments.tax.additional
-      shipping_adjustments = order.adjustments.shipping
-
-      order.adjustments.eligible.each do |adjustment|
-        next if (tax_adjustments + shipping_adjustments).include?(adjustment)
-
-        items << {
-          Name: adjustment.label,
-          Quantity: 1,
-          Amount: {
-            currencyID: order.currency,
-            value: adjustment.amount
-          }
-        }
-      end
-
-      # Because PayPal doesn't accept $0 items at all.
-      # See https://github.com/spree-contrib/better_spree_paypal_express/issues/10
-      # "It can be a positive or negative value but not zero."
-      items.reject! do |item|
-        item[:Amount][:value].zero?
       end
     end
 

--- a/app/services/paypal_items_builder.rb
+++ b/app/services/paypal_items_builder.rb
@@ -8,10 +8,10 @@ class PaypalItemsBuilder
   def call
     items = order.line_items.map(&method(:line_item_data))
 
-    tax_adjustments = order.adjustments.tax
-    shipping_adjustments = order.adjustments.shipping
+    tax_adjustments = order.all_adjustments.tax
+    shipping_adjustments = order.all_adjustments.shipping
 
-    order.adjustments.eligible.each do |adjustment|
+    order.all_adjustments.eligible.each do |adjustment|
       next if (tax_adjustments + shipping_adjustments).include?(adjustment)
 
       items << adjustment_data(adjustment)

--- a/app/services/paypal_items_builder.rb
+++ b/app/services/paypal_items_builder.rb
@@ -15,11 +15,9 @@ class PaypalItemsBuilder
     # Because PayPal doesn't accept $0 items at all.
     # See https://github.com/spree-contrib/better_spree_paypal_express/issues/10
     # "It can be a positive or negative value but not zero."
-    items.reject! do |item|
+    items.reject do |item|
       item[:Amount][:value].zero?
     end
-
-    items
   end
 
   private

--- a/app/services/paypal_items_builder.rb
+++ b/app/services/paypal_items_builder.rb
@@ -8,11 +8,7 @@ class PaypalItemsBuilder
   def call
     items = order.line_items.map(&method(:line_item_data))
 
-    shipping_and_tax_adjustments = order.all_adjustments.shipping + order.all_adjustments.tax
-
-    order.all_adjustments.eligible.each do |adjustment|
-      next if shipping_and_tax_adjustments.include?(adjustment)
-
+    relevant_adjustments.each do |adjustment|
       items << adjustment_data(adjustment)
     end
 
@@ -29,6 +25,11 @@ class PaypalItemsBuilder
   private
 
   attr_reader :order
+
+  def relevant_adjustments
+    # Tax total and shipping costs are added separately, so they're not included here.
+    order.all_adjustments.eligible - order.all_adjustments.tax - order.all_adjustments.shipping
+  end
 
   def line_item_data(item)
     {

--- a/app/services/paypal_items_builder.rb
+++ b/app/services/paypal_items_builder.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class PaypalItemsBuilder
+  def initialize(order)
+    @order = order
+  end
+
+  def call
+    items = order.line_items.map(&method(:line_item))
+
+    tax_adjustments = order.adjustments.tax.additional
+    shipping_adjustments = order.adjustments.shipping
+
+    order.adjustments.eligible.each do |adjustment|
+      next if (tax_adjustments + shipping_adjustments).include?(adjustment)
+
+      items << {
+        Name: adjustment.label,
+        Quantity: 1,
+        Amount: {
+          currencyID: order.currency,
+          value: adjustment.amount
+        }
+      }
+    end
+
+    # Because PayPal doesn't accept $0 items at all.
+    # See https://github.com/spree-contrib/better_spree_paypal_express/issues/10
+    # "It can be a positive or negative value but not zero."
+    items.reject! do |item|
+      item[:Amount][:value].zero?
+    end
+
+    items
+  end
+
+  private
+
+  attr_reader :order
+
+  def line_item(item)
+    {
+      Name: item.product.name,
+      Number: item.variant.sku,
+      Quantity: item.quantity,
+      Amount: {
+        currencyID: item.order.currency,
+        value: item.price
+      },
+      ItemCategory: "Physical"
+    }
+  end
+end

--- a/app/services/paypal_items_builder.rb
+++ b/app/services/paypal_items_builder.rb
@@ -8,11 +8,10 @@ class PaypalItemsBuilder
   def call
     items = order.line_items.map(&method(:line_item_data))
 
-    tax_adjustments = order.all_adjustments.tax
-    shipping_adjustments = order.all_adjustments.shipping
+    shipping_and_tax_adjustments = order.all_adjustments.shipping + order.all_adjustments.tax
 
     order.all_adjustments.eligible.each do |adjustment|
-      next if (tax_adjustments + shipping_adjustments).include?(adjustment)
+      next if shipping_and_tax_adjustments.include?(adjustment)
 
       items << adjustment_data(adjustment)
     end

--- a/app/services/paypal_items_builder.rb
+++ b/app/services/paypal_items_builder.rb
@@ -8,7 +8,7 @@ class PaypalItemsBuilder
   def call
     items = order.line_items.map(&method(:line_item_data))
 
-    tax_adjustments = order.adjustments.tax.additional
+    tax_adjustments = order.adjustments.tax
     shipping_adjustments = order.adjustments.shipping
 
     order.adjustments.eligible.each do |adjustment|

--- a/spec/services/paypal_items_builder_spec.rb
+++ b/spec/services/paypal_items_builder_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe PaypalItemsBuilder do
+  let(:order) { create(:completed_order_with_fees) }
+  let(:service) { described_class.new(order) }
+  let(:items) { described_class.new(order).call }
+
+  it "lists line items" do
+    line_item = order.line_items.first
+
+    expect(items.first[:Name]).to eq line_item.variant.name
+    expect(items.first[:Number]).to eq line_item.variant.sku
+    expect(items.first[:Quantity]).to eq line_item.quantity
+    expect(items.first[:Amount]).to eq(currencyID: order.currency,
+                                       value: line_item.price)
+    expect(items.first[:ItemCategory]).to eq "Physical"
+  end
+
+  context "listing adjustments" do
+    let!(:admin_adjustment) {
+      create(:adjustment, label: "Admin Adjustment", order: order, adjustable: order,
+                          amount: 12, source: nil, originator: nil, state: "closed")
+    }
+    let!(:ineligible_adjustment) {
+      create(:adjustment, label: "Ineligible Adjustment", order: order, adjustable: order,
+                          amount: 34, eligible: false, state: "closed")
+    }
+    let!(:zone) { create(:zone_with_member) }
+    let!(:included_tax_rate) {
+      create(:tax_rate, amount: 12, included_in_price: true, zone: zone,
+                        calculator: ::Calculator::DefaultTax.new)
+    }
+    let!(:additional_tax_rate) {
+      create(:tax_rate, amount: 34, included_in_price: false, zone: zone,
+                        calculator: ::Calculator::DefaultTax.new)
+    }
+    let!(:included_tax_adjustment) {
+      create(:adjustment, label: "Included Tax Adjustment", order: order,
+                          adjustable: order.line_items.first, amount: 56,
+                          originator: included_tax_rate, included: true, state: "closed")
+    }
+    let!(:additional_tax_adjustment) {
+      create(:adjustment, label: "Additional Tax Adjustment", order: order, adjustable: order,
+                          amount: 78, originator: additional_tax_rate, state: "closed")
+    }
+    let!(:enterprise_fee) { create(:enterprise_fee) }
+    let!(:line_item_enterprise_fee) {
+      create(:adjustment, label: "Line Item Fee", order: order, adjustable: order,
+                          amount: 91, originator: enterprise_fee, source: order.line_items.first,
+                          state: "closed")
+    }
+    let!(:order_enterprise_fee) {
+      create(:adjustment, label: "Order Fee", order: order, adjustable: order,
+                          amount: 23, originator: enterprise_fee, state: "closed")
+    }
+
+    it "should add up to the order total, minus any additional tax and the shipping cost" do
+      items_total = items.sum { |i| i[:Quantity] * i[:Amount][:value] }
+      order_tax_total = order.all_adjustments.tax.additional.sum(:amount)
+
+      expect(items_total).to eq(order.total - order_tax_total - order.ship_total)
+    end
+
+    it "lists the payment fee adjustment" do
+      payment_fee = items.find{ |i| i[:Name] == I18n.t('payment_method_fee') }
+
+      expect(payment_fee[:Quantity]).to eq 1
+      expect(payment_fee[:Amount]).to eq(currencyID: order.currency,
+                                         value: order.all_adjustments.payment_fee.first.amount)
+    end
+
+    it "lists admin adjustments" do
+      admin_item = items.find{ |i| i[:Name] == admin_adjustment.label }
+
+      expect(order.all_adjustments.admin.count).to eq 1
+      expect(admin_item[:Quantity]).to eq 1
+      expect(admin_item[:Amount]).to eq(currencyID: order.currency,
+                                        value: order.all_adjustments.admin.first.amount)
+    end
+
+    it "lists enterprise fee adjustments" do
+      line_item_fee = items.find{ |i| i[:Name] == line_item_enterprise_fee.label }
+      order_fee = items.find{ |i| i[:Name] == order_enterprise_fee.label }
+
+      expect(order.all_adjustments.enterprise_fee.count).to eq 2
+
+      expect(line_item_fee[:Quantity]).to eq 1
+      expect(line_item_fee[:Amount]).to eq(currencyID: order.currency,
+                                           value: line_item_enterprise_fee.amount)
+      expect(order_fee[:Quantity]).to eq 1
+      expect(order_fee[:Amount]).to eq(currencyID: order.currency,
+                                       value: order_enterprise_fee.amount)
+    end
+
+    it "does not list tax adjustments" do
+      tax_adjustment_items = items.select do |i|
+        i[:Name].in? [additional_tax_adjustment.label, included_tax_adjustment.label]
+      end
+
+      expect(order.all_adjustments.tax.inclusive.count).to eq 1
+      expect(order.all_adjustments.tax.additional.count).to eq 1
+      expect(tax_adjustment_items.count).to be_zero
+    end
+
+    it "does not list the shipping fee" do
+      shipping_fee_item = items.find{ |i| i[:Name] == I18n.t('shipping') }
+
+      expect(order.all_adjustments.shipping.count).to eq 1
+      expect(shipping_fee_item).to be_nil
+    end
+
+    it "does not list ineligible adjustments" do
+      ineligible_item = items.detect{ |i| i[:Name] == ineligible_adjustment.label }
+
+      expect(order.adjustments.where(eligible: false).count).to eq 1
+      expect(ineligible_item).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Part 1 of #6928 

Improves test coverage on the way adjustments are listed/included when building a Paypal payment. Extracts the logic to a service and tests it. Some of this coverage was not adequate, meaning that changes to adjustments code were not triggering relevant test failures.

Also future-proofs the adjustments-fetching logic a bit, so it will work with upcoming adjustments changes without needing to be rewritten.

#### What should we test?
<!-- List which features should be tested and how. -->

Paypal payments on orders with adjustments should have correct totals.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Increased test coverage on Paypal adjustments handling

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
