### PR TITLE
Deprecations: certain uses of #uniq

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -3,7 +3,7 @@ class Schedule < ActiveRecord::Base
 
   has_many :order_cycle_schedules, dependent: :destroy
   has_many :order_cycles, through: :order_cycle_schedules
-  has_many :coordinators, -> { uniq }, through: :order_cycles
+  has_many :coordinators, -> { distinct }, through: :order_cycles
 
   scope :with_coordinator, lambda { |enterprise| joins(:order_cycles).where('coordinator_id = ?', enterprise.id).select('DISTINCT schedules.*') }
 

--- a/lib/open_food_network/sales_tax_report.rb
+++ b/lib/open_food_network/sales_tax_report.rb
@@ -70,7 +70,7 @@ module OpenFoodNetwork
     def relevant_rates
       return @relevant_rates unless @relevant_rates.nil?
 
-      @relevant_rates = Spree::TaxRate.uniq
+      @relevant_rates = Spree::TaxRate.distinct
     end
 
     def totals_of(line_items)

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -41,7 +41,7 @@ namespace :ofn do
 
           # For each variant in the exchange
           products = Spree::Product.joins(:variants_including_master).where('spree_variants.id IN (?)', exchange.variants).pluck(:id).uniq
-          producers = Enterprise.joins(:supplied_products).where("spree_products.id IN (?)", products).uniq
+          producers = Enterprise.joins(:supplied_products).where("spree_products.id IN (?)", products).distinct
           producers.each do |producer|
             next if producer == exchange.receiver
 


### PR DESCRIPTION
#### What? Why?

`Enumerable#uniq` is not deprecated (eg calling `#uniq` on an `Array` object), but now using `#uniq` on an `ActiveRecord::Relation` is deprecated in favour of `#distinct` (which modifies the query itself, as opposed to iterating over the results of the query).

There's probably a lot more places where we could refactor some existing code where we technically are using `#uniq` on array objects, eg `SomeObject.pluck(:id).uniq` could be `SomeObject.distinct.pluck(:id)` and it would be more performant, but we can leave that for another time.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated deprecated #uniq syntax

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
