### PR TITLE
Update path to +1 map icon

### DIFF
--- a/app/assets/javascripts/darkswarm/services/map_configuration.js.erb.coffee
+++ b/app/assets/javascripts/darkswarm/services/map_configuration.js.erb.coffee
@@ -4,7 +4,7 @@ Darkswarm.factory "MapConfiguration", ->
       center:
         latitude: -37.4713077
         longitude: 144.7851531
-      cluster_icon: "<%= image_path('map_009-cluster.svg') %>"
+      cluster_icon: "/map_icons/map_009-cluster.svg"
       zoom: 12
       additional_options:
         # mapTypeId: 'satellite'
@@ -12,4 +12,3 @@ Darkswarm.factory "MapConfiguration", ->
         mapTypeControl: false
         streetViewControl: false
       styles: [{"featureType":"landscape","stylers":[{"saturation":-100},{"lightness":65},{"visibility":"on"}]},{"featureType":"poi","stylers":[{"saturation":-100},{"lightness":51},{"visibility":"simplified"}]},{"featureType":"road.highway","stylers":[{"saturation":-100},{"visibility":"simplified"}]},{"featureType":"road.arterial","stylers":[{"saturation":-100},{"lightness":30},{"visibility":"on"}]},{"featureType":"road.local","stylers":[{"saturation":-100},{"lightness":40},{"visibility":"on"}]},{"featureType":"transit","stylers":[{"saturation":-100},{"visibility":"simplified"}]},{"featureType":"administrative.province","stylers":[{"visibility":"off"}]},{"featureType":"water","elementType":"labels","stylers":[{"visibility":"on"},{"lightness":-25},{"saturation":-100}]},{"featureType":"water","elementType":"geometry","stylers":[{"hue":"#ffff00"},{"lightness":-25},{"saturation":-97}]},{"featureType":"road","elementType": "labels.icon","stylers":[{"visibility":"off"}]}]
-


### PR DESCRIPTION
#### What? Why?

Closes #6829 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
We updated the path for every icon *except* the +1 icon when we fixed this the first time.


#### What should we test?
<!-- List which features should be tested and how. -->

The +1 map icon should appear. No clearing of any cache is required.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where the +1 icon did not appear on the group maps.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
