### PR TITLE
Update CanCan permissions on adjustments

### DIFF
--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -290,12 +290,8 @@ module Spree
       can [:destroy], Spree::Adjustment do |adjustment|
         if user.admin?
           true
-        elsif adjustment.adjustable.instance_of? Spree::Order
-          order = adjustment.adjustable
-          user.enterprises.include?(order.distributor) ||
-            order.order_cycle.andand.coordinated_by?(user)
-        elsif adjustment.adjustable.instance_of? Spree::LineItem
-          order = adjustment.adjustable.order
+        else
+          order = adjustment.order
           user.enterprises.include?(order.distributor) ||
             order.order_cycle.andand.coordinated_by?(user)
         end


### PR DESCRIPTION
#### What? Why?

Closes #7341 

The previous permissions assumed that an adjustment's "adjustable" could only be only line items or orders, and that's no longer true. It's now commonly a shipment or a payment as well.

#### What should we test?
<!-- List which features should be tested and how. -->

Shipping and Payment fee adjustments can be deleted by non-superadmin enterprise users.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed a permissions issue when deleting shipping or payment fee adjustments

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
