### PR TITLE
Remove wkhtmltopdf-binary version pin and bump gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem 'roadie-rails', '~> 1.3.0'
 
 gem 'combine_pdf'
 gem 'wicked_pdf'
-gem 'wkhtmltopdf-binary', '0.12.5' # We need to upgrade our CI before we can bump this :/
+gem 'wkhtmltopdf-binary'
 
 gem 'immigrant'
 gem 'roo', '~> 2.8.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,7 +588,7 @@ GEM
       chronic (>= 0.6.3)
     wicked_pdf (2.1.0)
       activesupport
-    wkhtmltopdf-binary (0.12.5)
+    wkhtmltopdf-binary (0.12.6.5)
     xml-simple (1.1.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -713,7 +713,7 @@ DEPENDENCIES
   webmock
   whenever
   wicked_pdf
-  wkhtmltopdf-binary (= 0.12.5)
+  wkhtmltopdf-binary
 
 RUBY VERSION
    ruby 2.5.8p224


### PR DESCRIPTION
#### What? Why?

Related to #7324 

Previously we were tied to a lower version that maintained compatibility with Ubuntu 14 (which we used in Semaphore). We can drop this version pin now and upgrade it. PDF tests should work locally now on Ubuntu 20 :tada:

#### What should we test?
<!-- List which features should be tested and how. -->

I ran a build for this in Ubuntu 16 and it passed. We should do some quick checks of PDF creation as well.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Upgraded wkhtmltopdf-binary gem

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
