### PR TITLE
Add web-console gem for debugging in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,6 +162,7 @@ group :test do
 end
 
 group :development do
+  gem 'web-console'
   gem 'debugger-linecache'
   gem 'pry'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
       nokogiri (~> 1)
     bcrypt (3.1.16)
     bigdecimal (1.4.2)
+    bindex (0.8.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     bugsnag (6.20.0)
@@ -640,6 +641,11 @@ GEM
       view_component (>= 2.2)
     warden (1.2.9)
       rack (>= 2.0.9)
+    web-console (4.1.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     webdrivers (4.6.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -785,6 +791,7 @@ DEPENDENCIES
   view_component
   view_component_storybook
   web!
+  web-console
   webdrivers
   webmock
   whenever


### PR DESCRIPTION
#### What? Why?

This gem is a default in new Rails 6.x apps. It shows a console when a page throws an error in development at the line where the error was raised. 


#### What should we test?
<!-- List which features should be tested and how. -->
No test


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Added web-console gem for debugging in development
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
