### PR TITLE
prevent deleting only item in confirmed order

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/edit_bought_order_controller.js.coffee
@@ -3,7 +3,7 @@ Darkswarm.controller "EditBoughtOrderController", ($scope, $resource, $timeout, 
   $scope.removeEnabled = true
 
   $scope.deleteLineItem = (id) ->
-    if Cart.has_one_line_item()
+    if Cart.isOnlyItemInOrder(id)
       Messages.error(t 'orders_cannot_remove_the_final_item')
       $scope.removeEnabled = false
       $timeout (->

--- a/app/assets/javascripts/darkswarm/services/cart.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/cart.js.coffee
@@ -115,8 +115,9 @@ Darkswarm.factory 'Cart', (CurrentOrder, Variants, $timeout, $http, $modal, $roo
       @line_items = []
       localStorageService.clearAll() # One day this will have to be moar GRANULAR
 
-    has_one_line_item: =>
-      @line_items_finalised.length == 1
+    isOnlyItemInOrder: (id) =>
+      deletedItem = @line_items_finalised.find((item) -> item.id == id)
+      @line_items_finalised.filter((item) -> item.order_id == deletedItem.order_id).length == 1
 
     removeFinalisedLineItem: (id) =>
       @line_items_finalised = @line_items_finalised.filter (item) ->

--- a/app/serializers/api/line_item_serializer.rb
+++ b/app/serializers/api/line_item_serializer.rb
@@ -1,5 +1,5 @@
 class Api::LineItemSerializer < ActiveModel::Serializer
-  attributes :id, :quantity, :max_quantity, :price
+  attributes :id, :quantity, :max_quantity, :price, :order_id
 
   has_one :variant, serializer: Api::VariantSerializer
 end

--- a/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/cart_spec.js.coffee
@@ -225,9 +225,10 @@ describe 'Cart service', ->
   describe "when modifying a confirmed order", ->
     it "displays flash error when attempting to remove final item", ->
       spyOn(RailsFlashLoader, 'loadFlash')
-      li = {variant: {id: 1}, quantity: 3}
-      Cart.line_items_finalised = [li]
-      expect(Cart.has_one_line_item()).toBe(true)
+      li = {id: 1, order_id: 1, variant: {id: 1}, quantity: 3}
+      li2 = {id: 2, order_id: 2, variant: {id: 2}, quantity: 1}
+      Cart.line_items_finalised = [li, li2]
+      expect(Cart.isOnlyItemInOrder(li.id)).toBe(true)
 
   it "pops the queue", ->
     Cart.update_enqueued = true


### PR DESCRIPTION
#### What? Why?

Closes #5546 

when there are multiple confirmed orders, it is possible for the customer to delete all items in one of them, which causes an issue where there is a confirmed order with no items in it (see issue for more details). This PR aims to fix this bug.


#### What should we test?
whether its possible to delete the last remaining item in a confirmed order through the Edit Cart page


#### Release notes
prevented customer from deleting the last remaining item in a confirmed order when there are multiple confirmed orders.

Changelog Category: User facing changes
