### PR TITLE
Add resumed to list of allowable order states to view the payment tab

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -134,7 +134,7 @@ module Spree
       #
       # Otherwise redirect user to that step
       def can_transition_to_payment
-        return if @order.payment? || @order.complete? || @order.canceled?
+        return if @order.payment? || @order.complete? || @order.canceled? || @order.resumed?
 
         flash[:notice] = Spree.t(:fill_in_customer_info)
         redirect_to spree.edit_admin_order_customer_url(@order)

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -297,6 +297,17 @@ describe Spree::Admin::PaymentsController, type: :controller do
         spree_get :index, order_id: order.number
         expect(response.status).to eq 200
       end
+
+      context "order is then resumed" do
+        before do
+          order.resume
+        end
+
+        it "still renders the payments tab" do
+          spree_get :index, order_id: order.number
+          expect(response.status).to eq 200
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #7011

This adds "resumed" to the list of states that an order can be in. 


#### What should we test?
<!-- List which features should be tested and how. -->
Visiting the payments tab on a resumed order.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where orders in the Resumed state could not access the payments tab.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
