### PR TITLE
Stripe stock check

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -118,7 +118,10 @@ class CheckoutController < ::BaseController
   def cancel_incomplete_payments
     # The checkout could not complete due to stock running out. We void any pending (incomplete)
     # Stripe payments here as the order will need to be changed and resubmitted (or abandoned).
-    @order.payments.incomplete.each(&:void!)
+    @order.payments.incomplete.each do |payment|
+      payment.void!
+      payment.adjustment&.update_columns(eligible: false, state: "finalized")
+    end
     flash[:notice] = I18n.t("checkout.payment_cancelled_due_to_stock")
   end
 

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -118,7 +118,7 @@ class CheckoutController < ::BaseController
   def cancel_incomplete_payments
     # The checkout could not complete due to stock running out. We void any pending (incomplete)
     # Stripe payments here as the order will need to be changed and resubmitted (or abandoned).
-    @order.payments.pending.each(&:void!)
+    @order.payments.incomplete.each(&:void!)
     flash[:notice] = I18n.t("checkout.payment_cancelled_due_to_stock")
   end
 

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -72,7 +72,7 @@ module Spree
         transition from: [:processing, :pending, :checkout, :requires_authorization], to: :completed
       end
       event :void do
-        transition from: [:pending, :completed, :checkout], to: :void
+        transition from: [:pending, :completed, :requires_authorization, :checkout], to: :void
       end
       # when the card brand isnt supported
       event :invalidate do

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -49,7 +49,7 @@ module Spree
     scope :incomplete, -> { where(state: %w(checkout pending requires_authorization)) }
     scope :pending, -> { with_state('pending') }
     scope :failed, -> { with_state('failed') }
-    scope :valid, -> { where('state NOT IN (?)', %w(failed invalid)) }
+    scope :valid, -> { where.not(state: %w(failed invalid)) }
     scope :authorization_action_required, -> { where.not(cvv_response_message: nil) }
     scope :requires_authorization, -> { with_state("requires_authorization") }
     scope :with_payment_intent, ->(code) { where(response_code: code) }

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -46,6 +46,7 @@ module Spree
     scope :from_credit_card, -> { where(source_type: 'Spree::CreditCard') }
     scope :with_state, ->(s) { where(state: s.to_s) }
     scope :completed, -> { with_state('completed') }
+    scope :incomplete, -> { where(state: %w(checkout pending requires_authorization)) }
     scope :pending, -> { with_state('pending') }
     scope :failed, -> { with_state('failed') }
     scope :valid, -> { where('state NOT IN (?)', %w(failed invalid)) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1315,6 +1315,7 @@ en:
       message_html: "I agree to the seller's %{terms_and_conditions_link} and the platform %{tos_link}."
       terms_and_conditions: "Terms and Conditions"
     failed: "The checkout failed. Please let us know so that we can process your order."
+    payment_cancelled_due_to_stock: "Payment cancelled: the checkout could not be completed due to stock issues."
   shops:
     hubs:
       show_closed_shops: "Show closed shops"

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -49,8 +49,7 @@ describe CheckoutController, type: :controller do
     let(:shipping_method) { distributor.shipping_methods.first }
 
     before do
-      order.line_items << create(:line_item,
-                                 variant: order_cycle.variants_distributed_by(distributor).first)
+      order.contents.add(order_cycle.variants_distributed_by(distributor).first)
 
       allow(controller).to receive(:current_distributor).and_return(distributor)
       allow(controller).to receive(:current_order_cycle).and_return(order_cycle)

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -91,19 +91,47 @@ describe CheckoutController, type: :controller do
       allow(OrderCycleDistributedVariants).to receive(:new).and_return(order_cycle_distributed_variants)
     end
 
-    it "redirects when some items are out of stock" do
-      allow(order).to receive_message_chain(:insufficient_stock_lines, :empty?).and_return false
+    context "running out of stock" do
+      it "redirects when some items are out of stock" do
+        allow(order).to receive_message_chain(:insufficient_stock_lines, :empty?).and_return false
 
-      get :edit
-      expect(response).to redirect_to cart_path
-    end
+        get :edit
+        expect(response).to redirect_to cart_path
+      end
 
-    it "redirects when some items are not available" do
-      allow(order).to receive_message_chain(:insufficient_stock_lines, :empty?).and_return true
-      expect(order_cycle_distributed_variants).to receive(:distributes_order_variants?).with(order).and_return(false)
+      it "redirects when some items are not available" do
+        allow(order).to receive_message_chain(:insufficient_stock_lines, :empty?).and_return true
+        expect(order_cycle_distributed_variants).to receive(:distributes_order_variants?).with(order).and_return(false)
 
-      get :edit
-      expect(response).to redirect_to cart_path
+        get :edit
+        expect(response).to redirect_to cart_path
+      end
+
+      context "after redirecting back from Stripe" do
+        let(:order) { create(:order_with_totals_and_distribution) }
+        let!(:payment) { create(:payment, state: "pending", amount: order.total, order: order) }
+
+        before do
+          allow(order).to receive_message_chain(:insufficient_stock_lines, :empty?).and_return(false)
+          allow(order_cycle_distributed_variants).to receive(:distributes_order_variants?).
+            with(order).and_return(true)
+          allow(controller).to receive(:valid_payment_intent_provided?) { true }
+          order.save
+          allow(order).to receive_message_chain(:payments, :completed) { [] }
+          allow(order).to receive_message_chain(:payments, :pending) { [payment] }
+        end
+
+        it "cancels the payment and resets the order to cart" do
+          expect(payment).to receive(:void!).and_call_original
+
+          spree_post :edit
+
+          expect(response).to redirect_to cart_path
+          expect(flash[:notice]).to eq I18n.t('checkout.payment_cancelled_due_to_stock')
+
+          expect(order.state).to eq "cart"
+        end
+      end
     end
 
     describe "when items are available and in stock" do

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -118,7 +118,7 @@ describe CheckoutController, type: :controller do
           allow(controller).to receive(:valid_payment_intent_provided?) { true }
           order.save
           allow(order).to receive_message_chain(:payments, :completed) { [] }
-          allow(order).to receive_message_chain(:payments, :pending) { [payment] }
+          allow(order).to receive_message_chain(:payments, :incomplete) { [payment] }
         end
 
         it "cancels the payment and resets the order to cart" do


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/7692

Handles Stripe payments when checkout fails due to stock issues (frontoffice).

This can occur when stock is reduced after the user is redirected to Stripe and before they are redirected back. The stock is insufficient, the order is not complete, the user is bounced back to the cart, but a *pending* Stripe payment is left on the order.

This explicitly voids the leftover payment when the checkout fails in this case, so it's not sitting there in the Stripe account. Also improves user feedback so the user is informed the payment they just authorized has been canceled instead of captured.

#### What should we test?
<!-- List which features should be tested and how. -->

Checkout with Stripe where the user is redirected for authorization and the stock runs out before they have finished authorizing.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
