### PR TITLE
[rails 5-2] More fixes to rspec syntax

### DIFF
--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open_food_network/permissions'
 
 module OpenFoodNetwork

--- a/lib/open_food_network/order_cycle_permissions.rb
+++ b/lib/open_food_network/order_cycle_permissions.rb
@@ -1,3 +1,5 @@
+require 'open_food_network/permissions'
+
 module OpenFoodNetwork
   # Class which is used for determining the permissions around a single order cycle and user
   # both of which are set at initialization

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -17,7 +17,7 @@ module Admin
         end
 
         it "returns an empty @collection" do
-          get :index, format: :html
+          get :index, as: :html
           expect(assigns(:collection)).to eq []
         end
       end
@@ -34,13 +34,13 @@ module Admin
             let(:params) { { format: :json, enterprise_id: enterprise.id } }
 
             it "scopes @collection to customers of that enterprise" do
-              get :index, params
+              get :index, params: params
               expect(assigns(:collection)).to eq [customer]
             end
 
             it "serializes the data" do
               expect(ActiveModel::ArraySerializer).to receive(:new)
-              get :index, params
+              get :index, params: params
             end
 
             context 'when the customer_balance feature is enabled' do
@@ -57,13 +57,13 @@ module Admin
 
                 expect(customers_with_balance).to receive(:query) { Customer.none }
 
-                get :index, params
+                get :index, params: params
               end
 
               it 'serializes using CustomerWithBalanceSerializer' do
                 expect(Api::Admin::CustomerWithBalanceSerializer).to receive(:new)
 
-                get :index, params
+                get :index, params: params
               end
             end
 
@@ -75,20 +75,20 @@ module Admin
               it 'calls Customer.of' do
                 expect(Customer).to receive(:of).twice.with(enterprise) { Customer.none }
 
-                get :index, params
+                get :index, params: params
               end
 
               it 'serializes calling the UserBalanceCalculator' do
                 expect(OpenFoodNetwork::UserBalanceCalculator)
                   .to receive(:new).with(customer.email, customer.enterprise) { calculator }
 
-                get :index, params
+                get :index, params: params
               end
             end
 
             context 'when the customer has no orders' do
               it 'includes the customer balance in the response' do
-                get :index, params
+                get :index, params: params
                 expect(json_response.first["balance"]).to eq("$0.00")
               end
             end
@@ -103,7 +103,7 @@ module Admin
               end
 
               it 'includes the customer balance in the response' do
-                get :index, params
+                get :index, params: params
                 expect(json_response.first["balance"]).to eq("$-10.00")
               end
             end
@@ -124,7 +124,7 @@ module Admin
               end
 
               it 'includes the customer balance in the response' do
-                get :index, params
+                get :index, params: params
                 expect(json_response.first["balance"]).to eq("$10.00")
               end
             end
@@ -134,7 +134,7 @@ module Admin
               let!(:line_item) { create(:line_item, order: order, price: 10.0) }
 
               it 'includes the customer balance in the response' do
-                get :index, params
+                get :index, params: params
                 expect(json_response.first["balance"]).to eq("$0.00")
               end
             end
@@ -156,7 +156,7 @@ module Admin
 
               it 'includes the customer balance in the response' do
                 expect(order.payment_total).to eq(0)
-                get :index, params
+                get :index, params: params
                 expect(json_response.first["balance"]).to eq('$-10.00')
               end
             end
@@ -164,7 +164,7 @@ module Admin
 
           context "and enterprise_id is not given in params" do
             it "returns an empty collection" do
-              get :index, format: :json
+              get :index, as: :json
               expect(assigns(:collection)).to eq []
             end
           end
@@ -176,7 +176,7 @@ module Admin
           end
 
           it "returns an empty collection" do
-            get :index, format: :json
+            get :index, as: :json
             expect(assigns(:collection)).to eq []
           end
         end
@@ -276,7 +276,7 @@ module Admin
           end
 
           it "renders the customer as json" do
-            get :show, format: :json, id: customer.id
+            get :show, as: :json, params: { id: customer.id }
             expect(JSON.parse(response.body)["id"]).to eq customer.id
           end
         end
