### PR TITLE
Get the whole list of products on order cycle changes

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
@@ -11,6 +11,8 @@ Darkswarm.controller "ProductsCtrl", ($scope, $sce, $filter, $rootScope, Product
   $scope.supplied_taxons = null
   $scope.supplied_properties = null
   $scope.showFilterSidebar = false
+  $scope.activeTaxons = []
+  $scope.activeProperties = []
 
   # Update filters after initial load of shop tab
   $timeout =>

--- a/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/products_controller.js.coffee
@@ -22,6 +22,7 @@ Darkswarm.controller "ProductsCtrl", ($scope, $sce, $filter, $rootScope, Product
   $rootScope.$on "orderCycleSelected", ->
     $scope.update_filters()
     $scope.clearAll()
+    $scope.page = 1
 
   $scope.update_filters = ->
     order_cycle_id = OrderCycle.order_cycle.order_cycle_id

--- a/app/views/shop/messages/_select_oc.html.haml
+++ b/app/views/shop/messages/_select_oc.html.haml
@@ -1,4 +1,4 @@
-.content.footer-pad{ "darker-background" => true, "ng-controller" => "ProductsCtrl", "ng-show" => "order_cycle.order_cycle_id == null" }
+.content.footer-pad{ "darker-background" => true, "ng-show" => "order_cycle.order_cycle_id == null" }
   .row
     .small-12.columns
       .select-oc-message

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -1,5 +1,5 @@
 %form{action: main_app.cart_path}
-  %products{"ng-controller" => "ProductsCtrl", "ng-init" => "refreshStaleData()", "ng-show" => "order_cycle.order_cycle_id != null", "ng-cloak" => true }
+  %products{"ng-init" => "refreshStaleData()", "ng-show" => "order_cycle.order_cycle_id != null", "ng-cloak" => true }
 
     = render partial: "shop/products/searchbar"
 

--- a/app/views/shop/products/_form.html.haml
+++ b/app/views/shop/products/_form.html.haml
@@ -9,7 +9,7 @@
           .medium-12.large-9.columns.full
             = render partial: "shop/products/search_feedback"
 
-            %div.pad-top{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading' }
+            %div.pad-top{ "infinite-scroll" => "loadMore()", "infinite-scroll-distance" => "1", "infinite-scroll-disabled" => 'Products.loading', "infinite-scroll-immediate-check": "false" }
               %product.animate-repeat{"ng-controller" => "ProductNodeCtrl", "ng-repeat" => "product in Products.products track by product.id", "id" => "product-{{ product.id }}"}
                 = render "shop/products/summary"
                 .shop-variants

--- a/app/views/shopping_shared/tabs/_shop.html.haml
+++ b/app/views/shopping_shared/tabs/_shop.html.haml
@@ -2,10 +2,11 @@
   .order-cycle-bar.hide-for-large-up
     = render partial: "shopping_shared/order_cycles"
 
-  - if no_open_order_cycles?
-    = render partial: "shop/messages/closed_shop"
-  - else
-    = render partial: "shop/messages/select_oc"
+  %div{"ng-controller" => "ProductsCtrl"}
+    - if no_open_order_cycles?
+      = render partial: "shop/messages/closed_shop"      
+    - else
+      = render partial: "shop/messages/select_oc"
 
-  -# Rendering the form, even if there are no open OCs, makes display only shops possible
-  = render partial: "shop/products/form"
+    -# Rendering the form, even if there are no open OCs, makes display only shops possible
+    = render partial: "shop/products/form"

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -159,6 +159,31 @@ feature "As a consumer I want to shop with a distributor", js: true do
             end
           end
         end
+
+        describe "two order cycles and more than 20 products for each" do
+          before do
+            20.times do
+              product = create(:simple_product, supplier: supplier)
+              add_variant_to_order_cycle(exchange1, product.variants.first)
+              add_variant_to_order_cycle(exchange2, product.variants.first)
+            end
+          end
+
+          it "show the whole products list for each OC" do
+            visit shop_path
+            select "turtles", from: "order_cycle_id"
+            select "frogs", from: "order_cycle_id"
+            expect(page).to have_selector("product", count: 10)
+            scroll_to(page.find(".product-listing"), align: :bottom)
+            expect(page).to have_selector("product", count: 20)
+
+            scroll_to(page.find("distributor"))
+            select "turtles", from: "order_cycle_id"
+            expect(page).to have_selector("product", count: 10)
+            scroll_to(page.find(".product-listing"), align: :bottom)
+            expect(page).to have_selector("product", count: 20)
+          end
+        end
       end
     end
 

--- a/spec/features/consumer/shopping/shopping_spec.rb
+++ b/spec/features/consumer/shopping/shopping_spec.rb
@@ -161,6 +161,12 @@ feature "As a consumer I want to shop with a distributor", js: true do
         end
 
         describe "two order cycles and more than 20 products for each" do
+          around do |example|
+            Capybara.raise_server_errors = false
+            example.run
+            Capybara.raise_server_errors = true
+          end
+
           before do
             20.times do
               product = create(:simple_product, supplier: supplier)


### PR DESCRIPTION
#### What? Why?
 - `ProductsCtrl` loaded twice: so we asked twice for the list of products for each store.
 - Values that were watched by Angular was not initialized: therefore they triggered a change (from `undefined` to `[]`) which was unnecessary
 - We now reinit the `page` params to `1` as we change the order cycle
 - Do not call `loadMore` immediately: this led to calling the next 10 products although this was not necessary. 

Therefore, I reduce the number of requests to `api/v0/order_cycles/6/products.json` by 2 ? (depending on user behavior of course)

Closes #7458

#### What should we test?
1. Create a shop with more than 1 open order cycle
2. Assign more than 30 products to each order cycle
3. Go to this shop, load the first order cycle, then scroll the page to display all the 30 (or more) products
4. Change order cycle, products list should refresh, and load more items (30 or more) when scrolling the product list


#### Release notes

Changelog Category: User facing changes | Technical changes


