### PR TITLE
/admin/orders : fix incorrect value of the mail field in the mailto link

### DIFF
--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -74,7 +74,8 @@
         %span.state{'ng-class' => 'order.shipment_state', 'ng-if' => 'order.shipment_state'}
           {{'js.admin.orders.shipment_states.' + order.shipment_state | t}}
       %td
-        = mail_to "{{order.email}}"
+        %a{ ng: { href: "mailto:{{order.email}}" } }
+          {{order.email}}
         %br
         {{order.full_name}}
       %td.align-center


### PR DESCRIPTION
#### What? Why?
Closes #7126 
The link to the email of the user's order was wrong. Fixing it. 


#### What should we test?
1. Log in as admin.
2. Go to /admin/orders
3. Click on an email address.
4. Should  be a clickable link (such as `mailto:user@email.com`)


<img width="308" alt="Capture d’écran 2021-03-18 à 15 10 48" src="https://user-images.githubusercontent.com/296452/111640392-7470f400-87fc-11eb-8ba2-5d663abe6b15.png">
<img width="229" alt="Capture d’écran 2021-03-18 à 15 10 53" src="https://user-images.githubusercontent.com/296452/111640417-78047b00-87fc-11eb-8969-674ca3cd787e.png">

#### Release notes
Fix wrong user email link issue in /admin/orders 
Changelog Category: User facing changes

