### PR TITLE
Add 'context' variable: used to specify display of the unit price tooltip inside cart sidebar

### DIFF
--- a/app/assets/javascripts/shared/directives/question_mark_tooltip.js.coffee
+++ b/app/assets/javascripts/shared/directives/question_mark_tooltip.js.coffee
@@ -4,7 +4,7 @@ OFNShared.directive "questionMarkWithTooltip", ($tooltip)->
   # Subsequently we patch the scope, template and restrictions
   tooltip = $tooltip 'questionMarkWithTooltip', 'questionMarkWithTooltip', 'click'
   tooltip.scope =
-    variant: "="
+    context: "="
     key: "="
   tooltip.templateUrl = "shared/question_mark_with_tooltip_icon.html"
   tooltip.replace = true


### PR DESCRIPTION
#### What? Why?
Probably due to merge _conflict_ (or maybe badly managed by myself), the variable `context` (which is used to specify some CSS depending on where the tooltip is displayed) was lost. Add it inside the scope of the directive as it's passed to the template.

Closes #7223 



#### What should we test?
Open the cart sidebar with, at least, one product. Click on the question mark about the unit price, and see the tooltip well displayed:
<img width="411" alt="Capture d’écran 2021-03-25 à 22 51 24" src="https://user-images.githubusercontent.com/296452/112548575-ba115c00-8dbc-11eb-82cd-51cf29ec118c.png">



#### Release notes
Fix unit price tooltip display issue in cart sidebar.

Changelog Category: User facing changes
