### PR TITLE
Update unscoping of deleted_at on Adjustment originator association

### DIFF
--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -38,7 +38,7 @@ module Spree
 
     belongs_to :adjustable, polymorphic: true
     belongs_to :source, polymorphic: true
-    belongs_to :originator, polymorphic: true
+    belongs_to :originator, -> { with_deleted }, polymorphic: true
     belongs_to :order, class_name: "Spree::Order"
 
     belongs_to :tax_rate, -> { where spree_adjustments: { originator_type: 'Spree::TaxRate' } },
@@ -140,13 +140,6 @@ module Spree
 
     def has_tax?
       included_tax.positive?
-    end
-
-    # Allow accessing soft-deleted originator objects
-    def originator
-      return if originator_type.blank?
-
-      originator_type.constantize.unscoped { super }
     end
 
     private

--- a/app/models/spree/return_authorization.rb
+++ b/app/models/spree/return_authorization.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class ReturnAuthorization < ActiveRecord::Base
+    acts_as_paranoid
+
     belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations
 
     has_many :inventory_units, inverse_of: :return_authorization

--- a/db/migrate/20210407170804_add_deleted_at_to_return_authorizations.rb
+++ b/db/migrate/20210407170804_add_deleted_at_to_return_authorizations.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToReturnAuthorizations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spree_return_authorizations, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210329123820) do
+ActiveRecord::Schema.define(version: 20210407170804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -754,6 +754,7 @@ ActiveRecord::Schema.define(version: 20210329123820) do
     t.datetime "created_at",                                                             null: false
     t.datetime "updated_at",                                                             null: false
     t.integer  "stock_location_id"
+    t.datetime "deleted_at"
   end
 
   create_table "spree_roles", force: :cascade do |t|


### PR DESCRIPTION
#### What? Why?

Adds soft-deletion to ReturnAuthorization and improves loading of adjustments that have a soft-deleted originator eg an EnterpriseFee.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build. There's a test for soft-deletion on adjustment originators [here](https://github.com/openfoodfoundation/openfoodnetwork/blob/2c17d12f6edfa59dd283ac08f9ff78ece39b6757/spec/models/enterprise_fee_spec.rb#L157).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added soft-deletion to ReturnAuthorization and improved unscoping on adjustment originators.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
