### PR TITLE
Refactor Stripe SCA backoffice payment authorization

### DIFF
--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -52,6 +52,9 @@ module Spree
         rescue Spree::Core::GatewayError => e
           flash[:error] = e.message.to_s
           redirect_to spree.new_admin_order_payment_path(@order)
+        rescue StateMachines::InvalidTransition
+          flash[:error] = I18n.t('authorization_failure')
+          redirect_to spree.new_admin_order_payment_path(@order)
         end
       end
 

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -36,8 +36,14 @@ module Spree
           end
 
           @payment.authorize!(full_order_path(@payment.order))
-          @payment.request_user_authorization do
+          auth_requested = @payment.request_user_authorization do
             PaymentMailer.authorize_payment(@payment).deliver_later
+          end
+
+          if auth_requested
+            flash[:error] = I18n.t('action_required')
+            redirect_to spree.new_admin_order_payment_path(@order)
+            return
           end
 
           if @order.completed?

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -174,10 +174,6 @@ module Spree
       def authorize_stripe_sca_payment
         @payment.authorize!(full_order_path(@payment.order))
 
-        unless @payment.pending? || @payment.requires_authorization?
-          raise Spree::Core::GatewayError, I18n.t('authorization_failure')
-        end
-
         return unless @payment.requires_authorization?
 
         PaymentMailer.authorize_payment(@payment).deliver_later

--- a/app/controllers/spree/admin/payments_controller.rb
+++ b/app/controllers/spree/admin/payments_controller.rb
@@ -172,8 +172,6 @@ module Spree
       end
 
       def authorize_stripe_sca_payment
-        return unless @payment.payment_method.instance_of?(Spree::Gateway::StripeSCA)
-
         @payment.authorize!(full_order_path(@payment.order))
 
         unless @payment.pending? || @payment.requires_authorization?

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -107,7 +107,7 @@ module Spree
       end
 
       def authorize(_money, _creditcard, _gateway_options)
-        ActiveMerchant::Billing::Response.new(true, "", {}, {})
+        Gateway::SuccessfulResponse.new
       end
     end
   end

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -105,6 +105,10 @@ module Spree
         end
         refund_transaction_response
       end
+
+      def authorize(_money, _creditcard, _gateway_options)
+        ActiveMerchant::Billing::Response.new(true, "", {}, {})
+      end
     end
   end
 end

--- a/app/models/spree/gateway/stripe_connect.rb
+++ b/app/models/spree/gateway/stripe_connect.rb
@@ -56,6 +56,10 @@ module Spree
         profile_storer.create_customer_from_token
       end
 
+      def authorize(_money, _creditcard, _gateway_options)
+        ActiveMerchant::Billing::Response.new(true, "", {}, {})
+      end
+
       private
 
       # In this gateway, what we call 'secret_key' is the 'login'

--- a/app/models/spree/gateway/stripe_connect.rb
+++ b/app/models/spree/gateway/stripe_connect.rb
@@ -57,7 +57,7 @@ module Spree
       end
 
       def authorize(_money, _creditcard, _gateway_options)
-        ActiveMerchant::Billing::Response.new(true, "", {}, {})
+        Gateway::SuccessfulResponse.new
       end
 
       private

--- a/app/models/spree/gateway/stripe_sca.rb
+++ b/app/models/spree/gateway/stripe_sca.rb
@@ -69,8 +69,8 @@ module Spree
 
       # NOTE: the name of this method is determined by Spree::Payment::Processing
       def authorize(money, creditcard, gateway_options)
-        authorize_response =
-          provider.authorize(*options_for_authorize(money, creditcard, gateway_options))
+        options = *options_for_authorize(money, creditcard, gateway_options)
+        authorize_response = provider.authorize(*options)
         Stripe::AuthorizeResponsePatcher.new(authorize_response).call!
       rescue Stripe::StripeError => e
         failed_activemerchant_billing_response(e.message)

--- a/app/models/spree/gateway/successful_response.rb
+++ b/app/models/spree/gateway/successful_response.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  class Gateway
+    class SuccessfulResponse < ActiveMerchant::Billing::Response
+      def initialize(message = "")
+        super(true, message, {}, {})
+      end
+    end
+  end
+end

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -29,7 +29,7 @@ module Spree
         return unless requires_authorization?
 
         yield if block_given?
-        raise Spree::Core::GatewayError, I18n.t('action_required')
+        true
       end
 
       def purchase!

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -23,7 +23,6 @@ module Spree
       def authorize!(return_url = nil)
         started_processing!
         gateway_action(source, :authorize, :pend, return_url: return_url)
-        raise Spree::Core::GatewayError, I18n.t('authorization_failure') unless pending?
       end
 
       def purchase!

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -23,6 +23,7 @@ module Spree
       def authorize!(return_url = nil)
         started_processing!
         gateway_action(source, :authorize, :pend, return_url: return_url)
