### PR TITLE
[Rails 5.2] More missing helpers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,7 @@ class ApplicationController < ActionController::Base
   helper 'markdown'
   helper 'footer_links'
   helper 'discourse'
+  helper 'checkout'
 
   protect_from_forgery
 

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -10,6 +10,7 @@ module Spree
       helper 'admin/orders'
       helper 'admin/enterprises'
       helper 'enterprise_fees'
+      helper 'angular_form'
 
       layout '/spree/layouts/admin'
 

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -9,6 +9,7 @@ module Spree
       helper 'admin/injection'
       helper 'admin/orders'
       helper 'admin/enterprises'
+      helper 'enterprise_fees'
 
       layout '/spree/layouts/admin'
 

--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -8,6 +8,7 @@ module Spree
       helper 'spree/admin/orders'
       helper 'admin/injection'
       helper 'admin/orders'
+      helper 'admin/enterprises'
 
       layout '/spree/layouts/admin'
 


### PR DESCRIPTION
#### What? Why?

Closes #7091 

I think this covers the last of the missing helper methods.

#### What should we test?
<!-- List which features should be tested and how. -->

No more `method_missing` errors in the build.