### PR TITLE
Move Rspec retries count to CI config and remove in local environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ env:
   DISABLE_KNAPSACK: true
   TIMEZONE: UTC
   COVERAGE: true
+  RSPEC_RETRY_RETRY_COUNT: 3
 
 jobs:
   test-controllers-and-serializers:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,7 +101,7 @@ RSpec.configure do |config|
   # Show retries in test output
   config.verbose_retry = true
   # Set maximum retry count
-  config.default_retry_count = 3
+  config.default_retry_count = 0
 
   # Force colored output, whether or not the output is a TTY
   config.color_mode = :on


### PR DESCRIPTION
#### What? Why?

When running tests locally we want them to fail immediately. Moves the retry setting to the CI config so it's not used locally.

Reference: https://github.com/NoRedInk/rspec-retry#environment-variables

#### What should we test?
<!-- List which features should be tested and how. -->

.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Moved Rspec retry count to CI config

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes