### PR TITLE
Adjustments controller index

### DIFF
--- a/app/controllers/spree/admin/adjustments_controller.rb
+++ b/app/controllers/spree/admin/adjustments_controller.rb
@@ -18,7 +18,12 @@ module Spree
       end
 
       def collection
-        parent.all_adjustments.eligible
+        order_adjustments = parent.adjustments.where.not(originator_type: 'EnterpriseFee')
+        admin_adjustments = parent.adjustments.admin
+        payment_fees = parent.all_adjustments.payment_fee.eligible
+        shipping_fees = parent.all_adjustments.shipping
+
+        order_adjustments.or(admin_adjustments) | payment_fees.or(shipping_fees)
       end
 
       def find_resource

--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -118,6 +118,10 @@ module Spree
       Spree::Money.new(amount, currency: currency)
     end
 
+    def admin?
+      originator_type.nil?
+    end
+
     def immutable?
       state != "open"
     end

--- a/app/views/spree/admin/adjustments/_edit_form.html.haml
+++ b/app/views/spree/admin/adjustments/_edit_form.html.haml
@@ -5,18 +5,19 @@
       = text_field :adjustment, :amount, :class => 'fullwidth'
       = f.error_message_on :amount
 
-  .four.columns
-    = f.field_container :included_tax do
-      = f.label :included_tax, t(:included_tax)
-      = f.text_field :included_tax, disabled: true, class: 'fullwidth',
-        value: number_with_precision(f.object.included_tax, precision: 2)
-      = f.error_message_on :included_tax
+  - if @adjustment.admin?
+    .four.columns
+      = f.field_container :included_tax do
+        = f.label :included_tax, t(:included_tax)
+        = f.text_field :included_tax, disabled: true, class: 'fullwidth',
+          value: number_with_precision(f.object.included_tax, precision: 2)
+        = f.error_message_on :included_tax
 
-  .omega.four.columns
-    = f.field_container :tax_rate_id do
-      = f.label :tax_rate_id, t(:tax_rate)
-      = select_tag :tax_rate_id, options_from_collection_for_select(Spree::TaxRate.all, :id, :name, @tax_rate_id), prompt: t(:remove_tax), class: 'select2 fullwidth'
-      = f.error_message_on :tax_rate_id
+    .omega.four.columns
+      = f.field_container :tax_rate_id do
+        = f.label :tax_rate_id, t(:tax_rate)
+        = select_tag :tax_rate_id, options_from_collection_for_select(Spree::TaxRate.all, :id, :name, @tax_rate_id), prompt: t(:remove_tax), class: 'select2 fullwidth'
+        = f.error_message_on :tax_rate_id
 
 .row
   .alpha.omega.twelve.columns


### PR DESCRIPTION
#### What? Why?

Second part of #7418

Some of the logic around which adjustments are displayed in the table here changed recently. Apparently enterprise fees should not be included (see discussion in #7418). The upstream Spree version just displays all adjustments unconditionally here, but Spree doesn't have our enterprise fees implementation...

Also, this makes sense; if you edited an enterprise fee adjustment it would be recalculated when the "Update and Recalculate Fess" button is pressed and the changes would be reverted.

Note: I think we'll probably want to overhaul the adjustments tab pretty soon and maybe rethink the way it works and displays things, but this addresses the immediate issue in the bug report.

#### What should we test?
<!-- List which features should be tested and how. -->

Enterprise Fee adjustments are not shown in admin edit order page.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Enteprise Fee adjustments are removed from admin edit order page

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes