### PR TITLE
Added some extra tests to subscriptions_spec.rb

### DIFF
--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -238,8 +238,7 @@ feature 'Subscriptions' do
         expect(page).to have_input "ship_address_city", with: 'Natte Yallock'
         expect(page).to have_input "ship_address_zipcode", with: '3465'
         expect(page).to have_input "ship_address_phone", with: '0400 123 456'
-        expect(page).to have_input "ship_address_country_id", with: 'Australia'
-        expect(page).to have_input "ship_address_state_id", with: 'Victoria'
+
 
         click_button('Next')
         expect(page).to have_content 'NAME OR SKU'


### PR DESCRIPTION
#### What? Why?
I added some more tests in this file to help with the robustness of the test suite
Addresses #7454

There was a request to add more coverage to the tests for subscription and I believe I was able to do that. I added one case where the bill_address_phone is reset to nothing after being set to '0400 123 456' and check that the page updates with one can't be blank message, then set the phone back to 0400 123 456. I noticed that after copying to the shipping address only a few fields were tested despite there being more fields listed in the _address.html.haml file so I tested that the extra fields were also written in. Finally I added a test where the first item a customer adds a product and they set the quantity to 0, to make sure the price is also zero at that point. I was going to add a test for 'Please add at least one product' but I was not sure if that would cause the test case to fail since technically there was a product added with zero quantity. However, if that message should appear with a quantity of zero for a product I believe it could be added after line 255 in the file.



#### What should we test?
Since this is meant for coverage determine if the coverage from this test increase. Additionally, when shipping, make sure all fields of the shipping address are copied over if the user clicks on copy and I suppose determine if a product with a quantity of zero should warrant a 'Please add at least one product' message as I couldn't determine the functionality for that myself (I am new to this project).



#### Release notes
Added extra (simple) tests to the subscriptions_spec.rb


