### PR TITLE
Update custom error messages for Rails 6.2+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'acts-as-taggable-on', '~> 8.0'
 gem 'angularjs-file-upload-rails', '~> 2.4.1'
 gem 'bigdecimal', '3.0.2'
 gem 'bootsnap', require: false
-gem 'custom_error_message', github: 'jeremydurham/custom-err-msg'
+gem 'custom_error_message', github: 'andrewpbrett/custom-err-msg'
 gem 'dalli'
 gem 'figaro'
 gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/jeremydurham/custom-err-msg.git
-  revision: 3a8ec9dddc7a5b0aab7c69a6060596de300c68f4
+  remote: https://github.com/andrewpbrett/custom-err-msg.git
+  revision: f65d7d20f042e8b26d56adeadf03b7d1c2a70368
   specs:
     custom_error_message (1.1.1)
 


### PR DESCRIPTION
#### What? Why?

Closes #7854

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We might also consider bringing the two classes that the gem provides into the codebase directly and removing the dependency.

#### What should we test?
<!-- List which features should be tested and how. -->
There are a few places we use this, for example whenever you see "At least one hub must be selected" when adding a shipping method as a superadmin, for example. We should test that the error message is displayed correctly there. If one works, they all should work. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed deprecation message related to custom error message gem
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
