### PR TITLE
Fix sample_data by filtering params for products

### DIFF
--- a/lib/tasks/sample_data/product_factory.rb
+++ b/lib/tasks/sample_data/product_factory.rb
@@ -60,7 +60,7 @@ module SampleData
 
     def create_product(hash)
       log "- #{hash[:name]}"
-      params = hash.merge(
+      params = hash.slice(:name, :price).merge(
         supplier_id: hash[:supplier].id,
         primary_taxon_id: hash[:taxons].first.id,
         variant_unit: "weight",


### PR DESCRIPTION

#### What? Why?

We were passing too many parameters to the product creation. Rails 5.2
complained that products don't have a distributor. Filtering the
parameters helps.


#### What should we test?
<!-- List which features should be tested and how. -->

No test.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Updated our sample data creation for devs to work with Rails 5.2.

