### PR TITLE
Don't show the Notifications setting for profile only enterprises in the Users section

### DIFF
--- a/app/views/admin/enterprises/form/_users.html.haml
+++ b/app/views/admin/enterprises/form/_users.html.haml
@@ -14,20 +14,21 @@
     - else
       = owner_email
 
-.row
-  .three.columns.alpha
-    =f.label :user_ids, t('.notifications')
-    - if full_permissions
-      %span.required *
-    %div{'ofn-with-tip' => t('.contact_tip')}
-      %a= t('admin.whats_this')
-  .eight.columns.omega
-    - if full_permissions
-      %select.select2.fullwidth{id: 'receives_notifications_dropdown', name: 'receives_notifications', ng: {model: 'receivesNotifications', init: "receivesNotifications = '#{@enterprise.contact.id}'"}}
-        %option{ng: {repeat: 'user in Enterprise.users', selected: "user.id == #{@enterprise.contact.id}", hide: '!user.confirmed'}, value: '{{user.id}}'}
-          {{user.email}}
-    - else
-      = @enterprise.contact.email
+- if @enterprise.is_distributor
+  .row
+    .three.columns.alpha
+      =f.label :user_ids, t('.notifications')
+      - if full_permissions
+        %span.required *
+      %div{'ofn-with-tip' => t('.contact_tip')}
+        %a= t('admin.whats_this')
+    .eight.columns.omega
+      - if full_permissions
+        %select.select2.fullwidth{id: 'receives_notifications_dropdown', name: 'receives_notifications', ng: {model: 'receivesNotifications', init: "receivesNotifications = '#{@enterprise.contact.id}'"}}
+          %option{ng: {repeat: 'user in Enterprise.users', selected: "user.id == #{@enterprise.contact.id}", hide: '!user.confirmed'}, value: '{{user.id}}'}
+            {{user.email}}
+      - else
+        = @enterprise.contact.email
 
 .row
   .three.columns.alpha

--- a/spec/views/admin/enterprises/form/_users.html.haml_spec.rb
+++ b/spec/views/admin/enterprises/form/_users.html.haml_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "admin/enterprises/form/_users.html.haml" do
+  let(:enterprise) { build(:enterprise) }
+
+  before do
+    assign(:enterprise, enterprise)
+    admin_user = build(:admin_user)
+    allow(admin_user).to receive(:admin?) { true }
+    allow(view).to receive_messages(
+      f: enterprise_form,
+      spree_current_user: admin_user,
+    )
+  end
+
+  describe "notifications setting" do
+    it "is visible when an enterprise is a distributor" do
+      enterprise.sells = "any"
+
+      render
+
+      expect(rendered).to have_selector("select[name='receives_notifications']")
+    end
+
+    it "is not visible when an enterprise is a only a profile" do
+      enterprise.sells = "none"
+
+      render
+
+      expect(rendered).not_to have_selector("select[name='receives_notifications']")
+    end
+  end
+
+  private
+
+  def enterprise_form
+    form_for(enterprise) { |f| @enterprise_form = f }
+    @enterprise_form
+  end
+end


### PR DESCRIPTION
Fixes #1797

If a enterprise has only set up a profile they won't be getting any order notification emails so showing this setting could be confusing.

#### What should we test?

1. Go to the **Admin > Enterprise > Users** section for a profile only enterprise and check the **Notifications** setting _is not_ visible.
2. Go to the **Admin > Enterprise > Users** section for a hub or shop enterprise and check the **Notifications** setting _is_ visible.

#### Release notes

Don't show the Notifications setting for profile only enterprises in the Users section

Changelog Category: User facing changes
