### PR TITLE
Fix Variant Unit Scale field initialization in Edit Product form

### DIFF
--- a/app/assets/javascripts/admin/products/controllers/edit_units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/edit_units_controller.js.coffee
@@ -9,7 +9,7 @@ angular.module("admin.products").controller "editUnitsCtrl", ($scope, VariantUni
   if $scope.product.variant_unit == 'items'
     $scope.variant_unit_with_scale = 'items'
   else
-    $scope.variant_unit_with_scale = $scope.product.variant_unit + '_' + $scope.product.variant_unit_scale
+    $scope.variant_unit_with_scale = $scope.product.variant_unit + '_' + $scope.product.variant_unit_scale.replace(/\.0$/, '');
 
   $scope.setFields = ->
     if $scope.variant_unit_with_scale == 'items'

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -488,7 +488,7 @@ feature '
           expect(flash_message).to eq('Product "a product" has been successfully updated!')
           product.reload
           expect(product.variant_unit).to eq(var_unit)
-          # TODO -> expect(page).to have_select('product_variant_unit_with_scale', :selected => dropdown_option)
+          expect(page).to have_select('product_variant_unit_with_scale', selected: dropdown_option)
           expect(product.variant_unit_scale).to eq(var_unit_scale)
         end
       end


### PR DESCRIPTION
#### What? Why?
VariantUnitManager.variantUnitOptions() returns array formatted like this:
```
["Weight (g)", "weight_1"]
```
and `product.variant_unit_scale` is formatted like this `weight_1.0` there is no possible match for the `<select />` element
So, remove the trailing `.0` from `product.variant_unit_scale` to match the options

**NB** : not sure of this one, still in `Draft`

Closes #7180 


#### What should we test?
##### Before, as super admin:
Make sure you have all unit types selected in admin/general_settings/edit -> Available Units
##### Then, as admin:
 1. Visit /admin/products/<product_name>/edit
 2. Select an option on Variant Unit Scale on the dropdown, and click Update.
 3. See that the option is well initialized with your previous saved option
 4. Repeat for other units.


#### Release notes
Initialize Variant Unit Scale field in the Edit Product form with its value

Changelog Category: User facing changes

