### PR TITLE
Update default scopes with acts_as_paranoid

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -7,20 +7,18 @@ class ProducerMailer < Spree::BaseMailer
     @producer = producer
     @order_cycle = order_cycle
 
-    with_unscoped_products_and_variants do
-      load_data
+    load_data
 
-      I18n.with_locale(owner_locale) do
-        return unless orders?(order_cycle, producer)
+    I18n.with_locale(owner_locale) do
+      return unless orders?(order_cycle, producer)
 
-        mail(
-          to: @producer.contact.email,
-          from: from_address,
-          subject: subject,
-          reply_to: @coordinator.contact.email,
-          cc: @coordinator.contact.email
-        )
-      end
+      mail(
+        to: @producer.contact.email,
+        from: from_address,
+        subject: subject,
+        reply_to: @coordinator.contact.email,
+        cc: @coordinator.contact.email
+      )
     end
   end
 
@@ -75,23 +73,5 @@ class ProducerMailer < Spree::BaseMailer
 
   def tax_total_from_line_items(line_items)
     Spree::Money.new line_items.to_a.sum(&:included_tax)
-  end
-
-  # This hack makes ActiveRecord skip the default_scope (deleted_at IS NULL)
-  # when eager loading associations. Further details:
-  # https://github.com/rails/rails/issues/11036
-  def with_unscoped_products_and_variants
-    variant_default_scopes = Spree::Variant.default_scopes
-    product_default_scopes = Spree::Product.default_scopes
-
-    Spree::Variant.default_scopes = []
-    Spree::Product.default_scopes = []
-
-    return_value = yield
-
-    Spree::Variant.default_scopes = variant_default_scopes
-    Spree::Product.default_scopes = product_default_scopes
-
-    return_value
   end
 end

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -10,7 +10,7 @@ module Spree
     include LineItemBasedAdjustmentHandling
 
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items
-    belongs_to :variant, class_name: "Spree::Variant"
+    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant"
     belongs_to :tax_category, class_name: "Spree::TaxCategory"
 
     has_one :product, through: :variant
@@ -152,18 +152,6 @@ module Spree
 
     def assign_stock_changes_to=(shipment)
       @preferred_shipment = shipment
-    end
-
-    # Remove product default_scope `deleted_at: nil`
-    def product
-      variant.product
-    end
-
-    # This ensures that LineItems always have access to soft-deleted variants.
-    # In some situations, unscoped super will be nil. In these cases,
-    #   we fetch the variant using variant_id. See issue #4946 for more details.
-    def variant
-      Spree::Variant.unscoped { super } || Spree::Variant.unscoped.find(variant_id)
     end
 
     def cap_quantity_at_stock!

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -13,7 +13,8 @@ module Spree
 
     acts_as_paranoid
 
-    belongs_to :product, touch: true, class_name: 'Spree::Product'
+    belongs_to :product, -> { with_deleted }, touch: true, class_name: 'Spree::Product'
+
     delegate_belongs_to :product, :name, :description, :permalink, :available_on,
                         :tax_category_id, :shipping_category_id, :meta_description,
                         :meta_keywords, :tax_category, :shipping_category
@@ -186,13 +187,6 @@ module Spree
 
     def amount_in(currency)
       price_in(currency).try(:amount)
-    end
-
-    # Product may be created with deleted_at already set,
-    # which would make AR's default finder return nil.
-    # This is a stopgap for that little problem.
-    def product
-      Spree::Product.unscoped { super }
     end
 
     # can_supply? is implemented in VariantStock

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -190,8 +190,17 @@ module Spree
         end
       end
 
-      it "finds line items sorted by name and unit_value" do
-        expect(o.line_items.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
+      describe "#sorted_by_name_and_unit_value" do
+        it "finds line items sorted by name and unit_value" do
+          expect(o.line_items.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
+        end
+
+        it "includes soft-deleted products/variants" do
+          li3.variant.product.destroy
+
+          expect(o.line_items.reload.sorted_by_name_and_unit_value).to eq([li6, li5, li4, li3])
+          expect(o.line_items.sorted_by_name_and_unit_value.to_sql).to_not match "deleted_at"
+        end
       end
 
       it "finds line items from a given order cycle" do


### PR DESCRIPTION
#### What? Why?

Hopefully closes #7225

Fixes an issue where the `LineItem#sorted_by_name_and_unit_value` scope was not working with removal of the default scopes on line item and variant, which meant that the join in the scope was excluding soft-deleted items that should not have been excluded.

Since Rails 4.2 (I think?) we can now define scopes directly on associations (yay :tada:), so to override the default `deleted_at` scope for a specific association that uses soft-deletion, we can now do this:
```ruby
belongs_to :variant, -> { with_deleted }
```
instead of this:
```ruby
def variant
  Spree::Variant.unscoped { super } # this does not work nicely with joins...
end
```

There's half a dozen other places where we can do this as well, but I'll cover them in a separate PR.

#### What should we test?
<!-- List which features should be tested and how. -->

See #7225

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed issue with deleted_at scopes when displaying line items

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
