### PR TITLE
Products and Inventory import: Items units

### DIFF
--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -333,6 +333,34 @@ feature "Product Import", js: true do
       expect(page).to have_input "variant-overrides-#{Spree::Product.find_by(name: 'Beets').variants.first.id}-price", with: "3.2"
     end
 
+    it "handles the Items unit for inventory import" do
+
+      product = create(:simple_product, supplier: enterprise, on_hand: nil, name: 'Aubergine', unit_value: '1', variant_unit_scale: nil, variant_unit: "items", variant_unit_name: "Bag")
+      csv_data = CSV.generate do |csv|
+        csv << ["name", "distributor", "producer", "category", "on_hand", "price", "unit_type", "units", "on_demand", "variant_unit_name"]
+        csv << ["Aubergine", "Another Enterprise", "User Enterprise", "Vegetables", "", "3.3",  "kg", "1", "true", "Bag"]
+      end
+
+      File.write('/tmp/test.csv', csv_data)
+      visit main_app.admin_product_import_path
+      select2_select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
+      attach_file 'file', '/tmp/test.csv'
+      click_button 'Upload'
+      proceed_to_validation
+      expect(page).to have_selector '.item-count', text: "1"
+      expect(page).to have_no_selector '.invalid-count'
+      expect(page).to have_selector '.inv-create-count', text: '1'
+      save_data
+
+      expect(page).to have_selector '.inv-created-count', text: '1'
+
+      visit main_app.admin_inventory_path
+
+      expect(page).to have_content "Aubergine"
+      expect(page).to have_select "variant-overrides-#{Spree::Product.find_by(name: 'Aubergine').variants.first.id}-on_demand", selected: "Yes"
+      expect(page).to have_input "variant-overrides-#{Spree::Product.find_by(name: 'Aubergine').variants.first.id}-price", with: "3.3"
+    end
+
     it "handles on_demand and on_hand validations with inventory" do
       csv_data = CSV.generate do |csv|
         csv << ["name", "distributor", "producer", "category", "on_hand", "price", "units", "on_demand"]

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -325,6 +325,12 @@ feature "Product Import", js: true do
       save_data
 
       expect(page).to have_selector '.inv-created-count', text: '1'
+
+      visit main_app.admin_inventory_path
+
+      expect(page).to have_content "Beets"
+      expect(page).to have_select "variant-overrides-#{Spree::Product.find_by(name: 'Beets').variants.first.id}-on_demand", selected: "Yes"
+      expect(page).to have_input "variant-overrides-#{Spree::Product.find_by(name: 'Beets').variants.first.id}-price", with: "3.2"
     end
 
     it "handles on_demand and on_hand validations with inventory" do

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -411,6 +411,43 @@ feature "Product Import", js: true do
       end
     end
 
+    it "imports lines with item products" do
+      csv_data = CSV.generate do |csv|
+        csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "variant_unit_name", "shipping_category_id"]
+        csv << ["Cupcake", "User Enterprise", "Cake", "5", "2.2", "1", "", "Bunch", shipping_category_id_str]
+      end
+      File.write('/tmp/test.csv', csv_data)
+
+      visit main_app.admin_product_import_path
+
+      expect(page).to have_content "Select a spreadsheet to upload"
+      attach_file 'file', '/tmp/test.csv'
+      click_button 'Upload'
+
+      proceed_to_validation
+
+      expect(page).to have_selector '.item-count', text: "1"
+      expect(page).to have_no_selector '.invalid-count'
+      expect(page).to have_selector '.create-count', text: "1"
+      expect(page).to have_no_selector '.update-count'
+
+      save_data
+
+      expect(page).to have_selector '.created-count', text: '1'
+      expect(page).to have_no_selector '.updated-count'
+      expect(page).to have_content "GO TO PRODUCTS PAGE"
+      expect(page).to have_content "UPLOAD ANOTHER FILE"
+
+      visit spree.admin_products_path
+
+      within "#p_#{Spree::Product.find_by(name: 'Cupcake').id}" do
+        expect(page).to have_input "product_name", with: "Cupcake"
+        expect(page).to have_select "variant_unit_with_scale", selected: "Items"
+        expect(page).to have_input "variant_unit_name", with: "Bunch"
+        expect(page).to have_content "5" #on_hand
+      end
+    end
+
     it "does not allow import for lines with unknown units" do
       csv_data = CSV.generate do |csv|
         csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type", "shipping_category_id"]


### PR DESCRIPTION
#### What? Why?

Partially addresses #7405.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This PR adds test coverage on product and inventory import with `Items` units; this was found to be missing from this feature spec.

Also adds a UI validation on `/products` and `/inventory` page for product and inventory import.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Adds coverage on product and inventory import with Item units.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
