### PR TITLE
Fix N+1 on variants when loading incoming exchange products

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -101,11 +101,7 @@ module Spree
 
     scope :visible_for, lambda { |enterprise|
       joins(:inventory_items).
-        where(
-          'inventory_items.enterprise_id = (?) AND inventory_items.visible = (?)',
-          enterprise,
-          true
-        )
+        where(inventory_items: { enterprise_id: enterprise.id, visible: true })
     }
 
     scope :not_hidden_for, lambda { |enterprise|

--- a/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
@@ -19,21 +19,13 @@ module Api
         end
 
         def variants
-          load_variants.map { |variant| { id: variant.id, label: variant.full_name } }
+          object.variants.map { |variant| { id: variant.id, label: variant.full_name } }
         end
 
         private
 
         def order_cycle
           options[:order_cycle]
-        end
-
-        def load_variants
-          if order_cycle.present? && order_cycle.prefers_product_selection_from_coordinator_inventory_only?
-            object.variants.visible_for(order_cycle.coordinator)
-          else
-            object.variants
-          end
         end
       end
     end

--- a/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
@@ -19,19 +19,21 @@ module Api
         end
 
         def variants
-          variants = if order_cycle.present? &&
-                        order_cycle.prefers_product_selection_from_coordinator_inventory_only?
-                       object.variants.visible_for(order_cycle.coordinator)
-                     else
-                       object.variants
-                     end
-          variants.map { |variant| { id: variant.id, label: variant.full_name } }
+          load_variants.map { |variant| { id: variant.id, label: variant.full_name } }
         end
 
         private
 
         def order_cycle
           options[:order_cycle]
+        end
+
+        def load_variants
+          if order_cycle.present? && order_cycle.prefers_product_selection_from_coordinator_inventory_only?
+            object.variants.visible_for(order_cycle.coordinator)
+          else
+            object.variants
+          end
         end
       end
     end

--- a/app/services/exchange_products_renderer.rb
+++ b/app/services/exchange_products_renderer.rb
@@ -14,7 +14,14 @@ class ExchangeProductsRenderer
                else
                  products_for_outgoing_exchange
                end
-    relation.includes(:variants)
+
+    relation = relation.includes(:variants)
+
+    if @order_cycle.present? && @order_cycle.prefers_product_selection_from_coordinator_inventory_only?
+      relation = relation.visible_for(@order_cycle.coordinator)
+    end
+
+    relation
   end
 
   def exchange_variants(incoming, enterprise)

--- a/app/services/exchange_products_renderer.rb
+++ b/app/services/exchange_products_renderer.rb
@@ -16,12 +16,7 @@ class ExchangeProductsRenderer
                end
 
     relation = relation.includes(:variants)
-
-    if @order_cycle.present? && @order_cycle.prefers_product_selection_from_coordinator_inventory_only?
-      relation = relation.visible_for(@order_cycle.coordinator)
-    end
-
-    relation
+    filter_visible(relation)
   end
 
   def exchange_variants(incoming, enterprise)

--- a/app/services/exchange_products_renderer.rb
+++ b/app/services/exchange_products_renderer.rb
@@ -9,11 +9,12 @@ class ExchangeProductsRenderer
   end
 
   def exchange_products(incoming, enterprise)
-    if incoming
-      products_for_incoming_exchange(enterprise)
-    else
-      products_for_outgoing_exchange
-    end
+    relation = if incoming
+                 products_for_incoming_exchange(enterprise)
+               else
+                 products_for_outgoing_exchange
+               end
+    relation.includes(:variants)
   end
 
   def exchange_variants(incoming, enterprise)
@@ -47,7 +48,6 @@ class ExchangeProductsRenderer
 
   def products_for_outgoing_exchange
     supplied_products(enterprises_for_outgoing_exchange.select(:id)).
-      includes(:variants).
       where("spree_variants.id": incoming_exchanges_variants)
   end
 


### PR DESCRIPTION
#### What? Why?

Fixes the following N+1

```
user: root
GET /api/exchanges/1/products.json
USE eager loading detected
  Spree::Product => [:variants]
  Add to your query: .includes([:variants])
Call stack
  /usr/src/app/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb:28:in `variants'
  /usr/src/app/app/controllers/api/exchange_products_controller.rb:89:in `render_paginated_products'
  /usr/src/app/app/controllers/api/exchange_products_controller.rb:29:in `index'
  bin/rails:4:in `require'
  bin/rails:4:in `<main>'
```

#### What should we test?

Green build.

#### Release notes
Fix N+1 on variants when loading incoming exchange products
Changelog Category: Technical changes
