### PR TITLE
Add indexes on adjustments polymorphic associations

### DIFF
--- a/db/migrate/20210320003951_update_adjustments_indexes.rb
+++ b/db/migrate/20210320003951_update_adjustments_indexes.rb
@@ -1,0 +1,8 @@
+class UpdateAdjustmentsIndexes < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :spree_adjustments, :adjustable_id
+
+    add_index :spree_adjustments, [:adjustable_type, :adjustable_id]
+    add_index :spree_adjustments, [:originator_type, :originator_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210315163900) do
+ActiveRecord::Schema.define(version: 20210320003951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -372,8 +372,9 @@ ActiveRecord::Schema.define(version: 20210315163900) do
     t.string   "state",           limit: 255
     t.integer  "order_id"
     t.boolean  "included",                                             default: false
-    t.index ["adjustable_id"], name: "index_adjustments_on_order_id", using: :btree
+    t.index ["adjustable_type", "adjustable_id"], name: "index_spree_adjustments_on_adjustable_type_and_adjustable_id", using: :btree
     t.index ["order_id"], name: "index_spree_adjustments_on_order_id", using: :btree
+    t.index ["originator_type", "originator_id"], name: "index_spree_adjustments_on_originator_type_and_originator_id", using: :btree
   end
 
   create_table "spree_assets", force: :cascade do |t|
@@ -468,14 +469,14 @@ ActiveRecord::Schema.define(version: 20210315163900) do
   create_table "spree_line_items", force: :cascade do |t|
     t.integer  "order_id"
     t.integer  "variant_id"
-    t.integer  "quantity",                                                                  null: false
-    t.decimal  "price",                            precision: 10, scale: 2,                 null: false
-    t.datetime "created_at",                                                                null: false
-    t.datetime "updated_at",                                                                null: false
+    t.integer  "quantity",                                                 null: false
+    t.decimal  "price",                           precision: 10, scale: 2, null: false
+    t.datetime "created_at",                                               null: false
+    t.datetime "updated_at",                                               null: false
     t.integer  "max_quantity"
-    t.string   "currency",             limit: 255
-    t.decimal  "distribution_fee",                 precision: 10, scale: 2
-    t.decimal  "final_weight_volume",              precision: 10, scale: 2
+    t.string   "currency",            limit: 255
+    t.decimal  "distribution_fee",                precision: 10, scale: 2
+    t.decimal  "final_weight_volume",             precision: 10, scale: 2
     t.integer  "tax_category_id"
     t.index ["order_id"], name: "index_line_items_on_order_id", using: :btree
     t.index ["variant_id"], name: "index_line_items_on_variant_id", using: :btree


### PR DESCRIPTION
#### What? Why?

Adds some additional indexes to the primary polymorphic associations on the adjustments table. There's quite a few different ways we fetch and scope adjustments, and they behave a bit differently. The queries are quite different when calling (for example) `order.adjustments`, `order.all_adjustments.enterprise_fee`, `order.line_item_adjustments.tax`, etc. I ran some before and after  comparisons using `EXPLAIN` with commonly-used queries. In some cases there was no real difference, and in other cases these changes made the query cost about 12x smaller (depending on the queries and scopes used), eg: reducing the cost from 236 to 18.

Some relevant reading on indexing polymorphic associations: 
- https://github.com/rails/rails/commit/9cdd0a1fdf8308985231242d378e3a1c29c4ab00
- https://mauricio.github.io/2008/09/27/handling-database-indexes-for-rails-polymorphic-associations.html
- https://blog.smartlogic.io/2008-06-13-ruby-on-rails-polymorphic-association-benchmarks/

The compound index is effective for general queries on those associations, but in many cases when applying scopes we also are primarily filtering on the `*_type` columns.

I've left out the `source` association here because a) it isn't really used in querying, and b) we'll be deleting it soon.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build, or feel free to do some query testing :+1:

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved indexes on adjustments table

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
