### PR TITLE
Add code coverage reporting to our CI build with Codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run controller tests
         run: bundle exec rspec --profile -- spec/controllers spec/serializers
 
+      - name: Codecov
+        uses: codecov/codecov-action@v1.3.1
+
   test-models:
     runs-on: ubuntu-18.04
     services:
@@ -91,6 +94,9 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec --profile -- spec/models
+
+      - name: Codecov
+        uses: codecov/codecov-action@v1.3.1
 
   test-admin-features-1:
     runs-on: ubuntu-18.04
@@ -133,6 +139,9 @@ jobs:
       - name: Run admin feature tests
         run: bundle exec rspec --profile -- spec/features/admin/[a-o0-9]*_spec.rb
 
+      - name: Codecov
+        uses: codecov/codecov-action@v1.3.1
+
   test-admin-features-2:
     runs-on: ubuntu-18.04
     services:
@@ -174,6 +183,9 @@ jobs:
       - name: Run admin feature tests
         run: bundle exec rspec --profile -- spec/features/admin/[p-z]*_spec.rb
 
+      - name: Codecov
+        uses: codecov/codecov-action@v1.3.1
+
   test-consumer-features:
     runs-on: ubuntu-18.04
     services:
@@ -214,6 +226,9 @@ jobs:
 
       - name: Run consumer feature tests
         run: bundle exec rspec --profile -- spec/features/consumer
+
+      - name: Codecov
+        uses: codecov/codecov-action@v1.3.1
 
   test-engines-etc:
     runs-on: ubuntu-18.04
@@ -299,3 +314,6 @@ jobs:
 
       - name: Run admin feature folders, engines, lib
         run: bundle exec rspec --profile --pattern "engines/*/spec/{,/*/**}/*_spec.rb,spec/features/admin/*/*_spec.rb,spec/lib/{,/*/**}/*_spec.rb"
+
+      - name: Codecov
+        uses: codecov/codecov-action@v1.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 env:
   DISABLE_KNAPSACK: true
   TIMEZONE: UTC
+  COVERAGE: true
 
 jobs:
   test-controllers-and-serializers:

--- a/.simplecov
+++ b/.simplecov
@@ -16,3 +16,6 @@ SimpleCov.start 'rails' do
   add_filter '/log'
   add_filter '/db'
 end
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov

--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,6 @@
 #!/bin/env ruby
 
 SimpleCov.start 'rails' do
-  minimum_coverage 54
-
   add_filter '/bin/'
   add_filter '/config/'
   add_filter '/jobs/application_job.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,7 @@ group :test, :development do
 end
 
 group :test do
+  gem 'codecov', require: false
   gem 'simplecov', require: false
   gem 'test-prof'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
+    codecov (0.5.1)
+      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -618,6 +620,7 @@ DEPENDENCIES
   cancancan (~> 1.15.0)
   capybara
   catalog!
+  codecov
   coffee-rails (~> 4.2.2)
   combine_pdf
   compass-rails

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build](https://github.com/openfoodfoundation/openfoodnetwork/actions/workflows/build.yml/badge.svg)](https://github.com/openfoodfoundation/openfoodnetwork/actions/workflows/build.yml)
+[![codecov](https://codecov.io/gh/openfoodfoundation/openfoodnetwork/branch/master/graph/badge.svg?token=FBSOod4qiu)](https://codecov.io/gh/openfoodfoundation/openfoodnetwork)
 [![Code Climate](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork.png)](https://codeclimate.com/github/openfoodfoundation/openfoodnetwork)
 
 # Open Food Network


### PR DESCRIPTION
#### What? Why?

Closes #4435

It analyzes the coverage of all CI build jobs and uploads the reports to our Codecov account that I previously set up. See https://app.codecov.io/gh/openfoodfoundation/openfoodnetwork/pulls?page=1&state=open&order=-pullid.

Codecov is free for open source so we're good :ok_hand: 

#### What should we test?

Green build.

#### Release notes

Added code coverage reporting to our CI build with Codecov
Changelog Category: Technical changes
