### PR TITLE
Improve DFC Provider logic to use existing business logic

### DIFF
--- a/engines/dfc_provider/README.md
+++ b/engines/dfc_provider/README.md
@@ -8,3 +8,5 @@ Basically, it allows an OFN user linked to an enterprise:
 * to be authenticated thanks to an Access Token from DFC Authorization server (using an OIDC implementation)
 
 The API endpoint for the catalog is `/api/dfc_provider/enterprise/prodcuts.json` and you need to pass the token inside an authentication header (`Authentication: Bearer 123mytoken456`).
+
+This feature is still under active development.

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
@@ -8,7 +8,7 @@ module DfcProvider
 
       before_action :check_authorization,
                     :check_user,
-                    :check_enterprise
+                    :set_enterprise
 
       respond_to :json
 
@@ -26,7 +26,7 @@ module DfcProvider
         head :unauthorized
       end
 
-      def check_enterprise
+      def set_enterprise
         current_enterprise
       end
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
@@ -7,8 +7,7 @@ module DfcProvider
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
       before_action :check_authorization,
-                    :check_user,
-                    :set_enterprise
+                    :check_user
 
       respond_to :json
 
@@ -26,8 +25,10 @@ module DfcProvider
         head :unauthorized
       end
 
-      def set_enterprise
-        current_enterprise
+      def check_enterprise
+        return if current_enterprise.present?
+
+        not_found
       end
 
       def current_enterprise
@@ -35,8 +36,6 @@ module DfcProvider
           case params[enterprise_id_param_name]
           when 'default'
             current_user.enterprises.first!
-          when nil
-            nil
           else
             current_user.enterprises.find(params[enterprise_id_param_name])
           end

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
@@ -32,10 +32,13 @@ module DfcProvider
 
       def current_enterprise
         @current_enterprise ||=
-          if params[enterprise_id_param_name] == 'default'
-            current_user.enterprises.first!
+          case params[enterprise_id_param_name]
+          when 'default'
+            return current_user.enterprises.first!
+          when nil
+            return nil
           else
-            current_user.enterprises.find(params[enterprise_id_param_name])
+            return current_user.enterprises.find(params[enterprise_id_param_name])
           end
       end
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/base_controller.rb
@@ -34,11 +34,11 @@ module DfcProvider
         @current_enterprise ||=
           case params[enterprise_id_param_name]
           when 'default'
-            return current_user.enterprises.first!
+            current_user.enterprises.first!
           when nil
-            return nil
+            nil
           else
-            return current_user.enterprises.find(params[enterprise_id_param_name])
+            current_user.enterprises.find(params[enterprise_id_param_name])
           end
       end
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
@@ -5,6 +5,8 @@
 module DfcProvider
   module Api
     class CatalogItemsController < DfcProvider::Api::BaseController
+      before_action :check_enterprise
+
       def index
         # CatalogItem is nested into an entreprise which is also nested into
         # an user on the DFC specifications, as defined here:

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
@@ -21,10 +21,7 @@ module DfcProvider
 
       def variant
         @variant ||=
-          Spree::Variant.
-            joins(product: :supplier).
-            where('enterprises.id' => current_enterprise.id).
-            find(params[:id])
+          DfcProvider::VariantFetcher.new(current_enterprise).scope.find(params[:id])
       end
     end
   end

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Controller used to provide the API products for the DFC application
+# CatalogItems are items that are being sold by the entreprise.
 module DfcProvider
   module Api
     class CatalogItemsController < DfcProvider::Api::BaseController

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/catalog_items_controller.rb
@@ -6,6 +6,10 @@ module DfcProvider
   module Api
     class CatalogItemsController < DfcProvider::Api::BaseController
       def index
+        # CatalogItem is nested into an entreprise which is also nested into
+        # an user on the DFC specifications, as defined here:
+        # https://datafoodconsortium.gitbook.io/dfc-standard-documentation
+        #  /technical-specification/api-examples
         render json: current_user, serializer: DfcProvider::PersonSerializer
       end
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/enterprises_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/enterprises_controller.rb
@@ -4,6 +4,8 @@
 module DfcProvider
   module Api
     class EnterprisesController < DfcProvider::Api::BaseController
