### PR TITLE
[Adjustments] Persist shipment_total on orders

### DIFF
--- a/app/controllers/api/shipments_controller.rb
+++ b/app/controllers/api/shipments_controller.rb
@@ -27,13 +27,13 @@ module Api
       unlock = params[:shipment].delete(:unlock)
 
       if unlock == 'yes'
-        @shipment.adjustment.open
+        @shipment.fee_adjustment.open
       end
 
       @shipment.update(shipment_params[:shipment])
 
       if unlock == 'yes'
-        @shipment.adjustment.close
+        @shipment.fee_adjustment.close
       end
 
       render json: @shipment.reload, serializer: Api::ShipmentSerializer, status: :ok

--- a/app/controllers/spree/admin/adjustments_controller.rb
+++ b/app/controllers/spree/admin/adjustments_controller.rb
@@ -15,7 +15,11 @@ module Spree
       end
 
       def collection
-        parent.adjustments.eligible
+        parent.adjustments.eligible | parent.shipment_adjustments.shipping
+      end
+
+      def find_resource
+        parent.all_adjustments.eligible.find(params[:id])
       end
 
       # Choose a default tax rate to show on the edit form. The adjustment stores its included

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -7,7 +7,7 @@ module CheckoutHelper
     adjustments = order.adjustments.eligible
     exclude = opts[:exclude] || {}
 
-    adjustments = adjustments.to_a
+    adjustments = adjustments.to_a + order.shipment_adjustments.to_a
 
     # Remove empty tax adjustments and (optionally) shipping fees
     adjustments.reject! { |a| a.originator_type == 'Spree::TaxRate' && a.amount == 0 }

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -38,6 +38,8 @@ module Spree
     belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address'
     alias_attribute :shipping_address, :ship_address
 
+    alias_attribute :ship_total, :shipment_total
+
     has_many :state_changes, as: :stateful
     has_many :line_items, -> { order('created_at ASC') }, dependent: :destroy
     has_many :payments, dependent: :destroy
@@ -68,7 +70,7 @@ module Spree
     accepts_nested_attributes_for :payments
     accepts_nested_attributes_for :shipments
 
-    delegate :admin_and_handling_total, :payment_fee, :ship_total, to: :adjustments_fetcher
+    delegate :admin_and_handling_total, :payment_fee, to: :adjustments_fetcher
     delegate :update_totals, to: :updater
     delegate :create_line_item_fees!, :create_order_fees!, :update_order_fees!,
              :update_line_item_fees!, :recreate_all_fees!, to: :fee_handler
@@ -392,10 +394,6 @@ module Spree
 
     def find_line_item_by_variant(variant)
       line_items.detect { |line_item| line_item.variant_id == variant.id }
-    end
-
-    def ship_total
-      adjustments.shipping.sum(:amount)
     end
 
     def tax_total

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -631,7 +631,7 @@ module Spree
       shipments.each do |shipment|
         next if shipment.shipped?
 
-        update_adjustment! shipment.adjustment if shipment.adjustment
+        update_adjustment! shipment.fee_adjustment if shipment.fee_adjustment
         save_or_rescue_shipment(shipment)
       end
     end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -47,6 +47,7 @@ module Spree
              dependent: :destroy
 
     has_many :line_item_adjustments, through: :line_items, source: :adjustments
+    has_many :shipment_adjustments, through: :shipments, source: :adjustments
     has_many :all_adjustments, class_name: 'Spree::Adjustment', dependent: :destroy
 
     has_many :shipments, dependent: :destroy do

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -698,7 +698,7 @@ module Spree
     end
 
     def shipping_tax
-      adjustments(:reload).shipping.sum(:included_tax)
+      shipment_adjustments(:reload).shipping.sum(:included_tax)
     end
 
     def enterprise_fee_tax
@@ -706,7 +706,7 @@ module Spree
     end
 
     def total_tax
-      (adjustments.to_a + line_item_adjustments.to_a).sum(&:included_tax)
+      (adjustments.to_a + shipment_adjustments.to_a + line_item_adjustments.to_a).sum(&:included_tax)
     end
 
     def price_adjustment_totals

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -437,7 +437,7 @@ module Spree
     def finalize!
       touch :completed_at
 
-      adjustments.update_all state: 'closed'
+      all_adjustments.update_all state: 'closed'
 
       # update payment and shipment(s) states, and save
       updater.update_payment_state

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -12,7 +12,7 @@ module Spree
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :inventory_units, dependent: :delete_all
-    has_one :adjustment, as: :source, dependent: :destroy
+    has_many :adjustments, as: :adjustable, dependent: :destroy
 
     before_create :generate_shipment_number
     after_save :ensure_correct_adjustment, :update_order
@@ -258,6 +258,10 @@ module Spree
       inventory_units.create(variant_id: variant.id, state: state, order_id: order.id)
     end
 
+    def adjustment
+      @adjustment ||= adjustments.shipping.first
+    end
+
     def ensure_correct_adjustment
       if adjustment
         adjustment.originator = shipping_method
@@ -267,7 +271,7 @@ module Spree
         adjustment.reload
       elsif selected_shipping_rate_id
         shipping_method.create_adjustment(shipping_method.adjustment_label,
-                                          order,
+                                          self,
                                           self,
                                           true,
                                           "open")

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -18,6 +18,7 @@ module Spree
     after_save :ensure_correct_adjustment, :update_order
 
     attr_accessor :special_instructions
+    alias_attribute :amount, :cost
 
     accepts_nested_attributes_for :address
     accepts_nested_attributes_for :inventory_units
@@ -140,15 +141,6 @@ module Spree
     def currency
       order ? order.currency : Spree::Config[:currency]
     end
-
-    # The adjustment amount associated with this shipment (if any)
-    #   Returns only the first adjustment to match the shipment
-    #   There should never really be more than one.
-    def cost
-      adjustment ? adjustment.amount : 0
-    end
-
-    alias_method :amount, :cost
 
     def display_cost
       Spree::Money.new(cost, currency: currency)

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -265,12 +265,12 @@ module Spree
     def ensure_correct_adjustment
       if adjustment
         adjustment.originator = shipping_method
-        adjustment.label = shipping_method.adjustment_label
+        adjustment.label = adjustment_label
         adjustment.amount = selected_shipping_rate.cost if adjustment.open?
         adjustment.save!
         adjustment.reload
       elsif selected_shipping_rate_id
