### PR TITLE
[7470] Add delete action test to ShippingCategoriesController spec

### DIFF
--- a/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
@@ -13,7 +13,7 @@ module Spree
         it "creates a shipping shipping category" do
           expect {
             spree_post :create, shipping_category: { name: "Frozen" }
-          }.to change(Spree::ShippingCategory.all, :count).by(1)
+          }.to change { Spree::ShippingCategory.count }.by(1)
 
           expect(response).to redirect_to spree.admin_shipping_categories_url
         end
@@ -31,7 +31,7 @@ module Spree
           shipping_category = create(:shipping_category)
           expect {
             spree_delete :destroy, id: shipping_category.id
-          }.to change(Spree::ShippingCategory.all, :count).by(-1)
+          }.to change { Spree::ShippingCategory.count }.by(-1)
 
           expect(response).to redirect_to spree.admin_shipping_categories_url
         end

--- a/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_categories_controller_spec.rb
@@ -26,6 +26,15 @@ module Spree
           expect(response).to redirect_to spree.admin_shipping_categories_url
           expect(shipping_category.reload.name).to eq "Super Frozen"
         end
+
+        it "deletes an existing shipping category" do
+          shipping_category = create(:shipping_category)
+          expect {
+            spree_delete :destroy, id: shipping_category.id
+          }.to change(Spree::ShippingCategory.all, :count).by(-1)
+
+          expect(response).to redirect_to spree.admin_shipping_categories_url
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Part of https://github.com/openfoodfoundation/openfoodnetwork/issues/7470 (there are still feature specs to write as part of #7470)

ShippingCategoriesController spec was missing a test for the delete action. This PR adds this missing test.

#### What should we test?
N/A

#### Release notes
Add delete action test to ShippingCategoriesController spec

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

#### Dependencies
N/A

#### Documentation updates
N/A
