### PR TITLE
Fix #5018: Allow access to payments tab for canceled orders 

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -130,11 +130,11 @@ module Spree
       # At this point admin should have passed through Customer Details step
       # where order.next is called which leaves the order in payment step
       #
-      # Orders in complete step also allows to access this controller
+      # Orders in complete or canceled step also allows to access this controller
       #
       # Otherwise redirect user to that step
       def can_transition_to_payment
-        return if @order.payment? || @order.complete?
+        return if @order.payment? || @order.complete? || @order.canceled?
 
         flash[:notice] = Spree.t(:fill_in_customer_info)
         redirect_to spree.edit_admin_order_customer_url(@order)

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -278,4 +278,25 @@ describe Spree::Admin::PaymentsController, type: :controller do
       end
     end
   end
+
+  describe '#index' do
+    context "order is canceled but has a completed payment" do
+      let(:payment_method) do
+        create(
+          :stripe_sca_payment_method,
+          distributor_ids: [create(:distributor_enterprise).id],
+          preferred_enterprise_id: create(:enterprise).id
+        )
+      end
+      let!(:order) { create(:order, state: 'canceled') }
+      let!(:payment) do
+        create(:payment, order: order, payment_method: payment_method, amount: order.total)
+      end
+
+      it "renders the payments tab" do
+        spree_get :index, order_id: order.number
+        expect(response.status).to eq 200
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5018

This allows a shop manager to view the payments tab when editing a canceled order, so that they can void the payment and thus not have the order show as Credit Owed if there was already a payment completed for the order. 

#### What should we test?
- Create an order on the BO
- Compete a credit card payment for the order
- Cancel the order
- You should be able to access the Payments tab on the Edit Order page


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where the Payments tab would not appear for canceled orders in the back office. 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