-        shipping_method.create_adjustment(shipping_method.adjustment_label,
+        shipping_method.create_adjustment(adjustment_label,
                                           self,
                                           self,
                                           true,
@@ -280,6 +280,10 @@ module Spree
 
       update_amounts if adjustment
       update_adjustment_included_tax if adjustment
+    end
+
+    def adjustment_label
+      I18n.t('shipping')
     end
 
     private

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -168,6 +168,15 @@ module Spree
       !shipped?
     end
 
+    def update_amounts
+      return unless selected_shipping_rate
+
+      self.update_columns(
+        cost: selected_shipping_rate.cost,
+        updated_at: Time.zone.now
+      )
+    end
+
     def manifest
       inventory_units.group_by(&:variant).map do |variant, units|
         states = {}
@@ -273,6 +282,7 @@ module Spree
         reload # ensure adjustment is present on later saves
       end
 
+      update_amounts if adjustment
       update_adjustment_included_tax if adjustment
     end
 

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -161,10 +161,8 @@ module Spree
     end
 
     def update_amounts
-      return unless selected_shipping_rate
-
-      self.update_columns(
-        cost: selected_shipping_rate.cost,
+      update_columns(
+        cost: adjustment&.amount || 0.0,
         updated_at: Time.zone.now
       )
     end
@@ -278,7 +276,7 @@ module Spree
         reload # ensure adjustment is present on later saves
       end
 
-      update_amounts if adjustment
+      update_amounts if adjustment&.amount != cost
       update_adjustment_included_tax if adjustment
     end
 

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -10,7 +10,7 @@ module Spree
 
     default_scope -> { where(deleted_at: nil) }
 
-    has_many :shipments
+    has_many :shipments, through: :shipping_rates
     has_many :shipping_method_categories
     has_many :shipping_categories, through: :shipping_method_categories
     has_many :shipping_rates, inverse_of: :shipping_method

--- a/app/models/spree/shipping_method.rb
+++ b/app/models/spree/shipping_method.rb
@@ -54,10 +54,6 @@ module Spree
       where("spree_shipping_methods.display_on is null OR spree_shipping_methods.display_on = ''")
     }
 
-    def adjustment_label
-      I18n.t('shipping')
-    end
-
     # Here we allow checkout with shipping methods without zones (see issue #3928 for details)
     #   and also checkout with addresses outside of the zones of the selected shipping method
     # This method could be used, like in Spree, to validate shipping method zones on checkout.

--- a/app/serializers/api/order_detailed_serializer.rb
+++ b/app/serializers/api/order_detailed_serializer.rb
@@ -5,8 +5,16 @@ module Api
     has_one :bill_address, serializer: Api::AddressSerializer
 
     has_many :line_items, serializer: Api::LineItemSerializer
-    has_many :adjustments, serializer: Api::AdjustmentSerializer
 
     has_many :payments, serializer: Api::PaymentSerializer
+
+    attributes :adjustments
+
+    def adjustments
+      adjustments = object.all_adjustments.where(
+        "adjustable_type IN ('Spree::Order','Spree::Shipment')"
+      ).order("label DESC")
+      ActiveModel::ArraySerializer.new(adjustments, each_serializer: Api::AdjustmentSerializer)
+    end
   end
 end

--- a/app/services/order_adjustments_fetcher.rb
+++ b/app/services/order_adjustments_fetcher.rb
@@ -25,10 +25,6 @@ class OrderAdjustmentsFetcher
     sum_adjustments "payment_fee"
   end
 
-  def ship_total
-    sum_adjustments "shipping"
-  end
-
   def line_item_adjustments(line_item)
     if adjustments_eager_loaded?
       adjustments.select{ |adjustment| adjustment.source_id == line_item.id }

--- a/app/services/order_tax_adjustments_fetcher.rb
+++ b/app/services/order_tax_adjustments_fetcher.rb
@@ -22,7 +22,7 @@ class OrderTaxAdjustmentsFetcher
   def all
     Spree::Adjustment
       .with_tax
-      .where(order_adjustments.or(line_item_adjustments))
+      .where(order_adjustments.or(line_item_adjustments).or(shipment_adjustments))
       .order('created_at ASC')
   end
 
@@ -34,6 +34,11 @@ class OrderTaxAdjustmentsFetcher
   def line_item_adjustments
     table[:adjustable_id].eq_any(order.line_item_ids)
       .and(table[:adjustable_type].eq('Spree::LineItem'))
+  end
+
+  def shipment_adjustments
+    table[:order_id].eq(order.id)
+      .and(table[:adjustable_type].eq('Spree::Shipment'))
   end
 
   def table

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -40,7 +40,7 @@
               = label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method)
               = select_tag :selected_shipping_rate_id, options_for_select(shipment.shipping_rates.backend.map { |sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id), { :class => 'select2 fullwidth', :data => { 'shipment-number' => shipment.number } }
 
-            - if shipment.adjustment && shipment.adjustment.closed?
+            - if shipment.fee_adjustment&.closed?
               %div.field.omega.four.columns
                 %label
                   = Spree.t(:associated_adjustment_closed)
@@ -58,18 +58,18 @@
               = link_to '', '', :class => 'cancel-method icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
       %tr.show-method.total
         %td{ :colspan => "4" }
-          - if shipment.adjustment.present?
+          - if shipment.fee_adjustment.present?
             %strong
-              = "#{shipment.adjustment.label}: #{shipment.shipping_method.name}"
+              = "#{shipment.fee_adjustment.label}: #{shipment.shipping_method.name}"
           - else
             = Spree.t(:cannot_set_shipping_method_without_address)
 
         %td.total{ :align => "center" }
-          - if shipment.adjustment.present?
+          - if shipment.fee_adjustment.present?
             %span
-              = shipment.adjustment.display_amount
+              = shipment.fee_adjustment.display_amount
 
-        - if shipment.adjustment.present? && !shipment.shipped?
+        - if shipment.fee_adjustment.present? && !shipment.shipped?
           %td.actions
             - if can? :update, shipment
               = link_to '', '', :class => 'edit-method icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')

--- a/db/migrate/20210207120825_set_default_shipment_cost.rb
+++ b/db/migrate/20210207120825_set_default_shipment_cost.rb
@@ -1,0 +1,11 @@
+class SetDefaultShipmentCost < ActiveRecord::Migration
+  def up
+    change_column_null :spree_shipments, :cost, false, 0.0
+    change_column_default :spree_shipments, :cost, 0.0
+  end
+
+  def down
+    change_column_null :spree_shipments, :cost, true
+    change_column_default :spree_shipments, :cost, nil
+  end
+end

--- a/db/migrate/20210211115125_migrate_shipment_fees_to_shipments.rb
+++ b/db/migrate/20210211115125_migrate_shipment_fees_to_shipments.rb
@@ -1,0 +1,18 @@
+class MigrateShipmentFeesToShipments < ActiveRecord::Migration
+  def up
+    # Shipping fee adjustments currently have the order as the `adjustable` and the shipment as
+    # the `source`. Both `source` and `adjustable` will now be the shipment. The `originator` is
+    # the shipping method, and this is unchanged.
+    Spree::Adjustment.where(originator_type: 'Spree::ShippingMethod').update_all(
+      "adjustable_id = source_id, adjustable_type = 'Spree::Shipment'"
+    )
+  end
+
+  def down
+    # Just in case: reversing this migration requires setting the `adjustable` back to the order.
+    # The type is 'Spree::Order', and the order's id is still available on the `order_id` field.
+    Spree::Adjustment.where(originator_type: 'Spree::ShippingMethod').update_all(
+      "adjustable_id = order_id, adjustable_type = 'Spree::Order'"
+    )
+  end
+end

--- a/db/migrate/20210228130023_add_shipment_total_to_orders.rb
+++ b/db/migrate/20210228130023_add_shipment_total_to_orders.rb
@@ -1,0 +1,10 @@
+class AddShipmentTotalToOrders < ActiveRecord::Migration
+  def up
+    add_column :spree_orders, :shipment_total, :decimal,
+               precision: 10, scale: 2, null: false, default: 0.0
+  end
+
+  def down
+    remove_column :spree_orders, :shipment_total
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -815,12 +815,12 @@ ActiveRecord::Schema.define(version: 20210216203057) do
   create_table "spree_shipments", force: :cascade do |t|
     t.string   "tracking",          limit: 255
     t.string   "number",            limit: 255
-    t.decimal  "cost",                          precision: 10, scale: 2
+    t.decimal  "cost",                          precision: 10, scale: 2, default: 0.0, null: false
     t.datetime "shipped_at"
     t.integer  "order_id"
     t.integer  "address_id"
-    t.datetime "created_at",                                             null: false
-    t.datetime "updated_at",                                             null: false
+    t.datetime "created_at",                                                          null: false
+    t.datetime "updated_at",                                                          null: false
     t.string   "state",             limit: 255
     t.integer  "stock_location_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210216203057) do
+ActiveRecord::Schema.define(version: 20210228130023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -575,6 +575,7 @@ ActiveRecord::Schema.define(version: 20210216203057) do
     t.integer  "created_by_id"
     t.decimal  "included_tax_total",               precision: 10, scale: 2, default: 0.0, null: false
     t.decimal  "additional_tax_total",             precision: 10, scale: 2, default: 0.0, null: false
+    t.decimal  "shipment_total",                   precision: 10, scale: 2, default: 0.0, null: false
   end
 
   add_index "spree_orders", ["completed_at", "user_id", "created_by_id", "created_at"], name: "spree_orders_completed_at_user_id_created_by_id_created_at_idx", using: :btree

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -57,11 +57,12 @@ module OrderManagement
       end
 
       def update_adjustment_total
-        order.adjustment_total = adjustments.eligible.sum(:amount)
+        order.adjustment_total = adjustments.eligible.sum(:amount) +
+                                 all_adjustments.shipping.sum(:amount)
         order.additional_tax_total = all_adjustments.tax.additional.sum(:amount)
         order.included_tax_total = order.line_item_adjustments.tax.sum(:included_tax) +
                                    all_adjustments.enterprise_fee.sum(:included_tax) +
-                                   adjustments.shipping.sum(:included_tax) +
+                                   all_adjustments.shipping.sum(:included_tax) +
                                    adjustments.admin.sum(:included_tax)
       end
 

--- a/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
+++ b/engines/order_management/app/services/order_management/reports/enterprise_fee_summary/scope.rb
@@ -52,7 +52,7 @@ module OrderManagement
 
         def for_orders
           chain_to_scope do
-            where(adjustable_type: "Spree::Order")
+            where(adjustable_type: ["Spree::Order", "Spree::Shipment"])
           end
         end
 
@@ -81,8 +81,7 @@ module OrderManagement
             <<-JOIN_STRING.strip_heredoc
               LEFT OUTER JOIN spree_orders
                 ON (
-                  spree_adjustments.adjustable_type = 'Spree::Order'
-                    AND spree_orders.id = spree_adjustments.adjustable_id
+                  spree_orders.id = spree_adjustments.order_id
                     AND spree_orders.completed_at IS NOT NULL
                 )
             JOIN_STRING

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -27,6 +27,12 @@ module OrderManagement
           expect(order.item_total).to eq(20)
         end
 
+        it "updates shipment total" do
+          allow(order).to receive_message_chain(:shipments, :sum) { 10 }
+          updater.update_shipment_total
+          expect(order.shipment_total).to eq 10
+        end
+
         it "updates adjustment totals" do
           allow(order).to receive_message_chain(:adjustments, :eligible, :sum).and_return(-10)
           allow(order).to receive_message_chain(:all_adjustments, :tax, :additional, :sum).and_return(20)

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -31,11 +31,11 @@ module OrderManagement
           allow(order).to receive_message_chain(:adjustments, :eligible, :sum).and_return(-10)
           allow(order).to receive_message_chain(:all_adjustments, :tax, :additional, :sum).and_return(20)
           allow(order).to receive_message_chain(:all_adjustments, :enterprise_fee, :sum).and_return(10)
-          allow(order).to receive_message_chain(:adjustments, :shipping, :sum).and_return(5)
+          allow(order).to receive_message_chain(:all_adjustments, :shipping, :sum).and_return(5)
           allow(order).to receive_message_chain(:adjustments, :admin, :sum).and_return(2)
 
           updater.update_adjustment_total
-          expect(order.adjustment_total).to eq(-10)
+          expect(order.adjustment_total).to eq(-5)
           expect(order.additional_tax_total).to eq(20)
           expect(order.included_tax_total).to eq(17)
         end

--- a/lib/open_food_network/sales_tax_report.rb
+++ b/lib/open_food_network/sales_tax_report.rb
@@ -96,8 +96,7 @@ module OpenFoodNetwork
     end
 
     def shipping_cost_for(order)
-      shipping_cost = order.adjustments.find_by(label: "Shipping").andand.amount
-      shipping_cost.nil? ? 0.0 : shipping_cost
+      order.shipments.first&.cost || 0.0
     end
 
     def tax_included_in(line_item)

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -79,7 +79,7 @@ module OpenFoodNetwork
     end
 
     def adjustment_detail_rows(order, invoice_number, opts)
-      adjustments(order).map do |adjustment|
+      admin_adjustments(order).map do |adjustment|
         adjustment_detail_row(adjustment, invoice_number, opts)
       end
     end
@@ -167,7 +167,7 @@ module OpenFoodNetwork
        order.paid? ? I18n.t(:y) : I18n.t(:n)]
     end
 
-    def adjustments(order)
+    def admin_adjustments(order)
       order.adjustments.admin
     end
 

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -118,7 +118,7 @@ module OpenFoodNetwork
     end
 
     def shipping_summary_rows(order, invoice_number, opts)
-      [summary_row(order, I18n.t(:report_header_delivery_shipping_cost), total_shipping(order), invoice_number, tax_on_shipping_s(order), opts)]
+      [summary_row(order, I18n.t(:report_header_delivery_shipping_cost), order.ship_total, invoice_number, tax_on_shipping_s(order), opts)]
     end
 
     def payment_summary_rows(order, invoice_number, opts)
@@ -193,10 +193,6 @@ module OpenFoodNetwork
 
     def total_taxable_fees(order)
       order.all_adjustments.enterprise_fee.with_tax.sum(:amount)
-    end
-
-    def total_shipping(order)
-      order.all_adjustments.shipping.sum(:amount)
     end
 
     def total_transaction(order)

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -188,23 +188,23 @@ module OpenFoodNetwork
     end
 
     def total_untaxable_fees(order)
-      order.adjustments.enterprise_fee.without_tax.sum(:amount)
+      order.all_adjustments.enterprise_fee.without_tax.sum(:amount)
     end
 
     def total_taxable_fees(order)
-      order.adjustments.enterprise_fee.with_tax.sum(:amount)
+      order.all_adjustments.enterprise_fee.with_tax.sum(:amount)
     end
 
     def total_shipping(order)
-      order.adjustments.shipping.sum(:amount)
+      order.all_adjustments.shipping.sum(:amount)
     end
 
     def total_transaction(order)
-      order.adjustments.payment_fee.sum(:amount)
+      order.all_adjustments.payment_fee.sum(:amount)
     end
 
     def tax_on_shipping_s(order)
-      tax_on_shipping = order.adjustments.shipping.sum(:included_tax) > 0
+      tax_on_shipping = order.all_adjustments.shipping.sum(:included_tax) > 0
       tax_on_shipping ? I18n.t(:report_header_gst_on_income) : I18n.t(:report_header_gst_free_income)
     end
 

--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -289,7 +289,7 @@ module Api
           )
           expect(json_response[:adjustments].second).to include(
             'label' => "Shipping",
-            'amount' => order.adjustments.shipping.first.amount.to_s
+            'amount' => order.shipment_adjustments.first.amount.to_s
           )
 
           expect(json_response[:payments].first[:amount]).to eq order.payments.first.amount.to_s

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -106,7 +106,7 @@ describe LineItemsController, type: :controller do
         item_num = order.line_items.length
         initial_fees = item_num * (shipping_fee + payment_fee)
         expect(order.adjustment_total).to eq initial_fees
