### PR TITLE
Move line item rendering to a collection in cart page

### DIFF
--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -17,8 +17,7 @@
           %th.cart-item-delete-header
 
       %tbody#line_items{"data-hook" => ""}
-        = order_form.fields_for :line_items do |item_form|
-          = render :partial => 'line_item', :locals => { :variant => item_form.object.variant, :line_item => item_form.object, :item_form => item_form }
+        = render partial: 'line_item', collection: order_form.object.line_items, locals: {order_form: order_form}
 
       = render 'bought' if show_bought_items? && @order.cart?
 

--- a/app/views/spree/orders/_line_item.html.haml
+++ b/app/views/spree/orders/_line_item.html.haml
@@ -1,37 +1,39 @@
-%tr.line-item{class: "variant-#{variant.id}"}
-  %td.cart-item-description{'data-hook' => "cart_item_description"}
+- variant = line_item.variant
+= order_form.fields_for :line_items, line_item do |item_form|
+  %tr.line-item{class: "variant-#{variant.id}"}
+    %td.cart-item-description{'data-hook' => "cart_item_description"}
 
-    %div.item-thumb-image{"data-hook" => "cart_item_image"}
-      = render 'spree/shared/variant_thumbnail', variant: variant
+      %div.item-thumb-image{"data-hook" => "cart_item_image"}
+        = render 'spree/shared/variant_thumbnail', variant: variant
 
-    = render 'spree/shared/line_item_name', line_item: line_item
+      = render 'spree/shared/line_item_name', line_item: line_item
 
-    - if @insufficient_stock_lines.andand.include? line_item
-      %span.out-of-stock
-        = variant.in_stock? ? t(".insufficient_stock", :on_hand => variant.on_hand) : t(".out_of_stock")
-        %br/
+      - if @insufficient_stock_lines.andand.include? line_item
+        %span.out-of-stock
+          = variant.in_stock? ? t(".insufficient_stock", :on_hand => variant.on_hand) : t(".out_of_stock")
+          %br/
 
-    - if @unavailable_order_variants.andand.include? line_item.variant
-      %span.out-of-stock
-        = t(".unavailable_item")
-        %br/
+      - if @unavailable_order_variants.andand.include? line_item.variant
+        %span.out-of-stock
+          = t(".unavailable_item")
+          %br/
 
-  %td.text-right.cart-item-price{"data-hook" => "cart_item_price"}
-    = line_item.single_display_amount_with_adjustments.to_html
-    - if feature? :unit_price, spree_current_user
-      %br
-      %span.unit-price
-        = line_item.unit_price_price_and_unit
-  %td.text-center.cart-item-quantity{"data-hook" => "cart_item_quantity"}
-    - finalized_quantity = @order.completed? ? line_item.quantity : 0
-    = item_form.number_field :quantity,
-      :min => 0, "ofn-on-hand" => "#{variant.on_demand && 9999 || variant.on_hand}",
-      "finalizedquantity" => finalized_quantity, :class => "line_item_quantity", :size => 5,
-      "ng-model" => "line_item_#{line_item.id}",
-      "validate-stock-quantity" => true
-  %td.cart-item-total.text-right{"data-hook" => "cart_item_total"}
-    = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
+    %td.text-right.cart-item-price{"data-hook" => "cart_item_price"}
+      = line_item.single_display_amount_with_adjustments.to_html
+      - if feature? :unit_price, spree_current_user
+        %br
+        %span.unit-price
+          = line_item.unit_price_price_and_unit
+    %td.text-center.cart-item-quantity{"data-hook" => "cart_item_quantity"}
+      - finalized_quantity = @order.completed? ? line_item.quantity : 0
+      = item_form.number_field :quantity,
+        :min => 0, "ofn-on-hand" => "#{variant.on_demand && 9999 || variant.on_hand}",
+        "finalizedquantity" => finalized_quantity, :class => "line_item_quantity", :size => 5,
+        "ng-model" => "line_item_#{line_item.id}",
+        "validate-stock-quantity" => true
+    %td.cart-item-total.text-right{"data-hook" => "cart_item_total"}
+      = line_item.display_amount_with_adjustments.to_html unless line_item.quantity.nil?
 
-  %td.cart-item-delete.text-center{"data-hook" => "cart_item_delete"}
-    %a.delete{href: "#", id: "delete_#{dom_id(line_item)}"}
-      %i.delete.ofn-i_026-trash
+    %td.cart-item-delete.text-center{"data-hook" => "cart_item_delete"}
+      %a.delete{href: "#", id: "delete_#{dom_id(line_item)}"}
+        %i.delete.ofn-i_026-trash


### PR DESCRIPTION
#### What? Why?

Performance improvement from an upstream Spree commit. Brings a significant boost to rendering speeds (especially with larger numbers of items in the cart) by rendering a collection instead of N partials. 50%+ reduction in rendering times reported in original PR.

#### What should we test?
<!-- List which features should be tested and how. -->

Line items are shown correctly on the cart page. The page should load faster, especially when larger numbers of line items are in the cart.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved cart rendering performance

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
