### PR TITLE
Fix coverage in development skipping Codecov

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -16,5 +16,7 @@ SimpleCov.start 'rails' do
   add_filter '/lib/tasks/sample_data/'
 end
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
+if ENV['CI']
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end


### PR DESCRIPTION
#### What? Why?

the way we have it set up, Simplecov generates a report in Codecov's format and tries to send it to them, which fails.

This gets us back to the former Simplecov setup. This lets you check the visual coverage report navigating to  coverage/index.html`.

#### What should we test?

Green build. I already got my coverage report back after tweaking this.

#### Release notes
Fix coverage in development skipping Codecov
Changelog Category: Technical changes
