### PR TITLE
Remove Semaphore CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Build Status](https://semaphoreci.com/api/v1/openfoodfoundation/openfoodnetwork-2/branches/master/badge.svg)](https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2)
-[![Code Climate](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork.png)](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork)
 [![Build](https://github.com/openfoodfoundation/openfoodnetwork/actions/workflows/build.yml/badge.svg)](https://github.com/openfoodfoundation/openfoodnetwork/actions/workflows/build.yml)
+[![Code Climate](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork.png)](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork)
 
 # Open Food Network
 


### PR DESCRIPTION
#### What? Why?

We're now relying on Github Actions as CI build so that's the only indicator we should check to see if the build is passing in `master`.

#### What should we test?

Nothing.

#### Release notes
Remove Semaphore CI badge from README
Changelog Category: Technical changes