+      before_action :check_enterprise
+
       def show
         render json: current_enterprise, serializer: DfcProvider::EnterpriseSerializer
       end

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/persons_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/persons_controller.rb
@@ -4,7 +4,7 @@
 module DfcProvider
   module Api
     class PersonsController < DfcProvider::Api::BaseController
-      skip_before_action :check_enterprise
+      skip_before_action :set_enterprise
 
       before_action :check_user_accessibility
 

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/persons_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/persons_controller.rb
@@ -4,8 +4,6 @@
 module DfcProvider
   module Api
     class PersonsController < DfcProvider::Api::BaseController
-      skip_before_action :set_enterprise
-
       before_action :check_user_accessibility
 
       def show

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Controller used to provide the SuppliedProducts API for the DFC application
+# SuppliedProducts are products that are managed by an entrerprise.
 module DfcProvider
   module Api
     class SuppliedProductsController < DfcProvider::Api::BaseController

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
@@ -5,6 +5,8 @@
 module DfcProvider
   module Api
     class SuppliedProductsController < DfcProvider::Api::BaseController
+      before_action :check_enterprise
+
       def show
         render json: variant, serializer: DfcProvider::SuppliedProductSerializer
       end

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
@@ -13,10 +13,7 @@ module DfcProvider
 
       def variant
         @variant ||=
-          Spree::Variant.
-            joins(product: :supplier).
-            where('enterprises.id' => current_enterprise.id).
-            find(params[:id])
+          DfcProvider::VariantFetcher.new(current_enterprise).scope.find(params[:id])
       end
     end
   end

--- a/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
+++ b/engines/dfc_provider/app/controllers/dfc_provider/api/supplied_products_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Controller used to provide the SuppliedProducts API for the DFC application
-# SuppliedProducts are products that are managed by an entrerprise.
+# SuppliedProducts are products that are managed by an enterprise.
 module DfcProvider
   module Api
     class SuppliedProductsController < DfcProvider::Api::BaseController

--- a/engines/dfc_provider/app/serializers/dfc_provider/address_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/address_serializer.rb
@@ -3,7 +3,7 @@
 # Serializer used to render the DFC Address from an OFN User
 # into JSON-LD format based on DFC ontology
 module DfcProvider
-  class AddressSerializer < ActiveModel::Serializer
+  class AddressSerializer < BaseSerializer
     attribute :type, key: '@type'
     attribute :city, key: 'dfc:city'
     attribute :country, key: 'dfc:country'

--- a/engines/dfc_provider/app/serializers/dfc_provider/base_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/base_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Serializer used to render the DFC Address from an OFN User
+# into JSON-LD format based on DFC ontology
+module DfcProvider
+  class BaseSerializer < ActiveModel::Serializer
+    private
+
+    def host
+      Rails.application.routes.default_url_options[:host]
+    end
+
+    def dfc_provider_routes
+      DfcProvider::Engine.routes.url_helpers
+    end
+  end
+end

--- a/engines/dfc_provider/app/serializers/dfc_provider/catalog_item_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/catalog_item_serializer.rb
@@ -43,7 +43,7 @@ module DfcProvider
     def reference_id
       dfc_provider_routes.api_dfc_provider_enterprise_supplied_product_url(
         enterprise_id: object.product.supplier_id,
-        id: object.product_id,
+        id: object.id,
         host: host
       )
     end

--- a/engines/dfc_provider/app/serializers/dfc_provider/catalog_item_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/catalog_item_serializer.rb
@@ -3,7 +3,7 @@
 # Serializer used to render a DFC CatalogItem from an OFN Product
 # into JSON-LD format based on DFC ontology
 module DfcProvider
-  class CatalogItemSerializer < ActiveModel::Serializer
+  class CatalogItemSerializer < BaseSerializer
     attribute :id, key: '@id'
     attribute :type, key: '@type'
     attribute :references, key: 'dfc:references'
@@ -17,7 +17,7 @@ module DfcProvider
       dfc_provider_routes.api_dfc_provider_enterprise_catalog_item_url(
         enterprise_id: object.product.supplier_id,
         id: object.id,
-        host: root_url
+        host: host
       )
     end
 