@@ -287,7 +287,7 @@ module Admin
           end
 
           it "prevents me from updating the customer" do
-            get :show, format: :json, id: customer.id
+            get :show, as: :json, params: { id: customer.id }
             expect(response).to redirect_to unauthorized_path
           end
         end

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -464,21 +464,21 @@ describe Admin::EnterprisesController, type: :controller do
     end
 
     context "when an order_cycle_id is provided in params" do
-      before { get :for_order_cycle, format: :json, order_cycle_id: 1 }
+      before { get :for_order_cycle, as: :json, params: { order_cycle_id: 1 } }
       it "initializes permissions with the existing OrderCycle" do
         expect(OpenFoodNetwork::OrderCyclePermissions).to have_received(:new).with(user, "existing OrderCycle")
       end
     end
 
     context "when a coordinator is provided in params" do
-      before { get :for_order_cycle, format: :json, coordinator_id: 1 }
+      before { get :for_order_cycle, as: :json, params: { coordinator_id: 1 } }
       it "initializes permissions with a new OrderCycle" do
         expect(OpenFoodNetwork::OrderCyclePermissions).to have_received(:new).with(user, "new OrderCycle")
       end
     end
 
     context "when both an order cycle and a coordinator are provided in params" do
-      before { get :for_order_cycle, format: :json, order_cycle_id: 1, coordinator_id: 1 }
+      before { get :for_order_cycle, as: :json, params: { order_cycle_id: 1, coordinator_id: 1 } }
       it "initializes permissions with the existing OrderCycle" do
         expect(OpenFoodNetwork::OrderCyclePermissions).to have_received(:new).with(user, "existing OrderCycle")
       end

--- a/spec/controllers/admin/invoice_settings_controller_spec.rb
+++ b/spec/controllers/admin/invoice_settings_controller_spec.rb
@@ -20,7 +20,7 @@ describe Admin::InvoiceSettingsController, type: :controller do
 
     it "disables invoices" do
       expect {
-        post :update, params
+        post :update, params: params
       }.to change {
         Spree::Config[:enable_invoices?]
       }.to(false)
@@ -28,7 +28,7 @@ describe Admin::InvoiceSettingsController, type: :controller do
 
     it "changes the invoice style" do
       expect {
-        post :update, params
+        post :update, params: params
       }.to change {
         Spree::Config[:invoice_style2?]
       }.to(true)
@@ -36,7 +36,7 @@ describe Admin::InvoiceSettingsController, type: :controller do
 
     it "disables receipt printing" do
       expect {
-        post :update, params
+        post :update, params: params
       }.to change {
         Spree::Config[:enable_receipt_printing?]
       }.to(true)

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -20,7 +20,7 @@ module Admin
 
         context "html" do
           it "doesn't load any data" do
-            get :index, format: :html
+            get :index, as: :html
             expect(assigns(:collection)).to be_empty
           end
         end
@@ -28,7 +28,7 @@ module Admin
         context "json" do
           context "where ransack conditions are specified" do
             it "loads order cycles that closed within the past month, and orders without a close_at date" do
-              get :index, format: :json
+              get :index, as: :json
               expect(assigns(:collection)).to_not include oc1, oc2
               expect(assigns(:collection)).to include oc3, oc4
             end
@@ -38,7 +38,7 @@ module Admin
             let(:q) { { orders_close_at_gt: 45.days.ago } }
 
             it "loads order cycles that closed after the specified date, and orders without a close_at date" do
-              get :index, format: :json, q: q
+              get :index, as: :json, params: { q: q }
               expect(assigns(:collection)).to_not include oc1
               expect(assigns(:collection)).to include oc2, oc3, oc4
             end
@@ -47,7 +47,7 @@ module Admin
               before { q.merge!(id_not_in: [oc2.id, oc4.id]) }
 
               it "loads order cycles that meet all conditions" do
-                get :index, format: :json, q: q
+                get :index, format: :json, params: { q: q }
                 expect(assigns(:collection)).to_not include oc1, oc2, oc4
                 expect(assigns(:collection)).to include oc3
               end