-        expect(order.shipments.last.adjustment.included_tax).to eq 1.2
+        expect(order.shipments.last.fee_adjustment.included_tax).to eq 1.2
 
         # Delete the item
         item = order.line_items.first
@@ -119,9 +119,9 @@ describe LineItemsController, type: :controller do
         order.reload
         order.shipment.reload
         expect(order.adjustment_total).to eq initial_fees - shipping_fee - payment_fee
-        expect(order.shipments.last.adjustment.amount).to eq shipping_fee
+        expect(order.shipments.last.fee_adjustment.amount).to eq shipping_fee
         expect(order.payments.first.adjustment.amount).to eq payment_fee
-        expect(order.shipments.last.adjustment.included_tax).to eq 0.6
+        expect(order.shipments.last.fee_adjustment.included_tax).to eq 0.6
       end
     end
 

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -35,7 +35,9 @@ module Spree
       end
 
       describe "updating an adjustment" do
-        let(:adjustment) { create(:adjustment, adjustable: order, amount: 1100, included_tax: 100) }
+        let(:adjustment) {
+          create(:adjustment, adjustable: order, order: order, amount: 1100, included_tax: 100)
+        }
 
         it "sets included tax to zero when no tax rate is specified" do
           spree_put :update, order_id: order.number, id: adjustment.id, adjustment: { label: 'Testing included tax', amount: '110' }, tax_rate_id: ''