@@ -46,10 +46,6 @@ module DfcProvider
         id: object.product_id,
         host: root_url
       )
-    end
-
-    def dfc_provider_routes
-      DfcProvider::Engine.routes.url_helpers
     end
   end
 end

--- a/engines/dfc_provider/app/serializers/dfc_provider/catalog_item_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/catalog_item_serializer.rb
@@ -28,7 +28,7 @@ module DfcProvider
     def references
       {
         '@type' => '@id',
-        '@id' => "/supplied_products/#{object.product_id}"
+        '@id' => reference_id
       }
     end
 
@@ -44,7 +44,7 @@ module DfcProvider
       dfc_provider_routes.api_dfc_provider_enterprise_supplied_product_url(
         enterprise_id: object.product.supplier_id,
         id: object.product_id,
-        host: root_url
+        host: host
       )
     end
   end

--- a/engines/dfc_provider/app/serializers/dfc_provider/enterprise_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/enterprise_serializer.rb
@@ -18,7 +18,7 @@ module DfcProvider
     def id
       dfc_provider_routes.api_dfc_provider_enterprise_url(
         id: object.id,
-        host: root_url
+        host: host
       )
     end
 

--- a/engines/dfc_provider/app/serializers/dfc_provider/enterprise_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/enterprise_serializer.rb
@@ -3,7 +3,7 @@
 # Serializer used to render a DFC Enterprise from an OFN Enterprise
 # into JSON-LD format based on DFC ontology
 module DfcProvider
-  class EnterpriseSerializer < ActiveModel::Serializer
+  class EnterpriseSerializer < BaseSerializer
     attribute :id, key: '@id'
     attribute :type, key: '@type'
     attribute :vat_number, key: 'dfc:VATnumber'
@@ -42,12 +42,6 @@ module DfcProvider
       Spree::Variant.
         joins(product: :supplier).
         where('enterprises.id' => object.id)
-    end
-
-    private
-
-    def dfc_provider_routes
-      DfcProvider::Engine.routes.url_helpers
     end
   end
 end

--- a/engines/dfc_provider/app/serializers/dfc_provider/enterprise_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/enterprise_serializer.rb
@@ -33,15 +33,11 @@ module DfcProvider
     end
 
     def supplies
-      Spree::Variant.
-        joins(product: :supplier).
-        where('enterprises.id' => object.id)
+      DfcProvider::VariantFetcher.new(object).scope
     end
 
     def manages
-      Spree::Variant.
-        joins(product: :supplier).
-        where('enterprises.id' => object.id)
+      DfcProvider::VariantFetcher.new(object).scope
     end
   end
 end

--- a/engines/dfc_provider/app/serializers/dfc_provider/offer_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/offer_serializer.rb
@@ -3,7 +3,7 @@
 # Serializer used to render the DFC Offer from an OFN Product
 # into JSON-LD format based on DFC ontology
 module DfcProvider
-  class OfferSerializer < ActiveModel::Serializer
+  class OfferSerializer < BaseSerializer
     attribute :id, key: '@id'
     attribute :type, key: '@type'
     attribute :offers_to, key: 'dfc:offers_to'

--- a/engines/dfc_provider/app/serializers/dfc_provider/offer_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/offer_serializer.rb
@@ -6,7 +6,7 @@ module DfcProvider
   class OfferSerializer < ActiveModel::Serializer
     attribute :id, key: '@id'
     attribute :type, key: '@type'
-    attribute :offeres_to, key: 'dfc:offeres_to'
+    attribute :offers_to, key: 'dfc:offers_to'
     attribute :price, key: 'dfc:price'
     attribute :stock_limitation, key: 'dfc:stockLimitation'
 
@@ -18,7 +18,7 @@ module DfcProvider
       'dfc:Offer'
     end
 
