### PR TITLE
Don't show duplicate adjustments in order edit

### DIFF
--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -5,9 +5,7 @@ module Admin
     # We exclude shipping method adjustments because they are displayed in a
     # separate table together with the order line items.
     def order_adjustments_for_display(order)
-      order.all_adjustments.enterprise_fee +
-        order.all_adjustments.payment_fee.eligible +
-        order.adjustments.admin
+      order.adjustments + order.all_adjustments.payment_fee.eligible
     end
   end
 end

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -22,7 +22,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       it "does not show ineligible payment adjustments" do
         adjustment = create(
           :adjustment,
-          adjustable: order,
+          adjustable: build(:payment),
           originator_type: "Spree::PaymentMethod",
           label: "invalid adjustment",
           eligible: false,

--- a/spec/helpers/admin/orders_helper_spec.rb
+++ b/spec/helpers/admin/orders_helper_spec.rb
@@ -13,15 +13,22 @@ describe Admin::OrdersHelper, type: :helper do
     end
 
     it "filters shipping method adjustments" do
-      create(:adjustment, order: order, adjustable: order, amount: 1,
+      create(:adjustment, order: order, adjustable: build(:shipment), amount: 1,
                           originator_type: "Spree::ShippingMethod")
 
       expect(helper.order_adjustments_for_display(order)).to eq []
     end
 
-    it "filters ineligible adjustments" do
-      create(:adjustment, adjustable: order, amount: 0, eligible: false,
-                          originator_type: "Spree::TaxRate")
+    it "filters ineligible payment adjustments" do
+      create(:adjustment, adjustable: build(:payment), amount: 0, eligible: false,
+                          originator_type: "Spree::PaymentMethod", order: order)
+
+      expect(helper.order_adjustments_for_display(order)).to eq []
+    end
+
+    it "filters out line item adjustments" do
+      create(:adjustment, adjustable: build(:line_item), amount: 0, eligible: false,
+                          originator_type: "EnterpriseFee", order: order)
 
       expect(helper.order_adjustments_for_display(order)).to eq []
     end


### PR DESCRIPTION
#### What? Why?

Part of #7418 

Line item adjustments are displayed separately, if we don't filter them in `#order_adjustments_for_display` they get displayed twice.

#### What should we test?
<!-- List which features should be tested and how. -->

When an order has line item adjustments and order adjustments, they should only be displayed once on the admin edit order page, and under the correct heading.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed issue with line item adjustments being displayed twice in order edit

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
