### PR TITLE
Remove UI for modifying line items on canceled orders

### DIFF
--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -284,6 +284,10 @@ module Spree
       I18n.t('shipping')
     end
 
+    def can_modify?
+      !shipped? && !order.canceled?
+    end
+
     private
 
     def manifest_unstock(item)

--- a/app/views/spree/admin/orders/_add_product.html.haml
+++ b/app/views/spree/admin/orders/_add_product.html.haml
@@ -5,7 +5,7 @@
     %legend{:align => "center"}= Spree.t(:add_product)
 
     - if @order.canceled?
-      = Spree.t(:cannot_add_item_to_canceled_order)
+      = t(".cannot_add_item_to_canceled_order")
     - else
       .field.twelve.columns.alpha{"data-hook" => "add_product_name"}
         = label_tag :add_variant_id, Spree.t(:name_or_sku)

--- a/app/views/spree/admin/orders/_add_product.html.haml
+++ b/app/views/spree/admin/orders/_add_product.html.haml
@@ -4,8 +4,11 @@
   %fieldset.no-border-bottom
     %legend{:align => "center"}= Spree.t(:add_product)
 
-    .field.twelve.columns.alpha{"data-hook" => "add_product_name"}
-      = label_tag :add_variant_id, Spree.t(:name_or_sku)
-      = hidden_field_tag :add_variant_id, "", :class => "variant_autocomplete fullwidth"
-      
+    - if @order.canceled?
+      = Spree.t(:cannot_add_item_to_canceled_order)
+    - else
+      .field.twelve.columns.alpha{"data-hook" => "add_product_name"}
+        = label_tag :add_variant_id, Spree.t(:name_or_sku)
+        = hidden_field_tag :add_variant_id, "", :class => "variant_autocomplete fullwidth"
+
   #stock_details

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -33,7 +33,7 @@
     %tbody{ "data-shipment-number" => "#{shipment.number}", "data-order-number" => "#{order.number}" }
       = render 'spree/admin/orders/shipment_manifest', order: order, shipment: shipment
 
-      - unless shipment.shipped?
+      - if shipment.can_modify?
         %tr.edit-method.hidden.total
           %td{ :colspan => "5" }
             %div.field.alpha.five.columns
@@ -69,7 +69,7 @@
             %span
               = shipment.fee_adjustment.display_amount
 
-        - if shipment.fee_adjustment.present? && !shipment.shipped?
+        - if shipment.fee_adjustment.present? && shipment.can_modify?
           %td.actions
             - if can? :update, shipment
               = link_to '', '', :class => 'edit-method icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')
@@ -81,7 +81,7 @@
           = text_field_tag :tracking, shipment.tracking
 
         %td.actions
-          - if can? :update, shipment
+          - if can?(:update, shipment) && !shipment.canceled?
             = link_to '', '', :class => 'save-tracking icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, :title => I18n.t('actions.save')
             = link_to '', '', :class => 'cancel-tracking icon_link icon-cancel no-text with-tip', :data => { :action => 'cancel' }, :title => I18n.t('actions.cancel')
 
@@ -95,5 +95,5 @@
             = Spree.t(:no_tracking_present)
 
         %td.actions
-          - if can? :update, shipment
+          - if can?(:update, shipment) && shipment.can_modify?
             = link_to '', '', :class => 'edit-tracking icon_link icon-edit no-text with-tip', :data => { :action => 'edit' }, :title => Spree.t('edit')

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -19,7 +19,7 @@
         = line_item_shipment_price(line_item, item.quantity)
 
       %td.cart-item-delete.actions{ "data-hook" => "cart_item_delete" }
-        - if !shipment.shipped? && can?(:update, shipment)
+        - if shipment.can_modify? && can?(:update, shipment)
           = link_to '', '#', :class => 'save-item icon_link icon-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => t('actions.save'), :style => 'display: none'
           = link_to '', '#', :class => 'cancel-item icon_link icon-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('actions.cancel'), :style => 'display: none'
           = link_to '', '#', :class => 'edit-item icon_link icon-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('actions.edit')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3043,7 +3043,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     back_to_payments_list: "Back To Payments List"
     return_authorizations: "Return Authorizations"
     cannot_create_returns: "Cannot create returns as this order has no shipped units."
-    cannot_add_item_to_canceled_order: "Cannot add item to canceled order"
     select_stock: "Select stock"
     location: "Location"
     count_on_hand: "Count On Hand"
@@ -3327,6 +3326,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           received: "Received"
           canceled: "Canceled"
       orders:
+        add_product:
+          cannot_add_item_to_canceled_order: "Cannot add item to canceled order"
         index:
           listing_orders: "Listing Orders"
           new_order: "New Order"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3043,6 +3043,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     back_to_payments_list: "Back To Payments List"
     return_authorizations: "Return Authorizations"
     cannot_create_returns: "Cannot create returns as this order has no shipped units."
+    cannot_add_item_to_canceled_order: "Cannot add item to canceled order"
     select_stock: "Select stock"
     location: "Location"
     count_on_hand: "Count On Hand"

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -343,6 +343,16 @@ feature '
           end
         end
       end
+
+      context "and the order has been canceled" do
+        it "does not allow modifying line items" do
+          order.cancel!
+          visit spree.edit_admin_order_path(order)
+          within("tr.stock-item", text: order.products.first.name) do
+            expect(page).to_not have_selector("a.edit-item")
+          end
+        end
+      end
     end
 
     scenario "creating an order with distributor and order cycle" do


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/7165 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This removes the UI for modifying line item quantities if the order is canceled. This prevents* the order total from being modified and will also address #7166. 

*prevents unless the admin edit order page is also open in another tab (hopefully a very rare scenario). @mkllnk is writing a PR to address preventing the request from being processed on the backend in that case. We're going to attach Maikel's PR to #7166. 

<img width="1391" alt="Screen Shot 2021-03-26 at 9 36 00 AM" src="https://user-images.githubusercontent.com/35588/112664030-b8748200-8e16-11eb-905e-2252a768eb65.png">

#### What should we test?
<!-- List which features should be tested and how. -->
Cancel an order. The admin edit order page should no longer allow adding/editing line items for the order. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where canceled orders could be modified, leading to discrepancies in customer balances and stock levels. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
