### PR TITLE
Create independent title string for 'Map' page

### DIFF
--- a/app/views/map/index.html.haml
+++ b/app/views/map/index.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title) do
-  = t :label_map
+  = t :map_title
 
 - content_for :injection_data do
   = inject_available_countries

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1682,6 +1682,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
 
   maps_open: "Open"
   maps_closed: "Closed"
+  map_title: "Map"
 
   hubs_buy: "Shop for:"
   hubs_shopping_here: "Shopping here"


### PR DESCRIPTION
#### What? Why?

The "map" page didn't have a separate Transifex string for the page title. Instead the string 'label_map' was being used, which is also used elsewhere on the website. So no good idea to change that.
To make the page title independent from 'label_map' the title string is changed to 'map_title' (like on shops page, producers page etc.).

#### What should we test?

- The string named 'map_title' is displayed as the page title on the 'map' page.
- Changing the value of 'map_title' changes the page title on the 'map' page.

#### Release notes

Make the page title of the 'map' page editable.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes