### PR TITLE
Added Advanced Settings Toggle to Incoming and Outgoing Products Tab

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -62,7 +62,7 @@ module Admin
       if @order_cycle_form.save
         respond_to do |format|
           flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
-          format.html { redirect_to main_app.edit_admin_order_cycle_path(@order_cycle) }
+          format.html { redirect_to request.referrer }
           format.json { render json: { success: true } }
         end
       else

--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -62,7 +62,7 @@ module Admin
       if @order_cycle_form.save
         respond_to do |format|
           flash[:notice] = I18n.t(:order_cycles_update_notice) if params[:reloading] == '1'
-          format.html { redirect_to request.referrer }
+          format.html { redirect_to request.referer }
           format.json { render json: { success: true } }
         end
       else

--- a/app/views/admin/order_cycles/_advanced_settings_toggle.html.haml
+++ b/app/views/admin/order_cycles/_advanced_settings_toggle.html.haml
@@ -1,0 +1,14 @@
+:javascript
+  function toggleSettings(){
+    if( $('#advanced_settings').is(":visible") ){
+      $('button#toggle_settings i').switchClass("icon-chevron-up","icon-chevron-down")
+    }
+    else {
+      $('button#toggle_settings i').switchClass("icon-chevron-down","icon-chevron-up")
+    }
+    $("#advanced_settings").slideToggle()
+  }
+%li
+  %button#toggle_settings{ onClick: 'toggleSettings()' }
+    = t('.advanced_settings')
+    %i.icon-chevron-down

--- a/app/views/admin/order_cycles/edit.html.haml
+++ b/app/views/admin/order_cycles/edit.html.haml
@@ -1,22 +1,9 @@
 - content_for :page_actions do
-  :javascript
-    function toggleSettings(){
-      if( $('#advanced_settings').is(":visible") ){
-        $('button#toggle_settings i').switchClass("icon-chevron-up","icon-chevron-down")
-      }
-      else {
-        $('button#toggle_settings i').switchClass("icon-chevron-down","icon-chevron-up")
-      }
-      $("#advanced_settings").slideToggle()
-    }
-
   - if can? :notify_producers, @order_cycle
     %li
       = button_to t(:notify_producers), main_app.notify_producers_admin_order_cycle_path, :id => 'admin_notify_producers', :confirm => t(:are_you_sure)
-  %li
-    %button#toggle_settings{ onClick: 'toggleSettings()' }
-      = t('.advanced_settings')
-      %i.icon-chevron-down
+
+  = render partial: "/admin/order_cycles/advanced_settings_toggle"
 
 #advanced_settings{ hidden: true }
   = render partial: "/admin/order_cycles/advanced_settings"

--- a/app/views/admin/order_cycles/incoming.html.haml
+++ b/app/views/admin/order_cycles/incoming.html.haml
@@ -1,3 +1,9 @@
+- content_for :page_actions do
+  = render partial: "/admin/order_cycles/advanced_settings_toggle"
+
+#advanced_settings{ hidden: true }
+  = render partial: "/admin/order_cycles/advanced_settings"
+
 - content_for :page_title do
   = t :edit_order_cycle
 

--- a/app/views/admin/order_cycles/outgoing.html.haml
+++ b/app/views/admin/order_cycles/outgoing.html.haml
@@ -1,3 +1,9 @@
+- content_for :page_actions do
+  = render partial: "/admin/order_cycles/advanced_settings_toggle"
+
+#advanced_settings{ hidden: true }
+  = render partial: "/admin/order_cycles/advanced_settings"
+
 - content_for :page_title do
   = t :edit_order_cycle
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -891,7 +891,6 @@ ar:
         cancel: "إلغاء"
         back_to_list: "العودة للقائمة"
       edit:
-        advanced_settings: "إعدادات متقدمة"
         save: "حفظ"
         save_and_next: "حفظ والتالي"
         next: "التالى"
@@ -944,6 +943,8 @@ ar:
         preferred_product_selection_from_coordinator_inventory_only_here: متسقين المخزون فقط
         preferred_product_selection_from_coordinator_inventory_only_all: جميع المنتجات المتاحة
         save_reload: حفظ وتحديث الصفحة
+      advanced_settings_toggle:
+        advanced_settings: "إعدادات متقدمة"
       coordinator_fees:
         add: إضافة رسوم منسق
       filters:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -928,7 +928,6 @@ ca:
         cancel: "Cancel·lar"
         back_to_list: "Tornar a la llista"
       edit:
-        advanced_settings: "Configuració avançada"
         save: "Desa"
         save_and_next: "Desa i següent"
         next: "Següent"
@@ -981,6 +980,8 @@ ca:
         preferred_product_selection_from_coordinator_inventory_only_here: Només inventari del coordinador
         preferred_product_selection_from_coordinator_inventory_only_all: Tots els productes disponibles
         save_reload: Desa i recarrega la pàgina
+      advanced_settings_toggle:
+        advanced_settings: "Configuració avançada"
       coordinator_fees:
         add: Afegeix una comissió del coordinador
       filters:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -887,7 +887,6 @@ cy:
         cancel: "Canslo"
         back_to_list: "Yn ôl i&#39;r Rhestr"
       edit:
-        advanced_settings: "Lleoliadau uwch"
         save: "Arbedwch"
         save_and_next: "Arbed a Nesaf"
         next: "Nesaf"
@@ -940,6 +939,8 @@ cy:
         preferred_product_selection_from_coordinator_inventory_only_here: Rhestr y Cydlynydd yn Unig
         preferred_product_selection_from_coordinator_inventory_only_all: Yr holl Gynhyrchion sydd ar Gael
         save_reload: Cadw a Ail-lwytho Tudalen
+      advanced_settings_toggle:
+        advanced_settings: "Lleoliadau uwch"
       coordinator_fees:
         add: Ychwanegu ffi cydlynydd
       filters:

--- a/config/locales/de_DE.yml
+++ b/config/locales/de_DE.yml
@@ -925,7 +925,6 @@ de_DE:
         cancel: "Abbrechen"
         back_to_list: "Zurück zur Liste"
       edit:
-        advanced_settings: "Erweiterte Einstellungen"
         save: "Speichern"
         save_and_next: "Speichern und weiter"
         next: "Weiter"
@@ -978,6 +977,8 @@ de_DE:
         preferred_product_selection_from_coordinator_inventory_only_here: Nur vom Katalog des Koordinators
         preferred_product_selection_from_coordinator_inventory_only_all: Alle verfügbaren Produkte
         save_reload: Speichern und neu laden
+      advanced_settings_toggle:
+        advanced_settings: "Erweiterte Einstellungen"
       coordinator_fees:
         add: Koordinatorgebühr hinzufügen
       filters:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -979,7 +979,6 @@ en:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -1032,6 +1031,8 @@ en:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -897,7 +897,6 @@ en_AU:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -950,6 +949,8 @@ en_AU:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_BE.yml
+++ b/config/locales/en_BE.yml
@@ -832,7 +832,6 @@ en_BE:
         create: "Create"
         cancel: "Cancel"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         next: "Next"
         cancel: "Cancel"
@@ -872,6 +871,8 @@ en_BE:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_CA.yml
+++ b/config/locales/en_CA.yml
@@ -923,7 +923,6 @@ en_CA:
         cancel: "Cancel"
         back_to_list: "Back to List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -976,6 +975,8 @@ en_CA:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_DE.yml
+++ b/config/locales/en_DE.yml
@@ -840,7 +840,6 @@ en_DE:
         create: "Create"
         cancel: "Cancel"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         next: "Next"
         cancel: "Cancel"
@@ -880,6 +879,8 @@ en_DE:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_FR.yml
+++ b/config/locales/en_FR.yml
@@ -925,7 +925,6 @@ en_FR:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -978,6 +977,8 @@ en_FR:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -923,7 +923,6 @@ en_GB:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -976,6 +975,8 @@ en_GB:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_IE.yml
+++ b/config/locales/en_IE.yml
@@ -923,7 +923,6 @@ en_IE:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -976,6 +975,8 @@ en_IE:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_IN.yml
+++ b/config/locales/en_IN.yml
@@ -862,7 +862,6 @@ en_IN:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -915,6 +914,8 @@ en_IN:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_NZ.yml
+++ b/config/locales/en_NZ.yml
@@ -889,7 +889,6 @@ en_NZ:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -942,6 +941,8 @@ en_NZ:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_PH.yml
+++ b/config/locales/en_PH.yml
@@ -855,7 +855,6 @@ en_PH:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -907,6 +906,8 @@ en_PH:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -923,7 +923,6 @@ en_US:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -976,6 +975,8 @@ en_US:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/en_ZA.yml
+++ b/config/locales/en_ZA.yml
@@ -856,7 +856,6 @@ en_ZA:
         cancel: "Cancel"
         back_to_list: "Back To List"
       edit:
-        advanced_settings: "Advanced Settings"
         save: "Save"
         save_and_next: "Save and Next"
         next: "Next"
@@ -909,6 +908,8 @@ en_ZA:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+      advanced_settings_toggle:
+        advanced_settings: "Advanced Settings"
       coordinator_fees:
         add: Add coordinator fee
       filters:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -927,7 +927,6 @@ es:
         cancel: "Cancelar"
         back_to_list: "Regresar a la lista"
       edit:
-        advanced_settings: "Configuración Avanzada"
         save: "Guardar"
         save_and_next: "Salvar y continuar"
         next: "Siguiente"
@@ -980,6 +979,8 @@ es:
         preferred_product_selection_from_coordinator_inventory_only_here: Solo el Inventario de la Coordinadora
         preferred_product_selection_from_coordinator_inventory_only_all: Todos los productos disponibles
         save_reload: Guardar y recargar la página
+      advanced_settings_toggle:
+        advanced_settings: "Configuración Avanzada"
       coordinator_fees:
         add: Añadir comisión para el coordinador
       filters:

--- a/config/locales/es_CO.yml
+++ b/config/locales/es_CO.yml
@@ -871,7 +871,6 @@ es_CO:
         cancel: "Cancelar"
         back_to_list: "Regresar a la lista"
       edit:
-        advanced_settings: "Configuración avanzada"
         save: "Guardar"
         save_and_next: "Guardar y continuar"
         next: "Siguiente"
@@ -924,6 +923,8 @@ es_CO:
         preferred_product_selection_from_coordinator_inventory_only_here: Solo el inventario del coordinador
         preferred_product_selection_from_coordinator_inventory_only_all: Todos los productos disponibles
         save_reload: Guardar y recargar la página
+      advanced_settings_toggle:
+        advanced_settings: "Configuración avanzada"
       coordinator_fees:
         add: Añadir comisión para el coordinador
       filters:

--- a/config/locales/es_CR.yml
+++ b/config/locales/es_CR.yml
@@ -858,7 +858,6 @@ es_CR:
         cancel: "Cancelar"
         back_to_list: "Regresar a la lista"
       edit:
-        advanced_settings: "Configuración avanzada"
         save: "Guardar"
         save_and_next: "Guardar y continuar"
         next: "Siguiente"
@@ -910,6 +909,8 @@ es_CR:
         preferred_product_selection_from_coordinator_inventory_only_here: Solo el inventario del coordinador
         preferred_product_selection_from_coordinator_inventory_only_all: Todos los productos disponibles
         save_reload: Guardar y recargar la página
+      advanced_settings_toggle:
+        advanced_settings: "Configuración avanzada"
       coordinator_fees:
         add: Añadir comisión para el coordinador
       filters:

--- a/config/locales/es_US.yml
+++ b/config/locales/es_US.yml
@@ -891,7 +891,6 @@ es_US:
         cancel: "Cancelar"
         back_to_list: "Regresar a la lista"
       edit:
-        advanced_settings: "Configuración Avanzada"
         save: "Guardar"
         save_and_next: "Salvar y continuar"
         next: "Siguiente"
@@ -944,6 +943,8 @@ es_US:
         preferred_product_selection_from_coordinator_inventory_only_here: Solo el Inventario de la Coordinadora
         preferred_product_selection_from_coordinator_inventory_only_all: Todos los productos disponibles
         save_reload: Guardar y recargar la página
+      advanced_settings_toggle:
+        advanced_settings: "Configuración Avanzada"
       coordinator_fees:
         add: Añadir comisión para el coordinador
       filters:

--- a/config/locales/fil_PH.yml
+++ b/config/locales/fil_PH.yml
@@ -858,7 +858,6 @@ fil_PH:
         cancel: "kanselahin"
         back_to_list: "bumalik sa listahan"
       edit:
-        advanced_settings: "Advanced settings"
         save: "i-save"
         save_and_next: "i-save at sunod"
         next: "sunod"
@@ -910,6 +909,8 @@ fil_PH:
         preferred_product_selection_from_coordinator_inventory_only_here: imbentaryo lamang ng coordinator
         preferred_product_selection_from_coordinator_inventory_only_all: lahat ng produktong mayroon
         save_reload: i-save at i-reload ang pahina
+      advanced_settings_toggle:
+        advanced_settings: "Advanced settings"
       coordinator_fees:
         add: magdagdag ng fee sa coordinator
       filters:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -927,7 +927,6 @@ fr:
         cancel: "Annuler"
         back_to_list: "Retour à la liste"
       edit:
-        advanced_settings: "Paramétrages avancés"
         save: "Sauvegarder"
         save_and_next: "Sauvegarder et suivant"
         next: "Suivant"
@@ -980,6 +979,8 @@ fr:
         preferred_product_selection_from_coordinator_inventory_only_here: Uniquement les produits du catalogue boutique
         preferred_product_selection_from_coordinator_inventory_only_all: Tous les produits disponibles dans les catalogues producteurs
         save_reload: Sauvegarder et rafraichir la page
+      advanced_settings_toggle:
+        advanced_settings: "Paramétrages avancés"
       coordinator_fees:
         add: Ajouter commission coordinateur
       filters:

--- a/config/locales/fr_BE.yml
+++ b/config/locales/fr_BE.yml
@@ -873,7 +873,6 @@ fr_BE:
         cancel: "Annuler"
         back_to_list: "Retour à la liste"
       edit:
-        advanced_settings: "Paramétrages avancés"
         save: "Sauvergarder"
         save_and_next: "Sauver et suivant"
         next: "Suivant"
@@ -926,6 +925,8 @@ fr_BE:
         preferred_product_selection_from_coordinator_inventory_only_here: Uniquement les produits du catalogue magasin
         preferred_product_selection_from_coordinator_inventory_only_all: Tous les produits disponibles dans les catalogues producteurs
         save_reload: Sauvegarder et rafraichir la page
+      advanced_settings_toggle:
+        advanced_settings: "Paramétrages avancés"
       coordinator_fees:
         add: Ajouter commission coordinateur
       filters:

--- a/config/locales/fr_CA.yml
+++ b/config/locales/fr_CA.yml
@@ -893,7 +893,6 @@ fr_CA:
         cancel: "Annuler"
         back_to_list: "Retour à la liste"
       edit:
-        advanced_settings: "Paramétrages avancés"
         save: "Enregistrer"
         save_and_next: "Sauvegarder et suivant"
         next: "Suivant"
@@ -946,6 +945,8 @@ fr_CA:
         preferred_product_selection_from_coordinator_inventory_only_here: Uniquement le catalogue boutique du coordinateur
         preferred_product_selection_from_coordinator_inventory_only_all: Tous les produits disponibles dans les catalogues producteurs
         save_reload: Sauvegarder et rafraichir la page
+      advanced_settings_toggle:
+        advanced_settings: "Paramétrages avancés"
       coordinator_fees:
         add: Ajouter commission coordinateur
       filters:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -924,7 +924,6 @@ it:
         cancel: "Annulla"
         back_to_list: "Indietro alla lista"
       edit:
-        advanced_settings: "Impostazioni avanzate"
         save: "Salva"
         save_and_next: "Salva e continua"
         next: "Prossimo"
@@ -977,6 +976,8 @@ it:
         preferred_product_selection_from_coordinator_inventory_only_here: Solo inventario del coordinatore
         preferred_product_selection_from_coordinator_inventory_only_all: Tutti i prodotti disponibili
         save_reload: Salva e ricarica la pagina
+      advanced_settings_toggle:
+        advanced_settings: "Impostazioni avanzate"
       coordinator_fees:
         add: Aggiungi un ricarico per il coordinamento
       filters:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -887,7 +887,6 @@ nb:
         cancel: "Avbryt"
         back_to_list: "Tilbake til Listen"
       edit:
-        advanced_settings: "Avanserte Innstillinger"
         save: "Lagre"
         save_and_next: "Lagre og Neste"
         next: "Neste"
@@ -940,6 +939,8 @@ nb:
         preferred_product_selection_from_coordinator_inventory_only_here: Kun Koordinators varelager
         preferred_product_selection_from_coordinator_inventory_only_all: Alle tilgjengelige produkter
         save_reload: Lagre og last siden på nytt
+      advanced_settings_toggle:
+        advanced_settings: "Avanserte Innstillinger"
       coordinator_fees:
         add: Legg til koordinatoravgift
       filters:

--- a/config/locales/nl_BE.yml
+++ b/config/locales/nl_BE.yml
@@ -875,7 +875,6 @@ nl_BE:
         cancel: "Annuleren"
         back_to_list: "Terug naar lijst"
       edit:
-        advanced_settings: "Geavanceerde Instellingen"
         save: "Save"
         save_and_next: "Opslaan en volgende"
         next: "Volgende"
@@ -928,6 +927,8 @@ nl_BE:
         preferred_product_selection_from_coordinator_inventory_only_here: 'Enkel Coördinator Inventaris '
         preferred_product_selection_from_coordinator_inventory_only_all: Alle Beschikbare Producten
         save_reload: Bewaar en Herlaad Webpagina
+      advanced_settings_toggle:
+        advanced_settings: "Geavanceerde Instellingen"
       coordinator_fees:
         add: Voeg Coördinatievergoeding toe
       filters:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -869,7 +869,6 @@ pl:
         cancel: "Anuluj"
         back_to_list: "Powrót do listy"
       edit:
-        advanced_settings: "Zaawansowane ustawienia"
         save: "Zapisz"
         save_and_next: "Zapisz i Dalej"
         next: "Kolejny"
@@ -922,6 +921,8 @@ pl:
         preferred_product_selection_from_coordinator_inventory_only_here: Tylko ekwipunek koordynatora
         preferred_product_selection_from_coordinator_inventory_only_all: Wszystkie dostępne produkty
         save_reload: Zapisz i załaduj ponownie stronę
+      advanced_settings_toggle:
+        advanced_settings: "Zaawansowane ustawienia"
       coordinator_fees:
         add: Dodaj opłatę koordynacyjną
       filters:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -879,7 +879,6 @@ pt:
         cancel: "Cancelar"
         back_to_list: "Voltar à Lista"
       edit:
-        advanced_settings: "Configurações Avançadas"
         save: "Guardar"
         save_and_next: "Guardar e Continuar"
         next: "Seguinte"
@@ -925,6 +924,8 @@ pt:
         preferred_product_selection_from_coordinator_inventory_only_here: Apenas inventário do coordenador
         preferred_product_selection_from_coordinator_inventory_only_all: Todos os Produtos Disponíveis
         save_reload: Guardar e recarregar página
+      advanced_settings_toggle:
+        advanced_settings: "Configurações Avançadas"
       coordinator_fees:
         add: Adicionar taxa de coordenador
       filters:

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -888,7 +888,6 @@ pt_BR:
         cancel: "Cancelar"
         back_to_list: "Voltar Para a Lista"
       edit:
-        advanced_settings: "Configurações avançadas"
         save: "Salvar"
         save_and_next: "Salvar e Seguir"
         next: "Próximo"
@@ -941,6 +940,8 @@ pt_BR:
         preferred_product_selection_from_coordinator_inventory_only_here: Apenas inventário do coordenador
         preferred_product_selection_from_coordinator_inventory_only_all: Todos os produtos disponíveis
         save_reload: Salvar e atualizar página
+      advanced_settings_toggle:
+        advanced_settings: "Configurações avançadas"
       coordinator_fees:
         add: Adicionar taxa de coordenador
       filters:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -925,7 +925,6 @@ ru:
         cancel: "Отмена"
         back_to_list: "Назад К Списку"
       edit:
-        advanced_settings: "Расширенные Настройки"
         save: "Сохранить"
         save_and_next: "Сохранить И Далее"
         next: "Далее"
@@ -978,6 +977,8 @@ ru:
         preferred_product_selection_from_coordinator_inventory_only_here: Только Товарная Номенклатура Координатора
         preferred_product_selection_from_coordinator_inventory_only_all: Все Доступные Товары
         save_reload: Сохранить и Обновить Страницу
