### PR TITLE
Require unit_value to be a number in the form

### DIFF
--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -11,7 +11,7 @@
       .field{'ng-controller' => 'variantUnitsCtrl'}
         = f.label :unit_value, "#{t('admin.'+@product.variant_unit)} ({{unitName(#{@product.variant_unit_scale}, '#{@product.variant_unit}')}})"
         = hidden_field_tag 'product_variant_unit_scale', @product.variant_unit_scale
-        = text_field_tag :unit_value_human, nil, {class: "fullwidth", 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
+        = number_field_tag :unit_value_human, nil, {step: "any", class: "fullwidth", 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
         = f.text_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}
 
     .field


### PR DESCRIPTION
#### What? Why?

This "further fixes" #6527 by adding to https://github.com/openfoodfoundation/openfoodnetwork/pull/6926

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Editing a variant and entering, e.g. "1-2" or any non-number. Decimals (e.g. `1.3`) should be allowed. 

I think we have adequate test coverage in #6926. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Added an error message to the Edit Variant form to warn that non-numbers are not allowed for weight. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