-    def offeres_to
+    def offers_to
       {
         '@type' => '@id',
         '@id' => nil

--- a/engines/dfc_provider/app/serializers/dfc_provider/person_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/person_serializer.rb
@@ -28,7 +28,7 @@ module DfcProvider
     def id
       dfc_provider_routes.api_dfc_provider_person_url(
         id: object.id,
-        host: root_url
+        host: host
       )
     end
 

--- a/engines/dfc_provider/app/serializers/dfc_provider/person_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/person_serializer.rb
@@ -3,7 +3,7 @@
 # Serializer used to render the DFC Person from an OFN User
 # into JSON-LD format based on DFC ontology
 module DfcProvider
-  class PersonSerializer < ActiveModel::Serializer
+  class PersonSerializer < BaseSerializer
     attribute :context, key: '@context'
     attribute :id, key: '@id'
     attribute :type, key: '@type'
@@ -44,12 +44,6 @@ module DfcProvider
 
     def affiliates
       object.enterprises
-    end
-
-    private
-
-    def dfc_provider_routes
-      DfcProvider::Engine.routes.url_helpers
     end
   end
 end

--- a/engines/dfc_provider/app/serializers/dfc_provider/supplied_product_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/supplied_product_serializer.rb
@@ -3,7 +3,7 @@
 # Serializer used to render a DFC SuppliedProduct from an OFN Variant
 # into JSON-LD format based on DFC ontology
 module DfcProvider
-  class SuppliedProductSerializer < ActiveModel::Serializer
+  class SuppliedProductSerializer < BaseSerializer
     attribute :id, key: '@id'
     attribute :type, key: '@type'
     attribute :unit, key: 'dfc:hasUnit'
@@ -63,10 +63,6 @@ module DfcProvider
 
     def unit_name
       object.unit_description.presence || 'piece'
-    end
-
-    def dfc_provider_routes
-      DfcProvider::Engine.routes.url_helpers
     end
   end
 end

--- a/engines/dfc_provider/app/serializers/dfc_provider/supplied_product_serializer.rb
+++ b/engines/dfc_provider/app/serializers/dfc_provider/supplied_product_serializer.rb
@@ -20,7 +20,7 @@ module DfcProvider
       dfc_provider_routes.api_dfc_provider_enterprise_supplied_product_url(
         enterprise_id: object.product.supplier_id,
         id: object.id,
-        host: root_url
+        host: host
       )
     end
 

--- a/engines/dfc_provider/app/services/dfc_provider/variant_fetcher.rb
+++ b/engines/dfc_provider/app/services/dfc_provider/variant_fetcher.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Service used to fetch variants related to an entreprise.
+# It improves maintenance as it is the central point requesting
+# Spree::Varaint inside the DfcProvider engine.
+module DfcProvider
+  class VariantFetcher
+    def initialize(enterprise)
+      @enterprise = enterprise
+    end
+
+    def scope
+      Spree::Variant.
+        joins(product: :supplier).
+        where('enterprises.id' => @enterprise.id)
+    end
+  end
+end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
@@ -29,7 +29,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
               before { api_get :index, enterprise_id: 'default' }
 
               it 'is successful' do
-                expect(response).to be_success
+                expect(response).to be_successful
               end
 
               it 'renders the required content' do
@@ -120,7 +120,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
             end
 
             it 'is successful' do
-              expect(response).to be_success
+              expect(response).to be_successful
             end
 
             it 'renders the required content' do

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
@@ -10,7 +10,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
   let!(:product) { create(:simple_product, supplier: enterprise ) }
   let!(:variant) { product.variants.first }
 
-  describe('.index') do
+  describe '.index' do
     context 'with authorization token' do
       before do
         request.headers['Authorization'] = 'Bearer 123456.abcdef.123456'
@@ -100,7 +100,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
     end
   end
 
-  describe('.show') do
+  describe '.show' do
     context 'with authorization token' do
       before do
         request.headers['Authorization'] = 'Bearer 123456.abcdef.123456'

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
@@ -29,7 +29,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
               before { api_get :index, enterprise_id: 'default' }
 
               it 'is successful' do
-                expect(response.status).to eq 200
+                expect(response).to be_success
               end
 
               it 'renders the required content' do
@@ -47,7 +47,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
 
               it 'returns not_found head' do
                 api_get :index, enterprise_id: enterprise.id
-                expect(response.status).to eq 404
+                expect(response).to be_not_found
               end
             end
           end
@@ -75,7 +75,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
 
           it 'is not found' do
             api_get :index, enterprise_id: 'default'
-            expect(response.status).to eq 404
+            expect(response).to be_not_found
           end
         end
       end
@@ -87,7 +87,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
             .and_return(nil)
 
           api_get :index, enterprise_id: 'default'
-          expect(response.status).to eq 401
+          expect(response.response_code).to eq(401)
         end
       end
     end
@@ -95,7 +95,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
     context 'without an authorization token' do
       it 'returns unprocessable_entity head' do
         api_get :index, enterprise_id: enterprise.id
-        expect(response.status).to eq 422
+        expect(response).to be_unprocessable
       end
     end
   end
@@ -120,7 +120,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
             end
 
             it 'is successful' do
-              expect(response.status).to eq 200
+              expect(response).to be_success
             end
 
             it 'renders the required content' do
@@ -137,7 +137,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
             end
 
             it 'is not found' do
-              expect(response.status).to eq 404
+              expect(response).to be_not_found
             end
           end
         end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/catalog_items_controller_spec.rb
@@ -116,9 +116,7 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
         context 'with an enterprise' do
           context 'given with an id' do
             before do
-              api_get :show,
-                      enterprise_id: enterprise.id,
-                      id: variant.id
+              api_get :show, enterprise_id: enterprise.id, id: variant.id
             end
 
             it 'is successful' do
@@ -126,10 +124,8 @@ describe DfcProvider::Api::CatalogItemsController, type: :controller do
             end
 
             it 'renders the required content' do
-              expect(response.body)
-                .to include('dfc:CatalogItem')
-              expect(response.body)
-                .to include("offers/#{variant.id}")
+              expect(response.body).to include('dfc:CatalogItem')
+              expect(response.body).to include("offers/#{variant.id}")
             end
           end
 

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/enterprises_spec.rb
@@ -27,7 +27,7 @@ describe DfcProvider::Api::EnterprisesController, type: :controller do
             before { api_get :show, id: 'default' }
 
             it 'is successful' do
-              expect(response).to be_success
+              expect(response).to be_successful
             end
 
             it 'renders the required content' do

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/enterprises_spec.rb
@@ -27,7 +27,7 @@ describe DfcProvider::Api::EnterprisesController, type: :controller do
             before { api_get :show, id: 'default' }
 
             it 'is successful' do
-              expect(response.status).to eq 200
+              expect(response).to be_success
             end
 
             it 'renders the required content' do
@@ -44,7 +44,7 @@ describe DfcProvider::Api::EnterprisesController, type: :controller do
             before { api_get :show, id: 999 }
 
             it 'is not found' do
-              expect(response.status).to eq 404
+              expect(response).to be_not_found
             end
           end
         end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/enterprises_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/enterprises_spec.rb
@@ -9,7 +9,7 @@ describe DfcProvider::Api::EnterprisesController, type: :controller do
   let!(:enterprise) { create(:distributor_enterprise, owner: user) }
   let!(:product) { create(:simple_product, supplier: enterprise ) }
 
-  describe('.show') do
+  describe '.show' do
     context 'with authorization token' do
       before do
         request.headers['Authorization'] = 'Bearer 123456.abcdef.123456'

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
@@ -7,7 +7,7 @@ describe DfcProvider::Api::PersonsController, type: :controller do
 
   let!(:user) { create(:user) }
 
-  describe('.show') do
+  describe '.show' do
     context 'with authorization token' do
       before do
         request.headers['Authorization'] = 'Bearer 123456.abcdef.123456'

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
@@ -24,7 +24,7 @@ describe DfcProvider::Api::PersonsController, type: :controller do
           before { api_get :show, id: user.id }
 
           it 'is successful' do
-            expect(response.status).to eq 200
+            expect(response).to be_success
           end
 
           it 'renders the required content' do
@@ -36,7 +36,7 @@ describe DfcProvider::Api::PersonsController, type: :controller do
           before { api_get :show, id: create(:user).id }
 
           it 'is not found' do
-            expect(response.status).to eq 404
+            expect(response).to be_not_found
           end
         end
       end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
@@ -21,10 +21,7 @@ describe DfcProvider::Api::PersonsController, type: :controller do
         end
 
         context 'given with an accessible id' do
-          before do
-            api_get :show,
-                    id: user.id
-          end
+          before { api_get :show, id: user.id }
 
           it 'is successful' do
             expect(response.status).to eq 200

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/persons_controller_spec.rb
@@ -24,7 +24,7 @@ describe DfcProvider::Api::PersonsController, type: :controller do
           before { api_get :show, id: user.id }
 
           it 'is successful' do
-            expect(response).to be_success
+            expect(response).to be_successful
           end
 
           it 'renders the required content' do

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
@@ -30,7 +30,7 @@ describe DfcProvider::Api::SuppliedProductsController, type: :controller do
             end
 
             it 'is successful' do
-              expect(response.status).to eq 200
+              expect(response).to be_success
             end
 
             it 'renders the required content' do
@@ -39,10 +39,10 @@ describe DfcProvider::Api::SuppliedProductsController, type: :controller do
           end
 
           context 'given with a wrong id' do
-            before { api_get :show, id: 999 }
+            before { api_get :show, enterprise_id: 'default', id: 999 }
 
             it 'is not found' do
-              expect(response.status).to eq 404
+              expect(response).to be_not_found
             end
           end
         end

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
@@ -26,9 +26,7 @@ describe DfcProvider::Api::SuppliedProductsController, type: :controller do
         context 'with an enterprise' do
           context 'given with an id' do
             before do
-              api_get :show,
-                      enterprise_id: 'default',
-                      id: variant.id
+              api_get :show, enterprise_id: 'default', id: variant.id
             end
 
             it 'is successful' do
@@ -36,8 +34,7 @@ describe DfcProvider::Api::SuppliedProductsController, type: :controller do
             end
 
             it 'renders the required content' do
-              expect(response.body)
-                .to include(variant.name)
+              expect(response.body).to include(variant.name)
             end
           end
 

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
@@ -10,7 +10,7 @@ describe DfcProvider::Api::SuppliedProductsController, type: :controller do
   let!(:product) { create(:simple_product, supplier: enterprise ) }
   let!(:variant) { product.variants.first }
 
-  describe('.show') do
+  describe '.show' do
     context 'with authorization token' do
       before do
         request.headers['Authorization'] = 'Bearer 123456.abcdef.123456'

--- a/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
+++ b/engines/dfc_provider/spec/controllers/dfc_provider/api/supplied_products_controller_spec.rb
@@ -30,7 +30,7 @@ describe DfcProvider::Api::SuppliedProductsController, type: :controller do
             end
 
             it 'is successful' do
-              expect(response).to be_success
+              expect(response).to be_successful
             end
 
             it 'renders the required content' do

--- a/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
@@ -31,7 +31,7 @@ describe DfcProvider::CatalogItemSerializer do
         'enterprises',
         product.supplier_id,
         'supplied_products',
-        product.id
+        variant.id
       ].join('/')
     }
 

