### PR TITLE
Remove included_tax scope from Adjustment

### DIFF
--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -72,9 +72,6 @@ module Spree
 
     scope :enterprise_fee, -> { where(originator_type: 'EnterpriseFee') }
     scope :admin,          -> { where(source_type: nil, originator_type: nil) }
-    scope :included_tax,   -> {
-      where(originator_type: 'Spree::TaxRate', adjustable_type: 'Spree::LineItem')
-    }
 
     scope :with_tax,       -> { where('spree_adjustments.included_tax <> 0') }
     scope :without_tax,    -> { where('spree_adjustments.included_tax = 0') }


### PR DESCRIPTION
#### What? Why?

This scope is no longer used, and it's name is exactly the same as other method names and database columns on multiple objects, which is quite confusing (and potentially dangerous!).

It theoretically returns tax adjustments that apply to line items, but we generally use `order.line_item_adjustments.tax` or `line_item.adjustments.tax` for that (which have no chance of clashing with other method names or attributes).

:fire::fire::fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed included_tax scope from Adjustment

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

