### PR TITLE
[Rails 6.1] Adapt code to circunvent security constraint on rails 6.1

### DIFF
--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -56,7 +56,7 @@ class Exchange < ApplicationRecord
   scope :by_enterprise_name, -> {
     joins('INNER JOIN enterprises AS sender   ON (sender.id   = exchanges.sender_id)').
       joins('INNER JOIN enterprises AS receiver ON (receiver.id = exchanges.receiver_id)').
-      order("CASE WHEN exchanges.incoming='t' THEN sender.name ELSE receiver.name END")
+      order(Arel.sql("CASE WHEN exchanges.incoming='t' THEN sender.name ELSE receiver.name END"))
   }
 
   # Exchanges on order cycles that are dated and are upcoming or open are cached

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -65,10 +65,10 @@ module Spree
     # Find line items that are from order sorted by variant name and unit value
     scope :sorted_by_name_and_unit_value, -> {
       joins(variant: :product).
-        reorder("
+        reorder(Arel.sql("
           lower(spree_products.name) asc,
             lower(spree_variants.display_name) asc,
-            spree_variants.unit_value asc")
+            spree_variants.unit_value asc"))
     }
 
     scope :from_order_cycle, lambda { |order_cycle|

--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -31,7 +31,9 @@ class ProductsRenderer
     return unless order_cycle
 
     @products ||= begin
-      results = distributed_products.products_relation.order(taxon_order)
+      results = distributed_products.
+        products_relation.
+        order(Arel.sql(taxon_order))
 
       filter_and_paginate(results).
         each { |product| product_scoper.scope(product) } # Scope results with variant_overrides

--- a/app/services/tax_rate_finder.rb
+++ b/app/services/tax_rate_finder.rb
@@ -77,6 +77,6 @@ class TaxRateFinder
     approximation = (included_tax / (amount - included_tax))
     return [] if approximation.infinite? || approximation.zero? || approximation.nan?
 
-    [Spree::TaxRate.order("ABS(amount - #{approximation})").first]
+    [Spree::TaxRate.order(Arel.sql("ABS(amount - #{approximation})")).first]
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #7610

I am not sure why these places in OFN require this Arel.sql. But they do fix the spec in rails 6.1

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
Green build.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Adapt code to rails 6.1


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
