### PR TITLE
Fixes Alphabetical Sorting In Packing Reports 

### DIFF
--- a/lib/open_food_network/packing_report.rb
+++ b/lib/open_food_network/packing_report.rb
@@ -53,7 +53,7 @@ module OpenFoodNetwork
           { group_by: proc { |line_item| line_item.order.distributor },
             sort_by: proc { |distributor| distributor.name } },
           { group_by: proc { |line_item| line_item.order },
-            sort_by: proc { |order| order.bill_address.lastname },
+            sort_by: proc { |order| order.bill_address.lastname.downcase },
             summary_columns: [proc { |_line_items| "" },
                               proc { |_line_items| "" },
                               proc { |_line_items| "" },
@@ -89,7 +89,7 @@ module OpenFoodNetwork
          { group_by: proc { |line_item| line_item.full_name },
            sort_by: proc { |full_name| full_name } },
          { group_by: proc { |line_item| line_item.order },
-           sort_by: proc { |order| order.bill_address.lastname } }]
+           sort_by: proc { |order| order.bill_address.lastname.downcase } }]
       end
     end
 

--- a/spec/features/admin/reports_spec.rb
+++ b/spec/features/admin/reports_spec.rb
@@ -93,8 +93,8 @@ feature '
       login_as_admin_and_visit spree.admin_reports_path
     end
 
-    let(:bill_address1) { create(:address, lastname: "Aman") }
-    let(:bill_address2) { create(:address, lastname: "Bman") }
+    let(:bill_address1) { create(:address, lastname: "MULLER") }
+    let(:bill_address2) { create(:address, lastname: "Mistery") }
     let(:distributor_address) { create(:address, address1: "distributor address", city: 'The Shire', zipcode: "1234") }
     let(:distributor) { create(:distributor_enterprise, address: distributor_address) }
     let(:order1) { create(:order, distributor: distributor, bill_address: bill_address1) }
@@ -127,6 +127,22 @@ feature '
         ["Hub", "Code", "First Name", "Last Name", "Supplier", "Product", "Variant", "Quantity", "TempControlled?"]
       ].sort)
       expect(page).to have_selector 'table#listing_orders tbody tr', count: 5 # Totals row per order
+    end
+
+    scenario "Alphabetically Sorted Pack by Customer" do
+      click_link "Pack By Customer"
+      click_button 'Search'
+      
+      rows = find("table#listing_orders").all("tr")
+      table = rows.map { |r| r.all("th,td").map { |c| c.text.strip }[3] }
+      expect(table).to eq([
+        "Last Name",
+        order2.bill_address.lastname,
+        "",
+        order1.bill_address.lastname,
+        order1.bill_address.lastname,
+        ""
+      ])
     end
 
     scenario "Pack By Supplier" do


### PR DESCRIPTION
#### What? Why?

Closes #1156

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Currently the generated packing reports are supposed to be sorted in alphabetical order by last name. However, incorrectly capitalized letters causes incorrect sorting order. To fix this, we sorted by the lowercase version of the last name rather than the last name directly. 


#### What should we test?
<!-- List which features should be tested and how. -->
Packing reports with inconsistent capitalization rules should be sorted ignoring case. For example, a row with last name 'MULLER' should after a row with last name 'Mistery'. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Alphabetical sorting of packing reports correctly ignores case.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
