### PR TITLE
[Rails 5] Payment and shipment states

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -199,8 +199,7 @@ module Spree
     end
 
     def update_order
-      order.payments.reload
-      order.update!
+      order.reload.update!
     end
 
     # Necessary because some payment gateways will refuse payments with

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -329,7 +329,7 @@ module Spree
     end
 
     def update_order
-      order.update!
+      order.reload.update!
     end
   end
 end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -338,6 +338,10 @@ feature "As a consumer I want to check out my cart", js: true do
         order = Spree::Order.complete.first
         expect(order.special_instructions).to eq "SpEcIaL NoTeS"
 
+        # Shipment and payments states should be set
+        expect(order.payment_state).to eq "balance_due"
+        expect(order.shipment_state).to eq "pending"
+
         # And the Spree tax summary should not be displayed
         expect(page).not_to have_content product.tax_category.name
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1212,20 +1212,11 @@ describe Spree::Order do
         expect { order.next! }.to change { order.state }.from("delivery").to("payment")
       end
 
-      it "advances to complete state despite error" do
+      # Regression test for https://github.com/openfoodfoundation/openfoodnetwork/issues/3924
+      it "advances to complete state without error" do
         advance_to_delivery_state(order)
-        # advance to payment state
         order.next!
-
         create(:payment, order: order)
-        # https://github.com/openfoodfoundation/openfoodnetwork/issues/3924
-        observed_error = ActiveRecord::RecordNotUnique.new(
-          "PG::UniqueViolation",
-          StandardError.new
-        )
-        expect(order.shipment).to receive(:save).and_call_original
-        expect(order.shipment).to receive(:save).and_call_original
-        expect(order.shipment).to receive(:save).and_raise(observed_error)
 
         expect { order.next! }.to change { order.state }.from("payment").to("complete")
       end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -442,7 +442,7 @@ describe Spree::Shipment do
 
   context "update_order" do
     it "should update order" do
-      expect(order).to receive(:update!)
+      expect(order).to receive_message_chain(:reload, :update!)
       shipment.__send__(:update_order)
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #7003, and probably #7004

For some reason the order objects were stale here when calling `order.update!` from callbacks in either a payment or shipment object during checkout, which was overwriting `payment_state` and `shipment_state` with `nil` on the order.

#### What should we test?
<!-- List which features should be tested and how. -->

See #7003 and #7004

