### PR TITLE
Product import with images

### DIFF
--- a/app/models/product_import/entry_processor.rb
+++ b/app/models/product_import/entry_processor.rb
@@ -170,6 +170,8 @@ module ProductImport
       )
       product.supplier_id = entry.producer_id
 
+      attach_image_from_url(entry, product)
+
       if product.save
         ensure_variant_updated(product, entry)
         @products_created += 1
@@ -185,6 +187,8 @@ module ProductImport
       variant = entry.product_object
       variant.import_date = @import_time
 
+      attach_image_from_url(entry, variant.product)
+
       if variant.valid? && variant.save
         @updated_ids.push variant.id
         true
@@ -192,6 +196,12 @@ module ProductImport
         assign_errors variant.errors.full_messages, entry.line_number
         false
       end
+    end
+
+    def attach_image_from_url(entry, product)
+      return if entry.image_url.blank? || product.images.present?
+
+      ImageImporter.new.import(entry.image_url, product)
     end
 
     def assign_errors(errors, line_number)

--- a/app/models/product_import/spreadsheet_entry.rb
+++ b/app/models/product_import/spreadsheet_entry.rb
@@ -11,7 +11,8 @@ module ProductImport
     include ActiveModel::Validations
 
     attr_accessor :line_number, :valid, :validates_as, :product_object, :product_validations,
-                  :on_hand_nil, :has_overrides, :units, :unscaled_units, :unit_type, :tax_category, :shipping_category, :id, :product_id, :producer, :producer_id, :distributor, :distributor_id, :name, :display_name, :sku, :unit_value, :unit_description, :variant_unit, :variant_unit_scale, :variant_unit_name, :display_as, :category, :primary_taxon_id, :price, :on_hand, :on_demand, :tax_category_id, :shipping_category_id, :description, :import_date, :enterprise, :enterprise_id
+                  :on_hand_nil, :has_overrides, :units, :unscaled_units, :unit_type, :tax_category, :shipping_category, :id, :product_id, :producer, :producer_id, :distributor, :distributor_id, :name, :display_name, :sku, :unit_value, :unit_description, :variant_unit, :variant_unit_scale, :variant_unit_name, :display_as, :category, :primary_taxon_id, :price, :on_hand, :on_demand, :tax_category_id, :shipping_category_id, :description, :import_date, :enterprise, :enterprise_id,
+                  :image_url
 
     NON_DISPLAY_ATTRIBUTES = ['id', 'product_id', 'unscaled_units', 'variant_id', 'enterprise',
                               'enterprise_id', 'producer_id', 'distributor_id', 'primary_taxon',
@@ -25,7 +26,7 @@ module ProductImport
 
     NON_ASSIGNABLE_ATTRIBUTES = ['producer', 'producer_id', 'category', 'shipping_category',
                                  'tax_category', 'units', 'unscaled_units', 'unit_type',
-                                 'enterprise', 'enterprise_id'].freeze
+                                 'enterprise', 'enterprise_id', 'image_url'].freeze
 
     def initialize(attrs)
       @validates_as = ''

--- a/app/services/image_importer.rb
+++ b/app/services/image_importer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class ImageImporter
+  # Accessing any URI provided by the user has the risk of server side request
+  # forgery (SSRF). We need to make sure that we only access public servers
+  # and that we deny access to the local network. A user controlled domain can
+  # resolve to a local IP address or the destination can redirect to a local IP
+  # address. We are whitelisting well known CDN domains here which are not
+  # controlled by the user and don't redirect to user-defined addresses.
+  # https://medium.com/in-the-weeds/8cb2b1c96fe8
+  module URIValidator
+    class Error < StandardError
+      def initialize(msg)
+        super(I18n.t(msg, scope: "image_importer.uri_validator.error"))
+      end
+    end
+
+    ALLOWED_DOMAINS = [
+      "cdn.digitaloceanspaces.com",
+    ].freeze
+
+    def self.validate!(url)
+      uri = URI.parse(url)
+
+      raise Error, :connection_not_protected unless uri.scheme == "https"
+      raise Error, :domain_not_allowed unless domain_allowed?(uri.host)
+
+      uri
+    end
+
+    def self.domain_allowed?(domain)
+      ALLOWED_DOMAINS.any? do |good_domain|
+        domain == good_domain ||
+          domain.ends_with?(".#{good_domain}")
+      end
+    end
+  end
+
+  def import(url, product)
+    uri = URIValidator.validate!(url)
+    product.master.images.new(
+      attachment: uri.open,
+    )
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,6 +187,11 @@ en:
       not_array_error: "must be an array"
       invalid_element_error: "must contain only valid integers"
 
+  image_importer:
+    uri_validator:
+      error:
+        connection_not_protected: "Connection not protected"
+        domain_not_allowed: "Domain not allowed"
   enterprise_mailer:
     confirmation_instructions:
       subject: "Please confirm the email address for %{enterprise}"

--- a/spec/features/admin/product_import_spec.rb
+++ b/spec/features/admin/product_import_spec.rb
@@ -53,12 +53,13 @@ feature "Product Import", js: true do
 
   let(:shipping_category_id_str) { Spree::ShippingCategory.all.first.id.to_s }
 