--- a/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -17,10 +17,10 @@ module Spree
 
         # Pay the order
         order.payments.first.complete
-        order.updater.update_payment_state
+        order.update!
 
         # Ship the order
-        order.reload.shipment.ship!
+        order.shipment.ship!
       end
 
       it "creates and updates a return authorization" do

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -280,6 +280,7 @@ describe Spree::OrdersController, type: :controller do
         expect(order.all_adjustments.length).to eq 2
         expect(item_num).to eq 2
         expect(order.adjustment_total).to eq expected_fees
+        expect(order.shipment_total).to eq 2 * shipping_fee
         expect(order.shipment.fee_adjustment.included_tax).to eq 1.2
 
         allow(subject).to receive(:spree_current_user) { order.user }
@@ -295,6 +296,7 @@ describe Spree::OrdersController, type: :controller do
 
         expect(order.reload.line_items.count).to eq 1
         expect(order.adjustment_total).to eq(1 * (shipping_fee + payment_fee))
+        expect(order.shipment_total).to eq(shipping_fee)
         expect(order.shipment.fee_adjustment.included_tax).to eq 0.6
       end
     end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -277,7 +277,7 @@ describe Spree::OrdersController, type: :controller do
         allow(Spree::Config).to receive(:shipping_tax_rate) { 0.25 }
 
         # Sanity check the fees
-        expect(order.adjustments.length).to eq 2
+        expect(order.all_adjustments.length).to eq 2
         expect(item_num).to eq 2
         expect(order.adjustment_total).to eq expected_fees
         expect(order.shipment.adjustment.included_tax).to eq 1.2

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -280,7 +280,7 @@ describe Spree::OrdersController, type: :controller do
         expect(order.all_adjustments.length).to eq 2
         expect(item_num).to eq 2
         expect(order.adjustment_total).to eq expected_fees
-        expect(order.shipment.adjustment.included_tax).to eq 1.2
+        expect(order.shipment.fee_adjustment.included_tax).to eq 1.2
 
         allow(subject).to receive(:spree_current_user) { order.user }
         allow(subject).to receive(:order_to_update) { order }
@@ -295,7 +295,7 @@ describe Spree::OrdersController, type: :controller do
 
         expect(order.reload.line_items.count).to eq 1
         expect(order.adjustment_total).to eq(1 * (shipping_fee + payment_fee))
-        expect(order.shipment.adjustment.included_tax).to eq 0.6
+        expect(order.shipment.fee_adjustment.included_tax).to eq 0.6
       end
     end
 

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -92,9 +92,10 @@ FactoryBot.define do
                          payment_method: evaluator.payment_method)
         order.recreate_all_fees!
         order.ship_address = evaluator.ship_address
-        while !order.completed? do break unless a = order.next! end
+        while !order.delivery? do break unless a = order.next! end
         order.select_shipping_method(evaluator.shipping_method.id)
-        order.save
+
+        while !order.completed? do break unless a = order.next! end
       end
     end
   end

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -46,6 +46,12 @@ FactoryBot.define do
             shipment.inventory_units.create(variant_id: line_item.variant_id)
           }
         end
+
+        # Ensure correct shipping cost is assigned to both shipping rate and shipment.
+        # This usually happens via Stock::Estimator when shipping rates are created.
+        computed_shipping_cost = shipment.shipping_method.calculator.compute(shipment.to_package)
+        shipment.selected_shipping_rate.update_columns(cost: computed_shipping_cost)
+        shipment.update_columns(cost: computed_shipping_cost)
       end
     end
   end

--- a/spec/features/admin/adjustments_spec.rb
+++ b/spec/features/admin/adjustments_spec.rb
@@ -42,7 +42,8 @@ feature '
 
   scenario "modifying taxed adjustments on an order" do
     # Given a taxed adjustment
