### PR TITLE
7626 fix unknown currency error

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -47,7 +47,11 @@ $ sudo -u postgres psql -c "CREATE USER ofn WITH SUPERUSER CREATEDB PASSWORD 'f0
 
 This will create the "ofn" user as superuser and allowing it to create databases. If this command fails, check the [troubleshooting section](#creating-the-database) for an alternative.
 
-Once done, run `script/setup`. If the script succeeds you're ready to start developing. If not, take a look at the output as it should be informative enough to help you troubleshoot.
+Next, it is _strongly recommended_ to run the setup script.
+```sh
+$ script/setup
+```
+If the script succeeds you're ready to start developing. If not, take a look at the output as it should be informative enough to help you troubleshoot.
 
 Now, your dreams of spinning up a development server can be realised:
 

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,2 +1,2 @@
 Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
-Money.default_currency = Money::Currency.new(Spree::Config[:currency])
+Money.default_currency = Money::Currency.new(ENV.fetch('CURRENCY'))

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -62,7 +62,7 @@ def create_admin_user
       role = Spree::Role.find_or_create_by(name: 'admin')
       admin.spree_roles << role
       admin.save
-      say "Done!"
+      say "New admin user persisted!"
     else
       say "There was some problems with persisting new admin user:"
       admin.errors.full_messages.each do |error|


### PR DESCRIPTION
#### What? Why?

Closes #[the issue number this PR is related to] https://github.com/openfoodfoundation/openfoodnetwork/issues/7626

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

New developers have noticed the following error when running the application/tests/console for the _second_ time. 
```
rake aborted!
Money::Currency::UnknownCurrency: Unknown currency '
```
This error is always produced if they do not run script/setup (and therefore do not have a config/application.yml file) before running application/tests/console for the _first_ time.

The sequence of events is as follows (I’ve verified these steps using byebug):

1. clone repo
2. dev runs `bundle exec [any command]`
3. The line `preference :currency, :string, default: "USD"` is hit in `config/application.rb`
4. `Money.default_currency = Money::Currency.new(Spree::Config[:currency])` is hit in `config/initializers/money.rb` - Spree::Config[:currency] is not set at this point and so it defaults to the default value set in the previous step (ie it is set to “USD”)
5. `Spree::Config['currency'] = ENV['CURRENCY']` is hit in `config/application.rb` - at this point, because we don’t have a config/application.yml file, ENV[‘CURRENCY’] does not exist and this sets Spree::config[:currency] to an empty string. **This empty string is cached**
6. dev runs `bundle exec [any command]` (second time)
7. `preference :currency, :string, default: "USD"` is hit in `config/application.rb`
8. `Money.default_currency = Money::Currency.new(Spree::Config[:currency])` is hit in `config/initializers/money.rb` - this time Spree::Config[:currency] is set to the cached value (an empty string), and this leads to the error.

Please note: This error is not solved by running `script/setup` (ie creating the config/application.yml) file, because even with ENV vars now present the following steps occur 
1. `script/setup` (ie config/application.yml is created and ENV vars are now available)
2. `bundle exec [any command]` (a third time)
3. `preference :currency, :string, default: "USD"` is hit in `config/application.rb`
4. `Money.default_currency = Money::Currency.new(Spree::Config[:currency])` is hit in `config/initializers/money.rb` -  Spree::Config[:currency] is still set to the cached value (an empty string), and this again leads to the same error.
5. And so on…in a loop

As you can see, the problem is that even with ENV vars available, because the application never gets to set  `Spree::Config['currency'] = ENV['CURRENCY']`, Spree::Config['currency'] remains set to an empty string and the application never loads past this line.

This PR therefore does two things:
- Strongly encourages new devs to run `script/setup` before doing anything else
- Replaces  `Money.default_currency = Money::Currency.new(Spree::Config[:currency])` with `Money.default_currency = Money::Currency.new(ENV.fetch(‘CURRENCY’)) `. This will still raise an error at the same line if ENV vars are not present, but this time:
        - the error will be more descriptive (`key not found: "CURRENCY" (KeyError)`)
        - once ENV[‘CURRENCY’] has been set, the application will no longer raise an error
        - we will no longer depend on a cached Spree::Config[:currency] when booting the application, which is safer as it avoids the potential for the error loop described above



#### What should we test?
1. git clone the repo
2. try running any `bundle exec` command twice (you should see an error)
3. run `script/setup`
4. try running any `bundle exec` command (you should no longer see an error)

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
I'm not sure what to write here. Maybe: fix unknown currency error for new developers on setup 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
No


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
I've already changed the relevant pages
