### PR TITLE
Move the position of order_cycle component to the shop into tab buttons

### DIFF
--- a/app/assets/stylesheets/darkswarm/_shop-navigation.scss
+++ b/app/assets/stylesheets/darkswarm/_shop-navigation.scss
@@ -9,7 +9,9 @@ ordercycle {
   width: 100%;
   border-radius: $radius-medium $radius-medium 0 0;
   margin-top: 1em;
-  padding: 1em 1.25em 0;
+  padding: 1em 1.25em 1em;
+  display: flex;
+  justify-content: center;
 
   p {
     max-width: 400px;
@@ -44,8 +46,6 @@ ordercycle {
     display: flex;
     font-size: 1em;
     border-radius: $radius-small;
-    margin-right: 10px;
-    margin-left: 10px;
 
     .select-label {
       background-color: rgba($teal-300, 0.5);
@@ -115,6 +115,8 @@ ordercycle {
     @include breakpoint(mobile) {
       display: flex;
       margin-right: 0;
+      margin-top: 1em;
+      margin-bottom: .3em;
     }
   }
 
@@ -182,11 +184,8 @@ shop ordercycle {
 }
 
 shop navigation ordercycle {
-  margin-top: 3.4em;
   padding: 1em;
-  height: 7.6em;
   position: absolute;
-  right: 1em;
 }
 
 .sub-header {

--- a/app/assets/stylesheets/darkswarm/distributor_header.scss
+++ b/app/assets/stylesheets/darkswarm/distributor_header.scss
@@ -11,14 +11,12 @@ section {
   display: block;
   background: $white;
   position: relative;
+  top: 2em;
   z-index: 20;
 
   .details {
     box-sizing: border-box;
     display: block;
-    min-height: 150px;
-    padding: 30px 0 0;
-    position: relative;
 
     img {
       display: block;
@@ -45,5 +43,9 @@ section {
         margin-bottom: 8px;
       }
     }
+  }
+
+  @include breakpoint(desktop) {
+    margin-bottom: 6em;
   }
 }

--- a/app/assets/stylesheets/darkswarm/shop_tabs.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.scss
@@ -28,14 +28,25 @@
   .page {
     text-align: center;
     border-top: 4px solid transparent;
-    display: inline-block;
+    display: flex;
+    justify-content: center;
     width: 100%;
-
+    
     >a {
+      position: absolute;
+      bottom: 0;
       outline: none;
       display: block;
       color: $black;
       font-family: "Oswald", sans-serif;
+
+      @include breakpoint(desktop) {
+        position: relative;
+      }
+
+      @include breakpoint(tablet) {
+        position: relative;
+      }
     }
 
     a {

--- a/app/assets/stylesheets/darkswarm/shop_tabs.scss
+++ b/app/assets/stylesheets/darkswarm/shop_tabs.scss
@@ -9,7 +9,7 @@
     color: $dark-grey;
     box-shadow: $distributor-header-shadow;
     position: relative;
-    z-index: 10;
+    z-index: 21;
 
     .columns {
       display: flex;

--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -20,10 +20,6 @@
   - content_for :order_cycle_form do
     = render partial: "change_order_cycle"
 
-  - content_for :ordercycle_sidebar do
-    .show-for-large-up.large-4.columns
-      = render partial: "shopping_shared/order_cycles"
-
   = render partial: "shopping_shared/header"
   = render partial: "shopping_shared/tabs"
 

--- a/app/views/shopping_shared/_tabs.html.haml
+++ b/app/views/shopping_shared/_tabs.html.haml
@@ -5,10 +5,11 @@
 
   #shop-tabs{ ng: { controller: "PageSelectionCtrl", init: "whitelistPages(#{shop_tab_names.to_json})", cloak: true } }
     .tab-buttons
-      .row
+      .flex.row
         .columns.small-12.large-8
           - shop_tabs.each do |tab|
             .page{ "ng-class" => "{ selected: selectedPage() == '#{tab[:name]}' }" }
               %a{ href: "##{tab[:name]}" }=tab[:title]
-
+        .columns.large-4.show-for-large-up
+          = render partial: "shopping_shared/order_cycles"
     .page-view{ ng: {include: "'shop/' + selectedPage() + '.html'" } }


### PR DESCRIPTION
What? Why?

Closes #7353

Change the position of the order_cycle component by merging with the guide buttons for a display without breaking the consistency, when there are two lines in the component title.

What should we test?

Test the position of the order cycle in each case:

* Default case `en`
 ![case1](https://user-images.githubusercontent.com/40550247/116004060-6d958800-a5d7-11eb-9abf-de31ef4b68c1.png)

* When there are two lines case `ca`
![case2](https://user-images.githubusercontent.com/40550247/116004188-fad8dc80-a5d7-11eb-8eae-7ce674c9cb31.png)

* When it's a mobile device, and there are two lines case `ca`
![case3](https://user-images.githubusercontent.com/40550247/116004420-07aa0000-a5d9-11eb-98aa-aac45e653fdd.png)

Release notes

Correct a display problem when the order cycle description has two lines.

Changelog Category: User facing changes