### PR TITLE
Ignore potential error in dev where default tax rate is nil

### DIFF
--- a/app/models/spree/tax_rate.rb
+++ b/app/models/spree/tax_rate.rb
@@ -114,7 +114,7 @@ module Spree
     end
 
     def default_zone_or_zone_match?(order)
-      Zone.default_tax.contains?(order.tax_zone) || order.tax_zone == zone
+      Zone.default_tax&.contains?(order.tax_zone) || order.tax_zone == zone
     end
 
     # Manually apply a TaxRate to a particular amount. TaxRates normally compute against


### PR DESCRIPTION
#### What? Why?

If the current tax rates are badly misconfigured, and an included-tax rate is being applied but a *default* rate does not exist (there are validations to stop this case from occurring, see `DefaultTaxZoneValidator`), this line can throw an error. This situation will not actually arise in production, but can happen fairly easily in dev or with staging data when switching datasets or messing around with local configurations, and when it does it's annoying.

Note: the logic in the check here is still good; if there's no default tax rate we check if the order's tax zone matches the zone for the current tax rate, which is correct. I just had a look and this little change is also present in Spree 2.4 (it wasn't included in the adjustments changes in 2.2).

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Avoid errors in development if tax rates are misconfigured

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
