### PR TITLE
Disable Bugsnag in tests to see if it can speed up tests a bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 env:
+  BUGSNAG_DISABLE_AUTOCONFIGURE: true
   DISABLE_KNAPSACK: true
   TIMEZONE: UTC
   COVERAGE: true


### PR DESCRIPTION
This is an experiment to see if disabling Bugsnag while running tests can speed things up a bit because I'm not sure if it needs to be active during tests.

Bugsnag hooks into ActiveRecord and makes lots of calls like `/bundles/gems/bugsnag-6.20.0/lib/bugsnag/integrations/rails/active_record_rescue.rb:25:in #run_callbacks` so preventing these may help.

#### What should we test?

If there is any noticeable speed improvement to the test suite.

#### Release notes

Changelog Category: Technical changes