### PR TITLE
Toggle unit price feature to individual users by email

### DIFF
--- a/config/initializers/feature_toggles.rb
+++ b/config/initializers/feature_toggles.rb
@@ -10,6 +10,12 @@ OpenFoodNetwork::FeatureToggle.enable(:customer_balance) do |user|
   end
 end
 
-OpenFoodNetwork::FeatureToggle.enable(:unit_price) do
-  ['development', 'staging'].include?(ENV['RAILS_ENV'])
+
+unit_price_beta_testers = ENV['BETA_TESTERS_FOR_UNIT_PRICE']&.split(/[\s,]+/) || []
+OpenFoodNetwork::FeatureToggle.enable(:unit_price) do |user|
+  if ['development', 'staging'].include?(ENV['RAILS_ENV'])
+    true
+  else
+    unit_price_beta_testers.include?(user.email)
+  end
 end


### PR DESCRIPTION
#### What? Why?
Closes #6870

This PR make it possible to activate unit price feature for connected user, one by one, with their email. This is done by filling the `env` variable  `BETA_TESTERS_FOR_UNIT_PRICE`, which is basically a list a email separated by comma :
```
BETA_TESTERS_FOR_UNIT_PRICE: ofn@example.com
```

This PR does't change the previous behavior, that is to say: 
_The unit price feature is activated on `staging` and `development` environment._ 


#### What should we test?
The feature is still active for `staging` and `development` environment, so testing is, to me, almost impossible.
But maybe @sauloperez has any idea?


#### Release notes
Enable the activation for unit price feature to individual user.

Changelog Category: Technical changes

