### PR TITLE
Implements feature toggle with flipper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,6 +114,7 @@ gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', branch: 'ofn-rails-4'
 gem 'good_migrations'
 
 gem 'flipper'
+gem 'flipper-active_record'
 gem 'flipper-ui'
 
 group :production, :staging do

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,9 @@ gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', branch: 'ofn-rails-4'
 
 gem 'good_migrations'
 
+gem 'flipper'
+gem 'flipper-ui'
+
 group :production, :staging do
   gem 'ddtrace'
   gem 'unicorn-worker-killer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,7 @@ GEM
       devise (>= 4.0.0, < 5.0.0)
     diff-lcs (1.4.4)
     docile (1.3.5)
+    erubi (1.10.0)
     erubis (2.7.0)
     eventmachine (1.2.7)
     excon (0.79.0)
@@ -232,6 +233,12 @@ GEM
     ffi (1.15.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
+    flipper (0.20.4)
+    flipper-ui (0.20.4)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.20.4)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, < 2.2.0)
     fog-aws (2.0.1)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
@@ -641,6 +648,8 @@ DEPENDENCIES
   factory_bot_rails (= 6.1.0)
   ffaker
   figaro
+  flipper
+  flipper-ui
   fog-aws (>= 0.6.0)
   foundation-icons-sass-rails
   foundation-rails (= 5.5.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,9 @@ GEM
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     flipper (0.20.4)
+    flipper-active_record (0.20.4)
+      activerecord (>= 5.0, < 7)
+      flipper (~> 0.20.4)
     flipper-ui (0.20.4)
       erubi (>= 1.0.0, < 2.0.0)
       flipper (~> 0.20.4)
@@ -649,6 +652,7 @@ DEPENDENCIES
   ffaker
   figaro
   flipper
+  flipper-active_record
   flipper-ui
   fog-aws (>= 0.6.0)
   foundation-icons-sass-rails

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -135,6 +135,10 @@ module Spree
       spree_orders.incomplete.where(created_by_id: id).order('created_at DESC').first
     end
 
+    def flipper_id
+      "#{self.class.name};#{id}"
+    end
+
     protected
 
     def password_required?

--- a/config/initializers/feature_toggles.rb
+++ b/config/initializers/feature_toggles.rb
@@ -3,7 +3,3 @@ require 'open_food_network/feature_toggle'
 OpenFoodNetwork::FeatureToggle.enable(:customer_balance) do |user|
   true
 end
-
-OpenFoodNetwork::FeatureToggle.enable(:unit_price) do
-  Rails.env.development?
-end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,16 @@
+require "flipper"
+require "flipper/adapters/active_record"
+
+Flipper.configure do |config|
+  config.default do
+    Flipper.new(Flipper::Adapters::ActiveRecord.new)
+  end
+end
+Rails.configuration.middleware.use Flipper::Middleware::Memoizer, preload_all: true
+
+Flipper.register(:admins) { |actor| actor.respond_to?(:admin?) && actor.admin? }
+
+if !Flipper[:unit_price].exist?
+  # Unit price default setup, could be overided by admin in the flipper-ui interface
+  Flipper.enable_group :unit_price, :admins
+end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -9,8 +9,3 @@ end
 Rails.configuration.middleware.use Flipper::Middleware::Memoizer, preload_all: true
 
 Flipper.register(:admins) { |actor| actor.respond_to?(:admin?) && actor.admin? }
-
-if !Flipper[:unit_price].exist?
-  # Unit price default setup, could be overided by admin in the flipper-ui interface
-  Flipper.enable_group :unit_price, :admins
-end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -3,6 +3,7 @@ Openfoodnetwork::Application.routes.draw do
 
     authenticated :spree_user, -> user { user.admin? } do
       mount DelayedJobWeb, at: '/delayed_job'
+      mount Flipper::UI.app(Flipper) => '/feature-toggle'
     end
 
     resources :bulk_line_items

--- a/db/migrate/20210326094519_create_flipper_tables.rb
+++ b/db/migrate/20210326094519_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210407170804) do
+ActiveRecord::Schema.define(version: 20210326094519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -248,6 +248,22 @@ ActiveRecord::Schema.define(version: 20210407170804) do
     t.index ["order_cycle_id"], name: "index_exchanges_on_order_cycle_id", using: :btree
     t.index ["receiver_id"], name: "index_exchanges_on_receiver_id", using: :btree
     t.index ["sender_id"], name: "index_exchanges_on_sender_id", using: :btree
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string   "key",        null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true, using: :btree
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string   "feature_key", null: false
+    t.string   "key",         null: false
+    t.string   "value"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true, using: :btree
   end
 
   create_table "inventory_items", force: :cascade do |t|
@@ -769,15 +785,15 @@ ActiveRecord::Schema.define(version: 20210407170804) do
   end
 
   create_table "spree_shipments", force: :cascade do |t|
-    t.string   "tracking",             limit: 255
-    t.string   "number",               limit: 255
-    t.decimal  "cost",                             precision: 10, scale: 2, default: "0.0", null: false
+    t.string   "tracking",          limit: 255
+    t.string   "number",            limit: 255
+    t.decimal  "cost",                          precision: 10, scale: 2, default: "0.0", null: false
     t.datetime "shipped_at"
     t.integer  "order_id"
     t.integer  "address_id"
-    t.datetime "created_at",                                                                null: false
-    t.datetime "updated_at",                                                                null: false
-    t.string   "state",                limit: 255
+    t.datetime "created_at",                                                             null: false
+    t.datetime "updated_at",                                                             null: false
+    t.string   "state",             limit: 255
     t.integer  "stock_location_id"
     t.decimal  "included_tax_total",               precision: 10, scale: 2, default: "0.0", null: false
     t.decimal  "additional_tax_total",             precision: 10, scale: 2, default: "0.0", null: false

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -25,21 +25,10 @@ module OpenFoodNetwork
   #   - if feature? :new_shiny_feature, spree_current_user
   #     = render "new_shiny_feature"
   #
-  class FeatureToggle
+  module FeatureToggle
     def self.enabled?(feature_name, user = nil)
-      new.enabled?(feature_name, user)
-    end
+      features = Thread.current[:features] || {}
 
-    def self.enable(feature_name, &block)
-      Thread.current[:features] ||= {}
-      Thread.current[:features][feature_name] = Feature.new(block)
-    end
-
-    def initialize
-      @features = Thread.current[:features] || {}
-    end
-
-    def enabled?(feature_name, user)
       if Flipper[feature_name].exist?
         Flipper.enabled?(feature_name, user)
       else
@@ -48,9 +37,10 @@ module OpenFoodNetwork
       end
     end
 
-    private
-
-    attr_reader :features
+    def self.enable(feature_name, &block)
+      Thread.current[:features] ||= {}
+      Thread.current[:features][feature_name] = Feature.new(block)
+    end
   end
 
   class Feature

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -40,8 +40,12 @@ module OpenFoodNetwork
     end
 
     def enabled?(feature_name, user)
-      feature = features.fetch(feature_name, DefaultFeature.new(feature_name))
-      feature.enabled?(user)
+      if Flipper[feature_name].exist?
+        Flipper.enabled?(feature_name, user)
+      else
+        feature = features.fetch(feature_name, DefaultFeature.new(feature_name))
+        feature.enabled?(user)
+      end
     end
 
     private

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -40,29 +40,13 @@ module OpenFoodNetwork
     end
 
     def enabled?(feature_name, user)
-      if user.present?
-        feature = features.fetch(feature_name, NullFeature.new)
-        feature.enabled?(user)
-      else
-        true?(env_variable_value(feature_name))
-      end
+      feature = features.fetch(feature_name, DefaultFeature.new(feature_name))
+      feature.enabled?(user)
     end
 
     private
 
     attr_reader :features
-
-    def env_variable_value(feature_name)
-      ENV.fetch(env_variable_name(feature_name), nil)
-    end
-
-    def env_variable_name(feature_name)
-      "OFN_FEATURE_#{feature_name.to_s.upcase}"
-    end
-
-    def true?(value)
-      value.to_s.casecmp("true").zero?
-    end
   end
 
   class Feature
@@ -79,9 +63,29 @@ module OpenFoodNetwork
     attr_reader :block
   end
 
-  class NullFeature
+  class DefaultFeature
+    attr_reader :feature_name
+
+    def initialize(feature_name)
+      @feature_name = feature_name
+    end
+
     def enabled?(_user)
-      false
+      true?(env_variable_value(feature_name))
+    end
+
+    private
+
+    def env_variable_value(feature_name)
+      ENV.fetch(env_variable_name(feature_name), nil)
+    end
+
+    def env_variable_name(feature_name)
+      "OFN_FEATURE_#{feature_name.to_s.upcase}"
+    end
+
+    def true?(value)
+      value.to_s.casecmp("true").zero?
     end
   end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -41,7 +41,8 @@ module OpenFoodNetwork
     end
 
     context 'when specifying users' do
-      let(:user) { build(:user) }
+      let(:insider) { build(:user) }
+      let(:outsider) { build(:user, email: "different") }
 
       context 'and the block does not specify arguments' do
         before do
@@ -49,20 +50,20 @@ module OpenFoodNetwork
         end
 
         it "returns the block's return value" do
-          expect(FeatureToggle.enabled?(:foo, user)).to eq('return value')
+          expect(FeatureToggle.enabled?(:foo, insider)).to eq('return value')
         end
       end
 
       context 'and the block specifies arguments' do
-        let(:users) { [user.email] }
+        let(:users) { [insider.email] }
 
         before do
           FeatureToggle.enable(:foo) { |user| users.include?(user&.email) }
         end
 
         it "returns the block's return value" do
-          expect(FeatureToggle.enabled?(:foo, user)).to eq(true)
-          expect(FeatureToggle.enabled?(:foo, OpenStruct.new(email: "different"))).to eq(false)
+          expect(FeatureToggle.enabled?(:foo, insider)).to eq(true)
+          expect(FeatureToggle.enabled?(:foo, outsider)).to eq(false)
           expect(FeatureToggle.enabled?(:foo, nil)).to eq(false)
         end
       end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -24,6 +24,17 @@ module OpenFoodNetwork
         expect(FeatureToggle.enabled?(:foo)).to be false
       end
 
+      it "uses Flipper configuration" do
+        Flipper.enable(:foo)
+        expect(FeatureToggle.enabled?(:foo)).to be true
+      end
+
+      it "uses Flipper over static config" do
+        Flipper.enable(:foo, false)
+        stub_foo("true")
+        expect(FeatureToggle.enabled?(:foo)).to be false
+      end
+
       def stub_foo(value)
         allow(ENV).to receive(:fetch).with("OFN_FEATURE_FOO", nil).and_return(value)
       end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -46,11 +46,13 @@ module OpenFoodNetwork
         let(:users) { [user.email] }
 
         before do
-          FeatureToggle.enable(:foo) { |user| users.include?(user.email) }
+          FeatureToggle.enable(:foo) { |user| users.include?(user&.email) }
         end
 
         it "returns the block's return value" do
           expect(FeatureToggle.enabled?(:foo, user)).to eq(true)
+          expect(FeatureToggle.enabled?(:foo, OpenStruct.new(email: "different"))).to eq(false)
+          expect(FeatureToggle.enabled?(:foo, nil)).to eq(false)
         end
       end
     end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -189,4 +189,11 @@ describe Spree::User do
       expect { user.destroy }.to raise_exception(Spree::User::DestroyWithOrdersError)
     end
   end
+
+  describe "#flipper_id" do
+    it "provides a unique id" do
+      user = Spree::User.new(id: 42)
+      expect(user.flipper_id).to eq "Spree::User;42"
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?
As we now know that we'll working more and more with feature toggle (to have a short cycle between products and dev, to avoid long term branches, ...) it's now time to have a great implementation with a small UI to manage it. 

This PR simply: 
 - Add `flipper`, `flipper-ui` and `flipper-active_record` gems and associated migration
 - Add one more route, used for the flipper ui: `/admin/feature-toggle` and only available for admin users
 - Define a `flipper_id` method on `User`
 - Initialize feature toggle behavior by:
   - Create an `admins` group for users who respond `true` to `.admin` property
   - Create a feature `unit_price` enabled for `admins` group
 - Remplace our implementation of `ApplicationHelper:feature?` by the flipper one. 

Closes #7193

#### What should we test?
We should basically test if the interface available in `/admin/feature-toggle` is consistent with the feature enabled or not in the UI (basically, in the shopfront).
By default, the interface looks like this

<img width="626" alt="Capture d’écran 2021-04-08 à 14 57 06" src="https://user-images.githubusercontent.com/296452/114031445-ac0f1100-987b-11eb-8eaa-4f7c98b6a911.png">

You must define a feature, by clicking on the `Add feature` button, and add `unit_price` (case sensitive): 

<img width="625" alt="Capture d’écran 2021-04-08 à 15 04 53" src="https://user-images.githubusercontent.com/296452/114031551-c812b280-987b-11eb-9cf2-97533f03492c.png">


Once it has been created, you can configure the feature:
<img width="608" alt="Capture d’écran 2021-04-08 à 15 05 24" src="https://user-images.githubusercontent.com/296452/114031649-da8cec00-987b-11eb-88bd-3024bc30c2fc.png">

By adding the `admins` group to the feature, you enable each users from this group to see the unit price feature inside the app: 

<img width="631" alt="Capture d’écran 2021-04-08 à 15 06 40" src="https://user-images.githubusercontent.com/296452/114031849-0f00a800-987c-11eb-8b0c-03e46077cede.png">

<img width="592" alt="Capture d’écran 2021-04-08 à 15 06 44" src="https://user-images.githubusercontent.com/296452/114031831-09a35d80-987c-11eb-8a52-26cfff802e51.png">


This interface reads from top to bottom: in our example, no specific actors has the feature enabled. Then, if the current user is a member of the admins group (which is true if the user is admin), it returns true and then displays the unit price feature. Otherwise, it continues the process from top to bottom to see if it's somewhere else the conditions can be true.

##### With this interface we can now:
 - Fully enable a feature (and see that for unlogged user it shows the unit price)
 - Fully disable a feature
 - Enable/Disable a feature for a group (and see that for admin user, it show or hide the unit price ; without having any effect on unlogged user)
 - Enable a feature for a specific user, knowing it's id used in database, by filling the flipper_id with: `Spree::User;[USER_ID]` as the image shows:

<img width="592" alt="Capture d’écran 2021-03-29 à 15 01 23" src="https://user-images.githubusercontent.com/296452/112840445-a1949080-909f-11eb-9dec-21e6d8da81d4.png">




#### Release notes
Add flipper to manage our feature toggling.

Changelog Category: Technical changes


#### Still in progress:
 - ~~What about the feature `connect_learn_homepage` used by `ApplicationHelper::feature?`~~ no need to know, because we still use the old method with `OpenFoodNetwork::FeatureToggle`
 - ~~Needs to update our test:     `allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(:unit_price, anything) { true }`~~ no need because we still use `OpenFoodNetwork::FeatureToggle.enabled?` as the logic has been set inside this method. 