### PR TITLE
Allow any quantity if variant is set to on demand

### DIFF
--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -120,6 +120,14 @@ module Spree
                        method: :put, icon: "icon-#{event}",
                        data: { confirm: confirm_message })
       end
+
+      def quantity_field_tag(manifest_item)
+        html_options = { min: 0, class: "line_item_quantity", size: 5 }
+        unless manifest_item.variant.on_demand
+          html_options.merge!(max: manifest_item.variant.on_hand + manifest_item.quantity)
+        end
+        number_field_tag :quantity, manifest_item.quantity, html_options
+      end
     end
   end
 end

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -14,7 +14,9 @@
           = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
       - unless shipment.shipped?
         %td.item-qty-edit.hidden
-          = number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5, :max => item.variant.on_hand + item.quantity
+          - html_options = { :min => 0, :class => "line_item_quantity", :size => 5 }
+          - html_options.merge!({ :max => item.variant.on_hand + item.quantity }) unless item.variant.on_demand
+          = number_field_tag :quantity, item.quantity, html_options
       %td.item-total.align-center
         = line_item_shipment_price(line_item, item.quantity)
 

--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -14,9 +14,7 @@
           = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
       - unless shipment.shipped?
         %td.item-qty-edit.hidden
-          - html_options = { :min => 0, :class => "line_item_quantity", :size => 5 }
-          - html_options.merge!({ :max => item.variant.on_hand + item.quantity }) unless item.variant.on_demand
-          = number_field_tag :quantity, item.quantity, html_options
+          = quantity_field_tag(item)
       %td.item-total.align-center
         = line_item_shipment_price(line_item, item.quantity)
 

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -146,6 +146,27 @@ feature '
     expect(order.reload.line_items.first.quantity).to eq(max_quantity)
   end
 
+  scenario "there are infinite items available (variant is on demand)" do
+    # Move the order back to the cart state
+    order.state = 'cart'
+    order.completed_at = nil
+    order.line_items.first.variant.update_attribute(:on_demand, true)
+
+    login_as_admin_and_visit spree.edit_admin_order_path(order)
+
+    within("tr.stock-item", text: order.products.first.name) do
+      find("a.edit-item").click
+      expect(page).to have_input(:quantity)
+      fill_in(:quantity, with: 1000)
+      find("a.save-item").click
+    end
+
+    within("tr.stock-item", text: order.products.first.name) do
+      expect(page).to have_text("1000 x")
+    end
+    expect(order.reload.line_items.first.quantity).to eq(1000)
+  end
+
   scenario "can't change distributor or order cycle once order has been finalized" do
     login_as_admin_and_visit spree.edit_admin_order_path(order)
 


### PR DESCRIPTION
#### What? Why?

Closes #7297 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
The admin order form had some logic to prevent more quantity than was available from being ordered. This checks if the variant is set to be on demand and allows any quantity to be ordered if so. 


#### What should we test?
<!-- List which features should be tested and how. -->
See issue gif: Changing the quantity of a line item with an on demand variant. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug in the admin edit order screen where on-demand variants could not have their quantity increased. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
