### PR TITLE
Fix #6949: Add default icon value if enterprise.category is nil

### DIFF
--- a/app/serializers/api/cached_enterprise_serializer.rb
+++ b/app/serializers/api/cached_enterprise_serializer.rb
@@ -129,7 +129,7 @@ module Api
         producer_shop: "map_003-producer-shop.svg",
         producer: "map_001-producer-only.svg",
       }
-      "/map_icons/" + icons[enterprise.category]
+      "/map_icons/" + (icons[enterprise.category] || "map_001-producer-only.svg")
     end
 
     # Choose regular icon font for enterprises.

--- a/app/serializers/api/enterprise_shopfront_list_serializer.rb
+++ b/app/serializers/api/enterprise_shopfront_list_serializer.rb
@@ -19,7 +19,7 @@ module Api
         producer_shop: "map_003-producer-shop.svg",
         producer: "map_001-producer-only.svg",
       }
-      "/map_icons/" + icons[enterprise.category]
+      "/map_icons/" + (icons[enterprise.category] || "map_001-producer-only.svg")
     end
 
     def icon_font

--- a/spec/serializers/api/cached_enterprise_serializer_spec.rb
+++ b/spec/serializers/api/cached_enterprise_serializer_spec.rb
@@ -97,4 +97,26 @@ describe Api::CachedEnterpriseSerializer do
       end
     end
   end
+
+  describe '#icon' do
+    context "enterpise has a unrecognized category" do
+      before do
+        allow(enterprise).to receive(:category) { "unknown_category" }
+      end
+
+      it "returns the map producer icon" do
+        expect(cached_enterprise_serializer.icon).to eq("/map_icons/map_001-producer-only.svg")
+      end
+    end
+
+    context "enterpise has a nil category" do
+      before do
+        allow(enterprise).to receive(:category) { nil }
+      end
+
+      it "returns the map producer icon" do
+        expect(cached_enterprise_serializer.icon).to eq("/map_icons/map_001-producer-only.svg")
+      end
+    end
+  end
 end

--- a/spec/serializers/api/enterprise_shopfront_list_serializer_spec.rb
+++ b/spec/serializers/api/enterprise_shopfront_list_serializer_spec.rb
@@ -19,4 +19,26 @@ describe Api::EnterpriseShopfrontListSerializer do
   it "serializes icons" do
     expect(serializer.to_json).to match "map_005-hub.svg"
   end
+
+  describe '#icon' do
+    context "enterpise has a unrecognized category" do
+      before do
+        allow(enterprise).to receive(:category) { "unknown_category" }
+      end
+
+      it "returns the map producer icon" do
+        expect(serializer.icon).to eq("/map_icons/map_001-producer-only.svg")
+      end
+    end
+
+    context "enterpise has a nil category" do
+      before do
+        allow(enterprise).to receive(:category) { nil }
+      end
+
+      it "returns the map producer icon" do
+        expect(serializer.icon).to eq("/map_icons/map_001-producer-only.svg")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #6949 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This protects against a nil value when looking up the icon to display for an enterprise.


#### What should we test?
<!-- List which features should be tested and how. -->
None/green build.



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug that would cause an shop's icon to not appear on the group map. 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
