### PR TITLE
Backoffice: Unit price not displaying when comma is the decimal separator

### DIFF
--- a/app/assets/javascripts/admin/products/services/unit_prices.js.coffee
+++ b/app/assets/javascripts/admin/products/services/unit_prices.js.coffee
@@ -1,6 +1,7 @@
-angular.module("admin.products").factory "UnitPrices", (VariantUnitManager, localizeCurrencyFilter) ->
+angular.module("admin.products").factory "UnitPrices", (VariantUnitManager, localizeCurrencyFilter, unlocalizeCurrencyFilter) ->
   class UnitPrices
     @displayableUnitPrice: (price, scale, unit_type, unit_value, variant_unit_name) ->
+      price = unlocalizeCurrencyFilter(price)
       if price && !isNaN(price) && unit_type && unit_value
         value = localizeCurrencyFilter(UnitPrices.price(price, scale, unit_type, unit_value, variant_unit_name))
         unit = UnitPrices.unit(scale, unit_type, variant_unit_name)

--- a/app/assets/javascripts/admin/utils/filters/unlocalize_currency.js.coffee
+++ b/app/assets/javascripts/admin/utils/filters/unlocalize_currency.js.coffee
@@ -1,0 +1,8 @@
+angular.module("admin.utils").filter "unlocalizeCurrency", ()->
+  # Convert string to number using injected currency configuration.
+  (price) ->
+    # used decimal separator from currency configuration
+    decimal_separator = I18n.toCurrency(.1, {precision: 1, unit: ''}).substring(1,2)
+    if (decimal_separator == ",")
+      price = price.replace(",", ".")
+    return parseFloat(price)

--- a/app/assets/javascripts/admin/utils/filters/unlocalize_currency.js.coffee
+++ b/app/assets/javascripts/admin/utils/filters/unlocalize_currency.js.coffee
@@ -1,8 +1,15 @@
 angular.module("admin.utils").filter "unlocalizeCurrency", ()->
   # Convert string to number using injected currency configuration.
   (price) ->
-    # used decimal separator from currency configuration
+    # used decimal and thousands separators from currency configuration
     decimal_separator = I18n.toCurrency(.1, {precision: 1, unit: ''}).substring(1,2)
+    thousands_separator = I18n.toCurrency(1000, {precision: 1, unit: ''}).substring(1,2)
+
+    if (price.length > 4)
+      # remove configured thousands separator if price is greater than 999
+      price = price.replaceAll(thousands_separator, '')
+      
     if (decimal_separator == ",")
       price = price.replace(",", ".")
+
     return parseFloat(price)

--- a/spec/features/admin/unit_price_spec.rb
+++ b/spec/features/admin/unit_price_spec.rb
@@ -5,36 +5,36 @@ require 'spec_helper'
 feature '
     As an admin
     I want to check the unit price of my products/variants
-' do
+', js: true do
   include AuthenticationHelper
   include WebHelper
-  
+
   let!(:stock_location) { create(:stock_location, backorderable_default: false) }
-  
+
   before do
     allow(OpenFoodNetwork::FeatureToggle).to receive(:enabled?).with(:unit_price, anything) { true }
   end
-  
-  describe "product", js: true do
+
+  describe "product" do
     scenario "creating a new product" do
       login_as_admin_and_visit spree.admin_products_path
       click_link 'New Product'
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
       fill_in 'Value', with: '1'
       fill_in 'Price', with: '1'
-      
+
       expect(find_field("Unit Price", disabled: true).value).to eq "$1.00 / kg"
     end
   end
 
-  describe "variant", js: true do
+  describe "variant" do
     scenario "creating a new variant" do
       product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
       login_as_admin_and_visit spree.admin_product_variants_path product
       click_link 'New Variant'
       fill_in 'Weight (g)', with: '1'
       fill_in 'Price', with: '1'
-      
+
       expect(find_field("Unit Price", disabled: true).value).to eq '$1,000.00 / kg'
     end
 
@@ -43,7 +43,7 @@ feature '
       variant = product.variants.first
       variant.update(price: 1.0)
       login_as_admin_and_visit spree.edit_admin_product_variant_path(product, variant)
-      
+
       expect(find_field("Unit Price", disabled: true).value).to eq '$1,000.00 / kg'
     end
   end

--- a/spec/features/admin/unit_price_spec.rb
+++ b/spec/features/admin/unit_price_spec.rb
@@ -47,4 +47,38 @@ feature '
       expect(find_field("Unit Price", disabled: true).value).to eq '$1,000.00 / kg'
     end
   end
