### PR TITLE
Make admin orders `complete` after adding customer info

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -11,7 +11,7 @@ module Spree
       before_action :can_transition_to_payment
       # We ensure that items are in stock before all screens if the order is in the Payment state.
       # This way, we don't allow someone to enter credit card details for an order only to be told
-      # that it can't be processed. 
+      # that it can't be processed.
       before_action :ensure_sufficient_stock_lines
 
       respond_to :html
@@ -35,9 +35,8 @@ module Spree
             return
           end
 
-          authorize_stripe_sca_payment
-
           if @order.completed?
+            authorize_stripe_sca_payment
             @payment.process!
             flash[:success] = flash_message_for(@payment, :successfully_created)
 


### PR DESCRIPTION
#### What? Why?

Closes #7665 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
As @Matt-Yorkley [suggested](https://github.com/openfoodfoundation/openfoodnetwork/issues/7665#issuecomment-844442720), if we complete the order when it's "placed" by the admin user, the stock is removed from inventory. Thus we avoid taking payment for an order only to find out somewhere later in the process that there is insufficient stock available. This flow is consistent with other scenarios where the order is complete but payment is still pending. 

In order to do this, we no longer raise an error if there are no existing payments when we call `process_payments` on an order. Instead, that call does nothing. That behavior came over from Spree and we haven't touched it since. 

As part of code review, we'll want to make sure that there aren't any unintended consequences, and probably check this against the work @lin-d-hop @filipefurtad0 and @jaycmb are doing with order states. 


#### What should we test?
Creating an admin order. After adding customer details, the order should be in the `complete` state. 
Other order scenarios should probably be covered by a green build. 



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where payment could be taken before checking that an order had sufficient stock to be filled. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