@@ -80,14 +80,14 @@ module Admin
         describe "and a coordinator_id is submitted as part of the request" do
           describe "when the user manages the enterprise" do
             it "renders the new template" do
-              get :new, coordinator_id: distributor1.id
+              get :new, params: { coordinator_id: distributor1.id }
               expect(response).to render_template :new
             end
           end
 
           describe "when the user does not manage the enterprise" do
             it "renders the set_coordinator template and sets a flash error" do
-              get :new, coordinator_id: distributor3.id
+              get :new, params: { coordinator_id: distributor3.id }
               expect(response).to render_template :set_coordinator
               expect(flash[:error]).to eq "You don't have permission to create an order cycle coordinated by that enterprise"
             end
@@ -101,7 +101,7 @@ module Admin
 
       context "as a manager of a shop" do
         let(:form_mock) { instance_double(OrderCycleForm) }
-        let(:params) { { format: :json, order_cycle: {} } }
+        let(:params) { { as: :json, order_cycle: {} } }
 
         before do
           controller_login_as_enterprise_user([shop])
@@ -336,7 +336,7 @@ module Admin
 
       describe "when an order cycle is deleteable" do
         it "allows the order_cycle to be destroyed" do
-          get :destroy, id: oc.id
+          get :destroy, params: { id: oc.id }
           expect(OrderCycle.find_by(id: oc.id)).to be nil
         end
       end
@@ -345,7 +345,7 @@ module Admin
         let!(:order) { create(:order, order_cycle: oc) }
 
         it "displays an error message when we attempt to delete it" do
-          get :destroy, id: oc.id
+          get :destroy, params: { id: oc.id }
           expect(response).to redirect_to admin_order_cycles_path
           expect(flash[:error]).to eq I18n.t('admin.order_cycles.destroy_errors.orders_present')
         end
@@ -355,7 +355,7 @@ module Admin
         let!(:schedule) { create(:schedule, order_cycles: [oc]) }
 
         it "displays an error message when we attempt to delete it" do
-          get :destroy, id: oc.id
+          get :destroy, params: { id: oc.id }
           expect(response).to redirect_to admin_order_cycles_path
           expect(flash[:error]).to eq I18n.t('admin.order_cycles.destroy_errors.schedule_present')
         end

--- a/spec/controllers/admin/proxy_orders_controller_spec.rb
+++ b/spec/controllers/admin/proxy_orders_controller_spec.rb
@@ -42,7 +42,7 @@ describe Admin::ProxyOrdersController, type: :controller do
 
           context "when cancellation succeeds" do
             it 'renders the cancelled proxy_order as json' do
-              get :cancel, params
+              get :cancel, params: params
               json_response = JSON.parse(response.body)
               expect(json_response['state']).to eq "canceled"
               expect(json_response['id']).to eq proxy_order.id
@@ -54,7 +54,7 @@ describe Admin::ProxyOrdersController, type: :controller do
             before { order_cycle.update(orders_close_at: 1.day.ago) }
 
             it "shows an error" do
-              get :cancel, params
+              get :cancel, params: params
               json_response = JSON.parse(response.body)
               expect(json_response['errors']).to eq ['Could not cancel the order']
             end
@@ -111,7 +111,7 @@ describe Admin::ProxyOrdersController, type: :controller do
 
           context "when resuming succeeds" do
             it 'renders the resumed proxy_order as json' do
-              get :resume, params
+              get :resume, params: params
               json_response = JSON.parse(response.body)
               expect(json_response['state']).to eq "resumed"
               expect(json_response['id']).to eq proxy_order.id
@@ -123,7 +123,7 @@ describe Admin::ProxyOrdersController, type: :controller do
             before { order_cycle.update(orders_close_at: 1.day.ago) }
 
             it "shows an error" do
-              get :resume, params
+              get :resume, params: params
               json_response = JSON.parse(response.body)
               expect(json_response['errors']).to eq ['Could not resume the order']
             end

--- a/spec/controllers/admin/schedules_controller_spec.rb
+++ b/spec/controllers/admin/schedules_controller_spec.rb
@@ -21,13 +21,13 @@ describe Admin::SchedulesController, type: :controller do
         let(:params) { { format: :json } }
 
         it "scopes @collection to schedules containing order_cycles coordinated by enterprises I manage" do