+      advanced_settings_toggle:
+        advanced_settings: "Расширенные Настройки"
       coordinator_fees:
         add: Добавить сбор координатора
       filters:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -495,7 +495,6 @@ sv:
         create: "Skapa"
         cancel: "Avbryt"
       edit:
-        advanced_settings: "Avancerade inställningar"
         next: "Näst"
         cancel: "Avbryt"
         choose_products_from: "Välj produkter från:"
@@ -523,6 +522,8 @@ sv:
         preferred_product_selection_from_coordinator_inventory_only_here: Enbart koordinatorns inventarielista
         preferred_product_selection_from_coordinator_inventory_only_all: Alla tillgängliga produkter
         save_reload: Spara och ladda om sidan
+      advanced_settings_toggle:
+        advanced_settings: "Avancerade inställningar"
       coordinator_fees:
         add: Lägg till koordinatoravgift
       form:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -887,7 +887,6 @@ tr:
         cancel: "İptal et"
         back_to_list: "Listeye geri dön"
       edit:
-        advanced_settings: "Gelişmiş Ayarlar"
         save: "Kaydet"
         save_and_next: "Kaydet ve İlerle"
         next: "Sonrakİ"
@@ -940,6 +939,8 @@ tr:
         preferred_product_selection_from_coordinator_inventory_only_here: Yalnızca Koordinatör Stokları
         preferred_product_selection_from_coordinator_inventory_only_all: Tüm Mevcut Ürünler
         save_reload: SAYFAYI KAYDET VE YENİDEN YÜKLE
+      advanced_settings_toggle:
+        advanced_settings: "Gelişmiş Ayarlar"
       coordinator_fees:
         add: Koordinatör ücreti ekle
       filters:

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -288,6 +288,42 @@ feature '
         occ = OrderCycle.last
         expect(occ.name).to eq("COPY OF #{oc.name}")
       end
+
+      scenario "changing advanced settings from incoming products and outgoing products tab" do
+        distributor_managed.update_attribute(:enable_subscriptions, true)
+        visit admin_order_cycles_path
+        click_link 'New Order Cycle'
+        select2_select 'Managed distributor', from: 'coordinator_id'
+        click_button "Continue >"
+
+        fill_in 'order_cycle_name', with: 'My order cycle 2'
+        fill_in 'order_cycle_orders_open_at', with: '2040-11-06 06:00:00'
+        fill_in 'order_cycle_orders_close_at', with: '2040-11-13 17:00:00'
+        click_button 'Create'
+
+        expect(page).to have_button 'Advanced Settings'
+        click_button 'Advanced Settings'
+        page.find('#order_cycle_preferred_product_selection_from_coordinator_inventory_only_true').click
+        click_button 'Save and Reload Page'
+
+        expect(page).to have_select 'new_supplier_id'
+        expect(page).not_to have_select 'new_supplier_id', with_options: [supplier_unmanaged.name]
+
+        expect(find(:select, 'new_supplier_id')).to have_selector(:option, 'Managed supplier', disabled: true)
+        expect(page).to have_button 'Next'
+        click_button 'Next'
+
+        expect(page).to have_button 'Advanced Settings'
+        click_button 'Advanced Settings'
+        page.find('#order_cycle_preferred_product_selection_from_coordinator_inventory_only_false').click
+        click_button 'Save and Reload Page'
+        click_button 'Advanced Settings'
+        page.find('#order_cycle_preferred_product_selection_from_coordinator_inventory_only_true').click
+        click_button 'Save and Reload Page'
+
+        expect(page).to have_button 'Back To List'
+        click_button 'Back To List'
+      end
     end
 
     context "that is a manager of a participating producer" do


### PR DESCRIPTION
#### What? Why?

Users aren't able to toggle the advanced settings box and choose between using inventory or all products on the incoming and outgoing products tab when creating/editing order cycles. Currently, users must first create their order cycle and go back and edit it later to change this. 

Closes #5128

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
User is able to access the advanced settings options on the incoming and outgoing products tabs when creating and editing order cycles. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Added advanced settings option to incoming and outgoing product tabs when creating and editing order cycles. 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
