### PR TITLE
[Rails 6.0] Add stripe test keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ env:
   DISABLE_KNAPSACK: true
   TIMEZONE: UTC
   COVERAGE: true
+  STRIPE_INSTANCE_SECRET_KEY: 'sk_test_9x7Au91q3BRmsPi1H2l6qvIf00lpLDKToD'
+  STRIPE_INSTANCE_PUBLISHABLE_KEY: 'pk_test_eEobkSV1pzlSnnXIxf1vXvOm00ASnsfCDd'
 
 jobs:
   test-controllers-and-serializers:

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe Spree::OrdersController, type: :controller do
   include OpenFoodNetwork::EmailHelper
   include CheckoutHelper
+  include StripeStubs
 
   let(:distributor) { double(:distributor) }
   let(:order) { create(:order) }
@@ -148,6 +149,7 @@ describe Spree::OrdersController, type: :controller do
         before do
           allow(payment).to receive(:response_code).and_return("invalid")
           allow(OrderPaymentFinder).to receive(:new).with(order).and_return(finder)
+          stub_payment_intent_get_request(payment_intent_id: "valid")
         end
 
         it "does not complete the payment" do

--- a/spec/support/request/stripe_stubs.rb
+++ b/spec/support/request/stripe_stubs.rb
@@ -14,8 +14,8 @@ module StripeStubs
       .to_return(payment_intent_redirect_response_mock(redirect_url))
   end
 
-  def stub_payment_intent_get_request(response: {}, stripe_account_header: true)
-    stub = stub_request(:get, "https://api.stripe.com/v1/payment_intents/pi_123")
+  def stub_payment_intent_get_request(response: {}, stripe_account_header: true, payment_intent_id: "pi_123")
+    stub = stub_request(:get, "https://api.stripe.com/v1/payment_intents/#{payment_intent_id}")
     stub = stub.with(headers: { 'Stripe-Account' => 'abc123' }) if stripe_account_header
     stub.to_return(payment_intent_authorize_response_mock(response))
   end


### PR DESCRIPTION
#### What? Why?

For some reason Stripe specs are failing in the Rails 6 branch without this in the ENV. If we don't want to check these into production (even though they're test keys) we could probably configure them with Github Secrets (and I can cycle mine).
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Green build


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Updated test config for Rails 6
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
