### PR TITLE
Update deprecated errors.set syntax

### DIFF
--- a/lib/spree/localized_number.rb
+++ b/lib/spree/localized_number.rb
@@ -35,7 +35,7 @@ module Spree
         return unless Spree::Config.enable_localized_number?
 
         @invalid_localized_number.andand.each do |error_attribute|
-          errors.set(error_attribute, [I18n.t('spree.localized_number.invalid_format')])
+          errors.add(error_attribute, I18n.t('spree.localized_number.invalid_format'))
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

```
DEPRECATION WARNING: ActiveModel::Errors#set is deprecated and will be removed in Rails 5.1. Use model.errors.add(:preferred_discount_amount, ["has an invalid format. Please enter a number."]) instead. (called from block (2 levels) in localize_number at /home/runner/work/openfoodnetwork/openfoodnetwork/lib/spree/localized_number.rb:38)
```

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Update deprecated syntax ActiveModel::Errors#set 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
