### PR TITLE
OrderBalance missing methods

### DIFF
--- a/app/models/concerns/balance.rb
+++ b/app/models/concerns/balance.rb
@@ -42,6 +42,6 @@ module Balance
   end
 
   def display_outstanding_balance
-    outstanding_balance.amount
+    outstanding_balance.display_amount
   end
 end

--- a/app/models/order_balance.rb
+++ b/app/models/order_balance.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 class OrderBalance
-  delegate :zero?, :abs, :to_s, to: :to_f
+  delegate :zero?, :abs, :to_s, to: :amount
 
   def initialize(order)
     @order = order
   end
 
   def label
-    to_f.negative? ? I18n.t(:credit_owed) : I18n.t(:balance_due)
+    amount.negative? ? I18n.t(:credit_owed) : I18n.t(:balance_due)
+  end
+
+  def display_amount
+    Spree::Money.new(amount, currency: order.currency)
   end
 
   def amount
-    Spree::Money.new(to_f, currency: order.currency)
-  end
-
-  def to_f
     if customer_balance_enabled?
       order.new_outstanding_balance
     else
@@ -24,7 +24,7 @@ class OrderBalance
   end
 
   def +(other)
-    to_f + other.to_f
+    amount + other.to_f
   end
 
   private

--- a/app/models/order_balance.rb
+++ b/app/models/order_balance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OrderBalance
-  delegate :zero?, :abs, :to_s, :to_f, :to_d, to: :amount
+  delegate :zero?, :abs, :to_s, :to_f, :to_d, :<, :>, to: :amount
 
   def initialize(order)
     @order = order

--- a/app/models/order_balance.rb
+++ b/app/models/order_balance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OrderBalance
-  delegate :zero?, :abs, :to_s, to: :amount
+  delegate :zero?, :abs, :to_s, :to_f, :to_d, to: :amount
 
   def initialize(order)
     @order = order

--- a/spec/models/order_balance_spec.rb
+++ b/spec/models/order_balance_spec.rb
@@ -325,6 +325,40 @@ describe OrderBalance do
     end
   end
 
+  describe '#to_f and #to_d' do
+    context 'when the customer_balance feature is disabled' do
+      before do
+        allow(OpenFoodNetwork::FeatureToggle)
+          .to receive(:enabled?).with(:customer_balance, user) { false }
+      end
+
+      before do
+        allow(order).to receive(:old_outstanding_balance) { 10 }
+      end
+
+      it 'returns the balance as a float or decimal' do
+        expect(order_balance.to_f).to eq(10.0)
+        expect(order_balance.to_d).to eq(10.0)
+      end
+    end
+
+    context 'when the customer_balance feature is enabled' do
+      before do
+        allow(OpenFoodNetwork::FeatureToggle)
+          .to receive(:enabled?).with(:customer_balance, user) { true }
+      end
+
+      before do
+        allow(order).to receive(:new_outstanding_balance) { 10 }
+      end
+
+      it 'returns the balance as a float or decimal' do
+        expect(order_balance.to_f).to eq(10.0)
+        expect(order_balance.to_d).to eq(10.0)
+      end
+    end
+  end
+
   describe '#+' do
     let(:other_order_balance) { described_class.new(order) }
 

--- a/spec/models/order_balance_spec.rb
+++ b/spec/models/order_balance_spec.rb
@@ -392,4 +392,42 @@ describe OrderBalance do
       end
     end
   end
+
+  context "with comparison operators" do
+    context 'when the customer_balance feature is disabled' do
+      before do
+        allow(OpenFoodNetwork::FeatureToggle)
+          .to receive(:enabled?).with(:customer_balance, user) { false }
+      end
+
+      before do
+        allow(order).to receive(:old_outstanding_balance) { 10 }
+      end
+
+      it 'correctly returns true or false' do
+        expect(order_balance > 5).to eq true
+        expect(order_balance > 20).to eq false
+        expect(order_balance < 15).to eq true
+        expect(order_balance < 5).to eq false
+      end
+    end
+
+    context 'when the customer_balance feature is enabled' do
+      before do
+        allow(OpenFoodNetwork::FeatureToggle)
+          .to receive(:enabled?).with(:customer_balance, user) { true }
+      end
+
+      before do
+        allow(order).to receive(:new_outstanding_balance) { 10 }
+      end
+
+      it 'correctly returns true or false' do
+        expect(order_balance > 5).to eq true
+        expect(order_balance > 20).to eq false
+        expect(order_balance < 15).to eq true
+        expect(order_balance < 5).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/order_balance_spec.rb
+++ b/spec/models/order_balance_spec.rb
@@ -14,7 +14,7 @@ describe OrderBalance do
           .to receive(:enabled?).with(:customer_balance, user) { false }
       end
 
-      context 'when the balance is postive' do
+      context 'when the balance is positive' do
         before do
           allow(order).to receive(:old_outstanding_balance) { 10 }
         end
@@ -51,7 +51,7 @@ describe OrderBalance do
           .to receive(:enabled?).with(:customer_balance, user) { true }
       end
 
-      context 'when the balance is postive' do
+      context 'when the balance is positive' do
         before do
           allow(order).to receive(:new_outstanding_balance) { 10 }
         end
@@ -83,7 +83,7 @@ describe OrderBalance do
     end
   end
 
-  describe '#amount' do
+  describe '#display_amount' do
     context 'when the customer_balance feature is disabled' do
       before do
         allow(order).to receive(:old_outstanding_balance) { 10 }
@@ -95,7 +95,7 @@ describe OrderBalance do
       end
 
       it 'returns the balance wraped in a Money object' do
-        expect(order_balance.amount).to eq(Spree::Money.new(10, currency: ENV['currency']))
+        expect(order_balance.display_amount).to eq(Spree::Money.new(10, currency: ENV['currency']))
       end
     end
 
@@ -110,7 +110,7 @@ describe OrderBalance do
       end
 
       it 'returns the balance wraped in a Money object' do
-        expect(order_balance.amount).to eq(Spree::Money.new(20, currency: ENV['currency']))
+        expect(order_balance.display_amount).to eq(Spree::Money.new(20, currency: ENV['currency']))
       end
     end
   end
@@ -191,7 +191,7 @@ describe OrderBalance do
     end
   end
 
-  describe '#to_f' do
+  describe '#amount' do
     context 'when the customer_balance feature is disabled' do
       before do
         allow(OpenFoodNetwork::FeatureToggle)
@@ -200,7 +200,7 @@ describe OrderBalance do
 
       it 'calls #outstanding_balance' do
         expect(order).to receive(:old_outstanding_balance)
-        order_balance.to_f
+        order_balance.amount
       end
     end
 
@@ -212,7 +212,7 @@ describe OrderBalance do
 
       it 'calls #new_outstanding_balance' do
         expect(order).to receive(:new_outstanding_balance)
-        order_balance.to_f
+        order_balance.amount
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #7293

There were some missing method issues where the code was expecting the object returned by `Order#oustanding_balance` to behave like a number and respond to methods like `#to_d`, which are not implemented in `OrderBalance`. More details [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/7293#issuecomment-810998236)

#### What should we test?
<!-- List which features should be tested and how. -->

Errors when processing subscriptions, detailed in #7293. Maybe a general check of order balances as well.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated interface in OrderBalance to handle additional methods.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
