### PR TITLE
Ensure Shipping Methods can be created with no tax category

### DIFF
--- a/app/views/spree/admin/shipping_methods/_form.html.haml
+++ b/app/views/spree/admin/shipping_methods/_form.html.haml
@@ -49,7 +49,8 @@
   %fieldset.tax_categories.no-border-bottom
     %legend{align: "center"}= t('.tax_category')
     = f.field_container :tax_categories do
-      = f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {}, :class => "select2 fullwidth"
+      = f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] },
+        { include_blank: t(:none) }, class: "select2 fullwidth"
       = error_message_on :shipping_method, :tax_category_id
 
   %fieldset.categories.no-border-bottom


### PR DESCRIPTION
#### What? Why?

The option to apply *no* tax category should be present in the dropdown when editing a shipping method.

#### What should we test?
<!-- List which features should be tested and how. -->

When creating or editing a shipping method, "None" can be selected for the tax category, and is the default on the create page.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed missing option in shipping methods for no tax category

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes