### PR TITLE
Add customer name into subscriptions list in order to search subscription by customer name

### DIFF
--- a/app/serializers/api/admin/subscription_serializer.rb
+++ b/app/serializers/api/admin/subscription_serializer.rb
@@ -5,7 +5,7 @@ module Api
     class SubscriptionSerializer < ActiveModel::Serializer
       attributes :id, :shop_id, :customer_id, :schedule_id, :payment_method_id, :shipping_method_id,
                  :begins_at, :ends_at,
-                 :customer_email, :schedule_name, :edit_path, :canceled_at, :paused_at, :state,
+                 :customer_email, :customer_name, :schedule_name, :edit_path, :canceled_at, :paused_at, :state,
                  :shipping_fee_estimate, :payment_fee_estimate
 
       has_many :subscription_line_items, serializer: Api::Admin::SubscriptionLineItemSerializer
@@ -32,6 +32,10 @@ module Api
 
       def customer_email
         object.customer.andand.email
+      end
+
+      def customer_name
+        object.customer.andand.name
       end
 
       def schedule_name

--- a/app/views/admin/subscriptions/_table.html.haml
+++ b/app/views/admin/subscriptions/_table.html.haml
@@ -38,7 +38,10 @@
         &nbsp;
   %tbody.panel-ctrl{ object: 'subscription', ng: { repeat: "subscription in subscriptions | filter:query as filteredSubscriptions track by subscription.id" } }
     %tr.subscription{ :id => "so_{{subscription.id}}", ng: { class: { even: "'even'", odd: "'odd'" } } }
-      %td.customer.text-center{ ng: { show: 'columns.customer.visible', bind: '::subscription.customer_email' } }
+      %td.customer.text-center{ ng: { show: 'columns.customer.visible'}}
+        %span{ "ng-bind": '::subscription.customer_email' }
+        %br
+        %span{ "ng-bind": '::subscription.customer_name' } 
       %td.schedule.text-center{ ng: { show: 'columns.schedule.visible', bind: '::subscription.schedule_name' } }
       %td.items.panel-toggle.text-center{ name: 'products', ng: { show: 'columns.items.visible' } }
         %h5{ ng: { bind: 'itemCount(subscription)' } }

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -17,6 +17,8 @@ feature 'Subscriptions' do
 
     context 'listing subscriptions' do
       let!(:subscription) { create(:subscription, shop: shop, with_items: true, with_proxy_orders: true) }
+      let!(:customer) { create(:customer, name: "Customer A") }
+      let!(:other_subscription) { create(:subscription, shop: shop, customer: customer, with_items: true, with_proxy_orders: true) }
       let!(:subscription2) { create(:subscription, shop: shop2, with_items: true, with_proxy_orders: true) }
       let!(:subscription_unmanaged) { create(:subscription, shop: shop_unmanaged, with_items: true, with_proxy_orders: true) }
 
@@ -57,10 +59,27 @@ feature 'Subscriptions' do
 
         # Using the Quick Search
         expect(page).to have_selector "tr#so_#{subscription.id}"
+        expect(page).to have_selector "tr#so_#{other_subscription.id}"
+
+        # Using the Quick Search: no result
         fill_in 'query', with: 'blah blah blah'
         expect(page).to have_no_selector "tr#so_#{subscription.id}"
+        expect(page).to have_no_selector "tr#so_#{other_subscription.id}"
+
+        # Using the Quick Search: filter by email
+        fill_in 'query', with: other_subscription.customer.email
+        expect(page).to have_selector "tr#so_#{other_subscription.id}"
+        expect(page).to have_no_selector "tr#so_#{subscription.id}"
+
+        # Using the Quick Search: filter by name
+        fill_in 'query', with: other_subscription.customer.name
+        expect(page).to have_selector "tr#so_#{other_subscription.id}"
+        expect(page).to have_no_selector "tr#so_#{subscription.id}"
+
+        # Using the Quick Search: reset filter
         fill_in 'query', with: ''
         expect(page).to have_selector "tr#so_#{subscription.id}"
+        expect(page).to have_selector "tr#so_#{other_subscription.id}"
 
         # Toggling columns
         expect(page).to have_selector "th.customer"


### PR DESCRIPTION
#### What? Why?
Add the customer name into the subscriptions table, thus, we can filter subscriptions by customer email
Closes #7403 


#### What should we test?
1. Create subscription with both user with name and user with no name
2. Go to `admin/subscriptions` and see that you can now filter by email but also by name of the customer


#### What does it look like?

<img width="866" alt="Capture d’écran 2021-04-20 à 16 05 53" src="https://user-images.githubusercontent.com/296452/115411421-bf16cf00-a1f3-11eb-9268-0a83a8637b0d.png">

![2021-04-20 16 06 00](https://user-images.githubusercontent.com/296452/115411426-c1792900-a1f3-11eb-9d83-ddf7b42f7fa4.gif)


#### Release notes
Search by customer name into the subscriptions list in backoffice.

Changelog Category: User facing changes
