### PR TITLE
Hide shipped orders from BOM

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -52,6 +52,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.loadOrders = ->
     RequestMonitor.load $scope.orders = Orders.index(
       "q[state_not_eq]": "canceled",
+      "q[shipment_state_not_eq]": "shipped",
       "q[completed_at_not_null]": "true",
       "q[distributor_id_eq]": $scope.distributorFilter,
       "q[order_cycle_id_eq]": $scope.orderCycleFilter,
@@ -62,6 +63,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.loadLineItems = ->
     RequestMonitor.load LineItems.index(
       "q[order_state_not_eq]": "canceled",
+      "q[order_shipment_state_not_eq]": "shipped",
       "q[order_completed_at_not_null]": "true",
       "q[order_distributor_id_eq]": $scope.distributorFilter,
       "q[variant_product_supplier_id_eq]": $scope.supplierFilter,

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -21,12 +21,16 @@ feature '
     end
 
     context "displaying the list of line items" do
-      let!(:o1) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
-      let!(:o2) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', shipment_state: 'ready', completed_at: Time.zone.now ) }
+      let!(:o2) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', shipment_state: 'ready', completed_at: Time.zone.now ) }
       let!(:o3) { create(:order_with_distributor, state: 'address', completed_at: nil ) }
+      let!(:o4) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o5) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:li1) { create(:line_item_with_shipment, order: o1) }
       let!(:li2) { create(:line_item_with_shipment, order: o2) }
       let!(:li3) { create(:line_item, order: o3 ) }
+      let!(:li4) { create(:line_item_with_shipment, order: o4) }
+      let!(:li5) { create(:line_item_with_shipment, order: o5) }
 
       before :each do
         visit_bulk_order_management
@@ -37,15 +41,22 @@ feature '
         expect(page).to have_selector "tr#li_#{li2.id}"
         expect(page).to have_no_selector "tr#li_#{li3.id}"
       end
+
+      it "displays only line items that are not shipped" do
+        expect(page).to have_selector "tr#li_#{li1.id}"
+        expect(page).to have_selector "tr#li_#{li2.id}"
+        expect(page).to have_no_selector "tr#li_#{li4.id}"
+        expect(page).to have_no_selector "tr#li_#{li5.id}"
+      end
     end
 
     context "displaying individual columns" do
       let!(:o1) {
-        create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now,
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now,
                                         bill_address: create(:address) )
       }
       let!(:o2) {
-        create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now,
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now,
                                         bill_address: nil )
       }
       let!(:li1) { create(:line_item_with_shipment, order: o1) }
@@ -99,8 +110,8 @@ feature '
     end
 
     describe "sorting of line items" do
-      let!(:o1) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now) }
-      let!(:o2) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now) }
+      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now) }
+      let!(:o2) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now) }
       let!(:li1) { create(:line_item_with_shipment, order: o1) }
       let!(:li2) { create(:line_item_with_shipment, order: o2) }
 
@@ -143,7 +154,7 @@ feature '
     end
 
     context "tracking changes" do
-      let!(:o1) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
       let!(:li1) { create(:line_item_with_shipment, order: o1, quantity: 5 ) }
 
       before :each do
@@ -203,7 +214,7 @@ feature '
                                          variant_unit: "weight", variants: [create(:variant, unit_value: 1000)] )
     }
     let!(:v1) { p1.variants.first }
-    let!(:o1) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+    let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
     let!(:li1) {
       create(:line_item_with_shipment, order: o1, variant: v1, quantity: 5, final_weight_volume: 1000,
                                        price: 10.00 )
@@ -282,7 +293,7 @@ feature '
         let!(:s1) { create(:supplier_enterprise) }
         let!(:s2) { create(:supplier_enterprise) }
         let!(:o1) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now,
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now,
                                           order_cycle: create(:simple_order_cycle) )
         }
         let!(:li1) {
@@ -326,11 +337,11 @@ feature '
         let!(:d1) { create(:distributor_enterprise) }
         let!(:d2) { create(:distributor_enterprise) }
         let!(:o1) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d1,
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now, distributor: d1,
                                           order_cycle: create(:simple_order_cycle) )
         }
         let!(:o2) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d2,
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now, distributor: d2,
                                           order_cycle: create(:simple_order_cycle) )
         }
         let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
@@ -369,11 +380,11 @@ feature '
         let!(:oc1) { create(:simple_order_cycle, distributors: [distributor]) }
         let!(:oc2) { create(:simple_order_cycle, distributors: [distributor]) }
         let!(:o1) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now,
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now,
                                           order_cycle: oc1 )
         }
         let!(:o2) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now,
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now,
                                           order_cycle: oc2 )
         }
         let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
@@ -416,11 +427,11 @@ feature '
         let!(:p1) { create(:product, supplier: s1) }
         let!(:p2) { create(:product, supplier: s2) }
         let!(:o1) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d1,
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now, distributor: d1,
                                           order_cycle: oc1 )
         }
         let!(:o2) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now, distributor: d2,
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now, distributor: d2,
                                           order_cycle: oc2 )
         }
         let!(:li1) { create(:line_item_with_shipment, order: o1, product: p1 ) }
@@ -469,9 +480,9 @@ feature '
     end
 
     context "using quick search" do
-      let!(:o1) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
-      let!(:o2) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
-      let!(:o3) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
+      let!(:o2) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
+      let!(:o3) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
       let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
       let!(:li2) { create(:line_item_with_shipment, order: o2 ) }
       let!(:li3) { create(:line_item_with_shipment, order: o3 ) }
@@ -493,17 +504,17 @@ feature '
 
     context "using date restriction controls" do
       let!(:o1) {
-        create(:order_with_distributor, state: 'complete',
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
                                         completed_at: Time.zone.today - 7.days - 1.second)
       }
       let!(:o2) {
-        create(:order_with_distributor, state: 'complete', completed_at: Time.zone.today - 7.days)
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.today - 7.days)
       }
       let!(:o3) {
-        create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now.end_of_day)
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now.end_of_day)
       }
       let!(:o4) {
-        create(:order_with_distributor, state: 'complete',
+        create(:order_with_distributor, state: 'complete', shipment_state: 'ready',
                                         completed_at: Time.zone.now.end_of_day + 1.second)
       }
       let!(:li1) { create(:line_item_with_shipment, order: o1, quantity: 1 ) }
@@ -582,8 +593,8 @@ feature '
     end
 
     context "bulk action controls" do
-      let!(:o1) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
-      let!(:o2) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
+      let!(:o2) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
       let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
       let!(:li2) { create(:line_item_with_shipment, order: o2 ) }
 
@@ -663,11 +674,11 @@ feature '
       context "using edit buttons" do
         let(:address) { create(:address) }
         let!(:o1) {
-          create(:order_with_distributor, ship_address: address, state: 'complete',
+          create(:order_with_distributor, ship_address: address, state: 'complete', shipment_state: 'ready',
                                           completed_at: Time.zone.now )
         }
         let!(:o2) {
-          create(:order_with_distributor, ship_address: address, state: 'complete',
+          create(:order_with_distributor, ship_address: address, state: 'complete', shipment_state: 'ready',
                                           completed_at: Time.zone.now )
         }
         let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
@@ -705,10 +716,10 @@ feature '
 
       context "using delete buttons" do
         let!(:o1) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now )
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now )
         }
         let!(:o2) {
-          create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now )
+          create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now )
         }
         let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
         let!(:li2) { create(:line_item_with_shipment, order: o2 ) }
@@ -731,8 +742,8 @@ feature '
     end
 
     context "clicking the link on variant name" do
