### PR TITLE
Replace assets config with public_file_server

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Openfoodnetwork::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -11,7 +11,7 @@ Openfoodnetwork::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,8 +10,8 @@ Openfoodnetwork::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_files = true
-  config.static_cache_control = "public, max-age=3600"
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Separate cache stores when running in parallel
   config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV['TEST_ENV_NUMBER']}")


### PR DESCRIPTION
#### What? Why?

This fixes the following deprecation warnings

```
DEPRECATION WARNING: `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
Please use `config.public_file_server.enabled = true` instead.
 (called from block in <top (required)> at /home/runner/work/openfoodnetwork/openfoodnetwork/config/environments/test.rb:13)
DEPRECATION WARNING: `config.static_cache_control` is deprecated and will be removed in Rails 5.1.
Please use
`config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }`
instead.
 (called from block in <top (required)> at /home/runner/work/openfoodnetwork/openfoodnetwork/config/environments/test.rb:14)
```

#### What should we test?

Green build.

#### Release notes
Replace assets test config with public_file_server
Changelog Category: Technical changes