### PR TITLE
[Rails 5.2] Fix deprecated syntax for reloading `#line_items` association

### DIFF
--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -104,7 +104,7 @@ module Spree
       else
         # Show order with original values, not newly entered ones
         @insufficient_stock_lines = @order.insufficient_stock_lines
-        @order.line_items(true)
+        @order.line_items.reload
         respond_with(@order)
       end
     end


### PR DESCRIPTION
Deprecated reload syntax. Fixes:

```
1) full-page cart viewing the cart updating quantities with insufficient stock available shows the quantities saved, not those submitted
     Failure/Error: @order.line_items(true)
     
     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # ./app/controllers/spree/orders_controller.rb:107:in `update'
     # ./lib/open_food_network/rack_request_blocker.rb:36:in `call'
     # ------------------
     # --- Caused by: ---
     # Capybara::ExpectationNotMet:
     #   expected to find text "Insufficient stock available, only 2 remaining" in "Internal Server Error\nwrong number of arguments (given 1, expected 0)\nWEBrick/1.4.2 (Ruby/2.5.8/2020-03-31) at 127.0.0.1:46283"
     #   ./spec/features/consumer/shopping/cart_spec.rb:215:in `block (5 levels) in <top (required)>'
```