### PR TITLE
Fix deprecation warning related to #reload

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -109,7 +109,7 @@ module Spree
     end
 
     def can_own_more_enterprises?
-      owned_enterprises(:reload).size < enterprise_limit
+      owned_enterprises.reload.size < enterprise_limit
     end
 
     def default_card


### PR DESCRIPTION
#### What? Why?

This fixes:

```
DEPRECATION WARNING: Passing an argument to force an association to
reload is now deprecated and will be removed in Rails 5.1. Please call
`reload` on the result collection proxy instead. (called from
can_own_more_enterprises? at /usr/src/app/app/models/spree/user.rb:112)
```

This method in particular gets called a lot of times so it'll have it's cost in performance. However, we have more methods calling `#reload` this way.

#### What should we test?

Green build.

#### Release notes
Fix deprecation warning related to #reload
Changelog Category: Technical changes