### PR TITLE
updated controller to redirect show to edit route

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -24,7 +24,7 @@ module Admin
 
     def show
       respond_to do |format|
-        format.html
+        format.html { redirect_to main_app.edit_admin_order_cycle_path(@order_cycle) }
         format.json do
           render_as_json @order_cycle, current_user: spree_current_user
         end


### PR DESCRIPTION
#### What? Why?

Closes #6943 

When you copy and paste part of a URL to go to an order cycle, you may see a server error. Per the issue, there is no view for show so if a URL is entered as https://openfoodnetwork.org.au/admin/order_cycles/6791 (without /edit), user will likely get an error. Simple fix was to redirect show to edit. 

#### What should we test?
Navigate to edit an order cycle.
Delete the /edit from the URL so that it looks like this: https://openfoodnetwork.org.au/admin/order_cycles/6791
Enter and you should get either the 'not found' error or get redirected to the order cycle edit page. 
