### PR TITLE
Verify line item when placing sub order (Fix #6680)

### DIFF
--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -62,6 +62,7 @@ class SubscriptionPlacementJob < ActiveJob::Base
     unavailable_stock_lines_for(order).each do |line_item|
       changes[line_item.id] = changes[line_item.id] || line_item.quantity
       line_item.update(quantity: 0)
+      Spree::OrderInventory.new(order).verify(line_item)
     end
     changes
   end

--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -62,7 +62,12 @@ class SubscriptionPlacementJob < ActiveJob::Base
     unavailable_stock_lines_for(order).each do |line_item|
       changes[line_item.id] = changes[line_item.id] || line_item.quantity
       line_item.update(quantity: 0)
-      Spree::OrderInventory.new(order).verify(line_item)
+
+      Spree::OrderInventory.new(order).verify(line_item, order.shipment)
+    end
+    if changes.present?
+      order.line_items.reload
+      order.update_order_fees!
     end
     changes
   end

--- a/app/models/spree/order_inventory.rb
+++ b/app/models/spree/order_inventory.rb
@@ -98,8 +98,7 @@ module Spree
         inventory_unit.destroy
         removed_quantity += 1
       end
-
-      shipment.destroy if shipment.inventory_units.count == 0
+      shipment.destroy if shipment.inventory_units.reload.count == 0
 
       # removing this from shipment, and adding to stock_location
       if order.completed?

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -115,6 +115,18 @@ describe SubscriptionPlacementJob do
           expect(changes[line_item2.id]).to be 3
           expect(changes[line_item3.id]).to be 3
         end
+
+        context "and the order has been placed" do
+          before do
+            allow(order).to receive(:ensure_available_shipping_rates) { true }
+            allow(order).to receive(:process_each_payment) { true }
+            job.send(:place_order, order.reload)
+          end
+
+          it "removes the unavailable items from the shipment" do
+            expect(order.shipment.manifest.size).to eq 1
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #6680 

It looks like when we place a subscription order and there isn't sufficient stock for one of the items, we leave the line item on the order with quantity 0, so that we can show the customer and shop owner what changed in their subscription order because of insufficient stock. 

However, since the `Shipment#manifest` method does not take the quantity of a line item into account, it determines (incorrectly) that there is still quantity 1 of those line items on the order. 

This removes the inventory unit from the shipment manifest, so that the item no longer appears on the order view in the admin view.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Placing a subscription order with unavailable stock. Previously the item remained on the order with quantity 0



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where subscription items that were out of stock would show up on the back office view of the order.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
