### PR TITLE
Fix Rbenv and ruby-build installation to get Ruby 2.5.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update && apt-get install -y \
   wait-for-it \
   imagemagick \
   unzip \
-  libjemalloc-dev
+  libjemalloc-dev \
+  libssl-dev
 
 # Setup ENV variables
 ENV PATH /usr/local/src/rbenv/shims:/usr/local/src/rbenv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,8 @@ WORKDIR /usr/src/app
 COPY .ruby-version .
 
 # Install Rbenv & Ruby
-RUN git clone --depth 1 --branch v1.1.2 https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
-    git clone --depth 1 --branch v20200520 https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build && \
-    ${RBENV_ROOT}/plugins/ruby-build/install.sh && \
+RUN git clone --depth 1 https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
+    git clone --depth 1 https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build && \
     echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh && \
     RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install $(cat .ruby-version) && \
     rbenv global $(cat .ruby-version) && \


### PR DESCRIPTION
#### What? Why?

This newer Ruby version can't be found on that ruby-build's branch that we were installing. The `docker-compose build` command works again.

:warning: we need https://github.com/openfoodfoundation/openfoodnetwork/pull/7698 first.

#### What should we test?

Nothing.

#### Release notes

Fix Ruby 2.5.9 installation in docker container.
Changelog Category: Technical changes