### PR TITLE
Reduce retention period of Spree state changes and log entries from 6 to 3 months

### DIFF
--- a/lib/tasks/data/remove_transient_data.rb
+++ b/lib/tasks/data/remove_transient_data.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class RemoveTransientData
-  MEDIUM_RETENTION = 6.months.ago.to_date
-  SHORT_RETENTION = 3.months.ago.to_date
+  RETENTION_PERIOD = 3.months.ago.to_date
 
   # This model lets us operate on the sessions DB table using ActiveRecord's
   # methods within the scope of this service. This relies on the AR's
@@ -13,9 +12,9 @@ class RemoveTransientData
   def call
     Rails.logger.info("#{self.class.name}: processing")
 
-    Spree::StateChange.where("created_at < ?", MEDIUM_RETENTION).delete_all
-    Spree::LogEntry.where("created_at < ?", MEDIUM_RETENTION).delete_all
-    Session.where("updated_at < ?", SHORT_RETENTION).delete_all
+    Spree::StateChange.where("created_at < ?", RETENTION_PERIOD).delete_all
+    Spree::LogEntry.where("created_at < ?", RETENTION_PERIOD).delete_all
+    Session.where("updated_at < ?", RETENTION_PERIOD).delete_all
 
     clear_old_cart_data!
   end
@@ -24,7 +23,7 @@ class RemoveTransientData
 
   def clear_old_cart_data!
     old_carts = Spree::Order.
-      where("spree_orders.state = 'cart' AND spree_orders.updated_at < ?", SHORT_RETENTION).
+      where("spree_orders.state = 'cart' AND spree_orders.updated_at < ?", RETENTION_PERIOD).
       merge(orders_without_payments)
 
     old_cart_line_items = Spree::LineItem.where(order_id: old_carts)

--- a/spec/lib/tasks/data/remove_transient_data_spec.rb
+++ b/spec/lib/tasks/data/remove_transient_data_spec.rb
@@ -5,8 +5,7 @@ require 'tasks/data/remove_transient_data'
 
 describe RemoveTransientData do
   describe '#call' do
-    let(:medium_retention) { RemoveTransientData::MEDIUM_RETENTION }
-    let(:short_retention) { RemoveTransientData::SHORT_RETENTION }
+    let(:retention_period) { RemoveTransientData::RETENTION_PERIOD }
 
     before do
       allow(Spree::StateChange).to receive(:delete_all)
@@ -16,21 +15,21 @@ describe RemoveTransientData do
     end
 
     it 'deletes state changes older than rentention_period' do
-      Spree::StateChange.create(created_at: medium_retention - 1.day)
+      Spree::StateChange.create(created_at: retention_period - 1.day)
 
       RemoveTransientData.new.call
       expect(Spree::StateChange.all).to be_empty
     end
 
     it 'deletes log entries older than retention_period' do
-      Spree::LogEntry.create(created_at: medium_retention - 1.day)
+      Spree::LogEntry.create(created_at: retention_period - 1.day)
 
       expect { RemoveTransientData.new.call }
         .to change(Spree::LogEntry, :count).by(-1)
     end
 
     it 'deletes sessions older than retention_period' do
-      RemoveTransientData::Session.create(session_id: 1, updated_at: short_retention - 1.day)
+      RemoveTransientData::Session.create(session_id: 1, updated_at: retention_period - 1.day)
 
       RemoveTransientData.new.call
 
@@ -45,12 +44,12 @@ describe RemoveTransientData do
       let!(:line_item) { create(:line_item, order: cart, variant: variant) }
       let!(:adjustment) { create(:adjustment, order: cart) }
 
-      let!(:old_cart) { create(:order, state: 'cart', updated_at: short_retention - 1.day) }
+      let!(:old_cart) { create(:order, state: 'cart', updated_at: retention_period - 1.day) }
       let!(:old_line_item) { create(:line_item, order: old_cart, variant: variant) }
       let!(:old_adjustment) { create(:adjustment, order: old_cart) }
 
       before do
-        old_cart.update_columns(updated_at: short_retention - 1.day)
+        old_cart.update_columns(updated_at: retention_period - 1.day)
       end
 
       it 'deletes cart orders and related objects older than retention_period' do


### PR DESCRIPTION
Spree state changes and log entries seem to be filling up quite quickly so this could help with performance.

Fixes #7123

#### What should we test?

Passing tests should cover it.

#### Release notes

Reduce retention period of Spree state changes and log entries from 6 to 3 months

Changelog Category: Technical changes