### PR TITLE
Use timezone as hour and minute offset from UTC in terms_and_conditions_spec.rb

### DIFF
--- a/spec/features/admin/enterprises/terms_and_conditions_spec.rb
+++ b/spec/features/admin/enterprises/terms_and_conditions_spec.rb
@@ -54,7 +54,7 @@ feature "Uploading Terms and Conditions PDF" do
 
         go_to_business_details
         expect(page).to have_selector "a[href*='logo-white.pdf'][target=\"_blank\"]"
-        expect(page).to have_content time.strftime("%F %T %Z")
+        expect(page).to have_content time.strftime("%F %T %z")
 
         # Replace PDF
         attach_file "enterprise[terms_and_conditions]", black_pdf_file_name


### PR DESCRIPTION
#### What? Why?
Closes #7127

Test fails, fix the test by using the right format.
https://apidock.com/ruby/DateTime/strftime


#### What should we test?
🟢 Green build for `spec/features/admin/enterprises/terms_and_conditions_spec.rb`


#### Release notes
Fix test issue.

Changelog Category: Technical changes


