### PR TITLE
Independent 'update cart' label

### DIFF
--- a/app/views/spree/orders/form/_cart_actions_row.html.haml
+++ b/app/views/spree/orders/form/_cart_actions_row.html.haml
@@ -3,7 +3,7 @@
   %td
     %button#update-button.secondary.radius.expand.small{"ng-class" => "{ alert: form.$dirty && form.$valid }"}
       %i.ofn-i_023-refresh
-      = t(:update)
+      = t(:orders_form_update_cart)
   %td
   %td#empty-cart.text-center
     %span#clear_cart_link{"data-hook" => ""}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1889,39 +1889,40 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   shops_signup_help_text: You need a better return. You need new buyers and logistics partners. You need your story told across wholesale, retail, and the kitchen table.
   shops_signup_detail: Here's the detail.
 
-  orders: Orders
-  orders_fees: Fees...
-  orders_edit_title: Shopping Cart
-  orders_edit_headline: Your shopping cart
-  orders_edit_time: Order ready for
-  orders_edit_continue: Continue shopping
-  orders_edit_checkout: Checkout
+  orders: "Orders"
+  orders_fees: "Fees..."
+  orders_edit_title: "Shopping Cart"
+  orders_edit_headline: "Your shopping cart"
+  orders_edit_time: "Order ready for"
+  orders_edit_continue: "Continue shopping"
+  orders_edit_checkout: "Checkout"
   orders_form_empty_cart: "Empty cart"
-  orders_form_subtotal: Produce subtotal
-  orders_form_admin: Admin & Handling
-  orders_form_total: Total
-  orders_oc_expired_headline: Orders have closed for this order cycle
+  orders_form_update_cart: "Update"
+  orders_form_subtotal: "Produce subtotal"
+  orders_form_admin: "Admin & Handling"
+  orders_form_total: "Total"
+  orders_oc_expired_headline: "Orders have closed for this order cycle"
   orders_oc_expired_text: "Sorry, orders for this order cycle closed %{time} ago! Please contact your hub directly to see if they can accept late orders."
   orders_oc_expired_text_others_html: "Sorry, orders for this order cycle closed %{time} ago! Please contact your hub directly to see if they can accept late orders <strong>%{link}</strong>."
   orders_oc_expired_text_link: "or see the other order cycles available at this hub"
   orders_oc_expired_email: "Email:"
   orders_oc_expired_phone: "Phone:"
-  orders_show_title: Order Confirmation
-  orders_show_time: Order ready on
+  orders_show_title: "Order Confirmation"
+  orders_show_time: "Order ready on"
   orders_show_order_number: "Order #%{number}"
-  orders_show_cancelled: Cancelled
-  orders_show_confirmed: Confirmed
+  orders_show_cancelled: "Cancelled"
+  orders_show_confirmed: "Confirmed"
   orders_your_order_has_been_cancelled: "Your order has been cancelled"
   orders_could_not_cancel: "Sorry, the order could not be cancelled"
   orders_cannot_remove_the_final_item: "Cannot remove the final item from an order, please cancel the order instead."
   orders_bought_items_notice:
-    one: An additional item is already confirmed for this order cycle
+    one: "An additional item is already confirmed for this order cycle"
     few: "%{count} additional items already confirmed for this order cycle"
     many: "%{count} additional items already confirmed for this order cycle"
     other: "%{count} additional items already confirmed for this order cycle"
-  orders_bought_edit_button: Edit confirmed items
+  orders_bought_edit_button: "Edit confirmed items"
   orders_bought_already_confirmed: "* already confirmed"
-  orders_confirm_cancel: Are you sure you want to cancel this order?
+  orders_confirm_cancel: "Are you sure you want to cancel this order?"
   order_processed_successfully: "Your order has been processed successfully"
 
   products_cart_distributor_choice: "Distributor for your order:"


### PR DESCRIPTION
#### What? Why?

Closes #7229 

The string 'Update' (the cart) on the cart edit page is now independent from string 'Update' on several buttons in admin.
Different translations may be needed (like 'update' vs. 'save').

* New line no. 1300 in en.yml
* Other changes are just added quotes to make the file more beautiful according to [i18n](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Internationalisation-%28i18n%29#development)

#### What should we test?
1. Put an item into the cart
2. Navigate to 'edit cart' page
3. Observe the label 'Update' when changing the translation of 'orders_form_update_cart'
--> The label should change accordingly
--> The label of buttons 'update' on admin pages remains unchanged, e.g.
* admin/contents/edit
* admin/enterprises

![grafik](https://user-images.githubusercontent.com/1790176/113357108-b2653080-9343-11eb-8346-37f42bbb38ca.png)

#### Release notes
Added independent translations for update cart labels

Changelog Category: User facing changes

#### Documentation updates
If translation is changed, screenshots might have to be updated.