-          get :index, params
+          get :index, params: params
           expect(assigns(:collection)).to eq [coordinated_schedule]
         end
 
         it "serializes the data" do
           expect(ActiveModel::ArraySerializer).to receive(:new)
-          get :index, params
+          get :index, params: params
         end
 
         context "and there is a schedule of an OC coordinated by _another_ enterprise I manage and the first enterprise is given" do
@@ -37,7 +37,7 @@ describe Admin::SchedulesController, type: :controller do
           let(:params) { { format: :json, enterprise_id: managed_coordinator.id } }
 
           it "scopes @collection to schedules containing order_cycles coordinated by the first enterprise" do
-            get :index, params
+            get :index, params: params
             expect(assigns(:collection)).to eq [coordinated_schedule]
           end
         end
@@ -45,7 +45,7 @@ describe Admin::SchedulesController, type: :controller do
 
       context "where I dont manage an order cycle coordinator" do
         it "returns an empty collection" do
-          get :index, format: :json
+          get :index, as: :json
           expect(assigns(:collection)).to be_nil
         end
       end

--- a/spec/controllers/admin/stripe_accounts_controller_spec.rb
+++ b/spec/controllers/admin/stripe_accounts_controller_spec.rb
@@ -15,7 +15,7 @@ describe Admin::StripeAccountsController, type: :controller do
     end
 
     it "redirects to Stripe Authorization url constructed OAuth" do
-      get :connect, enterprise_id: 1 # A deterministic id results in a deterministic state JWT token
+      get :connect, params: { enterprise_id: 1 } # A deterministic id results in a deterministic state JWT token
 
       expect(response).to redirect_to("https://connect.stripe.com/oauth/authorize?state=eyJhbGciOiJIUzI1NiJ9.eyJlbnRlcnByaXNlX2lkIjoiMSJ9.jSSFGn0bLhwuiQYK5ORmHWW7aay1l030bcfGwn1JbFg&scope=read_write&client_id=some_id&response_type=code")
     end
@@ -98,7 +98,7 @@ describe Admin::StripeAccountsController, type: :controller do
       end
 
       it "redirects to unauthorized" do
-        get :status, params
+        get :status, params: params
         expect(response).to redirect_to unauthorized_path
       end
     end
@@ -110,7 +110,7 @@ describe Admin::StripeAccountsController, type: :controller do
 
       context "when Stripe is not enabled" do
         it "returns with a status of 'stripe_disabled'" do
-          get :status, params
+          get :status, params: params
           json_response = JSON.parse(response.body)
           expect(json_response["status"]).to eq "stripe_disabled"
         end
@@ -121,7 +121,7 @@ describe Admin::StripeAccountsController, type: :controller do
 
         context "when no stripe account is associated with the specified enterprise" do
           it "returns with a status of 'account_missing'" do
-            get :status, params
+            get :status, params: params
             json_response = JSON.parse(response.body)
             expect(json_response["status"]).to eq "account_missing"
           end
@@ -136,7 +136,7 @@ describe Admin::StripeAccountsController, type: :controller do
             end
 
             it "returns with a status of 'access_revoked'" do
-              get :status, params
+              get :status, params: params
               json_response = JSON.parse(response.body)
               expect(json_response["status"]).to eq "access_revoked"
             end
@@ -157,7 +157,7 @@ describe Admin::StripeAccountsController, type: :controller do
             end
 
             it "returns with a status of 'connected'" do
-              get :status, params
+              get :status, params: params
               json_response = JSON.parse(response.body)
               expect(json_response["status"]).to eq "connected"
               # serializes required attrs

--- a/spec/controllers/admin/stripe_connect_settings_controller_spec.rb
+++ b/spec/controllers/admin/stripe_connect_settings_controller_spec.rb
@@ -82,7 +82,7 @@ describe Admin::StripeConnectSettingsController, type: :controller do
       before { allow(controller).to receive(:spree_current_user) { user } }
 
       it "does not allow access" do
-        get :update, params
+        get :update, params: params
         expect(response).to redirect_to unauthorized_path
       end
     end
