### PR TITLE
Record invalid payment states for debugging 

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,7 +294,7 @@ en:
   error: Error
   processing_payment: "Processing payment..."
   no_pending_payments: "No pending payments"
-  invalid_payment_state: "Invalid payment state"
+  invalid_payment_state: "Invalid payment state: %{state}"
   filter_results: Filter Results
   quantity: Quantity
   pick_up: Pick up

--- a/lib/stripe/payment_intent_validator.rb
+++ b/lib/stripe/payment_intent_validator.rb
@@ -23,9 +23,10 @@ module Stripe
     end
 
     def raise_if_not_in_capture_state(payment_intent_response)
-      return unless payment_intent_response.status != 'requires_capture'
+      state = payment_intent_response.status
+      return unless state != 'requires_capture'
 
-      raise Stripe::StripeError, I18n.t(:invalid_payment_state)
+      raise Stripe::StripeError, I18n.t(:invalid_payment_state, state: state)
     end
   end
 end

--- a/spec/lib/stripe/payment_intent_validator_spec.rb
+++ b/spec/lib/stripe/payment_intent_validator_spec.rb
@@ -40,7 +40,7 @@ module Stripe
         it "raises Stripe error with an invalid_payment_state message" do
           expect {
             validator.call(payment_intent_id, stripe_account_id)
-          }.to raise_error Stripe::StripeError, "Invalid payment state"
+          }.to raise_error Stripe::StripeError, "Invalid payment state: failed"
         end
       end
 

--- a/spec/models/spree/gateway/stripe_sca_spec.rb
+++ b/spec/models/spree/gateway/stripe_sca_spec.rb
@@ -39,6 +39,16 @@ describe Spree::Gateway::StripeSCA, type: :model do
 
       expect(response.success?).to eq true
     end
+
+    it "provides an error message to help developer debug" do
+      stub_request(:get, "https://api.stripe.com/v1/payment_intents/12345").
+        to_return(status: 200, body: capture_successful)
+
+      response = subject.purchase(order.total, credit_card, gateway_options)
+
+      expect(response.success?).to eq false
+      expect(response.message).to eq "Invalid payment state: succeeded"
+    end
   end
 
   def payment_intent(amount, status)

--- a/spec/models/spree/gateway/stripe_sca_spec.rb
+++ b/spec/models/spree/gateway/stripe_sca_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Spree::Gateway::StripeSCA, type: :model do
+  before { allow(Stripe).to receive(:api_key) { "sk_test_12345" } }
+
+  describe "#purchase" do
+    let(:order) { create(:order_with_totals_and_distribution) }
+    let(:credit_card) { create(:credit_card) }
+    let(:payment) {
+      create(
+        :payment,
+        state: "checkout",
+        order: order,
+        amount: order.total,
+        payment_method: subject,
+        source: credit_card,
+      )
+    }
+    let(:gateway_options) {
+      { order_id: order.number }
+    }
+    let(:payment_authorised) {
+      payment_intent(payment.amount, "requires_capture")
+    }
+    let(:capture_successful) {
+      payment_intent(payment.amount, "succeeded")
+    }
+
+    it "captures the payment" do
+      stub_request(:get, "https://api.stripe.com/v1/payment_intents/12345").
+        to_return(status: 200, body: payment_authorised)
+      stub_request(:post, "https://api.stripe.com/v1/payment_intents/12345/capture").
+        with(body: {"amount_to_capture" => "10.0"}).
+        to_return(status: 200, body: capture_successful)
+
+      response = subject.purchase(order.total, credit_card, gateway_options)
+
+      expect(response.success?).to eq true
+    end
+  end
+
+  def payment_intent(amount, status)
+    JSON.generate(
+      object: "payment_intent",
+      amount: amount,
+      status: status,
+      charges: { data: [{ id: "ch_1234", amount: amount }] }
+    )
+  end
+end


### PR DESCRIPTION
#### What? Why?

Helps with #7130. This is just a first part and doesn't solve the issue yet. But while I'm still working out a real fix, this can be helpful already in case this issue occurs again.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Apparently, we sometimes try to process a payment intent which is not in the right state. It probably has been processed already. It would be good to confirm this theory by logging the state the payment intent is in.

#### What should we test?
<!-- List which features should be tested and how. -->

Simple checkout with Stripe. Everything should work as normal.

You can try to reproduce the issue in #7130 but that may not be successful. It's okay if you can't reproduce it. It's not worth spending much time on that.

- Checkout paying via Stripe.
- When Stripe redirects you back to OFN, quickly reload the page. The timing can be tricky here and it's difficult to tell if you got it right.
- Check the order as admin and observe the state to be "payment" and the payment to be failed.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Record invalid payment states for debugging Stripe SCA issue #7130 and potentially others

