### PR TITLE
Decouple payments

### DIFF
--- a/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -25,7 +25,7 @@ module Spree
               @order.associate_user!(Spree.user_class.find_by(email: @order.email))
             end
 
-            OrderWorkflow.new(@order).complete
+            OrderWorkflow.new(@order).advance_to_payment
 
             @order.shipments.map(&:refresh_rates)
             flash[:success] = Spree.t('customer_details_updated')

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -28,11 +28,7 @@ module Spree
       def edit
         @order.shipments.map(&:refresh_rates)
 
-        OrderWorkflow.new(@order).complete
-
-        # The payment step shows an error of 'No pending payments'
-        # Clearing the errors from the order object will stop this error
-        # appearing on the edit page where we don't want it to.
+        OrderWorkflow.new(@order).advance_to_payment
         @order.errors.clear
       end
 

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -35,15 +35,16 @@ module Spree
             return
           end
 
-          authorize_stripe_sca_payment
-
           if @order.completed?
-            @payment.process!
+            authorize_stripe_sca_payment
+            @payment.process_offline!
             flash[:success] = flash_message_for(@payment, :successfully_created)
 
             redirect_to spree.admin_order_payments_path(@order)
           else
             OrderWorkflow.new(@order).complete!
+            authorize_stripe_sca_payment
+            @payment.process_offline!
 
             flash[:success] = Spree.t(:new_order_completed)
             redirect_to spree.edit_admin_order_url(@order)

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -50,6 +50,7 @@ module Spree
         amount: @order.total,
         payment_method: payment_method
       )
+      @order.process_payments!
       @order.next
       if @order.complete?
         flash.notice = Spree.t(:order_processed_successfully)

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -67,12 +67,6 @@ module Spree
                 transition to: :cart, unless: :completed?
               end
 
-              if states[:payment]
-                before_transition to: :complete do |order|
-                  order.process_payments! if order.payment_required?
-                end
-              end
-
               before_transition from: :cart, do: :ensure_line_items_present
 
               before_transition to: :delivery, do: :create_proposed_shipments

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -81,10 +81,10 @@ module Spree
       event :require_authorization do
         transition from: [:checkout, :processing], to: :requires_authorization
       end
-      event :failed_authorization do
+      event :fail_authorization do
         transition from: [:requires_authorization], to: :failed
       end
-      event :completed_authorization do
+      event :complete_authorization do
         transition from: [:requires_authorization], to: :completed
       end
     end

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -23,6 +23,14 @@ class OrderWorkflow
     result
   end
 
+  def advance_to_payment
+    until order.state == "payment"
+      break unless order.next
+
+      after_transition_hook(advance_order_options)
+    end
+  end
+
   private
 
   def advance_order_options

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -8,7 +8,7 @@ class OrderWorkflow
   end
 
   def complete
-    advance_order(advance_order_options)
+    advance_to_state("complete", advance_order_options)
   end
 
   def complete!
@@ -24,11 +24,7 @@ class OrderWorkflow
   end
 
   def advance_to_payment
-    until order.state == "payment"
-      break unless order.next
-
-      after_transition_hook(advance_order_options)
-    end
+    advance_to_state("payment", advance_order_options)
   end
 
   private
@@ -38,8 +34,8 @@ class OrderWorkflow
     { shipping_method_id: shipping_method_id }
   end
 
-  def advance_order(options)
-    until order.state == "complete"
+  def advance_to_state(target_state, options)
+    until order.state == target_state
       break unless order.next
 
       after_transition_hook(options)

--- a/app/services/place_proxy_order.rb
+++ b/app/services/place_proxy_order.rb
@@ -21,6 +21,7 @@ class PlaceProxyOrder
     load_changes
     return handle_empty_order if empty_order?
 
+    order.process_payments! if order.payment_required?
     move_to_completion
     send_placement_email
   rescue StandardError => e

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -36,17 +36,17 @@ class ProcessPaymentIntent
     process_payment
 
     if payment.reload.completed?
-      payment.completed_authorization
+      payment.complete_authorization
       payment.clear_authorization_url
 
       Result.new(ok: true)
     else
-      payment.failed_authorization
+      payment.fail_authorization
       payment.clear_authorization_url
       Result.new(ok: false, error: I18n.t("payment_could_not_complete"))
     end
   rescue Stripe::StripeError => e
-    payment.failed_authorization
+    payment.fail_authorization
     payment.clear_authorization_url
     Result.new(ok: false, error: e.message)
   end

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -46,6 +46,8 @@ class ProcessPaymentIntent
       Result.new(ok: false, error: I18n.t("payment_could_not_complete"))
     end
   rescue Stripe::StripeError => e
+    payment.failed_authorization
+    payment.clear_authorization_url
     Result.new(ok: false, error: e.message)
   end
 

--- a/app/services/process_payment_intent.rb
+++ b/app/services/process_payment_intent.rb
@@ -54,12 +54,8 @@ class ProcessPaymentIntent
   attr_reader :order, :payment_intent, :payment
 
   def process_payment
