### PR TITLE
Allow timezone from ENV vars, but use UTC as default

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,7 @@ Openfoodnetwork::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  config.time_zone = "UTC"
+  config.time_zone = ENV.fetch("TIMEZONE", "UTC")
 
   # Tests assume English text on the site.
   config.i18n.default_locale = "en"


### PR DESCRIPTION
#### What? Why?

Related to #7118 

Hopefully this will fix the current flakyness in the Bulk Order Management specs. See discussion in issue.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated timezone setting in test environment

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
