### PR TITLE
Drop product.price from /api/order_cycles/:id/products

### DIFF
--- a/app/serializers/api/product_serializer.rb
+++ b/app/serializers/api/product_serializer.rb
@@ -3,7 +3,7 @@ require "open_food_network/scope_variant_to_hub"
 class Api::ProductSerializer < ActiveModel::Serializer
   attributes :id, :name, :permalink, :meta_keywords
   attributes :group_buy, :notes, :description, :description_html
-  attributes :properties_with_values, :price
+  attributes :properties_with_values
 
   has_many :variants, serializer: Api::VariantSerializer
   has_one :master, serializer: Api::VariantSerializer
@@ -34,14 +34,6 @@ class Api::ProductSerializer < ActiveModel::Serializer
 
   def master
     options[:master_variants][object.id].andand.first
-  end
-
-  def price
-    if options[:enterprise_fee_calculator]
-      object.master.price + options[:enterprise_fee_calculator].indexed_fees_for(object.master)
-    else
-      object.master.price_with_fees(options[:current_distributor], options[:current_order_cycle])
-    end
   end
 
   private

--- a/app/serializers/api/product_serializer.rb
+++ b/app/serializers/api/product_serializer.rb
@@ -6,7 +6,6 @@ class Api::ProductSerializer < ActiveModel::Serializer
   attributes :properties_with_values
 
   has_many :variants, serializer: Api::VariantSerializer
-  has_one :master, serializer: Api::VariantSerializer
 
   has_one :primary_taxon, serializer: Api::TaxonSerializer
   has_many :taxons, serializer: Api::IdSerializer
@@ -30,10 +29,6 @@ class Api::ProductSerializer < ActiveModel::Serializer
 
   def variants
     options[:variants][object.id] || []
-  end
-
-  def master
-    options[:master_variants][object.id].andand.first
   end
 
   private

--- a/app/services/products_renderer.rb
+++ b/app/services/products_renderer.rb
@@ -19,7 +19,6 @@ class ProductsRenderer
                                      current_order_cycle: order_cycle,
                                      current_distributor: distributor,
                                      variants: variants_for_shop_by_id,
-                                     master_variants: master_variants_for_shop_by_id,
                                      enterprise_fee_calculator: enterprise_fee_calculator).to_json
   end
 
@@ -82,10 +81,6 @@ class ProductsRenderer
 
   def variants_for_shop_by_id
     index_by_product_id variants_for_shop.reject(&:is_master)
-  end
-
-  def master_variants_for_shop_by_id
-    index_by_product_id variants_for_shop.select(&:is_master)
   end
 
   def index_by_product_id(variants)

--- a/spec/serializers/api/product_serializer_spec.rb
+++ b/spec/serializers/api/product_serializer_spec.rb
@@ -13,25 +13,24 @@ describe Api::ProductSerializer do
   let!(:property) { create(:property) }
   let!(:product) { create(:product, primary_taxon: taxon, properties: [property], price: 20.00) }
   let(:variant1) { create(:variant, product: product) }
-  let(:variant2) { create(:variant, product: product) }
-  let(:master_variant) { product.master }
 
   let(:serializer) {
     described_class.new(product,
-                        variants: [variant1, variant2],
-                        master_variants: [master_variant],
+                        variants: [variant1],
                         current_distributor: distributor,
                         current_order_cycle: order_cycle)
   }
 
   before do
-    add_variant_to_order_cycle(exchange, master_variant)
     add_variant_to_order_cycle(exchange, variant1)
-    add_variant_to_order_cycle(exchange, variant2)
   end
 
   it "serializes various attributes" do
-    expect(serializer.serializable_hash.keys).to eq serialized_attributes
+    expect(serializer.serializable_hash.keys).to eq [
+      :id, :name, :permalink, :meta_keywords, :group_buy, :notes, :description, :description_html,
+      :properties_with_values, :variants, :primary_taxon, :taxons, :images, :supplier
+    ]
+
   end
 
   it "serializes product properties" do
@@ -42,63 +41,5 @@ describe Api::ProductSerializer do
 
   it "serializes taxons" do
     expect(serializer.serializable_hash[:taxons]).to eq [id: taxon.id]
-  end
-
-  describe "serializing price" do
-    context "without enterprise fees" do
-      it "returns the regular product price" do
-        product_price = serializer.serializable_hash[:price]
-        expect(product_price).to eq product.master.price
-      end
-    end
-
-    context "with enterprise fees" do
-      let(:simple_fee) { create(:enterprise_fee, enterprise: distributor, amount: 1000) }
-
-      before { exchange.enterprise_fees << simple_fee }
-
-      it "includes enterprise fees in the product price" do
-        product_price = serializer.serializable_hash[:price]
-        expect(product_price).to eq product.master.price + 1000
-      end
-    end
-
-    context "when a specific calculator is used in fees" do
-      let(:enterprise_fee_calculator) {
-        OpenFoodNetwork::EnterpriseFeeCalculator.new distributor, order_cycle
-      }
-      let(:serializer) {
-        described_class.new(product,
-                            variants: [variant1, variant2],
-                            master_variants: [master_variant],
-                            current_distributor: distributor,
-                            current_order_cycle: order_cycle,
-                            enterprise_fee_calculator: enterprise_fee_calculator)
-      }
-      let!(:fee_with_calculator) {
-        create(:enterprise_fee,
-               amount: 20,
-               fee_type: "admin",
-               calculator: ::Calculator::FlatPercentPerItem.
-                 new(preferred_flat_percent: 20))
-      }
-
-      before { exchange.enterprise_fees << fee_with_calculator }
-
-      it "applies the correct calculated fee in the product price" do
-        product_price = serializer.serializable_hash[:price]
-        expect(product_price).to eq product.master.price + (product.master.price / 100 * 20)
-      end
-    end
-  end
-
-  private
-
-  def serialized_attributes
-    [
-      :id, :name, :permalink, :meta_keywords, :group_buy, :notes, :description, :description_html,
-      :properties_with_values, :price, :variants, :master, :primary_taxon, :taxons, :images,
-      :supplier
-    ]
   end
 end


### PR DESCRIPTION
#### What? Why?

Its serializer it's only used by this endpoint and `app/assets/javascripts/templates/shop_variant.html.haml` doesn't rely on
the response's `product.price` but the variant's price.

Because our DB schema allows NULL on `spree_prices.amount`, a master variant without a price can cause the shopfront not to load products. This was the case in https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/60adfcc31cf9740007f82fc9.

#### What should we test?

before manually testing, I'd like to check whether our system specs cover all places where products are listed, either front or backoffice. I'd be surprised if we don't.

Either way, we need to ensure order cycles and shopfronts still load.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes