### PR TITLE
Fix failed SCA authentication on subs. order payment not reflected in OFN

### DIFF
--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -30,7 +30,7 @@ module Spree
       if params.key?("payment_intent")
         result = ProcessPaymentIntent.new(params["payment_intent"], @order).call!
         unless result.ok?
-          flash[:error] = "The payment could not be processed. #{result.error}"
+          flash[:error] = "#{I18n.t("payment_could_not_process")}. #{result.error}"
         end
         @order.reload
       end

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -28,7 +28,10 @@ module Spree
       @order = Spree::Order.find_by!(number: params[:id])
 
       if params.key?("payment_intent")
-        ProcessPaymentIntent.new(params["payment_intent"], @order).call!
+        result = ProcessPaymentIntent.new(params["payment_intent"], @order).call!
+        unless result.ok?
+          flash[:error] = "The payment could not be processed. #{result.error}"
+        end
         @order.reload
       end
     end

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -26,8 +26,11 @@ module Spree
 
     def show
       @order = Spree::Order.find_by!(number: params[:id])
-      ProcessPaymentIntent.new(params["payment_intent"], @order).call!
-      @order.reload
+
+      if params.key?("payment_intent")
+        ProcessPaymentIntent.new(params["payment_intent"], @order).call!
+        @order.reload
+      end
     end
 
     def empty

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -144,6 +144,10 @@ module Spree
       I18n.t('payment_method_fee')
     end
 
+    def mark_as_processed
+      update_attribute(:cvv_response_message, nil)
+    end
+
     private
 
     # Don't charge fees for invalid or failed payments.

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -33,12 +33,12 @@ class ProcessPaymentIntent
     validate_intent!
     return Result.new(ok: false) unless valid?
 
-    mark_as_processed
-
     OrderWorkflow.new(order).next
 
     if last_payment.can_complete?
       last_payment.complete!
+      last_payment.mark_as_processed
+
       Result.new(ok: true)
     else
       Result.new(ok: false, error: "The payment could not be completed")
@@ -62,10 +62,6 @@ class ProcessPaymentIntent
 
   def matches_last_payment?
     last_payment&.state == "pending" && last_payment&.response_code == payment_intent
-  end
-
-  def mark_as_processed
-    last_payment.update_attribute(:cvv_response_message, nil)
   end
 
   def stripe_account_id

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -23,10 +23,10 @@ class ProcessPaymentIntent
     end
   end
 
-  def initialize(payment_intent, order)
+  def initialize(payment_intent, order, last_payment = nil)
     @payment_intent = payment_intent
     @order = order
-    @last_payment = OrderPaymentFinder.new(order).last_payment
+    @last_payment = last_payment.presence || OrderPaymentFinder.new(order).last_payment
   end
 
   def call!
@@ -35,10 +35,15 @@ class ProcessPaymentIntent
 
     mark_as_processed
 
-    OrderWorkflow.new(@order).next
-    last_payment.complete! if last_payment.can_complete?
+    OrderWorkflow.new(order).next
 
-    Result.new(ok: true)
+    if last_payment.can_complete?
+      last_payment.complete!
+      Result.new(ok: true)
+    else
+      Result.new(ok: false, error: "The payment could not be completed")
+    end
+
   rescue Stripe::StripeError => e
     Result.new(ok: false, error: e.message)
   end

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -41,7 +41,7 @@ class ProcessPaymentIntent
 
       Result.new(ok: true)
     else
-      Result.new(ok: false, error: "The payment could not be completed")
+      Result.new(ok: false, error: I18n.t("payment_could_not_complete"))
     end
 
   rescue Stripe::StripeError => e

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -3,12 +3,26 @@
 # When directing a customer to Stripe to authorize the payment, we specify a
 # redirect_url that Stripe should return them to. When checking out, it's
 # /checkout; for admin payments and subscription payemnts it's the order url.
+#
 # This class confirms that the payment intent matches what's in our database,
 # marks the payment as complete, and removes the cvv_response_message field,
 # which we use to indicate that authorization is required. It also completes the
 # Order, if appropriate.
 
 class ProcessPaymentIntent
+  class Result
+    attr_reader :error
+
+    def initialize(ok:, error: "")
+      @ok = ok
+      @error = error
+    end
+
+    def ok?
+      @ok
+    end
+  end
+
   def initialize(payment_intent, order)
     @payment_intent = payment_intent
     @order = order
@@ -16,11 +30,17 @@ class ProcessPaymentIntent
   end
 
   def call!
-    return unless valid?
+    validate_intent!
+    return Result.new(ok: false) unless valid?
 
-    last_payment.update_attribute(:cvv_response_message, nil)
+    mark_as_processed
+
     OrderWorkflow.new(@order).next
     last_payment.complete! if last_payment.can_complete?
+
+    Result.new(ok: true)
+  rescue Stripe::StripeError => e
+    Result.new(ok: false, error: e.message)
   end
 
   private
@@ -28,14 +48,26 @@ class ProcessPaymentIntent
   attr_reader :order, :payment_intent, :last_payment
 
   def valid?
-    order.present? && valid_intent_string? && matches_last_payment?
+    order.present? && matches_last_payment?
   end
 
-  def valid_intent_string?
-    payment_intent&.starts_with?("pi_")
+  def validate_intent!
+    Stripe::PaymentIntentValidator.new.call(payment_intent, stripe_account_id)
   end
 
   def matches_last_payment?
     last_payment&.state == "pending" && last_payment&.response_code == payment_intent
