### PR TITLE
Fix `env` deprecated in Rails 5.0

### DIFF
--- a/app/controllers/metal_decorator.rb
+++ b/app/controllers/metal_decorator.rb
@@ -1,6 +1,6 @@
 # For the API
 ActionController::Metal.class_eval do
   def spree_current_user
-    @spree_current_user ||= env['warden'].user
+    @spree_current_user ||= request.env['warden'].user
   end
 end


### PR DESCRIPTION
#### What? Why?

I found it at the very bottom of the `test-consumer-features` CI build job. See: https://github.com/rails/rails/issues/23294.


#### What should we test?

Green build.

#### Release notes
Fix `env` deprecated in Rails 5.0
Changelog Category: Technical changes