--- a/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
@@ -9,26 +9,35 @@ describe DfcProvider::CatalogItemSerializer do
   subject { described_class.new(variant) }
 
   describe '#id' do
+    let(:catalog_item_id) {
+      [
+        'http://test.host/api/dfc_provider',
+        'enterprises',
+        product.supplier_id,
+        'catalog_items',
+        variant.id
+      ].join('/')
+    }
+
     it 'returns the expected value' do
-      expect(subject.id).to eq(
-        DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_catalog_item_url(
-          enterprise_id: product.supplier_id,
-          id: variant.id,
-          host: 'http://test.host'
-        )
-      )
+      expect(subject.id).to eq(catalog_item_id)
     end
   end
 
   describe '#references' do
+    let(:supplied_product_id) {
+      [
+        'http://test.host/api/dfc_provider',
+        'enterprises',
+        product.supplier_id,
+        'supplied_products',
+        product.id
+      ].join('/')
+    }
+
     it 'returns the expected value' do
       expect(subject.references).to eq(
-        "@id" =>
-          DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_supplied_product_url(
-            enterprise_id: product.supplier_id,
-            id: product.id,
-            host: 'http://test.host'
-          ),
+        "@id" => supplied_product_id,
         "@type" => "@id"
       )
     end

--- a/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe DfcProvider::CatalogItemSerializer do
+  let!(:product) { create(:simple_product ) }
+  let!(:variant) { product.variants.first }
+
+  subject { described_class.new(variant) }
+
+  describe '#id' do
+    it 'returns the expected value' do
+      expect(subject.id).to eq(
+        DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_catalog_item_url(
+          enterprise_id: product.supplier_id,
+          id: variant.id,
+          host: 'http://test.host'
+        )
+      )
+    end
+  end
+
+  describe '#references' do
+    it 'returns the expected value' do
+      expect(subject.references).to eq(
+        {
+          "@id" =>
+            DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_supplied_product_url(
+              enterprise_id: product.supplier_id,
+              id: product.id,
+              host: 'http://test.host'
+            ),
+          "@type" => "@id"
+        }
+      )
+    end
+  end
+end

