### PR TITLE
Raise errors in specs with missing translations

### DIFF
--- a/app/views/admin/variant_overrides/_hidden_products.html.haml
+++ b/app/views/admin/variant_overrides/_hidden_products.html.haml
@@ -8,7 +8,7 @@
       %tr
         %th.producer=t('admin.producer')
         %th.product=t('admin.product')
-        %th.variant=t('(admin.variant')
+        %th.variant=t('admin.variant')
         %th.add=t('admin.variant_overrides.index.add')
     %tbody{ ng: { repeat: 'product in filteredProducts | limitTo:productLimit' } }
       %tr{ id: "v_{{variant.id}}", ng: { repeat: 'variant in product.variants | inventoryVariants:hub_id:views' } }

--- a/app/views/spree/admin/orders/_filters.html.haml
+++ b/app/views/spree/admin/orders/_filters.html.haml
@@ -35,7 +35,7 @@
       .field
         = label_tag nil, t(:shipping_method)
         = select_tag("shipping_method_id",
-            options_for_select(Spree::ShippingMethod.managed_by(spree_current_user).collect {|s| [t("spree.shipping_method.#{s.name}"), s.id]}),
+            options_for_select(Spree::ShippingMethod.managed_by(spree_current_user).collect {|s| [t("spree.shipping_method_names.#{s.name}"), s.id]}),
             {include_blank: true, class: 'select2', 'ng-model' => 'shipping_method_id'})
     .field-block.alpha.eight.columns
       = label_tag nil, t(:distributors)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,9 @@ Openfoodnetwork::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Tests should fail when translations are missing.
+  config.action_view.raise_on_missing_translations = true
+
   config.time_zone = ENV.fetch("TIMEZONE", "UTC")
 
   # Tests assume English text on the site.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,11 @@ en:
             shipping_method:
               not_available_to_shop: "is not available to %{shop}"
 
+  card_details: "Card details"
+  card_type: "Card type"
+  cardholder_name: "Cardholder name"
+  community_forum_url: "Community forum URL"
+  customer_instructions: "Customer instructions"
   devise:
     confirmations:
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
@@ -137,12 +142,40 @@ en:
         updated: "Your password was changed successfully. You are now signed in."
         send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
 
+  home_page_alert_html: "Home page alert HTML"
+  hub_signup_case_studies_html: "Hub signup case studies HTML"
+  hub_signup_detail_html: "Hub signup detail HTML"
+  hub_signup_pricing_table_html: "Hub signup pricing table HTML"
+  group_signup_case_studies_html: "Group signup case studies HTML"
+  group_signup_detail_html: "Group signup detail HTML"
+  group_signup_pricing_table_html: "Group signup pricing table HTML"
+  item_description: "Item description"
+  menu_1_icon_name: "Menu 1 icon name"
+  menu_2_icon_name: "Menu 2 icon name"
+  menu_3_icon_name: "Menu 3 icon name"
+  menu_4_icon_name: "Menu 4 icon name"
+  menu_5_icon_name: "Menu 5 icon name"
+  menu_6_icon_name: "Menu 6 icon name"
+  menu_7_icon_name: "Menu 7 icon name"
   models:
     order_cycle:
       cloned_order_cycle_name: "COPY OF %{order_cycle}"
     tax_rate:
       included_in_price: "Included in price"
 
+  open_street_map_enabled: "Open Street Map enabled"
+  open_street_map_default_latitude: "Open Street Map default latitude"
+  open_street_map_default_longitude: "Open Street Map default longitude"
+  open_street_map_provider_name: "Open Street Map provider name"
+  open_street_map_provider_options: "Open Street Map provider options"
+  producer_signup_case_studies_html: "Producer signup case studies HTML"
+  producer_signup_detail_html: "Producer signup detail HTML"
+  producer_signup_pricing_table_html: "Producer signup pricing table HTML"
+  producers_social: "Producers social"
+  resume_order: "Resume order"
+  sku: "SKU"
+  subtotal: "Subtotal"
+  tax_rate: "Tax rate"
   validators:
     date_time_string_validator:
       not_string_error: "must be a string"
@@ -169,6 +202,7 @@ en:
   producer_mailer:
     order_cycle:
       subject: "Order cycle report for %{producer}"
+  provider_settings: "Provider settings"
   shipment_mailer:
     shipped_email:
       dear_customer: "Dear Customer,"
