### PR TITLE
Temporarily remove Codecov report upload actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Run controller tests
         run: bundle exec rspec --profile -- spec/controllers spec/serializers
 
-      - name: Codecov
-        uses: codecov/codecov-action@v1.3.1
-
   test-models:
     runs-on: ubuntu-18.04
     services:
@@ -95,9 +92,6 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec --profile -- spec/models
-
-      - name: Codecov
-        uses: codecov/codecov-action@v1.3.1
 
   test-admin-features-1:
     runs-on: ubuntu-18.04
@@ -140,9 +134,6 @@ jobs:
       - name: Run admin feature tests
         run: bundle exec rspec --profile -- spec/features/admin/[a-o0-9]*_spec.rb
 
-      - name: Codecov
-        uses: codecov/codecov-action@v1.3.1
-
   test-admin-features-2:
     runs-on: ubuntu-18.04
     services:
@@ -184,9 +175,6 @@ jobs:
       - name: Run admin feature tests
         run: bundle exec rspec --profile -- spec/features/admin/[p-z]*_spec.rb
 
-      - name: Codecov
-        uses: codecov/codecov-action@v1.3.1
-
   test-consumer-features:
     runs-on: ubuntu-18.04
     services:
@@ -227,9 +215,6 @@ jobs:
 
       - name: Run consumer feature tests
         run: bundle exec rspec --profile -- spec/features/consumer
-
-      - name: Codecov
-        uses: codecov/codecov-action@v1.3.1
 
   test-engines-etc:
     runs-on: ubuntu-18.04
@@ -320,6 +305,3 @@ jobs:
 
       - name: Run admin feature folders, engines, lib
         run: bundle exec rspec --profile --pattern "engines/*/spec/{,/*/**}/*_spec.rb,spec/features/admin/*/*_spec.rb,spec/lib/{,/*/**}/*_spec.rb"
-
-      - name: Codecov
-        uses: codecov/codecov-action@v1.5.0


### PR DESCRIPTION
#### What? Why?

Related to #7750 

Uploading Codecov reports after a test run is currently broken and causing builds to fail even if the tests all pass...


#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Disabled codecov uploads

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes