### PR TITLE
Shipment controller: test coverage and improvements

### DIFF
--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -34,7 +34,9 @@ module Api
           @shipment.fee_adjustment.open
         end
 
-        @shipment.update(shipment_params)
+        if @shipment.update(shipment_params)
+          @order.updater.update_totals_and_states
+        end
 
         if unlock == 'yes'
           @shipment.fee_adjustment.close

--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -31,7 +31,7 @@ module Api
         unlock = params[:shipment].delete(:unlock)
 
         if unlock == 'yes'
-          @shipment.fee_adjustment.open
+          @shipment.fee_adjustment.fire_events(:open)
         end
 
         if @shipment.update(shipment_params)

--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -34,7 +34,7 @@ module Api
           @shipment.fee_adjustment.open
         end
 
-        @shipment.update(shipment_params[:shipment])
+        @shipment.update(shipment_params)
 
         if unlock == 'yes'
           @shipment.fee_adjustment.close
@@ -94,7 +94,7 @@ module Api
 
       def find_and_update_shipment
         @shipment = @order.shipments.find_by!(number: params[:id])
-        @shipment.update(shipment_params[:shipment]) if shipment_params[:shipment].present?
+        @shipment.update(shipment_params)
         @shipment.reload
       end
 
@@ -113,10 +113,9 @@ module Api
       end
 
       def shipment_params
-        params.permit(
-          [:id, :order_id, :variant_id, :quantity,
-           { shipment: [:tracking, :selected_shipping_rate_id] }]
-        )
+        return {} unless params.has_key? :shipment
+
+        params.require(:shipment).permit(:tracking, :selected_shipping_rate_id)
       end
     end
   end

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -20,6 +20,10 @@ module OrderManagement
       # associations try to save and then in turn try to call +update!+ again.)
       def update
         update_all_adjustments
+        update_totals_and_states
+      end
+
+      def update_totals_and_states
         update_totals
 
         if order.completed?

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -225,12 +225,7 @@ describe Api::V0::ShipmentsController, type: :controller do
 
           expect(order.shipment.shipping_method).to eq shipping_method2
           expect(order.shipment.cost).to eq 20
-          expect(order.total).to eq 60 # order totals have not been updated
-          expect(order.payment_state).to eq "paid" # payment state not updated
-
-          order.update! # Simulate "Update and recalculate fees" button
-
-          expect(order.total).to eq 70 # order total has now changed
+          expect(order.total).to eq 70 # item total is 50, shipping cost is 20
           expect(order.payment_state).to eq "balance_due" # total changed, payment is due
         end
       end

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -176,7 +176,67 @@ describe Api::V0::ShipmentsController, type: :controller do
       end
     end
 
-    context "can transition a shipment from ready to ship" do
+    describe "#update" do
+      let!(:distributor) { create(:distributor_enterprise) }
+      let!(:shipping_method1) {
+        create(:shipping_method_with, :flat_rate, distributors: [distributor], amount: 10)
+      }
+      let!(:shipping_method2) {
+        create(:shipping_method_with, :flat_rate, distributors: [distributor], amount: 20)
+      }
+      let!(:order_cycle) { create(:order_cycle, distributors: [distributor]) }
+      let!(:order) {
+        create(:completed_order_with_totals, order_cycle: order_cycle, distributor: distributor)
+      }
+      let(:new_shipping_rate) {
+        order.shipment.shipping_rates.select{ |sr| sr.shipping_method == shipping_method2 }.first
+      }
+      let(:params) {
+        {
+          id: order.shipment.number,
+          order_id: order.number,
+          shipment: {
+            selected_shipping_rate_id: new_shipping_rate.id
+          }
+        }
+      }
+
+      before do
+        order.shipments.first.shipping_methods = [shipping_method1, shipping_method2]
+        order.select_shipping_method(shipping_method1.id)
+        order.update!
+        order.update_columns(
+          payment_total: 60,
+          payment_state: "paid"
+        )
+      end
+
+      context "when an order has multiple shipping methods available which could be chosen" do
+        it "allows changing the selected shipping rate (changing the shipping method)" do
+          expect(order.shipment.shipping_method).to eq shipping_method1
+          expect(order.shipment.cost).to eq 10
+          expect(order.total).to eq 60 # item total is 50, shipping cost is 10
+          expect(order.payment_state).to eq "paid" # order is fully paid for
+
+          api_put :update, params
+          expect(response.status).to eq 200
+
+          order.reload
+
+          expect(order.shipment.shipping_method).to eq shipping_method2
+          expect(order.shipment.cost).to eq 20
+          expect(order.total).to eq 60 # order totals have not been updated
+          expect(order.payment_state).to eq "paid" # payment state not updated
+
+          order.update! # Simulate "Update and recalculate fees" button
+
+          expect(order.total).to eq 70 # order total has now changed
+          expect(order.payment_state).to eq "balance_due" # total changed, payment is due
+        end
+      end
+    end
+
+    context "#ship" do
       before do
         allow_any_instance_of(Spree::Order).to receive_messages(paid?: true, complete?: true)
         # For the shipment notification email

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -244,20 +244,13 @@ describe Api::V0::ShipmentsController, type: :controller do
               }.to_not change { order.reload.shipment.fee_adjustment.amount }
             end
 
-            xit "updates closed adjustments with unlock option selected" do
+            it "updates closed adjustments with unlock option selected" do
               params[:shipment][:unlock] = "yes"
 
               expect {
                 api_put :update, params
                 expect(response.status).to eq 200
               }.to change { order.reload.shipment.fee_adjustment.amount }
-            end
-
-            it "hits a fatal error when the unlock option is used" do
-              params[:shipment][:unlock] = "yes"
-
-              api_put :update, params
-              expect(response.status).to eq 422
             end
           end
         end

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -41,7 +41,8 @@ FactoryBot.define do
     end
 
     trait :flat_rate do
-      calculator { Calculator::FlatRate.new(preferred_amount: 50.0) }
+      transient { amount { 50.0 } }
+      calculator { Calculator::FlatRate.new(preferred_amount: amount) }
     end
 
     trait :expensive_name do


### PR DESCRIPTION
#### What? Why?

- Adds some important test coverage to the logic in `Api::ShipmentController#update`, which was completely missing :warning:
- Tidies up a few bits and makes them easier to follow
- Fixes a bug found in `Api::ShipmentController#update` whilst writing specs
- Splits the `Order::Updater#update` method into two parts to allow calling one without the other (notes in commit message)
- Resolves an issue where changing the selected shipping method on a shipment via the controller leaves the order in a messy state. Also avoids Spree's solution to that problem, which is clearly horrible (notes in commit message)!

#### What should we test?
<!-- List which features should be tested and how. -->

When editing an order via admin and changing the selected shipping method, the order should be updated correctly. Also, if the order total changes as a result of switching shipping method and no longer matches the payment total, the payment state should also change to reflect that.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added test coverage in Api::ShipmentsController and improved updating shipments logic

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
