### PR TITLE
Add enterprise name to subject and body of shipment shipped email

### DIFF
--- a/app/mailers/spree/shipment_mailer.rb
+++ b/app/mailers/spree/shipment_mailer.rb
@@ -4,10 +4,14 @@ module Spree
   class ShipmentMailer < BaseMailer
     def shipped_email(shipment, resend = false)
       @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find(shipment)
-      subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      base_subject = t('spree.shipment_mailer.shipped_email.subject')
-      subject += "#{Spree::Config[:site_name]} #{base_subject} ##{@shipment.order.number}"
+      subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '') + base_subject
       mail(to: @shipment.order.email, from: from_address, subject: subject)
+    end
+
+    private
+
+    def base_subject
+      "#{@shipment.order.distributor.name} #{default_i18n_subject} ##{@shipment.order.number}"
     end
   end
 end

--- a/app/views/spree/shipment_mailer/shipped_email.html.haml
+++ b/app/views/spree/shipment_mailer/shipped_email.html.haml
@@ -1,7 +1,7 @@
 %p
   = t('.dear_customer')
 %p
-  = t('.instructions')
+  = t('.instructions', distributor: @shipment.order.distributor.name)
 
 %p
   = "============================================================"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3807,7 +3807,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     shipment_mailer:
       shipped_email:
         dear_customer: "Dear Customer,"
-        instructions: "Your order has been shipped"
+        instructions: "Your order from %{distributor} has been shipped"
         shipment_summary: "Shipment Summary"
         subject: "Shipment Notification"
         thanks: "Thank you for your business."

--- a/spec/mailers/shipment_mailer_spec.rb
+++ b/spec/mailers/shipment_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Spree::ShipmentMailer do
   let(:shipment) do
-    order = build(:order)
+    order = build(:order_with_distributor)
     product = build(:product, name: %{The "BEST" product})
     variant = build(:variant, product: product)
     line_item = build(:line_item, variant: variant, order: order, quantity: 1, price: 5)
@@ -13,6 +13,7 @@ describe Spree::ShipmentMailer do
     allow(shipment).to receive_messages(tracking_url: "TRACK_ME")
     shipment
   end
+  let(:distributor) { shipment.order.distributor }
 
   context ":from not set explicitly" do
     it "falls back to spree config" do
@@ -32,5 +33,15 @@ describe Spree::ShipmentMailer do
     expect {
       Spree::ShipmentMailer.shipped_email(shipment.id).deliver_now
     }.to_not raise_error
+  end
+
+  it "includes the distributor's name in the subject" do
+    shipment_email = Spree::ShipmentMailer.shipped_email(shipment)
+    expect(shipment_email.subject).to include("#{distributor.name} Shipment Notification")
+  end
+
+  it "includes the distributor's name in the body" do
+    shipment_email = Spree::ShipmentMailer.shipped_email(shipment)
+    expect(shipment_email.body).to include("Your order from #{distributor.name} has been shipped")
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #7052

In the subject I replaced the OFN site name with the distributor name because maybe the subject would be too long with the OFN site name and the distributor name.

#### What should we test?

Ship an order and check the shipment email subject and body contains the distributor name.

#### Release notes

Add enterprise name to subject and body of shipment shipped email

Changelog Category: User facing changes