### PR TITLE
Test building component through our styleguide with tailwind

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,4 @@
 <link href='https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" media="screen" href="http://localhost:3000/assets/darkswarm/all.css" />
+<link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,3 +2,18 @@
 <link rel="stylesheet" media="screen" href="http://localhost:3000/assets/darkswarm/all.css" />
 <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
 
+<style type="text/css">
+  input[type="text"] {
+    box-shadow: none;
+    margin: auto;
+    border: none;
+    height: auto;
+    padding: 0;
+  }
+  input[type="text"]:focus {
+    background-color: inherit;
+  }
+  input[type="checkbox"] {
+    margin: 0;
+  }
+</style>

--- a/app/components/filter_field_component.rb
+++ b/app/components/filter_field_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FilterFieldComponent < ViewComponent::Base
+  attr_reader :title, :open, :options, :selected
+
+  def initialize(title:, open:, options:, selected:)
+    super()
+    @title = title
+    @open = open
+    @options = options
+    @selected = selected
+  end
+end

--- a/app/components/filter_field_component/filter_field_component.html.haml
+++ b/app/components/filter_field_component/filter_field_component.html.haml
@@ -1,0 +1,31 @@
+%div.max-w-max
+  %div.bg-white.border.border-gray-300.py-2.px-5.relative.max-w-max.rounded-sm
+    %div.text-gray-500.absolute.-top-2.px-3.-ml-3.bg-white.text-xs= @title
+    %div.inline-flex.items-center.justify-between.pt-2
+      - if @selected.length > 0
+        %div.inline-flex.items-center.leading-sm.px-3.py-1.bg-gray-100.rounded-full.-ml-3
+          %div.text-xs.text-gray-600
+            = @selected
+          %div.text-blue-400.ml-3.cursor-pointer
+            %svg{xmlns: "http://www.w3.org/2000/svg", class:"h-5 w-5", viewBox: "0 0 20 20", fill: "currentColor"}
+              %path{"fill-rule": "evenodd", "d": "M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z", "clip-rule": "evenodd"}
+      - else
+        %div.text-sm.py-1.text-gray-600
+          All categories
+
+      %div.leading-4.text-gray-500.ml-4.mt-1.cursor-pointer
+        %svg{xmlns: "http://www.w3.org/2000/svg", class: "h-5 w-5", viewBox: "0 0 20 20", fill: "currentColor"}
+          %path{"fill-rule": "evenodd", d: "M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z", "clip-rule": "evenodd" }
+  - if @open
+    %div.bg-white.border.border-gray-300.min-w-max.shadow.mt-1
+      %div.bg-white.border.border-gray-300.m-1.h-8.inline-flex.items-center.rounded-sm
+        %div.text-gray-400.px-2
+          %svg{xmlns: "http://www.w3.org/2000/svg", class: "h-5 w-5", viewBox: "0 0 20 20", fill: "currentColor"}
+            %path{"fill-rule": "evenodd", "d": "M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z", "clip-rule": "evenodd"}
+        %input.outline-none.border-none.shadow-none.focus:bg-white{type: "text", placeholder: "Search categories" }
+      %div.bg-white.border-t.border-gray-300.flex.flex-col.px-2.max-h-20.overflow-x-scroll
+        - @options.each do |x|
+          %label.inline-flex.items-center.mt-2
+            %input.form-checkbox.h-4.w-4.text-gray-600{type: "checkbox", checked: @selected === x}
+            %span.ml-2.text-gray-500= x
+

--- a/spec/components/stories/filter_field_component_stories.rb
+++ b/spec/components/stories/filter_field_component_stories.rb
@@ -1,0 +1,37 @@
+class FilterFieldComponentStories < ViewComponent::Storybook::Stories
+  story(:default) do
+    controls do
+      text(:title, "Categories")
+      boolean(:open, false)
+      array(:options, [])
+      text(:selected, "")
+    end
+  end
+
+  story(:open) do
+    controls do
+      text(:title, "Categories")
+      boolean(:open, true)
+      array(:options, ["label 1", "label 2", "label 3", "label 4", "label 5", "label 6", "label 7"])
+      text(:selected, "")
+    end
+  end
+
+  story(:one_selected_option_and_closed) do
+    controls do
+      text(:title, "Categories")
+      boolean(:open, false)
+      array(:options, ["label 1", "label 2", "label 3", "label 4", "label 5", "label 6", "label 7"])
+      text(:selected, "label 3")
+    end
+  end
+
+  story(:one_selected_option_and_open) do
+    controls do
+      text(:title, "Categories")
+      boolean(:open, true)
+      array(:options, ["label 1", "label 2", "label 3", "label 4", "label 5", "label 6", "label 7"])
+      text(:selected, "label 3")
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

The aim of this PR is only to demonstrate and show a _real_ example of how we can customize our next components thanks to tailwind css framework.
There is no build and so this is not usable at all inside the app, only in storybook. 
The component view is here : `app/components/filter_field_component/filter_field_component.html.haml` 
Please, @openfoodfoundation/core-devs we need our inputs. 🙏 

_**Must not be merged. Only here for reviews.**_

#### Component screenshot
##### Closed
<img width="203" alt="Capture d’écran 2021-05-04 à 17 29 44" src="https://user-images.githubusercontent.com/296452/117028781-53a62480-acfe-11eb-9981-e3ce7945804d.png">


##### Opened
<img width="237" alt="Capture d’écran 2021-05-04 à 17 28 28" src="https://user-images.githubusercontent.com/296452/117028587-25284980-acfe-11eb-987f-8a0a0a0fa550.png">

##### Closed with one selected option
<img width="203" alt="Capture d’écran 2021-05-04 à 17 28 41" src="https://user-images.githubusercontent.com/296452/117028617-2ce7ee00-acfe-11eb-8fa3-2cb789c90a49.png">

##### Opened with one selected option
<img width="221" alt="Capture d’écran 2021-05-04 à 17 30 08" src="https://user-images.githubusercontent.com/296452/117028851-615baa00-acfe-11eb-8988-cc66ff732f7e.png">





References #7501, #7199

