### PR TITLE
Add bullet footer

### DIFF
--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -3,6 +3,7 @@
 if defined?(Bullet) && ENV.fetch("ENABLE_BULLET", false)
   Rails.application.config.after_initialize do
     Bullet.enable = true
+    Bullet.add_footer = true
     Bullet.bullet_logger = true
     Bullet.rails_logger = true
   end


### PR DESCRIPTION
#### What?

Left corner of the page will show the bullet warnings

Example:

![2021-05-09_16-47-38](https://user-images.githubusercontent.com/1689020/117576556-b163b380-b0e6-11eb-8cb1-34eb849a5014.png)

####  Why?
If we are serious about eliminating N+1 queries, this could be a helpful reminder.
On pages where there are no issues, the warning won't show.
It might be annoying, but annoying works :wink: Having this reminder has forced me to fix many warning lately.

#### Side thoughts
1. The `bullet` gem in the Gemfile is in `development` **and** `test` mode - why do we also need it in `test` mode?

2. Bullet is started in an initializer that checks for the `ENABLE_BULLET` ENV var. Maybe it would be nice to have it always on, but only in `development`?
This would help newcomers see if we have N+1 issues, without them having to dig and find out how to enable bullet (in development mode only).

Related commits:
ed41888ba4
f684b5b234 

Bullet docs:
https://github.com/flyerhzm/bullet#install