### PR TITLE
Increase DB connection pool size for specs

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch('OFN_DB_POOL', 5) %>
+  pool: <%= ENV.fetch('OFN_DB_POOL', 6) %>
   host: <%= ENV.fetch('OFN_DB_HOST', 'localhost') %>
   username: <%= ENV.fetch('OFN_DB_USERNAME', 'ofn') %>
   password: <%= ENV.fetch('OFN_DB_PASSWORD', 'f00d') %>


### PR DESCRIPTION
#### What? Why?

Closes #7391

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

A spec failed with this message:

    ActiveRecord::ConnectionTimeoutError:
      could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use

The error seems to be raised when trying to authenticate the user
through Devise in a before_action block. Increasing the pool size by one
helped.

I don't know why our app needs more than 5 connections at the same time.
Maybe some gem "forgets" to release connections?



#### What should we test?
<!-- List which features should be tested and how. -->

No test needed. This change affects only the dev and test config.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Resolved intermittent failures of an automated test.