+  let(:file) { Tempfile.new(["test", ".csv"]) }
+
   describe "when importing products from uploaded file" do
     before do
       allow(Spree::Config).to receive(:available_units).and_return("g,lb,oz,kg,T,mL,L,kL")
       login_as_admin
     end
-    after { File.delete('/tmp/test.csv') }
 
     it "validates entries and saves them if they are all valid and allows viewing new items in Bulk Products" do
       csv_data = CSV.generate do |csv|
@@ -69,12 +70,12 @@ feature "Product Import", js: true do
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg",
                 shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
       expect(page).to have_content "Select a spreadsheet to upload"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -118,12 +119,12 @@ feature "Product Import", js: true do
                 shipping_category_id_str]
         csv << ["Bad Potatoes", "", "Vegetables", "6", "6", "6", ""]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
       expect(page).to have_content "Select a spreadsheet to upload"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -143,12 +144,12 @@ feature "Product Import", js: true do
         csv << ["Carrots", "User Enterprise", "Vegetables", "5", "3.20", "500", "g",
                 tax_category.name, shipping_category.name]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
       expect(page).to have_content "Select a spreadsheet to upload"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -176,12 +177,12 @@ feature "Product Import", js: true do
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "1", "kg",
                 shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
       expect(page).to have_content "Select a spreadsheet to upload"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -223,11 +224,11 @@ feature "Product Import", js: true do
         csv << ["Carrots", "User Enterprise", "Vegetables", "500", "3.20", "500", "g",
                 shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
 
       check "settings_reset_all_absent"
 
@@ -256,10 +257,10 @@ feature "Product Import", js: true do
         csv << ["Beans", "User Enterprise", "Vegetables", "7", "2.50", "250", "g", nil,
                 shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -295,11 +296,11 @@ feature "Product Import", js: true do
         csv << ["Cabbage", "Another Enterprise", "User Enterprise", "Vegetables", "2001", "1.50",
                 "500"]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
       select2_select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -356,11 +357,11 @@ feature "Product Import", js: true do
                 "1", "true"]
       end
 
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
       select2_select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -392,10 +393,10 @@ feature "Product Import", js: true do
                 "kg", "1", "true", "Bag"]
       end
 
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
       visit main_app.admin_product_import_path
       select2_select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
       proceed_to_validation
       expect(page).to have_selector '.item-count', text: "1"
