### PR TITLE
Replace deprecated use of :reload argument

### DIFF
--- a/app/models/enterprise_relationship.rb
+++ b/app/models/enterprise_relationship.rb
@@ -81,7 +81,7 @@ class EnterpriseRelationship < ActiveRecord::Base
   end
 
   def has_permission?(name)
-    permissions(:reload).map(&:name).map(&:to_sym).include? name.to_sym
+    permissions.reload.map(&:name).map(&:to_sym).include? name.to_sym
   end
 
   private

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -280,7 +280,7 @@ module Spree
     # Spree::OrderContents#add is the more modern version in Spree history
     #   but this add_variant has been customized for OFN FrontOffice.
     def add_variant(variant, quantity = 1, max_quantity = nil, currency = nil)
-      line_items(:reload)
+      line_items.reload
       current_item = find_line_item_by_variant(variant)
 
       # Notify bugsnag if we get line items with a quantity of zero
@@ -638,7 +638,7 @@ module Spree
     end
 
     def remove_variant(variant)
-      line_items(:reload)
+      line_items.reload
       current_item = find_line_item_by_variant(variant)
       current_item.andand.destroy
     end
@@ -664,11 +664,11 @@ module Spree
     end
 
     def shipping_tax
-      shipment_adjustments(:reload).shipping.sum(:included_tax)
+      shipment_adjustments.reload.shipping.sum(:included_tax)
     end
 
     def enterprise_fee_tax
-      adjustments(:reload).enterprise_fee.sum(:included_tax)
+      adjustments.reload.enterprise_fee.sum(:included_tax)
     end
 
     def total_tax

--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -80,8 +80,8 @@ module Spree
         create_adjustment(label, order, order)
       end
 
-      order.adjustments(:reload)
-      order.line_items(:reload)
+      order.adjustments.reload
+      order.line_items.reload
       # TaxRate adjustments (order.adjustments.tax)
       #   and line item adjustments (tax included on line items) consist of 100% tax
       (order.adjustments.tax + order.line_item_adjustments.reload).each do |adjustment|

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -109,7 +109,7 @@ module Spree
     end
 
     def can_own_more_enterprises?
-      owned_enterprises(:reload).size < enterprise_limit
+      owned_enterprises.reload.size < enterprise_limit
     end
 
     def default_card

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -244,7 +244,7 @@ module Spree
     end
 
     def destruction
-      exchange_variants(:reload).destroy_all
+      exchange_variants.reload.destroy_all
       yield
     end
 

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -24,7 +24,7 @@ describe LineItemsController, type: :controller do
       get :bought, format: :json
       expect(response.status).to eq 200
       json_response = JSON.parse(response.body)
-      expect(json_response.length).to eq completed_order.line_items(:reload).count
+      expect(json_response.length).to eq completed_order.line_items.reload.count
       expect(json_response[0]['id']).to eq completed_order.line_items.first.id
     end
   end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -103,7 +103,7 @@ describe Enterprise do
 
       it "validates ownership limit" do
         expect(u1.enterprise_limit).to be 5
-        expect(u1.owned_enterprises(:reload)).to eq [e]
+        expect(u1.owned_enterprises.reload).to eq [e]
         4.times { create(:enterprise, owner: u1) }
         e2 = create(:enterprise, owner: u2)
         expect {

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -178,7 +178,7 @@ module Spree
         let!(:order)       { create(:order, bill_address: create(:address)) }
         let!(:line_item)   { create(:line_item, order: order) }
         let(:tax_rate)     { create(:tax_rate, included_in_price: true, calculator: ::Calculator::FlatRate.new(preferred_amount: 0.1)) }
-        let(:adjustment)   { line_item.adjustments(:reload).first }
+        let(:adjustment)   { line_item.adjustments.reload.first }
 
         before do
           order.reload
@@ -274,7 +274,7 @@ module Spree
         let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator, coordinator_fees: [enterprise_fee], distributors: [coordinator], variants: [variant]) }
         let(:line_item)   { create(:line_item, variant: variant) }
         let(:order)       { create(:order, line_items: [line_item], order_cycle: order_cycle, distributor: coordinator) }
-        let(:adjustment)  { order.adjustments(:reload).enterprise_fee.first }
+        let(:adjustment)  { order.adjustments.reload.enterprise_fee.first }
 
         context "when enterprise fees have a fixed tax_category" do
           before do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -786,13 +786,13 @@ describe Spree::Order do
 
     it "removes the variant's line item" do
       order.remove_variant v1
-      expect(order.line_items(:reload).map(&:variant)).to eq([v2])
+      expect(order.line_items.reload.map(&:variant)).to eq([v2])
     end
 
     it "does nothing when there is no matching line item" do
       expect do
         order.remove_variant v3
-      end.to change(order.line_items(:reload), :count).by(0)
+      end.to change(order.line_items.reload, :count).by(0)
     end
 
     context "when the item has an associated adjustment" do
@@ -809,7 +809,7 @@ describe Spree::Order do
 
       it "removes the variant's line item" do
         order.remove_variant v1
-        expect(order.line_items(:reload).map(&:variant)).to eq([v2])
+        expect(order.line_items.reload.map(&:variant)).to eq([v2])
       end
 
       it "removes the variant's adjustment" do

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -353,8 +353,8 @@ module Spree
           end
 
           it "copies the properties on master variant to the first standard variant" do
-            expect(product.variants(:reload).length).to eq 1
-            standard_variant = product.variants(:reload).first
+            expect(product.variants.reload.length).to eq 1
+            standard_variant = product.variants.reload.first
             expect(standard_variant.price).to eq product.master.price
           end
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -40,11 +40,11 @@ describe Spree::User do
       let!(:e2) { create(:enterprise, owner: u1) }
 
       it "provides access to owned enterprises" do
-        expect(u1.owned_enterprises(:reload)).to include e1, e2
+        expect(u1.owned_enterprises.reload).to include e1, e2
       end
 
       it "enforces the limit on the number of enterprise owned" do
-        expect(u2.owned_enterprises(:reload)).to eq []
+        expect(u2.owned_enterprises.reload).to eq []
         u2.owned_enterprises << e1
         expect { u2.save! }.to_not raise_error
         expect do
@@ -62,8 +62,8 @@ describe Spree::User do
       let!(:g3) { create(:enterprise_group, owner: u2) }
 
       it "provides access to owned groups" do
-        expect(u1.owned_groups(:reload)).to match_array([g1, g2])
-        expect(u2.owned_groups(:reload)).to match_array([g3])
+        expect(u1.owned_groups.reload).to match_array([g1, g2])
+        expect(u2.owned_groups.reload).to match_array([g3])
       end
     end
 

--- a/spec/services/cart_service_spec.rb
+++ b/spec/services/cart_service_spec.rb
@@ -55,7 +55,7 @@ describe CartService do
         order.add_variant variant, 1, 2
 
         cart_service.populate({ variants: {} }, true)
-        order.line_items(:reload)
+        order.line_items.reload
         li = order.find_line_item_by_variant(variant)
         expect(li).not_to be
       end


### PR DESCRIPTION
#### What? Why?

Passing :reload as an argument is now deprecated in favour of calling the #reload method on the object.

Replaces all remaining uses.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Replaced deprecated reload syntax

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
