### PR TITLE
Don't charge duplicate fees for pending SCA payments

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -126,7 +126,9 @@ module Spree
     end
 
     def ensure_correct_adjustment
-      revoke_adjustment_eligibility if ['failed', 'invalid'].include?(state)
+      if ['failed', 'invalid'].include?(state) || authorization_action_required?
+        revoke_adjustment_eligibility
+      end
       return if adjustment.try(:finalized?)
 
       if adjustment
@@ -141,6 +143,10 @@ module Spree
 
     def adjustment_label
       I18n.t('payment_method_fee')
+    end
+
+    def reinstate_adjustment_eligibility!
+      adjustment.update_attribute(:eligible, true)
     end
 
     private

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -19,6 +19,7 @@ class ProcessPaymentIntent
     return unless valid?
 
     last_payment.update_attribute(:cvv_response_message, nil)
+    last_payment.reinstate_adjustment_eligibility!
     OrderWorkflow.new(@order).next
     last_payment.complete! if !last_payment.completed?
   end

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -32,6 +32,7 @@ describe ProcessPaymentIntent do
 
       before do
         allow(order).to receive(:deliver_order_confirmation_email)
+        payment.adjustment.update_attribute(:eligible, false)
       end
 
       it "completes the payment" do
@@ -39,6 +40,7 @@ describe ProcessPaymentIntent do
         payment.reload
         expect(payment.state).to eq("completed")
         expect(payment.cvv_response_message).to be nil
+        expect(payment.adjustment.eligible).to be true
       end
 
       it "completes the order" do


### PR DESCRIPTION


#### What? Why?

Close #6683
Here we mark an adjustment as ineligible if there SCA auth is required on a payment. Then when the customer completes SCA authorization, we process the payment intent and mark the adjustment as eligible again. 
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Creating a payment that requires SCA authorization should not add a transaction fee to the order until the payment is authorized by the customer. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where back office payments would create duplicate transaction fees each time a payment failed or needed authorization. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
