### PR TITLE
Show Terms of Service at checkout if required 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ app/public
 public/system
 public/stylesheets
 public/images
+public/files
 public/spree
 public/assets
 config/abr.yml

--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -3,7 +3,7 @@
 module TermsAndConditionsHelper
   def render_terms_and_conditions
     if platform_terms_required? && terms_and_conditions_activated?
-      render("checkout/terms_and_conditions") + render("checkout/platform_terms_of_service")
+      render("checkout/all_terms_and_conditions")
     elsif platform_terms_required?
       render "checkout/platform_terms_of_service"
     elsif terms_and_conditions_activated?

--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module TermsAndConditionsHelper
+  def platform_terms_required?
+    Spree::Config.shoppers_require_tos
+  end
+
   def terms_and_conditions_activated?
     current_order.distributor.terms_and_conditions.file?
   end

--- a/app/helpers/terms_and_conditions_helper.rb
+++ b/app/helpers/terms_and_conditions_helper.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module TermsAndConditionsHelper
+  def render_terms_and_conditions
+    if platform_terms_required? && terms_and_conditions_activated?
+      render("checkout/terms_and_conditions") + render("checkout/platform_terms_of_service")
+    elsif platform_terms_required?
+      render "checkout/platform_terms_of_service"
+    elsif terms_and_conditions_activated?
+      render "checkout/terms_and_conditions"
+    end
+  end
+
   def platform_terms_required?
     Spree::Config.shoppers_require_tos
   end

--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -113,6 +113,7 @@ module Spree
     # Legal Preferences
     preference :footer_tos_url, :string, default: "/Terms-of-service.pdf"
     preference :enterprises_require_tos, :boolean, default: false
+    preference :shoppers_require_tos, :boolean, default: false
     preference :privacy_policy_url, :string, default: nil
     preference :cookies_consent_banner_toggle, :boolean, default: false
     preference :cookies_policy_matomo_section, :boolean, default: false

--- a/app/views/checkout/_all_terms_and_conditions.html.haml
+++ b/app/views/checkout/_all_terms_and_conditions.html.haml
@@ -1,0 +1,4 @@
+%p
+  %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_accepted=false" } }
+  %label.small{for: "accept_terms"}
+    = t('.message_html', terms_and_conditions_link: link_to( t(".terms_and_conditions"), current_order.distributor.terms_and_conditions.url, target: '_blank'), tos_link: link_to(t(".terms_of_service"), Spree::Config.footer_tos_url, target: "_blank"))

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -16,6 +16,7 @@
   = render "checkout/payment", f: f
   = render "checkout/already_ordered", f: f if show_bought_items?
   = render "checkout/terms_and_conditions"
+  = render "checkout/platform_terms_of_service" if platform_terms_required?
   %p
     %button.button.primary{ type: :submit, ng: { disabled: "terms_and_conditions_activated && !terms_and_conditions_accepted" } }
       = t :checkout_send

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -18,6 +18,6 @@
   = render "checkout/terms_and_conditions"
   = render "checkout/platform_terms_of_service" if platform_terms_required?
   %p
-    %button.button.primary{ type: :submit, ng: { disabled: "terms_and_conditions_activated && !terms_and_conditions_accepted" } }
+    %button.button.primary{ type: :submit, ng: { disabled: "(terms_and_conditions_activated && !terms_and_conditions_accepted) || platform_tos_accepted == false" } }
       = t :checkout_send
     / {{ checkout.$valid }}

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -15,7 +15,7 @@
   = render "checkout/shipping", f: f
   = render "checkout/payment", f: f
   = render "checkout/already_ordered", f: f if show_bought_items?
-  = render "checkout/terms_and_conditions", f: f
+  = render "checkout/terms_and_conditions"
   %p
     %button.button.primary{ type: :submit, ng: { disabled: "terms_and_conditions_activated && !terms_and_conditions_accepted" } }
       = t :checkout_send

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -15,8 +15,7 @@
   = render "checkout/shipping", f: f
   = render "checkout/payment", f: f
   = render "checkout/already_ordered", f: f if show_bought_items?
-  = render "checkout/terms_and_conditions"
-  = render "checkout/platform_terms_of_service" if platform_terms_required?
+  = render_terms_and_conditions
   %p
     %button.button.primary{ type: :submit, ng: { disabled: "terms_and_conditions_accepted == false || platform_tos_accepted == false" } }
       = t :checkout_send

--- a/app/views/checkout/_form.html.haml
+++ b/app/views/checkout/_form.html.haml
@@ -18,6 +18,6 @@
   = render "checkout/terms_and_conditions"
   = render "checkout/platform_terms_of_service" if platform_terms_required?
   %p
