### PR TITLE
adds test coverage related to customer balance, #6366

### DIFF
--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1357,4 +1357,27 @@ describe Spree::Order do
       end
     end
   end
+
+  describe "editing a complete order, with two line items" do
+    let!(:payment_method) { create(:payment_method) }
+    let!(:shipping_method) { create(:shipping_method) }
+    let(:order) { create(:order_ready_to_ship, line_items_count: 2) }
+    let(:item_num) { order.line_items.length }
+
+    context "updates the customer balance correctly" do
+      it "when an item is removed" do
+        order.line_items.first.destroy
+        order.update!
+        expect(item_num).to eq 1
+        expect(order.payment_state).to eq('credit_owed')
+      end
+
+      it "when the quantity of an item is increased" do
+        expect(item_num).to eq 2
+        order.line_items.second.update_attribute(:quantity, 2)
+        order.update!
+        expect(order.payment_state).to eq('balance_due')
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #6733 and #6731.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds test coverage to #6366, namely to the two following cases:

- partial refunds on paid orders (balance = 0): adding/removing some items
- or a line item -> the order turns to the "balance due" / "credit owed", respectively

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Verifies the `payment_state` of a (ready to ship) order, when:
- a line item is removed
- the quantity of an item is increased  

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes

Technical changes.

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

None.