### PR TITLE
Only show primary producers on shopfront list of producers (fix #4218)

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -250,7 +250,7 @@ class Enterprise < ActiveRecord::Base
 
   def plus_relatives_and_oc_producers(order_cycles)
     oc_producer_ids = Exchange.in_order_cycle(order_cycles).incoming.pluck :sender_id
-    Enterprise.relatives_of_one_union_others(id, oc_producer_ids | [id])
+    Enterprise.is_primary_producer.relatives_of_one_union_others(id, oc_producer_ids | [id])
   end
 
   def relatives_including_self

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -599,4 +599,19 @@ describe Enterprise do
       end
     end
   end
+
+  describe "#plus_relatives_and_oc_producers" do
+    it "does not find non-produders " do
+      supplier = create(:supplier_enterprise)
+      distributor = create(:distributor_enterprise, is_primary_producer: false)
+      product = create(:product)
+      order_cycle = create(
+        :simple_order_cycle,
+        suppliers: [supplier],
+        distributors: [distributor],
+        variants: [product.master]
+      )
+      expect(distributor.plus_relatives_and_oc_producers(order_cycle)).to eq([supplier])
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #4218

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This limits the list of producers on the shopfront Producers tab to those enterprises who are primary producers; that is, it does not show hub-only enterprises.


#### What should we test?
<!-- List which features should be tested and how. -->
Enterprises that are hubs and not primary producers should not show up on that tab for a hub. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where non-producing enterprises would show up on the shopfront's list of producers.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
