### PR TITLE
Rails 5.2 add T&Cs helper

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -6,9 +6,6 @@ class CheckoutController < ::BaseController
   layout 'darkswarm'
 
   include OrderStockCheck
-  include CheckoutHelper
-  include OrderCyclesHelper
-  include EnterprisesHelper
 
   helper 'terms_and_conditions'
   helper 'checkout'

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -10,6 +10,8 @@ class CheckoutController < ::BaseController
   include OrderCyclesHelper
   include EnterprisesHelper
 
+  helper 'terms_and_conditions'
+  
   ssl_required
 
   # We need pessimistic locking to avoid race conditions.

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -11,7 +11,8 @@ class CheckoutController < ::BaseController
   include EnterprisesHelper
 
   helper 'terms_and_conditions'
-  
+  helper 'checkout'
+
   ssl_required
 
   # We need pessimistic locking to avoid race conditions.

--- a/app/helpers/injection_helper.rb
+++ b/app/helpers/injection_helper.rb
@@ -2,6 +2,8 @@ require 'open_food_network/enterprise_injection_data'
 
 module InjectionHelper
   include SerializerHelper
+  include EnterprisesHelper
+  include OrderCyclesHelper
 
   def inject_enterprises(enterprises = nil)
     inject_json_array(

--- a/app/mailers/spree/order_mailer.rb
+++ b/app/mailers/spree/order_mailer.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class OrderMailer < BaseMailer
-    helper ::CheckoutHelper
+    helper 'checkout'
     helper SpreeCurrencyHelper
     helper Spree::Admin::PaymentsHelper
     helper OrderHelper

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,5 +1,5 @@
 class SubscriptionMailer < Spree::BaseMailer
-  helper CheckoutHelper
+  helper 'checkout'
   helper MailerHelper
   helper ShopMailHelper
   helper OrderHelper


### PR DESCRIPTION
#### What? Why?

Continues #7091

Adding checkout helper to checkout controller also fixes lots of specs related to undefined method `display_checkout_subtotal'

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
Green build.
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Adapt code to rails 5.2


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
