### PR TITLE
Set Stripe api key directly in tests instead of using `allow`

### DIFF
--- a/spec/controllers/admin/stripe_accounts_controller_spec.rb
+++ b/spec/controllers/admin/stripe_accounts_controller_spec.rb
@@ -6,7 +6,7 @@ describe Admin::StripeAccountsController, type: :controller do
   let(:enterprise) { create(:distributor_enterprise) }
 
   before do
-    allow(Stripe).to receive(:client_id) { "some_id" }
+    Stripe.client_id = "some_id"
   end
 
   describe "#connect" do
@@ -86,7 +86,7 @@ describe Admin::StripeAccountsController, type: :controller do
     end
 
     before do
-      allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+      Stripe.api_key = "sk_test_12345"
       Spree::Config.set(stripe_connect_enabled: false)
     end
 

--- a/spec/controllers/admin/stripe_connect_settings_controller_spec.rb
+++ b/spec/controllers/admin/stripe_connect_settings_controller_spec.rb
@@ -30,7 +30,7 @@ describe Admin::StripeConnectSettingsController, type: :controller do
 
       context "when a Stripe API key is not set" do
         before do
-          allow(Stripe).to receive(:api_key) { nil }
+          Stripe.api_key = nil
         end
 
         it "sets the account status to :empty_api_key_error_html" do
@@ -42,7 +42,7 @@ describe Admin::StripeConnectSettingsController, type: :controller do
 
       context "when a Stripe API key is set" do
         before do
-          allow(Stripe).to receive(:api_key) { "sk_test_xxxx" }
+          Stripe.api_key = "sk_test_xxxx"
         end
 
         context "and the request to retrieve Stripe account info fails" do

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -153,7 +153,7 @@ describe CheckoutController, type: :controller do
         }
 
         before do
-          allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+          Stripe.api_key = "sk_test_12345"
           stub_payment_intent_get_request
           stub_successful_capture_request(order: order)
 

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_refunds_spec.rb
@@ -31,7 +31,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
         end
 
         before do
-          allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+          Stripe.api_key = "sk_test_12345"
         end
 
         context "where the request succeeds" do
@@ -90,7 +90,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
         end
 
         before do
-          allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+          Stripe.api_key = "sk_test_12345"
         end
 
         context "where the request succeeds" do
@@ -152,7 +152,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
         let(:stripe_account) { create(:stripe_account, enterprise: shop) }
 
         before do
-          allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+          Stripe.api_key = "sk_test_12345"
           allow(StripeAccount).to receive(:find_by) { stripe_account }
         end
 
@@ -236,7 +236,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
         end
 
         before do
-          allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+          Stripe.api_key = "sk_test_12345"
 
           stub_payment_intent_get_request stripe_account_header: false
         end

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::CreditCardsController, type: :controller do
   let(:token) { "tok_234bd2c22" }
 
   before do
-    allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+    Stripe.api_key = "sk_test_12345"
     allow(controller).to receive(:spree_current_user) { user }
   end
 

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe Spree::OrdersController, type: :controller do
   include OpenFoodNetwork::EmailHelper
   include CheckoutHelper
+  include StripeStubs
 
   let(:distributor) { double(:distributor) }
   let(:order) { create(:order) }
@@ -148,6 +149,7 @@ describe Spree::OrdersController, type: :controller do
         before do
           allow(payment).to receive(:response_code).and_return("invalid")
           allow(OrderPaymentFinder).to receive(:new).with(order).and_return(finder)
+          stub_payment_intent_get_request(payment_intent_id: "valid")
         end
 
         it "does not complete the payment" do

--- a/spec/features/admin/payment_method_spec.rb
+++ b/spec/features/admin/payment_method_spec.rb
@@ -47,7 +47,7 @@ feature '
 
       before do
         Spree::Config.set(stripe_connect_enabled: true)
