### PR TITLE
Rearrange order updater tests to make them method-centric

### DIFF
--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -141,114 +141,119 @@ module OrderManagement
         updater.update
       end
 
-      it "is failed if no valid payments" do
-        allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(true)
+      describe "#update_payment_state" do
+        context "when the order has no valid payments" do
+          it "is failed" do
+            allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(true)
 
-        updater.update_payment_state
-        expect(order.payment_state).to eq('failed')
-      end
-
-      context "payment total is greater than order total" do
-        it "is credit_owed" do
-          order.payment_total = 2
-          order.total = 1
-
-          expect {
             updater.update_payment_state
-          }.to change { order.payment_state }.to 'credit_owed'
-        end
-      end
-
-      context "order total is greater than payment total" do
-        it "is credit_owed" do
-          order.payment_total = 1
-          order.total = 2
-
-          expect {
-            updater.update_payment_state
-          }.to change { order.payment_state }.to 'balance_due'
-        end
-      end
-
-      context "order total equals payment total" do
-        it "is paid" do
-          order.payment_total = 30
-          order.total = 30
-
-          expect {
-            updater.update_payment_state
-          }.to change { order.payment_state }.to 'paid'
-        end
-      end
-
-      context "order is canceled" do
-        before do
-          order.state = 'canceled'
-        end
-
-        context "and is still unpaid" do
-          it "is void" do
-            order.payment_total = 0
-            order.total = 30
-            expect {
-              updater.update_payment_state
-            }.to change { order.payment_state }.to 'void'
+            expect(order.payment_state).to eq('failed')
           end
         end
 
-        context "and is paid" do
+        context "payment total is greater than order total" do
           it "is credit_owed" do
-            order.payment_total = 30
-            order.total = 30
-            allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
-            allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
+            order.payment_total = 2
+            order.total = 1
+
             expect {
               updater.update_payment_state
             }.to change { order.payment_state }.to 'credit_owed'
           end
         end
 
-        context "and payment is refunded" do
-          it "is void" do
-            order.payment_total = 0
-            order.total = 30
-            allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
-            allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
+        context "order total is greater than payment total" do
+          it "is credit_owed" do
+            order.payment_total = 1
+            order.total = 2
+
             expect {
               updater.update_payment_state
-            }.to change { order.payment_state }.to 'void'
-          end
-        end
-      end
-
-      context 'when the set payment_state does not match the last payment_state' do
-        before { order.payment_state = 'previous_to_paid' }
-
-        context 'and the order is being updated' do
-          before { allow(order).to receive(:persisted?) { true } }
-
-          it 'creates a new state_change for the order' do
-            expect { updater.update_payment_state }
-              .to change { order.state_changes.size }.by(1)
+            }.to change { order.payment_state }.to 'balance_due'
           end
         end
 
-        context 'and the order is being created' do
-          before { allow(order).to receive(:persisted?) { false } }
+        context "order total equals payment total" do
+          it "is paid" do
+            order.payment_total = 30
+            order.total = 30
 
-          it 'creates a new state_change for the order' do
+            expect {
+              updater.update_payment_state
+            }.to change { order.payment_state }.to 'paid'
+          end
+        end
+
+        context "order is canceled" do
+          before { order.state = 'canceled' }
+
+          context "and is still unpaid" do
+            it "is void" do
+              order.payment_total = 0
+              order.total = 30
+
+              expect {
+                updater.update_payment_state
+              }.to change { order.payment_state }.to 'void'
+            end
+          end
+
+          context "and is paid" do
+            it "is credit_owed" do
+              order.payment_total = 30
+              order.total = 30
+              allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
+              allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
+
+              expect {
+                updater.update_payment_state
+              }.to change { order.payment_state }.to 'credit_owed'
+            end
+          end
+
+          context "and payment is refunded" do
+            it "is void" do
+              order.payment_total = 0
+              order.total = 30
+              allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
+              allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
+
+              expect {
+                updater.update_payment_state
+              }.to change { order.payment_state }.to 'void'
+            end
+          end
+        end
+
+        context 'when the set payment_state matches the last payment_state' do
+          before { order.payment_state = 'paid' }
+
+          it 'does not create any state_change' do
             expect { updater.update_payment_state }
               .not_to change { order.state_changes.size }
           end
         end
-      end
 
-      context 'when the set payment_state matches the last payment_state' do
-        before { order.payment_state = 'paid' }
+        context 'when the set payment_state does not match the last payment_state' do
+          before { order.payment_state = 'previous_to_paid' }
 
-        it 'does not create any state_change' do
-          expect { updater.update_payment_state }
-            .not_to change { order.state_changes.size }
+          context 'and the order is being updated' do
+            before { allow(order).to receive(:persisted?) { true } }
+
+            it 'creates a new state_change for the order' do
+              expect { updater.update_payment_state }
+                .to change { order.state_changes.size }.by(1)
+            end
+          end
+
+          context 'and the order is being created' do
+            before { allow(order).to receive(:persisted?) { false } }
+
+            it 'creates a new state_change for the order' do
+              expect { updater.update_payment_state }
+                .not_to change { order.state_changes.size }
+            end
+          end
         end
       end
 

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -202,8 +202,8 @@ module OrderManagement
             it "is credit_owed" do
               order.payment_total = 30
               order.total = 30
-              allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
-              allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
+              allow(order).to receive_message_chain(:payments, :valid, :empty?) { false }
+              allow(order).to receive_message_chain(:payments, :completed, :empty?) { false }
 
               expect {
                 updater.update_payment_state
@@ -215,8 +215,8 @@ module OrderManagement
             it "is void" do
               order.payment_total = 0
               order.total = 30
-              allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
-              allow(order).to receive_message_chain(:payments, :completed, :empty?).and_return(false)
+              allow(order).to receive_message_chain(:payments, :valid, :empty?) { false }
+              allow(order).to receive_message_chain(:payments, :completed, :empty?) { false }
 
               expect {
                 updater.update_payment_state


### PR DESCRIPTION
#### What? Why?

If these are unit tests, it's much easier to find a `describe` with the method under test and putting all the tests exercising that method together.

It turns out that `#update_payment_state` is by far the method that we test the most here, which leads me to think:

a) this class might be doing too many things.
b) other methods might not be that well covered.

I recommend you look at the final state of that file. As this is just moving things around, it's very hard to decipher the diff.

#### What should we test?

Green build.

#### Release notes
Rearrange order updater tests to make them method-centric
Changelog Category: Technical changes
