### PR TITLE
Show unit price in the bulk buy modal

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/shop_variant_with_unit_price.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/shop_variant_with_unit_price.js.coffee
@@ -4,4 +4,5 @@ Darkswarm.directive "shopVariantWithUnitPrice", ->
   templateUrl: 'shop_variant_with_unit_price.html'
   scope:
     variant: '='
+    show_unit_price: '=showunitprice'
   controller: 'ShopVariantCtrl'

--- a/app/assets/javascripts/templates/bulk_buy_modal.html.haml
+++ b/app/assets/javascripts/templates/bulk_buy_modal.html.haml
@@ -2,11 +2,20 @@
   .columns.small-12
     %h3{"ng-bind" => "::variant.extended_name"}
 
-.row.variant-bulk-buy-price-summary
-  .columns.small-6
-    .variant-unit {{ ::variant.unit_to_display }}
-  .columns.small-6
+.flex.variant-bulk-buy-price-summary{style: "justify-content: space-around;"}
+  .variant-unit
+    {{ ::variant.unit_to_display }}
+  .div
     {{ variant.line_item.total_price | localizeCurrency }}
+
+  .unit-price{"ng-if": "show_unit_price"}
+    %question-mark-with-tooltip{"question-mark-with-tooltip": "_",
+    "question-mark-with-tooltip-append-to-body": "true",
+    "question-mark-with-tooltip-placement": "top",
+    "question-mark-with-tooltip-animation": true,
+    style: "margin-right: 5px",
+    key: "'js.shopfront.unit_price_tooltip'"} 
+    {{ variant.unit_price_price | localizeCurrency }}&nbsp;/&nbsp;{{ variant.unit_price_unit }}
 
 .row
   .columns.small-12.medium-6

--- a/app/assets/stylesheets/shared/question-mark-icon.scss
+++ b/app/assets/stylesheets/shared/question-mark-icon.scss
@@ -37,8 +37,6 @@
       content: "";
       color: $white;
       vertical-align: super;
-      position: relative;
-      top: 2px;
     }
   }
 }

--- a/app/assets/stylesheets/shared/question-mark-icon.scss
+++ b/app/assets/stylesheets/shared/question-mark-icon.scss
@@ -56,6 +56,7 @@
   margin-left: -7.4rem;
   margin-top: -0.1rem;
   background-color: transparent;
+  z-index: $modal-zIndex + 1;
 
   .background {
     position: fixed;

--- a/app/assets/stylesheets/shared/variables/variables.scss
+++ b/app/assets/stylesheets/shared/variables/variables.scss
@@ -4,6 +4,9 @@ $white: #fff;
 $dynamic-blue: #3d8dd1;
 $teal-500: #0096ad;
 
+/* Defined in foundation-rails components/_reveal.scss */
+$modal-zIndex: 1005;
+
 @font-face {
 	font-family: 'OFN';
 	src: font-url('OFN-v2.eot');

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -14,7 +14,7 @@
                 = render "shop/products/summary"
                 .shop-variants
                   - if feature? :unit_price, spree_current_user
-                    %shop-variant-with-unit-price{variant: 'variant', "ng-repeat" => "variant in product.variants | orderBy: ['name_to_display','unit_value'] track by variant.id", "id" => "variant-{{ variant.id }}", "ng-class" => "{'out-of-stock': !variant.on_demand && variant.on_hand == 0}"}
+                    %shop-variant-with-unit-price{showunitprice: 'true', variant: 'variant', "ng-repeat" => "variant in product.variants | orderBy: ['name_to_display','unit_value'] track by variant.id", "id" => "variant-{{ variant.id }}", "ng-class" => "{'out-of-stock': !variant.on_demand && variant.on_hand == 0}"}
                   - else
                     %shop-variant{variant: 'variant', "ng-repeat" => "variant in product.variants | orderBy: ['name_to_display','unit_value'] track by variant.id", "id" => "variant-{{ variant.id }}", "ng-class" => "{'out-of-stock': !variant.on_demand && variant.on_hand == 0}"}
               %product{"ng-show" => "Products.loading"}


### PR DESCRIPTION
#### What? Why?

Show unit price in the bulk buy modal.
Closes #7426

#### What should we test?
You need to enable group buy for the product from `/admin/products/<product_name>/group_buy_options`

##### When `unit_price` feature toggle is enabled
In a shop front, we should display the unit price information near the product (and specially for a _bulk_ one):
<img width="866" alt="Capture d’écran 2021-04-15 à 11 08 36" src="https://user-images.githubusercontent.com/296452/114844302-f3952000-9dda-11eb-8064-4c6619bd7de6.png">

And when you click on button to add product into cart, the bulk buy modal should open with unit price information:
<img width="457" alt="Capture d’écran 2021-04-15 à 11 08 40" src="https://user-images.githubusercontent.com/296452/114844292-f09a2f80-9dda-11eb-9b77-05c616fd6f0d.png">



##### When `unit_price` feature toggle is not enabled
Nothing should change, the bulk buy modal should not display the unit price information:
<img width="457" alt="Capture d’écran 2021-04-15 à 11 10 41" src="https://user-images.githubusercontent.com/296452/114844577-3951e880-9ddb-11eb-945d-c55156d0bc1c.png">


#### Release notes
Display unit price information into the bulk but modal.

Changelog Category: User facing changes
