### PR TITLE
Add banner to Flipper UI to warn the admin users

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -6,6 +6,14 @@ Flipper.configure do |config|
     Flipper.new(Flipper::Adapters::ActiveRecord.new)
   end
 end
+
+if Rails.env.production?
+  Flipper::UI.configure do |config|
+    config.banner_text = '⚠️ Production environment: be aware that the changes have an impact on the application. Please, read the how-to before: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Feature-toggle-with-Flipper'
+    config.banner_class = 'danger'
+  end
+end
+
 Rails.configuration.middleware.use Flipper::Middleware::Memoizer, preload_all: true
 
 Flipper.register(:admins) { |actor| actor.respond_to?(:admin?) && actor.admin? }


### PR DESCRIPTION



#### What? Why?
Also add a link (escaped sadly...) to the wiki page: https://github.com/openfoodfoundation/openfoodnetwork/wiki/Feature-toggle-with-Flipper

Closes #7422 



<img width="604" alt="Capture d’écran 2021-04-19 à 14 46 03" src="https://user-images.githubusercontent.com/296452/115239293-d768ea00-a11e-11eb-879c-3b92c6fa6ffb.png">



#### What should we test?
Don't know how to test this one, since the banner should only display in production environment. 



#### Release notes
Add a warning banner into Flipper UI admin 


Changelog Category: User facing changes