-    adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order, amount: 110, included_tax: 10)
+    adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order,
+                        amount: 110, included_tax: 10, order: order)
 
     # When I go to the adjustments page for the order
     login_as_admin_and_visit spree.admin_orders_path
@@ -65,7 +66,8 @@ feature '
 
   scenario "modifying an untaxed adjustment on an order" do
     # Given an untaxed adjustment
-    adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order, amount: 110, included_tax: 0)
+    adjustment = create(:adjustment, label: "Extra Adjustment", adjustable: order,
+                        amount: 110, included_tax: 0, order: order)
 
     # When I go to the adjustments page for the order
     login_as_admin_and_visit spree.admin_orders_path

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -323,7 +323,7 @@ feature '
 
       scenario "editing shipping fees" do
         click_link "Adjustments"
-        shipping_adjustment_tr_selector = "tr#spree_adjustment_#{order.adjustments.shipping.first.id}"
+        shipping_adjustment_tr_selector = "tr#spree_adjustment_#{order.shipment_adjustments.first.id}"
         page.find("#{shipping_adjustment_tr_selector} td.actions a.icon-edit").click
 
         fill_in "Amount", with: "5"

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -394,11 +394,11 @@ feature '
       let!(:line_item1) { create(:line_item, variant: product1.master, price: 12.54, quantity: 1, order: order1) }
       let!(:line_item2) { create(:line_item, variant: product2.master, price: 500.15, quantity: 3, order: order1) }
 
-      let!(:adj_shipping) { create(:adjustment, adjustable: order1, label: "Shipping", originator: shipping_method, amount: 100.55, included_tax: 10.06) }
-      let!(:adj_fee1) { create(:adjustment, adjustable: order1, originator: enterprise_fee1, label: "Enterprise fee untaxed", amount: 10, included_tax: 0) }
-      let!(:adj_fee2) { create(:adjustment, adjustable: order1, originator: enterprise_fee2, label: "Enterprise fee taxed", amount: 20, included_tax: 2) }
-      let!(:adj_manual1) { create(:adjustment, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 30, included_tax: 0) }
-      let!(:adj_manual2) { create(:adjustment, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 40, included_tax: 3) }
+      let!(:adj_shipping) { create(:adjustment, order: order1, adjustable: order1, label: "Shipping", originator: shipping_method, amount: 100.55, included_tax: 10.06) }
+      let!(:adj_fee1) { create(:adjustment, order: order1, adjustable: order1, originator: enterprise_fee1, label: "Enterprise fee untaxed", amount: 10, included_tax: 0) }
+      let!(:adj_fee2) { create(:adjustment, order: order1, adjustable: order1, originator: enterprise_fee2, label: "Enterprise fee taxed", amount: 20, included_tax: 2) }
+      let!(:adj_manual1) { create(:adjustment, order: order1, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 30, included_tax: 0) }
+      let!(:adj_manual2) { create(:adjustment, order: order1, adjustable: order1, originator: nil, source: nil, label: "Manual adjustment", amount: 40, included_tax: 3) }
 
       before do
         order1.update_attribute :email, 'customer@email.com'

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -386,7 +386,7 @@ feature "As a consumer I want to check out my cart", js: true do
 
             # There are two orders - our order and our new cart
             o = Spree::Order.complete.first
-            expect(o.adjustments.shipping.first.amount).to eq(4.56)
+            expect(o.shipment_adjustments.first.amount).to eq(4.56)
             expect(o.payments.first.amount).to eq(10 + 1.23 + 4.56) # items + fees + shipping
           end
         end

--- a/spec/features/consumer/shopping/orders_spec.rb
+++ b/spec/features/consumer/shopping/orders_spec.rb
@@ -108,6 +108,7 @@ feature "Order Management", js: true do
 
     before do
       order.shipment.shipping_method.calculator.update(preferred_amount: 5.0)
+      order.refresh_shipment_rates
       order.save
       order.reload
 

--- a/spec/helpers/checkout_helper_spec.rb
+++ b/spec/helpers/checkout_helper_spec.rb
@@ -41,14 +41,14 @@ describe CheckoutHelper, type: :helper do
 
     before do
       # Sanity check initial adjustments state
-      expect(order.adjustments.shipping.count).to eq 1
+      expect(order.shipment_adjustments.count).to eq 1
       expect(order.adjustments.enterprise_fee.count).to eq 1
     end
 
     it "collects adjustments on the order" do
       adjustments = helper.checkout_adjustments_for(order)
 
-      shipping_adjustment = order.adjustments.shipping.first
+      shipping_adjustment = order.shipment_adjustments.first
       expect(adjustments).to include shipping_adjustment
 
       admin_fee_summary = adjustments.last

--- a/spec/lib/open_food_network/sales_tax_report_spec.rb
+++ b/spec/lib/open_food_network/sales_tax_report_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
 require 'open_food_network/sales_tax_report'
 
 module OpenFoodNetwork

--- a/spec/lib/open_food_network/user_balance_calculator_spec.rb
+++ b/spec/lib/open_food_network/user_balance_calculator_spec.rb
@@ -10,12 +10,12 @@ module OpenFoodNetwork
       let!(:hub1) { create(:distributor_enterprise) }
 
       let!(:o1) {
-        create(:order_with_totals_and_distribution,
+        create(:order_with_totals_and_distribution, :completed,
                user: user1, distributor: hub1,
                completed_at: 1.day.ago)
       } # total=13 (10 + 3 shipping fee)
       let!(:o2) {
-        create(:order_with_totals_and_distribution,
+        create(:order_with_totals_and_distribution, :completed,
                user: user1, distributor: hub1,
                completed_at: 1.day.ago)
       } # total=13 (10 + 3 shipping fee)
@@ -28,6 +28,13 @@ module OpenFoodNetwork
                          state: "completed")
       }
 
+      before do
+        # Sanity check the order
+        expect(o1.total).to eq 13
+        expect(o1.ready_to_ship?).to eq true
+        expect(o1.paid?).to eq true
+      end
+
       it "finds the correct balance for this email and enterprise" do
         expect(UserBalanceCalculator.new(o1.email, hub1).balance).to eq(-9) # = 15 + 2 - 13 - 13
       end
