### PR TITLE
Fix deprecation issues with pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,8 +165,8 @@ end
 group :development do
   gem 'debugger-linecache'
   gem 'foreman'
-  gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry', '~> 0.13.0'
+  gem 'pry-byebug', '~> 3.9.0'
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,12 +430,12 @@ GEM
       ttfunk
     pg (1.2.3)
     power_assert (2.0.0)
-    pry (0.14.1)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.8.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     raabro (1.4.0)
     racc (1.5.2)
@@ -765,8 +765,8 @@ DEPENDENCIES
   paypal-sdk-merchant (= 1.117.2)
   pdf-reader
   pg (~> 1.2.3)
-  pry
-  pry-byebug
+  pry (~> 0.13.0)
+  pry-byebug (~> 3.9.0)
   rack-mini-profiler (< 3.0.0)
   rack-rewrite
   rack-ssl


### PR DESCRIPTION
#### What? Why?

The latest version of pry-byebug and the latest version of pry have some weird compatibility issues. The solution requires downgrading pry slightly and upgrading pry-byebug. Fixes:
```
lib/ruby/gems/2.7.0/gems/pry-byebug-3.8.0/lib/pry-byebug/control_d_handler.rb:5:
warning: control_d_handler's arity of 2 parameters was deprecated (eval_string, pry_instance).Now it gets passed just 1 parameter (pry_instance)
```

#### What should we test?
<!-- List which features should be tested and how. -->

Green build / warnings fixed.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed issues with pry-byebug 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
