### PR TITLE
Bump cancancan to 1.15.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'activerecord-postgresql-adapter'
 gem 'pg', '~> 0.21.0'
 
 gem 'acts_as_list', '0.9.19'
-gem 'cancancan', '~> 1.7.0'
+gem 'cancancan', '~> 1.15.0'
 gem 'ffaker'
 gem 'highline', '2.0.3' # Necessary for the install generator
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    cancancan (1.7.1)
+    cancancan (1.15.0)
     capybara (3.32.2)
       addressable
       mini_mime (>= 0.1.3)
@@ -608,7 +608,7 @@ DEPENDENCIES
   bugsnag
   bullet
   byebug
-  cancancan (~> 1.7.0)
+  cancancan (~> 1.15.0)
   capybara
   catalog!
   coffee-rails (~> 4.2.2)


### PR DESCRIPTION
#### What? Why?

Conservative bump to a newer version that fixes some deprecated syntax for Rails 5.x (eg #before_filter). This is the first significant `CanCan` update in a very long time...

#### What should we test?
<!-- List which features should be tested and how. -->

Green build? `CanCan` permissions are used in countless tests.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Bump cancancan to 1.15.0

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

