### PR TITLE
Show product variant SKU in Xero report

### DIFF
--- a/lib/open_food_network/xero_invoices_report.rb
+++ b/lib/open_food_network/xero_invoices_report.rb
@@ -69,7 +69,7 @@ module OpenFoodNetwork
 
     def line_item_detail_row(line_item, invoice_number, opts)
       row(line_item.order,
-          line_item.product.sku,
+          line_item.variant.sku,
           line_item.product_and_full_name,
           line_item.quantity.to_s,
           line_item.price.to_s,


### PR DESCRIPTION
#### What? Why?

Closes #7615 

This change was done so that the detailed Xero report generates the product variant SKU in order to be more clear. 

![image](https://user-images.githubusercontent.com/65319144/121203657-e9037e00-c893-11eb-8040-b3100a211389.png)


#### What should we test?
- Detailed Xero report should show variant SKU instead of showing the product SKU for all variants.

#### Release notes
- Detailed Xero report now generates SKU of each variant rather than show product SKU for all variants.

Changelog Category: User facing changes 
