### PR TITLE
DCOTW: Spree::Config[:auto_capture]

### DIFF
--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -36,8 +36,6 @@ module Spree
     preference :allow_ssl_in_development_and_test, :boolean, default: false
     preference :allow_ssl_in_production, :boolean, default: true
     preference :allow_ssl_in_staging, :boolean, default: true
-    # Automatically capture the credit card (as opposed to just authorize and capture later)
-    preference :auto_capture, :boolean, default: false
     # Replace with the name of a zone if you would like to limit the countries
     preference :checkout_zone, :string, default: nil
     preference :currency, :string, default: "USD"

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -31,10 +31,6 @@ module Spree
         provider_class.new
       end
 
-      def auto_capture?
-        true
-      end
-
       def method_type
         'paypal'
       end

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -6,22 +6,14 @@ module Spree
       def process!
         return unless validate!
 
-        if payment_method.auto_capture?
-          purchase!
-        else
-          authorize!
-        end
+        purchase!
       end
 
       def process_offline!
         return unless validate!
         return if authorization_action_required?
 
-        if payment_method.auto_capture?
-          charge_offline!
-        else
-          authorize!
-        end
+        charge_offline!
       end
 
       def authorize!(return_url = nil)

--- a/app/models/spree/payment_method.rb
+++ b/app/models/spree/payment_method.rb
@@ -89,10 +89,6 @@ module Spree
       true
     end
 
-    def auto_capture?
-      Spree::Config[:auto_capture]
-    end
-
     def supports?(_source)
       true
     end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -22,10 +22,6 @@ Spree.config do |config|
   config.address_requires_state = true
   config.admin_interface_logo = '/default_images/ofn-logo.png'
 
-  # -- spree_paypal_express
-  # Auto-capture payments. Without this option, payments must be manually captured in the paypal interface.
-  config.auto_capture = true
-
   # S3 settings
   config.s3_bucket = ENV['S3_BUCKET'] if ENV['S3_BUCKET']
   config.s3_access_key = ENV['S3_ACCESS_KEY'] if ENV['S3_ACCESS_KEY']

--- a/spec/models/spree/order/payment_spec.rb
+++ b/spec/models/spree/order/payment_spec.rb
@@ -9,9 +9,6 @@ module Spree
     let(:bogus) { create(:bogus_payment_method, distributors: [create(:enterprise)]) }
 
     before do
-      # So that Payment#purchase! is called during processing
-      Spree::Config[:auto_capture] = true
-
       allow(order).to receive_message_chain(:line_items, :empty?).and_return(false)
       allow(order).to receive_messages total: 100
     end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -81,17 +81,9 @@ describe Spree::Payment do
       end
 
       context "#process!" do
-        it "should purchase if with auto_capture" do
+        it "should call purchase!" do
           payment = build_stubbed(:payment, payment_method: gateway)
-          expect(payment.payment_method).to receive(:auto_capture?).and_return(true)
           expect(payment).to receive(:purchase!)
-          payment.process!
-        end
-
-        it "should authorize without auto_capture" do
-          payment = build_stubbed(:payment, payment_method: gateway)
-          expect(payment.payment_method).to receive(:auto_capture?).and_return(false)
-          expect(payment).to receive(:authorize!)
           payment.process!
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -172,7 +172,6 @@ RSpec.configure do |config|
       spree_config.checkout_zone = checkout_zone
       spree_config.currency = currency
       spree_config.shipping_instructions = true
-      spree_config.auto_capture = true
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Dead code of the week, episode 2. Removes `Spree::Config[:auto_capture]` and related code. 

We set this value to `true` unconditionally in an initializer, and then check the value in various places via Spree::Config. It's never `false`, and it's not configurable, so we can just drop it and remove the related conditionals.

:fire::fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Payment states on Paypal and payment methods that use cards should behave as before, in term of their payment state after the order is submitted.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed unnecessary code Spree::Config[:auto_capture]

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

