### PR TITLE
[Rails 5.2] Fix missing card number during checkout

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -201,7 +201,6 @@ module Spree
     end
 
     def update_order
-      order.payments.reload
       order.update!
     end
 

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -274,7 +274,7 @@ module Api
 
       before do
         order.finalize!
-        create(:check_payment, order: order, amount: order.total)
+        order.payments << create(:check_payment, order: order, amount: order.total)
         allow(controller).to receive(:spree_current_user) { order.distributor.owner }
       end
 

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -65,7 +65,7 @@ feature '
     context "with a capturable order" do
       before do
         order.finalize! # ensure order has a payment to capture
-        create :check_payment, order: order, amount: order.total
+        order.payments << create(:check_payment, order: order, amount: order.total)
       end
 
       scenario "capture payment" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1188,7 +1188,7 @@ describe Spree::Order do
       it "advances to complete state without error" do
         advance_to_delivery_state(order)
         order.next!
-        create(:payment, order: order)
+        order.payments << create(:payment, order: order)
 
         expect { order.next! }.to change { order.state }.from("payment").to("complete")
       end


### PR DESCRIPTION
Closes #7386 

- Removes reloading of payments in payment after_save callback. This resolved an issue where we store credit card numbers on the payment source object in memory _only_ (we don't persist them), and if the object is reloaded the card number vanishes before the payment is processed.
- Updates some test setups to ensure programaticllay added payments in tests are actually assigned to `order.payments`.

Fixes:
```
1) As a consumer I want to check out my cart guest checkout purchasing with basic details filled credit card payments with a credit card payment method using Spree::Gateway::Bogus takes us to the order confirmation page when submitted with a valid credit card
     Failure/Error: expect(page).to have_content "Your order has been processed successfully"
       expected to find text "Your order has been processed successfully" in "SHOPS\nMAP\nPRODUCERS\nGROUPS\nABOUT
    ...
# ./spec/features/consumer/shopping/checkout_spec.rb:485:in `block (8 levels) in <top (required)>'
```