### PR TITLE
Scope variant to take overrides into account in packer

### DIFF
--- a/engines/order_management/app/services/order_management/stock/packer.rb
+++ b/engines/order_management/app/services/order_management/stock/packer.rb
@@ -15,9 +15,12 @@ module OrderManagement
         order.line_items.each do |line_item|
           next unless stock_location.stock_item(line_item.variant)
 
-          on_hand, backordered = stock_location.fill_status(line_item.variant, line_item.quantity)
-          package.add line_item.variant, on_hand, :on_hand if on_hand.positive?
-          package.add line_item.variant, backordered, :backordered if backordered.positive?
+          variant = line_item.variant
+          OpenFoodNetwork::ScopeVariantToHub.new(order.distributor).scope(variant)
+
+          on_hand, backordered = stock_location.fill_status(variant, line_item.quantity)
+          package.add variant, on_hand, :on_hand if on_hand.positive?
+          package.add variant, backordered, :backordered if backordered.positive?
         end
         package
       end


### PR DESCRIPTION
#### What? Why?

Closes #7337

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

See comments on the issue for an extended discussion, but it appears that backoffice orders weren't accounting for inventory variant overrides ... ever?

#### What should we test?
<!-- List which features should be tested and how. -->
Set a product (Tomatoes) to have 0 on hand and "on demand?" unchecked in the product list
Add Tomatoes to Inventory and set On Hand to 10 and On Demand to No
Add Tomatoes to a back office order
Enter customer details
Before this PR:
Get stuck at "Address" state
After this PR: 
Moves to "Payment" state

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
