### PR TITLE
Disallow changes of canceled order

### DIFF
--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -8,6 +8,7 @@ module Api
       respond_to :json
 
       before_action :find_order
+      before_action :refuse_changing_cancelled_orders, only: [:add, :remove]
       before_action :find_and_update_shipment, only: [:ship, :ready, :add, :remove]
 
       def create
@@ -93,6 +94,10 @@ module Api
         @shipment = @order.shipments.find_by!(number: params[:id])
         @shipment.update(shipment_params[:shipment]) if shipment_params[:shipment].present?
         @shipment.reload
+      end
+
+      def refuse_changing_cancelled_orders
+        render status: :unprocessable_entity if @order.canceled?
       end
 
       def scoped_variant(variant_id)

--- a/app/controllers/spree/admin/adjustments_controller.rb
+++ b/app/controllers/spree/admin/adjustments_controller.rb
@@ -30,6 +30,9 @@ module Spree
       end
 
       def skip_changing_canceled_orders
+        return unless @order.canceled?
+
+        flash[:error] = t("admin.adjustments.skipped_changing_canceled_order")
         redirect_to admin_order_adjustments_path(@order) if @order.canceled?
       end
 

--- a/app/controllers/spree/admin/adjustments_controller.rb
+++ b/app/controllers/spree/admin/adjustments_controller.rb
@@ -5,6 +5,7 @@ module Spree
 
       prepend_before_action :set_included_tax, only: [:create, :update]
       before_action :set_order_id, only: [:create, :update]
+      before_action :skip_changing_canceled_orders, only: [:create, :update]
       after_action :update_order, only: [:create, :update, :destroy]
       before_action :set_default_tax_rate, only: :edit
       before_action :enable_updates, only: :update
@@ -26,6 +27,10 @@ module Spree
 
       def set_order_id
         @adjustment.order_id = parent.id
+      end
+
+      def skip_changing_canceled_orders
+        redirect_to admin_order_adjustments_path(@order) if @order.canceled?
       end
 
       # Choose a default tax rate to show on the edit form. The adjustment stores its included

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -366,6 +366,8 @@ en:
     rename: "Rename"
 
   admin:
+    adjustments:
+      skipped_changing_canceled_order: "You can't change a cancelled order."
     # Common properties / models
     begins_at: Begins At
     begins_on: Begins On

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -161,8 +161,6 @@ describe Api::V0::ShipmentsController, type: :controller do
         end
 
         it "doesn't adjusts stock when adding a variant" do
