### PR TITLE
Enable customer_balance toggle in tests

### DIFF
--- a/config/initializers/feature_toggles.rb
+++ b/config/initializers/feature_toggles.rb
@@ -1,9 +1,7 @@
 require 'open_food_network/feature_toggle'
 
-beta_testers = ENV['BETA_TESTERS']&.split(/[\s,]+/) || []
-
 OpenFoodNetwork::FeatureToggle.enable(:customer_balance) do |user|
-  !Rails.env.test?
+  true
 end
 
 OpenFoodNetwork::FeatureToggle.enable(:unit_price) do

--- a/engines/order_management/spec/services/order_management/subscriptions/payment_setup_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/payment_setup_spec.rb
@@ -17,7 +17,7 @@ module OrderManagement
 
           before do
             allow(order).to receive(:pending_payments).once { [] }
-            allow(order).to receive(:old_outstanding_balance) { 5 }
+            allow(order).to receive(:new_outstanding_balance) { 5 }
             allow(order).to receive(:subscription) { subscription }
           end
 
@@ -31,14 +31,15 @@ module OrderManagement
           before { allow(order).to receive(:pending_payments).once { [payment] } }
 
           context "when the payment total doesn't match the outstanding balance on the order" do
-            before { allow(order).to receive(:old_outstanding_balance) { 5 } }
+            before { allow(order).to receive(:new_outstanding_balance) { 5 } }
+
             it "updates the payment total to reflect the outstanding balance" do
               expect{ payment_setup.call! }.to change(payment, :amount).from(10).to(5)
             end
           end
 
           context "when the payment total matches the outstanding balance on the order" do
-            before { allow(order).to receive(:old_outstanding_balance) { 10 } }
+            before { allow(order).to receive(:new_outstanding_balance) { 10 } }
 
             it "does nothing" do
               expect{ payment_setup.call! }.to_not change(payment, :amount).from(10)
@@ -51,7 +52,7 @@ module OrderManagement
           let!(:payment2) { create(:payment, order: order) }
 
           before do
-            allow(order).to receive(:old_outstanding_balance) { 7 }
+            allow(order).to receive(:new_outstanding_balance) { 7 }
             allow(order).to receive(:pending_payments).once { [payment1, payment2] }
           end
 

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -43,47 +43,20 @@ module Admin
               get :index, params: params
             end
 
-            context 'when the customer_balance feature is enabled' do
-              let(:customers_with_balance) { instance_double(CustomersWithBalance) }
+            it 'calls CustomersWithBalance' do
+              customers_with_balance = instance_double(CustomersWithBalance) 
+              allow(CustomersWithBalance)
+                .to receive(:new).with(enterprise) { customers_with_balance }
 
-              before do
-                allow(OpenFoodNetwork::FeatureToggle)
-                  .to receive(:enabled?).with(:customer_balance, enterprise.owner) { true }
-              end
+              expect(customers_with_balance).to receive(:query) { Customer.none }
 
-              it 'calls CustomersWithBalance' do
-                allow(CustomersWithBalance)
-                  .to receive(:new).with(enterprise) { customers_with_balance }
-
-                expect(customers_with_balance).to receive(:query) { Customer.none }
-
-                get :index, params: params
-              end
-
-              it 'serializes using CustomerWithBalanceSerializer' do
-                expect(Api::Admin::CustomerWithBalanceSerializer).to receive(:new)
-
-                get :index, params: params
-              end
+              get :index, params: params
             end
 
-            context 'when the customer_balance feature is not enabled' do
-              let(:calculator) do
-                instance_double(OpenFoodNetwork::UserBalanceCalculator, balance: 0)
-              end
+            it 'serializes using CustomerWithBalanceSerializer' do
+              expect(Api::Admin::CustomerWithBalanceSerializer).to receive(:new)
 
-              it 'calls Customer.of' do
-                expect(Customer).to receive(:of).twice.with(enterprise) { Customer.none }
-
-                get :index, params: params
-              end
-
-              it 'serializes calling the UserBalanceCalculator' do
-                expect(OpenFoodNetwork::UserBalanceCalculator)
-                  .to receive(:new).with(customer.email, customer.enterprise) { calculator }
-
-                get :index, params: params
-              end
+              get :index, params: params
             end
 
             context 'when the customer has no orders' do

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -15,7 +15,7 @@ describe Spree::OrderMailer do
     end
 
     context 'when the order has outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 123 } }
+      before { allow(order).to receive(:new_outstanding_balance) { 123 } }
 
       it 'renders the amount as money' do
         expect(email.body).to include('$123')
@@ -23,7 +23,7 @@ describe Spree::OrderMailer do
     end
 
     context 'when the order has no outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 0 } }
