### PR TITLE
Fix clashing loggers

### DIFF
--- a/app/services/mail_configuration.rb
+++ b/app/services/mail_configuration.rb
@@ -2,15 +2,29 @@
 #   by setting entries on the Spree Config
 #   and initializing Spree:MailSettings that uses the Spree::Config.
 class MailConfiguration
-  # @param entries [Hash] Spree Config entries
-  def self.entries=(entries)
-    entries.each do |name, value|
+  def self.apply!
+    configuration.each do |name, value|
       Spree::Config[name] = value
     end
     apply_mail_settings
   end
 
   private
+
+  def self.configuration
+    {
+      mail_host: ENV.fetch('MAIL_HOST'),
+      mail_domain: ENV.fetch('MAIL_DOMAIN'),
+      mail_port: ENV.fetch('MAIL_PORT'),
+      mail_auth_type: ENV.fetch('MAIL_AUTH_TYPE', 'login'),
+      smtp_username: ENV.fetch('SMTP_USERNAME'),
+      smtp_password: ENV.fetch('SMTP_PASSWORD'),
+      secure_connection_type: ENV.fetch('MAIL_SECURE_CONNECTION', 'None'),
+      mails_from: ENV.fetch('MAILS_FROM', "no-reply@#{ENV.fetch('MAIL_DOMAIN')}"),
+      mail_bcc: ENV.fetch('MAIL_BCC', ''),
+      intercept_email: ''
+    }
+  end
 
   def self.apply_mail_settings
     Spree::Core::MailSettings.init

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,4 +1,3 @@
-Delayed::Worker.logger = Logger.new(Rails.root.join('log', 'delayed_job.log'))
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_run_time = 15.minutes
 

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -18,6 +18,7 @@ Spree::Gateway.class_eval do
 end
 
 Spree.config do |config|
+  config.site_url = ENV['SITE_URL'] if ENV['SITE_URL']
   config.shipping_instructions = true
   config.address_requires_state = true
   config.admin_interface_logo = '/default_images/ofn-logo.png'

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -31,6 +31,10 @@ Spree.config do |config|
   config.s3_protocol = ENV.fetch('S3_PROTOCOL', 'https')
 end
 
+# Read mail configuration from ENV vars at boot time and ensure the values are
+# applied correctly in Spree::Config.
+MailConfiguration.apply!
+
 # Attachments settings
 Spree::Image.set_attachment_attribute(:path, ENV['ATTACHMENT_PATH']) if ENV['ATTACHMENT_PATH']
 Spree::Image.set_attachment_attribute(:url, ENV['ATTACHMENT_URL']) if ENV['ATTACHMENT_URL']

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,22 +2,8 @@
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 require 'yaml'
 
-def set_mail_configuration
-  MailConfiguration.entries= {
-    mail_host: ENV.fetch('MAIL_HOST'),
-    mail_domain: ENV.fetch('MAIL_DOMAIN'),
-    mail_port: ENV.fetch('MAIL_PORT'),
-    mail_auth_type: ENV.fetch('MAIL_AUTH_TYPE', 'login'),
-    smtp_username: ENV.fetch('SMTP_USERNAME'),
-    smtp_password: ENV.fetch('SMTP_PASSWORD'),
-    secure_connection_type: ENV.fetch('MAIL_SECURE_CONNECTION', 'None'),
-    mails_from: ENV.fetch('MAILS_FROM', "no-reply@#{ENV.fetch('MAIL_DOMAIN')}"),
-    mail_bcc: ENV.fetch('MAIL_BCC', ''),
-    intercept_email: ''
-  }
-end
 # We need mail_configuration to create a user account, because it sends a confirmation email.
-set_mail_configuration
+MailConfiguration.apply!
 
 puts "[db:seed] Seeding Roles"
 Spree::Role.where(:name => "admin").first_or_create

--- a/lib/spree/core/mail_settings.rb
+++ b/lib/spree/core/mail_settings.rb
@@ -12,7 +12,7 @@ module Spree
       end
 
       def override!
