### PR TITLE
Replace duplicate #unauthorized method with module inclusion

### DIFF
--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -21,18 +21,6 @@ module Spree
         flash[:notice] = warning if warning.present?
       end
 
-      # This is in Spree::Core::ControllerHelpers::Auth
-      # But you can't easily reopen modules in Ruby
-      def unauthorized
-        if spree_current_user
-          flash[:error] = t(:authorization_failure)
-          redirect_to '/unauthorized'
-        else
-          store_location
-          redirect_to main_app.root_path(anchor: "login?after_login=#{request.env['PATH_INFO']}")
-        end
-      end
-
       protected
 
       def model_class

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3093,7 +3093,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     adjustment: "Adjustment"
     all: "All"
     associated_adjustment_closed: "Associated adjustment closed"
-    authorization_failure: "Authorization failure"
     back_to_adjustments_list: "Back to adjustments"
     back_to_users_list: "Back to users"
     back_to_zones_list: "Back to zones"

--- a/lib/spree/core/controller_helpers/auth.rb
+++ b/lib/spree/core/controller_helpers/auth.rb
@@ -25,7 +25,7 @@ module Spree
         # For example, a popup window might simply close itself.
         def unauthorized
           if spree_current_user
-            flash[:error] = Spree.t(:authorization_failure)
+            flash[:error] = t(:authorization_failure)
             redirect_to '/unauthorized'
           else
             store_location


### PR DESCRIPTION
#### What? Why?

I found it while working on https://github.com/openfoodfoundation/openfoodnetwork/pull/7433. 

No reason to risk diverging their implementations. The one in the `Auth` module and this one are exact copies.

#### What should we test?

Green build.

#### Release notes
Replace duplicate #unauthorized method with module inclusion
Changelog Category: Technical changes
