### PR TITLE
Rename #charge_shipping_and_payment_fees! to #set_payment_amount!

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -788,7 +788,7 @@ module Spree
     # before the shipping method is set. This results in the customer not being
     # charged for their order's shipping. To fix this, we refresh the payment
     # amount here.
-    def charge_shipping_and_payment_fees!
+    def set_payment_amount!
       update_totals
       return unless pending_payments.any?
 

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -82,7 +82,7 @@ module Spree
               after_transition to: :delivery, do: :create_tax_charge!
               after_transition to: :resumed,  do: :after_resume
               after_transition to: :canceled, do: :after_cancel
-              after_transition to: :payment, do: :charge_shipping_and_payment_fees!
+              after_transition to: :payment, do: :set_payment_amount!
             end
           end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1268,7 +1268,7 @@ describe Spree::Order do
     end
   end
 
-  describe '#charge_shipping_and_payment_fees!' do
+  describe '#set_payment_amount!' do
     let(:order) do
       shipment = build(:shipment_with, :shipping_method, shipping_method: build(:shipping_method))
       build(:order, shipments: [shipment] )
@@ -1281,8 +1281,8 @@ describe Spree::Order do
         allow(order).to receive(:payment_required?) { true }
       end
 
-      it 'calls charge_shipping_and_payment_fees! and updates totals' do
-        expect(order).to receive(:charge_shipping_and_payment_fees!)
+      it 'calls #set_payment_amount! and updates totals' do
+        expect(order).to receive(:set_payment_amount!)
         expect(order).to receive(:update_totals).at_least(:once)
 
         order.next


### PR DESCRIPTION
#### What? Why?

Renames `Order#charge_shipping_and_payment_fees!` to `Order#set_payment_amount!`.

This method sets the order's payment amount during the checkout. It doesn't really have anything to do with charging shipping or payment fees... :see_no_evil: 

#### What should we test?
<!-- List which features should be tested and how. -->

Green build

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Renamed #charge_shipping_and_payment_fees! to #set_payment_amount!

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