-      let!(:o1) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
-      let!(:o2) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
+      let!(:o2) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
       let!(:li1) { create(:line_item_with_shipment, order: o1 ) }
       let!(:li2) { create(:line_item_with_shipment, order: o2 ) }
       let!(:p3) {
@@ -740,7 +751,7 @@ feature '
                                            variant_unit: "weight", variants: [create(:variant, unit_value: 1000)] )
       }
       let!(:v3) { p3.variants.first }
-      let!(:o3) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
+      let!(:o3) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
       let!(:li3) {
         create(:line_item_with_shipment, order: o3, variant: v3, quantity: 3, max_quantity: 6 )
       }
@@ -805,11 +816,11 @@ feature '
     let(:d1) { create(:distributor_enterprise, name: 'First Distributor') }
     let(:d2) { create(:distributor_enterprise, name: 'Another Distributor') }
     let!(:o1) {
-      create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now,
+      create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now,
                                       distributor: d1 )
     }
     let!(:o2) {
-      create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now,
+      create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now,
                                       distributor: d2 )
     }
     let!(:line_item_distributed) {

--- a/spec/features/admin/bulk_order_management_spec.rb
+++ b/spec/features/admin/bulk_order_management_spec.rb
@@ -21,8 +21,8 @@ feature '
     end
 
     context "displaying the list of line items" do
-      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', shipment_state: 'ready', completed_at: Time.zone.now ) }
-      let!(:o2) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', shipment_state: 'ready', completed_at: Time.zone.now ) }
+      let!(:o1) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
+      let!(:o2) { create(:order_with_distributor, state: 'complete', shipment_state: 'ready', completed_at: Time.zone.now ) }
       let!(:o3) { create(:order_with_distributor, state: 'address', completed_at: nil ) }
       let!(:o4) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }
       let!(:o5) { create(:order_with_distributor, state: 'complete', completed_at: Time.zone.now ) }

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -45,7 +45,7 @@ describe "LineItemsCtrl", ->
       index: jasmine.createSpy('index').and.returnValue(lineItem)
       all: [lineItem]
 
-    httpBackend.expectGET("/api/v0/orders.json?q%5Bcompleted_at_gteq%5D=SomeDate&q%5Bcompleted_at_lt%5D=SomeDate&q%5Bcompleted_at_not_null%5D=true&q%5Bdistributor_id_eq%5D=&q%5Border_cycle_id_eq%5D=&q%5Bstate_not_eq%5D=canceled").respond {orders: [order], pagination: {page: 1, pages: 1, results: 1}}
+    httpBackend.expectGET("/api/v0/orders.json?q%5Bcompleted_at_gteq%5D=SomeDate&q%5Bcompleted_at_lt%5D=SomeDate&q%5Bcompleted_at_not_null%5D=true&q%5Bdistributor_id_eq%5D=&q%5Border_cycle_id_eq%5D=&q%5Bshipment_state_not_eq%5D=shipped&q%5Bstate_not_eq%5D=canceled").respond {orders: [order], pagination: {page: 1, pages: 1, results: 1}}
     httpBackend.expectGET("/admin/enterprises/visible.json?ams_prefix=basic&q%5Bsells_in%5D%5B%5D=own&q%5Bsells_in%5D%5B%5D=any").respond [distributor]
     httpBackend.expectGET("/admin/order_cycles.json?ams_prefix=basic&as=distributor&q%5Borders_close_at_gt%5D=SomeDate").respond [orderCycle]
     httpBackend.expectGET("/admin/enterprises/visible.json?ams_prefix=basic&q%5Bis_primary_producer_eq%5D=true").respond [supplier]


### PR DESCRIPTION
#### What? Why?

Closes #7457 

This change is needed so that there can't be any confusion caused be deleting already shipped orders through BOM.

#### GIF/Screenshot : 

![BOM](https://user-images.githubusercontent.com/65319144/121376662-53cdbb80-c95f-11eb-9820-a8c837417184.gif)


#### What should we test?
- There should be no canceled or shipped orders visible in BOM.

#### Release notes
- Removed shipped orders from BOM page.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 
