### PR TITLE
Fix broken payments report

### DIFF
--- a/lib/open_food_network/order_grouper.rb
+++ b/lib/open_food_network/order_grouper.rb
@@ -18,8 +18,7 @@ module OpenFoodNetwork
 
     def group_and_sort(rule, remaining_rules, items)
       branch = {}
-      groups = items.group_by { |item| rule[:group_by].call(item) }
-
+      groups = items.group_by { |item| rule[:group_by].call(item) }.select { |key, _value| !key.nil? }
       sorted_groups = groups.sort_by { |key, _value| rule[:sort_by].call(key) }
 
       sorted_groups.each do |property, items_by_property|


### PR DESCRIPTION
#### What? Why?

Closes #7021 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This might not be the ideal solution, but it illustrates what's causing the 500. There's a payment whose order has a `nil` payment_state. This removes that payment from the report. 

<s>We should check to see how we handle these payments currently</s>

Update: I get the same error in master if I have the same data; that is, if there is a payment whose order has a `nil` payment_state. So this probably isn't a Rails 5 specific regression, but maybe due to the fact that in testing Rails 5 (especially the SCA bug #7004 etc.) we got some orders into a weird state that wouldn't normally be seen. 

We could merge this to defensively guard against such orders, or we could reason that we *should* throw a 500 on the report if an order ever gets into this state. 


#### What should we test?
<!-- List which features should be tested and how. -->
The payments report should load


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
