### PR TITLE
Avoid NaN on unit price in the frontoffice

### DIFF
--- a/app/assets/javascripts/darkswarm/filters/format_unit_price.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/format_unit_price.js.coffee
@@ -1,0 +1,5 @@
+Darkswarm.filter "formatUnitPrice", (localizeCurrencyFilter) ->
+  (price, unit) ->
+    if price == null
+      return null
+    localizeCurrencyFilter(price) + "&nbsp;/&nbsp;" + unit

--- a/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
+++ b/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
@@ -8,7 +8,7 @@
       "price-breakdown-placement" => "bottom",
       "price-breakdown-animation" => true}
     {{ variant.price_with_fees | localizeCurrency }}
-    .unit-price.variant-unit-price
+    .unit-price.variant-unit-price{"ng-show" => "variant.unit_price_price"}
       %question-mark-with-tooltip{"question-mark-with-tooltip" => "_",
       "question-mark-with-tooltip-append-to-body" => "true",
       "question-mark-with-tooltip-placement" => "top",

--- a/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
+++ b/app/assets/javascripts/templates/shop_variant_with_unit_price.html.haml
@@ -14,7 +14,7 @@
       "question-mark-with-tooltip-placement" => "top",
       "question-mark-with-tooltip-animation" => true,
       key: "'js.shopfront.unit_price_tooltip'"}
-      {{ variant.unit_price_price | localizeCurrency }} / {{ variant.unit_price_unit }}
+      %span{ "ng-bind-html" => " variant.unit_price_price | formatUnitPrice:variant.unit_price_unit " }
         
   .medium-2.large-2.columns.total-price
     %span{"ng-class" => "{filled: variant.line_item.total_price}"}

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -208,6 +208,8 @@ module Spree
 
     def unit_price_price_and_unit
       unit_price = UnitPrice.new(variant)
+      return nil if unit_price.denominator.zero?
+
       Spree::Money.new(price_with_adjustments / unit_price.denominator).to_html +
         " / " + unit_price.unit
     end

--- a/app/views/shared/menu/_cart_sidebar.html.haml
+++ b/app/views/shared/menu/_cart_sidebar.html.haml
@@ -24,7 +24,7 @@
           %td
             .total-price.text-right {{ line_item.total_price | localizeCurrency }}
             - if feature? :unit_price, spree_current_user
-              .unit-price
+              .unit-price{"ng-show" => "line_item.variant.unit_price_price"}
                 %div{:style => "margin-right: 5px"}
                   %question-mark-with-tooltip{"question-mark-with-tooltip" => "_",
                   "question-mark-with-tooltip-append-to-body" => "true",

--- a/app/views/shared/menu/_cart_sidebar.html.haml
+++ b/app/views/shared/menu/_cart_sidebar.html.haml
@@ -33,7 +33,7 @@
                   key: "'js.shopfront.unit_price_tooltip'",
                   context: "'cart-sidebar'"}
                 .options-text
-                  {{ line_item.variant.unit_price_price | localizeCurrency }} / {{ line_item.variant.unit_price_unit }}
+                  %span{ "ng-bind-html" => " line_item.variant.unit_price_price | formatUnitPrice:line_item.variant.unit_price_unit " }
 
       .cart-empty{"ng-show" => "Cart.line_items.length == 0"}
         %p

--- a/app/views/spree/orders/_bought.html.haml
+++ b/app/views/spree/orders/_bought.html.haml
@@ -22,7 +22,7 @@
         %span.already-confirmed= t(:orders_bought_already_confirmed)
       %td.text-right.cart-item-price
         = line_item.single_display_amount_with_adjustments.to_html
-        - if feature? :unit_price, spree_current_user
+        - if feature? :unit_price, spree_current_user && line_item.unit_price_price_and_unit
           %br
           %span.unit-price
             = line_item.unit_price_price_and_unit

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -18,7 +18,7 @@
 
   %td.text-right.cart-item-price{"data-hook" => "cart_item_price"}
     = line_item.single_display_amount_with_adjustments.to_html
-    - if feature? :unit_price, spree_current_user
+    - if feature? :unit_price, spree_current_user && line_item.unit_price_price_and_unit
       %br
       %span.unit-price
         = line_item.unit_price_price_and_unit

--- a/spec/javascripts/unit/darkswarm/filters/format_unit_price_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/filters/format_unit_price_spec.js.coffee
@@ -1,0 +1,21 @@
+describe "ensuring unit price formatter", ->
+  filter = null
+
+  beforeEach ->
+    currencyconfig =
+      symbol: "$"
+      symbol_position: "before"
+      currency: "D"
+      hide_cents: "false"
+    module 'Darkswarm'
+    module ($provide)->
+      $provide.value "currencyConfig", currencyconfig
+      null
+    inject ($filter) ->
+      filter = $filter 'formatUnitPrice'
+
+  it "returns null when no price", ->
+    expect(filter(null, "whatever")).toBeNull()
+
+  it "returns wel formatted unit price", ->
+    expect(filter(12, "kg")).toEqual "$12.00&nbsp;/&nbsp;kg"


### PR DESCRIPTION
#### What? Why?
As we could set up a `0` value into the `Value` field when creating/editing a product/variant, this led a `NaN` being displayed in the front office.
This PR avoid this display, by not showing the unit price field if the value is `0`
Closes #7322

_NB_ : Only the two commits (deb416c46353c148f34c82c892c0eb301088ab1c and 45dd385e2b9c0beb7ac8c12da1c5b77e4ab531e5) are useful for this feature. The others are more or less about refactoring the code and add testing.

#### What should we test?
##### Product with `value `equal to `0`
1. Create a product or edit a variant is `0` to `value` field
2. Go to shopfront with this product: _no unit price should be displayed_
3. Add the product in the cart, open the cart sidebar: _no unit price should be displayed_
4. Go to the `cart` page (Edit): _no unit price should be displayed_
5. Checkout, see the order: _no unit price should be displayed_
6. Go to edit this order (if the shop is authorizing editing an order while order cycle is open): _no unit price should be displayed_

##### Product with `value` different from `0`
Unit price must be shown in the all previous different cases.

#### Release notes
Do not display unit price for a product when its value is 0.

Changelog Category: User facing changes