--- a/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/catalog_item_serializer_spec.rb
@@ -23,15 +23,13 @@ describe DfcProvider::CatalogItemSerializer do
   describe '#references' do
     it 'returns the expected value' do
       expect(subject.references).to eq(
-        {
-          "@id" =>
-            DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_supplied_product_url(
-              enterprise_id: product.supplier_id,
-              id: product.id,
-              host: 'http://test.host'
-            ),
-          "@type" => "@id"
-        }
+        "@id" =>
+          DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_supplied_product_url(
+            enterprise_id: product.supplier_id,
+            id: product.id,
+            host: 'http://test.host'
+          ),
+        "@type" => "@id"
       )
     end
   end

--- a/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
@@ -23,10 +23,8 @@ describe DfcProvider::SuppliedProductSerializer do
   describe '#unit' do
     it 'returns the rdfs label value' do
       expect(subject.unit).to eq(
-        {
-          '@id' => '/unit/piece',
-          'rdfs:label' => 'piece'
-        }
+        '@id' => '/unit/piece',
+        'rdfs:label' => 'piece'
       )
     end
   end

--- a/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
@@ -9,14 +9,18 @@ describe DfcProvider::SuppliedProductSerializer do
   subject { described_class.new(variant) }
 
   describe '#id' do
+    let(:supplied_product_id) {
+      [
+        'http://test.host/api/dfc_provider',
+        'enterprises',
+        product.supplier_id,
+        'supplied_products',
+        product.id
+      ].join('/')
+    }
+
     it 'returns the expected value' do
