### PR TITLE
Remove refund button from paypal completed order tab

### DIFF
--- a/app/views/spree/admin/payments/source_views/_paypal.html.haml
+++ b/app/views/spree/admin/payments/source_views/_paypal.html.haml
@@ -15,22 +15,3 @@
           = Spree.t(:transaction_id)
           \:
         %dd= payment.source.transaction_id
-    - if payment.source.state != 'refunded'
-      = button_link_to Spree.t('actions.refund', scope: :paypal),
-        spree.paypal_refund_admin_order_payment_path(@order, payment),
-        icon: 'icon-dollar'
-    - else
-      .alpha.six.columns
-        %dl
-          %dt
-            = Spree.t(:state, scope: :paypal)
-            \:
-          %dd= payment.source.state.titleize
-          %dt
-            = Spree.t(:refunded_at, scope: :paypal)
-            \:
-          %dd= pretty_time(payment.source.refunded_at)
-          %dt
-            = Spree.t(:refund_transaction_id, scope: :paypal)
-            \:
-          %dd= payment.source.refund_transaction_id


### PR DESCRIPTION
#### What? Why?

Closes #4416 
Removed the refund button from paypal order completed tab :
![image](https://user-images.githubusercontent.com/65319144/121003285-001a7100-c7ab-11eb-93ff-4285239165c6.png)

Platform does not support paypal partial refunds, so the button is misleading.



#### What should we test?
- That the refund button does not appear on a completed paypal order.



#### Release notes
- Removed "Refund $" button from PayPal completed order tab.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
