### PR TITLE
Add translations to shopfront sorting placeholders

### DIFF
--- a/app/views/admin/enterprises/form/_shop_preferences.html.haml
+++ b/app/views/admin/enterprises/form/_shop_preferences.html.haml
@@ -24,7 +24,7 @@
     = label :enterprise, :preferred_shopfront_product_sorting_method_by_category, t('.shopfront_sort_by_category')
   .eight.columns.omega
     %textarea.fullwidth{ id: 'enterprise_preferred_shopfront_taxon_order', name: 'enterprise[preferred_shopfront_taxon_order]', rows: 6,
-      'ofn-taxon-autocomplete' => '', 'multiple-selection' => 'true', placeholder: 'Category',
+      'ofn-taxon-autocomplete' => '', 'multiple-selection' => 'true', placeholder: t('.shopfront_sort_by_category_placeholder'),
       ng: { model: 'Enterprise.preferred_shopfront_taxon_order', readonly: "Enterprise.preferred_shopfront_product_sorting_method != 'by_category'" }}
 .row
   .three.columns.alpha
@@ -32,7 +32,7 @@
     = label :enterprise, :preferred_shopfront_product_sorting_method_by_producer, t('.shopfront_sort_by_producer')
   .eight.columns.omega
     %textarea.fullwidth{ id: 'enterprise_preferred_shopfront_producer_order', name: 'enterprise[preferred_shopfront_producer_order]', rows: 6,
-      'ofn-producer-autocomplete' => '', 'multiple-selection' => 'true', placeholder: 'Producer',
+      'ofn-producer-autocomplete' => '', 'multiple-selection' => 'true', placeholder: t('.shopfront_sort_by_producer_placeholder'),
       ng: { model: 'Enterprise.preferred_shopfront_producer_order', readonly: "Enterprise.preferred_shopfront_product_sorting_method != 'by_producer'" }}
 
 .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -879,6 +879,8 @@ en:
           display_ordering_in_shopfront: "Display ordering in shopfront:"
           shopfront_sort_by_category: "By category"
           shopfront_sort_by_producer: "By producer"
+          shopfront_sort_by_category_placeholder: "Category"
+          shopfront_sort_by_producer_placeholder: "Producer"
         social:
           twitter_placeholder: "eg. @the_prof"
           instagram_placeholder: "eg. the_prof"


### PR DESCRIPTION
#### What? Why?

Add missing translations for shopfront sorting method placeholder ("Category" and "Producer") on shop preferences page:

![image](https://user-images.githubusercontent.com/16342917/124805037-5a852980-df31-11eb-88fb-cdbdff6451e0.png)

#### What should we test?

Test that translations are working properly for the "Category" and "Producer" placeholders

#### Release notes

Added translation tags for shopfront sorting method field placeholders on shop preferences page

Changelog Category: User facing changes
