### PR TITLE
Add keys to handle some i18n issues

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3794,3 +3794,42 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         spree/payment:
           one: Payment
           other: Payments
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"


### PR DESCRIPTION
#### What? Why?

Closes #5679 
We're using the method `distance_of_time_in_words_to_now`  that is already translated thanks to `rails-i18n`, but it is missing few languages such as 'fr_BE'.
I've added needed keys into the file `en.yml`, which could be seen as useless (since is already correctly handled by `rails-i18n`) but this is the way we process i18n issues. The main drawback is that it forces us to add a lot of i18n keys that aren't necessary most of the time.

#### What should we test?
1. Use an instance that enables language such as `fr_BE`.
2. Go to a shop with a closed order cycle. 
3. Last words (such as "1 jour" in the screenshot below but could be different depending on the closing time) should be translated.

<img width="437" alt="Capture d’écran 2021-03-18 à 16 01 48" src="https://user-images.githubusercontent.com/296452/111647995-40e59800-8803-11eb-8583-d476a839384b.png">



#### Release notes
Fix i18n issue on frontshop with closed order cycle for some languages.

Changelog Category: User facing changes

