### PR TITLE
Avoid double processing payment

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -14,7 +14,7 @@ class CheckoutController < ::BaseController
 
   # We need pessimistic locking to avoid race conditions.
   # Otherwise we fail on duplicate indexes or end up with negative stock.
-  prepend_around_action CurrentOrderLocker, only: :update
+  prepend_around_action CurrentOrderLocker, only: [:edit, :update]
 
   prepend_before_action :check_hub_ready_for_checkout
   prepend_before_action :check_order_cycle_expiry

--- a/spec/controllers/checkout_controller_concurrency_spec.rb
+++ b/spec/controllers/checkout_controller_concurrency_spec.rb
@@ -47,9 +47,6 @@ describe CheckoutController, concurrency: true, type: :controller do
     allow(controller).to receive(:restrict_iframes)
   end
 
-  # This spec does not seem to be running in two threads in Rails 5. There are errors for the
-  # same response headers being set twice, possibly indicating that there is only one response
-  # as opposed to two separate requests in two threads?
   it "handles two concurrent orders successfully" do
     # New threads start running straight away. The breakpoint is after loading
     # the order and before advancing the order's state and making payments.

--- a/spec/controllers/checkout_controller_concurrency_spec.rb
+++ b/spec/controllers/checkout_controller_concurrency_spec.rb
@@ -42,12 +42,15 @@ describe CheckoutController, concurrency: true, type: :controller do
     allow(controller).to receive(:spree_current_user).and_return(order.user)
     allow(controller).to receive(:current_distributor).and_return(order.distributor)
     allow(controller).to receive(:current_order_cycle).and_return(order.order_cycle)
+
+    # Avoid setting headers as Rails 5 is not thread-safe here:
+    allow(controller).to receive(:restrict_iframes)
   end
 
   # This spec does not seem to be running in two threads in Rails 5. There are errors for the
   # same response headers being set twice, possibly indicating that there is only one response
   # as opposed to two separate requests in two threads?
-  xit "handles two concurrent orders successfully" do
+  it "handles two concurrent orders successfully" do
     # New threads start running straight away. The breakpoint is after loading
     # the order and before advancing the order's state and making payments.
     breakpoint.lock

--- a/spec/controllers/checkout_controller_concurrency_spec.rb
+++ b/spec/controllers/checkout_controller_concurrency_spec.rb
@@ -52,6 +52,12 @@ describe CheckoutController, concurrency: true, type: :controller do
     # the order and before advancing the order's state and making payments.
     breakpoint.lock
 
+    checkout_workflow_original = controller.method(:checkout_workflow)
+    expect(controller).to receive(:checkout_workflow) do |shipping_method_id|
+      breakpoint.synchronize {}
+      checkout_workflow_original.call(shipping_method_id)
+    end
+
     # Starting two checkout threads. The controller code will determine if
     # these two threads are synchronised correctly or run into a race condition.
     #


### PR DESCRIPTION
#### What? Why?

Closes #7130

Well, this is based on my theory of how the issue could have happened. We will see over time if the Bugsnag error re-appears. This happened only once in production.


<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

1. Checkout paying via Stripe.
2. When Stripe redirects you back to OFN, quickly reload the page. The timing can be tricky here and it's difficult to tell if you got it right.
3. Check the order as admin. If the order is in "payment" state and the payment is failed, the bug is still present. If the payment is still complete and the order is good as well then the bug has been fixed.

I saw that @filipefurtad0 triggered this 12 times in staging. So I hope you won't be able to reproduce it again. :smile: 
I think that the checkout redirects you to the cart page which may be confusing for users. But that's a different issue (not s2) and at least the order has been processed.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

Fix a rare bug that showed a failed Stripe payment even though it was successful.

