### PR TITLE
Remove duplicate specs

### DIFF
--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -157,47 +157,6 @@ module Api
           expect(json_response['pagination']).to eq pagination_data
         end
       end
-
-      context "when there is a pending payment requiring authorization" do
-        let!(:pending_payment) do
-          create(
-            :payment,
-            order: order1,
-            state: 'pending',
-            amount: 123.45,
-            cvv_response_message: "https://stripe.com/redirect"
-          )
-        end
-
-        before do
-          allow(controller).to receive(:spree_current_user) { distributor.owner }
-        end
-
-        it "returns false" do
-          get :index
-          expect(json_response['orders'].first['ready_to_capture']).to eq(false)
-        end
-      end
-
-      context "when there is a pending payment but it does not require authorization" do
-        let!(:pending_payment) do
-          create(
-            :payment,
-            order: order1,
-            state: 'pending',
-            amount: 123.45,
-          )
-        end
-
-        before do
-          allow(controller).to receive(:spree_current_user) { distributor.owner }
-        end
-
-        it "returns true" do
-          get :index
-          expect(json_response['orders'].first['ready_to_capture']).to eq(true)
-        end
-      end
     end
 
     describe "#show" do


### PR DESCRIPTION
#### What? Why?

The second of these is flaky; moreover, the OrdersController doesn't specifically have a method that they're testing. I think the ready_to_capture behaviors is adequately covered by https://github.com/openfoodfoundation/openfoodnetwork/blob/006236b8ddb90010826d7b56dc907c18f397244a/spec/serializers/api/admin/order_serializer_spec.rb#L39-L68


#### What should we test?
Green, non-flaky build.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Removed redundant specs
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
