### PR TITLE
Add non-breaking space to avoid unwanted line breaks on unit price

### DIFF
--- a/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
+++ b/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
@@ -14,7 +14,7 @@
       "question-mark-with-tooltip-placement" => "top",
       "question-mark-with-tooltip-animation" => true,
       key: "'js.shopfront.unit_price_tooltip'"}
-      {{ variant.unit_price_price | localizeCurrency }} / {{ variant.unit_price_unit }}
+      {{ variant.unit_price_price | localizeCurrency }}&nbsp;/&nbsp;{{ variant.unit_price_unit }}
         
   .medium-2.large-2.columns.total-price
     %span{"ng-class" => "{filled: variant.line_item.total_price}"}

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -209,7 +209,7 @@ module Spree
     def unit_price_price_and_unit
       unit_price = UnitPrice.new(variant)
       Spree::Money.new(price_with_adjustments / unit_price.denominator).to_html +
-        " / " + unit_price.unit
+        "&nbsp;/&nbsp;".html_safe + unit_price.unit
     end
 
     def scoper

--- a/app/views/shared/menu/_cart_sidebar.html.haml
+++ b/app/views/shared/menu/_cart_sidebar.html.haml
@@ -33,7 +33,7 @@
                   key: "'js.shopfront.unit_price_tooltip'",
                   context: "'cart-sidebar'"}
                 .options-text
-                  {{ line_item.variant.unit_price_price | localizeCurrency }} / {{ line_item.variant.unit_price_unit }}
+                  {{ line_item.variant.unit_price_price | localizeCurrency }}&nbsp;/&nbsp;{{ line_item.variant.unit_price_unit }}
 
       .cart-empty{"ng-show" => "Cart.line_items.length == 0"}
         %p


### PR DESCRIPTION
#### What? Why?
The title says it all ;)
Closes #7301


#### What should we test?
This should improve the previous behavior by not inserting line breaks into the unit price, and so having it on the same line, both in the `/cart` page and the `/order` page but also into a shop front, and in the cart sidebar.
<img width="409" alt="Capture d’écran 2021-04-02 à 16 50 34" src="https://user-images.githubusercontent.com/296452/113427292-0cfa9d00-93d5-11eb-8c69-d9c6c1507373.png">
<img width="527" alt="Capture d’écran 2021-04-02 à 17 01 33" src="https://user-images.githubusercontent.com/296452/113427314-15eb6e80-93d5-11eb-82da-f6b56009e7c1.png">



#### Release notes
Avoid line breaks on unit price

Changelog Category: User facing changes
