### PR TITLE
Email after commit

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -105,7 +105,7 @@ class Enterprise < ApplicationRecord
   after_touch :touch_distributors
   after_create :set_default_contact
   after_create :relate_to_owners_enterprises
-  after_create :send_welcome_email
+  after_create_commit :send_welcome_email
 
   after_rollback :restore_permalink
 

--- a/spec/services/sets/model_set_spec.rb
+++ b/spec/services/sets/model_set_spec.rb
@@ -51,7 +51,7 @@ describe Sets::ModelSet do
       attributes = { collection_attributes: { '1' => { name: 'deleteme' } } }
 
       ms = Sets::ModelSet.new(Enterprise, Enterprise.all, attributes, nil,
-                              proc { |attrs| attrs['name'] == 'deleteme' })
+                              proc { |attrs| attrs[:name] == 'deleteme' })
 
       expect { ms.save }.to change(Enterprise, :count).by(0)
     end


### PR DESCRIPTION
#### What? Why?

As a general rule, if you're triggering an email job as part of an after create/save callback, it should use after commit instead.

Why? The transaction can't finish until after the record is persisted (the data is committed) which includes the logic in the callbacks. So for example, if the transaction fails after the email job has been placed it will be rolled back, but the email job will already be in the queue, and it'll be referencing a record that doesn't actually exist (due to the rollback).

Review note: there was a failing test using `ModelSet` to update and delete enterprises. It was failing due to incorrect logic in the test itself (notes in commit message). 

#### What should we test?
<!-- List which features should be tested and how. -->

Quick check that welcome email is sent successfully after registering a new enterprise.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Changed enterprise registration email callback from after_create to after_create_commit

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
