### PR TITLE
Never return 0 for a denominator

### DIFF
--- a/app/assets/javascripts/admin/products/services/unit_prices.js.coffee
+++ b/app/assets/javascripts/admin/products/services/unit_prices.js.coffee
@@ -3,7 +3,7 @@ angular.module("admin.products").factory "UnitPrices", (VariantUnitManager, loca
     @displayableUnitPrice: (price, scale, unit_type, unit_value, variant_unit_name) ->
       if price && !isNaN(price) && unit_type && unit_value
         value = localizeCurrencyFilter(UnitPrices.price(price, scale, unit_type, unit_value, variant_unit_name))
-        unit = UnitPrices.unit(scale, unit_type, variant_unit_name)
+        unit = UnitPrices.unit(scale, unit_type, variant_unit_name, unit_value)
         return value + " / " + unit
       return null
 
@@ -12,18 +12,20 @@ angular.module("admin.products").factory "UnitPrices", (VariantUnitManager, loca
 
     @denominator: (scale, unit_type, unit_value) ->
       unit = @unit(scale, unit_type)
-      if unit == "lb"
+      if unit_value == 0
+        1
+      else if unit == "lb"
         unit_value / 453.6
       else if unit == "kg"
         unit_value / 1000
       else
         unit_value
 
-    @unit: (scale, unit_type, variant_unit_name = '') ->
-      if variant_unit_name.length > 0
-        variant_unit_name
-      else if unit_type == "items"
+    @unit: (scale, unit_type, variant_unit_name = '', unit_value = null) ->
+      if unit_value == 0 || unit_type == "items"
         "item"
+      else if variant_unit_name.length > 0
+        variant_unit_name
       else if VariantUnitManager.systemOfMeasurement(scale, unit_type) == "imperial"
         "lb"
       else if unit_type == "weight"

--- a/app/services/unit_price.rb
+++ b/app/services/unit_price.rb
@@ -7,6 +7,8 @@ class UnitPrice
   end
 
   def denominator
+    return 1 if @variant.unit_value.zero?
+
     # catches any case where unit is not kg, lb, or L.
     return @variant.unit_value if @product&.variant_unit == "items"
 
@@ -21,6 +23,7 @@ class UnitPrice
   end
 
   def unit
+    return I18n.t("item") if @variant.unit_value.zero?
     return "lb" if WeightsAndMeasures.new(@variant).system == "imperial"
 
     case @product&.variant_unit

--- a/spec/services/unit_prices_spec.rb
+++ b/spec/services/unit_prices_spec.rb
@@ -51,6 +51,14 @@ describe UnitPrice do
         expect(subject.unit).to eq("bunch")
       end
     end
+
+    context "unit value of 0" do
+      before { allow(variant).to receive(:unit_value) { 0 } }
+
+      it "returns 'item'" do
+        expect(subject.unit).to eq(I18n.t("item"))
+      end
+    end
   end
 
   describe "#denominator" do
@@ -99,6 +107,14 @@ describe UnitPrice do
         allow(product).to receive(:variant_unit) { "items" }
         variant.unit_value = 2
         expect(subject.denominator).to eq(2)
+      end
+    end
+
+    context "unit value of 0" do
+      before { allow(variant).to receive(:unit_value) { 0 } }
+
+      it "returns 1" do
+        expect(subject.denominator).to eq(1)
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/7322

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This handles cases where the unit value of a variant is set to 0, making it impossible to compute a unit price. Instead, we display the full price of the item. 

#### What should we test?
<!-- List which features should be tested and how. -->
A variant with a unit value of 0 should display a unit price instead of NaN


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where unit prices would display as NaN if the variant's unit value was set to 0. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
