### PR TITLE
[Rails 5.2] Fix callback in Classification and update spec

### DIFF
--- a/app/models/spree/classification.rb
+++ b/app/models/spree/classification.rb
@@ -15,7 +15,7 @@ module Spree
 
       errors.add :base, I18n.t(:spree_classification_primary_taxon_error, taxon: taxon.name,
                                                                           product: product.name)
-      false
+      throw :abort
     end
   end
 end

--- a/spec/models/spree/classification_spec.rb
+++ b/spec/models/spree/classification_spec.rb
@@ -4,14 +4,16 @@ require 'spec_helper'
 
 module Spree
   describe Classification do
-    let(:product) { build_stubbed(:simple_product) }
-    let(:taxon) { build_stubbed(:taxon) }
+    let(:product) { create(:simple_product) }
+    let(:taxon) { create(:taxon) }
 
     it "won't destroy if classification is the primary taxon" do
-      classification = Classification.new(taxon: taxon, product: product)
-      product.primary_taxon = taxon
+      classification = Classification.create(taxon: taxon, product: product)
+      product.update(primary_taxon: taxon)
+
       expect(classification.destroy).to be false
       expect(classification.errors.messages[:base]).to eq(["Taxon #{taxon.name} is the primary taxon of #{product.name} and cannot be deleted"])
+      expect(classification.reload).to be
     end
   end
 end


### PR DESCRIPTION
Fixes:
```
2) Spree::Classification won't destroy if classification is the primary taxon
(Used from /home/runner/work/openfoodnetwork/openfoodnetwork/spec/models/enterprise_group_spec.rb:43:in `block (3 levels) in <top (required)>')
     Failure/Error: expect(classification.destroy).to be false
```