@@ -35,7 +42,7 @@ module OpenFoodNetwork
       context "with another hub" do
         let!(:hub2) { create(:distributor_enterprise) }
         let!(:o3) {
-          create(:order_with_totals_and_distribution,
+          create(:order_with_totals_and_distribution, :completed,
                  user: user1, distributor: hub2,
                  completed_at: 1.day.ago)
         } # total=13 (10 + 3 shipping fee)
@@ -52,7 +59,7 @@ module OpenFoodNetwork
       context "with another user" do
         let!(:user2) { create(:user) }
         let!(:o4) {
-          create(:order_with_totals_and_distribution,
+          create(:order_with_totals_and_distribution, :completed,
                  user: user2, distributor: hub1,
                  completed_at: 1.day.ago)
         } # total=13 (10 + 3 shipping fee)
@@ -68,7 +75,7 @@ module OpenFoodNetwork
 
       context "with canceled orders" do
         let!(:o4) {
-          create(:order_with_totals_and_distribution,
+          create(:order_with_totals_and_distribution, :completed,
                  user: user1, distributor: hub1,
                  completed_at: 1.day.ago, state: "canceled")
         } # total=13 (10 + 3 shipping fee)
@@ -84,7 +91,7 @@ module OpenFoodNetwork
 
       context "with void payments" do
         let!(:o4) {
-          create(:order_with_totals_and_distribution,
+          create(:order_with_totals_and_distribution, :completed,
                  user: user1, distributor: hub1,
                  completed_at: 1.day.ago)
         } # total=13 (10 + 3 shipping fee)
@@ -100,7 +107,7 @@ module OpenFoodNetwork
 
       context "with invalid payments" do
         let!(:o4) {
-          create(:order_with_totals_and_distribution,
+          create(:order_with_totals_and_distribution, :completed,
                  user: user1, distributor: hub1,
                  completed_at: 1.day.ago)
         } # total=13 (10 + 3 shipping fee)
@@ -116,7 +123,7 @@ module OpenFoodNetwork
 
       context "with multiple payments on single order" do
         let!(:o4) {
-          create(:order_with_totals_and_distribution,
+          create(:order_with_totals_and_distribution, :completed,
                  user: user1, distributor: hub1,
                  completed_at: 1.day.ago)
         } # total=13 (10 + 3 shipping fee)

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -64,7 +64,7 @@ describe Spree::OrderMailer do
   end
 
   context "displays line item price" do
-    let(:order) { create(:order_with_totals_and_distribution) }
+    let(:order) { create(:order_with_totals_and_distribution, :completed) }
 
     specify do
       confirmation_email = Spree::OrderMailer.confirm_email_for_customer(order)

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -251,7 +251,8 @@ module Spree
         describe "the shipping charge" do
           it "is the adjustment amount" do
             order.shipments = [shipment]
-            expect(order.adjustments.first.amount).to eq(50)
+            expect(order.shipment_adjustments.first.amount).to eq(50)
+            expect(shipment.cost).to eq(50)
           end
         end
 

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -265,14 +265,14 @@ module Spree
             allow(Config).to receive(:shipping_tax_rate).and_return(0)
             order.shipments = [shipment]
 
-            expect(order.adjustments.first.included_tax).to eq(0)
+            expect(order.shipment_adjustments.first.included_tax).to eq(0)
           end
 
           it "records 0% tax on shipments when a rate is set but shipment_inc_vat is false" do
             allow(Config).to receive(:shipping_tax_rate).and_return(0.25)
             order.shipments = [shipment]
 
-            expect(order.adjustments.first.included_tax).to eq(0)
+            expect(order.shipment_adjustments.first.included_tax).to eq(0)
           end
         end
 
@@ -289,21 +289,21 @@ module Spree
             # total - ( total / (1 + rate) )
             # 50    - ( 50    / (1 + 0.25) )
             # = 10
-            expect(order.adjustments.first.included_tax).to eq(10.00)
+            expect(order.shipment_adjustments.first.included_tax).to eq(10.00)
           end
 
           it "records 0% tax on shipments when shipping_tax_rate is not set" do
             allow(Config).to receive(:shipping_tax_rate).and_return(0)
             order.shipments = [shipment]
 
-            expect(order.adjustments.first.included_tax).to eq(0)
+            expect(order.shipment_adjustments.first.included_tax).to eq(0)
           end
 
           it "records 0% tax on shipments when the distributor does not charge sales tax" do
             order.distributor.update! charges_sales_tax: false
             order.shipments = [shipment]
 
-            expect(order.adjustments.first.included_tax).to eq(0)
+            expect(order.shipment_adjustments.first.included_tax).to eq(0)
           end
         end
       end

--- a/spec/models/spree/order/adjustments_spec.rb
+++ b/spec/models/spree/order/adjustments_spec.rb
@@ -3,17 +3,21 @@
 require 'spec_helper'
 
 describe Spree::Order do
-  let(:order) { Spree::Order.new }
+  let(:order) { create(:order) }
 
   context "totaling adjustments" do
     let!(:adjustment1) { create(:adjustment, amount: 5) }
     let!(:adjustment2) { create(:adjustment, amount: 10) }
     let(:adjustments) { Spree::Adjustment.where(id: [adjustment1, adjustment2]) }
 
-    context "#ship_total" do
+    context "#shipment_total" do
+      before do
+        allow(order).to receive_message_chain(:shipments, :sum) { 20 }
+        order.updater.update_shipment_total
+      end
+
       it "should return the correct amount" do
-        allow(order).to receive_message_chain :adjustments, shipping: adjustments
-        expect(order.ship_total).to eq 15
+        expect(order.shipment_total).to eq 20
       end
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1092,7 +1092,7 @@ describe Spree::Order do
       expect(order.shipment_adjustments.length).to eq 1
       expect(item_num).to eq 2
       expect(order.adjustment_total).to eq expected_fees
-      expect(order.shipment.adjustment.included_tax).to eq 1.2
+      expect(order.shipment.fee_adjustment.included_tax).to eq 1.2
     end
 
     context "removing line_items" do
@@ -1101,7 +1101,7 @@ describe Spree::Order do
         order.save
 
         expect(order.adjustment_total).to eq expected_fees - shipping_fee - payment_fee
-        expect(order.shipment.adjustment.included_tax).to eq 0.6
+        expect(order.shipment.fee_adjustment.included_tax).to eq 0.6
       end
 
       context "when finalized fee adjustments exist on the order" do
@@ -1120,7 +1120,7 @@ describe Spree::Order do
           # Check if fees got updated
           order.reload
           expect(order.adjustment_total).to eq expected_fees
-          expect(order.shipment.adjustment.included_tax).to eq 1.2
+          expect(order.shipment.fee_adjustment.included_tax).to eq 1.2
         end
       end
     end
@@ -1133,7 +1133,7 @@ describe Spree::Order do
         order.save
 
         expect(order.adjustment_total).to eq expected_fees - (item_num * shipping_fee)
-        expect(order.shipment.adjustment.included_tax).to eq 0
+        expect(order.shipment.fee_adjustment.included_tax).to eq 0
       end
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -181,7 +181,7 @@ describe Spree::Order do
       allow(order).to receive :has_available_shipment
       allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_later
       adjustments = double
-      allow(order).to receive_messages adjustments: adjustments
+      allow(order).to receive_messages all_adjustments: adjustments
       expect(adjustments).to receive(:update_all).with(state: 'closed')
       order.finalize!
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1088,7 +1088,8 @@ describe Spree::Order do
       Spree::Config.shipping_tax_rate = 0.25
 
       # Sanity check the fees
-      expect(order.adjustments.length).to eq 2
+      expect(order.adjustments.length).to eq 1
+      expect(order.shipment_adjustments.length).to eq 1
       expect(item_num).to eq 2
       expect(order.adjustment_total).to eq expected_fees
       expect(order.shipment.adjustment.included_tax).to eq 1.2
@@ -1105,7 +1106,7 @@ describe Spree::Order do
 
       context "when finalized fee adjustments exist on the order" do
         let(:payment_fee_adjustment) { order.adjustments.payment_fee.first }
-        let(:shipping_fee_adjustment) { order.adjustments.shipping.first }
+        let(:shipping_fee_adjustment) { order.shipment_adjustments.first }
 
         before do
           payment_fee_adjustment.finalize!

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -25,17 +25,6 @@ describe Spree::Shipment do
     expect(shipment).to be_backordered
   end
 
-  context "#cost" do
-    it "should return the amount of any shipping charges that it originated" do
-      allow(shipment).to receive_message_chain :adjustment, amount: 10
-      expect(shipment.cost).to eq 10
-    end
-
-    it "should return 0 if there are no relevant shipping adjustments" do
-      expect(shipment.cost).to eq 0
-    end
-  end
-
   context "display_cost" do
     it "retuns a Spree::Money" do
       allow(shipment).to receive(:cost) { 21.22 }

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -428,15 +428,10 @@ describe Spree::Shipment do
   end
 
   describe "#update_amounts" do
-    it "updates shipping cost when selected_shipping_rate is present" do
-      allow(shipment).to receive(:selected_shipping_rate) { double(:rate, cost: 10) }
+    it "persists the shipping cost from the shipping fee adjustment" do
+      allow(shipment).to receive(:adjustment) { double(:adjustment, amount: 10) }
       expect(shipment).to receive(:update_columns).with(cost: 10, updated_at: kind_of(Time))
 
-      shipment.update_amounts
-    end
-
-    it "does nothing when selected_shipping_rate is not present" do
-      expect(shipment).to_not receive(:update_columns)
       shipment.update_amounts
     end
   end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -387,7 +387,7 @@ describe Spree::Shipment do
     it "should create adjustment when not present" do
       allow(shipment).to receive_messages(selected_shipping_rate_id: 1)
       expect(shipping_method).to receive(:create_adjustment).with(shipping_method.adjustment_label,
-                                                                  order, shipment, true, "open")
+                                                                  shipment, shipment, true, "open")
       shipment.__send__(:ensure_correct_adjustment)
     end
 
@@ -395,7 +395,7 @@ describe Spree::Shipment do
     it "should use the shipping method's adjustment label" do
       allow(shipment).to receive_messages(selected_shipping_rate_id: 1)
       allow(shipping_method).to receive_messages(adjustment_label: "Foobar")
-      expect(shipping_method).to receive(:create_adjustment).with("Foobar", order,
+      expect(shipping_method).to receive(:create_adjustment).with("Foobar", shipment,
                                                                   shipment, true, "open")
       shipment.__send__(:ensure_correct_adjustment)
     end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -415,7 +415,7 @@ describe Spree::Shipment do
       allow(shipment).
         to receive_messages(selected_shipping_rate: Spree::ShippingRate.new(cost: 10.00))
       adjustment = build(:adjustment)
-      allow(shipment).to receive_messages(adjustment: adjustment)
+      allow(shipment).to receive_messages(adjustment: adjustment, update_columns: true)
       allow(adjustment).to receive(:open?) { true }
       expect(shipment.adjustment).to receive(:originator=).with(shipping_method)
       expect(shipment.adjustment).to receive(:label=).with(shipping_method.adjustment_label)
@@ -429,7 +429,7 @@ describe Spree::Shipment do
       allow(shipment).
         to receive_messages(selected_shipping_rate: Spree::ShippingRate.new(cost: 10.00))
       adjustment = build(:adjustment)
-      allow(shipment).to receive_messages(adjustment: adjustment)
+      allow(shipment).to receive_messages(adjustment: adjustment, update_columns: true)
       allow(adjustment).to receive(:open?) { false }
       expect(shipment.adjustment).to receive(:originator=).with(shipping_method)
       expect(shipment.adjustment).to receive(:label=).with(shipping_method.adjustment_label)
@@ -444,6 +444,20 @@ describe Spree::Shipment do
     it "should update order" do
       expect(order).to receive(:update!)
       shipment.__send__(:update_order)
+    end
+  end
+
+  describe "#update_amounts" do
+    it "updates shipping cost when selected_shipping_rate is present" do
+      allow(shipment).to receive(:selected_shipping_rate) { double(:rate, cost: 10) }
+      expect(shipment).to receive(:update_columns).with(cost: 10, updated_at: kind_of(Time))
+
+      shipment.update_amounts
+    end
+
+    it "does nothing when selected_shipping_rate is not present" do
+      expect(shipment).to_not receive(:update_columns)
+      shipment.update_amounts
     end
   end
 

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -386,17 +386,8 @@ describe Spree::Shipment do
 
     it "should create adjustment when not present" do
       allow(shipment).to receive_messages(selected_shipping_rate_id: 1)
-      expect(shipping_method).to receive(:create_adjustment).with(shipping_method.adjustment_label,
+      expect(shipping_method).to receive(:create_adjustment).with(shipment.adjustment_label,
                                                                   shipment, shipment, true, "open")
-      shipment.__send__(:ensure_correct_adjustment)
-    end
-
-    # Regression test for #3138
-    it "should use the shipping method's adjustment label" do
-      allow(shipment).to receive_messages(selected_shipping_rate_id: 1)
-      allow(shipping_method).to receive_messages(adjustment_label: "Foobar")
-      expect(shipping_method).to receive(:create_adjustment).with("Foobar", shipment,
-                                                                  shipment, true, "open")
       shipment.__send__(:ensure_correct_adjustment)
     end
 
@@ -407,7 +398,7 @@ describe Spree::Shipment do
       allow(shipment).to receive_messages(adjustment: adjustment, update_columns: true)
       allow(adjustment).to receive(:open?) { true }
       expect(shipment.adjustment).to receive(:originator=).with(shipping_method)
-      expect(shipment.adjustment).to receive(:label=).with(shipping_method.adjustment_label)
+      expect(shipment.adjustment).to receive(:label=).with(shipment.adjustment_label)
       expect(shipment.adjustment).to receive(:amount=).with(10.00)
       allow(shipment.adjustment).to receive(:save!)
       expect(shipment.adjustment).to receive(:reload)
@@ -421,7 +412,7 @@ describe Spree::Shipment do
       allow(shipment).to receive_messages(adjustment: adjustment, update_columns: true)
       allow(adjustment).to receive(:open?) { false }
       expect(shipment.adjustment).to receive(:originator=).with(shipping_method)
-      expect(shipment.adjustment).to receive(:label=).with(shipping_method.adjustment_label)
+      expect(shipment.adjustment).to receive(:label=).with(shipment.adjustment_label)
       expect(shipment.adjustment).not_to receive(:amount=).with(10.00)
       allow(shipment.adjustment).to receive(:save!)
       expect(shipment.adjustment).to receive(:reload)

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -382,7 +382,10 @@ describe Spree::Shipment do
   end
 
   context "ensure_correct_adjustment" do
-    before { allow(shipment).to receive(:reload) }
+    before do
+      shipment.save
+      allow(shipment).to receive(:reload)
+    end
 
     it "should create adjustment when not present" do
       allow(shipment).to receive_messages(selected_shipping_rate_id: 1)

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -339,7 +339,7 @@ describe Spree::Shipment do
     before do
       allow(order).to receive(:update!)
       allow(shipment).to receive_messages(update_order: true, state: 'ready')
-      allow(shipment).to receive_messages(adjustment: charge)
+      allow(shipment).to receive_messages(fee_adjustment: charge)
       allow(shipping_method).to receive(:create_adjustment)
       allow(shipment).to receive(:ensure_correct_adjustment)
     end
@@ -368,8 +368,8 @@ describe Spree::Shipment do
     it "should finalize the shipment's adjustment" do
       allow(shipment).to receive(:send_shipped_email)
       shipment.ship!
-      expect(shipment.adjustment.state).to eq 'finalized'
-      expect(shipment.adjustment).to be_immutable
+      expect(shipment.fee_adjustment.state).to eq 'finalized'
+      expect(shipment.fee_adjustment).to be_immutable
     end
   end
 
@@ -398,13 +398,13 @@ describe Spree::Shipment do
       allow(shipment).
         to receive_messages(selected_shipping_rate: Spree::ShippingRate.new(cost: 10.00))
       adjustment = build(:adjustment)
-      allow(shipment).to receive_messages(adjustment: adjustment, update_columns: true)
+      allow(shipment).to receive_messages(fee_adjustment: adjustment, update_columns: true)
       allow(adjustment).to receive(:open?) { true }
-      expect(shipment.adjustment).to receive(:originator=).with(shipping_method)
-      expect(shipment.adjustment).to receive(:label=).with(shipment.adjustment_label)
-      expect(shipment.adjustment).to receive(:amount=).with(10.00)
-      allow(shipment.adjustment).to receive(:save!)
-      expect(shipment.adjustment).to receive(:reload)
+      expect(shipment.fee_adjustment).to receive(:originator=).with(shipping_method)
+      expect(shipment.fee_adjustment).to receive(:label=).with(shipment.adjustment_label)
+      expect(shipment.fee_adjustment).to receive(:amount=).with(10.00)
+      allow(shipment.fee_adjustment).to receive(:save!)
+      expect(shipment.fee_adjustment).to receive(:reload)
       shipment.__send__(:ensure_correct_adjustment)
     end
 
@@ -412,13 +412,13 @@ describe Spree::Shipment do
       allow(shipment).
         to receive_messages(selected_shipping_rate: Spree::ShippingRate.new(cost: 10.00))
       adjustment = build(:adjustment)
-      allow(shipment).to receive_messages(adjustment: adjustment, update_columns: true)
+      allow(shipment).to receive_messages(fee_adjustment: adjustment, update_columns: true)
       allow(adjustment).to receive(:open?) { false }
-      expect(shipment.adjustment).to receive(:originator=).with(shipping_method)
-      expect(shipment.adjustment).to receive(:label=).with(shipment.adjustment_label)
-      expect(shipment.adjustment).not_to receive(:amount=).with(10.00)
-      allow(shipment.adjustment).to receive(:save!)
-      expect(shipment.adjustment).to receive(:reload)
+      expect(shipment.fee_adjustment).to receive(:originator=).with(shipping_method)
+      expect(shipment.fee_adjustment).to receive(:label=).with(shipment.adjustment_label)
+      expect(shipment.fee_adjustment).not_to receive(:amount=).with(10.00)
+      allow(shipment.fee_adjustment).to receive(:save!)
+      expect(shipment.fee_adjustment).to receive(:reload)
       shipment.__send__(:ensure_correct_adjustment)
     end
   end
@@ -432,7 +432,7 @@ describe Spree::Shipment do
 
   describe "#update_amounts" do
     it "persists the shipping cost from the shipping fee adjustment" do
-      allow(shipment).to receive(:adjustment) { double(:adjustment, amount: 10) }
+      allow(shipment).to receive(:fee_adjustment) { double(:adjustment, amount: 10) }
       expect(shipment).to receive(:update_columns).with(cost: 10, updated_at: kind_of(Time))
 
       shipment.update_amounts

--- a/spec/models/spree/shipping_method_spec.rb
+++ b/spec/models/spree/shipping_method_spec.rb
@@ -176,5 +176,19 @@ module Spree
         expect(shipping_method.calculator.calculable).to eq(shipping_method)
       end
     end
+
+    # Regression test for Spree #4492
+    context "#shipments" do
+      let!(:shipping_method) { create(:shipping_method) }
+      let!(:shipment) do
+        shipment = create(:shipment)
+        shipment.shipping_rates.create!(shipping_method: shipping_method)
+        shipment
+      end
+
+      it "can gather all the related shipments" do
+        expect(shipping_method.shipments).to include(shipment)
+      end
+    end
   end
 end

--- a/spec/services/bulk_invoice_service_spec.rb
+++ b/spec/services/bulk_invoice_service_spec.rb
@@ -60,9 +60,9 @@ describe BulkInvoiceService do
     end
 
     it "orders with completed desc" do
-      order_old = create(:order_with_distributor, :completed, completed_at: 2.minutes.ago)
-      order_oldest = create(:order_with_distributor, :completed, completed_at: 4.minutes.ago)
-      order_older = create(:order_with_distributor, :completed, completed_at: 3.minutes.ago)
+      order_old = create(:order_with_distributor, :with_line_item, :completed, completed_at: 2.minutes.ago)
+      order_oldest = create(:order_with_distributor, :with_line_item, :completed, completed_at: 4.minutes.ago)
+      order_older = create(:order_with_distributor, :with_line_item, :completed, completed_at: 3.minutes.ago)
 
       expect(renderer).to receive(:render_to_string).with(order_old).ordered.and_return("")
       expect(renderer).to receive(:render_to_string).with(order_older).ordered.and_return("")

--- a/spec/services/order_tax_adjustments_fetcher_spec.rb
+++ b/spec/services/order_tax_adjustments_fetcher_spec.rb
@@ -86,7 +86,7 @@ describe OrderTaxAdjustmentsFetcher do
 
     subject { OrderTaxAdjustmentsFetcher.new(order).totals }
 
-    it "returns a hash with all 3 taxes" do
+    it "returns a hash with all 4 taxes" do
       expect(subject.size).to eq(4)
     end
 


### PR DESCRIPTION
#### What? Why?

- Adds a `shipment_total` column to `spree_orders` table. 
- Persists the shipment total on the order object when updating the order via Order::Updater

Note: target branch needs to be updated before merge.

#### What should we test?
<!-- List which features should be tested and how. -->

Order totals are correct after placing an order with shipping costs.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Persist shipment_total on orders

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
