### PR TITLE
Add some CSS specification to avoid page content up/down move

### DIFF
--- a/app/assets/stylesheets/shared/question-mark-icon.scss
+++ b/app/assets/stylesheets/shared/question-mark-icon.scss
@@ -36,6 +36,9 @@
       @include icon-font;
       content: "";
       color: $white;
+      vertical-align: super;
+      position: relative;
+      top: 2px;
     }
   }
 }
@@ -45,6 +48,7 @@
   width: 15px;
   min-width: 15px;
   height: 15px;
+  margin-left: 2px;
 }
 
 .joyride-tip-guide.question-mark-tooltip {

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -55,13 +55,13 @@
         - if feature? :unit_price, spree_current_user
           .four.columns{ ng: { app: 'ofn.admin'}}
             = f.field_container :unit_price do
-              = f.label :unit_price, t(".unit_price")
-              %question-mark-with-tooltip{"question-mark-with-tooltip" => "_",
+              %div{style: "display: flex"}
+                = f.label :unit_price, t(".unit_price")
+                %question-mark-with-tooltip{"question-mark-with-tooltip" => "_",
                   "question-mark-with-tooltip-append-to-body" => "true",
                   "question-mark-with-tooltip-placement" => "top",
                   "question-mark-with-tooltip-animation" => true, 
                   key: "'js.admin.unit_price_tooltip'"}
-              %br/
               = f.text_field :price, {"class" => 'fullwidth', "disabled" =>  true, "ng-model" => "unit_price"}
               %div{style: "color: black"}
                 = t(".unit_price_legend")

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -39,13 +39,13 @@
         = hidden_field_tag 'product_variant_unit', @product.variant_unit
         = hidden_field_tag 'product_variant_unit_name', @product.variant_unit_name
         = f.field_container :unit_price do
-          = f.label :unit_price, t(".unit_price"), {style: "display: inline-block"}
-          %question-mark-with-tooltip{"question-mark-with-tooltip" => "_",
-            "question-mark-with-tooltip-append-to-body" => "true",
-            "question-mark-with-tooltip-placement" => "top",
-            "question-mark-with-tooltip-animation" => true, 
-            key: "'js.admin.unit_price_tooltip'"}
-          %br/
+          %div{style: "display: flex"}
+            = f.label :unit_price, t(".unit_price"), {style: "display: inline-block"}
+            %question-mark-with-tooltip{"question-mark-with-tooltip" => "_",
+              "question-mark-with-tooltip-append-to-body" => "true",
+              "question-mark-with-tooltip-placement" => "top",
+              "question-mark-with-tooltip-animation" => true, 
+              key: "'js.admin.unit_price_tooltip'"}
           = f.text_field :price, {"class" => 'fullwidth', "disabled" =>  true, "ng-model" => "unit_price"}
           %div{style: "color: black"}
             = t("spree.admin.products.new.unit_price_legend")


### PR DESCRIPTION
#### What? Why?
Avoid page content to move up and down as we click on the unit price question mark to display tooltip.
##### How?
 - Use `display: flex`
 - Improve the display of the blue cross by a better alignement into the circle

Closes #7215


#### What should we test?
Test the unit price tooltip into the admin section. Should not lead to a page content up and down move.
See pages:
- `/admin/products/[$PRODUCT_NAME]/variants/[$PRODUCT_VARIANT_ID]/edit`
- `/admin/products/[$PRODUCT_NAME]/variants/new`
- `/admin/products/new`
![2021-03-25 23 23 50](https://user-images.githubusercontent.com/296452/112551387-3a39c080-8dc1-11eb-9a85-2866aba79d1e.gif)



#### Release notes
Fix display issue on unit price tooltip.

Changelog Category: User facing changes

