### PR TITLE
Update adjustments

### DIFF
--- a/db/migrate/20210315163900_update_associations.rb
+++ b/db/migrate/20210315163900_update_associations.rb
@@ -1,0 +1,13 @@
+class UpdateAssociations < ActiveRecord::Migration[5.0]
+  class Spree::Adjustment < ActiveRecord::Base
+    belongs_to :adjustable, polymorphic: true
+    belongs_to :order, class_name: "Spree::Order"
+  end
+
+  def up
+    # Updates any adjustments missing an order association
+    Spree::Adjustment.where(order_id: nil, adjustable_type: "Spree::Order").find_each do |adjustment|
+      adjustment.update_column(:order_id, adjustment.adjustable_id)
+    end
+  end
+end

--- a/db/migrate/20210315163900_update_associations.rb
+++ b/db/migrate/20210315163900_update_associations.rb
@@ -6,8 +6,8 @@ class UpdateAssociations < ActiveRecord::Migration[5.0]
 
   def up
     # Updates any adjustments missing an order association
-    Spree::Adjustment.where(order_id: nil, adjustable_type: "Spree::Order").find_each do |adjustment|
-      adjustment.update_column(:order_id, adjustment.adjustable_id)
-    end
+    Spree::Adjustment.
+      where(order_id: nil, adjustable_type: "Spree::Order").
+      update_all("order_id = adjustable_id")
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210312095840) do
+ActiveRecord::Schema.define(version: 20210315163900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
#### What? Why?

Closes #7120

Data migration to ensure any adjustments created without an order are re-associated with their order.

Included schema changes from running db:migrate in a separate commit; the formatting in `schema.rb` has changed a bit in Rails 5, so I wanted to keep the diffs separate.

#### What should we test?
<!-- List which features should be tested and how. -->

If we deploy to a staging server that has a couple of faulty adjustments, they should be fixed afterwards.

- uk-staging has outdated adjustments.
- au-staging doesn't.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Data migration to fix any adjustments missing an order id

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
