### PR TITLE
Tooltip added for 'New Schedule' and 'New Order Cycle' 

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/with_tip.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/with_tip.js.coffee
@@ -3,6 +3,7 @@ angular.module("admin.utils").directive "ofnWithTip", ($sanitize)->
     element.attr('data-powertip', $sanitize(attrs.ofnWithTip))
     element.powerTip
       smartPlacement: true
+      placement: element.attr('powertip-location')
       fadeInTime: 50
       fadeOutTime: 50
       intentPollInterval: 300

--- a/app/views/admin/order_cycles/index.html.haml
+++ b/app/views/admin/order_cycles/index.html.haml
@@ -7,10 +7,10 @@
 = content_for :page_actions do
   - if subscriptions_enabled?
     %li
-      %a.button.icon-plus#new-schedule{ "schedule-dialog" => true }
+      %a.button.icon-plus#new-schedule{ "schedule-dialog" => true, "ofn-with-tip" => t('.new_schedule_tooltip'), "powertip-location" => 's' }
         = t('admin.order_cycles.index.new_schedule')
   %li#new_order_cycle_link
-    = button_link_to t(:new_order_cycle), main_app.new_admin_order_cycle_path, icon: 'icon-plus', id: 'admin_new_order_cycle_link'
+    = button_link_to t(:new_order_cycle), main_app.new_admin_order_cycle_path, icon: 'icon-plus', id: 'admin_new_order_cycle_link', "ofn-with-tip" => t(:new_order_cycle_tooltip), "powertip-location" => 's'
 
 = admin_inject_column_preferences module: 'admin.orderCycles'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1079,6 +1079,7 @@ en:
         schedule: Schedule
         schedules: Schedules
         new_schedule: New Schedule
+        new_schedule_tooltip: The frequency with which a subscription order is placed
       name_and_timing_form:
         name: Name
         orders_open: Orders open at
@@ -2241,6 +2242,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   price_sack: "Price Sack"
   new_order_cycles: "New Order Cycles"
   new_order_cycle: "New Order Cycle"
+  new_order_cycle_tooltip: "Open shop for a certain time period"
   select_a_coordinator_for_your_order_cycle: "Select a coordinator for your order cycle"
   notify_producers: 'Notify producers'
   edit_order_cycle: "Edit Order Cycle"


### PR DESCRIPTION
#### What? Why?
Add tooltip to provide more information to user.

Closes - https://github.com/openfoodfoundation/openfoodnetwork/issues/7924

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
As mentioned in issue this will be helpful for users , as it adds more context for the buttons


#### What should we test?
In the admin -> Order Cycles Page. Hover over buttons `New Schedule` and `New Order Cycle`. You should see tooltip for both.

**Expected Result**
<img width="493" alt="Screenshot 2021-07-13 at 8 04 42 PM" src="https://user-images.githubusercontent.com/9512872/125471908-8d72fec0-ac5d-46cb-81ff-5acffab6ec1a.png">
<img width="488" alt="Screenshot 2021-07-13 at 8 04 36 PM" src="https://user-images.githubusercontent.com/9512872/125471915-d940fedb-9de5-471c-82a2-0aad743a8a2a.png">


Another thing to note is that I had to edit a js file to change the location of the tooltip. Tooltip by default are `North` facing. Given the UI for the above buttons, having the tooltip on the north, didnt look good because of the common blue color. Here is what it looked like

<img width="442" alt="Screenshot 2021-07-13 at 8 14 19 PM" src="https://user-images.githubusercontent.com/9512872/125472656-c0966016-0656-4319-a3ee-fae60ef64f5d.png">

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Tooltip added for buttons New Schedule and New order Cycle

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 

