### PR TITLE
Updated translations to close #6666

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2512,6 +2512,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   back_to_orders_list: "Back to order list"
   no_orders_found: "No Orders Found"
   order_information: "Order Information"
+  new_payment: "New Payment"
   date_completed: "Date Completed"
   amount: "Amount"
   state_names:
@@ -3029,10 +3030,11 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"
     name_or_sku: "Name or SKU (enter at least first 4 characters of product name)"
-    resend: Resend
-    back_to_orders_list: Back To Orders List
-    return_authorizations: Return Authorizations
-    cannot_create_returns: Cannot create returns as this order has no shipped units.
+    resend: "Resend"
+    back_to_orders_list: "Back To Orders List"
+    back_to_payments_list: "Back To Payments List"
+    return_authorizations: "Return Authorizations"
+    cannot_create_returns: "Cannot create returns as this order has no shipped units."
     select_stock: "Select stock"
     location: "Location"
     count_on_hand: "Count On Hand"


### PR DESCRIPTION
#### What? Why?

Closes #6666 

#### What should we test?
1. Translation of button 'New Payment' works on /admin/orders/Rxxxxxxxxxx/payments
2. Translation of button 'Back To Payments List' works on /admin/orders/Rxxxxxxxxxx/payments/new

#### Release notes
Fixed missing translations in payments section (admin/orders)

Changelog Category: User facing changes