-          pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/7166"
-
           expect {
             api_put :add, params.merge(variant_id: existing_variant.to_param)
             expect(response.status).to eq(422)
@@ -170,8 +168,6 @@ describe Api::V0::ShipmentsController, type: :controller do
         end
 
         it "doesn't adjusts stock when removing a variant" do
-          pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/7166"
-
           expect {
             api_put :remove, params.merge(variant_id: existing_variant.to_param)
             expect(response.status).to eq(422)

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -154,6 +154,30 @@ describe Api::V0::ShipmentsController, type: :controller do
           }.to change { existing_variant.reload.on_hand }.by(2)
         end
       end
+
+      context "for canceled orders" do
+        before do
+          expect(order.cancel).to eq true
+        end
+
+        it "doesn't adjusts stock when adding a variant" do
+          pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/7166"
+
+          expect {
+            api_put :add, params.merge(variant_id: existing_variant.to_param)
+            expect(response.status).to eq(422)
+          }.to_not change { existing_variant.reload.on_hand }
+        end
+
+        it "doesn't adjusts stock when removing a variant" do
+          pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/7166"
+
+          expect {
+            api_put :remove, params.merge(variant_id: existing_variant.to_param)
+            expect(response.status).to eq(422)
+          }.to_not change { existing_variant.reload.on_hand }
+        end
+      end
     end
 
     context "can transition a shipment from ready to ship" do

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -160,14 +160,14 @@ describe Api::V0::ShipmentsController, type: :controller do
           expect(order.cancel).to eq true
         end
 
-        it "doesn't adjusts stock when adding a variant" do
+        it "doesn't adjust stock when adding a variant" do
           expect {
             api_put :add, params.merge(variant_id: existing_variant.to_param)
             expect(response.status).to eq(422)
           }.to_not change { existing_variant.reload.on_hand }
         end
 
-        it "doesn't adjusts stock when removing a variant" do
+        it "doesn't adjust stock when removing a variant" do
           expect {
             api_put :remove, params.merge(variant_id: existing_variant.to_param)
             expect(response.status).to eq(422)

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -128,16 +128,17 @@ describe Api::V0::ShipmentsController, type: :controller do
       end
 
       it 'adds a variant to a shipment' do
-        api_put :add, params.merge(variant_id: new_variant.to_param)
-        expect(response.status).to eq(200)
-        expect(inventory_units_for(new_variant).size).to eq 2
+        expect {
+          api_put :add, params.merge(variant_id: new_variant.to_param)
+          expect(response.status).to eq(200)
+        }.to change { inventory_units_for(new_variant).size }.by(2)
       end
 
       it 'removes a variant from a shipment' do
-        api_put :remove, params.merge(variant_id: existing_variant.to_param)
-
-        expect(response.status).to eq(200)
-        expect(inventory_units_for(existing_variant).size).to eq(1)
+        expect {
+          api_put :remove, params.merge(variant_id: existing_variant.to_param)
+          expect(response.status).to eq(200)
+        }.to change { inventory_units_for(existing_variant).size }.by(-2)
       end
     end
 

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -110,7 +110,7 @@ describe Api::V0::ShipmentsController, type: :controller do
       expect(response.status).to eq(422)
     end
 
-    context 'for completed shipments' do
+    describe "#add and #remove" do
       let(:order) { create :completed_order_with_totals }
       let(:line_item) { order.line_items.first }
       let(:existing_variant) { line_item.variant }
@@ -127,18 +127,20 @@ describe Api::V0::ShipmentsController, type: :controller do
         line_item.update!(quantity: 3)
       end
 
-      it 'adds a variant to a shipment' do
-        expect {
-          api_put :add, params.merge(variant_id: new_variant.to_param)
-          expect(response.status).to eq(200)
-        }.to change { inventory_units_for(new_variant).size }.by(2)
-      end
+      context 'for completed shipments' do
+        it 'adds a variant to a shipment' do
+          expect {
+            api_put :add, params.merge(variant_id: new_variant.to_param)
+            expect(response.status).to eq(200)
+          }.to change { inventory_units_for(new_variant).size }.by(2)
+        end
 
-      it 'removes a variant from a shipment' do
-        expect {
-          api_put :remove, params.merge(variant_id: existing_variant.to_param)
-          expect(response.status).to eq(200)
-        }.to change { inventory_units_for(existing_variant).size }.by(-2)
+        it 'removes a variant from a shipment' do
+          expect {
+            api_put :remove, params.merge(variant_id: existing_variant.to_param)
+            expect(response.status).to eq(200)
+          }.to change { inventory_units_for(existing_variant).size }.by(-2)
+        end
       end
     end
 

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -135,11 +135,23 @@ describe Api::V0::ShipmentsController, type: :controller do
           }.to change { inventory_units_for(new_variant).size }.by(2)
         end
 
+        it 'adjusts stock when adding a variant' do
+          expect {
+            api_put :add, params.merge(variant_id: new_variant.to_param)
+          }.to change { new_variant.reload.on_hand }.by(-2)
+        end
+
         it 'removes a variant from a shipment' do
           expect {
             api_put :remove, params.merge(variant_id: existing_variant.to_param)
             expect(response.status).to eq(200)
           }.to change { inventory_units_for(existing_variant).size }.by(-2)
+        end
+
+        it 'adjusts stock when removing a variant' do
+          expect {
+            api_put :remove, params.merge(variant_id: existing_variant.to_param)
+          }.to change { existing_variant.reload.on_hand }.by(2)
         end
       end
     end

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -65,7 +65,7 @@ describe Api::V0::ShipmentsController, type: :controller do
 
         spree_post :create, params
 
-        expect(json_response["id"]). to eq(original_shipment_id)
+        expect(json_response["id"]).to eq(original_shipment_id)
         expect_valid_response
         expect(order.shipment.reload.inventory_units.size).to eq 2
         expect(order.reload.line_items.first.variant.price).to eq(variant.price)

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -112,26 +112,32 @@ describe Api::V0::ShipmentsController, type: :controller do
 
     context 'for completed shipments' do
       let(:order) { create :completed_order_with_totals }
+      let(:line_item) { order.line_items.first }
+      let(:existing_variant) { line_item.variant }
+      let(:new_variant) { create(:variant) }
+      let(:params) {
+        {
+          quantity: 2,
+          order_id: order.to_param,
+          id: order.shipments.first.to_param
+        }
+      }
+
+      before do
+        line_item.update!(quantity: 3)
+      end
 
       it 'adds a variant to a shipment' do
-        api_put :add, variant_id: variant.to_param,
-                      quantity: 2,
-                      order_id: order.to_param,
-                      id: order.shipments.first.to_param
-
+        api_put :add, params.merge(variant_id: new_variant.to_param)
         expect(response.status).to eq(200)
-        expect(inventory_units_for(variant).size).to eq 2
+        expect(inventory_units_for(new_variant).size).to eq 2
       end
 
       it 'removes a variant from a shipment' do
-        order.contents.add(variant, 2)
-        api_put :remove, variant_id: variant.to_param,
-                         quantity: 1,
-                         order_id: order.to_param,
-                         id: order.shipments.first.to_param
+        api_put :remove, params.merge(variant_id: existing_variant.to_param)
 
         expect(response.status).to eq(200)
-        expect(inventory_units_for(variant).size).to eq(1)
+        expect(inventory_units_for(existing_variant).size).to eq(1)
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #7166.
Complements #7228 and #7265.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Updating cancelled orders messes with stock and payment amounts. So we decided to not allow that. Previous PRs removed the UI but here I'm also putting guards in the controllers so that this doesn't happen accidentally or via the API.

#### What should we test?
<!-- List which features should be tested and how. -->

* Checkout for a completed order.
* Add, remove and adjust line items of the order as shop owner. Everything should work as normal.
* Open a new tab to change adjustments, as normal.
* Open a third tab to cancel the order.
* Going back to the previous two tabs, try to change adjustments or line items. It should not change anything.
* Reload the pages and observe that the edit buttons are gone.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

It's not possible to change the contents of cancelled orders any more to avoid inconsistencies.


