### PR TITLE
Remove papertrail initializer

### DIFF
--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,0 @@
-PaperTrail.config.track_associations = false


### PR DESCRIPTION
#### What? Why?

This setting is now deprecated and triggers this message:
```
Association Tracking for PaperTrail has been extracted to a separate gem.
To use it, please add `paper_trail-association_tracking` to your Gemfile.
If you don't use it (most people don't, that's the default) and you set `track_associations = false`
somewhere (probably a rails initializer) you can remove that line now.
```

#### What should we test?
<!-- List which features should be tested and how. -->

Nothing to test; the removed setting is already the default. The warning is gone :ok_hand:

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed unnecessary Papertrail initializer

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes