### PR TITLE
Check stock before doing anything related to admin payments

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -9,6 +9,9 @@ module Spree
       before_action :load_payment, only: [:fire, :show]
       before_action :load_data
       before_action :can_transition_to_payment
+      # We ensure that items are in stock before all screens if the order is in the Payment state.
+      # This way, we don't allow someone to enter credit card details for an order only to be told
+      # that it can't be processed. 
       before_action :ensure_sufficient_stock_lines
 
       respond_to :html

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -144,7 +144,7 @@ module Spree
       end
 
       def ensure_sufficient_stock_lines
-        return if @order.insufficient_stock_lines.blank? || !@order.payment?
+        return if !@order.payment? || @order.insufficient_stock_lines.blank?
 
         out_of_stock_items = @order.insufficient_stock_lines.map do |line_item|
           line_item.variant.name

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -146,12 +146,15 @@ module Spree
       def ensure_sufficient_stock_lines
         return if !@order.payment? || @order.insufficient_stock_lines.blank?
 
-        out_of_stock_items = @order.insufficient_stock_lines.map do |line_item|
+        flash[:error] = I18n.t("spree.orders.line_item.insufficient_stock",
+          on_hand: "0 #{out_of_stock_item_names}")
+        redirect_to spree.edit_admin_order_url(@order)
+      end
+
+      def out_of_stock_item_names
+        @order.insufficient_stock_lines.map do |line_item|
           line_item.variant.name
         end.join(", ")
-        flash[:error] = I18n.t("spree.orders.line_item.insufficient_stock",
-          on_hand: "0 #{out_of_stock_items}")
-        redirect_to spree.edit_admin_order_url(@order)
       end
 
       def load_order

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -309,5 +309,19 @@ describe Spree::Admin::PaymentsController, type: :controller do
         end
       end
     end
+
+    context "the order contains an item that is out of stock" do
+      let!(:order) { create(:order, distributor: shop, state: 'payment') }
+
+      before do
+        order.line_items.first.variant.update_attribute(:on_hand, 0)
+      end
+
+      it "redirects to the order details page" do
+        spree_get :index, order_id: order.number
+        expect(response.status).to eq 302
+        expect(response.location).to eq spree.edit_admin_order_url(order)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #7614 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We could go about fixing this in a few different ways. The lightest, most specific way is to explicitly check stock in a before action in the controller. If there is insufficient stock, and the order is in the payment state, we alert the admin and redirect to the order details page. 

This is also, however, a fantastic example of a place where we should think about unifying the order and payment state transitions between front and backend, as in https://github.com/openfoodfoundation/openfoodnetwork/issues/7511. Ping @lin-d-hop & @filipefurtad0. And an example of how the transitions in the two models are coupled pretty tightly. 

#### What should we test?
<!-- List which features should be tested and how. -->
1. create admin order
2. add product that is in stock
3. enter customer details
4. confirm that order is now in Payment state
5. set product to 0 stock
6. visit the Payments screen on the admin order page
7. it should redirect to the order details page and have a flash message saying that the product is out of stock. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where creating an admin payment for an order with out of stock items returned an error message but created the payment in Stripe. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
