### PR TITLE
Fix HTML bug on new payment method page

### DIFF
--- a/app/assets/javascripts/admin/payment_methods/controllers/providers_controller.js.coffee
+++ b/app/assets/javascripts/admin/payment_methods/controllers/providers_controller.js.coffee
@@ -2,6 +2,6 @@ angular.module("admin.paymentMethods").controller "ProvidersCtrl", ($scope, paym
   if paymentMethod.type
     $scope.include_html = "/admin/payment_methods/show_provider_preferences?" +
       "provider_type=#{paymentMethod.type};" +
-      "pm_id=#{paymentMethod.id};"
+      "pm_id=#{paymentMethod.id || ''};"
   else
     $scope.include_html = ""

--- a/spec/javascripts/unit/admin/controllers/providers_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/controllers/providers_controller_spec.js.coffee
@@ -27,4 +27,4 @@ describe "ProvidersCtrl", ->
         ctrl = $controller 'ProvidersCtrl', {$scope: scope, paymentMethod: paymentMethod }
 
     it "sets the include_html porperty on scope to some address", ->
-      expect(scope.include_html).toBe "/admin/payment_methods/show_provider_preferences?provider_type=NOT NULL;pm_id=#{paymentMethod.id};"
+      expect(scope.include_html).toBe "/admin/payment_methods/show_provider_preferences?provider_type=NOT NULL;pm_id=#{paymentMethod.id || ''};"


### PR DESCRIPTION
#### What? Why?

Closes #7762 

When trying to add a new payment method in ``/admin/payment_methods/new``, the page breaks when you forget a required field.

It was because `"pm_id=#{paymentMethod.id''}"` in `payment_methods/controllers/providers_controller.js.coffee` was passing NULL value when creating a *new* payment method. We can fix it by changing it to `"pm_id=#{paymentMethod.id || ''}"`. This will ensure pm_id is empty when creating a new payment method.

#### Screenshot/GIF
![new_pay_m](https://user-images.githubusercontent.com/65319144/121721915-68968480-cb02-11eb-824a-41577f4f5536.gif)

#### What should we test?
- That the page doesn't break and only the error partial is displayed when fields are missed before clicking on ``Create`` button

#### Release notes
- Fixed the bug where payment_methods page appears inside the new payments method page when payment method not saved succesfully.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