-      expect(subject.id).to eq(
-        DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_supplied_product_url(
-          enterprise_id: product.supplier_id,
-          id: variant.id,
-          host: 'http://test.host'
-        )
-      )
+      expect(subject.id).to eq(supplied_product_id)
     end
   end
 

--- a/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe DfcProvider::SuppliedProductSerializer do
+  let!(:product) { create(:simple_product ) }
+  let!(:variant) { product.variants.first }
+
+  subject { described_class.new(variant) }
+
+  describe '#id' do
+    it 'returns the expected value' do
+      expect(subject.id).to eq(
+        DfcProvider::Engine.routes.url_helpers.api_dfc_provider_enterprise_supplied_product_url(
+          enterprise_id: product.supplier_id,
+          id: variant.id,
+          host: 'http://test.host'
+        )
+      )
+    end
+  end
+
+  describe '#unit' do
+    it 'returns the rdfs label value' do
+      expect(subject.unit).to eq(
+        {
+          '@id' => '/unit/piece',
+          'rdfs:label' => 'piece'
+        }
+      )
+    end
+  end
+end

--- a/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
+++ b/engines/dfc_provider/spec/serializers/dfc_provider/supplied_product_serializer_spec.rb
@@ -15,7 +15,7 @@ describe DfcProvider::SuppliedProductSerializer do
         'enterprises',
         product.supplier_id,
         'supplied_products',
-        product.id
+        variant.id
       ].join('/')
     }
 


### PR DESCRIPTION
What? Why?

Closes #6157.
This will improve DFC Provider codebase, and its maintenance.
The first commits are actually related to suggestions from this PR https://github.com/openfoodfoundation/openfoodnetwork/pull/5810.

What should we test?

Automated tests and Rubocop should be sufficient for testing.
Release notes

    Improve DFC Provider logic to use existing business logic

Changelog Category: Changed