### PR TITLE
Fix payment capture handling in Api::OrdersController

### DIFF
--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -47,7 +47,7 @@ module Api
     private
 
     def payment_capture_failed
-      render json: { error: t(:payment_processing_failed) }, status: :unprocessable_entity
+      render json: { error: I18n.t(:payment_processing_failed) }, status: :unprocessable_entity
     end
 
     def serialized_orders(orders)

--- a/spec/controllers/api/orders_controller_spec.rb
+++ b/spec/controllers/api/orders_controller_spec.rb
@@ -285,6 +285,18 @@ module Api
           expect(order.reload.pending_payments.empty?).to be true
           expect_order
         end
+
+        context "when payment is not required" do
+          before do
+            allow_any_instance_of(Spree::Order).to receive(:payment_required?) { false }
+          end
+
+          it "returns an error" do
+            put :capture, params: { id: order.number }
+
+            expect(json_response['error']).to eq I18n.t(:payment_processing_failed)
+          end
+        end
       end
 
       describe "#ship" do


### PR DESCRIPTION
#### What? Why?

Closes #7109 

Fixes:
```
NoMethodError: undefined method `t' for #<Api::OrdersController:0x0000000013834290>
Location
app/controllers/api/orders_controller.rb:50 - payment_capture_failed
```

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough, a regression test is added.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed displaying of errors when payment capture fails.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