+        raise Spree::Core::GatewayError, I18n.t('authorization_failure') unless pending?
       end
 
       def purchase!

--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -25,6 +25,13 @@ module Spree
         gateway_action(source, :authorize, :pend, return_url: return_url)
       end
 
+      def request_user_authorization
+        return unless requires_authorization?
+
+        yield if block_given?
+        raise Spree::Core::GatewayError, I18n.t('action_required')
+      end
+
       def purchase!
         started_processing!
         gateway_action(source, :purchase, :complete)

--- a/app/models/spree/payment_method/check.rb
+++ b/app/models/spree/payment_method/check.rb
@@ -18,11 +18,11 @@ module Spree
       end
 
       def capture(*_args)
-        ActiveMerchant::Billing::Response.new(true, "", {}, {})
+        Gateway::SuccessfulResponse.new
       end
 
       def void(*_args)
-        ActiveMerchant::Billing::Response.new(true, "", {}, {})
+        Gateway::SuccessfulResponse.new
       end
 
       def authorize(_money, _creditcard, _gateway_options)

--- a/app/models/spree/payment_method/check.rb
+++ b/app/models/spree/payment_method/check.rb
@@ -25,6 +25,10 @@ module Spree
         ActiveMerchant::Billing::Response.new(true, "", {}, {})
       end
 
+      def authorize(_money, _creditcard, _gateway_options)
+        Gateway::SuccessfulResponse.new
+      end
+
       def source_required?
         false
       end

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -169,7 +169,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
       create(:payment, order: order, payment_method: payment_method, amount: order.total)
     end
 
-    let(:successful_response) { ActiveMerchant::Billing::Response.new(true, "Yay!") }
+    let(:successful_response) { Spree::Gateway::SuccessfulResponse.new("Yay!") }
 
     context 'on credit event' do
       let(:params) { { e: 'credit', order_id: order.number, id: payment.id } }

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -35,6 +35,18 @@ describe Spree::Admin::PaymentsController, type: :controller do
                                                     completed_at: Time.zone.now)
       end
 
+      context "when the payment cannot be saved" do
+        before do
+          allow_any_instance_of(Spree::Payment).to receive(:save).and_return(false)
+        end
+
+        it "redirects to the list of payments" do
+          spree_post :create, payment: params, order_id: order.number
+
+          expect(response).to redirect_to(spree.admin_order_payments_url(order))
+        end
+      end
+
       context "with Check payment (payment.process! does nothing)" do
         it "redirects to list of payments with success flash" do
           spree_post :create, payment: params, order_id: order.number

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -80,7 +80,9 @@ describe Spree::Admin::PaymentsController, type: :controller do
 
         context "where payment.authorize! does not move payment to pending state" do
           before do
-            allow_any_instance_of(Spree::Payment).to receive(:authorize!).and_return(true)
+            allow_any_instance_of(Spree::Payment)
+              .to receive(:authorize!)
+              .and_raise(Spree::Core::GatewayError, I18n.t('authorization_failure'))
           end
 
           it "redirects to new payment page with flash error" do

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -158,18 +158,13 @@ describe Spree::Admin::PaymentsController, type: :controller do
       end
 
       def redirects_to_list_of_payments_with_success_flash
-        expect_redirect_to spree.admin_order_payments_url(order)
+        expect(response).to redirect_to spree.admin_order_payments_url(order)
         expect(flash[:success]).to eq "Payment has been successfully created!"
       end
 
       def redirects_to_new_payment_page_with_flash_error(flash_error)
-        expect_redirect_to spree.new_admin_order_payment_url(order)
+        expect(response).to redirect_to spree.new_admin_order_payment_url(order)
         expect(flash[:error]).to eq flash_error
-      end
-
-      def expect_redirect_to(path)
-        expect(response.status).to eq 302
-        expect(response.location).to eq path
       end
     end
   end

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -40,7 +40,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
           spree_post :create, payment: params, order_id: order.number
 
           redirects_to_list_of_payments_with_success_flash
-          expect(order.reload.payments.last.state).to eq "checkout"
+          expect(order.reload.payments.last.state).to eq "pending"
         end
       end
 
@@ -56,7 +56,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
           spree_post :create, payment: params, order_id: order.number
 
           redirects_to_new_payment_page_with_flash_error("Payment Gateway Error")
-          expect(order.reload.payments.last.state).to eq "checkout"
+          expect(order.reload.payments.last.state).to eq "pending"
         end
       end
 
@@ -98,6 +98,7 @@ describe Spree::Admin::PaymentsController, type: :controller do
               payment.update state: "requires_authorization"
             end
           end
+
           it "redirects to new payment page with flash error" do
             spree_post :create, payment: params, order_id: order.number
 

