### PR TITLE
[Rails 5.2] Fix deprecated use of #stub in payment spec

### DIFF
--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -7,7 +7,7 @@ describe Spree::Payment do
     let(:order) { create(:order) }
     let(:gateway) do
       gateway = Spree::Gateway::Bogus.new(environment: 'test', active: true)
-      gateway.stub source_required: true
+      allow(gateway).to receive(:source_required) { true }
       gateway
     end
 


### PR DESCRIPTION
Fixes:
```
Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /home/runner/work/openfoodnetwork/openfoodnetwork/spec/models/spree/payment_spec.rb:10:in `block (3 levels) in <top (required)>'.
     RuntimeError:

       stubbed models are not allowed to access the database - Spree::Product#touch(updated_at,{:time=>2021-04-10 14:24:50 UTC})
```