### PR TITLE
Use `autocomplete: off` on bulk product page form

### DIFF
--- a/app/views/spree/admin/products/index/_products.html.haml
+++ b/app/views/spree/admin/products/index/_products.html.haml
@@ -1,5 +1,5 @@
 %div.sixteen.columns.alpha{ 'ng-hide' => 'RequestMonitor.loading || products.length == 0' }
-  %form{ name: 'bulk_product_form' }
+  %form{ name: 'bulk_product_form', autocomplete: "off" }
     %save-bar{ dirty: "bulk_product_form.$dirty", persist: "false" }
       %input.red{ type: "button", value: t(:save_changes), ng: { click: "submitProducts()", disabled: "!bulk_product_form.$dirty" } }
       %input{ type: "button", value: t(:close), 'ng-click' => "cancel('#{admin_products_path}')" }


### PR DESCRIPTION
#### What? Why?

Closes #7839 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Chrome "helpfully" remembers the values that were filled in the last time it saw a form. But if the last time it saw this form, you were on page 2 of the product list, and you hit the back button so now you're on page 1, and if page 2 of the products list has "Mackerel" in the fifth name field, now, back on page 1, Chrome sticks "Mackerel" in the fifth name field, even though the fifth name field corresponds to a totally different product now because we're on page 1. 

See also: https://stackoverflow.com/questions/15738259/disabling-chrome-autofill

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug that could autofill names for and thus corrupt products after using the back button on Chrome
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
