### PR TITLE
Stop Codecov failing good pull requests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,4 +322,4 @@ jobs:
         run: bundle exec rspec --profile --pattern "engines/*/spec/{,/*/**}/*_spec.rb,spec/features/admin/*/*_spec.rb,spec/lib/{,/*/**}/*_spec.rb"
 
       - name: Codecov
-        uses: codecov/codecov-action@v1.3.1
+        uses: codecov/codecov-action@v1.5.0


### PR DESCRIPTION
#### What? Why?

Something doesn't quite work with our Codecov setup. It somehow thinks
that the coverage is decreasing even though it's either not changing or
even increasing.

Until those problems are resolved, let's not mark pull requests as
failed so that we can rely on the pull's overall status report.

I also updated the version of the used Codecov action. Maybe that improves things.

#### What should we test?
<!-- List which features should be tested and how. -->

Pull request is marked as "passed".

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Codecov doesn't fail pull requests, just reports on them.