+      before { allow(order).to receive(:new_outstanding_balance) { 0 } }
 
       it 'displays the payment status' do
         expect(email.body).to include(I18n.t(:email_payment_not_paid))
@@ -58,7 +58,7 @@ describe Spree::OrderMailer do
     end
 
     context 'when the order has outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 123 } }
+      before { allow(order).to receive(:new_outstanding_balance) { 123 } }
 
       it 'renders the amount as money' do
         expect(email.body).to include('$123')
@@ -66,8 +66,6 @@ describe Spree::OrderMailer do
     end
 
     context 'when the order has no outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 0 } }
-
       it 'displays the payment status' do
         expect(email.body).to include(I18n.t(:email_payment_not_paid))
       end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -88,7 +88,7 @@ describe SubscriptionMailer, type: :mailer do
     end
 
     context 'when the order has outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 123 } }
+      before { allow(order).to receive(:new_outstanding_balance) { 123 } }
 
       it 'renders the amount as money' do
         expect(email.body).to include('$123')
@@ -96,7 +96,7 @@ describe SubscriptionMailer, type: :mailer do
     end
 
     context 'when the order has no outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 0 } }
+      before { allow(order).to receive(:new_outstanding_balance) { 0 } }
 
       it 'displays the payment status' do
         expect(email.body).to include(I18n.t(:email_payment_not_paid))
@@ -141,7 +141,7 @@ describe SubscriptionMailer, type: :mailer do
     end
 
     context 'when the order has outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 123 } }
+      before { allow(order).to receive(:new_outstanding_balance) { 123 } }
 
       it 'renders the amount as money' do
         expect(email.body).to include('$123')
@@ -149,7 +149,7 @@ describe SubscriptionMailer, type: :mailer do
     end
 
     context 'when the order has no outstanding balance' do
-      before { allow(order).to receive(:old_outstanding_balance) { 0 } }
+      before { allow(order).to receive(:new_outstanding_balance) { 0 } }
 
       it 'displays the payment status' do
         expect(email.body).to include(I18n.t(:email_payment_not_paid))

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -310,7 +310,7 @@ describe Spree::Order do
 
   context "#display_outstanding_balance" do
     it "returns the value as a spree money" do
-      allow(order).to receive(:old_outstanding_balance) { 10.55 }
+      allow(order).to receive(:new_outstanding_balance) { 10.55 }
       expect(order.display_outstanding_balance).to eq Spree::Money.new(10.55)
     end
   end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -382,7 +382,7 @@ describe Spree::Payment do
           end
 
           it "resulting payment should have correct values" do
-            allow(payment.order).to receive(:old_outstanding_balance) { 100 }
+            allow(payment.order).to receive(:new_outstanding_balance) { 100 }
             allow(payment).to receive(:credit_allowed) { 10 }
 
             offsetting_payment = payment.credit!

--- a/spec/serializers/api/order_serializer_spec.rb
+++ b/spec/serializers/api/order_serializer_spec.rb
@@ -6,6 +6,10 @@ describe Api::OrderSerializer do
   let(:serializer) { Api::OrderSerializer.new order }
   let(:order) { create(:completed_order_with_totals) }
 
+  before do
+    allow(order).to receive(:balance_value).and_return(-1.23)
+  end
+
   describe '#serializable_hash' do
     let!(:completed_payment) do
       create(:payment, order: order, state: 'completed', amount: order.total - 1)
@@ -31,30 +35,8 @@ describe Api::OrderSerializer do
   end
 
   describe '#outstanding_balance' do
-    context 'when the customer_balance feature is enabled' do
-      before do
-        allow(OpenFoodNetwork::FeatureToggle)
-          .to receive(:enabled?).with(:customer_balance, order.user) { true }
-
-        allow(order).to receive(:balance_value).and_return(-1.23)
-      end
-
-      it "returns the object's balance_value from the users perspective" do
-        expect(serializer.serializable_hash[:outstanding_balance]).to eq(1.23)
-      end
-    end
-
-    context 'when the customer_balance is disabled' do
-      before do
-        allow(OpenFoodNetwork::FeatureToggle)
-          .to receive(:enabled?).with(:customer_balance, order.user) { false }
-
-        allow(order).to receive(:old_outstanding_balance).and_return(123.0)
-      end
-
-      it 'calls #outstanding_balance on the object' do
-        expect(serializer.serializable_hash[:outstanding_balance]).to eq(123.0)
-      end
+    it "returns the object's balance_value from the users perspective" do
+      expect(serializer.serializable_hash[:outstanding_balance]).to eq(1.23)
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

This makes all tests exercise the new branch that `OrderBalance` abstracts. It follows up #7363 addressing code review comments.

#### What should we test?

Green build.

#### Release notes

Enable customer_balance toggle in tests
Changelog Category: Technical changes