### PR TITLE
[Rails 6.0] Replace be_success on test_response with status 200

### DIFF
--- a/engines/order_management/spec/controllers/order_management/reports/bulk_coop_controller_spec.rb
+++ b/engines/order_management/spec/controllers/order_management/reports/bulk_coop_controller_spec.rb
@@ -17,7 +17,7 @@ describe OrderManagement::Reports::BulkCoopController, type: :controller do
     it "renders the report form" do
       get :new
 
-      expect(response).to be_success
+      expect(response.status).to eq 200
       expect(response).to render_template(new_template_path)
     end
   end
@@ -32,7 +32,7 @@ describe OrderManagement::Reports::BulkCoopController, type: :controller do
           }, report_format: "csv"
         }
 
-        expect(response).to be_success
+        expect(response.status).to eq 200
         expect(response.body).not_to be_blank
         expect(response.header["Content-Type"]).to eq("text/csv")
       end

--- a/engines/order_management/spec/controllers/order_management/reports/enterprise_fee_summaries_controller_spec.rb
+++ b/engines/order_management/spec/controllers/order_management/reports/enterprise_fee_summaries_controller_spec.rb
@@ -17,7 +17,7 @@ describe OrderManagement::Reports::EnterpriseFeeSummariesController, type: :cont
     it "renders the report form" do
       get :new
 
-      expect(response).to be_success
+      expect(response.status).to eq 200
       expect(response).to render_template(new_template_path)
     end
   end
@@ -29,7 +29,7 @@ describe OrderManagement::Reports::EnterpriseFeeSummariesController, type: :cont
           report: { start_at: "2018-10-09 07:30:00" }, report_format: "csv"
         }
 
-        expect(response).to be_success
+        expect(response.status).to eq 200
         expect(response.body).not_to be_blank
         expect(response.header["Content-Type"]).to eq("text/csv")
       end

--- a/spec/controllers/api/v0/enterprises_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprises_controller_spec.rb
@@ -31,7 +31,7 @@ describe Api::V0::EnterprisesController, type: :controller do
 
       it "creates as sells=any when it is not a producer" do
         api_post :create, { enterprise: new_enterprise_params }
-        expect(response).to be_success
+        expect(response.status).to eq 201
 
         enterprise = Enterprise.last
         expect(enterprise.sells).to eq('any')
@@ -44,7 +44,7 @@ describe Api::V0::EnterprisesController, type: :controller do
           enterprise: new_enterprise_params.
             merge({ user_ids: [enterprise_owner.id, manager1.id, manager2.id] })
         }
-        expect(response).to be_success
+        expect(response.status).to eq 201
 
         enterprise = Enterprise.last
         expect(enterprise.user_ids).to match_array([enterprise_owner.id, manager1.id, manager2.id])
@@ -83,7 +83,7 @@ describe Api::V0::EnterprisesController, type: :controller do
 
       it "I can update enterprise image" do
         api_post :update_image, logo: 'a logo', id: enterprise.id
-        expect(response).to be_success
+        expect(response.status).to eq 200
       end
     end
   end

--- a/spec/controllers/api/v0/logos_controller_spec.rb
+++ b/spec/controllers/api/v0/logos_controller_spec.rb
@@ -30,7 +30,7 @@ module Api
         it "removes logo" do
           spree_delete :destroy, enterprise_id: enterprise
 
-          expect(response).to be_success
+          expect(response.status).to eq 200
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
           expect(enterprise.logo?).to be false
@@ -53,7 +53,7 @@ module Api
 
         it "allows removal of logo" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response).to be_success
+          expect(response.status).to eq 200
         end
       end
 
@@ -62,7 +62,7 @@ module Api
 
         it "allows removal of logo" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response).to be_success
+          expect(response.status).to eq 200
         end
       end
 

--- a/spec/controllers/api/v0/promo_images_controller_spec.rb
+++ b/spec/controllers/api/v0/promo_images_controller_spec.rb
@@ -30,7 +30,7 @@ module Api
         it "removes promo image" do
           spree_delete :destroy, enterprise_id: enterprise
 
-          expect(response).to be_success
+          expect(response.status).to eq 200
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
           expect(enterprise.promo_image?).to be false
@@ -53,7 +53,7 @@ module Api
 
         it "allows removal of promo image" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response).to be_success
+          expect(response.status).to eq 200
         end
       end
 
@@ -62,7 +62,7 @@ module Api
 
         it "allows removal of promo image" do
           spree_delete :destroy, enterprise_id: enterprise
-          expect(response).to be_success
+          expect(response.status).to eq 200
         end
       end
 

--- a/spec/controllers/api/v0/statuses_controller_spec.rb
+++ b/spec/controllers/api/v0/statuses_controller_spec.rb
@@ -10,21 +10,21 @@ module Api
       it "returns alive when up to date" do
         Spree::Config.last_job_queue_heartbeat_at = Time.now.in_time_zone
         get :job_queue
-        expect(response).to be_success
+        expect(response.status).to eq 200
         expect(response.body).to eq({ alive: true }.to_json)
       end
 
       it "returns dead otherwise" do
         Spree::Config.last_job_queue_heartbeat_at = 10.minutes.ago
         get :job_queue
