### PR TITLE
Remove Spree::Config[:allow_ssl_in_development_and_test]

### DIFF
--- a/app/controllers/spree/admin/general_settings_controller.rb
+++ b/app/controllers/spree/admin/general_settings_controller.rb
@@ -4,8 +4,7 @@ module Spree
       def edit
         @preferences_general = [:site_name, :default_seo_title, :default_meta_keywords,
                                 :default_meta_description, :site_url]
-        @preferences_security = [:allow_ssl_in_production,
-                                 :allow_ssl_in_staging, :allow_ssl_in_development_and_test]
+        @preferences_security = [:allow_ssl_in_production, :allow_ssl_in_staging]
         @preferences_currency = [:display_currency, :hide_cents]
       end
 

--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -33,7 +33,6 @@ module Spree
     preference :allow_backorder_shipping, :boolean, default: false
     preference :allow_checkout_on_gateway_error, :boolean, default: false
     preference :allow_guest_checkout, :boolean, default: true
-    preference :allow_ssl_in_development_and_test, :boolean, default: false
     preference :allow_ssl_in_production, :boolean, default: true
     preference :allow_ssl_in_staging, :boolean, default: true
     # Replace with the name of a zone if you would like to limit the countries

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3219,7 +3219,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     default_meta_description: "Default Meta Description"
     default_meta_keywords: "Default Meta Keywords"
     security_settings: "Security Settings"
-    allow_ssl_in_development_and_test: "Allow SSL to be used when in development and test modes"
     allow_ssl_in_production: "Allow SSL to be used in production mode"
     allow_ssl_in_staging: "Allow SSL to be used in staging mode"
     currency_decimal_mark: "Currency decimal mark"

--- a/lib/spree/core/controller_helpers/ssl.rb
+++ b/lib/spree/core/controller_helpers/ssl.rb
@@ -29,9 +29,8 @@ module Spree
           def self.ssl_supported?
             return Spree::Config[:allow_ssl_in_production] if Rails.env.production?
             return Spree::Config[:allow_ssl_in_staging] if Rails.env.staging?
-            return unless Rails.env.development? || Rails.env.test?
 
-            Spree::Config[:allow_ssl_in_development_and_test]
+            false
           end
 
           private


### PR DESCRIPTION
#### What? Why?

Unconditionally disables forced https-redirects in dev and test. For some reason this is triggering and redirecting to https for me in dev with Rails 6.0.

It's not a useful setting anyway... :fire:

#### What should we test?
<!-- List which features should be tested and how. -->

The app boots in dev, and you can visit admin pages.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed Spree config setting: allow_ssl_in_development_and_test

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
