### PR TITLE
[Rails 5.2] Add missing Stripe API request stub

### DIFF
--- a/spec/features/consumer/shopping/checkout_stripe_spec.rb
+++ b/spec/features/consumer/shopping/checkout_stripe_spec.rb
@@ -219,7 +219,8 @@ feature "Check out with Stripe", js: true do
           stub_add_metadata_request(payment_method: "pm_123", response: {})
           stub_payment_intents_post_request order: order
           stub_successful_capture_request order: order
-          stub_customers_post_request email: user.email
+          stub_customers_post_request email: "test@test.com" # First checkout with default details
+          stub_customers_post_request email: user.email # Second checkout with saved user details
           stub_payment_method_attach_request
         end
 


### PR DESCRIPTION
The first time the checkout is submitted here it uses the defaults in `CheckoutRequestHelper#fill_out_details`.

The second time uses the customer's saved details.

Fixes:
```
3) Check out with Stripe using Stripe SCA with a logged in user saving a card and re-using it allows saving a card and re-using it
     Failure/Error: raise exception.message
     
     RuntimeError:
       Real HTTP connections are disabled. Unregistered request: POST https://api.stripe.com/v1/customers with body 'email=test%40test.com' with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic c2tfdGVzdF8xMjM0NTo=', 'Connection'=>'close', 'Content-Type'=>'application/x-www-form-urlencoded', 'Stripe-Version'=>'2019-05-16', 'User-Agent'=>'Stripe/v1 ActiveMerchantBindings/1.119.0', 'X-Stripe-Client-User-Agent'=>'{"bindings_version":"1.119.0","lang":"ruby","lang_version":"2.5.8 p224 (2020-03-31)","platform":"x86_64-linux","publisher":"active_merchant"}', 'X-Stripe-Client-User-Metadata'=>'{"ip":null}'}
```