-        ActionMailer::Base.default_url_options[:host] ||= Config.site_url
+        ActionMailer::Base.default_url_options[:host] ||= ENV.fetch("SITE_URL", Config.site_url)
         ActionMailer::Base.smtp_settings = mail_server_settings
         ActionMailer::Base.perform_deliveries = true
       end

--- a/spec/services/mail_configuration_spec.rb
+++ b/spec/services/mail_configuration_spec.rb
@@ -3,33 +3,29 @@
 require 'spec_helper'
 
 describe MailConfiguration do
-  describe 'entries=' do
-    let(:mail_settings) { instance_double(Spree::Core::MailSettings) }
-    let(:entries) do
-      { smtp_username: "smtp_username", mail_auth_type: "login" }
-    end
-
+  describe 'apply!' do
     before do
-      allow(Spree::Core::MailSettings).to receive(:init) { mail_settings }
-    end
-
-    # keeps spree_config unchanged
-    around do |example|
-      original_smtp_username = Spree::Config[:smtp_username]
-      original_mail_auth_type = Spree::Config[:mail_auth_type]
-      example.run
-      Spree::Config[:smtp_username] = original_smtp_username
-      Spree::Config[:mail_auth_type] = original_mail_auth_type
+      allow(Spree::Core::MailSettings).to receive(:init) { true }
     end
 
     it 'sets config entries in the Spree Config' do
-      described_class.entries = entries
-      expect(Spree::Config[:smtp_username]).to eq("smtp_username")
-      expect(Spree::Config[:mail_auth_type]).to eq("login")
+      allow(Spree::Config).to receive(:[]=)
+
+      described_class.apply!
+      expect(Spree::Config).to have_received(:[]=).with(:mail_host, "example.com")
+      expect(Spree::Config).to have_received(:[]=).with(:mail_domain, "example.com")
+      expect(Spree::Config).to have_received(:[]=).with(:mail_port, "25")
+      expect(Spree::Config).to have_received(:[]=).with(:mail_auth_type, "login")
+      expect(Spree::Config).to have_received(:[]=).with(:smtp_username, "ofn")
+      expect(Spree::Config).to have_received(:[]=).with(:smtp_password, "f00d")
+      expect(Spree::Config).to have_received(:[]=).with(:secure_connection_type, "None")
+      expect(Spree::Config).to have_received(:[]=).with(:mails_from, "no-reply@example.com")
+      expect(Spree::Config).to have_received(:[]=).with(:mail_bcc, "")
+      expect(Spree::Config).to have_received(:[]=).with(:intercept_email, "")
     end
 
     it 'initializes the mail settings' do
-      described_class.entries = entries
+      described_class.apply!
       expect(Spree::Core::MailSettings).to have_received(:init)
     end
   end


### PR DESCRIPTION
#### What? Why?

Related to #7670 
Depends on https://github.com/openfoodfoundation/ofn-install/pull/740

There's been come weird [Bugsnags](https://app.bugsnag.com/open-food-france/coopcircuits/errors/60a634609010590007701d6f?filters[event.since][0]=30d&filters[error.status][0]=open) in Staging with the new release, where it looks like DelayedJob is trying to pass log entries to the cache store instead of the logger (in a totally crazy way) and failing loudly.

There have been a few changes under the hood in Rails around the way the cache store is instrumented ([more context here](https://github.com/openfoodfoundation/openfoodnetwork/commit/02a1116fffb1a7513e39e56ad5ad5adae40e4d5a)). There seems to have been a bit of a clash between the instrumentation that logs entries for the cache and the instrumentation for DelayedJob. Looks like it might be a bug in DelayedJob itself, in how it handles passing the logger object to child processes when it forks. Anyway, it's fixed.

Also changed: mail configs are now initialized when the app boots. This means restarting unicorn will now pick up any changes in mail configs that have been provisioned since the last deployment, and mail configs will not be wiped out when deploying a branch that changes the cache store.

Note: we can do a much bigger refactor on the way mail configs are handled to make it a lot nicer, but it'll need more work and separate testing. This PR just does enough to unblock the current release.

#### What should we test?
<!-- List which features should be tested and how. -->

The weird errors in Bugsnag should stop. We should check delayed job is okay (and test all emails).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed errors in Staging due to outdated cache logging configuration

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
