### PR TITLE
[Adjustments] Remove Adjustment#set_eligibility

### DIFF
--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -87,16 +87,6 @@ module Spree
 
     localize_number :amount
 
-    # Update the boolean _eligible_ attribute which determines which adjustments
-    # count towards the order's adjustment_total.
-    def set_eligibility
-      result = mandatory || amount != 0
-      update_columns(
-        eligible: result,
-        updated_at: Time.zone.now
-      )
-    end
-
     # Update both the eligibility and amount of the adjustment. Adjustments
     # delegate updating of amount to their Originator when present, but only if
     # +locked+ is false. Adjustments that are +locked+ will never change their amount.
@@ -119,7 +109,6 @@ module Spree
       # the order object. After calling a reload, the source is the Shipment.
       reload
       originator.update_adjustment(self, calculable || source) if originator.present?
-      set_eligibility
     end
 
     def currency

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -24,6 +24,7 @@ describe Spree::Admin::OrdersController, type: :controller do
           :adjustment,
           adjustable: order,
           label: "invalid adjustment",
+          eligible: false,
           amount: 0
         )
 

--- a/spec/helpers/admin/orders_helper_spec.rb
+++ b/spec/helpers/admin/orders_helper_spec.rb
@@ -18,8 +18,9 @@ describe Admin::OrdersHelper, type: :helper do
       expect(helper.order_adjustments_for_display(order)).to eq []
     end
 
-    it "filters zero tax rate adjustments" do
-      create(:adjustment, adjustable: order, amount: 0, originator_type: "Spree::TaxRate")
+    it "filters ineligible adjustments" do
+      create(:adjustment, adjustable: order, amount: 0, eligible: false,
+                          originator_type: "Spree::TaxRate")
 
       expect(helper.order_adjustments_for_display(order)).to eq []
     end

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -36,11 +36,6 @@ module Spree
           adjustment.update!
         end
 
-        it "should set the eligibility" do
-          expect(adjustment).to receive(:set_eligibility)
-          adjustment.update!
-        end
-
         it "should ask the originator to update_adjustment" do
           expect(originator).to receive(:update_adjustment)
           adjustment.update!
@@ -65,33 +60,6 @@ module Spree
         allow(adjustment).to receive_messages originator: nil
         expect(adjustment).not_to receive(:amount=)
         adjustment.update!
-      end
-    end
-
-    context "#eligible? after #set_eligibility" do
-      context "when amount is 0" do
-        before { adjustment.amount = 0 }
-        it "should be eligible if mandatory?" do
-          adjustment.mandatory = true
-          adjustment.set_eligibility
-          expect(adjustment).to be_eligible
-        end
-
-        it "should not be eligible unless mandatory?" do
-          adjustment.mandatory = false
-          adjustment.set_eligibility
-          expect(adjustment).to_not be_eligible
-        end
-      end
-
-      context "when amount is greater than 0" do
-        before { adjustment.amount = 25.00 }
-
-        it "should be eligible if mandatory?" do
-          adjustment.mandatory = true
-          adjustment.set_eligibility
-          expect(adjustment).to be_eligible
-        end
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Removes the `#set_eligibility` method from `Spree::Adjustment`.

All adjustments are "eligible" by default (at the database level). Adjustments for payment fees can have their eligibility explicitly revoked if the associated payment fails. The only other reason an adjustment can be marked as "ineligible" is if it's amount is zero. This is not really necessary, as adjustments are generally summed together, and an adjustment with zero amount will make no difference in any of the totals. Also, if an adjustment would have a zero amount when it's created, it gets ignored instead of saved.

This removed bit of code was adding an additional database hit every time an adjustment was updated (which happens often), essentially for no reason.

:fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Green build? I'm not sure what could be manually tested here...

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed Adjustment#set_eligibility

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
