### PR TITLE
Add a delay on sending order confirmation emails

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -343,8 +343,8 @@ module Spree
     def deliver_order_confirmation_email
       return if subscription.present?
 
-      Spree::OrderMailer.confirm_email_for_customer(id).deliver_later
-      Spree::OrderMailer.confirm_email_for_shop(id).deliver_later
+      Spree::OrderMailer.confirm_email_for_customer(id).deliver_later(wait: 10.seconds)
+      Spree::OrderMailer.confirm_email_for_shop(id).deliver_later(wait: 10.seconds)
     end
 
     # Helper methods for checkout steps


### PR DESCRIPTION
#### What? Why?

Related to #7723 

There's a race condition here that means the order's address is not always present when the email is first sent (and fails), but it *is* present shortly after (when the email sending is automatically retried). The fix here is a temporary solution, it should address the symptoms but doesn't address the underlying cause.

#### What should we test?
<!-- List which features should be tested and how. -->

We can do a quick check placing an order in staging and seeing if it still creates a Bugsnag error.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added slight delay on order confirmation email sending

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes