### PR TITLE
Run Github CI build on pull_request event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   workflow_dispatch:
   push:
+  pull_request:
 
 env:
   DISABLE_KNAPSACK: true


### PR DESCRIPTION
#### What? Why?

As is, we're seeing builds almost only on merge commits and not on
others. Also, the build status is not displayed at the bottom of the
PR.

Once we see this fixed and have a better understanding, we can decide
whether or not we remove the `push` event. I guess both we'll be needed.
#### What should we test?

Green Github build.

#### Release notes
Run Github CI build on pull_request event
Changelog Category: Technical changes