### PR TITLE
Dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,70 @@
+# Default ENV vars (primarily for the development environment).
+# Create `.env.development.local` or `.env.test.local` to add any local overrides.
+
+# Time zone must match the operating system time zone in order to pass all tests.
+# This string is the key for the MAPPING hash constant in ActiveSupport::TimeZone.
+# Documentation including the hash="https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
+TIMEZONE="Melbourne"
+
+# Default country for dropdowns etc. See for codes="http://en.wikipedia.org/wiki/ISO_3166-1
+DEFAULT_COUNTRY_CODE="AU"
+
+# Locale for translation.
+LOCALE="en"
+
+# For multilingual - ENV doesn't have array so pass it as string with commas
+AVAILABLE_LOCALES="en,es"
+
+# Spree zone.
+CHECKOUT_ZONE="Australia"
+
+# Find currency codes at http://en.wikipedia.org/wiki/ISO_4217.
+CURRENCY="AUD"
+
+# The whenever gem can set the `MAILTO` variable for our cron jobs.
+# You can define an email address to notify if any job outputs something.
+# But you need a working mail server setup so that the message is delivered.
+# See: config/schedule.rb
+# SCHEDULE_NOTIFICATIONS="admin@example.com"
+
+# Mail settings
+MAIL_HOST="example.com"
+MAIL_DOMAIN="example.com"
+MAIL_PORT="25"
+SMTP_USERNAME="ofn"
+SMTP_PASSWORD="f00d"
+
+# Optional mail settings
+# MAIL_SECURE_CONNECTION="TLS' # 'None' (default), 'SSL' or 'TLS'
+# MAILS_FROM="hello@example.com"
+# MAIL_BCC="manager@example.com"
+
+# Javascript error reporting via Bugsnag.
+# BUGSNAG_JS_KEY=""
+
+# SingleSignOn login for Discourse
+#
+# DISCOURSE_SSO_SECRET should be a random string. It must be the same as provided to your Discourse instance.
+# DISCOURSE_SSO_SECRET=""
+#
+# DISCOURSE_URL must be the URL of your Discourse instance.
+# DISCOURSE_URL="https://noticeboard.openfoodnetwork.org.au"
+
+# see="https://developers.google.com/maps/documentation/javascript/get-api-key
+# GOOGLE_MAPS_API_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Stripe Connect details for instance account
+# Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings
+# Under 'Connect', the Redirect URI should be set to https://YOUR_SERVER_URL/stripe/callbacks (e.g. https://openfoodnetwork.org.uk/stripe/callbacks)
+# Under 'Webhooks', you should set up a Connect endpoint pointing to https://YOUR_SERVER_URL/stripe/webhooks e.g. (https://openfoodnetwork.org.uk/stripe/webhooks)
+# STRIPE_INSTANCE_SECRET_KEY="sk_test_xxxxxx" # This can be a test key or a live key
+# STRIPE_INSTANCE_PUBLISHABLE_KEY="pk_test_xxxx" # This can be a test key or a live key
+# STRIPE_CLIENT_ID="ca_xxxx" # This can be a development ID or a production ID
+# STRIPE_ENDPOINT_SECRET="whsec_xxxx"
+
+# Feature toggles
+#
+# Adding user emails separated by commas will enable them the use of certain features. See
+# config/initializers/feature_toggles.rb for details.
+#
+# BETA_TESTERS="ofn@example.com,superadmin@example.com"

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,5 @@
+# ENV vars for the development environment
+# Override locally with `.env.development.local`
+
+SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+

--- a/.env.development
+++ b/.env.development
@@ -3,3 +3,5 @@
 
 SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
+OFN_REDIS_URL="redis://localhost:6379/1"
+OFN_REDIS_JOBS_URL="redis://localhost:6379/2"

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+# ENV vars for the test environment
+# Override locally with `.env.test.local`
+
+SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .rbenv-version
 .python-version
 .byebug_history
+.env.local
+.env.development.local
+.env.test.local
 .swp
 *.swo
 *.swp

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 ruby "2.7.3"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
+gem 'dotenv-rails', require: 'dotenv/rails-now' # Load ENV vars before other gems
+
 gem 'rails', '~> 6.1.4'
 
 gem 'activemerchant', '>= 1.78.0'
@@ -70,7 +72,6 @@ gem 'bigdecimal', '3.0.2'
 gem 'bootsnap', require: false
 gem 'custom_error_message', github: 'jeremydurham/custom-err-msg'
 gem 'dalli'
-gem 'figaro'
 gem 'geocoder'
 gem 'gmaps4rails'
 gem 'mimemagic', '> 0.3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,10 @@ GEM
       devise (>= 4.0.0, < 5.0.0)
     diff-lcs (1.4.4)
     docile (1.3.5)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     e2mmap (0.1.0)
     erubi (1.10.0)
     et-orbi (1.2.4)
@@ -267,8 +271,6 @@ GEM
     faraday-net_http_persistent (1.1.0)
     ffaker (2.18.0)
     ffi (1.15.1)
-    figaro (1.2.0)
-      thor (>= 0.14.0, < 2)
     flipper (0.20.4)
     flipper-active_record (0.20.4)
       activerecord (>= 5.0, < 7)
@@ -721,9 +723,9 @@ DEPENDENCIES
   devise-encryptable
   devise-token_authenticatable
   dfc_provider!
+  dotenv-rails
   factory_bot_rails (= 6.2.0)
   ffaker
-  figaro
   flipper
   flipper-active_record
   flipper-ui

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Openfoodnetwork::Application.configure do
   if !!ENV["PROFILE"]
     config.cache_store = :redis_cache_store, {
       driver: :hiredis,
-      url: ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/0"),
+      url: ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/1"),
       expires_in: 90.minutes
     }
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,15 @@
-redis_jobs_url = ENV.fetch("OFN_REDIS_JOBS_URL", "redis://localhost:6381/0")
+# Redis connection configuration for Sidekiq
+
+redis_connection_settings = {
+  url: ENV.fetch("OFN_REDIS_JOBS_URL", "redis://localhost:6381/0"),
+  network_timeout: 5,
+  expires_in: Rails.env.development? ? 90.minutes : nil
+}
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: redis_jobs_url, network_timeout: 5 }
+  config.redis = redis_connection_settings
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: redis_jobs_url, network_timeout: 5 }
+  config.redis = redis_connection_settings
 end


### PR DESCRIPTION
#### What? Why?

Twinned with https://github.com/openfoodfoundation/ofn-install/pull/751

Introduces **Dotenv** for ENV var management on a per-environment basis. 

This means:
- instead of having all environment variables defined in `application.yml`, we can have them in separate files
- devs can also add local overrides that are gitignored, so for example you can load some French data in your dev database, and apply alternate locale/country settings without it affecting the test suite (which often expects the default country to be Australia, or the currency to be AUD, for example)
- the current manual step in dev environment setup where we need to copy `config/application.example.yml` to `config/application.yml` is removed

#### What should we test?
<!-- List which features should be tested and how. -->

Build should be green. Environment variables should all be the same after deployment. Can also be tested locally in dev via booting the app or the console, or running tests.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added Dotenv for better ENV var management

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