-        expect(response).to be_success
+        expect(response.status).to eq 200
         expect(response.body).to eq({ alive: false }.to_json)
       end
 
       it "returns dead when no heartbeat recorded" do
         Spree::Config.last_job_queue_heartbeat_at = nil
         get :job_queue
-        expect(response).to be_success
+        expect(response.status).to eq 200
         expect(response.body).to eq({ alive: false }.to_json)
       end
     end

--- a/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
+++ b/spec/controllers/api/v0/terms_and_conditions_controller_spec.rb
@@ -26,7 +26,7 @@ module Api
         it "removes terms and conditions file" do
           spree_delete :destroy, enterprise_id: enterprise
 
-          expect(response).to be_success
+          expect(response.status).to eq 200
           expect(json_response["id"]).to eq enterprise.id
           enterprise.reload
           expect(enterprise.terms_and_conditions?).to be false

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -118,7 +118,7 @@ describe CheckoutController, type: :controller do
 
         it "does not redirect" do
           get :edit
-          expect(response).to be_success
+          expect(response.status).to eq 200
         end
 
         it "returns a specific flash message when Spree::Core::GatewayError occurs" do

--- a/spec/controllers/shop_controller_spec.rb
+++ b/spec/controllers/shop_controller_spec.rb
@@ -36,7 +36,7 @@ describe ShopController, type: :controller do
         oc2 = create(:simple_order_cycle, distributors: [distributor])
 
         spree_post :order_cycle, order_cycle_id: oc2.id
-        expect(response).to be_success
+        expect(response.status).to eq 200
         expect(controller.current_order_cycle).to eq(oc2)
       end
 
@@ -48,7 +48,7 @@ describe ShopController, type: :controller do
           oc2 = create(:simple_order_cycle, distributors: [distributor])
 
           spree_post :order_cycle, order_cycle_id: oc2.id
-          expect(response).to be_success
+          expect(response.status).to eq 200
           expect(response.body).to have_content oc2.id
         end
 
@@ -68,7 +68,7 @@ describe ShopController, type: :controller do
 
           it "returns the new order cycle details" do
             spree_post :order_cycle, order_cycle_id: oc2.id
-            expect(response).to be_success
+            expect(response.status).to eq 200
             expect(response.body).to have_content oc2.id
           end
         end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -24,7 +24,7 @@ describe Spree::OrdersController, type: :controller do
 
       it "loads page" do
         get :show, params: { id: order.number, token: order.token }
-        expect(response).to be_success
+        expect(response.status).to eq 200
       end
 
       it "stores order token in session as 'access_token'" do
@@ -43,7 +43,7 @@ describe Spree::OrdersController, type: :controller do
 
       it "loads page" do
         get :show, params: { id: order.number }
-        expect(response).to be_success
+        expect(response.status).to eq 200
       end
     end
 
@@ -52,7 +52,7 @@ describe Spree::OrdersController, type: :controller do
 
       it "loads page" do
         get :show, params: { id: order.number }
-        expect(response).to be_success
+        expect(response.status).to eq 200
       end
     end
 
@@ -113,7 +113,7 @@ describe Spree::OrdersController, type: :controller do
         it "completes the payment" do
           get :show, params: { id: order.number, payment_intent: payment_intent }
 
-          expect(response).to be_success
+          expect(response.status).to eq 200
           payment.reload
           expect(payment.cvv_response_message).to be nil
           expect(payment.state).to eq("completed")
@@ -153,7 +153,7 @@ describe Spree::OrdersController, type: :controller do
         it "does not complete the payment" do
           get :show, params: { id: order.number, payment_intent: payment_intent }
 
-          expect(response).to be_success
+          expect(response.status).to eq 200
           payment.reload
           expect(payment.cvv_response_message).to eq("https://stripe.com/redirect")
           expect(payment.state).to eq("pending")

--- a/spec/controllers/user_passwords_controller_spec.rb
+++ b/spec/controllers/user_passwords_controller_spec.rb
@@ -15,7 +15,7 @@ describe UserPasswordsController, type: :controller do
   describe "create" do
     it "returns errors" do
       spree_post :create, spree_user: {}
-      expect(response).to be_success
+      expect(response.status).to eq 200
       expect(response).to render_template "spree/user_passwords/new"
     end
 

--- a/spec/performance/shop_controller_spec.rb
+++ b/spec/performance/shop_controller_spec.rb
@@ -38,7 +38,7 @@ describe ShopController, type: :controller, performance: true do
     it "returns products via json" do
       results = multi_benchmark(3, cache_key_patterns: cache_key_patterns) do
         get :products, xhr: true
-        expect(response).to be_success
+        expect(response.status).to eq 200
       end
     end
   end


### PR DESCRIPTION
In rails 6 response.success? is not supported.

#### What? Why?
For some reason reponse.success? is not present in rails 6, so we use status = 200


#### What should we test?
pr no test. only specs changed


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
update code to rails 6


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
