### PR TITLE
Suppress "Line items can't be blank" message on order creation process

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -38,11 +38,12 @@ module Spree
         @order.recreate_all_fees!
 
         unless order_params.present? && @order.update(order_params) && @order.line_items.present?
-          if @order.line_items.empty?
+          if @order.line_items.empty? && !params[:suppress_error_msg]
             @order.errors.add(:line_items, Spree.t('errors.messages.blank'))
           end
-          return redirect_to(spree.edit_admin_order_path(@order),
-                             flash: { error: @order.errors.full_messages.join(', ') })
+
+          flash[:error] = @order.errors.full_messages.join(', ') if @order.errors.present?
+          return redirect_to spree.edit_admin_order_path(@order)
         end
 
         if @order.complete?

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -61,6 +61,13 @@ feature '
     select2_select order_cycle.name, from: 'order_order_cycle_id'
     click_button 'Next'
 
+    expect(page).not_to have_selector '.flash.error'
+    expect(page).not_to have_content "Line items can't be blank"
+
+    click_button "Update And Recalculate Fees"
+    expect(page).to have_selector '.flash.error'
+    expect(page).to have_content "Line items can't be blank"
+
     # it suppresses validation errors when setting distribution
     expect(page).not_to have_selector '#errorExplanation'
     expect(page).to have_content 'ADD PRODUCT'


### PR DESCRIPTION
#### What? Why?
When creating a new order, it's not necessary to display the "Line items can't be blank" as the order has just been created and the user is rightly doing configuration.

The param `suppress_error_msg` was already passed through the request, but unused.
See commit 38c25c412f5e09015d2f5a3c35b28a5a5a5320bb that creates the `suppress_error_msg` param.

Closes #6205





#### What should we test?
1. Go on to `admin/orders`
2. Click on "new order"
3. Select DISTRIBUTOR and ORDER CYCLE
4. Click on "Next"
5. You shouldn't see the red banner message
6. Click on "Update And Recalculate Fees" button. You should see the red banner on top of screen

##### Order creation process: no red banner on top
![2021-04-21 12 37 45](https://user-images.githubusercontent.com/296452/115540616-7ff18800-a29e-11eb-95d4-bc04ad217a71.gif)

##### Update And Recalculate Fees on this new order: red banner on top
(this gif is done just after the previous one)
![2021-04-21 12 38 10](https://user-images.githubusercontent.com/296452/115540673-8c75e080-a29e-11eb-88f9-b6908f3b7dd9.gif)



#### Release notes
Delete inappropriate error message on order creation

Changelog Category: User facing changes


