### PR TITLE
Add automated tests for unit price in backoffice

### DIFF
--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -31,7 +31,7 @@
             %input{ type: 'hidden', 'ng-value' => 'product.variant_unit_scale', name: 'product[variant_unit_scale]' }
         .two.columns
           = f.field_container :unit_value do
-            = f.label :product_unit_value_with_description, t(".value"), 'ng-disabled' => "!hasUnit(product)"
+            = f.label :unit_value_with_description, t(".value"), 'ng-disabled' => "!hasUnit(product)"
             %span.required *
             %input.fullwidth{ id: 'product_unit_value_with_description', 'ng-model' => 'product.master.unit_value_with_description', :type => 'text', placeholder: "eg. 2", 'ng-disabled' => "!hasUnit(product)" }
             %input{ type: 'hidden', 'ng-value' => 'product.master.unit_value', name: 'product[unit_value]' }

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -62,7 +62,8 @@
                   "question-mark-with-tooltip-placement" => "top",
                   "question-mark-with-tooltip-animation" => true, 
                   key: "'js.admin.unit_price_tooltip'"}
-              = f.text_field :price, {"class" => 'fullwidth', "disabled" =>  true, "ng-model" => "unit_price"}
+              %input{ "type" => "text", "id" => "product_unit_price", "name" => "product[unit_price]",
+                  "class" => 'fullwidth', "disabled" =>  true, "ng-model" => "unit_price"}
               %div{style: "color: black"}
                 = t(".unit_price_legend")
       .sixteen.columns.alpha

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -46,7 +46,8 @@
               "question-mark-with-tooltip-placement" => "top",
               "question-mark-with-tooltip-animation" => true, 
               key: "'js.admin.unit_price_tooltip'"}
-          = f.text_field :price, {"class" => 'fullwidth', "disabled" =>  true, "ng-model" => "unit_price"}
+          %input{ "type" => "text", "id" => "variant_unit_price", "name" => "variant[unit_price]",
+            "class" => 'fullwidth', "disabled" => true, "ng-model" => "unit_price"}
           %div{style: "color: black"}
             = t("spree.admin.products.new.unit_price_legend")
     %div{ 'set-on-demand' => '' }

--- a/app/views/spree/admin/variants/_form.html.haml
+++ b/app/views/spree/admin/variants/_form.html.haml
@@ -9,7 +9,7 @@
   - if product_has_variant_unit_option_type?(@product)
     - if @product.variant_unit != 'items'
       .field
-        = f.label :unit_value, "#{t('admin.'+@product.variant_unit)} ({{unitName(#{@product.variant_unit_scale}, '#{@product.variant_unit}')}})"
+        = label_tag :unit_value_human, "#{t('admin.'+@product.variant_unit)} ({{unitName(#{@product.variant_unit_scale}, '#{@product.variant_unit}')}})"
         = hidden_field_tag 'product_variant_unit_scale', @product.variant_unit_scale
         = text_field_tag :unit_value_human, nil, {class: "fullwidth", 'ng-model' => 'unit_value_human', 'ng-change' => 'updateValue()'}
         = f.text_field :unit_value, {hidden: true, 'ng-value' => 'unit_value'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3689,6 +3689,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         form:
           sku: "SKU"
           price: "Price"
+          unit_price: "Unit Price"
           display_as: "Display As"
           display_name: "Display Name"
           display_as_placeholder: 'eg. 2 kg'

--- a/spec/features/admin/unit_price_spec.rb
+++ b/spec/features/admin/unit_price_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+feature '
+    As an admin
+    I want to check the unit price of my products/variants
+' do
+  include AuthenticationHelper
+  include WebHelper
+  
+  let!(:stock_location) { create(:stock_location, backorderable_default: false) }
+  
+  before do
+    allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(:unit_price, anything) { true }
+  end
+  
+  describe "product", js: true do
+    scenario "creating a new product" do
+      login_as_admin_and_visit spree.admin_products_path
+      click_link 'New Product'
+      select "Weight (kg)", from: 'product_variant_unit_with_scale'
+      fill_in 'Value', with: '1'
+      fill_in 'Price', with: '1'
+      
+      expect(find_field("Unit Price", disabled: true).value).to eq "$1.00 / kg"
+    end
+  end
+
+  describe "variant", js: true do
+    scenario "creating a new variant" do
+      product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
+      login_as_admin_and_visit spree.admin_product_variants_path product
+      click_link 'New Variant'
+      fill_in 'Weight (g)', with: '1'
+      fill_in 'Price', with: '1'
+      
+      expect(find_field("Unit Price", disabled: true).value).to eq '$1,000.00 / kg'
+    end
+
+    scenario "editing a variant" do
+      product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
+      variant = product.variants.first
+      variant.update(price: 1.0)
+      login_as_admin_and_visit spree.edit_admin_product_variant_path(product, variant)
+      
+      expect(find_field("Unit Price", disabled: true).value).to eq '$1,000.00 / kg'
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?
This PR adds 3 tests for unit price in backoffice, for each 3 cases: 
 - creating a new product
 - creating a new variant
 - editing an existing variant

Closes #7069




#### What should we test?
Green build.



#### Release notes
Add automated tests for unit price in backoffice

Changelog Category: Technical changes

