### PR TITLE
Remove require_dependency or use require

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Base controller for OFN's API
-require_dependency 'spree/api/controller_setup'
+require "spree/api/controller_setup"
 require "spree/core/controller_helpers/ssl"
 
 module Api

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency 'spree/authentication_helpers'
+require "spree/authentication_helpers"
 require "application_responder"
 require 'cancan'
 require 'spree/core/controller_helpers/auth'

--- a/app/models/calculator/default_tax.rb
+++ b/app/models/calculator/default_tax.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require_dependency 'spree/calculator'
 require 'open_food_network/enterprise_fee_calculator'
 
 module Calculator

--- a/app/models/calculator/flat_percent_item_total.rb
+++ b/app/models/calculator/flat_percent_item_total.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require_dependency 'spree/calculator'
 require 'spree/localized_number'
 
 module Calculator

--- a/app/models/calculator/flat_percent_per_item.rb
+++ b/app/models/calculator/flat_percent_per_item.rb
@@ -1,4 +1,3 @@
-require_dependency 'spree/calculator'
 require 'spree/localized_number'
 
 class Calculator::FlatPercentPerItem < Spree::Calculator

--- a/app/models/calculator/flat_rate.rb
+++ b/app/models/calculator/flat_rate.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require_dependency 'spree/calculator'
 require 'spree/localized_number'
 
 module Calculator

--- a/app/models/calculator/flexi_rate.rb
+++ b/app/models/calculator/flexi_rate.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require_dependency 'spree/calculator'
 require 'spree/localized_number'
 
 module Calculator

--- a/app/models/calculator/per_item.rb
+++ b/app/models/calculator/per_item.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require_dependency 'spree/calculator'
 require 'spree/localized_number'
 
 module Calculator

--- a/app/models/calculator/price_sack.rb
+++ b/app/models/calculator/price_sack.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require_dependency 'spree/calculator'
 # For #to_d method on Ruby 1.8
 require 'bigdecimal/util'
 require 'spree/localized_number'

--- a/engines/web/app/controllers/web/api/v0/cookies_consent_controller.rb
+++ b/engines/web/app/controllers/web/api/v0/cookies_consent_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency 'web/cookies_consent'
+require "web/cookies_consent"
 
 module Web
   module Api


### PR DESCRIPTION
This comes from the rails 6 upgrade. See here https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#require-dependency

#### What should we test?
We can test the cookies banner functionality: make sure the cookies banner appears and disappears after acceptance and that it will not show up on a second visit in another browser tab.
The calculator changes will be validated by the build :+1:

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Remove old style code no longer required.


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
