### PR TITLE
Remove custom feature toggles

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -10,16 +10,8 @@
 
   #panes
     = render "home/brandstory"
-
-    - if feature? :connect_learn_homepage
-      = render "home/learn"
-      = render "home/connect"
-      = render "home/system"
-    - else
-      = render "home/system"
-      = render "home/cta"
-
+    = render "home/system"
+    = render "home/cta"
     = render "home/stats"
-
 
   = render "shared/footer"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1476,8 +1476,6 @@ en:
   label_producers: "Producers"
   label_groups: "Groups"
   label_about: "About"
-  label_connect: "Connect"
-  label_learn: "Learn"
   label_blog: "Blog"
   label_support: "Support"
   label_shopping: "Shopping"
@@ -1570,12 +1568,6 @@ en:
   brandstory_part4: "It works everywhere. It changes everything."
   brandstory_part5_strong: "We call it Open Food Network."
   brandstory_part6: "We all love food. Now we can love our food system too."
-
-  learn_body: "Explore models, stories and resources to support you to develop your fair food business or organisation.  Find training, events and other opportunities to learn from peers."
-  learn_cta: "Get Inspired"
-
-  connect_body: "Search our full directories of producers, hubs and groups to find fair food traders near you.  List your business or organisation on the OFN so buyers can find you.  Join the community to get advice and solve problems together."
-  connect_cta: "Go Exploring"
 
   system_headline: "Shopping - here's how it works."
   system_step1: "1. Search"

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -1,63 +1,15 @@
 module OpenFoodNetwork
-  # This feature toggles implementation provides two mechanisms to conditionally enable features.
+  # Feature toggles are configured via Flipper.
   #
-  # You can configure features via the Flipper config and web interface. See:
+  # We define features in the initializer and then it can be customised via the
+  # web interface on each server.
   #
   # - config/initializers/flipper.rb
   # - http://localhost:3000/admin/feature-toggle/features
   #
-  # Alternatively, you can choose which users have the feature toggled on. To do that you need to
-  # register the feature and its users from an initializer like:
-  #
-  #   require 'open_food_network/feature_toggle'
-  #   OpenFoodNetwork::FeatureToggle.enable(:new_shiny_feature, ['ofn@example.com'])
-  #
-  # Note, however, that it'd be better to read the user emails from an ENV var provisioned with
-  # ofn-install:
-  #
-  #   require 'open_food_network/feature_toggle'
-  #   OpenFoodNetwork::FeatureToggle.enable(:new_shiny_feature, ENV['PRODUCT_TEAM'])
-  #
-  # You can then check it from a view like:
-  #
-  #   - if feature? :new_shiny_feature, spree_current_user
-  #     = render "new_shiny_feature"
-  #
   module FeatureToggle
     def self.enabled?(feature_name, user = nil)
-      features = Thread.current[:features] || {}
-
-      if Flipper[feature_name].exist?
-        Flipper.enabled?(feature_name, user)
-      else
-        feature = features.fetch(feature_name, DefaultFeature.new)
-        feature.enabled?(user)
-      end
-    end
-
-    def self.enable(feature_name, &block)
-      Thread.current[:features] ||= {}
-      Thread.current[:features][feature_name] = Feature.new(block)
-    end
-  end
-
-  class Feature
-    def initialize(block)
-      @block = block
-    end
-
-    def enabled?(user)
-      block.call(user)
-    end
-
-    private
-
-    attr_reader :block
-  end
-
-  class DefaultFeature
-    def enabled?(_user)
-      false
+      Flipper.enabled?(feature_name, user)
     end
   end
 end

--- a/lib/open_food_network/feature_toggle.rb
+++ b/lib/open_food_network/feature_toggle.rb
@@ -1,12 +1,10 @@
 module OpenFoodNetwork
   # This feature toggles implementation provides two mechanisms to conditionally enable features.
   #
-  # You can provide an ENV var with the prefix `OFN_FEATURE_` and query it using the
-  # `ApplicationHelper#feature?` helper method. For instance, providing the ENV var
-  # `OFN_FEATURE_NEW_SHINNY_FEATURE` you could then query it from view as follows:
+  # You can configure features via the Flipper config and web interface. See:
   #
