### PR TITLE
[Rails 5.2] Fix validation problem in inventory items

### DIFF
--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -3,8 +3,8 @@ class InventoryItem < ActiveRecord::Base
   belongs_to :variant, class_name: "Spree::Variant"
 
   validates :variant_id, uniqueness: { scope: :enterprise_id }
-  validates :enterprise_id, presence: true
-  validates :variant_id, presence: true
+  validates :enterprise, presence: true
+  validates :variant, presence: true
   validates :visible, inclusion: { in: [true, false], message: I18n.t(:inventory_item_visibility_error) }
 
   scope :visible, -> { where(visible: true) }


### PR DESCRIPTION
#### What? Why?
Similar to #7186 but for inventory items

Fixes build error:
```

 19) OrderCycle product exchanges listing variant distributed by a particular distributor when default settings are in play with soft-deleted variants does not consider soft-deleted variants to be currently distributed in the oc
      Failure/Error: let!(:p1_v_visible) { create(:variant, product: p1, inventory_items: [create(:inventory_item, enterprise: d2, visible: true)]) }
      
      ActiveRecord::RecordInvalid:
        Validation failed: Inventory items is invalid
      # ./spec/models/order_cycle_spec.rb:178:in `block (3 levels) in <top (re
```
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
Green build.
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Adapt code to rails 5.2


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
