### PR TITLE
Add unit price for already bought products in cart page

### DIFF
--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -22,6 +22,10 @@
         %span.already-confirmed= t(:orders_bought_already_confirmed)
       %td.text-right.cart-item-price
         = line_item.single_display_amount_with_adjustments.to_html
+        - if feature? :unit_price, spree_current_user
+          %br
+          %span.unit-price
+            = line_item.unit_price_price_and_unit
       %td.text-center.cart-item-quantity
         = line_item.quantity
       %td.cart-item-total.text-right


### PR DESCRIPTION
#### What? Why?
This PR adds unit price information for already bought products (but order cycle still open) in cart page: that was simply an omission.
Closes #7224 

#### What should we test?
1. _As admin_: Set a hub to allow editing of previously placed orders (within the time the OC is open)
2. _As customer_: after having some orders placed, verify that the price info appears for the items in the cart, but not for items on previously placed orders

<img width="930" alt="Capture d’écran 2021-03-26 à 09 48 07" src="https://user-images.githubusercontent.com/296452/112606704-bca19f00-8e18-11eb-8115-19fc70973f4f.png">


#### Release notes
Add unit price information for already bought products in cart page

Changelog Category: User facing changes
