### PR TITLE
Allow viewing of payments made with deleted pyment methods in admin

### DIFF
--- a/app/views/spree/admin/payments/show.html.haml
+++ b/app/views/spree/admin/payments/show.html.haml
@@ -10,7 +10,8 @@
 - content_for :page_actions do
   %li= button_link_to Spree.t(:back_to_payments_list), spree.admin_order_payments_url(@order), icon: 'icon-arrow-left'
 
-= render partial: "spree/admin/payments/source_views/#{@payment.payment_method.method_type}", locals: { payment: @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment }
+- if @payment.payment_method.present?
+  = render partial: "spree/admin/payments/source_views/#{@payment.payment_method.method_type}", locals: { payment: @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment }
 
 .align-center
   %h5


### PR DESCRIPTION
#### What? Why?

Closes #5118 

This PR enables an admin user to view payments made with already deleted payment methods.

![method-delete](https://user-images.githubusercontent.com/65319144/123795532-bd5b3d00-d901-11eb-9125-08e6bc4bfa56.gif)


#### What should we test?
- There should be no snail when visiting `admin/orders/#order_no/payments/` when the payment method used has been deleted.

#### Release notes
- You can now view payment in admin after payment method has been deleted.

Changelog Category: User facing changes 
