### PR TITLE
Reduce unnecessary updates in Payment#revoke_adjustment_eligibility

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -154,8 +154,10 @@ module Spree
       return unless adjustment.try(:reload)
       return if adjustment.finalized?
 
-      adjustment.update_attribute(:eligible, false)
-      adjustment.finalize!
+      adjustment.update(
+        eligible: false,
+        state: "finalized"
+      )
     end
 
     def validate_source


### PR DESCRIPTION
#### What? Why?

This method was triggering two separate adjustment updates, and each of those updates could trigger callbacks, and those could trigger other callbacks. Here we're achieving the same thing, but with only one update.

#### What should we test?
<!-- List which features should be tested and how. -->

A quick sanity check that transaction fees on failed payments are working correctly (not added to the order total).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved efficiency when revoking adjustment eligibility.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

