### PR TITLE
[Rails 5.2] Update order after changing its contents

### DIFF
--- a/app/models/spree/order_contents.rb
+++ b/app/models/spree/order_contents.rb
@@ -46,7 +46,7 @@ module Spree
       end
 
       line_item.save
-      order.reload
+      order.reload.update!
       line_item
     end
 
@@ -61,7 +61,7 @@ module Spree
         line_item.save!
       end
 
-      order.reload
+      order.reload.update!
       line_item
     end
   end


### PR DESCRIPTION
#### What? Why?

Fixes `./spec/models/spree/order_contents_spec.rb:84` and `./spec/models/spree/order_contents_spec.rb:78`

I'm not sure why this would be changed by Rails 5.2, or if it might break other specs. Let's see what the build says. 

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
