### PR TITLE
Fix problem in rails 5.2 order workflow

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -201,7 +201,7 @@ module Spree
     end
 
     def update_order
-      order.reload.update!
+      order.update!
     end
 
     # Necessary because some payment gateways will refuse payments with


### PR DESCRIPTION
#### What? Why?

Closes #7188

7188 is caused by our crazy callbacks on order workflow.
We have in order
before_save :update_payment_fees!, if: :complete?

That does
payment.save

and payment has
after_save :update_order

which does
order.reload.update!

We are reloading the order before we save it!?
I wonder if we can simply remove the reload here. It does solve the broken spec in #7188 rails 5-2


<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
Green build.
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category:  Technical changes
Simplify order callbacks to fix problem in rails 5.2


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
