### PR TITLE
LineItem option_values callbacks

### DIFF
--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -35,7 +35,7 @@ module Spree
     before_save :calculate_final_weight_volume, if: :quantity_changed?,
                                                 unless: :final_weight_volume_changed?
     after_save :update_order
-    after_save :update_units
+    after_save :update_unit_option_values
     before_destroy :update_inventory_before_destroy
     after_destroy :update_order
 

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -35,7 +35,7 @@ module Spree
     before_save :calculate_final_weight_volume, if: :quantity_changed?,
                                                 unless: :final_weight_volume_changed?
     after_save :update_order
-    after_save :update_unit_option_values
+    after_commit :update_unit_option_values, on: [:create, :update]
     before_destroy :update_inventory_before_destroy
     after_destroy :update_order
 

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -437,7 +437,7 @@ module Spree
 
       option_types.delete self.class.all_variant_unit_option_types
       option_types << variant_unit_option_type if variant_unit.present?
-      variants_including_master.each(&:update_units)
+      variants_including_master.each(&:update_unit_option_values)
     end
 
     def touch_distributors

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -70,7 +70,7 @@ module Spree
     before_validation :update_weight_from_unit_value, if: ->(v) { v.product.present? }
 
     after_save :save_default_price
-    after_save :update_units
+    after_save :update_unit_option_values
 
     after_create :create_stock_items
     after_create :set_position

--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -70,7 +70,7 @@ module Spree
     before_validation :update_weight_from_unit_value, if: ->(v) { v.product.present? }
 
     after_save :save_default_price
-    after_save :update_unit_option_values
+    after_commit :update_unit_option_values, on: [:create, :update]
 
     after_create :create_stock_items
     after_create :set_position

--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -85,8 +85,7 @@ module VariantUnits
     end
 
     def delete_unit_option_values
-      ovs = option_values.where(option_type_id: Spree::Product.all_variant_unit_option_types)
-      option_values.destroy ovs
+      option_values.destroy_all
     end
 
     def weight_from_unit_value

--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -72,7 +72,7 @@ module VariantUnits
       options_text
     end
 
-    def update_units
+    def update_unit_option_values
       delete_unit_option_values
 
       option_type = product.variant_unit_option_type

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -23,13 +23,15 @@ module Spree
         expect(line_item.order).to receive(:create_tax_charge!)
         line_item.destroy
       end
+    end
 
-      it "fetches deleted products" do
+    context "soft-deletion on associations" do
+      it "fetches soft-deleted products" do
         line_item.product.destroy
         expect(line_item.reload.product).to be_a Spree::Product
       end
 
-      it "fetches deleted variants" do
+      it "fetches soft-deleted variants" do
         line_item.variant.destroy
         expect(line_item.reload.variant).to be_a Spree::Variant
       end


### PR DESCRIPTION
#### What? Why?

Moves callbacks on variants and line items which can trigger a bunch of additional database transactions related to unit option values into `after_commit` callbacks instead of `after_save`. 

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
