### PR TITLE
Keep status bar with message without auto-close

### DIFF
--- a/app/assets/javascripts/admin/utils/services/status_message.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/status_message.js.coffee
@@ -1,11 +1,11 @@
-angular.module("admin.utils").factory "StatusMessage", ($timeout) ->
+angular.module("admin.utils").factory "StatusMessage", ->
   new class StatusMessage
     types:
-      progress: {timeout: false, style: {color: '#ff9906'}}
-      alert:    {timeout: 5000,  style: {color: 'grey'}}
-      notice:   {timeout: false, style: {color: 'grey'}}
-      success:  {timeout: 5000,  style: {color: '#9fc820'}}
-      failure:  {timeout: false, style: {color: '#da5354'}}
+      progress: {style: {color: '#ff9906'}}
+      alert:    {style: {color: 'grey'}}
+      notice:   {style: {color: 'grey'}}
+      success:  {style: {color: '#9fc820'}}
+      failure:  {style: {color: '#da5354'}}
 
     statusMessage:
       text: ""
@@ -25,13 +25,7 @@ angular.module("admin.utils").factory "StatusMessage", ($timeout) ->
     display: (type, text) ->
       @statusMessage.text = text
       @statusMessage.style = @types[type].style
-      $timeout.cancel @statusMessage.timeout  if @statusMessage.timeout
-      timeout = @types[type].timeout
-      if timeout
-        @statusMessage.timeout = $timeout =>
-          @clear()
-        , timeout, true
-      null # So we don't return weird timeouts
+      null
 
     clear: ->
       @statusMessage.text = ''

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -199,7 +199,7 @@ feature '
           expect(page).to have_field "price", with: "100.00"
         end
         click_button "Save Changes"
-        expect(page).to have_no_selector "#save-bar"
+        expect(page).to have_content "All changes saved"
         li1.reload
         expect(li1.final_weight_volume).to eq 2000
         expect(li1.price).to eq 20.00


### PR DESCRIPTION

#### What? Why?

Closes #7231.

![Screenshot from 2021-03-26 14-01-10](https://user-images.githubusercontent.com/3524483/112572320-0ea8eb80-8e3e-11eb-89a7-25c4811b4fdb.png)

The message would disappear after five seconds which can be confusing for the user (they may miss an important message) and makes our specs flaky.

This avoids CI fails like this one:
```
     Failure/Error: expect(page).to have_content I18n.t("js.changes_saved")
       expected to find text "Changes saved." in "Logged in as : shelly@spencerortiz.info Account Logout Store\nDASHBOARD\nPRODUCTS\nORDER CYCLES\nORDERS\nREPORTS\nENTERPRISES\nCUSTOMERS\nPRODUCTS\nINVENTORY\nIMPORT\nInventory\nWhat's this?\nQUICK SEARCH\nSHOP\nEnterprise 279\nEnterprise 279\nPRODUCER\nAll\nIMPORTED\nAll\n\nThere are 3 new products available to add to your inventory.    \n×\n  ACTIONS\n  VIEWING: INVENTORY PRODUCTS\n    COLUMNS\nChanges to one override remain unsaved.\nPRODUCER PRODUCT PRICE ON HAND ON DEMAND?\nEnterprise 281 Product #136 - 9001\n1g\nUse producer stock settings\nYes\nNo\n2g, S\nUse producer stock settings\nYes\nNo\nEnterprise 281 Product #140 - 4196\n8g, S\nUse producer stock settings\nYes\nNo\nEnterprise 283 Product #138 - 9684\n2g, S\nUse producer stock settings\nYes\nNo"
     # ./spec/features/admin/variant_overrides_spec.rb:368:in `block (7 levels) in <top (required)>'
```



#### What should we test?
<!-- List which features should be tested and how. -->

The status bar is used on many admin pages:

- products
- inventory
- customers
- order cycles
- payments
- subscriptions

Check on each of these pages that you can change things, the bar appears as before and then doesn't disappear. And despite the bar being there, you can continue your work.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

The status bar on admin pages does not disappear after five seconds any more.

