### PR TITLE
Fix font import from Darkswarm to admin

### DIFF
--- a/app/assets/stylesheets/shared/variables/variables.scss
+++ b/app/assets/stylesheets/shared/variables/variables.scss
@@ -3,7 +3,18 @@ $radius-small: 0.25em;
 $white: #fff;
 $dynamic-blue: #3d8dd1;
 $teal-500: #0096ad;
-@import "../../darkswarm/style"; // Import "OFN" font
+
+@font-face {
+	font-family: 'OFN';
+	src: font-url('OFN-v2.eot');
+	src: font-url('OFN-v2.eot') format('embedded-opentype'),
+		font-url('OFN-v2.woff') format('woff'),
+		font-url('OFN-v2.ttf') format('truetype'),
+		font-url('OFN-v2.svg') format('svg');
+	font-weight: normal;
+	font-style: normal;
+}
+
 @mixin icon-font {
   font-family: "OFN";
   display: inline-block;


### PR DESCRIPTION
#### What? Why?
Admin CSS included CSS files from Darkswarm, with inappropriate selectors (with ugly side effects).
Only copy/paster the needed part (OFN font definition)

Closes #7220

##### How?
Do not import darkswarm css file into admin, but only needed selector


#### What should we test?
 - Bad font shouldn't be present in any cases suggested in #7220
 - Unit price question mark with tooltip should have a cross to close it once it opened.


#### Release notes
Fix display issue about font.

Changelog Category: User facing changes

