### PR TITLE
[Rails 5.2] Checkout controller locking

### DIFF
--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -46,7 +46,7 @@ describe CheckoutController, type: :controller do
     before do
       allow(controller).to receive(:current_order).and_return(order)
       allow(order).to receive(:distributor).and_return(distributor)
-      order.order_cycle = order_cycle
+      order.update(order_cycle: order_cycle)
 
       allow(OrderCycleDistributedVariants).to receive(:new).and_return(order_cycle_distributed_variants)
     end


### PR DESCRIPTION
The test setup here left the object with unsaved changes, which doesn't work nicely with the new order locking added recently on the edit action.

Fixes ~5 specs including:
```
5) CheckoutController redirection to cart and stripe redirects when some items are out of stock
     Failure/Error:
       order.with_lock do
         lock_variants_of(order)
         yield
       end

     RuntimeError:
       Locking a record with unpersisted changes is not supported. Use `save` to persist the changes, or `reload` to discard them explicitly.
     # ./app/services/current_order_locker.rb:22:in `lock_order_and_variants'
     # ./app/services/current_order_locker.rb:11:in `around'
     # ./spec/controllers/checkout_controller_spec.rb:57:in `block (3 levels) in <top (required)>'
```