### PR TITLE
[Rails 6.0] Fix enterprise permalink spec

### DIFF
--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -195,7 +195,7 @@ describe Enterprise do
       e2 = create(:enterprise, permalink: "not_taken")
       e2.permalink = "taken"
       e2.save
-      expect(e2.permalink).to eq "not_taken"
+      expect(e2.reload.permalink).to eq "not_taken"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

We have a custom method `restore_permalink` on Enterprise so that if you change the permalink to one that's already taken, we set it back to the old permalink in the form. We also warn you before you try to update the permalink if it's taken. 

For some reason the spec in Rails 6 requires us to reload the Enterprise to find the old permalink. I verified that in the form, the old one is restored. 
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Green build. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Updated enterprise spec to be compatible with Rails 6
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
