### PR TITLE
Add bootsnap gem (again)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem "active_model_serializers", "0.8.4"
 gem 'activerecord-session_store'
 gem 'acts-as-taggable-on', '~> 7.0'
 gem 'angularjs-file-upload-rails', '~> 2.4.1'
+gem 'bootsnap', require: false
 gem 'custom_error_message', github: 'jeremydurham/custom-err-msg'
 gem 'dalli'
 gem 'figaro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
       json (~> 1.4)
       nokogiri (~> 1)
     bcrypt (3.1.16)
+    bootsnap (1.7.5)
+      msgpack (~> 1.0)
     bugsnag (6.20.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
@@ -680,6 +682,7 @@ DEPENDENCIES
   awesome_nested_set
   awesome_print
   aws-sdk (= 1.67.0)
+  bootsnap
   bugsnag
   bullet
   byebug

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -4,3 +4,4 @@ require 'rubygems'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bootsnap/setup'


### PR DESCRIPTION
#### What? Why?

This change was previously merged into the Rails 5.2 branch via [this PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/7388), but seems to have completely vanished?! Maybe there was a force-push somewhere :confused: 

Adds the [bootsnap Gem](https://github.com/Shopify/bootsnap) (developed by Spotify), which cuts the time the app takes to boot in half. This gem is now included in all new Rails projects by default since 5.2.

#### What should we test?
<!-- List which features should be tested and how. -->

As before; the app boots in half the time. You can try it in dev. 

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added bootsnap gem

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes


