### PR TITLE
Checkout made to redirect to shop front when OC closed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,7 +153,7 @@ class ApplicationController < ActionController::Base
       current_order.empty!
       current_order.set_order_cycle! nil
       flash[:info] = I18n.t('order_cycle_closed')
-      redirect_to main_app.root_url
+      redirect_to main_app.shop_path
     end
   end
 

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -100,7 +100,7 @@ describe BaseController, type: :controller do
     end
   end
 
-  it "redirects to home with message if order cycle is expired" do
+  it "redirects to shopfront with message if order cycle is expired" do
     expect(controller).to receive(:current_order_cycle).and_return(oc)
     expect(controller).to receive(:current_order).and_return(order).twice
     expect(oc).to receive(:closed?).and_return(true)
@@ -109,7 +109,7 @@ describe BaseController, type: :controller do
 
     get :index
 
-    expect(response).to redirect_to root_url
+    expect(response).to redirect_to shop_url
     expect(flash[:info]).to eq I18n.t('order_cycle_closed')
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #5571

**Changes made:** `redirect_to main_app.root_path` changed to `redirect_to main_app.shop_path`

![image](https://user-images.githubusercontent.com/65319144/118190763-30e3e080-b461-11eb-850f-e50ff8d9174e.png)


This change makes it so that whenever a user clicks on checkout after an OC is closed, one of the following happens :  

**A)** In a shopfront with **two** OC's, page will redirect to shopfront and automatically the other OC 

![OC_bug_fixed1](https://user-images.githubusercontent.com/65319144/118190571-f11cf900-b460-11eb-9799-f72e520d771b.gif)

**B)** In a shopfront with **one** OC, page will show shopfront as closed

![OC_bug_fixed2](https://user-images.githubusercontent.com/65319144/118190862-5a9d0780-b461-11eb-974f-aa3f09ceb5c3.gif)

**C)** In a page with **multiple** OC's, page will redirect to shopfront with red OC selection

![OC_bug_fixed3](https://user-images.githubusercontent.com/65319144/118190934-73a5b880-b461-11eb-82be-e6cfe970725c.gif)



#### What should we test?
- That the above works as shown.



#### Release notes
- Fixed OC closed redirects to home page bug.

Changelog Category: User facing changes 