-    if order.state == "payment"
-      # Moves the order to completed, which calls #process_payments!
-      OrderWorkflow.new(order).next
-    else
-      order.process_payments!
-    end
+    OrderWorkflow.new(order).next if order.state == "payment"
+    order.process_payments!
   end
 
   def ready_for_capture?

--- a/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -16,7 +16,6 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           :order_with_totals_and_distribution,
           state: 'cart',
           shipments: [shipment],
-          payments: [create(:payment)],
           distributor: distributor,
           user: nil,
           email: nil,
@@ -47,7 +46,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           spree_post :update, order: { email: user.email, bill_address_attributes: address_params,
                                        ship_address_attributes: address_params },
                               order_id: order.number
-        }.to change { order.reload.state }.from("cart").to("complete")
+        }.to change { order.reload.state }.from("cart").to("payment")
       end
 
       context "when adding details of a registered user" do

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -48,7 +48,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
         let!(:payment_method) { create(:stripe_connect_payment_method, distributors: [shop]) }
         before do
           allow_any_instance_of(Spree::Payment).
-            to receive(:process!).
+            to receive(:process_offline!).
             and_raise(Spree::Core::GatewayError.new("Payment Gateway Error"))
         end
 
@@ -110,7 +110,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
             allow_any_instance_of(Spree::Payment).to receive(:authorize!) do |payment|
               payment.update state: "pending"
             end
-            allow_any_instance_of(Spree::Payment).to receive(:process!).and_return(true)
+            allow_any_instance_of(Spree::Payment).to receive(:process_offline!).and_return(true)
           end
 
           it "makes a payment with the provided card details" do

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -171,8 +171,8 @@ describe Spree::OrdersController, type: :controller do
           expect(response.status).to eq 200
           expect(flash[:error]).to eq("#{I18n.t('payment_could_not_process')}. error message")
           payment.reload
-          expect(payment.cvv_response_message).to eq("https://stripe.com/redirect")
-          expect(payment.state).to eq("requires_authorization")
+          expect(payment.cvv_response_message).to be nil
+          expect(payment.state).to eq("failed")
         end
       end
 

--- a/spec/models/spree/order/checkout_spec.rb
+++ b/spec/models/spree/order/checkout_spec.rb
@@ -118,38 +118,6 @@ describe Spree::Order::Checkout do
         end
       end
     end
-
-    context "from payment" do
-      before do
-        order.state = 'payment'
-      end
-
-      context "when payment is required" do
-        before do
-          allow(order).to receive_messages confirmation_required?: false
-          allow(order).to receive_messages payment_required?: true
-        end
-
-        it "transitions to complete" do
-          expect(order).to receive(:process_payments!).once.and_return true
-          order.next!
-          expect(order.state).to eq "complete"
-        end
-      end
-
-      # Regression test for Spree #2028
-      context "when payment is not required" do
-        before do
-          allow(order).to receive_messages payment_required?: false
-        end
-
-        it "does not call process payments" do
-          expect(order).to_not receive(:process_payments!)
-          order.next!
-          expect(order.state).to eq "complete"
-        end
-      end
-    end
   end
 
   describe 'event :restart_checkout' do

--- a/spec/models/spree/order/state_machine_spec.rb
+++ b/spec/models/spree/order/state_machine_spec.rb
@@ -31,9 +31,9 @@ describe Spree::Order do
         context "when credit card processing fails" do
           before { allow(order).to receive_messages process_payments!: false }
 
-          it "should not complete the order" do
+          it "should still complete the order" do
             order.next
-            expect(order.state).to eq "payment"
+            expect(order.state).to eq "complete"
           end
         end
       end
@@ -41,9 +41,9 @@ describe Spree::Order do
       context "when payment processing fails" do
         before { allow(order).to receive_messages process_payments!: false }
 
-        it "cannot transition to complete" do
+        it "can transition to complete" do
           order.next
-          expect(order.state).to eq "payment"
+          expect(order.state).to eq "complete"
         end
       end
     end

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -65,7 +65,7 @@ describe ProcessPaymentIntent do
 
         it "does not complete the payment" do
           service.call!
-          expect(payment.reload.state).to eq("requires_authorization")
+          expect(payment.reload.state).to eq("failed")
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #7665 
Closes #7510 

This is still a first attempt, but I think it's ready for review. 

There's been quite a few bugs whose root cause is that we authorize/take payment before making sure that we can move the order to the `complete` state. 

This PR removes the callback in the Order state machine that was calling `process_payments` as part of the transition to `complete`. Instead, it moves that decision/responsibility (when and if to process payments) to the caller. 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
We'll want to do a pretty thorough test of checkout, admin payments, and subscription payments to make sure the changes to the test suite don't break anything that we aren't expecting. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Updated the Order workflow to make completing an order and processing payments two separate steps. 
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
The first 13 commits in this PR are in #7708, so once that's been merged, we can rebase and just use the additional two (or more) from this branch. 


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