--- a/spec/models/spree/gateway/pay_pal_express_spec.rb
+++ b/spec/models/spree/gateway/pay_pal_express_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Spree::Gateway::PayPalExpress, type: :model do
+  describe "#authorize" do
+    it "returns a succesful response" do
+      response = subject.authorize(nil, nil, nil)
+      expect(response).to be_kind_of(Spree::Gateway::SuccessfulResponse)
+    end
+  end
+end

--- a/spec/models/spree/gateway/succesful_response_spec.rb
+++ b/spec/models/spree/gateway/succesful_response_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Spree::Gateway::SuccessfulResponse do
+  describe "#initialize" do
+    it "returns a succesful response" do
+      response = described_class.new
+
+      expect(response.success?).to eq(true)
+      expect(response.message).to eq("")
+      expect(response.params).to eq({})
+    end
+  end
+end
+

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -439,7 +439,7 @@ describe Spree::Payment do
             end
 
             let(:successful_response) do
-              ActiveMerchant::Billing::Response.new(true, "Yay!")
+              Spree::Gateway::SuccessfulResponse.new("Yay!")
             end
 
             it 'lets the new payment to be saved' do
@@ -962,7 +962,7 @@ describe Spree::Payment do
         end
 
         context "when the payment is processed successfully" do
-          let(:successful_response) { ActiveMerchant::Billing::Response.new(true, "Yay!") }
+          let(:successful_response) { Spree::Gateway::SuccessfulResponse.new("Yay!") }
 
           before do
             allow(payment_method).to receive(:purchase) { successful_response }

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -196,6 +196,13 @@ describe Spree::Payment do
             }.to raise_error(Spree::Core::GatewayError)
           end
         end
+
+        context "when the payment cannot transition to the success state" do
+          it "raises StateMachines::InvalidTransition" do
+            allow(payment).to receive(:pend).and_return(false)
+            expect { payment.authorize! }.to raise_error(StateMachines::InvalidTransition)
+          end
+        end
       end
 
       context "purchase" do

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -164,8 +164,8 @@ describe Spree::Payment do
           end
 
           it "should make payment pending" do
-            expect(payment).to receive(:pend!)
             payment.authorize!
+            expect(payment).to be_pending
           end
         end
 


### PR DESCRIPTION
#### What? Why?


This removes the tight coupling of the /admin/payments_controller, the one dealing with backoffice payments, with StripeSCA. It's a refactoring that will ease future changes. I won't get into details about why coupling is bad. That's well known, I think.

Here are the things we did to solve this:

* Replace the offending line `return unless @payment.payment_method.instance_of?(Spree::Gateway::StripeSCA)` with polymorphism. Spree's Gateways are meant to stick to a shared interface between all them, implementing the [Adapter pattern](https://en.wikipedia.org/wiki/Adapter_pattern) I'd say, so that consumers are agnostic of the particular details each gateway is concerned with. In this case, most of them don't require authorization. That's why we implemented this operation as a no op :ok_hand: 
* Decoupling the controller from the payment states by checking state machine errors. If `Payment::Processing` fails to change the payment state, it'll let us know with a `StateMachine::InvalidTransition`. No need to check for each possible state as done in https://github.com/openfoodfoundation/openfoodnetwork/pull/7809/files#diff-e3391ddb14a78e0ed8ced3c32cd647c691a34a0e18590e64d4a262e481d66fceL179-L181. What if they change as happened recently? this code would break.
* Replace exceptions as a way to reuse logic. That's what https://github.com/openfoodfoundation/openfoodnetwork/pull/7809/files#diff-e3391ddb14a78e0ed8ced3c32cd647c691a34a0e18590e64d4a262e481d66fceL185-L186 were doing. That's a confusing way to do that because it's not an error scenario.
* Extend the controller's test coverage. There was a case that wasn't covered. This makes it safe to deal with future refactorings.

Now, this is a good middle grown. The situation is better than the one we found, it's easy to review and revert if needed. Going any further (I did) clutters the diff too much. What @andrewpbrett and I agree needs to be done now is to extract that logic out in a service (or any other abstractions) so that we leave the `flash` and `redirect_to` calls in the controller but the business logic is nicely encapsulated elsewhere. That will remove the duplication we left there.

#### What should we test?

backoffice payments with the supported gateways: Cash (no action?), PayPal, StripeSCA, and Stripe Connect can probably be skipped. Although we do have implementations for Bogus and Bogus Simple and not entirely sure we use them. Time for a DB query from Metabase to get some counts.

Now, if you catch any regression @filipefurtad0 please, let's create an issue so we can keep track of it. I did pay attention to controller tests but I haven't checked feature ones.

#### Release notes
Refactor Stripe SCA backoffice payment authorization to lower the coupling in the controller
Changelog Category: Technical changes