-        allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+        Stripe.api_key = "sk_test_12345"
         stub_request(:get, "https://api.stripe.com/v1/accounts/acc_connected123").to_return(body: JSON.generate(stripe_account_mock))
         stub_request(:get, "https://api.stripe.com/v1/accounts/acc_revoked123").to_return(status: 404)
       end

--- a/spec/features/consumer/account/cards_spec.rb
+++ b/spec/features/consumer/account/cards_spec.rb
@@ -22,8 +22,8 @@ feature "Credit Cards", js: true do
     before do
       login_as user
 
-      allow(Stripe).to receive(:api_key) { "sk_test_12345" }
-      allow(Stripe).to receive(:publishable_key) { "some_token" }
+      Stripe.api_key = "sk_test_12345"
+      Stripe.publishable_key = "some_token"
       Spree::Config.set(stripe_connect_enabled: true)
 
       stub_request(:get, "https://api.stripe.com/v1/customers/cus_AZNMJ").

--- a/spec/helpers/enterprises_helper_spec.rb
+++ b/spec/helpers/enterprises_helper_spec.rb
@@ -266,7 +266,7 @@ describe EnterprisesHelper, type: :helper do
 
         before do
           Spree::Config.set(stripe_connect_enabled: true)
-          allow(Stripe).to receive(:publishable_key) { "some_key" }
+          Stripe.publishable_key = "some_key"
         end
 
         it "includes Stripe payment methods with a valid stripe accounts" do

--- a/spec/lib/stripe/account_connector_spec.rb
+++ b/spec/lib/stripe/account_connector_spec.rb
@@ -15,7 +15,7 @@ module Stripe
       let(:connector) { AccountConnector.new(user, params) }
 
       before do
-        allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+        Stripe.api_key = "sk_test_12345"
       end
 
       context "when the connection was cancelled by the user" do

--- a/spec/lib/stripe/credit_card_cloner_spec.rb
+++ b/spec/lib/stripe/credit_card_cloner_spec.rb
@@ -24,7 +24,7 @@ module Stripe
       }
 
       before do
-        allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+        Stripe.api_key = "sk_test_12345"
 
         stub_customers_post_request email: credit_card.user.email,
                                     response: { customer_id: new_customer_id },

--- a/spec/lib/stripe/payment_intent_validator_spec.rb
+++ b/spec/lib/stripe/payment_intent_validator_spec.rb
@@ -12,7 +12,7 @@ module Stripe
       let(:payment_intent_response_mock) { { status: 200, body: payment_intent_response_body } }
 
       before do
-        allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+        Stripe.api_key = "sk_test_12345"
 
         stub_request(:get, "https://api.stripe.com/v1/payment_intents/#{payment_intent_id}")
           .with(headers: { 'Stripe-Account' => stripe_account_id })

--- a/spec/lib/stripe/profile_storer_spec.rb
+++ b/spec/lib/stripe/profile_storer_spec.rb
@@ -14,7 +14,7 @@ module Stripe
       let(:customer_response_mock) { { status: 200, body: customer_response_body } }
 
       before do
-        allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+        Stripe.api_key = "sk_test_12345"
 
         stub_request(:post, "https://api.stripe.com/v1/customers")
           .with(basic_auth: ["sk_test_12345", ""], body: { email: payment.order.email })

--- a/spec/models/spree/gateway/stripe_connect_spec.rb
+++ b/spec/models/spree/gateway/stripe_connect_spec.rb
@@ -15,7 +15,7 @@ describe Spree::Gateway::StripeConnect, type: :model do
   let(:stripe_account_id) { "acct_123" }
 
   before do
-    allow(Stripe).to receive(:api_key) { "sk_test_123456" }
+    Stripe.api_key = "sk_test_123456"
     allow(subject).to receive(:stripe_account_id) { stripe_account_id }
     allow(subject).to receive(:options_for_purchase_or_auth).and_return(['money', 'cc', 'opts'])
     allow(subject).to receive(:provider).and_return provider