-    %button.button.primary{ type: :submit, ng: { disabled: "(terms_and_conditions_activated && !terms_and_conditions_accepted) || platform_tos_accepted == false" } }
+    %button.button.primary{ type: :submit, ng: { disabled: "terms_and_conditions_accepted == false || platform_tos_accepted == false" } }
       = t :checkout_send
     / {{ checkout.$valid }}

--- a/app/views/checkout/_platform_terms_of_service.html.haml
+++ b/app/views/checkout/_platform_terms_of_service.html.haml
@@ -1,0 +1,4 @@
+%p
+  %input{ type: "checkbox", id: "platform_tos_accepted" }
+  %label.small{for: "platform_tos_accepted"}
+    = t(".message_html", tos_link: link_to(t(".terms_of_service"), Spree::Config.footer_tos_url, target: "_blank"))

--- a/app/views/checkout/_platform_terms_of_service.html.haml
+++ b/app/views/checkout/_platform_terms_of_service.html.haml
@@ -1,4 +1,4 @@
 %p
-  %input{ type: "checkbox", id: "platform_tos_accepted" }
+  %input{ type: "checkbox", id: "platform_tos_accepted", ng: { model: "platform_tos_accepted", init: "platform_tos_accepted = false" } }
   %label.small{for: "platform_tos_accepted"}
     = t(".message_html", tos_link: link_to(t(".terms_of_service"), Spree::Config.footer_tos_url, target: "_blank"))

--- a/app/views/checkout/_terms_and_conditions.html.haml
+++ b/app/views/checkout/_terms_and_conditions.html.haml
@@ -1,4 +1,4 @@
 - if terms_and_conditions_activated?
   %p
-    %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_activated=#{terms_and_conditions_activated?}; terms_and_conditions_accepted=#{terms_and_conditions_already_accepted?}" } }
+    %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_accepted=#{terms_and_conditions_already_accepted?}" } }
       %label.small{for: "accept_terms"}= t('.message_html', terms_and_conditions_link: link_to( t( '.link_text' ), current_order.distributor.terms_and_conditions.url, target: '_blank'))

--- a/app/views/checkout/_terms_and_conditions.html.haml
+++ b/app/views/checkout/_terms_and_conditions.html.haml
@@ -1,4 +1,3 @@
-- if terms_and_conditions_activated?
-  %p
-    %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_accepted=#{terms_and_conditions_already_accepted?}" } }
-      %label.small{for: "accept_terms"}= t('.message_html', terms_and_conditions_link: link_to( t( '.link_text' ), current_order.distributor.terms_and_conditions.url, target: '_blank'))
+%p
+  %input{ type: 'checkbox', id: 'accept_terms', ng: { model: "terms_and_conditions_accepted", init: "terms_and_conditions_accepted=#{terms_and_conditions_already_accepted?}" } }
+    %label.small{for: "accept_terms"}= t('.message_html', terms_and_conditions_link: link_to( t( '.link_text' ), current_order.distributor.terms_and_conditions.url, target: '_blank'))

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -33,6 +33,9 @@
               = preference_field_tag(:enterprises_require_tos, Spree::Config[:enterprises_require_tos], :type => Spree::Config.preference_type(:enterprises_require_tos))
               = label_tag(:enterprises_require_tos, t('.enterprises_require_tos')) + tag(:br)
             .field
+              = preference_field_tag(:shoppers_require_tos, Spree::Config[:shoppers_require_tos], :type => Spree::Config.preference_type(:shoppers_require_tos))
+              = label_tag(:shoppers_require_tos, t('.shoppers_require_tos')) + tag(:br)
+            .field
               = preference_field_tag(:cookies_consent_banner_toggle, Spree::Config[:cookies_consent_banner_toggle], :type => Spree::Config.preference_type(:cookies_consent_banner_toggle))
               = label_tag(:cookies_consent_banner_toggle, t('.cookies_consent_banner_toggle')) + tag(:br)
             .field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1246,6 +1246,9 @@ en:
     terms_and_conditions:
       message_html: "I agree to the seller's %{terms_and_conditions_link}."
       link_text: "Terms and Conditions"
+    platform_terms_of_service:
+      message_html: "I agree to the platform %{tos_link}."
+      terms_of_service: "Terms of Service"
     failed: "The checkout failed. Please let us know so that we can process your order."
   shops:
     hubs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3582,6 +3582,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           cookies_consent_banner_toggle: "Display cookies consent banner"
           privacy_policy_url: "Privacy Policy URL"
           enterprises_require_tos: "Enterprises must accept Terms of Service"
+          shoppers_require_tos: "Shoppers must accept Terms of Service"
           cookies_policy_matomo_section: "Display Matomo section on cookies policy page"
           footer_tos_url: "Terms of Service URL"
     checkout:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1249,6 +1249,10 @@ en:
     platform_terms_of_service:
       message_html: "I agree to the platform %{tos_link}."
       terms_of_service: "Terms of Service"