-  #   - if feature? :new_shiny_feature
-  #     = render "new_shiny_feature"
+  # - config/initializers/flipper.rb
+  # - http://localhost:3000/admin/feature-toggle/features
   #
   # Alternatively, you can choose which users have the feature toggled on. To do that you need to
   # register the feature and its users from an initializer like:
@@ -32,7 +30,7 @@ module OpenFoodNetwork
       if Flipper[feature_name].exist?
         Flipper.enabled?(feature_name, user)
       else
-        feature = features.fetch(feature_name, DefaultFeature.new(feature_name))
+        feature = features.fetch(feature_name, DefaultFeature.new)
         feature.enabled?(user)
       end
     end
@@ -58,28 +56,8 @@ module OpenFoodNetwork
   end
 
   class DefaultFeature
-    attr_reader :feature_name
-
-    def initialize(feature_name)
-      @feature_name = feature_name
-    end
-
     def enabled?(_user)
-      true?(env_variable_value(feature_name))
-    end
-
-    private
-
-    def env_variable_value(feature_name)
-      ENV.fetch(env_variable_name(feature_name), nil)
-    end
-
-    def env_variable_name(feature_name)
-      "OFN_FEATURE_#{feature_name.to_s.upcase}"
-    end
-
-    def true?(value)
-      value.to_s.casecmp("true").zero?
+      false
     end
   end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -14,34 +14,5 @@ module OpenFoodNetwork
         expect(FeatureToggle.enabled?(:foo)).to be true
       end
     end
-
-    context 'when specifying users' do
-      let(:insider) { build(:user) }
-      let(:outsider) { build(:user, email: "different") }
-
-      context 'and the block does not specify arguments' do
-        before do
-          FeatureToggle.enable(:foo) { 'return value' }
-        end
-
-        it "returns the block's return value" do
-          expect(FeatureToggle.enabled?(:foo, insider)).to eq('return value')
-        end
-      end
-
-      context 'and the block specifies arguments' do
-        let(:users) { [insider.email] }
-
-        before do
-          FeatureToggle.enable(:foo) { |user| users.include?(user&.email) }
-        end
-
-        it "returns the block's return value" do
-          expect(FeatureToggle.enabled?(:foo, insider)).to eq(true)
-          expect(FeatureToggle.enabled?(:foo, outsider)).to eq(false)
-          expect(FeatureToggle.enabled?(:foo, nil)).to eq(false)
-        end
-      end
-    end
   end
 end

--- a/spec/lib/open_food_network/feature_toggle_spec.rb
+++ b/spec/lib/open_food_network/feature_toggle_spec.rb
@@ -5,21 +5,6 @@ require 'spec_helper'
 module OpenFoodNetwork
   describe FeatureToggle do
     context 'when users are not specified' do
-      it "returns true when feature is on" do
-        stub_foo("true")
-        expect(FeatureToggle.enabled?(:foo)).to be true
-      end
-
-      it "returns false when feature is off" do
-        stub_foo("false")
-        expect(FeatureToggle.enabled?(:foo)).to be false
-      end
-
-      it "returns false when feature is unspecified" do
-        stub_foo("maybe")
-        expect(FeatureToggle.enabled?(:foo)).to be false
-      end
-
       it "returns false when feature is undefined" do
         expect(FeatureToggle.enabled?(:foo)).to be false
       end
@@ -27,16 +12,6 @@ module OpenFoodNetwork
       it "uses Flipper configuration" do
         Flipper.enable(:foo)
         expect(FeatureToggle.enabled?(:foo)).to be true
-      end
-
-      it "uses Flipper over static config" do
-        Flipper.enable(:foo, false)
-        stub_foo("true")
-        expect(FeatureToggle.enabled?(:foo)).to be false
-      end
-
-      def stub_foo(value)
-        allow(ENV).to receive(:fetch).with("OFN_FEATURE_FOO", nil).and_return(value)
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #2395

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Australia had some custom homepage content which was the last remaining use case for our old, custom feature toggle implementation. That feature toggle has been broken for a while though and doesn't seem to be needed. It's time to clean up and use only Flipper as our source of truth for feature toggles.

#### What should we test?
<!-- List which features should be tested and how. -->

We don't have any features toggled at the moment and can't test this. Next time we add a toggled feature, we have to check that it's toggled.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Remove unused custom feature toggle implementations.

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

Not a dependency, but we can clean up ofn-install as well.