### PR TITLE
Escalating paranoia

### DIFF
--- a/app/models/spree/inventory_unit.rb
+++ b/app/models/spree/inventory_unit.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class InventoryUnit < ActiveRecord::Base
-    belongs_to :variant, class_name: "Spree::Variant"
+    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant"
     belongs_to :order, class_name: "Spree::Order"
     belongs_to :shipment, class_name: "Spree::Shipment"
     belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization",
@@ -57,11 +57,6 @@ module Spree
     def find_stock_item
       Spree::StockItem.find_by(stock_location_id: shipment.stock_location_id,
                                variant_id: variant_id)
-    end
-
-    # Remove variant default_scope `deleted_at: nil`
-    def variant
-      Spree::Variant.unscoped { super }
     end
 
     private

--- a/app/models/spree/price.rb
+++ b/app/models/spree/price.rb
@@ -4,7 +4,7 @@ module Spree
   class Price < ActiveRecord::Base
     acts_as_paranoid without_default_scope: true
 
-    belongs_to :variant, class_name: 'Spree::Variant'
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
 
     validate :check_price
     validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
@@ -24,11 +24,6 @@ module Spree
 
     def price=(price)
       self[:amount] = parse_price(price)
-    end
-
-    # Allow prices to access associated soft-deleted variants.
-    def variant
-      Spree::Variant.unscoped { super }
     end
 
     private

--- a/app/models/spree/stock_item.rb
+++ b/app/models/spree/stock_item.rb
@@ -5,7 +5,7 @@ module Spree
     acts_as_paranoid
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items
-    belongs_to :variant, class_name: 'Spree::Variant'
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
     has_many :stock_movements
 
     validates :stock_location, :variant, presence: true
@@ -35,10 +35,6 @@ module Spree
     # Tells whether it's available to be included in a shipment
     def available?
       in_stock? || backorderable?
-    end
-
-    def variant
-      Spree::Variant.unscoped { super }
     end
 
     def count_on_hand=(value)

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -34,7 +34,7 @@ module Spree
     accepts_nested_attributes_for :images
 
     has_one :default_price,
-            -> { where currency: Spree::Config[:currency] },
+            -> { with_deleted.where(currency: Spree::Config[:currency]) },
             class_name: 'Spree::Price',
             dependent: :destroy
     has_many :prices,
@@ -150,11 +150,6 @@ module Spree
                                             currency || Spree::Config[:currency]).
                                           where('spree_prices.amount IS NOT NULL').
                                           select("spree_variants.id"))
-    end
-
-    # Allow variant to access associated soft-deleted prices.
-    def default_price
-      Spree::Price.unscoped { super }
     end
 
     def price_with_fees(distributor, order_cycle)

--- a/app/models/subscription_line_item.rb
+++ b/app/models/subscription_line_item.rb
@@ -1,6 +1,6 @@
 class SubscriptionLineItem < ActiveRecord::Base
   belongs_to :subscription, inverse_of: :subscription_line_items
-  belongs_to :variant, class_name: 'Spree::Variant'
+  belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
 
   validates :subscription, presence: true
   validates :variant, presence: true
@@ -10,11 +10,6 @@ class SubscriptionLineItem < ActiveRecord::Base
 
   def total_estimate
     (price_estimate || 0) * (quantity || 0)
-  end
-
-  # Ensure SubscriptionLineItem always has access to soft-deleted Variant attribute
-  def variant
-    Spree::Variant.unscoped { super }
   end
 
   # Used to calculators to estimate fees

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -742,4 +742,21 @@ module Spree
       end
     end
   end
+
+
+  describe "#default_price" do
+    let(:variant) { create(:variant) }
+    let(:default_price) { variant.default_price }
+
+    context "when the default price is soft-deleted" do
+      it "can access the default price" do
+        price_id = default_price.id
+
+        default_price.destroy
+
+        expect(variant.reload.default_price).to be_a Spree::Price
+        expect(variant.default_price.id).to eq price_id
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Following #7239 

Updates various places where we use outdated syntax to unscope `deleted_at` on associations that use soft-deletion via the **paranoia** gem.

![paranoia](https://media.giphy.com/media/9rjKLsynBodhiIovdD/giphy.gif)

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated more syntax around unscoping deleted_at on associations

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
