### PR TITLE
Remove arrows on number input when adding items

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-inputs.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-inputs.scss
@@ -117,6 +117,13 @@ button.bulk-buy-add.variant-quantity {
   }
 }
 
+// Hide number arrows on Chrome, Safari, Edge, Opera
+.variant-quantity::-webkit-outer-spin-button,
+.variant-quantity::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .variant-bulk-buy-price-summary {
   color: $disabled-med;
   margin-bottom: 1em;


### PR DESCRIPTION
#### What? Why?

Closes #7306

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Previously when adding an item we were seeing the arrows displaying in the number input on Desktop Chrome/Safari/Edge. This change removes the arrows since we have plus/minus buttons.

On desktop:

- Safari (fixed)
![safari](https://user-images.githubusercontent.com/20247757/113899590-f40a3700-979a-11eb-9165-2d2b222c3b3a.gif)

- Firefox (no change)
![firefox](https://user-images.githubusercontent.com/20247757/113899593-f4a2cd80-979a-11eb-8b41-8fb138d08b5d.gif)

- Chrome (fixed)
![chrome](https://user-images.githubusercontent.com/20247757/113899595-f53b6400-979a-11eb-9e33-7c3d26399c29.gif)



#### What should we test?
- UI fix, no tests needed



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
- Removes arrows showing up on number input on Chrome/Safari/Edge

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
- none



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
- none
