### PR TITLE
Fix shipment state

### DIFF
--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -327,6 +327,7 @@ module Spree
     end
 
     def after_ship
+      order.update_column(:shipment_state, "shipped")
       inventory_units.each(&:ship!)
       fee_adjustment.finalize!
       send_shipped_email

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -93,14 +93,14 @@ module OrderManagement
       # The +shipment_state+ value helps with reporting, etc. since it provides a quick and easy way
       #   to locate Orders needing attention.
       def update_shipment_state
-        order.shipment_state = if order.shipment&.backordered?
-                                 'backorder'
-                               else
-                                 # It returns nil if there is no shipment
-                                 order.shipment&.state
-                               end
+        order.shipment_state = derived_shipment_state
 
         order.state_changed('shipment')
+      end
+
+      def derived_shipment_state
+        # It returns nil if there is no shipment
+        order.shipment&.backordered? ? 'backorder' : order.shipment&.state
       end
 
       # Updates the +payment_state+ attribute according to the following logic:

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -93,6 +93,7 @@ feature '
 
         expect(page).to have_css "i.success"
         expect(order.reload.shipments.any?(&:shipped?)).to be true
+        expect(order.shipment_state).to eq("shipped")
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #7462 

In 605a94e3c9608972e935633726b39e98df09ea68 it looks like we inadvertently removed some code that updated the order after saving a shipment. 

This PR does a more limited update to sync the `shipment_state` field on the order after it's been shipped. 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
