### PR TITLE
Make sure the Resend Confirmation and Send/Print Invoice links display for resumed orders

### DIFF
--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -16,7 +16,7 @@ module Spree
         @order ||= order
         links = []
         links << edit_order_link unless action_name == "edit"
-        links.concat(complete_order_links) if @order.complete?
+        links.concat(complete_order_links) if @order.complete? || @order.resumed?
         links << ship_order_link if @order.ready_to_ship?
         links << cancel_order_link if @order.can_cancel?
         links


### PR DESCRIPTION
These are links inside the Actions drop down menu on the edit order view. Before they were missing if an order was in a resumed state.

Fixes #5946

#### What should we test?

1. Click into a complete but unshipped order in the admin area.
2. Cancel the order
3. Click _Resume_
4. Open the _Actions_ drop down menu and make sure it contains _Resend Confirmation_, _Send Invoice_ and _Print Invoice_ links.

#### Release notes

Make sure the Resend Confirmation and Send/Print Invoice links display for resumed orders.

Changelog Category: User facing changes