### PR TITLE
Update Payment after_save callback

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -201,7 +201,19 @@ module Spree
     end
 
     def update_order
-      order.update!
+      if completed?
+        order.updater.update_payment_total
+      end
+
+      if order.completed?
+        order.updater.update_payment_state
+        order.updater.update_shipments
+        order.updater.update_shipment_state
+      end
+
+      if self.completed? || order.completed?
+        order.updater.persist_totals
+      end
     end
 
     # Necessary because some payment gateways will refuse payments with

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -201,7 +201,7 @@ module Spree
     end
 
     def update_order
-      if completed?
+      if completed? || void?
         order.updater.update_payment_total
       end
 

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -201,19 +201,7 @@ module Spree
     end
 
     def update_order
-      if completed? || void?
-        order.updater.update_payment_total
-      end
-
-      if order.completed?
-        order.updater.update_payment_state
-        order.updater.update_shipments
-        order.updater.update_shipment_state
-      end
-
-      if self.completed? || order.completed?
-        order.updater.persist_totals
-      end
+      OrderManagement::Order::Updater.new(order).after_payment_update(self)
     end
 
     # Necessary because some payment gateways will refuse payments with

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -38,7 +38,7 @@ module OrderManagement
       # - adjustment_total - total value of all adjustments
       # - total - order total, it's the equivalent to item_total plus adjustment_total
       def update_totals
-        order.payment_total = payments.completed.sum(:amount)
+        update_payment_total
         update_item_total
         update_adjustment_total
         update_order_total
@@ -47,6 +47,10 @@ module OrderManagement
       # Give each of the shipments a chance to update themselves
       def update_shipments
         shipments.each { |shipment| shipment.update!(order) }
+      end
+
+      def update_payment_total
+        order.payment_total = payments.completed.sum(:amount)
       end
 
       def update_item_total

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -141,6 +141,22 @@ module OrderManagement
         order.ship_address = order.address_from_distributor
       end
 
+      def after_payment_update(payment)
+        if payment.completed? || payment.void?
+          update_payment_total
+        end
+
+        if order.completed?
+          update_payment_state
+          update_shipments
+          update_shipment_state
+        end
+
+        if payment.completed? || order.completed?
+          persist_totals
+        end
+      end
+
       private
 
       def round_money(value)

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
   let!(:shop) { create(:enterprise) }
   let!(:user) { shop.owner }
-  let!(:order) { create(:order, distributor: shop, state: 'complete') }
+  let!(:order) { create(:completed_order_with_totals, distributor: shop) }
   let!(:line_item) { create(:line_item, order: order, price: 5.0) }
 
   before do

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -531,15 +531,29 @@ describe Spree::Payment do
     end
 
     context "#save" do
-      it "should call order#update!" do
-        gateway.name = 'Gateway'
-        gateway.distributors << create(:distributor_enterprise)
-        gateway.save!
+      context "completed payments" do
+        it "updates order payment total" do
+          payment = create(:payment, amount: 100, order: order, state: "completed")
+          expect(order.payment_total).to eq payment.amount
+        end
+      end
 
-        order = create(:order)
-        payment = Spree::Payment.create(amount: 100, order: order, payment_method: gateway)
-        expect(order).to receive(:update!)
-        payment.save
+      context "non-completed payments" do
+        it "doesn't update order payment total" do
+          expect {
+            create(:payment, amount: 100, order: order)
+          }.not_to change { order.payment_total }
+        end
+      end
+
+      context "completed orders" do
+        before { allow(order).to receive(:completed?) { true } }
+
+        it "updates payment_state and shipments" do
+          expect(order.updater).to receive(:update_payment_state)
+          expect(order.updater).to receive(:update_shipment_state)
+          create(:payment, amount: 100, order: order)
+        end
       end
 
       context "when profiles are supported" do

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -556,11 +556,19 @@ describe Spree::Payment do
       end
 
       context "completed orders" do
+        let(:order_updater) { OrderManagement::Order::Updater.new(order) }
+
         before { allow(order).to receive(:completed?) { true } }
 
         it "updates payment_state and shipments" do
-          expect(order.updater).to receive(:update_payment_state)
-          expect(order.updater).to receive(:update_shipment_state)
+          expect(OrderManagement::Order::Updater).to receive(:new).with(order).
+            and_return(order_updater)
+
+          expect(order_updater).to receive(:after_payment_update).with(kind_of(Spree::Payment)).
+            and_call_original
+
+          expect(order_updater).to receive(:update_payment_state)
+          expect(order_updater).to receive(:update_shipment_state)
           create(:payment, amount: 100, order: order)
         end
       end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -546,6 +546,15 @@ describe Spree::Payment do
         end
       end
 
+      context 'when the payment was completed but now void' do
+        let(:payment) { create(:payment, amount: 100, order: order, state: 'completed') }
+
+        it 'updates order payment total' do
+          payment.void
+          expect(order.payment_total).to eq 0
+        end
+      end
+
       context "completed orders" do
         before { allow(order).to receive(:completed?) { true } }
 


### PR DESCRIPTION
#### What? Why?

Backports a couple of commits from Spree 2.4 that reduce the strain caused by calling `order.update!` from the `after_save` callback in `Spree::Payment` by selectively calling only the parts it needs to. This avoids a lot of extra adjustments updates and unnecessary transactions that are not needed.

#### What should we test?
<!-- List which features should be tested and how. -->

Payment total and shipping/payment states should be correct when completing an order or updating a payment.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Reduced transactions in Payment after_save callback.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

