### PR TITLE
Cleaner and consistent design of front-end footer

### DIFF
--- a/app/assets/stylesheets/darkswarm/footer.scss
+++ b/app/assets/stylesheets/darkswarm/footer.scss
@@ -4,7 +4,7 @@
 
 footer {
   .row {
-    p a {
+    p {
       font-size: 1rem;
     }
 
@@ -107,6 +107,11 @@ footer {
         color: rgba($disabled-med, 0.35);
       }
 
+      #secure {
+        font-size: 1.5rem;
+        font-weight: 300;
+      }		
+
       .social-icons {
         margin-bottom: 0.9rem;
         padding-top: 0.1rem;
@@ -129,7 +134,7 @@ footer {
       }
     }
 
-    .legal a {
+    .legal p {
       font-size: 0.875rem;
     }
   }

--- a/app/assets/stylesheets/darkswarm/footer.scss
+++ b/app/assets/stylesheets/darkswarm/footer.scss
@@ -5,7 +5,7 @@
 footer {
   .row {
     p a {
-      font-size: 0.875rem;
+      font-size: 1rem;
     }
 
     a, a * {
@@ -108,8 +108,8 @@ footer {
       }
 
       .social-icons {
-        margin-bottom: 0.25rem;
-        margin-top: 0.75rem;
+        margin-bottom: 0.9rem;
+        padding-top: 0.1rem;
 
         a {
           i {
@@ -127,6 +127,10 @@ footer {
           }
         }
       }
+    }
+
+    .legal a {
+      font-size: 0.875rem;
     }
   }
 }

--- a/app/assets/stylesheets/darkswarm/footer.scss
+++ b/app/assets/stylesheets/darkswarm/footer.scss
@@ -107,10 +107,10 @@ footer {
         color: rgba($disabled-med, 0.35);
       }
 
-      #secure {
+      p.text-big {
         font-size: 1.5rem;
         font-weight: 300;
-      }		
+      }
 
       .social-icons {
         margin-bottom: 0.9rem;

--- a/app/helpers/footer_links_helper.rb
+++ b/app/helpers/footer_links_helper.rb
@@ -15,4 +15,8 @@ module FooterLinksHelper
              target: '_blank',
              rel: 'noopener' )
   end
+
+  def show_social_icons?
+    ContentConfig.footer_facebook_url.present? || ContentConfig.footer_twitter_url.present? || ContentConfig.footer_instagram_url.present? || ContentConfig.footer_linkedin_url.present? || ContentConfig.footer_googleplus_url.present? || ContentConfig.footer_pinterest_url.present?
+  end
 end

--- a/app/helpers/footer_links_helper.rb
+++ b/app/helpers/footer_links_helper.rb
@@ -17,6 +17,8 @@ module FooterLinksHelper
   end
 
   def show_social_icons?
-    ContentConfig.footer_facebook_url.present? || ContentConfig.footer_twitter_url.present? || ContentConfig.footer_instagram_url.present? || ContentConfig.footer_linkedin_url.present? || ContentConfig.footer_googleplus_url.present? || ContentConfig.footer_pinterest_url.present?
+    ContentConfig.footer_facebook_url.present? || ContentConfig.footer_twitter_url.present? ||
+      ContentConfig.footer_instagram_url.present? || ContentConfig.footer_linkedin_url.present? ||
+      ContentConfig.footer_googleplus_url.present? || ContentConfig.footer_pinterest_url.present?
   end
 end

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -31,25 +31,26 @@
         // This is the instance-managed set of links:
         %h4
           = t '.footer_contact_headline'
-        %p.social-icons
-          - if ContentConfig.footer_facebook_url.present?
-            %a{href: ContentConfig.footer_facebook_url}
-              %i.ofn-i_044-facebook
-          - if ContentConfig.footer_twitter_url.present?
-            %a{href: ContentConfig.footer_twitter_url}
-              %i.ofn-i_041-twitter
-          - if ContentConfig.footer_instagram_url.present?
-            %a{href: ContentConfig.footer_instagram_url}
-              %i.ofn-i_043-instagram
-          - if ContentConfig.footer_linkedin_url.present?
-            %a{href: ContentConfig.footer_linkedin_url}
-              %i.ofn-i_042-linkedin
-          - if ContentConfig.footer_googleplus_url.present?
-            %a{href: ContentConfig.footer_googleplus_url}
-              %i.ofn-i_046-g
-          - if ContentConfig.footer_pinterest_url.present?
-            %a{href: ContentConfig.footer_pinterest_url}
-              %i.ofn-i_045-pintrest
+        - if ContentConfig.footer_facebook_url.present? || ContentConfig.footer_twitter_url.present? || ContentConfig.footer_instagram_url.present? || ContentConfig.footer_linkedin_url.present? || ContentConfig.footer_googleplus_url.present? || ContentConfig.footer_pinterest_url.present?
+          %p.social-icons
+            - if ContentConfig.footer_facebook_url.present?
+              %a{href: ContentConfig.footer_facebook_url}
+                %i.ofn-i_044-facebook
+            - if ContentConfig.footer_twitter_url.present?
+              %a{href: ContentConfig.footer_twitter_url}
+                %i.ofn-i_041-twitter
+            - if ContentConfig.footer_instagram_url.present?
+              %a{href: ContentConfig.footer_instagram_url}
+                %i.ofn-i_043-instagram
+            - if ContentConfig.footer_linkedin_url.present?
+              %a{href: ContentConfig.footer_linkedin_url}
+                %i.ofn-i_042-linkedin
+            - if ContentConfig.footer_googleplus_url.present?
+              %a{href: ContentConfig.footer_googleplus_url}
+                %i.ofn-i_046-g
+            - if ContentConfig.footer_pinterest_url.present?
+              %a{href: ContentConfig.footer_pinterest_url}
+                %i.ofn-i_045-pintrest
         - if ContentConfig.footer_email.present?
           %p
             %a{href: ContentConfig.footer_email.reverse, mailto: true, target: '_blank'}
@@ -92,7 +93,7 @@
         %hr.hr-light
         %br
 
-    .row
+    .row.legal
       .small-12.medium-3.medium-offset-2.columns.text-left
         %a{href: main_app.root_path}
           %img{src: ContentConfig.footer_logo.url, width: "220"}
@@ -107,10 +108,9 @@
         %p.text-small
           = t '.footer_legal_text_html', {content_license: link_to('CC BY-SA 3.0', 'https://creativecommons.org/licenses/by-sa/3.0/'), code_license: link_to('AGPL 3', 'https://tldrlegal.com/license/gnu-affero-general-public-license-v3-(agpl-3.0)' )}
         %p.text-small
-          %div
-            - if Spree::Config.privacy_policy_url.present?
-              = t '.footer_data_text_with_privacy_policy_html', {cookies_policy: cookies_policy_link.html_safe, privacy_policy: privacy_policy_link.html_safe }
-            - else
-              = t '.footer_data_text_without_privacy_policy_html', {cookies_policy: cookies_policy_link.html_safe }
+          - if Spree::Config.privacy_policy_url.present?
+            = t '.footer_data_text_with_privacy_policy_html', {cookies_policy: cookies_policy_link.html_safe, privacy_policy: privacy_policy_link.html_safe }
+          - else
+            = t '.footer_data_text_without_privacy_policy_html', {cookies_policy: cookies_policy_link.html_safe }
       .medium-2.columns.text-center
         / Placeholder

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -15,7 +15,7 @@
         %p.secure-icon
           %i.ofn-i_017-locked
       .small-12.medium-6.columns.text-center
-        %p.secure-text#secure
+        %p.text-big.secure-text
           = t '.footer_secure'
         %p.secure-text
           = t '.footer_secure_text'

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -15,7 +15,7 @@
         %p.secure-icon
           %i.ofn-i_017-locked
       .small-12.medium-6.columns.text-center
-        %p.text-big.secure-text
+        %p.secure-text#secure
           = t '.footer_secure'
         %p.secure-text
           = t '.footer_secure_text'
@@ -31,7 +31,7 @@
         // This is the instance-managed set of links:
         %h4
           = t '.footer_contact_headline'
-        - if ContentConfig.footer_facebook_url.present? || ContentConfig.footer_twitter_url.present? || ContentConfig.footer_instagram_url.present? || ContentConfig.footer_linkedin_url.present? || ContentConfig.footer_googleplus_url.present? || ContentConfig.footer_pinterest_url.present?
+        - if show_social_icons?
           %p.social-icons
             - if ContentConfig.footer_facebook_url.present?
               %a{href: ContentConfig.footer_facebook_url}

--- a/engines/web/spec/features/consumer/cookies_spec.rb
+++ b/engines/web/spec/features/consumer/cookies_spec.rb
@@ -155,7 +155,7 @@ feature "Cookies", js: true do
   end
 
   def click_footer_cookies_policy_link_and_wait
-    find("div > a", text: "cookies policy").click
+    find(".legal a", text: "cookies policy").click
     sleep 2
   end
 


### PR DESCRIPTION
#### What? Why?

In the current footer design I found four things which are not perfectly designed:

1. Tiny font for important links below 'Keep in touch', 'Navigate' and 'Join us'
2. Misaligned rows between 'Keep in touch' and 'Navigate'
3. Different font sizes of text and link below 'Join us'
4. Different font size of last paragraph in the legal section

![footer old](https://user-images.githubusercontent.com/1790176/109551353-bf86c980-7ad0-11eb-8d81-2c39da1bf326.JPG)

#### What should we test?

- Re 1: Font size of links is slightly increased
- Re 2: Rows are well aligned on all relevant screen sizes (unless there is a line break)
- Re 2: Rows are well aligned also if no social icons are shown (to be configured in admin/config/content)
- Re 3: Text and link below 'Join us' have the same font size
- Re 4: Text of last paragraph in the legal section has the same font size as the other legal paragraphs
- General: Responsive behaviour is still working as expected
- General: Design is good on all relevant screen sizes

This is what it should look like:

![Footer](https://user-images.githubusercontent.com/1790176/109551356-c01f6000-7ad0-11eb-8a7f-f8d2055d5ba4.JPG)

#### Release notes
Cleaner and consistent design of front-end footer

Changelog Category: User facing changes