### PR TITLE
Render enterprise rows as a collection

### DIFF
--- a/app/views/spree/admin/overview/_enterprises.html.haml
+++ b/app/views/spree/admin/overview/_enterprises.html.haml
@@ -25,8 +25,7 @@
         %span.centered.three.columns
           = t "spree_admin_enterprises_fees"
     %div.sixteen.columns.alpha.list
-      - @enterprises.each do |enterprise|
-        = render 'enterprise_row', { enterprise: enterprise }
+      = render partial: 'enterprise_row', collection: @enterprises, as: :enterprise
 
     %a.sixteen.columns.alpha.button.bottom.blue{ href: "#{main_app.admin_enterprises_path}" }
       = t "spree_admin_overview_enterprises_footer"


### PR DESCRIPTION
#### What? Why?

Improves rendering in admin overview.

Note: this is a bit like an N+1 query, but for rendering. If there are 30 enterprises, the partial file would previously have been loaded and parsed 30 times; but if we render it as a collection it'll load the partial once and substantially improve the performance.

#### What should we test?
<!-- List which features should be tested and how. -->

Enterprise listed in a table in the admin overview page should display correctly. Page load should be faster if there are more enterprises.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved rendering performance in admin overview page.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
