### PR TITLE
Add missing shipment_states I18n key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3617,6 +3617,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       pending: pending
       ready: ready
       shipped: shipped
+      canceled: canceled
     payment_states:
       balance_due: balance due
       completed: completed


### PR DESCRIPTION
#### What? Why?

I spot `[missing "en.spree.shipment_states.canceled" translation]` while checking the transactions tab on /account for an order that was canceled.

#### What should we test?

The following error should be gone and properly translated in English

![Screenshot from 2021-03-03 12-19-48](https://user-images.githubusercontent.com/762088/109798236-cd486600-7c1a-11eb-871a-d1d989f9f9e5.png)

#### Release notes

Added missing translation key to user account's transactions.
Changelog Category: User facing changes