### PR TITLE
Remove unused RSpec specs filtering

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,9 +96,6 @@ RSpec.configure do |config|
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
 
-  # Filters
-  config.filter_run_excluding skip: true, future: true, to_figure_out: true
-
   # Retry
   config.verbose_retry = true
   # Try twice (retry once)


### PR DESCRIPTION
#### What? Why?

This was introduced ages ago and became dead code as no specs use these filters anymore.

It stems from the work done in https://github.com/openfoodfoundation/openfoodnetwork/pull/6902/.

#### What should we test?
Green build.

#### Release notes
Removed unused RSpec specs filtering
Changelog Category: Technical changes