### PR TITLE
Fix old pending locale-related spec

### DIFF
--- a/spec/features/admin/multilingual_spec.rb
+++ b/spec/features/admin/multilingual_spec.rb
@@ -35,16 +35,10 @@ feature 'Multilingual', js: true do
   end
 
   it 'fallbacks to default_locale' do
-    pending 'current spree core has a bug if not available locale is provided'
-    # undefined method `delete_if' for "translation missing: it.date.month_names":String
-    # inside core/app/views/spree/admin/shared/_translations.html.erb
-
-    # I18n-js fallsback to 'en'
     visit spree.admin_dashboard_path(locale: 'it')
-    expect(get_i18n_locale).to eq 'it'
+    expect(get_i18n_locale).to eq 'en'
     expect(get_i18n_translation('spree_admin_overview_enterprises_header')).to eq 'My Enterprises'
+    expect(page).to have_content 'My Enterprises'
     expect(admin_user.locale).to be_nil
-    # This still is italian until we change enforce_available_locales to `true`
-    expect(page).to have_content 'Le Mie Aziende'
   end
 end


### PR DESCRIPTION
#### What? Why?

This is the correct behavior: if you set a language that is not available, it'll fall back to English.

I found this while working on https://github.com/openfoodfoundation/openfoodnetwork/pull/6902.

#### What should we test?

Green build.

#### Release notes

Re-enable old pending locale-related test
Changelog Category: Technical changes