### PR TITLE
Remove explicit dependency on sass gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'angular-rails-templates', '>= 0.3.0'
 gem 'awesome_nested_set'
 gem 'ransack', '2.4.2'
 gem 'responders'
-gem 'sass', '~> 3.4.0' # this restriction originates from foundation-rails's version
 gem 'sass-rails', '< 5.1.0' # this restriction originates from the compass-rails's version
 
 gem 'i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -769,7 +769,6 @@ DEPENDENCIES
   rswag
   rubocop
   rubocop-rails
-  sass (~> 3.4.0)
   sass-rails (< 5.1.0)
   select2-rails!
   selenium-webdriver


### PR DESCRIPTION
#### What? Why?

We still depend on it via compass and foundation-rails but it's not
explicit any more.

The sass gem has been deprecated in favour of the faster sassc gem.
But sassc has been deprecated in favour of dart-sass which is an npm
package.

https://github.com/sass/ruby-sass#ruby-sass-has-reached-end-of-life
https://github.com/sass/sassc#sassc

This is confusing but we don't have to worry about it because it's not
a direct dependency and other gems can solve the dependency selection
for us, I think. :smile:


#### What should we test?
<!-- List which features should be tested and how. -->

Deploy to staging and check that no errors were raised.
Check the home page for the usual look. You would notice straight away if CSS compilation failed.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Remove explicit dependency on sass gem

