### PR TITLE
Rearrange and cover balance in subs mailer specs

### DIFF
--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -8,7 +8,10 @@ describe SubscriptionMailer, type: :mailer do
 
   before { setup_email }
 
-  describe "order placement" do
+  describe '#placement_email' do
+    subject(:email) { SubscriptionMailer.placement_email(order, changes) }
+    let(:changes) { {} }
+
     let(:shop) { create(:enterprise) }
     let(:customer) { create(:customer, enterprise: shop) }
     let(:subscription) { create(:subscription, shop: shop, customer: customer, with_items: true) }
@@ -16,31 +19,24 @@ describe SubscriptionMailer, type: :mailer do
     let!(:order) { proxy_order.initialise_order! }
 
     context "when changes have been made to the order" do
-      let(:changes) { {} }
-
-      before do
-        changes[order.line_items.first.id] = 2
-        expect do
-          SubscriptionMailer.placement_email(order, changes).deliver_now
-        end.to change{ SubscriptionMailer.deliveries.count }.by(1)
-      end
+      before { changes[order.line_items.first.id] = 2 }
 
       it "sends the email, which notifies the customer of changes made" do
+        expect { email.deliver_now }.to change { SubscriptionMailer.deliveries.count }.by(1)
+
         body = SubscriptionMailer.deliveries.last.body.encoded
+
         expect(body).to include "This order was automatically created for you."
         expect(body).to include "Unfortunately, not all products that you requested were available."
       end
     end
 
     context "and changes have not been made to the order" do
-      before do
-        expect do
-          SubscriptionMailer.placement_email(order, {}).deliver_now
-        end.to change{ SubscriptionMailer.deliveries.count }.by(1)
-      end
-
       it "sends the email" do
+        expect { email.deliver_now }.to change { SubscriptionMailer.deliveries.count }.by(1)
+
         body = SubscriptionMailer.deliveries.last.body.encoded
+
         expect(body).to include "This order was automatically created for you."
         expect(body).to_not include "Unfortunately, not all products that you requested were available."
       end
@@ -52,12 +48,9 @@ describe SubscriptionMailer, type: :mailer do
 
       let(:shop) { create(:enterprise, allow_order_changes: true) }
 
-      let(:email) { SubscriptionMailer.deliveries.last }
-      let(:body) { email.body.encoded }
+      let(:body) { SubscriptionMailer.deliveries.last.body.encoded }
 
-      before do
-        SubscriptionMailer.placement_email(order, {}).deliver_now
-      end
+      before { email.deliver_now }
 
       context "when the customer has a user account" do
         let(:customer) { create(:customer, enterprise: shop) }
@@ -93,21 +86,36 @@ describe SubscriptionMailer, type: :mailer do
         end
       end
     end
+
+    context 'when the order has outstanding balance' do
+      before { allow(order).to receive(:outstanding_balance) { 123 } }
+
+      it 'renders the amount as money' do
+        expect(email.body).to include('$123')
+      end
+    end
+
+    context 'when the order has no outstanding balance' do
+      before { allow(order).to receive(:outstanding_balance) { 0 } }
+
+      it 'displays the payment status' do
+        expect(email.body).to include(I18n.t(:email_payment_not_paid))
+      end
+    end
   end
 
-  describe "order confirmation" do
+  describe '#confirmation_email' do
+    subject(:email) { SubscriptionMailer.confirmation_email(order) }
+
     let(:customer) { create(:customer) }
     let(:subscription) { create(:subscription, customer: customer, with_items: true) }
     let(:proxy_order) { create(:proxy_order, subscription: subscription) }
     let!(:order) { proxy_order.initialise_order! }
-
-    before do
-      expect do
-        SubscriptionMailer.confirmation_email(order).deliver_now
-      end.to change{ SubscriptionMailer.deliveries.count }.by(1)
-    end
+    let(:user) { order.user }
 
     it "sends the email" do
+      expect { email.deliver_now }.to change{ SubscriptionMailer.deliveries.count }.by(1)
+
       body = SubscriptionMailer.deliveries.last.body.encoded
       expect(body).to include "This order was automatically placed for you"
     end
@@ -115,14 +123,11 @@ describe SubscriptionMailer, type: :mailer do
     describe "linking to order page" do
       let(:order_link_href) { "href=\"#{order_url(order)}\"" }
 
-      let(:email) { SubscriptionMailer.deliveries.last }
-      let(:body) { email.body.encoded }
-
       context "when the customer has a user account" do
         let(:customer) { create(:customer) }
 
         it "provides link to view details" do
-          expect(body).to match /#{order_link_href}/
+          expect(email.body.encoded).to include(order_url(order))
         end
       end
 
@@ -130,8 +135,24 @@ describe SubscriptionMailer, type: :mailer do
         let(:customer) { create(:customer, user: nil) }
 
         it "does not provide link" do
-          expect(body).to_not match /#{order_link_href}/
+          expect(email.body).to_not match /#{order_link_href}/
         end
+      end
+    end
+
+    context 'when the order has outstanding balance' do
+      before { allow(order).to receive(:outstanding_balance) { 123 } }
+
+      it 'renders the amount as money' do
+        expect(email.body).to include('$123')
+      end
+    end
+
+    context 'when the order has no outstanding balance' do
+      before { allow(order).to receive(:outstanding_balance) { 0 } }
+
+      it 'displays the payment status' do
+        expect(email.body).to include(I18n.t(:email_payment_not_paid))
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

This moves them to a more unit-like style where the mailer methods are the subjects. However, I did so only for the methods that show order balance and thus we want to be extra sure of their coverage.

#### What should we test?

Green build.

#### Release notes
Rearrange and cover the balance in subs mailer specs
Changelog Category: Technical changes