### PR TITLE
Allow :site_name to be picked up from ENV vars

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -19,6 +19,7 @@ end
 
 Spree.config do |config|
   config.site_url = ENV['SITE_URL'] if ENV['SITE_URL']
+  config.site_name = ENV['SITE_NAME'] if ENV['SITE_NAME']
   config.shipping_instructions = true
   config.address_requires_state = true
   config.admin_interface_logo = '/default_images/ofn-logo.png'


### PR DESCRIPTION
#### What? Why?

This mimics what we did in 6377736f4. This way provisioning an instance from scratch doesn't require configuring things from the backoffice, which will simplify the rollout of https://github.com/openfoodfoundation/ofn-install/pull/734.


#### What should we test?

A dev test will suffice. We need to see that whatever value there's in `ENV['SITE_NAME']` takes precedence.

#### Release notes
Allow :site_name to be picked up from ENV vars
Changelog Category: Technical changes