### PR TITLE
Encapsulate enterprise fee tax spec

### DIFF
--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require_relative '../../../../db/migrate/20210406161242_migrate_enterprise_fee_tax_amounts'
 
 feature "full-page cart", js: true do
   include AuthenticationHelper


### PR DESCRIPTION
#### What? Why?

Unblocks #7394.

It still used application code which could randomly fail specs. This makes the following spec run pass again:

```sh
rspec ./spec/features/consumer/shopping/cart_spec.rb[1:1:3:1]\
 ./spec/migrations/migrate_enterprise_fee_tax_amounts_spec.rb[1:1:1:1] --seed 0
```

The commit is best viewed with whitespace changes ignored.
![Screenshot from 2021-06-24 14-07-34](https://user-images.githubusercontent.com/3524483/123201221-9530a000-d4f5-11eb-8462-309ab6476905.png)


#### What should we test?
<!-- List which features should be tested and how. -->

No further test needed.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

An order-dependent spec failure has been fixed.

