### PR TITLE
Add payment method description to invoice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,6 +153,7 @@ group :test do
   gem 'test-prof'
   gem 'webmock'
   gem 'rails-controller-testing'
+  gem 'pdf-reader'
   # See spec/spec_helper.rb for instructions
   # gem 'perftools.rb'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.0)
     actioncable (5.2.6)
       actionpack (= 5.2.6)
       nio4r (~> 2.0)
@@ -113,6 +114,7 @@ GEM
       activerecord (>= 4.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    afm (0.2.2)
     andand (1.3.3)
     angular-rails-templates (1.1.0)
       railties (>= 4.2, < 7)
@@ -284,6 +286,7 @@ GEM
       temple (>= 0.8.0)
       tilt
     hashdiff (1.0.1)
+    hashery (2.1.2)
     highline (2.0.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -384,6 +387,12 @@ GEM
       xml-simple
     paypal-sdk-merchant (1.117.2)
       paypal-sdk-core (~> 0.3.0)
+    pdf-reader (2.4.2)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.2.3)
     power_assert (2.0.0)
     pry (0.13.1)
@@ -571,6 +580,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.4)
+    ttfunk (1.7.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -694,6 +704,7 @@ DEPENDENCIES
   paperclip (~> 3.4.1)
   paranoia (~> 2.4)
   paypal-sdk-merchant (= 1.117.2)
+  pdf-reader
   pg (~> 1.2.3)
   pry
   pry-byebug

--- a/app/helpers/spree/payment_methods_helper.rb
+++ b/app/helpers/spree/payment_methods_helper.rb
@@ -1,9 +1,13 @@
 module Spree
   module PaymentMethodsHelper
-    def payment_method_name(payment)
+    def payment_method(payment)
       # hack to allow us to retrieve the name of a "deleted" payment method
       id = payment.payment_method_id
-      Spree::PaymentMethod.find_with_destroyed(id).name
+      Spree::PaymentMethod.find_with_destroyed(id)
+    end
+
+    def payment_method_name(payment)
+      payment_method(payment).name
     end
   end
 end

--- a/app/views/spree/shared/_payment.html.haml
+++ b/app/views/spree/shared/_payment.html.haml
@@ -13,3 +13,8 @@
     = t :email_payment_summary
 - if @order.payments.any?
   = render partial: 'spree/shared/payments_list', locals: { payments: @order.payments }
+  - if last_payment_method(@order).present?
+    %p.callout{style: "margin-top: 40px"}
+      %strong
+        = t :email_payment_description
+    %p{style: "margin: 5px"}= last_payment_method(@order).description

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1669,6 +1669,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   email_order_summary_includes_tax: "(includes tax):"
   email_payment_paid: PAID
   email_payment_not_paid: NOT PAID
+  email_payment_description: Payment Description at Checkout
   email_payment_summary: Payment summary
   email_payment_method: "Paying via:"
   email_so_placement_intro_html: "You have a new order with <strong>%{distributor}</strong>"

--- a/spec/features/admin/invoice_print_spec.rb
+++ b/spec/features/admin/invoice_print_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+feature '
+    As an administrator
+    I want to print a invoice as PDF
+', js: false do
+  include WebHelper
+  include AuthenticationHelper
+
+  let(:user) { create(:user) }
+  let(:product) { create(:simple_product) }
+  let(:distributor) { create(:distributor_enterprise, owner: user, charges_sales_tax: true) }
+  let(:order_cycle) do
+    create(:simple_order_cycle, name: 'One', distributors: [distributor],
+                                variants: [product.variants.first])
+  end
+
+  let(:order) do
+    create(:order_with_totals_and_distribution, user: user, distributor: distributor,
+                                                order_cycle: order_cycle, state: 'complete',
+                                                payment_state: 'balance_due')
+  end
+
+  describe "that contains right Payment Description at Checkout information" do
+    let!(:payment_method1) do
+      create(:stripe_sca_payment_method, distributors: [distributor], description: "description1")
+    end
+    let!(:payment_method2) do
+      create(:stripe_sca_payment_method, distributors: [distributor], description: "description2")
+    end
+
+    context "with no payment" do
+      it "do not display the payment description information" do
+        login_as_admin_and_visit spree.print_admin_order_path(order)
+        convert_pdf_to_page
+        expect(page).to have_no_content 'Payment Description at Checkout'
+      end
+    end
+
+    context "with one payment" do
+      let!(:payment1) do
+        create(:payment, order: order, state: 'completed', payment_method: payment_method1)
+      end
+      before do
+        order.save!
+      end
+
+      it "display the payment description section" do
+        login_as_admin_and_visit spree.print_admin_order_path(order)
+        convert_pdf_to_page
+        expect(page).to have_content 'Payment Description at Checkout'
+        expect(page).to have_content 'description1'
+      end
+    end
+
+    context "with two payments, and one that failed" do
+      before do
+        order.update payments: []
+        order.payments << create(:payment, order: order, state: 'completed',
+                                           payment_method: payment_method1, created_at: 1.day.ago)
+        order.payments << create(:payment, order: order, state: 'failed',
+                                           payment_method: payment_method2, created_at: 2.days.ago)
+        order.save!
+      end
+
+      it "display the payment description section and use the one from the completed payment" do
+        login_as_admin_and_visit spree.print_admin_order_path(order)
+        convert_pdf_to_page
+        expect(page).to have_content 'Payment Description at Checkout'
+        expect(page).to have_content 'description1'
+      end
+    end
+
+    context "with two completed payments" do
+      before do
+        order.update payments: []
+        order.payments << create(:payment, order: order, state: 'completed',
+                                           payment_method: payment_method1, created_at: 2.days.ago)
+        order.payments << create(:payment, order: order, state: 'completed',
+                                           payment_method: payment_method2, created_at: 1.day.ago)
+        order.save!
+      end
+
+      it "display the payment description section and use the one from the last payment" do
+        login_as_admin_and_visit spree.print_admin_order_path(order)
+        convert_pdf_to_page
+        expect(page).to have_content 'Payment Description at Checkout'
+        expect(page).to have_content 'description2'
+      end
+    end
+  end
+end
+
+def convert_pdf_to_page
+  temp_pdf = Tempfile.new('pdf')
+  temp_pdf << page.source.force_encoding('UTF-8')
+  reader = PDF::Reader.new(temp_pdf)
+  pdf_text = reader.pages.map(&:text)
+  temp_pdf.close
+  page.driver.response.instance_variable_set('@body', pdf_text)
+end


### PR DESCRIPTION
#### What? Why?
This PR add a last section to an invoice: Payment Description at Checkout to display the payment method description.
The Payment Description must be the _the one used when the order was placed._ (ref: https://github.com/openfoodfoundation/openfoodnetwork/issues/6359#issuecomment-725241162)


Closes #6359

<img width="744" alt="Capture d’écran 2021-05-04 à 13 29 40" src="https://user-images.githubusercontent.com/296452/116997201-c900fd80-acdc-11eb-8d68-40290a6faa80.png">



#### What should we test?
 1. Log in as a Manager of the Enterprise
 2. Go to Orders
 3. Check one order (or many) and click on `Print invoices` button
 4. Then, click on any order
 5. On button `Actions` both test the `Send Invoice` and `Print Invoice`
<img width="252" alt="Capture d’écran 2021-05-04 à 13 27 33" src="https://user-images.githubusercontent.com/296452/116997533-36149300-acdd-11eb-83ab-2331d3028052.png">
 6. You should see invoices with Payment Description at Checkout. The content of the Payment Description at Checkout section must be the same that is shown to the customer on URL: `http://localhost:3000/orders/[ORDER_ID]` (the customer order confirmation)

#### Release notes
Add payment description at checkout on invoices
Changelog Category: User facing changes
