### PR TITLE
Shipment callback state update

### DIFF
--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -331,6 +331,15 @@ module Spree
       fee_adjustment.finalize!
       send_shipped_email
       touch :shipped_at
+      update_order_shipment_state
+    end
+
+    def update_order_shipment_state
+      new_state = order.updater.update_shipment_state
+      order.update_columns(
+        shipment_state: new_state,
+        updated_at: Time.now,
+      )
     end
 
     def send_shipped_email

--- a/app/models/spree/shipment.rb
+++ b/app/models/spree/shipment.rb
@@ -338,7 +338,7 @@ module Spree
       new_state = order.updater.update_shipment_state
       order.update_columns(
         shipment_state: new_state,
-        updated_at: Time.now,
+        updated_at: Time.zone.now,
       )
     end
 

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -101,6 +101,7 @@ module OrderManagement
                                end
 
         order.state_changed('shipment')
+        order.shipment_state
       end
 
       # Updates the +payment_state+ attribute according to the following logic:

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -93,6 +93,7 @@ feature '
 
         expect(page).to have_css "i.success"
         expect(order.reload.shipments.any?(&:shipped?)).to be true
+        expect(order.shipment_state).to eq("shipped")
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #7462

Brings in a missed change to `Spree::Shipment` from the 2.2 branch. This should have been added along with recent changes to shipment callbacks.

#### What should we test?
<!-- List which features should be tested and how. -->

Order shipment state should say "shipped" after clicking the "ship" button, and not "ready".

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
