### PR TITLE
Use the same Rubocop config on Code Climate as locally 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,7 +4,7 @@ plugins:
     enabled: true
     channel: "rubocop-1-12"
     config:
-      file: ".rubocop_styleguide.yml"
+      file: ".rubocop.yml"
   scss-lint:
     enabled: true
     checks:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ version: "2"
 plugins:
   rubocop:
     enabled: true
-    channel: "rubocop-0-76"
+    channel: "rubocop-1-12"
     config:
       file: ".rubocop_styleguide.yml"
   scss-lint:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,8 @@ inherit_from:
   # The automatically generated todo list to ignore all current violations.
   - .rubocop_todo.yml
 
-  # Our Open Food Network style guide. It's used by Code Climate. If you want to see all violations,
-  # then use only that configuration (like Code Climate):
+  # Our Open Food Network style guide. If you want to see all violations,
+  # then use only that configuration:
   #
   #     bundle exec rubocop -c .rubocop_styleguide.yml
   #

--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -1,9 +1,6 @@
 # Our Open Food Network style guide.
 #
-# These are the rules we agreed upon and we work towards. Code Climate uses
-# these rules to rate our code and detect new violations. But when you run
-# rubocop locally, the default configuration file `.rubocop.yml` loads
-# our "todo lists" to ignore all current violations.
+# These are the rules we agreed upon and we work towards.
 AllCops:
   NewCops: disable
   SuggestExtensions: false


### PR DESCRIPTION
#### What? Why?

We configured Code Climate to be aware of all open issues instead of ignoring open issues via the rubocop todo lists. We were hoping that Code Climate could give us some nice stats like progress if it's aware of all our open issues. But the graphs don't tell us anything.

In addition, developers get confused about how our setup works because running rubocop locally would yield different results to the feedback Code Climate gave on pull requests. And new violations had to be added in two places. Adding it to a rubocop todo list made sure that the violation didn't come up when running rubocop locally. But Code Climate would still complain about it and we needed to accept it there, too.

So it's better to have one source of truth for our open style issues and that is our rubocop config in this repository. It contains two todo lists that document all violations we would like to fix in the future but it's okay to submit pull requests that don't fix those.

Instead of accepting new style issues in Code Climate, every pull request with new violations has to add them to the rubocop config. I hope that this will make rubocop more useful and encourage developers to reduce code style debt.

#### What should we test?
<!-- List which features should be tested and how. -->

No test.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Simpler setup of code quality checks.

#### Context

Here are some screens of the Code Climate dashboard. I can't see anything useful in there.

![Screenshot from 2021-03-31 15-17-38](https://user-images.githubusercontent.com/3524483/113091280-5b723500-9237-11eb-95ac-6b1c38cf06c1.png)
![Screenshot from 2021-03-31 15-21-16](https://user-images.githubusercontent.com/3524483/113091288-61681600-9237-11eb-8964-1f593a9bd70d.png)
![Screenshot from 2021-03-31 15-20-44](https://user-images.githubusercontent.com/3524483/113091291-62994300-9237-11eb-8053-e5224cb46976.png)
![Screenshot from 2021-03-31 15-19-37](https://user-images.githubusercontent.com/3524483/113091294-6331d980-9237-11eb-97b3-b00d1f2f5c7b.png)
![Screenshot from 2021-03-31 15-18-17](https://user-images.githubusercontent.com/3524483/113091298-64630680-9237-11eb-8f1d-a8bb6bad8b4e.png)
![Screenshot from 2021-03-31 15-18-07](https://user-images.githubusercontent.com/3524483/113091300-64fb9d00-9237-11eb-9fad-4b4484af6528.png)
