### PR TITLE
[Rails 5.2] Relation#Uniq is deprecated, distinct is recommended instead

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -173,7 +173,7 @@ module Spree
     scope :in_distributors, lambda { |distributors|
       with_order_cycles_outer.
         where('(o_exchanges.incoming = ? AND o_exchanges.receiver_id IN (?))', false, distributors).
-        uniq
+        distinct
     }
 
     # Products supplied by a given enterprise or distributed via that enterprise through an OC


### PR DESCRIPTION
#### What? Why?


From https://stackoverflow.com/questions/39575398/rails-uniq-vs-distinct

In rails5.2 build it will fix these errors:
```

Failure/Error:
         supplier_ids = Spree::Product.in_distributors(distributors.select('enterprises.id')).
           select('spree_products.supplier_id')
       
       ArgumentError:
         wrong number of arguments (given 1, expected 0)
       # ./app/controllers/spree/admin/reports_controller.rb:242:in `select'
```



#### What should we test?
Green build.
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Adapt code to work with rails 5.2


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
