### PR TITLE
[Adjustments] Update line item taxes

### DIFF
--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -174,11 +174,11 @@ module Spree
     end
 
     def has_tax?
-      adjustments.included_tax.any?
+      adjustments.tax.any?
     end
 
     def included_tax
-      adjustments.included_tax.sum(:included_tax)
+      adjustments.tax.inclusive.sum(:amount)
     end
 
     def tax_rates

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -662,7 +662,9 @@ module Spree
     end
 
     def total_tax
-      all_adjustments.sum(:included_tax)
+      adjustments.sum(:included_tax) +
+        shipment_adjustments.sum(:included_tax) +
+        line_item_adjustments.tax.sum(:amount)
     end
 
     def has_taxes_included

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -84,7 +84,7 @@ module Spree
       order.line_items.reload
       # TaxRate adjustments (order.adjustments.tax)
       #   and line item adjustments (tax included on line items) consist of 100% tax
-      (order.adjustments.tax + order.line_item_adjustments.reload).each do |adjustment|
+      order.adjustments.tax.additional.each do |adjustment|
         adjustment.set_absolute_included_tax! adjustment.amount
       end
     end

--- a/app/services/tax_rate_finder.rb
+++ b/app/services/tax_rate_finder.rb
@@ -75,7 +75,7 @@ class TaxRateFinder
   # to the included tax.
   def find_closest_tax_rates_from_included_tax(amount, included_tax)
     approximation = (included_tax / (amount - included_tax))
-    return [] if approximation.infinite? || approximation.zero?
+    return [] if approximation.infinite? || approximation.zero? || approximation.nan?
 
     [Spree::TaxRate.order("ABS(amount - #{approximation})").first]
   end

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -59,7 +59,7 @@ module OrderManagement
       def update_adjustment_total
         order.adjustment_total = all_adjustments.additional.eligible.sum(:amount)
         order.additional_tax_total = all_adjustments.tax.additional.sum(:amount)
-        order.included_tax_total = order.line_item_adjustments.tax.sum(:included_tax) +
+        order.included_tax_total = order.line_item_adjustments.tax.inclusive.sum(:amount) +
                                    all_adjustments.enterprise_fee.sum(:included_tax) +
                                    all_adjustments.shipping.sum(:included_tax) +
                                    adjustments.admin.sum(:included_tax)

--- a/lib/open_food_network/sales_tax_report.rb
+++ b/lib/open_food_network/sales_tax_report.rb
@@ -100,7 +100,7 @@ module OpenFoodNetwork
     end
 
     def tax_included_in(line_item)
-      line_item.adjustments.sum(:included_tax)
+      line_item.adjustments.tax.inclusive.sum(:amount)
     end
 
     def shipment_inc_vat

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -185,9 +185,9 @@ module Spree
           tax_rate.adjust(order)
         end
 
-        it "has 100% tax included" do
+        it "has tax included" do
           expect(adjustment.amount).to be > 0
-          expect(adjustment.included_tax).to eq(adjustment.amount)
+          expect(adjustment.included).to be true
         end
 
         it "does not crash when order data has been updated previously" do
@@ -365,7 +365,7 @@ module Spree
                 # so tax on the enterprise_fee adjustment will be 0
                 # Tax on line item is: 0.2/1.2 x $10 = $1.67
                 expect(adjustment.included_tax).to eq(0.0)
-                expect(line_item.adjustments.first.included_tax).to eq(1.67)
+                expect(line_item.adjustments.tax.first.amount).to eq(1.67)
               end
             end
 
@@ -395,7 +395,7 @@ module Spree
                 # gives tax on fee of 0.2/1.2 x $50 = $8.33
                 # Tax on line item is: 0.2/1.2 x $10 = $1.67
                 expect(adjustment.included_tax).to eq(8.33)
-                expect(line_item.adjustments.first.included_tax).to eq(1.67)
+                expect(line_item.adjustments.tax.first.amount).to eq(1.67)
               end
             end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -443,7 +443,10 @@ module Spree
       let(:li_no_tax)   { create(:line_item) }
       let(:li_tax)      { create(:line_item) }
       let(:tax_rate)    { create(:tax_rate, calculator: ::Calculator::DefaultTax.new) }
-      let!(:adjustment) { create(:adjustment, adjustable: li_tax, originator: tax_rate, label: "TR", amount: 123, included_tax: 10.00) }
+      let!(:adjustment) {
+        create(:adjustment, adjustable: li_tax, originator: tax_rate, label: "TR",
+                            amount: 10.00, included: true)
+      }
 
       context "checking if a line item has tax included" do
         it "returns true when it does" do

--- a/spec/services/order_tax_adjustments_fetcher_spec.rb
+++ b/spec/services/order_tax_adjustments_fetcher_spec.rb
@@ -44,8 +44,9 @@ describe OrderTaxAdjustmentsFetcher do
                               tax_category: tax_category20,
                               calculator: Calculator::FlatRate.new(preferred_amount: 48.0))
     end
-    let(:additional_adjustment) do
-      create(:adjustment, amount: 50.0, included_tax: tax_rate25.compute_tax(50.0))
+    let(:admin_adjustment) do
+      create(:adjustment, order: order, amount: 50.0, included_tax: tax_rate25.compute_tax(50.0),
+                          source: nil, label: "Admin Adjustment")
     end
 
     let(:order_cycle) do
@@ -62,8 +63,7 @@ describe OrderTaxAdjustmentsFetcher do
         line_items: [line_item1, line_item2],
         bill_address: create(:address),
         order_cycle: order_cycle,
-        distributor: coordinator,
-        adjustments: [additional_adjustment]
+        distributor: coordinator
       )
     end
 
@@ -80,6 +80,8 @@ describe OrderTaxAdjustmentsFetcher do
     end
 
     before do
+      order.reload
+      order.adjustments << admin_adjustment
       order.create_tax_charge!
       order.recreate_all_fees!
     end
@@ -102,7 +104,7 @@ describe OrderTaxAdjustmentsFetcher do
       expect(subject[tax_rate20]).to eq(8.0)
     end
 
-    it "contains tax on order adjustment" do
+    it "contains tax on admin adjustment" do
       expect(subject[tax_rate25]).to eq(10.0)
     end
   end


### PR DESCRIPTION
#### What? Why?

Updates the way line item included taxes are fetched, so we no longer depend on the `included_tax` column in the `spree_adjustments` table. This column is basically deprecated and in the process of being removed.

The same figure (included tax amount on a line item) is available with: `line_item.adjustments.tax.inclusive.sum(:amount)`.

#### What should we test?
<!-- List which features should be tested and how. -->

Line Item tax amounts are displayed correctly when using included taxes.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
