### PR TITLE
fix content moving when cart is open

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
@@ -7,9 +7,11 @@ Darkswarm.directive "bodyScroll", ($rootScope, BodyScroll) ->
         document.body.style.top = "-#{window.scrollY}px"
         document.body.style.position = 'fixed'
         document.body.style.overflowY = 'scroll'
+        document.body.style.width = '100%'
       else
         scrollY = parseInt(document.body.style.top)
         document.body.style.position = ''
         document.body.style.top = ''
         document.body.style.overflowY = ''
+        document.body.style.width = ''
         window.scrollTo(0, scrollY * -1) if scrollY

--- a/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
@@ -4,6 +4,12 @@ Darkswarm.directive "bodyScroll", ($rootScope, BodyScroll) ->
   link: (scope, elem, attrs) ->
     $rootScope.$on "toggleBodyScroll", ->
       if BodyScroll.disabled
-        elem.addClass "disable-scroll"
+        document.body.style.top = "-#{window.scrollY}px"
+        document.body.style.position = 'fixed'
+        document.body.style.overflowY = 'scroll'
       else
-        elem.removeClass "disable-scroll"
+        scrollY = parseInt(document.body.style.top)
+        document.body.style.position = ''
+        document.body.style.top = ''
+        document.body.style.overflowY = ''
+        window.scrollTo(0, scrollY * -1) if scrollY

--- a/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
@@ -9,9 +9,9 @@ Darkswarm.directive "bodyScroll", ($rootScope, BodyScroll) ->
         document.body.style.overflowY = 'scroll'
         document.body.style.width = '100%'
       else
-        scrollY = parseInt(document.body.style.top)
+        scrollY = parseInt(document.body.style.top) * -1
         document.body.style.position = ''
         document.body.style.top = ''
         document.body.style.overflowY = ''
         document.body.style.width = ''
-        window.scrollTo(0, scrollY * -1) if scrollY
+        window.scrollTo(0, scrollY) if scrollY

--- a/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/body_scroll.js.coffee
@@ -3,7 +3,7 @@ Darkswarm.directive "bodyScroll", ($rootScope, BodyScroll) ->
   scope: true
   link: (scope, elem, attrs) ->
     $rootScope.$on "toggleBodyScroll", ->
-      if BodyScroll.disabled
+      if BodyScroll.disabled && document.body.scrollHeight > document.body.clientHeight
         document.body.style.top = "-#{window.scrollY}px"
         document.body.style.position = 'fixed'
         document.body.style.overflowY = 'scroll'

--- a/app/assets/stylesheets/darkswarm/ui.scss
+++ b/app/assets/stylesheets/darkswarm/ui.scss
@@ -165,7 +165,3 @@ a.button.large {
 .flex {
   display: flex;
 }
-
-.disable-scroll {
-  overflow: hidden;
-}


### PR DESCRIPTION
#### What? Why?

Closes #5916 

This is the simplest solution I found. The advantage is that it keeps the whole content from shifting (including static content like the header, footer and background), however the scrollbar stays visible, although inactive. Please let me know if this is ok!


#### What should we test?
Test whether there is any content shift when toggling the cart menu, both in mobile and desktop


#### Release notes
Prevented content from shifting when toggling cart menu

Changelog Category: User facing changes
