### PR TITLE
[Adjustments] Simplify order tax adjustments

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -662,9 +662,7 @@ module Spree
     end
 
     def total_tax
-      adjustments.sum(:included_tax) +
-        shipment_adjustments.sum(:included_tax) +
-        line_item_adjustments.tax.sum(:amount)
+      additional_tax_total + included_tax_total
     end
 
     def has_taxes_included

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -82,11 +82,6 @@ module Spree
 
       order.adjustments.reload
       order.line_items.reload
-      # TaxRate adjustments (order.adjustments.tax)
-      #   and line item adjustments (tax included on line items) consist of 100% tax
-      order.adjustments.tax.additional.each do |adjustment|
-        adjustment.set_absolute_included_tax! adjustment.amount
-      end
     end
 
     def default_zone_or_zone_match?(order)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -692,7 +692,7 @@ describe Spree::Order do
         amount: 123,
         included_tax: 2
       )
-      order.reload
+      order.update!
     end
 
     it "returns a sum of all tax on the order" do


### PR DESCRIPTION
#### What? Why?

Following #6973

Simplifies order taxes, removing another use of the `included_tax` column (which is deprecated and being slowly removed).

Note: the first three commits here are PR #6973, the last two are what's added by this PR.

#### What should we test?
<!-- List which features should be tested and how. -->

When using **additional taxes** (which are recorded directly on the order object), the amounts should be added correctly and be included in the total.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed use of included_tax column with order tax adjustments

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
