### PR TITLE
[Rails 5.2] Locking issues

### DIFF
--- a/lib/spree/core/controller_helpers/order.rb
+++ b/lib/spree/core/controller_helpers/order.rb
@@ -52,7 +52,7 @@ module Spree
 
           return unless @current_order
 
-          @current_order.last_ip_address = ip_address
+          @current_order.update_columns(last_ip_address: ip_address)
           session[:order_id] = @current_order.id
           @current_order
         end


### PR DESCRIPTION
#### What? Why?

Loading the current_order object and then leaving it with unpersisted changes breaks order locking with this error (in various places):
```
RuntimeError:
        Locking a record with unpersisted changes is not supported. Use `save` to persist the changes, or `reload` to discard them explicitly.
```

#### What should we test?
<!-- List which features should be tested and how. -->

Fixed locking errors: "Locking a record with unpersisted changes..."