### PR TITLE
Sets feature toggle off on staging, by default

### DIFF
--- a/config/initializers/feature_toggles.rb
+++ b/config/initializers/feature_toggles.rb
@@ -11,5 +11,5 @@ OpenFoodNetwork::FeatureToggle.enable(:customer_balance) do |user|
 end
 
 OpenFoodNetwork::FeatureToggle.enable(:unit_price) do
-  ['development', 'staging'].include?(ENV['RAILS_ENV'])
+  Rails.env.development?
 end


### PR DESCRIPTION
#### What? Why?

It sets feature toggles in staging environments to `off`, by default - thanks for the advice here @sauloperez :+1: 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Follows-up on the latest strategy around feature toggles - details here:
https://github.com/openfoodfoundation/openfoodnetwork/wiki/Feature-toggles

#### What should we test?
<!-- List which features should be tested and how. -->

We can check that features are toggled off, after staging pull-requests.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Makes features toggled by default only for development environments.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
