### PR TITLE
Fix balances order cycle report regression

### DIFF
--- a/app/queries/outstanding_balance.rb
+++ b/app/queries/outstanding_balance.rb
@@ -30,8 +30,8 @@ class OutstandingBalance
   # a little longer. See https://github.com/rails/arel/pull/400 for details.
   def statement
     <<-SQL.strip_heredoc
-      CASE WHEN state IN #{non_fulfilled_states_group.to_sql} THEN payment_total
-           WHEN state IS NOT NULL THEN payment_total - total
+      CASE WHEN "spree_orders"."state" IN #{non_fulfilled_states_group.to_sql} THEN "spree_orders"."payment_total"
+           WHEN "spree_orders"."state" IS NOT NULL THEN "spree_orders"."payment_total" - "spree_orders"."total"
       ELSE 0 END
     SQL
   end

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -291,6 +291,30 @@ describe Spree::Admin::ReportsController, type: :controller do
     end
   end
 
+
+  context 'Order Cycle Management' do
+    let!(:present_objects) { [orderA1, orderA2, orderB1, orderB2] }
+
+    context 'when the customer_balance feature is enabled' do
+      before do
+        allow(OpenFoodNetwork::FeatureToggle)
+          .to receive(:enabled?).with(:customer_balance, kind_of(Spree::User)) { true }
+
+        controller_login_as_enterprise_user [coordinator1]
+      end
+
+      it 'renders the delivery report' do
+        spree_post :order_cycle_management, {
+          q: { completed_at_lt: 1.day.ago },
+          shipping_method_in: [ "123" ], # We just need to search for shipping methods
+          report_type: "delivery",
+        }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
   context "Admin" do
     before { controller_login_as_admin }
 

--- a/spec/queries/outstanding_balance_spec.rb
+++ b/spec/queries/outstanding_balance_spec.rb
@@ -12,8 +12,8 @@ describe OutstandingBalance do
       normalized_sql_statement = normalize(outstanding_balance.statement)
 
       expect(normalized_sql_statement).to eq(normalize(<<-SQL))
-        CASE WHEN state IN ('canceled', 'returned') THEN payment_total
-             WHEN state IS NOT NULL THEN payment_total - total
+        CASE WHEN "spree_orders"."state" IN ('canceled', 'returned') THEN "spree_orders"."payment_total"
+             WHEN "spree_orders"."state" IS NOT NULL THEN "spree_orders"."payment_total" - "spree_orders"."total"
         ELSE 0 END
       SQL
     end


### PR DESCRIPTION
#### What? Why?

This fixes the error UK is experiencing:

```
PG::AmbiguousColumn: ERROR: column reference "state" is ambiguous LINE 1: SELECT DISTINCT spree_orders.*, CASE WHEN state IN ('cancele... ^ : SELECT DISTINCT spree_orders.*, CASE WHEN state IN ('canceled', 'returned') THEN payment_total WHEN state IS NOT NULL THEN payment_total - total ELSE 0 END AS balance_value, spree_orders.* FROM "spree_orders" INNER JOIN "spree_shipments"
```

See https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/6058c45989d37300079e8312?event_id=6058ccd30075af73bcb20000&i=sk&m=nw.

#### What should we test?

Green build is enough. I managed to reproduce it in a test.

#### Release notes

Fix Order Cycle Management Delivery report when :customer_balance toggle is enabled.
Changelog Category: User facing changes