### PR TITLE
Handle lang management on user passwords controller

### DIFF
--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class LocalesController < BaseController
+  def show
+    UserLocaleSetter.new(spree_current_user, params[:id], cookies).set_locale
+    redirect_back fallback_location: main_app.root_url
+  end
+end

--- a/app/controllers/spree/user_passwords_controller.rb
+++ b/app/controllers/spree/user_passwords_controller.rb
@@ -17,6 +17,9 @@ module Spree
 
     ssl_required
 
+    include I18nHelper
+    before_action :set_locale
+
     # Overridden due to bug in Devise.
     #   respond_with resource, :location => new_session_path(resource_name)
     # is generating bad url /session/new.user

--- a/app/views/shared/menu/_language_selector.html.haml
+++ b/app/views/shared/menu/_language_selector.html.haml
@@ -5,4 +5,4 @@
   %ul.dropdown
     - OpenFoodNetwork::I18nConfig.selectable_locales.each do |l|
       %li
-        %a{href: "?locale=#{l.to_s}" }= t('language_name', locale: l)
+        = link_to t('language_name', locale: l), main_app.locale_path(l.to_s)

--- a/app/views/shared/menu/_language_selector.html.haml
+++ b/app/views/shared/menu/_language_selector.html.haml
@@ -3,6 +3,6 @@
     %i.ofn-i_071-globe
     %span= t 'language_name'
   %ul.dropdown
-    - OpenFoodNetwork::I18nConfig.selectable_locales.each do |l|
+    - OpenFoodNetwork::I18nConfig.locale_options.each do |l|
       %li
         = link_to t('language_name', locale: l), main_app.locale_path(l.to_s)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Openfoodnetwork::Application.routes.draw do
   get "/register", to: "registration#index", as: :registration
   get "/register/auth", to: "registration#authenticate", as: :registration_auth
   post "/user/registered_email", to: "spree/users#registered_email"
+  resources :locales, only: [:show]
 
   # Redirects to global website
   get "/connect", to: redirect("https://openfoodnetwork.org/#{ENV['DEFAULT_COUNTRY_CODE'].andand.downcase}/connect/")

--- a/lib/open_food_network/i18n_config.rb
+++ b/lib/open_food_network/i18n_config.rb
@@ -5,6 +5,11 @@ module OpenFoodNetwork
   # Currently, language settings are read from the environment.
   # See: config/application.yml
   class I18nConfig
+    # Users don't need to select the already selected locale.
+    def self.locale_options
+      selectable_locales - [I18n.locale.to_s]
+    end
+
     # Locales that can be selected by users.
     def self.selectable_locales
       ENV["AVAILABLE_LOCALES"].andand.split(/[\s,]+/) || []

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -127,7 +127,7 @@ feature 'Multilingual', js: true do
 
         find('.language-switcher').click
         within '.language-switcher .dropdown' do
-          expect(page).to have_link I18n.t('language_name', locale: :en), href: '/locales/en'
+          expect(page).not_to have_link I18n.t('language_name', locale: :en), href: '/locales/en'
           expect(page).to have_link I18n.t('language_name', locale: :es, default: 'Language Name'),
                                     href: '/locales/es'
 

--- a/spec/features/consumer/multilingual_spec.rb
+++ b/spec/features/consumer/multilingual_spec.rb
@@ -127,11 +127,11 @@ feature 'Multilingual', js: true do
 
         find('.language-switcher').click
         within '.language-switcher .dropdown' do
-          expect(page).to have_link I18n.t('language_name', locale: :en), href: '?locale=en'
+          expect(page).to have_link I18n.t('language_name', locale: :en), href: '/locales/en'
           expect(page).to have_link I18n.t('language_name', locale: :es, default: 'Language Name'),
-                                    href: '?locale=es'
+                                    href: '/locales/es'
 
-          find('li a[href="?locale=es"]').click
+          find('li a[href="/locales/es"]').click
         end
 
         expect_menu_and_cookie_in_es


### PR DESCRIPTION
#### What? Why?

This PR adds a controller and a path: `set_lang` to actually set the lang of the application. Therefore, links into the dropdown are updated (to `/user/set_lang/[LANG]`)
It replace the old way to day: ie. having a link to `?locale=#{l.to_s}` which cannot be handled in some URLs (specially with `/user/spree_user/password/edit?reset_password_token=[TOKEN]` because it already had a params). 
Once the lang is set, it then redirect to the `HTTP_REFERER` url (ie. the current page where the user is).

At the same time, this PR remove the already selected langage from the dropdown (no need to change the current langage to the same):
<img width="390" alt="Capture d’écran 2021-06-28 à 11 38 34" src="https://user-images.githubusercontent.com/296452/123616457-98ce6a80-d806-11eb-846d-df7c7b29d62e.png">


Closes #7842

#### What should we test?
1. Visit the home page
2. Select another langage
3. Click `Login` and select the `Forgot Password?`
4. Type the email address of an existing account
5. Follow the link received per Email -> It should open a page to type the new password
6. This page should have the same language than the previous you selected
6. While on the password reset page, select another language. It's obviously should work



#### Release notes
Handle the change of the language on the user password change page.

Changelog Category: User facing changes

