### PR TITLE
Move byebug to test gem group so we can use it in specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,6 +152,7 @@ group :test, :development do
 end
 
 group :test do
+  gem 'byebug'
   gem 'codecov', require: false
   gem 'simplecov', require: false
   gem 'test-prof'
@@ -163,7 +164,6 @@ group :test do
 end
 
 group :development do
-  gem 'byebug'
   gem 'debugger-linecache'
   gem 'pry'
   gem 'pry-byebug'


### PR DESCRIPTION
#### What? Why?

I cant use byebug in specs I think since rails 6 upgrade.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
green build.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
Make byebug work again in specs.


#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
