### PR TITLE
Remove #deleted? method from Product and Variant

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -266,13 +266,6 @@ module Spree
       duplicator.duplicate
     end
 
-    # use deleted? rather than checking the attribute directly. this
-    # allows extensions to override deleted? if they want to provide
-    # their own definition.
-    def deleted?
-      !!deleted_at
-    end
-
     # split variants list into hash which shows mapping of opt value onto matching variants
     # eg categorise_variants_from_option(color) => {"red" -> [...], "blue" -> [...]}
     def categorise_variants_from_option(opt_type)

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -166,13 +166,6 @@ module Spree
       OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle).fees_by_type_for self
     end
 
-    # use deleted? rather than checking the attribute directly. this
-    # allows extensions to override deleted? if they want to provide
-    # their own definition.
-    def deleted?
-      deleted_at
-    end
-
     def option_value(opt_name)
       option_values.detect { |o| o.option_type.name == opt_name }.try(:presentation)
     end


### PR DESCRIPTION
#### What? Why?

This method is already supplied via the paranoia gem, there's no need to re-implement it here.

:fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed custom #deleted? methods form Product and Variant

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes