### PR TITLE
Avoid false alarms due to delayed HeartbeatJob

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,7 +9,7 @@
 
 :schedule:
   HeartbeatJob:
-    every: "5m"
+    every: ["5m", first_in: "0s"]
   SubscriptionPlacementJob:
     every: "5m"
   SubscriptionConfirmJob:


### PR DESCRIPTION

#### What? Why?

Closes #7764

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

When Sidekiq was restarted, the scheduler's time was reset and jobs were
executed later. Now we trigger the HeartbeatJob straight after a Sidekiq
boot and we shouldn't see any false alarms in our monitoring.


#### What should we test?
<!-- List which features should be tested and how. -->

Dev test:

* Log into the staging server and monitor the Sidekiq log: `tail -f ~/apps/openfoodnetwork/current/log/sidekiq.log`
* Deploy this pull request.
* Observe that the HeartbeatJob is executed straight after the deployment and doesn't wait another five minutes.
* Four minutes after the deploy, check that the API reports the job queue as alive: `/api/v0/status/job_queue`

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Avoid false alarms in server monitoring with sidekiq-scheduler.

