### PR TITLE
Update fees after changing a line item

### DIFF
--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -68,6 +68,7 @@ module Api
         quantity = params[:quantity].to_i
 
         @order.contents.add(variant, quantity, nil, @shipment)
+        @order.recreate_all_fees!
 
         render json: @shipment, serializer: Api::ShipmentSerializer, status: :ok
       end
@@ -77,6 +78,7 @@ module Api
         quantity = params[:quantity].to_i
 
         @order.contents.remove(variant, quantity, @shipment)
+        @order.recreate_all_fees!
         @shipment.reload if @shipment.persisted?
 
         render json: @shipment, serializer: Api::ShipmentSerializer, status: :ok

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -189,6 +189,27 @@ describe Api::V0::ShipmentsController, type: :controller do
           expect(inventory_units_for(variant).size).to eq 2
           expect(order.reload.line_items.last.price).to eq(variant_override.price)
         end
+
+        context "when line items have fees" do
+          let(:fee_order) {
+            instance_double(Spree::Order, number: "123", distributor: variant.product.supplier)
+          }
+          let(:contents) { instance_double(Spree::OrderContents) }
+
+          before do
+            allow(Spree::Order).to receive(:find_by!) { fee_order }
+            allow(controller).to receive(:find_and_update_shipment) { }
+            allow(fee_order).to receive(:contents) { contents }
+            allow(contents).to receive(:add) { }
+            allow(fee_order).to receive(:recreate_all_fees!)
+          end
+
+          it "recalculates fees for the line item" do
+            params[:order_id] = fee_order.number
+            spree_put :add, params
+            expect(fee_order).to have_received(:recreate_all_fees!)
+          end
+        end
       end
 
       context '#remove' do


### PR DESCRIPTION
#### What? Why?

Closes #7296; addresses https://github.com/openfoodfoundation/openfoodnetwork/issues/6806

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This fixes the issue, but maybe not in the most performant way possible. @Matt-Yorkley I tried a bunch of different variations of just calling `update_line_item_fees!` and reloading the order and line items, but this (falling back on `recreate_all_fees!`) was the only thing that worked...

I'd also like to write a better test. The most lightweight approach would be to spec the #add method in the controller to say that calling it should always call `recreate_all_fees!` (or whatever we end up going with). But that feels like a silly test to write, and it's also difficult (maybe not possible?) to get Rspec to expect a message on a database object. 


#### What should we test?
<!-- List which features should be tested and how. -->
See #7296 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Changing the quantity of line items for an order in the backoffice now automatically updates the appropriate fees. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
