### PR TITLE
Remove duplicative tax line on invoices

### DIFF
--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -10,8 +10,8 @@ module CheckoutHelper
 
     adjustments = order.all_adjustments.eligible.to_a
 
-    # Remove empty tax adjustments and (optionally) shipping fees
-    adjustments.reject! { |a| a.originator_type == 'Spree::TaxRate' && a.amount == 0 }
+    # Remove tax adjustments and (optionally) shipping fees
+    adjustments.reject! { |a| a.originator_type == 'Spree::TaxRate' }
     if exclude.include? :shipping
       adjustments.reject! { |a|
         a.originator_type == 'Spree::ShippingMethod'

--- a/app/views/spree/admin/orders/ticket.html.haml
+++ b/app/views/spree/admin/orders/ticket.html.haml
@@ -19,7 +19,7 @@
       '#{j(@order.distributor.address.address_part1)}' + '\x0A',     // text and line break
       '#{j(@order.distributor.address.address_part2)}' + '\x0A',
       '#{j(@order.distributor.contact.email)}' + '\x0A',
-      '\x0A',                   // line break    
+      '\x0A',                   // line break
       '\x1B' + '\x61' + '\x32', // right align
       '#{j(l(Time.zone.now.to_date))}' + '\x0A',
       '#{j(@order.number)}' + '\x0A',
@@ -73,5 +73,3 @@
     = javascript_include_tag "qz/ticket-popup.js"
   %body
     %div#printer-list
-
-


### PR DESCRIPTION
#### What? Why?

Closes #7890 
Closes #7894 

<s>This groups tax adjustments with the same originator (a Spree::TaxRate) together at checkout and on the invoice. 

I just realized that this will create a new adjustment any time the invoice is generated or the page is viewed? We're doing something similar with the admin and handling adjustments, and they're not saved to the database (or, at least not immediately), but I'm not sure that this is the right approach.</s>

This now omits the tax adjustments line item if `:tax_rate` is passed in to the `checkout_adjustments_for` method in the `exclude` array, and updates all places where we call that method and passes `:tax_rate`, which is to say that it always omits them. If we confirm that this is the desired behavior we can simplify the PR quite a bit and just always omit them.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
See issue


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where taxes on taxes on enterprise fees were showing up separately on invoices, making the totals appear incorrect.
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
