### PR TITLE
Add convenience script to install Ruby

### DIFF
--- a/script/rbenv-install.sh
+++ b/script/rbenv-install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Install our selected Ruby version defined in the .ruby-version file.
+#
+# If our ruby-build version is outdated and it can't build the version we want
+# then we try upgrading ruby-build and installing again.
+
+if rbenv install --skip-existing; then
+  echo "Ruby is installed."
+else
+  echo "Upgrading rbenv's ruby-build:"
+  git -C "$(rbenv root)"/plugins/ruby-build pull
+
+  rbenv install
+fi


### PR DESCRIPTION
#### What? Why?

We updated Ruby a few times recently and I find it very convenient to just call this script instead of typing the Ruby version.


#### What should we test?
<!-- List which features should be tested and how. -->

Dev test:

```sh
./script/rbenv-install.sh
```

It shouldn't raise any error. I've used this in another project and it has been great so far. :smile: 

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Add convenience script to install Ruby

