### PR TITLE
Defend against nils in variant serializer

### DIFF
--- a/app/serializers/api/variant_serializer.rb
+++ b/app/serializers/api/variant_serializer.rb
@@ -41,7 +41,7 @@ class Api::VariantSerializer < ActiveModel::Serializer
   end
 
   def unit_price_price
-    price_with_fees / unit_price.denominator
+    price_with_fees / (unit_price.denominator || 1)
   end
 
   def unit_price_unit

--- a/spec/serializers/api/variant_serializer_spec.rb
+++ b/spec/serializers/api/variant_serializer_spec.rb
@@ -25,4 +25,22 @@ describe Api::VariantSerializer do
         :tag_list # Used to apply tag rules
       )
   end
+
+  describe "#unit_price_price" do
+    context "without fees" do
+      it "displays the price divided by the unit price denominator" do
+        allow(subject).to receive_message_chain(:unit_price, :denominator) { 1000 }
+
+        expect(subject.unit_price_price).to eq(variant.price / 1000)
+      end
+    end
+
+    context "when the denominator returns nil" do
+      it "returns the price" do
+        allow(subject).to receive_message_chain(:unit_price, :denominator) { nil }
+
+        expect(subject.unit_price_price).to eq(variant.price)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

If `unit_price.denominator` ever returns `nil`, the serializer won't explode now :ok_hand:

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be ok here. The added test was failing before and is passing now after the change. Also this feature isn't toggled on in production yet.

Relevant Bugsnag events:
- https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/606317bb58a23d00077bad66?filters[event.since][0]=30d&filters[error.status][0]=open
- https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/606317cd432c1d000813ad6b?filters[event.since][0]=30d&filters[error.status][0]=open

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added defensive code in variant serializer to deal with potential nils

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