@@ -95,7 +95,7 @@ describe Admin::StripeConnectSettingsController, type: :controller do
 
       it "sets global config to the specified values" do
         expect(Spree::Config.stripe_connect_enabled).to be true
-        get :update, params
+        get :update, params: params
         expect(Spree::Config.stripe_connect_enabled).to be false
       end
     end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -19,7 +19,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
       context 'as a regular user' do
         it 'redirects to unauthorized' do
-          get :index, params
+          get :index, params: params
           expect(response).to redirect_to unauthorized_path
         end
       end
@@ -32,7 +32,7 @@ describe Admin::SubscriptionsController, type: :controller do
           let!(:subscription) { create(:subscription, shop: shop) }
 
           it 'renders the index page with appropriate data' do
-            get :index, params
+            get :index, params: params
             expect(response).to render_template 'index'
             expect(assigns(:collection)).to eq [] # No collection loaded
             expect(assigns(:shops)).to eq [shop] # Shops are loaded
@@ -41,7 +41,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
         context "where I don't manage a shop that is set up for subscriptions" do
           it 'renders the setup_explanation page' do
-            get :index, params
+            get :index, params: params
             expect(response).to render_template 'setup_explanation'
             expect(assigns(:collection)).to eq [] # No collection loaded
             expect(assigns(:shop)).to eq shop # First SO enabled shop is loaded
@@ -56,7 +56,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
       context 'as a regular user' do
         it 'redirects to unauthorized' do
-          get :index, params
+          get :index, params: params
           expect(response).to redirect_to unauthorized_path
         end
       end
@@ -67,7 +67,7 @@ describe Admin::SubscriptionsController, type: :controller do
         let!(:subscription2) { create(:subscription, shop: shop2) }
 
         it 'renders the collection as json' do
-          get :index, params
+          get :index, params: params
           json_response = JSON.parse(response.body)
           expect(json_response.count).to be 2
           expect(json_response.map{ |so| so['id'] }).to include subscription.id, subscription2.id
@@ -77,7 +77,7 @@ describe Admin::SubscriptionsController, type: :controller do
           before { params.merge!(q: { shop_id_eq: shop2.id }) }
 
           it "restricts the list of subscriptions" do
-            get :index, params
+            get :index, params: params
             json_response = JSON.parse(response.body)
             expect(json_response.count).to be 1
             ids = json_response.map{ |so| so['id'] }
@@ -99,7 +99,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
     it 'loads the preloads the necessary data' do
       expect(controller).to receive(:load_form_data)
-      get :new, subscription: { shop_id: shop.id }
+      get :new, params: { subscription: { shop_id: shop.id } }
       expect(assigns(:subscription)).to be_a_new Subscription
       expect(assigns(:subscription).shop).to eq shop
     end
@@ -238,7 +238,7 @@ describe Admin::SubscriptionsController, type: :controller do
 
     it 'loads the preloads the necessary data' do
       expect(controller).to receive(:load_form_data)
-      get :edit, id: subscription.id
+      get :edit, params: { id: subscription.id }
       expect(assigns(:subscription)).to eq subscription
     end
   end

--- a/spec/controllers/admin/variant_overrides_controller_spec.rb
+++ b/spec/controllers/admin/variant_overrides_controller_spec.rb
@@ -21,7 +21,7 @@ describe Admin::VariantOverridesController, type: :controller do
         end
 
         it "redirects to unauthorized" do
-          put :bulk_update, format: format, variant_overrides: variant_override_params
+          put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
           expect(response).to redirect_to unauthorized_path
         end
       end
@@ -33,7 +33,7 @@ describe Admin::VariantOverridesController, type: :controller do
 
         context "but the producer has not granted VO permission" do
           it "redirects to unauthorized" do
-            put :bulk_update, format: format, variant_overrides: variant_override_params
+            put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
             expect(response).to redirect_to unauthorized_path
           end
 
@@ -41,7 +41,7 @@ describe Admin::VariantOverridesController, type: :controller do
             other_variant_override = create(:variant_override, hub: hub, variant: create(:variant))
             expect(controller).not_to receive(:authorize!).with(:update, other_variant_override)
 
-            put :bulk_update, format: format, variant_overrides: variant_override_params
+            put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
           end
         end
 
@@ -51,7 +51,7 @@ describe Admin::VariantOverridesController, type: :controller do
           end
 
           it "loads data" do
-            put :bulk_update, format: format, variant_overrides: variant_override_params
+            put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
             expect(assigns[:hubs]).to eq [hub]
             expect(assigns[:producers]).to eq [variant.product.supplier]
             expect(assigns[:hub_permissions]).to eq Hash[hub.id, [variant.product.supplier.id]]
@@ -59,7 +59,7 @@ describe Admin::VariantOverridesController, type: :controller do
           end
 
           it "allows me to update the variant override" do
-            put :bulk_update, format: format, variant_overrides: variant_override_params
+            put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
 
             variant_override.reload
             expect(variant_override.price).to eq 123.45
@@ -72,7 +72,7 @@ describe Admin::VariantOverridesController, type: :controller do
             let(:variant_override_params) { [{ id: variant_override.id, price: "", count_on_hand: "", default_stock: nil, resettable: nil, sku: nil, on_demand: nil }] }
 
             it "destroys the variant override" do
-              put :bulk_update, format: format, variant_overrides: variant_override_params
+              put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
               expect(VariantOverride.find_by(id: variant_override.id)).to be_nil
             end
           end
@@ -84,7 +84,7 @@ describe Admin::VariantOverridesController, type: :controller do
             before { deleted_variant.update_attribute :deleted_at, Time.zone.now }
 
             it "allows to update other variant overrides" do
-              put :bulk_update, format: format, variant_overrides: variant_override_params
+              put :bulk_update, as: format, params: { variant_overrides: variant_override_params }
 
               expect(response).to_not redirect_to unauthorized_path
               variant_override.reload
@@ -118,7 +118,7 @@ describe Admin::VariantOverridesController, type: :controller do
         end
 
         it "redirects to unauthorized" do
-          put :bulk_reset, params
+          put :bulk_reset, params: params
           expect(response).to redirect_to unauthorized_path
         end
       end
@@ -130,7 +130,7 @@ describe Admin::VariantOverridesController, type: :controller do
 
         context "where the producer has not granted create_variant_overrides permission to the hub" do
           it "restricts access" do
-            put :bulk_reset, params
+            put :bulk_reset, params: params
             expect(response).to redirect_to unauthorized_path
           end
         end
@@ -139,7 +139,7 @@ describe Admin::VariantOverridesController, type: :controller do
           let!(:er1) { create(:enterprise_relationship, parent: producer, child: hub, permissions_list: [:create_variant_overrides]) }
 
           it "loads data" do
-            put :bulk_reset, params
+            put :bulk_reset, params: params
             expect(assigns[:hubs]).to eq [hub]
             expect(assigns[:producers]).to eq [producer]
             expect(assigns[:hub_permissions]).to eq Hash[hub.id, [producer.id]]
@@ -149,7 +149,7 @@ describe Admin::VariantOverridesController, type: :controller do
           it "updates stock to default values where reset is enabled" do
             expect(variant_override1.reload.count_on_hand).to eq 5 # reset enabled
             expect(variant_override2.reload.count_on_hand).to eq 2 # reset disabled
-            put :bulk_reset, params
+            put :bulk_reset, params: params
             expect(variant_override1.reload.count_on_hand).to eq 7 # reset enabled
             expect(variant_override2.reload.count_on_hand).to eq 2 # reset disabled
           end
@@ -164,7 +164,7 @@ describe Admin::VariantOverridesController, type: :controller do
 
             it "does not reset count_on_hand for variant_overrides not in params" do
               expect {
-                put :bulk_reset, params
+                put :bulk_reset, params: params
               }.to_not change{ variant_override3.reload.count_on_hand }
             end
           end

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -44,7 +44,7 @@ describe Api::BaseController do
     end
 
     it "using an invalid token param" do
-      get :index, token: "fake_key"
+      get :index, params: { token: "fake_key" }
       expect(json_response).to eq( "error" => "Invalid API key (fake_key) specified." )
     end
   end