+    all_terms_and_conditions:
+      message_html: "I agree to the seller's %{terms_and_conditions_link} and the platform %{tos_link}."
+      terms_and_conditions: "Terms and Conditions"
+      terms_of_service: "Terms of Service"
     failed: "The checkout failed. Please let us know so that we can process your order."
   shops:
     hubs:

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -218,13 +218,11 @@ feature "As a consumer I want to check out my cart", js: true do
         expect(page).to have_link("Terms of Service", href: tos_url)
         expect(page).to have_button("Place order now", disabled: true)
 
+        # Both Ts&Cs and TOS appear in the one label for the one checkbox.
         check "Terms and Conditions"
-        expect(page).to have_button("Place order now", disabled: true)
-
-        check "Terms of Service"
         expect(page).to have_button("Place order now", disabled: false)
 
-        uncheck "Terms and Conditions"
+        uncheck "Terms of Service"
         expect(page).to have_button("Place order now", disabled: true)
       end
     end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -120,15 +120,10 @@ feature "As a consumer I want to check out my cart", js: true do
       end
 
       it "shows only applicable content" do
-        # Unifying several specs here to speed up test run.
-
-        # it doesn't tell about previous orders
         expect(page).to have_no_content("You have an order for this order cycle already.")
 
-        # doesn't show link to terms and conditions
         expect(page).to have_no_link("Terms and Conditions")
 
-        # doesn't show link to platform terms of service
         expect(page).to have_no_link("Terms of Service")
       end
     end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -119,15 +119,16 @@ feature "As a consumer I want to check out my cart", js: true do
         end
       end
 
-      it "doesn't tell about previous orders" do
+      it "shows only applicable content" do
+        # Unifying several specs here to speed up test run.
+
+        # it doesn't tell about previous orders
         expect(page).to have_no_content("You have an order for this order cycle already.")
-      end
 
-      it "doesn't show link to terms and conditions" do
+        # doesn't show link to terms and conditions
         expect(page).to have_no_link("Terms and Conditions")
-      end
 
-      it "doesn't show link to platform terms of service" do
+        # doesn't show link to platform terms of service
         expect(page).to have_no_link("Terms of Service")
       end
     end

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -126,6 +126,10 @@ feature "As a consumer I want to check out my cart", js: true do
       it "doesn't show link to terms and conditions" do
         expect(page).to have_no_link("Terms and Conditions")
       end
+
+      it "doesn't show link to platform terms of service" do
+        expect(page).to have_no_link("Terms of Service")
+      end
     end
 
     context "when distributor has T&Cs" do
@@ -168,6 +172,21 @@ feature "As a consumer I want to check out my cart", js: true do
             expect(page).to have_button("Place order now", disabled: true)
           end
         end
+      end
+    end
+
+    context "when the platform's terms of service have to be accepted" do
+      let(:tos_url) { "https://example.org/tos" }
+
+      before do
+        allow(Spree::Config).to receive(:shoppers_require_tos).and_return(true)
+        allow(Spree::Config).to receive(:footer_tos_url).and_return(tos_url)
+      end
+
+      it "shows a link to the terms" do
+        visit checkout_path
+        expect(page).to have_link("Terms of Service", href: tos_url)
+        expect(find_link("Terms of Service")[:target]).to eq "_blank"
       end
     end
 

--- a/spec/helpers/terms_and_conditions_helper_spec.rb
+++ b/spec/helpers/terms_and_conditions_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe TermsAndConditionsHelper, type: :helper do
+  describe "#platform_terms_required?" do
+    it "returns true" do
+      expect(Spree::Config).to receive(:shoppers_require_tos).and_return(true)
+      expect(helper.platform_terms_required?).to eq true
+    end
+
+    it "returns false" do
+      expect(Spree::Config).to receive(:shoppers_require_tos).and_return(false)
+      expect(helper.platform_terms_required?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #6327

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Instance managers can now switch to requiring shoppers to accept the platform's terms of service on every checkout. Remembering if a user agreed already is out of scope and handled in #6328.

Admin:
![Screenshot from 2021-03-10 17-11-41](https://user-images.githubusercontent.com/3524483/110584819-f1c8b300-81c3-11eb-8c4d-1affe7f9ff85.png)

Checkout:
![Screenshot from 2021-03-10 17-11-12](https://user-images.githubusercontent.com/3524483/110584829-f55c3a00-81c3-11eb-9daf-29d07c650e9a.png)


#### What should we test?
<!-- List which features should be tested and how. -->

All combinations of platform TOS required or not and a shop needing terms and conditions accepted or not.
The checkout should remember if a customer agreed to the seller's Ts&Cs but doesn't for the platform TOS.
Checking out should work as normal.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

Instance managers can now switch to requiring shoppers to accept the platform's terms of service on every checkout.



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

I don't think that this needs documenting yet. When the epic is finished we may want to include this in the super user guide.