### PR TITLE
Reorder has_many relationship with :through option

### DIFF
--- a/app/models/spree/option_type.rb
+++ b/app/models/spree/option_type.rb
@@ -2,9 +2,9 @@
 
 module Spree
   class OptionType < ApplicationRecord
-    has_many :products, through: :product_option_types
     has_many :option_values, -> { order(:position) }, dependent: :destroy
     has_many :product_option_types, dependent: :destroy
+    has_many :products, through: :product_option_types
 
     validates :name, :presentation, presence: true
     default_scope -> { order("#{table_name}.position") }


### PR DESCRIPTION
#### What? Why?

If an association is using `:through`, it should be defined after the association it's connected to. 

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Reordered has_many relationships in Spree::OptionType

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
