### PR TITLE
Fix showing soft-deleted products in producer mailer

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -63,7 +63,7 @@ class ProducerMailer < Spree::BaseMailer
       includes(:option_values, variant: [:product, { option_values: :option_type }]).
       from_order_cycle(order_cycle).
       sorted_by_name_and_unit_value.
-      merge(Spree::Product.in_supplier(producer)).
+      merge(Spree::Product.with_deleted.in_supplier(producer)).
       merge(Spree::Order.by_state('complete'))
   end
 


### PR DESCRIPTION
#### What? Why?

The test at `spec/mailers/producer_mailer_spec.rb:115` was failing (probably introduced in #7239) but we missed it before, as the CI was not reporting failures in some jobs (which is now fixed via #7249). That test is currently failing in master.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build :heavy_check_mark::heavy_check_mark::heavy_check_mark: 

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed regression in producer mailer with soft-deleted products

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes