### PR TITLE
Remove eventmachine gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,10 +172,5 @@ group :development do
 
   gem "view_component_storybook", require: "view_component/storybook/engine"
 
-  # 1.0.9 fixed openssl issues on macOS https://github.com/eventmachine/eventmachine/issues/602
-  # While we don't require this gem directly, no dependents forced the upgrade to a version
-  # greater than 1.0.9, so we just required the latest available version here.
-  gem 'eventmachine', '>= 1.2.3'
-
   gem 'rack-mini-profiler', '< 3.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,6 @@ GEM
     diff-lcs (1.4.4)
     docile (1.3.5)
     erubi (1.10.0)
-    eventmachine (1.2.7)
     excon (0.79.0)
     execjs (2.7.0)
     factory_bot (6.2.0)
@@ -666,7 +665,6 @@ DEPENDENCIES
   devise-encryptable
   devise-token_authenticatable
   dfc_provider!
-  eventmachine (>= 1.2.3)
   factory_bot_rails (= 6.2.0)
   ffaker
   figaro


### PR DESCRIPTION
#### What? Why?

This was a dependency of a dependency a long time ago, related to guard and zeus. It's currently only installed in dev. History [here](https://github.com/openfoodfoundation/openfoodnetwork/commit/9d7f63db429317b19d4c69b27088850efde3ba93).

#### What should we test?
<!-- List which features should be tested and how. -->

.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed eventmachine gem

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
