### PR TITLE
Decode DFC token with public key

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,11 +93,6 @@ Openfoodnetwork::Application.routes.draw do
 
   get 'sitemap.xml', to: 'sitemap#index', defaults: { format: 'xml' }
 
-  unless Rails.env.production?
-    # Mount DFC API endpoints
-    mount DfcProvider::Engine, at: '/'
-  end
-
   # Mount Spree's routes
   mount Spree::Core::Engine, :at => '/'
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -1,4 +1,9 @@
 Openfoodnetwork::Application.routes.draw do
+  unless Rails.env.production?
+    # Mount DFC API endpoints
+    mount DfcProvider::Engine, at: '/'
+  end
+  
   namespace :api do
     namespace :v0 do
       resources :products do

--- a/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
+++ b/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
@@ -14,10 +14,10 @@ module DfcProvider
     end
 
     def decode_token
+      rsa_public = OpenSSL::PKey::RSA.new(DFC_PUBLIC_KEY)
       data = JWT.decode(
         @access_token,
-        nil,
-        false
+        rsa_public, true, { algorithm: 'RS256' }
       )
 
       @header = data.last
@@ -27,5 +27,11 @@ module DfcProvider
     def find_ofn_user
       Spree::User.where(email: @payload['email']).first
     end
+
+    private
+
+    DFC_PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnL0KaRkAKtWcc0TnwtlNVQ58PsB8guPirh1OCnNUqr71q3zyAqh5t6oWIRCTS5eqr2zhb/Je3QOeX2l0tGZ2YVQIBhvIGHcYfpMvrT+Loqsh3rHYiRLXs+YvUIM0tyWeQlpDMeqQ/t1G61FcF+HsiOBRvhaho7e+cV1hO1QvzcoxeMleexPdK+dnL4qHGKELf1oZmvFKcUAHG8IOcoxJn3KYdJsEbRj3jTAliTCXxGXmY++0c48pSV2iaOhxxlgR4AZTH+fSveAosGSPSYDYL9xVCyrRHFRgkHlIcw61hF6YyEE5G5b4MEumafBiLKZ9HJfjAhZv3kcD72nTGgJrMQIDAQAB
+-----END PUBLIC KEY-----"
   end
 end

--- a/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
+++ b/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
@@ -11,6 +11,8 @@ module DfcProvider
     def process
       decode_token
       find_ofn_user
+    rescue JWT::DecodeError
+      return nil
     end
 
     private

--- a/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
+++ b/engines/dfc_provider/app/services/dfc_provider/authorization_control.rb
@@ -13,6 +13,8 @@ module DfcProvider
       find_ofn_user
     end
 
+    private
+
     def decode_token
       rsa_public = OpenSSL::PKey::RSA.new(DFC_PUBLIC_KEY)
       data = JWT.decode(
@@ -27,8 +29,6 @@ module DfcProvider
     def find_ofn_user
       Spree::User.where(email: @payload['email']).first
     end
-
-    private
 
     DFC_PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnL0KaRkAKtWcc0TnwtlNVQ58PsB8guPirh1OCnNUqr71q3zyAqh5t6oWIRCTS5eqr2zhb/Je3QOeX2l0tGZ2YVQIBhvIGHcYfpMvrT+Loqsh3rHYiRLXs+YvUIM0tyWeQlpDMeqQ/t1G61FcF+HsiOBRvhaho7e+cV1hO1QvzcoxeMleexPdK+dnL4qHGKELf1oZmvFKcUAHG8IOcoxJn3KYdJsEbRj3jTAliTCXxGXmY++0c48pSV2iaOhxxlgR4AZTH+fSveAosGSPSYDYL9xVCyrRHFRgkHlIcw61hF6YyEE5G5b4MEumafBiLKZ9HJfjAhZv3kcD72nTGgJrMQIDAQAB

--- a/engines/dfc_provider/spec/services/authorization_control_spec.rb
+++ b/engines/dfc_provider/spec/services/authorization_control_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe DfcProvider::AuthorizationControl do
+  let(:test_public_key) { "-----BEGIN PUBLIC KEY-----
+MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgFb9ARWvTPr3/I3rO7dx/83c0UGR
+5A8nkvxAj3hsm23c0SFJLGxBfFTy+CcuGJWe2Yu6V+zxo0i3yeR99jjWUBPmyIol
+FLHKjzLCaHNlTuY+N6CkQCtHVDLKHopfl/t3xZabuaqhPXA1SYb4Gm12DwMGznXY
+X6yOmI+kVDBkhlL/AgMBAAE=
+-----END PUBLIC KEY-----" }
+
+  # token to encode the payload: { "email": "fredo.farmer@hub.com" }
+  let(:valid_token) {
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImZyZWRvLmZhcm1lckBodWIuY29tIn0.TKxGbScx_zvZpWG40ikaXrp5PH2PDEtFSxeFHR2-VnmkezAQhvvVSEnMeiDbMmfKNwSNy2JLmL1ky7TuARq86RqwKYnjMX9HLDCUzq52VTG0ZK6uYX2J2PCibSzOLu5-67BkGwe5yglQaKrSvqtoAimSxetNqA59rCp6WXxxP8g"
+  }
+  let(:invalid_token) { "invalid" }
+
+  describe "processing a valid token" do
+    let(:user) { instance_double(Spree::User) }
+    let(:authorization_control) { DfcProvider::AuthorizationControl.new(valid_token) }
+
+    it "returns the correct OFN user" do
+      allow(Spree::User).to receive(:where).with(email: "fredo.farmer@hub.com") { [user] }
+      expect(authorization_control.process).to eq(user)
+    end
+  end
+
+  describe "processing an invalid token" do
+    let(:authorization_control) { DfcProvider::AuthorizationControl.new(invalid_token) }
+
+    it "returns nil" do
+      expect(authorization_control.process).to be nil
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/5134

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This should allow us to enable the DFC endpoints. We look for an `access_token` in the request headers from the DFC prototype and use their public key to decode it; unless the token has been signed with the DFC's private key, the token will not be decoded. 

If the token contains a payload like:

```
{
  "email": "fredo.hub.farmer@example.org"
}
```

...that user will be the `current_user` for the request and the API will return any resources that that user has access to. 

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
