### PR TITLE
[Rails 6.0] Fix problem in erb template by explicitly setting format to js

### DIFF
--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -26,4 +26,4 @@
     var shipments = [];
     - @order.shipments.each do |shipment|
       shipments.push(#{shipment.to_json(:root => false, :include => [:inventory_units, :stock_location]).html_safe});
-    = render :partial => 'spree/admin/shared/update_order_state', :handlers => [:erb]
+    = render :partial => 'spree/admin/shared/update_order_state', :handlers => [:erb], :formats => [:js]


### PR DESCRIPTION

#### What? Why?
In rails 6 the erb template is called with html and fails. We need to set format to js so the js.erb file is loaded.


#### What should we test?
<!-- List which features should be tested and how. -->
I am not completely sure where this is used. I think this are the payment and shipment status on the admin order page.




#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Adapt code to rails 6


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
