### PR TITLE
[Rails 5.2] Redirect back

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -68,14 +68,16 @@ module Spree
       rescue Spree::Core::GatewayError => e
         flash[:error] = e.message.to_s
       ensure
-        redirect_to :back
+        redirect_back fallback_location: spree.admin_dashboard_path
       end
 
       def resend
         Spree::OrderMailer.confirm_email_for_customer(@order.id, true).deliver_later
         flash[:success] = t('admin.orders.order_email_resent')
 
-        respond_with(@order) { |format| format.html { redirect_to :back } }
+        respond_with(@order) do |format|
+          format.html { redirect_back(fallback_location: spree.admin_dashboard_path) }
+        end
       end
 
       def invoice

--- a/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -8,7 +8,7 @@ module Spree
       def fire
         @return_authorization.public_send("#{params[:e]}!")
         flash[:success] = Spree.t(:return_authorization_updated)
-        redirect_to :back
+        redirect_back fallback_location: spree.admin_dashboard_path
       end
 
       protected


### PR DESCRIPTION
#### What? Why?

Closes #7492

The syntax for `redirect_to :back` has changed in 5.2.

The new method requires a fallback. Redirecting back involves checking the referrer header to figure out the user's previous page, which (in the old version) could theoretically encounter an error if for some reason the header was empty. 

In both cases here we're in an admin page, so we put the main admin dashboard as fallback (although in theory the fallback will never be used).

#### What should we test?
<!-- List which features should be tested and how. -->

The redirect errors encountered in #7492 should be resolved.