--- a/spec/models/spree/gateway/stripe_sca_spec.rb
+++ b/spec/models/spree/gateway/stripe_sca_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Spree::Gateway::StripeSCA, type: :model do
-  before { allow(Stripe).to receive(:api_key) { "sk_test_12345" } }
+  before { Stripe.api_key = "sk_test_12345" }
 
   describe "#purchase" do
     let(:order) { create(:order_with_totals_and_distribution) }

--- a/spec/models/stripe_account_spec.rb
+++ b/spec/models/stripe_account_spec.rb
@@ -12,8 +12,8 @@ describe StripeAccount do
     let!(:stripe_account) { create(:stripe_account, enterprise: enterprise, stripe_user_id: stripe_user_id) }
 
     before do
-      allow(Stripe).to receive(:api_key) { "sk_test_12345" }
-      allow(Stripe).to receive(:client_id) { client_id }
+      Stripe.api_key = "sk_test_12345"
+      Stripe.client_id = client_id
     end
 
     context "when the Stripe API disconnect fails" do

--- a/spec/requests/checkout/stripe_connect_spec.rb
+++ b/spec/requests/checkout/stripe_connect_spec.rb
@@ -68,7 +68,7 @@ describe "checking out an order with a Stripe Connect payment method", type: :re
     allow(OrderCycleDistributedVariants).to receive(:new) { order_cycle_distributed_variants }
     allow(order_cycle_distributed_variants).to receive(:distributes_order_variants?) { true }
 
-    allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+    Stripe.api_key = "sk_test_12345"
     order.update(distributor_id: enterprise.id, order_cycle_id: order_cycle.id)
     order.reload.update_totals
     set_order order

--- a/spec/requests/checkout/stripe_sca_spec.rb
+++ b/spec/requests/checkout/stripe_sca_spec.rb
@@ -87,7 +87,7 @@ describe "checking out an order with a Stripe SCA payment method", type: :reques
     allow(OrderCycleDistributedVariants).to receive(:new) { order_cycle_distributed_variants }
     allow(order_cycle_distributed_variants).to receive(:distributes_order_variants?) { true }
 
-    allow(Stripe).to receive(:api_key) { "sk_test_12345" }
+    Stripe.api_key = "sk_test_12345"
     order.update(distributor_id: enterprise.id, order_cycle_id: order_cycle.id)
     order.reload.update_totals
     set_order order

--- a/spec/support/request/stripe_helper.rb
+++ b/spec/support/request/stripe_helper.rb
@@ -30,8 +30,8 @@ module StripeHelper
   end
 
   def setup_stripe
-    allow(Stripe).to receive(:api_key) { "sk_test_12345" }
-    allow(Stripe).to receive(:publishable_key) { "pk_test_12345" }
+    Stripe.api_key = "sk_test_12345"
+    Stripe.publishable_key = "pk_test_12345"
     Spree::Config.set(stripe_connect_enabled: true)
   end
 end

--- a/spec/support/request/stripe_stubs.rb
+++ b/spec/support/request/stripe_stubs.rb
@@ -14,8 +14,8 @@ module StripeStubs
       .to_return(payment_intent_redirect_response_mock(redirect_url))
   end
 
-  def stub_payment_intent_get_request(response: {}, stripe_account_header: true)
-    stub = stub_request(:get, "https://api.stripe.com/v1/payment_intents/pi_123")
+  def stub_payment_intent_get_request(response: {}, stripe_account_header: true, payment_intent_id: "pi_123")
+    stub = stub_request(:get, "https://api.stripe.com/v1/payment_intents/#{payment_intent_id}")
     stub = stub.with(headers: { 'Stripe-Account' => 'abc123' }) if stripe_account_header
     stub.to_return(payment_intent_authorize_response_mock(response))
   end


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/7357
See also https://github.com/openfoodfoundation/openfoodnetwork/pull/7327

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
This allows us to update the Stripe gem, which also clears the way for Rails 6.0


#### What should we test?
<!-- List which features should be tested and how. -->
Green build.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Updated tests to be compatible with latest Stripe gem
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
