### PR TITLE
Datetimepicker for order cycles: add keyup event listener on hour/minute inputs

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/order_cycles.js.erb.coffee
+++ b/app/assets/javascripts/admin/order_cycles/order_cycles.js.erb.coffee
@@ -3,12 +3,18 @@ angular.module('admin.orderCycles', ['ngTagsInput', 'admin.indexUtils', 'admin.e
     require: "ngModel"
     link: (scope, element, attrs, ngModel) ->
       $timeout ->
-        flatpickr(element,  Object.assign({},
+        fp = flatpickr(element,  Object.assign({},
                             window.FLATPICKR_DATETIME_DEFAULT, {
                             onOpen: (selectedDates, dateStr, instance) ->
                               instance.setDate(ngModel.$modelValue)
                               instance.input.dispatchEvent(new Event('focus', { bubbles: true }));
                             }));
+        fp.minuteElement.addEventListener "keyup", (e) ->
+          if !isNaN(event.target.value)
+            fp.setDate(fp.selectedDates[0].setMinutes(e.target.value), true)
+        fp.hourElement.addEventListener "keyup", (e) ->
+          if !isNaN(event.target.value)
+            fp.setDate(fp.selectedDates[0].setHours(e.target.value), true)            
 
   .directive 'ofnOnChange', ->
     (scope, element, attrs) ->

--- a/spec/features/admin/order_cycles/simple_spec.rb
+++ b/spec/features/admin/order_cycles/simple_spec.rb
@@ -604,6 +604,16 @@ feature '
     end
   end
 
+  scenario "modify the minute of a order cycle with the keyboard, check that the modifications are taken into account" do
+    order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
+    login_as_admin_and_visit admin_order_cycles_path
+    find("#oc#{order_cycle.id}_orders_close_at").click
+    datetime = Time.at(Time.zone.local(2040, 10, 17, 0o6, 0o0, 0o0))
+    input = find(".flatpickr-calendar.open .flatpickr-minute")
+    input.send_keys datetime.strftime("%M").to_s.strip
+    expect(page).to have_content "You have unsaved changes"
+  end
+
   scenario "deleting an order cycle" do
     order_cycle = create(:simple_order_cycle, name: "Translusent Berries")
     login_as_admin_and_visit admin_order_cycles_path


### PR DESCRIPTION
#### What? Why?

Closes #7689 

The idea here is simply to watch for `keyup` event into the two input fields (for hour and minute) and then set the flatpickr  date (and triggering the `onChange` event). Therefore, once a user use the keyboard to change the hour/minute of the date, the original-linked input is synchronized, and the global form could be saved without closing the datetimepicker (which was the original issue)
![2021-05-27 16 52 57](https://user-images.githubusercontent.com/296452/119848659-48fd3a80-bf0c-11eb-93fb-2beda2983881.gif)

#### What should we test?
1. Go to `admin/order_cycles`
2. Open a datetimepicker (for `open` or `close` field)
3. Change the minute (or hour, or both) by typing the value with your keyboard (not by clicking the arrow which should be always functional)
4. You should see that the original-linked input is synchronized and the red `Save` button appear to save it
5. Click on save, reload. You should that the date is _effectively_ saved.



#### Release notes
Save the datetimepicker hour/minute values when user enter value with keyboard.

Changelog Category: User facing changes