+
+  describe "when admin use es as default language (and comma as decimal separator)", :debug do
+    scenario "creating a new product with a comma separated decimal price" do
+      login_as_admin_and_visit spree.admin_dashboard_path(locale: 'es')
+      visit spree.admin_products_path
+      click_link 'Nuevo producto'
+      select "Peso (kg)", from: 'product_variant_unit_with_scale'
+      fill_in 'Valor', with: '1'
+      fill_in 'Precio', with: '1,5'
+
+      expect(find_field("Precio por unidad", disabled: true).value).to eq "1,50 $ / kg"
+    end
+
+    scenario "creating a new variant with a comma separated decimal price" do
+      product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
+      login_as_admin_and_visit spree.admin_dashboard_path(locale: 'es')
+      visit spree.admin_product_variants_path product
+      click_link 'Nueva Variante'
+      fill_in 'Peso (g)', with: '1'
+      fill_in 'Precio', with: '1,5'
+
+      expect(find_field("Precio por unidad", disabled: true).value).to eq '1.500,00 $ / kg'
+    end
+
+    scenario "editing a variant with a comma separated decimal price" do
+      product = create(:simple_product, variant_unit: "weight", variant_unit_scale: "1")
+      variant = product.variants.first
+      variant.update(price: 1.5)
+      login_as_admin_and_visit spree.admin_dashboard_path(locale: 'es')
+      visit spree.edit_admin_product_variant_path(product, variant)
+
+      expect(find_field("Precio por unidad", disabled: true).value).to eq '1.500,00 $ / kg'
+    end
+  end
 end

--- a/spec/javascripts/unit/admin/filters/unlocalize_currency_spec.js.coffee
+++ b/spec/javascripts/unit/admin/filters/unlocalize_currency_spec.js.coffee
@@ -1,0 +1,29 @@
+describe 'convert string to number with configurated currency', ->
+  filter = null
+
+  beforeEach ->
+    module 'ofn.admin'
+    inject ($filter) ->
+      filter = $filter('unlocalizeCurrency')
+
+  describe "with point as decimal separator for I18n service", ->
+
+    beforeEach -> 
+      spyOn(I18n, "toCurrency").and.returnValue "0.1"
+
+    it "handle point as decimal separator", ->
+      expect(filter("1.0")).toEqual 1.0
+
+    it "handle comma as decimal separator", ->
+      expect(filter("1,0")).toEqual 1.0
+
+  describe "with comma as decimal separator for I18n service", ->
+
+    beforeEach -> 
+      spyOn(I18n, "toCurrency").and.returnValue "0,1"
+
+    it "handle point as decimal separator", ->
+      expect(filter("1.0")).toEqual 1.0
+
+    it "handle comma as decimal separator", ->
+      expect(filter("1,0")).toEqual 1.0

--- a/spec/javascripts/unit/admin/filters/unlocalize_currency_spec.js.coffee
+++ b/spec/javascripts/unit/admin/filters/unlocalize_currency_spec.js.coffee
@@ -6,24 +6,86 @@ describe 'convert string to number with configurated currency', ->
     inject ($filter) ->
       filter = $filter('unlocalizeCurrency')
 
-  describe "with point as decimal separator for I18n service", ->
+  describe "with point as decimal separator and comma as thousands separator for I18n service", ->
 
-    beforeEach -> 
-      spyOn(I18n, "toCurrency").and.returnValue "0.1"
+    beforeEach ->
+      spyOn(I18n,'toCurrency').and.callFake (arg) -> 
+        if (arg == 0.1)
+          return "0.1" 
+        else if (arg == 1000)
+          return "1,000"
+    
+    it "handle point as decimal separator", ->
+      expect(filter("1.00")).toEqual 1.0
 
     it "handle point as decimal separator", ->
-      expect(filter("1.0")).toEqual 1.0
+      expect(filter("1.000")).toEqual 1.0
 
+    it "also handle comma as decimal separator", ->
+      expect(filter("1,00")).toEqual 1.0
+
+    it "handle point as decimal separator and comma as thousands separator", ->
+      expect(filter("1,000,000.00")).toEqual 1000000
+
+    it "handle integer number", ->
+      expect(filter("10")).toEqual 10
+
+    it "handle integer number with comma as thousands separator", ->
+      expect(filter("1,000")).toEqual 1000
+    
+    it "handle integer number with no thousands separator", ->
+      expect(filter("1000")).toEqual 1000
+  
+  describe "with comma as decimal separator and final point as thousands separator for I18n service", ->
+
+    beforeEach ->
+      spyOn(I18n,'toCurrency').and.callFake (arg) -> 
+        if (arg == 0.1)
+          return "0,1" 
+        else if (arg == 1000)
+          return "1.000"
+    
     it "handle comma as decimal separator", ->
