### PR TITLE
Ransack.search is deprecated. Use .ransack instead

### DIFF
--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -44,7 +44,7 @@ module Permissions
     def filtered_orders(orders)
       return orders unless filter_orders?
 
-      orders.complete.not_state(:canceled).search(search_params).result
+      orders.complete.not_state(:canceled).ransack(search_params).result
     end
 
     def filter_orders?

--- a/lib/open_food_network/order_and_distributor_report.rb
+++ b/lib/open_food_network/order_and_distributor_report.rb
@@ -36,7 +36,7 @@ module OpenFoodNetwork
     def search
       @permissions.visible_orders.select("DISTINCT spree_orders.*").
         complete.not_state(:canceled).
-        search(@params[:q])
+        ransack(@params[:q])
     end
 
     def table

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -51,7 +51,7 @@ module OpenFoodNetwork
         not_state(:canceled).
         distributed_by_user(@user).
         managed_by(@user).
-        search(params[:q])
+        ransack(params[:q])
     end
 
     def orders

--- a/lib/open_food_network/payments_report.rb
+++ b/lib/open_food_network/payments_report.rb
@@ -36,7 +36,7 @@ module OpenFoodNetwork
     end
 
     def search
-      Spree::Order.complete.not_state(:canceled).managed_by(@user).search(params[:q])
+      Spree::Order.complete.not_state(:canceled).managed_by(@user).ransack(params[:q])
     end
 
     def table_items

--- a/lib/open_food_network/reports/line_items.rb
+++ b/lib/open_food_network/reports/line_items.rb
@@ -38,7 +38,7 @@ module OpenFoodNetwork
       attr_reader :orders_relation, :order_permissions
 
       def search_orders
-        orders_relation.search(@params[:q])
+        orders_relation.ransack(@params[:q])
       end
 
       # From the line_items given, returns the ones that are editable by the user

--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -20,7 +20,7 @@ module OpenFoodNetwork
 
     def search
       permissions = ::Permissions::Order.new(@user)
-      permissions.editable_orders.complete.not_state(:canceled).search(@opts[:q])
+      permissions.editable_orders.complete.not_state(:canceled).ransack(@opts[:q])
     end
 
     def orders


### PR DESCRIPTION
#### What? Why?

We are still using the soon to be deprecated Ransack's `.search` method. We should be using `ransack` instead.

When running tests on master we get this warning:

 >  DEPRECATION WARNING: #search is deprecated and will be removed in 2.3, please use #ransack instead

Also, this dependabot PR was merged a few days ago (Bump ransack from 2.3.0 to 2.4.1): 
https://github.com/openfoodfoundation/openfoodnetwork/pull/7545

Ransack's official PR:
https://github.com/activerecord-hackery/ransack/pull/975