### PR TITLE
covers payment_state changes from item deletion

### DIFF
--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -91,9 +91,8 @@ describe LineItemsController, type: :controller do
 
                 it 'updates the payment state' do
                   expect(order.payment_state).to eq 'paid'
-                  delete :destroy, params
-                  expect(response.status).to eq 204
-                  order.update!
+                  delete :destroy, params           
+                  order.reload
                   expect(order.payment_state).to eq 'credit_owed'
                 end
               end

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -84,6 +84,19 @@ describe LineItemsController, type: :controller do
                 expect(response.status).to eq 204
                 expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
               end
+
+              context "after a payment is captured" do
+                let(:payment) { create(:check_payment, amount: order.total, order: order, state: 'completed') }
+                before { payment.capture! }
+
+                it 'updates the payment state' do
+                  expect(order.payment_state).to eq 'paid'
+                  delete :destroy, params
+                  expect(response.status).to eq 204
+                  order.update!
+                  expect(order.payment_state).to eq 'credit_owed'
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
#### What? Why?

Closes #6733

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds a controller level spec, in which the payment state is changed, due to the removal of a line item.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

A context block was added to the existing spec file `line_items_controller.spec`. This adds a payment to an order (`payment_state = paid`) and destroys a line item, changing the payment state to `credit_owed`.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
