### PR TITLE
Fix 5335 fresh

### DIFF
--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -114,7 +114,8 @@ module VariantStock
     # This is the original Spree::StockLocation#move,
     #   except that we raise an error if the stock item is missing,
     #   because, unlike Spree, we should always have exactly one stock item per variant.
-    return if self.deleted_at.present?
+    return if deleted_at.present?
+
     stock_item.stock_movements.create!(quantity: quantity, originator: originator)
   end
 
@@ -132,7 +133,7 @@ module VariantStock
 
   def raise_error_if_no_stock_item_available
     message = 'You need to save the variant to create a stock item before you can set stock levels.'
-    raise message if self.deleted_at.nil? && stock_items.empty?
+    raise message if deleted_at.nil? && stock_items.empty?
   end
 
   # Overwrites stock_item.count_on_hand

--- a/app/models/concerns/variant_stock.rb
+++ b/app/models/concerns/variant_stock.rb
@@ -114,6 +114,7 @@ module VariantStock
     # This is the original Spree::StockLocation#move,
     #   except that we raise an error if the stock item is missing,
     #   because, unlike Spree, we should always have exactly one stock item per variant.
+    return if self.deleted_at.present?
     stock_item.stock_movements.create!(quantity: quantity, originator: originator)
   end
 
@@ -131,7 +132,7 @@ module VariantStock
 
   def raise_error_if_no_stock_item_available
     message = 'You need to save the variant to create a stock item before you can set stock levels.'
-    raise message if stock_items.empty?
+    raise message if self.deleted_at.nil? && stock_items.empty?
   end
 
   # Overwrites stock_item.count_on_hand

--- a/app/models/spree/return_authorization.rb
+++ b/app/models/spree/return_authorization.rb
@@ -93,7 +93,7 @@ module Spree
     def process_return
       inventory_units.each do |iu|
         iu.return!
-        Spree::StockMovement.create!(stock_item_id: iu.find_stock_item.id, quantity: 1)
+        Spree::StockMovement.create!(stock_item_id: iu.find_stock_item.id, quantity: 1) if iu.find_stock_item
       end
 
       Adjustment.create(

--- a/app/models/spree/return_authorization.rb
+++ b/app/models/spree/return_authorization.rb
@@ -93,7 +93,10 @@ module Spree
     def process_return
       inventory_units.each do |iu|
         iu.return!
-        Spree::StockMovement.create!(stock_item_id: iu.find_stock_item.id, quantity: 1) if iu.find_stock_item
+        if iu.find_stock_item
+          Spree::StockMovement.create!(stock_item_id: iu.find_stock_item.id,
+                                       quantity: 1)
+        end
       end
 
       Adjustment.create(


### PR DESCRIPTION
**What? Why?**

Closes #5335

- Only moves stock_items for those variants which have deleted_at NIL
- Must raise error message only when variant's deleted_at is NIL and its stock_items are empty
- Also, moving stock_items for a product/variant which is deleted doesn't make sense while accepting return_authorizations thus it stock is moved only for those products/variants which have stock_item(s)

**What should we test?**

- If an Order is getting canceled for those products/variants which are deleted
- If a Return Authorization can be created (and also received) for those orders which have deleted products or variants as line_items

**Release notes**

Fix: Order (pre-shipped) can be canceled for deleted products (and variants)

Changelog Category: User facing changes | Technical changes

**Dependencies**

This PR doesn't have any dependency.

**Documentation updates**