### PR TITLE
Ensure order association is set correctly when adding admin adjustments

### DIFF
--- a/app/controllers/spree/admin/adjustments_controller.rb
+++ b/app/controllers/spree/admin/adjustments_controller.rb
@@ -2,17 +2,18 @@ module Spree
   module Admin
     class AdjustmentsController < ::Admin::ResourceController
       belongs_to 'spree/order', find_by: :number
-      destroy.after :reload_order
 
       prepend_before_action :set_included_tax, only: [:create, :update]
       before_action :set_order_id, only: [:create, :update]
+      after_action :update_order, only: [:create, :update, :destroy]
       before_action :set_default_tax_rate, only: :edit
       before_action :enable_updates, only: :update
 
       private
 
-      def reload_order
+      def update_order
         @order.reload
+        @order.update!
       end
 
       def collection

--- a/app/controllers/spree/admin/adjustments_controller.rb
+++ b/app/controllers/spree/admin/adjustments_controller.rb
@@ -5,6 +5,7 @@ module Spree
       destroy.after :reload_order
 
       prepend_before_action :set_included_tax, only: [:create, :update]
+      before_action :set_order_id, only: [:create, :update]
       before_action :set_default_tax_rate, only: :edit
       before_action :enable_updates, only: :update
 
@@ -20,6 +21,10 @@ module Spree
 
       def find_resource
         parent.all_adjustments.eligible.find(params[:id])
+      end
+
+      def set_order_id
+        @adjustment.order_id = parent.id
       end
 
       # Choose a default tax rate to show on the edit form. The adjustment stores its included

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -22,6 +22,8 @@ module Spree
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(0)
           expect(a.order_id).to eq(order.id)
+
+          expect(order.reload.total).to eq 110
         end
 
         it "calculates included tax when a tax rate is provided" do
@@ -33,6 +35,8 @@ module Spree
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(10)
           expect(a.order_id).to eq(order.id)
+
+          expect(order.reload.total).to eq 110
         end
       end
 
@@ -50,6 +54,8 @@ module Spree
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(0)
           expect(a.order_id).to eq(order.id)
+
+          expect(order.reload.total).to eq 110
         end
 
         it "calculates included tax when a tax rate is provided" do
@@ -61,6 +67,8 @@ module Spree
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(10)
           expect(a.order_id).to eq(order.id)
+
+          expect(order.reload.total).to eq 110
         end
       end
     end

--- a/spec/controllers/spree/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/spree/admin/adjustments_controller_spec.rb
@@ -21,6 +21,7 @@ module Spree
           expect(a.label).to eq('Testing included tax')
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(0)
+          expect(a.order_id).to eq(order.id)
         end
 
         it "calculates included tax when a tax rate is provided" do
@@ -31,6 +32,7 @@ module Spree
           expect(a.label).to eq('Testing included tax')
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(10)
+          expect(a.order_id).to eq(order.id)
         end
       end
 
@@ -47,6 +49,7 @@ module Spree
           expect(a.label).to eq('Testing included tax')
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(0)
+          expect(a.order_id).to eq(order.id)
         end
 
         it "calculates included tax when a tax rate is provided" do
@@ -57,6 +60,7 @@ module Spree
           expect(a.label).to eq('Testing included tax')
           expect(a.amount).to eq(110)
           expect(a.included_tax).to eq(10)
+          expect(a.order_id).to eq(order.id)
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes  #7108

The adjustment's order_id was not being set when creating admin adjustments via the UI, which meant some of the scopes were not applied correctly in some cases.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

When creating an adjustment via admin, the adjustment is added to the order total when recalculated.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed an issue with creating admin adjustments

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes

