### PR TITLE
Guard against variants that use items but have scales

### DIFF
--- a/app/services/weights_and_measures.rb
+++ b/app/services/weights_and_measures.rb
@@ -14,7 +14,7 @@ class WeightsAndMeasures
   end
 
   def system
-    scales = scales_for_variant_unit
+    return "custom" unless scales = scales_for_variant_unit
     return "custom" unless product_scale = @variant.product.variant_unit_scale
 
     scales[product_scale.to_f]['system']

--- a/spec/services/weights_and_measures_spec.rb
+++ b/spec/services/weights_and_measures_spec.rb
@@ -37,9 +37,15 @@ describe WeightsAndMeasures do
     end
 
     context "items" do
-      it "when scale is for items" do
+      it "when variant unit is items" do
         allow(product).to receive(:variant_unit) { "items" }
         allow(product).to receive(:variant_unit_scale) { nil }
+        expect(subject.system).to eq("custom")
+      end
+
+      it "when variant unit is items, even if the scale is present" do
+        allow(product).to receive(:variant_unit) { "items" }
+        allow(product).to receive(:variant_unit_scale) { 1.0 }
         expect(subject.system).to eq("custom")
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #7348 
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->


#### What should we test?
<!-- List which features should be tested and how. -->
A variant whose product has `variant_unit = items` and `variant_unit_scale` set to anything but `nil` would cause the shop to not load. I'm not sure if it's easy to get a product into that state through the UI; if it's not, a green build should be sufficient. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where item variants with unit scales would cause the shopfront to not load. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
