### PR TITLE
Add missing Spree translation keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3153,7 +3153,9 @@ See the %{link} to find out more about %{sitename}'s features and to start using
 
     shipping_methods: "Shipping Methods"
     shipping_method: "Shipping Method"
-
+    shipment: "Shipment"
+    payment: "Payment"
+    status: "Status"
     shipping_categories: "Shipping Categories"
     new_shipping_category: "New Shipping Category"
     back_to_shipping_categories: "Back To Shipping Categories"


### PR DESCRIPTION
#### What? Why?

Adds some missing Spree translation keys. Missing translation warnings have come up for these keys in test output.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added some missing translation keys.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
