### PR TITLE
Transform question mark to cross to close it (unit price)

### DIFF
--- a/app/assets/stylesheets/darkswarm/question-mark-icon.scss
+++ b/app/assets/stylesheets/darkswarm/question-mark-icon.scss
@@ -4,8 +4,6 @@
 }
 
 .question-mark-icon {
-  position: relative;
-  right: 1px;
   background-image: image-url("question-mark-icon.svg");
   background-size: cover;
   background-repeat: no-repeat;

--- a/app/assets/stylesheets/darkswarm/question-mark-icon.scss
+++ b/app/assets/stylesheets/darkswarm/question-mark-icon.scss
@@ -9,6 +9,7 @@
   background-image: image-url("question-mark-icon.svg");
   background-size: cover;
   background-repeat: no-repeat;
+  border-radius: 50%;
 
   // Reset button element css attributes
   padding: 0;
@@ -22,6 +23,17 @@
   &:focus {
     background-color: transparent;
   }
+
+  &.open {
+    background-image: none;
+    background-color: $teal-500;
+
+    &::before {
+      @include icon-font;
+      content: "";
+      color: $white;
+    }
+  }
 }
 
 .joyride-tip-guide.question-mark-tooltip {
@@ -29,7 +41,7 @@
   max-width: 65%;
   // JS needs to be tweaked to adjust for left alignment - this is dynamic can't rewrite in CSS
   margin-left: -7.4rem;
-  margin-top: 0.1rem;
+  margin-top: -0.1rem;
   background-color: transparent;
 
   .background {
@@ -39,6 +51,7 @@
     width: 100%;
     height: 100%;
     z-index: -1;
+    cursor: pointer;
   }
 
   .joyride-content-wrapper {


### PR DESCRIPTION
#### What? Why?
Question mark icon is now a cross when tooltip is opened. Easier to understand that you can close it.

Closes #6978 

#### What should we test?
1. In a shopfront, when `unit price` feature toggle is enabled, you should see a question mark icon.
2. Click on the question mark. The icon is now a cross.
3. Click outside. The tooltip should close and now the icon is a question mark again.

#### Screenshots
![2021-03-09 17 31 45](https://user-images.githubusercontent.com/296452/110504363-608f0900-80fd-11eb-95a5-dc96061f2591.gif)



#### Release notes
Improve behavior of the Unit Price tooltip by designing a close icon when opening the tooltip.
Changelog Category: User facing changes