+  end
+
+  def mark_as_processed
+    last_payment.update_attribute(:cvv_response_message, nil)
+  end
+
+  def stripe_account_id
+    StripeAccount.find_by(enterprise_id: preferred_enterprise_id).stripe_user_id
+  end
+
+  def preferred_enterprise_id
+    last_payment.payment_method.preferred_enterprise_id
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -349,6 +349,8 @@ en:
   height: "Height"
   width: "Width"
   depth: "Depth"
+  payment_could_not_process: "The payment could not be processed"
+  payment_could_not_complete: "The payment could not be completed"
 
   actions:
     create_and_add_another: "Create and Add Another"

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -926,4 +926,13 @@ describe Spree::Payment do
       end
     end
   end
+
+  describe "#mark_as_processed" do
+    let(:payment) { create(:payment, cvv_response_message: "message") }
+
+    it "removes the cvv_response_message" do
+      payment.mark_as_processed
+      expect(payment.cvv_response_message).to eq(nil)
+    end
+  end
 end

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -94,5 +94,27 @@ describe ProcessPaymentIntent do
         expect(payment.reload.state).to eq("failed")
       end
     end
+
+    context "when the payment can't be completed" do
+      let(:intent) { "pi_123" }
+      let(:service) { ProcessPaymentIntent.new(intent, order, payment) }
+
+      before do
+        allow(payment).to receive(:can_complete?).and_return(false)
+        allow(validator).to receive(:call).with(intent, anything).and_return(intent)
+      end
+
+      it "returns a failed result" do
+        result = service.call!
+
+        expect(result.ok?).to eq(false)
+        expect(result.error).to eq("The payment could not be completed")
+      end
+
+      it "does not complete the payment" do
+        service.call!
+        expect(payment.reload.state).to eq("pending")
+      end
+    end
   end
 end

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -8,17 +8,36 @@ describe ProcessPaymentIntent do
   describe "processing a payment intent" do
     let(:customer) { create(:customer) }
     let(:order) { create(:order, customer: customer, distributor: customer.enterprise, state: "payment") }
+    let(:payment_method) { create(:stripe_sca_payment_method) }
     let!(:payment) { create(
       :payment,
+      payment_method: payment_method,
       cvv_response_message: "https://stripe.com/redirect",
       response_code: "pi_123",
       order: order,
       state: "pending")
     }
+    let(:validator) { instance_double(Stripe::PaymentIntentValidator) }
+
+    before do
+      allow(Stripe::PaymentIntentValidator).to receive(:new).and_return(validator)
+    end
 
     context "an invalid intent" do
-      let(:invalid_intent) { "invalid" }
-      let(:service) { ProcessPaymentIntent.new(invalid_intent, order) }
+      let(:intent) { "invalid" }
+      let(:service) { ProcessPaymentIntent.new(intent, order) }
+
+      before do
+        allow(validator)
+          .to receive(:call).with(intent, anything).and_raise(Stripe::StripeError, "error message")
+      end
+
+      it "returns the error message" do
+        result = service.call!
+
+        expect(result.ok?).to eq(false)
+        expect(result.error).to eq("error message")
+      end
 
       it "does not complete the payment" do
         service.call!
@@ -27,11 +46,17 @@ describe ProcessPaymentIntent do
     end
 
     context "a valid intent" do
-      let(:valid_intent) { "pi_123" }
-      let(:service) { ProcessPaymentIntent.new(valid_intent, order) }
+      let(:intent) { "pi_123" }
+      let(:service) { ProcessPaymentIntent.new(intent, order) }
 
       before do
         allow(order).to receive(:deliver_order_confirmation_email)
+        allow(validator).to receive(:call).with(intent, anything).and_return(intent) 
+      end
+
+      it "validates the intent" do
+        service.call!
+        expect(validator).to have_received(:call)
       end
 
       it "completes the payment" do
@@ -49,11 +74,19 @@ describe ProcessPaymentIntent do
     end
 
     context "payment is in a failed state" do
-      let(:invalid_intent) { "invalid" }
-      let(:service) { ProcessPaymentIntent.new(invalid_intent, order) }
+      let(:intent) { "valid" }
+      let(:service) { ProcessPaymentIntent.new(intent, order) }
 
       before do
         payment.update_attribute(:state, "failed")
+        allow(validator).to receive(:call).with(intent, anything).and_return(intent)
+      end
+
+      it "does not return any error message" do
+        result = service.call!
+
+        expect(result.ok?).to eq(false)
+        expect(result.error).to eq("")
       end
 
       it "does not complete the payment" do

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -108,7 +108,7 @@ describe ProcessPaymentIntent do
         result = service.call!
 
         expect(result.ok?).to eq(false)
-        expect(result.error).to eq("The payment could not be completed")
+        expect(result.error).to eq(I18n.t("payment_could_not_complete"))
       end
 
       it "does not complete the payment" do


### PR DESCRIPTION
#### What? Why?

Closes #7509. This validates payment intents against Stripe and displays all the possible errors to the user.

This is how it looks:

![Peek 2021-05-06 12-29](https://user-images.githubusercontent.com/762088/117317387-c5f74000-ae89-11eb-848a-d29d5e8ebbf6.gif)

#### What should we test?

The exact scenario described in #7509.

#### Release notes

Fix Stripe's unauthorized payments not reflected in the order and show any possible error with the payment to the user.
Changelog Category: User facing changes
