### PR TITLE
[Rails 6.1] Upgrade thor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,9 +113,6 @@ gem 'jquery-migrate-rails'
 gem 'jquery-rails', '4.4.0'
 gem 'jquery-ui-rails', '~> 4.2'
 gem "select2-rails", github: "openfoodfoundation/select2-rails", branch: "v349_with_thor_v1"
-# Thor v0.20 works with both select2-rails 3.4.7 and railties 6.0.3.6
-#   To upgrade to thor v1 we need to upgrade select2-rails to v3.5 which requires some work
-gem 'thor', '~> 0.20'
 
 gem 'ofn-qz', github: 'openfoodfoundation/ofn-qz', branch: 'ofn-rails-4'
 

--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ gem 'foundation-rails', '= 5.5.2.1'
 gem 'jquery-migrate-rails'
 gem 'jquery-rails', '4.4.0'
 gem 'jquery-ui-rails', '~> 4.2'
-gem 'select2-rails', '~> 3.4.7'
+gem "select2-rails", github: "openfoodfoundation/select2-rails", branch: "v349_with_thor_v1"
 # Thor v0.20 works with both select2-rails 3.4.7 and railties 6.0.3.6
 #   To upgrade to thor v1 we need to upgrade select2-rails to v3.5 which requires some work
 gem 'thor', '~> 0.20'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,15 @@ GIT
   specs:
     ofn-qz (0.1.0)
 
+GIT
+  remote: https://github.com/openfoodfoundation/select2-rails.git
+  revision: fc240e85fbdf1878ff3c39d972c0cd9a312f5ed4
+  branch: v349_with_thor_v1
+  specs:
+    select2-rails (3.4.9)
+      sass-rails
+      thor (>= 0.14)
+
 PATH
   remote: engines/catalog
   specs:
@@ -563,9 +572,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    select2-rails (3.4.9)
-      sass-rails
-      thor (~> 0.14)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -764,7 +770,7 @@ DEPENDENCIES
   rubocop-rails
   sass (~> 3.4.0)
   sass-rails (< 5.1.0)
-  select2-rails (~> 3.4.7)
+  select2-rails!
   selenium-webdriver
   shoulda-matchers
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,7 @@ GEM
     test-prof (1.0.5)
     test-unit (3.4.2)
       power_assert
-    thor (0.20.3)
+    thor (1.1.0)
     thread_safe (0.3.6)
     thwait (0.2.0)
       e2mmap
@@ -783,7 +783,6 @@ DEPENDENCIES
   stripe
   test-prof
   test-unit (~> 3.4)
-  thor (~> 0.20)
   timecop
   uglifier (>= 1.0.3)
   unicorn-rails


### PR DESCRIPTION
#### What? Why?

select2-rails upgrade is blocking the upgrade to rails 6.1.
I tried relaxing the requirement for thor ≳ 14 in select2-rails so we could move thor to v1 and that would enable railities 6.1.
Looks like its workign as the green is build.

I dont have permissions to create the select2-rails repo in ofn, we can then push the branch 349_nothor to it and use it. That will enable the rails 6.1 upgrade.
EDIT: done. Now using modified select2-rails that works with thor v1. 


#### What should we test?
green build.
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