@@ -335,6 +369,8 @@ en:
     # Common properties / models
     begins_at: Begins At
     begins_on: Begins On
+    bill_address: "Bill address"
+    ship_address: "Ship address"
     customer: Customer
     date: Date
     email: Email
@@ -1122,6 +1158,7 @@ en:
       index:
         title: "Subscriptions"
         new: "New Subscription"
+      issue: "Issue"
       new:
         title: "New Subscription"
       edit:
@@ -1203,6 +1240,7 @@ en:
       yes_cancel_them: Cancel them
       no_keep_them: Keep them
       yes_i_am_sure: Yes, I'm sure
+      number: "Number"
       order_update_issues_msg: Some orders could not be automatically updated, this is most likely because they have been manually edited. Please review the issues listed below and make any adjustments to individual orders if required.
       no_results:
         no_subscriptions: No subscriptions yet...
@@ -2954,6 +2992,15 @@ See the %{link} to find out more about %{sitename}'s features and to start using
 
   order_management:
     reports:
+      bulk_coop:
+        filters:
+          bulk_coop_allocation: "Bulk Co-op Allocation"
+          bulk_coop_customer_payments: "Bulk Co-op Customer Payments"
+          bulk_coop_packing_sheets: "Bulk Co-op Packing Sheets"
+          bulk_coop_supplier_report: "Bulk Co-op Supplier Report"
+          date_range: "Date range"
+          generate_report: "Generate Report"
+          report_format_csv: "Report format CSV"
       enterprise_fee_summaries:
         filters:
           date_range: "Date Range"
@@ -2999,6 +3046,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
               tax_category_name: "Tax Category"
               total_amount: "$$ SUM"
         invalid_filter_parameters: "The filters you selected for this report are invalid."
+      report:
+        "none": "None"
 
   order: "Order"
   distribution: "Distribution"
@@ -3036,7 +3085,55 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   last: "Last"
 
   spree:
+    add_country: "Add country"
+    add_state: "Add state"
+    adjustment: "Adjustment"
+    all: "All"
+    associated_adjustment_closed: "Associated adjustment closed"
+    authorization_failure: "Authorization failure"
+    back_to_adjustments_list: "Back to adjustments"
+    back_to_users_list: "Back to users"
+    back_to_zones_list: "Back to zones"
+    bugherd_api_key: "Bugherd API key"
+    card_code: "Card code"
+    card_number: "Card number"
+    category: "Category"
+    created_successfully: "Created Successfully"
+    credit: "Credit"
+    editing_tax_category: "Editing tax category"
+    editing_tax_rate: "Editing tax rate"
+    editing_zone: "Editing zone"
+    expiration: "Expiration"
+    invalid_payment_provider: "Invalid payment provider"
+    items_cannot_be_shipped: "Items cannot be shipped"
+    gateway_config_unavailable: "Gateway config unavailable"
+    gateway_error: "Payment failed"
     more: "More"
+    new_adjustment: "New adjustment"
+    new_order_completed: "New order completed"
+    new_tax_category: "New Tax Category"
+    new_taxon: "New taxon"
+    new_user: "New user"
+    no_pending_payments: "No pending payments"
+    "none": "None"
+    not_found: "Not found"
+    notice_messages:
+      variant_deleted: "Variant deleted"
+    or: "Or"
+    order_processed_successfully: "Order processed successfully"
+    payment_method_not_supported: "Payment method not supported"
+    resend_authorization_email: "Resend authorization email"
+    rma_credit: "RMA credit"
+    server_error: "Server error"
+    shipping_method_names:
+      UPS Ground: "UPS Ground"
+    start_date: "Start date"
+    successfully_removed: "Successfully Removed"
+    taxonomy_edit: "Taxonomy edit"
+    taxonomy_tree_error: "Taxonomy tree error"
+    taxonomy_tree_instruction: "Taxonomy tree instruction"
+    tree: "Tree"
+    updating: "Updating"
     your_order_is_empty_add_product: "Your order is empty, please search for and add a product above"
     add_product: "Add Product"
     name_or_sku: "Name or SKU (enter at least first 4 characters of product name)"
@@ -3064,6 +3161,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     tracking_number: "Tracking Number"
     order_total: "Order Total"
     customer_details: "Customer Details"
+    customer_details_updated: "Customer Details updated"
     customer_search: "Customer Search"
     choose_a_customer: "Choose a customer"
     account: "Account"
@@ -3230,6 +3328,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     payment_method: "Payment Method"
     payment_processing_failed: "Payment could not be processed, please check the details you entered"
     not_available: "N/A"
+    sku: "SKU"
+    there_are_no_items_for_this_order: "There are no items for this order."
     order_populator:
       out_of_stock: ! '%{item} is out of stock.'
 
@@ -3258,8 +3358,19 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         login_nav:
           header:
             store: Store
+
+    validation:
+      must_be_int: "must be an integer"
+
     admin:
+      mail_methods:
+        send_testmail: "Send test email"
+        testmail:
+          delivery_success: "Test email sent."
+          error: "An error occurred trying to send the test email."
       unit_price_tooltip: "The unit price increases transparency by allowing your customers to easily compare prices between different products and packaging sizes. Note, that the final unit price displayed in the shopfront might differ as it is includes taxes & fees."
+      subscriptions:
+        number: "Number"
       tab:
         dashboard: "Dashboard"
         orders: "Orders"
@@ -3372,6 +3483,10 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       overview:
         enterprises_header:
           ofn_with_tip: Enterprises are Producers and/or Hubs and are the basic unit of organisation within the Open Food Network.
+        enterprise_row:
+          has_no_enterprise_fees: "has no enterprise fees"
+          has_no_payment_methods: "has no payment methods"
+          has_no_shipping_methods: "has no shipping methods"
         products:
           active_products:
             zero: "You don't have any active products."

--- a/engines/order_management/spec/features/order_management/reports/bulk_coop_spec.rb
+++ b/engines/order_management/spec/features/order_management/reports/bulk_coop_spec.rb
@@ -6,9 +6,9 @@ feature "bulk coop" do
   include AuthenticationHelper
   include WebHelper
 
-  scenario "generating Bulk Coop Supplier Report" do
+  scenario "generating Bulk Co-op Supplier Report" do
     login_as_admin_and_visit new_order_management_reports_bulk_coop_path
-    select "Bulk Coop Supplier Report", from: "report_report_type"
+    select "Bulk Co-op Supplier Report", from: "report_report_type"
     click_button 'Generate Report'
 
     expect(page).to have_table_row [
@@ -28,7 +28,7 @@ feature "bulk coop" do
 
   scenario "generating Bulk Co-op Allocation report" do
     login_as_admin_and_visit new_order_management_reports_bulk_coop_path
-    select "Bulk Coop Allocation", from: "report_report_type"
+    select "Bulk Co-op Allocation", from: "report_report_type"
     click_button 'Generate Report'
 
     expect(page).to have_table_row [
@@ -48,7 +48,7 @@ feature "bulk coop" do
 
   scenario "generating Bulk Co-op Packing Sheets report" do
     login_as_admin_and_visit new_order_management_reports_bulk_coop_path
-    select "Bulk Coop Packing Sheets", from: "report_report_type"
+    select "Bulk Co-op Packing Sheets", from: "report_report_type"
     click_button 'Generate Report'
 
     expect(page).to have_table_row [
@@ -61,7 +61,7 @@ feature "bulk coop" do
 
   scenario "generating Bulk Co-op Customer Payments report" do
     login_as_admin_and_visit new_order_management_reports_bulk_coop_path
-    select "Bulk Coop Customer Payments", from: "report_report_type"
+    select "Bulk Co-op Customer Payments", from: "report_report_type"
     click_button 'Generate Report'
 
     expect(page).to have_table_row [

--- a/spec/lib/spree/i18n_spec.rb
+++ b/spec/lib/spree/i18n_spec.rb
@@ -21,6 +21,10 @@ describe "i18n" do
         }
       }
     )
+
+    allow(ActionView::Base).
+      to receive(:raise_on_missing_translations).
+      and_return(false)
   end
 
   it "translates within the spree scope" do

--- a/spec/support/i18n_error_raising.rb
+++ b/spec/support/i18n_error_raising.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# From: https://robots.thoughtbot.com/better-tests-through-internationalization
-
-I18n.exception_handler = lambda do |_exception, _locale, key, _options|
-  raise "missing translation: #{key}"
-end


### PR DESCRIPTION
#### What? Why?

Related to #2626.

- Fixes #7169.
- Fixes #6388.
- Fixes #3816.


In a recent pull request review I noticed that a missing translation didn't raise and error in specs. The previous mechanism didn't seem to work and newer Rails versions have an easier config for this now.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Specs only.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Our automated tests cover missing translations again.