--- a/spec/controllers/api/shops_controller_spec.rb
+++ b/spec/controllers/api/shops_controller_spec.rb
@@ -23,7 +23,7 @@ describe Api::ShopsController, type: :controller do
 
     describe "#show" do
       it "returns shopfront data for an enterprise" do
-        get :show, id: producer.id
+        get :show, params: { id: producer.id }
 
         expect(json_response['name']).to eq 'Shopfront Test Producer'
         expect(json_response['hubs'][0]['name']).to eq 'Shopfront Test Hub'
@@ -33,7 +33,7 @@ describe Api::ShopsController, type: :controller do
 
     describe "#closed_shops" do
       it "returns data for all closed shops" do
-        get :closed_shops, {}
+        get :closed_shops, params: {}
 
         expect(json_response).not_to match hub.name
 

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -66,12 +66,12 @@ describe Spree::UsersController, type: :controller do
     let!(:user) { create(:user) }
 
     it "returns true if email corresponds to a registered user" do
-      post :registered_email, email: user.email
+      post :registered_email, params: { email: user.email }
       expect(json_response['registered']).to eq true
     end
 
     it "returns false if email does not correspond to a registered user" do
-      post :registered_email, email: 'nonregistereduser@example.com'
+      post :registered_email, params: { email: 'nonregistereduser@example.com' }
       expect(json_response['registered']).to eq false
     end
   end
@@ -79,14 +79,14 @@ describe Spree::UsersController, type: :controller do
   context '#load_object' do
     it 'should redirect to signup path if user is not found' do
       allow(controller).to receive_messages(spree_current_user: nil)
-      put :update, user: { email: 'foobar@example.com' }
+      put :update, params: { user: { email: 'foobar@example.com' } }
       expect(response).to redirect_to('/login')
     end
   end
 
   context '#create' do
     it 'should create a new user' do
-      post :create, user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' }
+      post :create, params: { user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' } }
       expect(assigns[:user].new_record?).to be_falsey
     end
   end

--- a/spec/controllers/stripe/webhooks_controller_spec.rb
+++ b/spec/controllers/stripe/webhooks_controller_spec.rb
@@ -21,7 +21,7 @@ describe Stripe::WebhooksController, type: :controller do
       end
 
       it "responds with a 400" do
-        post 'create', params
+        post 'create', params: params
         expect(response.status).to eq 400
       end
     end
@@ -32,7 +32,7 @@ describe Stripe::WebhooksController, type: :controller do
       end
 
       it "responds with a 401" do
-        post 'create', params
+        post 'create', params: params
         expect(response.status).to eq 401
       end
     end
@@ -50,7 +50,7 @@ describe Stripe::WebhooksController, type: :controller do
           before { allow(handler).to receive(:handle) { :garbage } }
 
           it "falls back to 200" do
-            post 'create', params
+            post 'create', params: params
             expect(response.status).to eq 200
           end
         end
@@ -59,7 +59,7 @@ describe Stripe::WebhooksController, type: :controller do
           before { allow(handler).to receive(:handle) { :unknown } }
 
           it "responds with 202" do
-            post 'create', params
+            post 'create', params: params
             expect(response.status).to eq 202
           end
         end
@@ -73,7 +73,7 @@ describe Stripe::WebhooksController, type: :controller do
 
         context "when the stripe_account id on the event does not match any known accounts" do
           it "doesn't delete any Stripe accounts, responds with 204" do
-            post 'create', params
+            post 'create', params: params
             expect(response.status).to eq 204
             expect(StripeAccount.all).to include stripe_account
           end
@@ -83,7 +83,7 @@ describe Stripe::WebhooksController, type: :controller do
           before { params["account"] = "webhook_id" }
 
           it "deletes Stripe accounts in response to a webhook" do
-            post 'create', params
+            post 'create', params: params
             expect(response.status).to eq 200
             expect(StripeAccount.all).not_to include stripe_account
           end


### PR DESCRIPTION
#### What? Why?

Closes #7090  
Fixing rspec syntax in rails 5.2
This PR fixes over over 90 specs in rails 5.2 build.


#### What should we test?
green build.
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: | Technical changes
Adapt test code to rails 5-2


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
