### PR TITLE
[Rails 5.2] LineItem order update callback

### DIFF
--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -226,7 +226,7 @@ module Spree
     end
 
     def update_order
-      return unless changed? || destroyed?
+      return unless saved_change_to_quantity? || destroyed?
 
       # update the order totals, etc.
       order.create_tax_charge!


### PR DESCRIPTION
The `#changed?` method here was not working as before, so the execution was never getting past this guard in various places where previously it did. This meant the callback was effectively disabled, and `order.update!` was not being called when it should be.

Fixes:
- spec/models/spree/order_contents_spec.rb:84
- spec/models/spree/order_contents_spec.rb:78
- various others where the order total hasn't been updated...