### PR TITLE
Add greater-than-zero validation to variant unit_value

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -59,6 +59,8 @@ module Spree
       %w(weight volume).include?(variant.product.andand.variant_unit)
     }
 
+    validates :unit_value, numericality: { greater_than: 0 }
+
     validates :unit_description, presence: true, if: ->(variant) {
       variant.product.andand.variant_unit.present? && variant.unit_value.nil?
     }

--- a/db/migrate/20210414171109_add_unit_value_constraint.rb
+++ b/db/migrate/20210414171109_add_unit_value_constraint.rb
@@ -1,0 +1,10 @@
+class AddUnitValueConstraint < ActiveRecord::Migration[5.0]
+  def up
+    execute "UPDATE spree_variants SET unit_value = 1 WHERE unit_value <= 0"
+    execute "ALTER TABLE spree_variants ADD CONSTRAINT positive_unit_value CHECK (unit_value > 0)"
+  end
+
+  def down
+    execute "ALTER TABLE spree_variants DROP CONSTRAINT positive_unit_value"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210326094519) do
+ActiveRecord::Schema.define(version: 20210414171109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/api/v0/variants_controller_spec.rb
+++ b/spec/controllers/api/v0/variants_controller_spec.rb
@@ -130,7 +130,7 @@ describe Api::V0::VariantsController, type: :controller do
 
     it "can create a new variant" do
       original_number_of_variants = variant.product.variants.count
-      api_post :create, variant: { sku: "12345", unit_value: "weight", unit_description: "L" }, product_id: variant.product.to_param
+      api_post :create, variant: { sku: "12345", unit_value: "1", unit_description: "L" }, product_id: variant.product.to_param
 
       expect(attributes.all?{ |attr| json_response.include? attr.to_s }).to eq(true)
       expect(response.status).to eq(201)

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -18,6 +18,11 @@ module Spree
         variant.price = 0
         expect(variant).to be_valid
       end
+
+      it "should validate unit_value is greater than 0" do
+        variant.unit_value = 0
+        expect(variant).to be_invalid
+      end
     end
 
     context "price parsing" do


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/7322

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Setting the unit value to zero (or to a negative number) doesn't make sense and leads to inaccurate unit prices. This change prevents variants from being saved unless they have a unit value > 0


#### What should we test?
<!-- List which features should be tested and how. -->
Saving a variant with a 0 or negative value should return an error message. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Don't allow the unit value of a variant to be 0 or negative. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
