### PR TITLE
[Rails 5.2] Stub OrderPaymentFinder to return correct object

### DIFF
--- a/spec/services/checkout/stripe_redirect_spec.rb
+++ b/spec/services/checkout/stripe_redirect_spec.rb
@@ -38,6 +38,8 @@ describe Checkout::StripeRedirect do
           it "returns the redirect path" do
             stripe_payment = create(:payment, payment_method_id: payment_method.id)
             order.payments << stripe_payment
+            allow(OrderPaymentFinder).to receive_message_chain(:new, :last_pending_payment).
+              and_return(stripe_payment)
             allow(stripe_payment).to receive(:authorize!) do
               # Authorization moves the payment state from checkout/processing to pending
               stripe_payment.state = 'pending'


### PR DESCRIPTION
`OrderPaymentFinder` (called from `OrderManagement::Order::StripeScaPaymentAuthorize`) re-fetches the payment object from the database, so the subsequent line that stubs `#authorize!` on that payment was not being applied to the correct object. This meant `#authorize!` was actually being called in a place where it was expected to be stubbed.

Fixes:
```
0) Checkout::StripeRedirect#path when payment_attributes are provided when payment method provided exists and the payment method is a stripe method returns the redirect path
     Failure/Error: @provider ||= provider_class.new(gateway_options)

     ArgumentError:
       Missing required parameter: login
     # ./app/models/spree/gateway.rb:33:in `new'
     # ./app/models/spree/gateway.rb:33:in `provider'
     # ./app/models/spree/gateway/stripe_sca.rb:69:in `authorize'
     # ./app/models/spree/payment/processing.rb:214:in `public_send'
     # ./app/models/spree/payment/processing.rb:214:in `block in gateway_action'
     # ./app/models/spree/payment/processing.rb:249:in `protect_from_connection_error'
     # ./app/models/spree/payment/processing.rb:211:in `gateway_action'
     # ./app/models/spree/payment/processing.rb:21:in `authorize!'
     # ./engines/order_management/app/services/order_management/order/stripe_sca_payment_authorize.rb:16:in `call!'
     # ./app/services/checkout/stripe_redirect.rb:18:in `path'
     # ./spec/services/checkout/stripe_redirect_spec.rb:50:in `block (6 levels) in <top (required)>'
     # -e:1:in `<main>'
```
