### PR TITLE
[Rails 5.2] Delete dead code in variants list page, this is old spree logic

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -289,12 +289,6 @@ module Spree
       }.inject(:or)
     end
 
-    def empty_option_values?
-      options.empty? || options.any? do |opt|
-        opt.option_type.option_values.empty?
-      end
-    end
-
     def property(property_name)
       return nil unless prop = properties.find_by(name: property_name)
 

--- a/app/views/spree/admin/variants/index.html.haml
+++ b/app/views/spree/admin/variants/index.html.haml
@@ -30,17 +30,9 @@
           = link_to_with_icon('icon-edit', Spree.t(:edit), edit_object_url(variant, @url_filters), no_text: true) unless variant.deleted?
           = link_to_delete(variant, { url: object_url(variant, @url_filters), no_text: true }) unless variant.deleted?
 
-- if @product.empty_option_values?
-  %p.first_add_option_types.no-objects-found
-    = t('.to_add_variants_you_must_first_define')
-    = link_to t('.option_types'), admin_product_url(@product)
-    = t('.and')
-    = link_to t('.option_values'), admin_option_types_url
+- content_for :page_actions do
+  %ul.inline-menu
+    %li#new_var_link
+      = link_to_with_icon('icon-plus', t('.new_variant'), new_admin_product_variant_url(@product, @url_filters), class: 'button')
 
-- else
-  - content_for :page_actions do
-    %ul.inline-menu
-      %li#new_var_link
-        = link_to_with_icon('icon-plus', t('.new_variant'), new_admin_product_variant_url(@product, @url_filters), class: 'button')
-
-      %li= link_to_with_icon('icon-filter', @deleted.blank? ? t('.show_deleted') : t('.show_active'), admin_product_variants_url(@product, @url_filters.merge(deleted: @deleted.blank? ? "on" : "off")), class: 'button')
+    %li= link_to_with_icon('icon-filter', @deleted.blank? ? t('.show_deleted') : t('.show_active'), admin_product_variants_url(@product, @url_filters.merge(deleted: @deleted.blank? ? "on" : "off")), class: 'button')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3679,7 +3679,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           price: "Price"
           options: "Options"
           no_results: "No results"
-          to_add_variants_you_must_first_define: "To add variants, you must first define"
           option_types: "Option Types"
           option_values: "Option Values"
           and: "and"


### PR DESCRIPTION
#### What? Why?

This fixes a spec in rails 5.2

Currently we dont need option types/Values to create variants and/or these are always created when a product is created in OFN.

#### What should we test?
Green build.
We can verify this in the UI.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Delete unused code.


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