-      expect(filter("1,0")).toEqual 1.0
+      expect(filter("1,00")).toEqual 1.0
+    
+    it "also handle point as decimal separator", ->
+      expect(filter("1.00")).toEqual 1.0
 
-  describe "with comma as decimal separator for I18n service", ->
+    it "handle point as decimal separator and final point as thousands separator", ->
+      expect(filter("1.000.000,00")).toEqual 1000000
 
-    beforeEach -> 
-      spyOn(I18n, "toCurrency").and.returnValue "0,1"
+    it "handle integer number", ->
+      expect(filter("10")).toEqual 10
 
-    it "handle point as decimal separator", ->
-      expect(filter("1.0")).toEqual 1.0
+    it "handle integer number with final point as thousands separator", ->
+      expect(filter("1.000")).toEqual 1000
 
+    it "handle integer number with no thousands separator", ->
+      expect(filter("1000")).toEqual 1000
+
+  describe "with comma as decimal separator and space as thousands separator for I18n service", ->
+
+    beforeEach ->
+      spyOn(I18n,'toCurrency').and.callFake (arg) -> 
+        if (arg == 0.1)
+          return "0,1" 
+        else if (arg == 1000)
+          return "1 000"
+    
     it "handle comma as decimal separator", ->
-      expect(filter("1,0")).toEqual 1.0
+      expect(filter("1,00")).toEqual 1.0
+
+    it "also handle final point as decimal separator", ->
+      expect(filter("1.00")).toEqual 1.0
+
+    it "handle point as decimal separator and space as thousands separator", ->
+      expect(filter("1 000 000,00")).toEqual 1000000
+
+    it "handle integer number", ->
+      expect(filter("10")).toEqual 10
+
+    it "handle integer number with space as thousands separator", ->
+      expect(filter("1 000")).toEqual 1000
+
+    it "handle integer number with no thousands separator", ->
+      expect(filter("1000")).toEqual 1000

--- a/spec/javascripts/unit/admin/products/services/unit_prices_spec.js.coffee
+++ b/spec/javascripts/unit/admin/products/services/unit_prices_spec.js.coffee
@@ -138,3 +138,19 @@ describe "UnitPrices service", ->
       unit_value = 453.6
       expect(UnitPrices.price(price, scale, unit_type, unit_value)).toEqual 1
       expect(UnitPrices.unit(scale, unit_type)).toEqual "lb"
+
+  describe "get unit price when price is a decimal string", ->
+    unit_type = "weight"
+
+    it "with price: '1,0'", ->
+      price = '1,0'
+      scale = 1
+      unit_value = 1
+      expect(UnitPrices.displayableUnitPrice(price, scale, unit_type, unit_value)).toEqual "$1,000.00 / kg"
+
+    it "with price: '1.0'", ->
+      price = '1.0'
+      scale = 1
+      unit_value = 1
+      expect(UnitPrices.displayableUnitPrice(price, scale, unit_type, unit_value)).toEqual "$1,000.00 / kg"
+    


### PR DESCRIPTION
#### What? Why?
Closes #7602

Unit price information is not displaying in the backoffice if the price contains comma (`,`) as the decimal separator. This seems to happen if the locale is set to `fr`


#### What should we test?
1. As an admin, change OFN language to `fr` (or others language that use comma as the decimal separator
2. Create a product with price with comma as decimal separator, eg: `1,5` (url: `http://localhost:3000/admin/products/new`)
3. See that the unit price field is well filled
<img width="515" alt="Capture d’écran 2021-05-11 à 15 25 26" src="https://user-images.githubusercontent.com/296452/117822787-206b1480-b26d-11eb-860d-7c45f7d8872f.png">
4. Display the list of products and click on the button to edit the associated variant of this new product
5. See that the price is `1,50` unit price is well filled.
<img width="395" alt="Capture d’écran 2021-05-11 à 15 24 20" src="https://user-images.githubusercontent.com/296452/117822583-f7e31a80-b26c-11eb-8422-3690913b25b4.png">


#### Release notes
Backoffice: display unit price if price is a number with decimal as comma separator
Changelog Category: User facing changes
