### PR TITLE
Fix #6964: don't try to complete a failed payment

### DIFF
--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -20,7 +20,7 @@ class ProcessPaymentIntent
 
     last_payment.update_attribute(:cvv_response_message, nil)
     OrderWorkflow.new(@order).next
-    last_payment.complete! if !last_payment.completed?
+    last_payment.complete! if last_payment.can_complete?
   end
 
   private

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -47,5 +47,19 @@ describe ProcessPaymentIntent do
         expect(order).to have_received(:deliver_order_confirmation_email)
       end
     end
+
+    context "payment is in a failed state" do
+      let(:invalid_intent) { "invalid" }
+      let(:service) { ProcessPaymentIntent.new(invalid_intent, order) }
+
+      before do
+        payment.update_attribute(:state, "failed")
+      end
+
+      it "does not complete the payment" do
+        service.call!
+        expect(payment.reload.state).to eq("failed")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #6964 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Here we only complete a payment if it's in a state where it can be completed, and list those states explicitly


#### What should we test?
<!-- List which features should be tested and how. -->
Choosing not to authorize an SCA payment should not result in a snail. 

This might be pretty difficult to write an automated test for since we're testing what happens when the customer interacts with the Stripe website. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
I don't think this is happening in production

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
