### PR TITLE
[Rails 5.2] line item changed

### DIFF
--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -226,7 +226,7 @@ module Spree
     end
 
     def update_order
-      return unless saved_change_to_quantity? || destroyed?
+      return unless saved_changes.present? || destroyed?
 
       # update the order totals, etc.
       order.create_tax_charge!


### PR DESCRIPTION
Seems like the `changed?` method previously used in this guard clause is more accurately replaced by `saved_changes.present?` in Rails 5.2.

In some cases here (where the object had just been saved for the first time) the guard clause was still stopping execution unexpectedly.

Fixes final model spec failure:
```
0) Spree::Adjustment inclusive and additional taxes tax adjustment creation with included taxes records the tax as included
     Failure/Error: expect(order.all_adjustments.tax.count).to eq 1

       expected: 1
            got: 0

       (compared using ==)
     # ./spec/models/spree/adjustment_spec.rb:514:in `block (5 levels) in <module:Spree>'
     # -e:1:in `<main>'
```
