### PR TITLE
Deprecations: #map with permitted attributes

### DIFF
--- a/app/services/permitted_attributes/order_cycle.rb
+++ b/app/services/permitted_attributes/order_cycle.rb
@@ -35,23 +35,8 @@ module PermittedAttributes
         :tag_list,
         tags: [:text],
         enterprise_fee_ids: [],
-        variants: permitted_variant_ids
+        variants: {}
       ]
-    end
-
-    # In rails 5 we will be able to permit random hash keys simply with :variants => {}
-    # See https://github.com/rails/rails/commit/e86524c0c5a26ceec92895c830d1355ae47a7034
-    #
-    # Until then, we need to create an array of variant IDs in order to permit them
-    def permitted_variant_ids
-      variant_ids(@params[:order_cycle][:incoming_exchanges]) +
-        variant_ids(@params[:order_cycle][:outgoing_exchanges])
-    end
-
-    def variant_ids(exchange_params)
-      return [] unless exchange_params
-
-      exchange_params.map { |exchange| exchange[:variants].map { |key, _value| key } }.flatten
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Resolves deprecation warning:
```
DEPRECATION WARNING: Method map is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from block in variant_ids at /home/runner/work/openfoodnetwork/openfoodnetwork/app/services/permitted_attributes/order_cycle.rb:54)
```

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed deprecation using #map with strong params 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
