### PR TITLE
Set Capybara retry count to 3 and remove conditional

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,12 +98,10 @@ RSpec.configure do |config|
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
 
-  # Retry
+  # Show retries in test output
   config.verbose_retry = true
-  # Try twice (retry once)
-  config.default_retry_count = 2
-  # Only retry when Selenium raises Net::ReadTimeout
-  config.exceptions_to_retry = [Net::ReadTimeout]
+  # Set maximum retry count
+  config.default_retry_count = 3
 
   # Force colored output, whether or not the output is a TTY
   config.color_mode = :on


### PR DESCRIPTION
#### What? Why?

Bumps the retry count for Capybara to automatically retry flaky tests when they're encountered.

This is a slippery slope and there are perfectly reasonable arguments _against_ doing this, but on a practical level I think retrying the occasional flaky spec (and adding an extra 10 seconds or so on to the build time) is categorically better than consistently failing the build and having to restart the whole thing (potentially multiple times).

#### What should we test?
<!-- List which features should be tested and how. -->

Hopefully less flaky build failures.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Increased test suite automatic retries.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