@@ -425,11 +426,11 @@ feature "Product Import", js: true do
         csv << ["Cabbage", "Another Enterprise", "User Enterprise", "Vegetables", nil, "1.50",
                 "500", nil]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
       select2_select I18n.t('admin.product_import.index.inventories'), from: "settings_import_into"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -473,12 +474,12 @@ feature "Product Import", js: true do
         csv << ["Potatoes", "User Enterprise", "Vegetables", "6", "6.50", "8", "oz",
                 shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
       expect(page).to have_content "Select a spreadsheet to upload"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -509,12 +510,12 @@ feature "Product Import", js: true do
         csv << ["Cupcake", "User Enterprise", "Cake", "5", "2.2", "1", "", "Bunch",
                 shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
       expect(page).to have_content "Select a spreadsheet to upload"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -548,12 +549,12 @@ feature "Product Import", js: true do
         csv << ["Heavy Carrots", "Unkown Enterprise", "Mouldy vegetables", "666", "3.20", "1",
                 "stones", shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
 
       expect(page).to have_content "Select a spreadsheet to upload"
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation
@@ -568,19 +569,20 @@ feature "Product Import", js: true do
   end
 
   describe "when dealing with uploaded files" do
+    let(:wrong_file) { Tempfile.new(["test", ".txt"]) }
+
     before { login_as_admin }
 
     it "checks filetype on upload" do
-      File.write('/tmp/test.txt', "Wrong filetype!")
+      File.write(wrong_file.path, "Wrong filetype!")
 
       visit main_app.admin_product_import_path
-      attach_file 'file', '/tmp/test.txt'
+      attach_file 'file', wrong_file.path
       click_button 'Upload'
 
       expect(page).to have_content "Importer could not process file: invalid filetype"
       expect(page).to have_no_selector 'input[type=submit][value="Save"]'
       expect(page).to have_content "Select a spreadsheet to upload"
-      File.delete('/tmp/test.txt')
     end
 
     it "returns an error if nothing was uploaded" do
@@ -592,26 +594,25 @@ feature "Product Import", js: true do
     end
 
     it "handles cases where no meaningful data can be read from the file" do
-      File.write('/tmp/test.csv', "A22££S\\\\\n**VA,,,AF..D")
+      File.write(file.path, "A22££S\\\\\n**VA,,,AF..D")
 
       visit main_app.admin_product_import_path
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       expect(page).to have_no_selector '.create-count'
       expect(page).to have_no_selector '.update-count'
       expect(page).to have_no_selector 'input[type=submit][value="Save"]'
-      File.delete('/tmp/test.csv')
     end
 
     it "handles cases where files contain malformed data" do
       csv_data = "name,producer,category,on_hand,price,units,unit_type,shipping_category\n"
       csv_data += "Malformed \rBrocolli,#{enterprise.name},Vegetables,8,2.50,200,g,#{shipping_category.name}\n"
 
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       visit main_app.admin_product_import_path
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       expect(page).to have_no_selector '.create-count'
@@ -619,14 +620,10 @@ feature "Product Import", js: true do
       expect(page).to have_no_selector 'input[type=submit][value="Save"]'
       expect(flash_message).to match(I18n.t('admin.product_import.model.malformed_csv',
                                             error_message: ""))
-
-      File.delete('/tmp/test.csv')
     end
   end
 
   describe "handling enterprise permissions" do
-    after { File.delete('/tmp/test.csv') }
-
     it "only allows product import into enterprises the user is permitted to manage" do
       csv_data = CSV.generate do |csv|
         csv << ["name", "producer", "category", "on_hand", "price", "units", "unit_type",
@@ -636,12 +633,12 @@ feature "Product Import", js: true do
         csv << ["Your Potatoes", "Another Enterprise", "Vegetables", "6", "6.50", "1", "kg",
                 shipping_category_id_str]
       end
-      File.write('/tmp/test.csv', csv_data)
+      File.write(file.path, csv_data)
 
       login_as user
       visit main_app.admin_product_import_path
 
-      attach_file 'file', '/tmp/test.csv'
+      attach_file 'file', file.path
       click_button 'Upload'
 
       proceed_to_validation

--- a/spec/services/image_importer_spec.rb
+++ b/spec/services/image_importer_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+
+describe ImageImporter do
+  describe ImageImporter::URIValidator do
+    describe ".validate!" do
+      it "refuses local paths" do
+        expect {
+          subject.validate!("file:///etc/passwd")
+        }.to raise_error "Connection not protected"
+      end
+
+      it "refuses unknown domains" do
+        expect {
+          subject.validate!("https://example.com")
+        }.to raise_error "Domain not allowed"
+      end
+
+      it "allows known domains" do
+        expect {
+          subject.validate!("https://cdn.digitaloceanspaces.com/image")
+        }.to_not raise_error
+      end
+
+      it "allows subdomains of known domains" do
+        expect {
+          subject.validate!("https://example.cdn.digitaloceanspaces.com/image")
+        }.to_not raise_error
+      end
+    end
+  end
+
+  describe "#import" do
+    let(:image) { Rails.root.join("spec/fixtures/files/promo.png") }
+    let(:url) {
+      "https://images-originals.sgp1.cdn.digitaloceanspaces.com/Market/Stalls/297/img-2508.png"
+    }
+    let(:product) { create(:product) }
+
+    before do
+      stub_request(:get, url).
+        to_return(
+          status: 200,
+          body: image.read,
+        )
+    end
+
+    it "downloads and attaches to the product" do
+      subject.import(url, product)
+
+      expect(product.images.size).to eq 1
+      expect(product.images.first.attachment.size).to eq 4511
+    end
+
+    it "attaches without saving to the database" do
+      expect {
+        subject.import(url, product)
+      }.to_not change {
+        Spree::Image.count
+      }
+
+      expect {
+        product.master.save!
+      }.to change {
+        Spree::Image.count
+      }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
### WIP

- [ ] The current whitelist prevents this from being used by anyone else. It would be good to filter URLs similar to https://medium.com/in-the-weeds/8cb2b1c96fe8 to make this available for everyone without further maintenance.
- [ ] The current addition adds complexity to the code. The product import code needs some refactoring to be extended more easily. I would suggest:
  - [ ] Every SpreadsheetEntry should reference a product and a variant instead of the current either/or.
  - [ ] We need a separate class for the product/variant index (cache) and use it during validation (not just creation) to distinguish between updating and creating new variants.
  - [ ] Every entry should implement `ActiveModel::Validations` so that we can call `valid?` on the entry and it will validate all associated data including the product and variant.

#### What? Why?

The Australian team is in the process of migrating lots of producers from another platform. We are importing hundreds of products and need to import the images, too. We first wrote a hacky script in #7938 but it would be much better to offer image import to everyone.


#### What should we test?
<!-- List which features should be tested and how. -->

1. Import products as before, without images.
2. Import products with images.
3. Update existing variants with images.

Images have to be hosted on a CDN domain ending in `cdn.digitaloceanspaces.com`. Here are some examples:

- https://recharge-images-originals.sgp1.cdn.digitaloceanspaces.com/Market/Stalls/297/tv_goldmedal.jpg
- https://recharge-images-originals.sgp1.cdn.digitaloceanspaces.com/Market/Stalls/297/img-2508.jpg
- https://recharge-images-originals.sgp1.cdn.digitaloceanspaces.com/newstallpics/gluten-free-plain-vic-farmers-market-1.jpg

Test display of validation errors on other URLs:

- file:///etc/password
- https://random.example.net

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

The product import can now import images as well.

#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

None.

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

This needs to go into the user guide, I guess.