### PR TITLE
[Rails 5.2] Handling empty permitted params

### DIFF
--- a/app/services/permitted_attributes/enterprise.rb
+++ b/app/services/permitted_attributes/enterprise.rb
@@ -7,7 +7,7 @@ module PermittedAttributes
     end
 
     def call
-      return @params[:enterprise] if @params[:enterprise].blank?
+      return {} if @params[:enterprise].blank?
 
       @params.require(:enterprise).permit(self.class.attributes)
     end

--- a/app/services/permitted_attributes/order_cycle.rb
+++ b/app/services/permitted_attributes/order_cycle.rb
@@ -7,7 +7,7 @@ module PermittedAttributes
     end
 
     def call
-      return @params[:order_cycle] if @params[:order_cycle].blank?
+      return {} if @params[:order_cycle].blank?
 
       @params.require(:order_cycle).permit(attributes)
     end

--- a/app/services/permitted_attributes/subscription.rb
+++ b/app/services/permitted_attributes/subscription.rb
@@ -7,7 +7,7 @@ module PermittedAttributes
     end
 
     def call
-      return @params[:subscription] if @params[:subscription].blank?
+      return {} if @params[:subscription].blank?
 
       @params.require(:subscription).permit(basic_permitted_attributes + other_permitted_attributes)
     end


### PR DESCRIPTION
#### What? Why?

This guard clause was returning an instance of an unpermitted `Actioncontroller::Params` object (containing an empty hash) here, which was causing unexpected results in various places. Returning an empty hash explicitly resolves the issue.

Fixes:
```
4) Admin::OrderCyclesController create as a manager of a shop when creation is successful returns success: true and a valid edit path
     Failure/Error:
       @order_cycle_params ||= PermittedAttributes::OrderCycle.new(params).call.
         to_h.with_indifferent_access

     ActionController::UnfilteredParameters:
       unable to convert unpermitted parameters to hash
     # ./app/controllers/admin/order_cycles_controller.rb:245:in `order_cycle_params'
     # ./app/controllers/admin/order_cycles_controller.rb:44:in `create'
     # ./spec/support/controller_requests_helper.rb:49:in `process_action_with_route'
     # ./spec/support/controller_requests_helper.rb:27:in `spree_post'
     # ./spec/controllers/admin/order_cycles_controller_spec.rb:124:in `block (5 levels) in <module:Admin>'
```
#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
