### PR TITLE
Change the position of order_cycle component into a shop front

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -181,11 +181,10 @@ shop ordercycle {
   }
 }
 
-shop navigation ordercycle {
-  margin-top: 3.4em;
+shop .tab-buttons ordercycle {
   padding: 1em;
-  height: 7.6em;
   position: absolute;
+  bottom: 0;
   right: 1em;
 }
 

--- a/app/assets/stylesheets/darkswarm/distributor_header.scss
+++ b/app/assets/stylesheets/darkswarm/distributor_header.scss
@@ -1,6 +1,8 @@
 @import "mixins";
 @import 'typography';
 
+$shop-navigation-zindex: 20;
+
 section {
   :not(shop) navigation {
     box-shadow: $distributor-header-shadow;
@@ -11,7 +13,7 @@ section {
   display: block;
   background: $white;
   position: relative;
-  z-index: 20;
+  z-index: $shop-navigation-zindex;
 
   .details {
     box-sizing: border-box;

--- a/app/assets/stylesheets/darkswarm/shop_tabs.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.scss
@@ -9,7 +9,7 @@
     color: $dark-grey;
     box-shadow: $distributor-header-shadow;
     position: relative;
-    z-index: 21; // +1 from .darkswarm navigation
+    z-index: $shop-navigation-zindex + 1;
 
     .columns {
       display: flex;

--- a/app/assets/stylesheets/darkswarm/shop_tabs.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.scss
@@ -9,7 +9,7 @@
     color: $dark-grey;
     box-shadow: $distributor-header-shadow;
     position: relative;
-    z-index: 10;
+    z-index: 21; // +1 from .darkswarm navigation
 
     .columns {
       display: flex;

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -20,10 +20,6 @@
   - content_for :order_cycle_form do
     = render partial: "change_order_cycle"
 
-  - content_for :ordercycle_sidebar do
-    .show-for-large-up.large-4.columns
-      = render partial: "shopping_shared/order_cycles"
-
   = render partial: "shopping_shared/header"
   = render partial: "shopping_shared/tabs"
 

--- a/app/views/shopping_shared/_tabs.html.haml
+++ b/app/views/shopping_shared/_tabs.html.haml
@@ -5,10 +5,11 @@
 
   #shop-tabs{ ng: { controller: "PageSelectionCtrl", init: "whitelistPages(#{shop_tab_names.to_json})", cloak: true } }
     .tab-buttons
-      .row
+      .flex.row
         .columns.small-12.large-8
           - shop_tabs.each do |tab|
             .page{ "ng-class" => "{ selected: selectedPage() == '#{tab[:name]}' }" }
               %a{ href: "##{tab[:name]}" }=tab[:title]
-
+        .columns.large-4.show-for-large-up
+          = render partial: "shopping_shared/order_cycles"
     .page-view{ ng: {include: "'shop/' + selectedPage() + '.html'" } }


### PR DESCRIPTION
#### What? Why?
Change the position of the order_cycle component and _attach_ it to `tab-buttons` in order to display it consistently. 

Closes #7353 



#### What should we test?
Test the good position of the order cycle in each cases:
 - Default case (in `en`)
<img width="439" alt="Capture d’écran 2021-04-19 à 20 50 26" src="https://user-images.githubusercontent.com/296452/115287709-e072af00-a150-11eb-88a9-a8b7e409ea75.png">

 - When it has two lines (in `ca`)
<img width="680" alt="Capture d’écran 2021-04-19 à 20 48 56" src="https://user-images.githubusercontent.com/296452/115287519-aacdc600-a150-11eb-8d50-3c01c9d3b769.png">

 - When tab has two lines (in `fr`)
<img width="1029" alt="Capture d’écran 2021-04-19 à 20 49 22" src="https://user-images.githubusercontent.com/296452/115287567-b9b47880-a150-11eb-84fa-0d7e4068a7f0.png">



#### Release notes
Fix a display issue when order cycle has two lines


Changelog Category: User facing changes