### PR TITLE
Removed N+1 queries while counting line_items

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -14,7 +14,7 @@ module Spree
 
     def show
       @payments_requiring_action = PaymentsRequiringAction.new(spree_current_user).query
-      @orders = orders_collection
+      @orders = orders_collection.includes(:line_items)
 
       customers = spree_current_user.customers
       @shops = Enterprise

--- a/app/serializers/api/order_serializer.rb
+++ b/app/serializers/api/order_serializer.rb
@@ -22,7 +22,7 @@ module Api
     end
 
     def item_count
-      object.line_items.sum(:quantity)
+      object.line_items.size
     end
 
     def completed_at

--- a/app/serializers/api/order_serializer.rb
+++ b/app/serializers/api/order_serializer.rb
@@ -14,7 +14,7 @@ module Api
     end
 
     def payments
-      object.payments.joins(:payment_method).includes(:spree_payments).where('state IN (?)', %w(completed pending))
+      object.payments.joins(:payment_method).where('state IN (?)', %w(completed pending))
     end
 
     def shop_id

--- a/app/serializers/api/order_serializer.rb
+++ b/app/serializers/api/order_serializer.rb
@@ -22,7 +22,7 @@ module Api
     end
 
     def item_count
-      object.line_items.inject(0) {|sum, line_item| sum + line_item.quantity}
+      object.line_items.sum(&:quantity)
     end
 
     def completed_at

--- a/app/serializers/api/order_serializer.rb
+++ b/app/serializers/api/order_serializer.rb
@@ -14,7 +14,7 @@ module Api
     end
 
     def payments
-      object.payments.joins(:payment_method).where('state IN (?)', %w(completed pending))
+      object.payments.joins(:payment_method).includes(:spree_payments).where('state IN (?)', %w(completed pending))
     end
 
     def shop_id
@@ -22,7 +22,7 @@ module Api
     end
 
     def item_count
-      object.line_items.size
+      object.line_items.inject(0) {|sum, line_item| sum + line_item.quantity}
     end
 
     def completed_at

--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :injection_data do
-  = inject_json_array("orders", @orders.all, Api::OrderSerializer)
+  = inject_json_array("orders", @orders.all.includes(:line_items), Api::OrderSerializer)
   = inject_json_array("shops", @shops.all, Api::ShopForOrdersSerializer)
   = inject_saved_credit_cards
 

--- a/app/views/spree/users/show.html.haml
+++ b/app/views/spree/users/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :injection_data do
-  = inject_json_array("orders", @orders.all.includes(:line_items), Api::OrderSerializer)
+  = inject_json_array("orders", @orders.all, Api::OrderSerializer)
   = inject_json_array("shops", @shops.all, Api::ShopForOrdersSerializer)
   = inject_saved_credit_cards
 


### PR DESCRIPTION
#### What? Why?

Previously when line_items are loaded in order to count quantity of items in `/account#/orders` , N+1 queries were being executed. This should now be fixed with this change.

Closes #7473

The number of orders under `account` are not limited so there can possibly be a large number of them, placing a huge load on the server. 

I fixed it by changing :

 `object.line_items.sum(:quantity)` in `app/serializers/api/order_serializer.rb` to 

![image](https://user-images.githubusercontent.com/65319144/117549662-520b9200-b059-11eb-9bd2-2356c6d4fd1d.png)

and `= inject_json_array("orders", @orders.all, Api::OrderSerializer)` in `app/views/spree/users/show.html.haml` to

![image](https://user-images.githubusercontent.com/65319144/117545660-58434380-b044-11eb-9e31-1cfa82e2e46c.png)

#### What should we test?

- That every time a new order is added to `account#/orders`, only a single line query is executed to load line_items.
- That on the user facing side, the correct quantity is counted.

#### Release notes

- N+1 is removed when loading line_items in `account#/orders`
- Loading spree_payments and enterprises still executes N+1 queries and has to be looked into : 
```
web_1     |   Spree::LineItem Load (1.3ms)  SELECT "spree_line_items".* FROM "spree_line_items" WHERE "spree_line_items"."order_id" IN (8, 7, 6) ORDER BY created_at ASC
web_1     |   Enterprise Load (1.4ms)  SELECT  "enterprises".* FROM "enterprises" WHERE "enterprises"."id" = $1 LIMIT $2  [["id", 5], ["LIMIT", 1]]
web_1     |   Spree::Payment Load (1.2ms)  SELECT "spree_payments".* FROM "spree_payments" INNER JOIN "spree_payment_methods" ON "spree_payment_methods"."id" = "spree_payments"."payment_method_id" AND "spree_payment_methods"."deleted_at" IS NULL WHERE "spree_payments"."order_id" = $1 AND (state IN ('completed','pending'))  [["order_id", 8]]
web_1     |   Enterprise Load (2.1ms)  SELECT  "enterprises".* FROM "enterprises" WHERE "enterprises"."id" = $1 LIMIT $2  [["id", 6], ["LIMIT", 1]]
web_1     |   Spree::Payment Load (1.2ms)  SELECT "spree_payments".* FROM "spree_payments" INNER JOIN "spree_payment_methods" ON "spree_payment_methods"."id" = "spree_payments"."payment_method_id" AND "spree_payment_methods"."deleted_at" IS NULL WHERE "spree_payments"."order_id" = $1 AND (state IN ('completed','pending'))  [["order_id", 7]]
web_1     |   Enterprise Load (1.1ms)  SELECT  "enterprises".* FROM "enterprises" WHERE "enterprises"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
web_1     |   Spree::Payment Load (1.7ms)  SELECT "spree_payments".* FROM "spree_payments" INNER JOIN "spree_payment_methods" ON "spree_payment_methods"."id" = "spree_payments"."payment_method_id" AND "spree_payment_methods"."deleted_at" IS NULL WHERE "spree_payments"."order_id" = $1 AND (state IN ('completed','pending'))  [["order_id", 6]]

```


<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

