### PR TITLE
Add validation to inventory page fields

### DIFF
--- a/app/models/variant_override.rb
+++ b/app/models/variant_override.rb
@@ -15,6 +15,8 @@ class VariantOverride < ApplicationRecord
   validates :variant, presence: true
   # Default stock can be nil, indicating stock should not be reset or zero, meaning reset to zero. Need to ensure this can be set by the user.
   validates :default_stock, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :price, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   default_scope { where(permission_revoked_at: nil) }
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -264,16 +264,6 @@ module Spree
           li.cap_quantity_at_stock!
           expect(li.quantity).to eq 2
         end
-
-        context "when count on hand is negative" do
-          before { vo.update(count_on_hand: -3) }
-
-          it "caps at zero" do
-            v.__send__(:stock_item).update_column(:count_on_hand, -2)
-            li.cap_quantity_at_stock!
-            expect(li.reload.quantity).to eq 0
-          end
-        end
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #1971

This adds validation to the `price` and `on hand` fields on the inventory form. 

#### What should we test?
Incorrect inputs will cause an error message to show up instead of saving or modifying the inputted value. This applies to negative numbers or non-numeric values.

#### Release notes
added validation to inventory page form

Changelog Category: User facing changes