### PR TITLE
Update Exchange touch on Enterprise to use #touch_later

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -12,7 +12,7 @@ class Exchange < ActiveRecord::Base
 
   belongs_to :order_cycle
   belongs_to :sender, class_name: 'Enterprise'
-  belongs_to :receiver, class_name: 'Enterprise', touch: true
+  belongs_to :receiver, class_name: 'Enterprise'
 
   has_many :exchange_variants, dependent: :destroy
   has_many :variants, through: :exchange_variants
@@ -22,6 +22,8 @@ class Exchange < ActiveRecord::Base
 
   validates :order_cycle, :sender, :receiver, presence: true
   validates :sender_id, uniqueness: { scope: [:order_cycle_id, :receiver_id, :incoming] }
+
+  after_save :touch_receiver
 
   accepts_nested_attributes_for :variants
 
@@ -94,5 +96,11 @@ class Exchange < ActiveRecord::Base
 
   def participant
     incoming? ? sender : receiver
+  end
+
+  def touch_receiver
+    return unless receiver&.persisted?
+
+    receiver.touch_later
   end
 end

--- a/spec/models/enterprise_caching_spec.rb
+++ b/spec/models/enterprise_caching_spec.rb
@@ -92,6 +92,13 @@ describe Enterprise do
               enterprise.reload
             }.to change { enterprise.updated_at }
           end
+
+          it "touches enterprise when a relevant exchange is updated" do
+            expect {
+              oc.exchanges.first.update!(updated_at: Time.zone.now)
+              enterprise.reload
+            }.to change { enterprise.updated_at }
+          end
         end
 
         it "touches enterprise when the product's variant is added to order cycle" do


### PR DESCRIPTION
#### What? Why?

Related to #7234 

Using `#touch_later` (new in Rails 5.0) instead of `#touch` can improve issues with deadlocks where multiple touch calls are triggered in a single update, for example where an exchange touches it's parent enterprise on save, and we do this:
```ruby
oc_with_lots_of_exchanges.exchanges.each{|ex| ex.clone! }
```

![Screenshot from 2021-03-26 12-51-10](https://user-images.githubusercontent.com/9029026/112634097-752c0a80-8e3a-11eb-9e02-e3657372fdde.png)


#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough here. There's a fair amount of test coverage on these touches, and I added an extra test.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved touch logic on Exchanges

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
