### PR TITLE
Add gem to watch after data migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,8 @@ gem 'select2-rails', '~> 3.4.7'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', branch: 'ofn-rails-4'
 
+gem 'good_migrations'
+
 group :production, :staging do
   gem 'ddtrace'
   gem 'unicorn-worker-killer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,9 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gmaps4rails (2.1.2)
+    good_migrations (0.0.2)
+      activerecord (>= 3.1)
+      railties (>= 3.1)
     haml (5.2.1)
       temple (>= 0.8.0)
       tilt
@@ -771,6 +774,7 @@ DEPENDENCIES
   fuubar (~> 2.5.1)
   geocoder
   gmaps4rails
+  good_migrations
   haml
   highline (= 2.0.3)
   i18n

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -225,6 +225,9 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gmaps4rails (2.1.2)
+    good_migrations (0.0.2)
+      activerecord (>= 3.1)
+      railties (>= 3.1)
     haml (5.2.0)
       temple (>= 0.8.0)
       tilt
@@ -596,6 +599,7 @@ DEPENDENCIES
   fuubar (~> 2.5.1)
   geocoder
   gmaps4rails
+  good_migrations
   haml
   highline (= 2.0.3)
   i18n


### PR DESCRIPTION
#### What? Why?

> This gem prevents Rails from auto-loading app code while it's running migrations, preventing the common mistake of referencing ActiveRecord models from migration code.

This will make us stop relying on @mkllnk to have robust data migrations that don't cause trouble in the future. We tend to miss adding AR's models when he's not reviewing.

#### What should we test?

No changes in the app's code, so green build.

#### Release notes

Add `good migrations` gem to watch after data migrations
Changelog Category: Technical changes