### PR TITLE
Add script to import product images from URL

### DIFF
--- a/app/services/image_importer.rb
+++ b/app/services/image_importer.rb
@@ -1,0 +1,22 @@
+class ImageImporter
+  def import(url, product)
+    attach(download(url), product)
+  end
+
+  private
+
+  def download(url)
+    local_file = Tempfile.new
+    remote_file = open(url)
+    IO.copy_stream(remote_file, local_file)
+    local_file
+  end
+
+  def attach(file, product)
+    Spree::Image.create(
+      attachment: file,
+      viewable_id: product.master.id,
+      viewable_type: Spree::Variant,
+    )
+  end
+end

--- a/lib/tasks/import_product_images.rake
+++ b/lib/tasks/import_product_images.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+namespace :ofn do
+  namespace :import do
+    desc "Importing images for products from CSV"
+    task :product_images, [:filename] => [:environment] do |_task, args|
+      COLUMNS = [:producer, :name, :image_url]
+
+      puts "Warning: use only with trusted URLs. This script will download whatever it can, including local secrets, and expose the file as an image file."
+
+      raise "Filename required" if args[:filename].blank?
+
+      csv = CSV.read(args[:filename], headers: true, header_converters: :symbol)
+      raise "CSV columns reqired: #{COLUMNS.map(&:to_s)}" if (COLUMNS - csv.headers).present?
+
+      csv.each.with_index do |entry, index|
+        puts "#{index} #{entry[:producer]}, #{entry[:name]}"
+        enterprise = Enterprise.find_by_name! entry[:producer]
+
+        product = Spree::Product.where(supplier: enterprise,
+                                       name: entry[:name],
+                                       deleted_at: nil).first
+        if product.nil?
+          puts " product not found."
+          next
+        end
+
+        if product.images.first.nil?
+          ImageImporter.new.import(entry[:image_url], product)
+          puts " image added."
+        else
+          # image = product.images.first
+          # image.update(attachment: entry[:image_url])
+          puts " image exists, not updated."
+        end
+      end
+    end
+  end
+end

--- a/spec/services/image_importer_spec.rb
+++ b/spec/services/image_importer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+
+describe ImageImporter do
+  let(:url) { Rails.root.join("spec/fixtures/files/logo.png").to_s }
+  let(:product) { create(:product) }
+
+  describe "#import" do
+    it "downloads and attaches to the product" do
+      expect {
+        subject.import(url, product)
+      }.to change {
+        Spree::Image.count
+      }.by(1)
+
+      expect(product.images.count).to eq 1
+      expect(product.images.first.attachment.size).to eq 6274
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

To import images to products from a CSV file with similar format to product importer CSV. 
We needed to do this quickly for over 100 products at short notice, so wrote a simple script.

Hopefully this functionality could be added to product importer in future, but it would require more security considerations.

#### What should we test?
```
rake ofn:import:product_images[staging-test.csv]
```

This has been tested on AU staging. To re-test, use different product names, or remove images from the products.
[staging-test.csv](https://github.com/openfoodfoundation/openfoodnetwork/files/6827221/staging-test.csv)

#### Release notes
Add script to import product images from URL

Changelog Category: Technical changes


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
The script is self-documenting (albeit very minimal).
There's currently no documentation about this kind of task in the wiki, so perhaps it's not necessary.
