### PR TITLE
Replace ActiveMerchant's deprecated gateway_mode

### DIFF
--- a/app/models/spree/gateway.rb
+++ b/app/models/spree/gateway.rb
@@ -28,7 +28,7 @@ module Spree
       gateway_options = options
       gateway_options.delete :login if gateway_options.key?(:login) && gateway_options[:login].nil?
       if gateway_options[:server]
-        ActiveMerchant::Billing::Base.gateway_mode = gateway_options[:server].to_sym
+        ActiveMerchant::Billing::Base.mode = gateway_options[:server].to_sym
       end
       @provider ||= provider_class.new(gateway_options)
     end


### PR DESCRIPTION
#### What? Why?

It's now just called `mode`. This avoids the warning:

    ../app/models/spree/gateway.rb:31:in `provider': Base#gateway_mode is deprecated in favor of Base#mode and will be removed in a future version

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Checkout via Stripe. It should succeed as usual (not charging a real card).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Replace ActiveMerchant's deprecated gateway_mode option

