### PR TITLE
[Rails 5.2] Fix taxon error handling in Api::TaxonsController

### DIFF
--- a/app/controllers/api/v0/taxons_controller.rb
+++ b/app/controllers/api/v0/taxons_controller.rb
@@ -28,7 +28,7 @@ module Api
         taxonomy = Spree::Taxonomy.find_by(id: params[:taxonomy_id])
 
         if taxonomy.nil?
-          @taxon.errors[:taxonomy_id] = I18n.t(:invalid_taxonomy_id, scope: 'spree.api')
+          @taxon.errors.add(:taxonomy_id, I18n.t(:invalid_taxonomy_id, scope: 'spree.api'))
           invalid_resource!(@taxon) && return
         end
 


### PR DESCRIPTION
Fixes:
```
Api::V0::TaxonsController as an admin cannot create a new taxon with invalid taxonomy_id
     Failure/Error: expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")

       expected: "Invalid resource. Please fix errors and try again."
            got: nil

       (compared using ==)
     # ./spec/controllers/api/v0/taxons_controller_spec.rb:105:in `block (3 levels) in <top (required)>'
```