### PR TITLE
Bump select2-rails to v3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ gem 'foundation-rails', '= 5.5.2.1'
 gem 'jquery-migrate-rails'
 gem 'jquery-rails', '4.4.0'
 gem 'jquery-ui-rails', '~> 4.2'
-gem 'select2-rails', '~> 3.4.7'
+gem 'select2-rails', '~> 3.5'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', branch: 'ofn-rails-4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,9 +530,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    select2-rails (3.4.9)
-      sass-rails
-      thor (~> 0.14)
+    select2-rails (3.5.11)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -721,7 +719,7 @@ DEPENDENCIES
   rubocop-rails
   sass (<= 4.7.1)
   sass-rails (< 6.0.0)
-  select2-rails (~> 3.4.7)
+  select2-rails (~> 3.5)
   selenium-webdriver
   shoulda-matchers
   simplecov


### PR DESCRIPTION
#### What? Why?
Relates to 4914, upgrades to v3.5.
This version is needed for with rails 6 because it resolves a gem version conflict related to thor version.

#### What should we test?
We need to test select2 components. In the admin side, any select box that allows the user to search.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Upgrade select2-rails dependency.

