### PR TITLE
Disable credit button on click

### DIFF
--- a/app/views/spree/admin/payments/_list.html.haml
+++ b/app/views/spree/admin/payments/_list.html.haml
@@ -16,4 +16,4 @@
           %span{class: "state #{payment.state}"}= t(payment.state, scope: :payment_states, default: payment.state.capitalize)
         %td.actions
           - payment.actions.each do |action|
-            = link_to_with_icon "icon-#{action}", Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: {action: action}
+            = link_to_with_icon "icon-#{action}", Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: {action: action, disable_with: ""}


### PR DESCRIPTION
#### What? Why?

Closes #6330 

When Enterprise users unknowingly double click on the credit button, the customer is issued a double refund. This is caused by the presence of two Unicorn workers in staging and production. 

We can fix this by adding `disable_with: ""` to ```data:``` in
```Ruby 
= link_to_with_icon "icon-#{action}", Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: {action: action}
```
GIF/Screenshot : 
![credit-refund](https://user-images.githubusercontent.com/65319144/121160789-04599380-c86a-11eb-8479-3e1195800d19.gif)

#### What should we test?
- That upon double-clicking the credit button in ``Payments`` page after reducing item quantity, the credit is only refunded once while there are 2 unicorn workers active.

#### Release notes
- Fixed the issuance of duplicate refunds when double-clicking on credit button.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
