### PR TITLE
DCOTW: Order#has_available_shipment

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -90,7 +90,6 @@ module Spree
     before_create :link_by_email
     after_create :create_tax_charge!
 
-    validate :has_available_shipment
     validates :email, presence: true,
                       format: /\A([\w\.%\+\-']+)@([\w\-]+\.)+([\w]{2,})\z/i,
                       if: :require_email
@@ -741,12 +740,6 @@ module Spree
       return if line_items.present?
 
       errors.add(:base, Spree.t(:there_are_no_items_for_this_order)) && (return false)
-    end
-
-    def has_available_shipment
-      return unless address?
-      return unless ship_address&.valid?
-      # errors.add(:base, :no_shipping_methods_available) if available_shipping_methods.empty?
     end
 
     def ensure_available_shipping_rates

--- a/spec/models/spree/order/state_machine_spec.rb
+++ b/spec/models/spree/order/state_machine_spec.rb
@@ -18,7 +18,6 @@ describe Spree::Order do
         order.run_callbacks(:create)
         allow(order).to receive_messages payment_required?: true
         allow(order).to receive_messages process_payments!: true
-        allow(order).to receive :has_available_shipment
       end
 
       context "when payment processing succeeds" do
@@ -114,7 +113,6 @@ describe Spree::Order do
     it "should send a cancel email" do
       # Stub methods that cause side-effects in this test
       allow(shipment).to receive(:cancel!)
-      allow(order).to receive :has_available_shipment
       allow(order).to receive :restock_items!
       mail_message = double "Mail::Message"
       order_id = nil
@@ -133,8 +131,6 @@ describe Spree::Order do
         allow(shipment).to receive(:update_order)
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
         allow(mail_message).to receive :deliver_later
-
-        allow(order).to receive :has_available_shipment
       end
     end
 
@@ -143,7 +139,6 @@ describe Spree::Order do
         # Stubs methods that cause unwanted side effects in this test
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
         allow(mail_message).to receive :deliver_later
-        allow(order).to receive :has_available_shipment
         allow(order).to receive :restock_items!
         allow(shipment).to receive(:cancel!)
       end
@@ -174,9 +169,6 @@ describe Spree::Order do
       allow(order).to receive_messages email: "user@spreecommerce.com"
       allow(order).to receive_messages state: "canceled"
       allow(order).to receive_messages allow_resume?: true
-
-      # Stubs method that cause unwanted side effects in this test
-      allow(order).to receive :has_available_shipment
     end
   end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -176,9 +176,6 @@ describe Spree::Order do
     end
 
     it "should freeze all adjustments" do
-      # Stub this method as it's called due to a callback
-      # and it's irrelevant to this test
-      allow(order).to receive :has_available_shipment
       allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_later
       adjustments = double
       allow(order).to receive_messages adjustments: adjustments


### PR DESCRIPTION
#### What? Why?

Dead code of the week, episode 3: `Spree::Order#has_available_shipment`.

In a previous version of Spree, the error that's part of this validation method was commented out. It's deleted in a later version of Spree.

:fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed unused code: Order#has_available_shipment

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
