### PR TITLE
Set up Bullet for development and testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,7 @@ group :test, :development do
   # Pretty printed test output
   gem 'atomic'
   gem 'awesome_print'
+  gem 'bullet'
   gem 'capybara'
   gem 'database_cleaner', require: false
   gem "factory_bot_rails", '5.2.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,9 @@ GEM
     bugsnag (6.19.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.4)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     cancancan (1.7.1)
     capybara (3.32.2)
@@ -700,6 +703,7 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
+    uniform_notifier (1.14.1)
     warden (1.2.7)
       rack (>= 1.0)
     webdrivers (4.6.0)
@@ -742,6 +746,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk (= 1.67.0)
   bugsnag
+  bullet
   byebug
   cancancan (~> 1.7.0)
   capybara

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -123,6 +123,9 @@ GEM
     bugsnag (6.18.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.4)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     cancancan (1.7.1)
     capybara (3.15.0)
@@ -524,6 +527,7 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
+    uniform_notifier (1.14.1)
     warden (1.2.9)
       rack (>= 2.0.9)
     webdrivers (4.2.0)
@@ -568,6 +572,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk (= 1.67.0)
   bugsnag
+  bullet
   byebug
   cancancan (~> 1.7.0)
   capybara

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+if defined?(Bullet)
+  Rails.application.config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+  end
+end


### PR DESCRIPTION
#### What? Why?

This will log any N+1 it finds, pointing to the line causing it and a way to solve it, aka. which `#includes` to add. Like so

```
web_1     | GET /admin/order_cycles.json?ams_prefix=index&q%5Borders_close_at_gt%5D=Sun+Jan+31+2021+00:00:00+GMT%2B0100+(Central+European+Standard+Time)
web_1     | USE eager loading detected
web_1     |   OrderCycle => [:coordinator]
web_1     |   Add to your query: .includes([:coordinator])
web_1     | Call stack
web_1     |   /usr/src/app/app/serializers/api/admin/index_order_cycle_serializer.rb:41:in `coordinator'
web_1     |   /usr/src/app/app/controllers/spree/admin/base_controller.rb:98:in `render_as_json'
web_1     |   /usr/src/app/app/controllers/admin/order_cycles_controller.rb:17:in `block (2 levels) in index'
web_1     |   /usr/src/app/app/controllers/admin/order_cycles_controller.rb:14:in `index'
web_1     |   bin/rails:4:in `require'
web_1     |   bin/rails:4:in `<main>'
```

We gave a try at Bullet long ago and abandoned it because it's not a silver bullet (pun intended) due to false positives. However, it's pretty clear that this won't happen often; we have endless N+1 still to fix.

I recently experienced how, relying on Bullet made it just extra 30s to fix additional N+1s other than the one I was fixing. Usually, finding the culprit line takes me more of 30min.

Hopefully, this will address my growing concern about not only not fixing enough N+1s but introducing new ones.

#### What should we test?

Nothing.

#### Release notes

Add Bullet to catch N+1s in testing and development
Changelog Category: Technical changes