### PR TITLE
Rebalance CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run tests
         run: bundle exec rspec spec/models
 
-  test-admin-features:
+  test-admin-features-1:
     runs-on: ubuntu-18.04
     services:
       postgres:
@@ -90,9 +90,9 @@ jobs:
           bundle exec rake db:schema:load RAILS_ENV=test
 
       - name: Run admin feature tests
-        run: bundle exec rspec --profile -- spec/features/admin/*_spec.rb
+        run: bundle exec rspec --profile -- spec/features/admin/[a-o]*_spec.rb
 
-  test-admin-features-folders:
+  test-admin-features-2:
     runs-on: ubuntu-18.04
     services:
       postgres:
@@ -131,7 +131,48 @@ jobs:
           bundle exec rake db:schema:load RAILS_ENV=test
 
       - name: Run admin feature tests
-        run: bundle exec rspec --profile --pattern "spec/features/admin/*/*_spec.rb"
+        run: bundle exec rspec --profile -- spec/features/admin/[p-z]*_spec.rb
+
+  test-admin-features-folders-and-controllers:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run admin feature tests
+        run: bundle exec rspec --profile --pattern "spec/controllers/{,/*/**}/*_spec.rb,spec/features/admin/*/*_spec.rb"
 
   test-consumer-features:
     runs-on: ubuntu-18.04
@@ -173,47 +214,6 @@ jobs:
 
       - name: Run consumer feature tests
         run: bundle exec rspec --profile -- spec/features/consumer
-
-  test-controllers:
-    runs-on: ubuntu-18.04
-    services:
-      postgres:
-        image: postgres:10
-        ports: ["5432:5432"]
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        env:
-          POSTGRES_DB: open_food_network_test
-          POSTGRES_USER: ofn
-          POSTGRES_PASSWORD: f00d
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.15.5'
-
-      - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Set up application.yml
-        run: cp config/application.yml.example config/application.yml
-
-      - name: Set up database
-        run: |
-          bundle exec rake db:create RAILS_ENV=test
-          bundle exec rake db:schema:load RAILS_ENV=test
-
-      - name: Run tests
-        run: bundle exec rspec spec/controllers
 
   test-other:
     runs-on: ubuntu-18.04
@@ -257,19 +257,4 @@ jobs:
         run: RAILS_ENV=test bundle exec rake karma:run
 
       - name: Run all other tests
-        run: |
-          bundle exec rspec \
-            spec/helpers/ \
-            spec/initializers/ \
-            spec/jobs/ \
-            spec/lib/ \
-            spec/mailers/ \
-            spec/queries/ \
-            spec/requests/ \
-            spec/serializers/ \
-            spec/services/ \
-            spec/validators/ \
-            spec/views
-
-      - name: Run engines tests
-        run: bundle exec rake ofn:specs:engines:rspec
+        run: bundle exec rspec --profile --pattern "engines/*/spec/{,/*/**}/*_spec.rb,spec/{helpers, initializers, jobs, lib, mailers, queries, requests, serializers, services, validators, views}/{,/*/**}/*_spec.rb"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,47 @@ env:
   TIMEZONE: UTC
 
 jobs:
+  test-controllers-and-serializers:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run controller tests
+        run: bundle exec rspec spec/controllers spec/serializers
+
   test-models:
     runs-on: ubuntu-18.04
     services:
@@ -133,47 +174,6 @@ jobs:
       - name: Run admin feature tests
         run: bundle exec rspec --profile -- spec/features/admin/[p-z]*_spec.rb
 
-  test-admin-features-folders-and-controllers:
-    runs-on: ubuntu-18.04
-    services:
-      postgres:
-        image: postgres:10
-        ports: ["5432:5432"]
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        env:
-          POSTGRES_DB: open_food_network_test
-          POSTGRES_USER: ofn
-          POSTGRES_PASSWORD: f00d
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.15.5'
-
-      - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Set up application.yml
-        run: cp config/application.yml.example config/application.yml
-
-      - name: Set up database
-        run: |
-          bundle exec rake db:create RAILS_ENV=test
-          bundle exec rake db:schema:load RAILS_ENV=test
-
-      - name: Run admin feature tests
-        run: bundle exec rspec --profile --pattern "spec/controllers/{,/*/**}/*_spec.rb,spec/features/admin/*/*_spec.rb"
-
   test-consumer-features:
     runs-on: ubuntu-18.04
     services:
@@ -215,7 +215,7 @@ jobs:
       - name: Run consumer feature tests
         run: bundle exec rspec --profile -- spec/features/consumer
 
-  test-other:
+  test-engines-etc:
     runs-on: ubuntu-18.04
     services:
       postgres:
@@ -257,4 +257,45 @@ jobs:
         run: RAILS_ENV=test bundle exec rake karma:run
 
       - name: Run all other tests
-        run: bundle exec rspec --profile --pattern "engines/*/spec/{,/*/**}/*_spec.rb,spec/{helpers, initializers, jobs, lib, mailers, queries, requests, serializers, services, validators, views}/{,/*/**}/*_spec.rb"
+        run: bundle exec rspec --profile --pattern "engines/*/spec/{,/*/**}/*_spec.rb,spec/{helpers, initializers, jobs, mailers, queries, requests, services, validators, views}/{,/*/**}/*_spec.rb"
+
+  test-the-rest:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:10
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: open_food_network_test
+          POSTGRES_USER: ofn
+          POSTGRES_PASSWORD: f00d
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up application.yml
+        run: cp config/application.yml.example config/application.yml
+
+      - name: Set up database
+        run: |
+          bundle exec rake db:create RAILS_ENV=test
+          bundle exec rake db:schema:load RAILS_ENV=test
+
+      - name: Run admin feature folders, serializers, jobs, lib
+        run: bundle exec rspec --profile --pattern "spec/features/admin/*/*_spec.rb,spec/lib/{,/*/**}/*_spec.rb"


### PR DESCRIPTION
#### What? Why?

Related to #6752

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Rebalances the CI jobs so that the build finishes faster.

This also pushes us to 7 jobs per build, with 20 workers. One reliably finishes in about 5 minutes, so even in the event where 3 builds start exactly simultaneously, they would still all finish in about 12 minutes, since a worker from the first build is freed up in time to start on the third build. I've also never seen any build get stuck waiting on another one to finish so far. 


#### What should we test?
<!-- List which features should be tested and how. -->
Green build, maybe in about 12-15 minutes? 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Rebalanced CI jobs to speed up test suite. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
