### PR TITLE
Refactor unit price i18n keys

### DIFF
--- a/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
+++ b/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
@@ -13,7 +13,7 @@
       "question-mark-with-tooltip-append-to-body" => "true",
       "question-mark-with-tooltip-placement" => "top",
       "question-mark-with-tooltip-animation" => true,
-      key: "'js.shopfront.unit_price_tooltip.shopfront'"}
+      key: "'js.shopfront.unit_price_tooltip'"}
       {{ variant.unit_price_price | localizeCurrency }} / {{ variant.unit_price_unit }}
         
   .medium-2.large-2.columns.total-price

--- a/app/views/shared/menu/_cart_sidebar.html.haml
+++ b/app/views/shared/menu/_cart_sidebar.html.haml
@@ -30,6 +30,7 @@
                   "question-mark-with-tooltip-append-to-body" => "true",
                   "question-mark-with-tooltip-placement" => "top",
                   "question-mark-with-tooltip-animation" => true,
+                  key: "'js.shopfront.unit_price_tooltip'",
                   context: "'cart-sidebar'"}
                 .options-text
                   {{ line_item.variant.unit_price_price | localizeCurrency }} / {{ line_item.variant.unit_price_unit }}

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -60,7 +60,7 @@
                   "question-mark-with-tooltip-append-to-body" => "true",
                   "question-mark-with-tooltip-placement" => "top",
                   "question-mark-with-tooltip-animation" => true, 
-                  key: "'js.shopfront.unit_price_tooltip.admin'"}
+                  key: "'js.admin.unit_price_tooltip'"}
               %br/
               = f.text_field :price, {"class" => 'fullwidth', "disabled" =>  true, "ng-model" => "unit_price"}
               %div{style: "color: black"}

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -44,7 +44,7 @@
             "question-mark-with-tooltip-append-to-body" => "true",
             "question-mark-with-tooltip-placement" => "top",
             "question-mark-with-tooltip-animation" => true, 
-            key: "'js.shopfront.unit_price_tooltip.admin'"}
+            key: "'js.admin.unit_price_tooltip'"}
           %br/
           = f.text_field :price, {"class" => 'fullwidth', "disabled" =>  true, "ng-model" => "unit_price"}
           %div{style: "color: black"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2551,6 +2551,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         There was a problem adding this product to the cart.
         Perhaps it has become unavailable or the shop is closing.
     admin:
+      unit_price_tooltip: "The unit price increases transparency by allowing your customers to easily compare prices between different products and packaging sizes. Note, that the final unit price displayed in the shopfront might differ as it is includes taxes & fees."
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
       modals:
         got_it: "Got it"
@@ -2789,9 +2790,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         min_quantity: "Min quantity"
         max_quantity: "Max quantity"
       price_breakdown: "Price breakdown"
-      unit_price_tooltip:
-        shopfront: "This is the unit price of this product. It allows you to compare the price of products independent of packaging sizes & weights."
-        admin: "The unit price increases transparency by allowing your customers to easily compare prices between different products and packaging sizes. Note, that the final unit price displayed in the shopfront might differ as it is includes taxes & fees."
+      unit_price_tooltip: "This is the unit price of this product. It allows you to compare the price of products independent of packaging sizes & weights."
     variants:
       on_demand:
         "yes": "On demand"
@@ -3258,6 +3257,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           header:
             store: Store
     admin:
+      unit_price_tooltip: "The unit price increases transparency by allowing your customers to easily compare prices between different products and packaging sizes. Note, that the final unit price displayed in the shopfront might differ as it is includes taxes & fees."
       tab:
         dashboard: "Dashboard"
         orders: "Orders"


### PR DESCRIPTION
#### What? Why?
Probably due to merge _conflicts_, some of the i18n keys were misplaced. Refactor this by creating two distincts keys:  `js.admin.unit_price_tooltip` and `js.shopfront.unit_price_tooltip`

Closes #7216 



#### What should we test?
 - We should have a green build
 - And we should have the right tooltip text both in the shopfront (for a specific shop and inside the cart sidebar) and in the admin (`/admin/products/new`): text are different.
<img width="303" alt="Capture d’écran 2021-03-25 à 18 00 50" src="https://user-images.githubusercontent.com/296452/112512967-2a57b780-8d94-11eb-8e6b-0a8158436e22.png">
<img width="296" alt="Capture d’écran 2021-03-25 à 18 00 55" src="https://user-images.githubusercontent.com/296452/112512971-2c217b00-8d94-11eb-97e3-33f1e00f407b.png">




#### Release notes
Fix unit price i18n issues.

Changelog Category: User facing changes


