### PR TITLE
Fix docker Jemalloc + Sidekiq setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV PATH /usr/local/src/rbenv/shims:/usr/local/src/rbenv/bin:$PATH
 ENV RBENV_ROOT /usr/local/src/rbenv
 ENV CONFIGURE_OPTS --disable-install-doc
 ENV BUNDLE_PATH /bundles
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
 
 WORKDIR /usr/src/app
 COPY .ruby-version .

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -8,6 +8,7 @@ The fastest way to make it work locally is to use Docker, you only need to setup
 Otherwise, for a local setup you will need:
 * Ruby and bundler (check current Ruby version in [.ruby-version](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/.ruby-version) file)
 * PostgreSQL database
+* Redis (for background jobs)
 * Chrome (for testing)
 
 The following guides will provide OS-specific step-by-step instructions to get these requirements installed:

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,9 @@
-if Rails.env.production? || Rails.env.staging?
-  redis_jobs_url = ENV.fetch("OFN_REDIS_JOBS_URL", "redis://localhost:6381/0")
+redis_jobs_url = ENV.fetch("OFN_REDIS_JOBS_URL", "redis://localhost:6381/0")
 
-  Sidekiq.configure_server do |config|
-    config.redis = { url: redis_jobs_url, network_timeout: 5 }
-  end
+Sidekiq.configure_server do |config|
+  config.redis = { url: redis_jobs_url, network_timeout: 5 }
+end
 
-  Sidekiq.configure_client do |config|
-    config.redis = { url: redis_jobs_url, network_timeout: 5 }
-  end
+Sidekiq.configure_client do |config|
+  config.redis = { url: redis_jobs_url, network_timeout: 5 }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - 5432:5432
     volumes:
       - 'postgres:/var/lib/postgresql/data'
+  redis:
+    image: redis
   web:
     tty: true
     stdin_open: true
@@ -25,8 +27,11 @@ services:
       - ./config/application.yml.example:/usr/src/app/config/application.yml
     depends_on:
       - db
+      - redis
     environment:
       OFN_DB_HOST: db
+      OFN_REDIS_URL: redis://redis/
+      OFN_REDIS_JOBS_URL: redis://redis
     command: >
       bash -c "wait-for-it -t 30 db:5432 &&
                rm -f tmp/pids/server.pid &&
@@ -44,8 +49,11 @@ services:
       - ./config/application.yml.example:/usr/src/app/config/application.yml
     depends_on:
       - db
+      - redis
     environment:
       OFN_DB_HOST: db
+      OFN_REDIS_URL: redis://redis
+      OFN_REDIS_JOBS_URL: redis://redis
     command: >
       bash -c "wait-for-it -t 30 db:5432 &&
                (bundle check || bundle install)


### PR DESCRIPTION
#### What? Why?

This fixes the docker setup which was failing due to the newly added jemalloc, causing a core dump due to `free(): invalid pointer` upon the first request, and Redis not being set up.

#### What should we test?

Nothing. I can finally place orders locally again :tada: 

#### Release notes
Fix docker jemalloc + sidekiq setup
Changelog Category: Technical changes