### PR TITLE
Use zeitwerk for autoloading 

### DIFF
--- a/app/models/spree/preferences/preferable.rb
+++ b/app/models/spree/preferences/preferable.rb
@@ -11,8 +11,6 @@
 # and copy all the definitions allowing the subclass to add
 # additional defintions without affecting the base
 
-require 'spree/preferences/store'
-
 module Spree
   module Preferences
     module Preferable

--- a/config/application.rb
+++ b/config/application.rb
@@ -98,17 +98,7 @@ module Openfoodnetwork
 
     # Register Spree calculators
     Rails.application.reloader.to_prepare do
-      Openfoodnetwork::Application.config.spree.calculators.shipping_methods = [
-        Calculator::FlatPercentItemTotal,
-        Calculator::FlatRate,
-        Calculator::FlexiRate,
-        Calculator::PerItem,
-        Calculator::PriceSack,
-        Calculator::Weight
-      ]
-    end
-    
-    initializer 'spree.register.calculators' do |app|
+      app = Openfoodnetwork::Application
       app.config.spree.calculators.shipping_methods = [
         Calculator::FlatPercentItemTotal,
         Calculator::FlatRate,
@@ -119,7 +109,7 @@ module Openfoodnetwork
       ]
 
       app.config.spree.calculators.add_class('enterprise_fees')
-      config.spree.calculators.enterprise_fees = [
+      app.config.spree.calculators.enterprise_fees = [
         Calculator::FlatPercentPerItem,
         Calculator::FlatRate,
         Calculator::FlexiRate,
@@ -129,7 +119,7 @@ module Openfoodnetwork
       ]
 
       app.config.spree.calculators.add_class('payment_methods')
-      config.spree.calculators.payment_methods = [
+      app.config.spree.calculators.payment_methods = [
         Calculator::FlatPercentItemTotal,
         Calculator::FlatRate,
         Calculator::FlexiRate,
@@ -138,7 +128,7 @@ module Openfoodnetwork
       ]
 
       app.config.spree.calculators.add_class('tax_rates')
-      config.spree.calculators.tax_rates = [
+      app.config.spree.calculators.tax_rates = [
         Calculator::DefaultTax
       ]
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -97,6 +97,17 @@ module Openfoodnetwork
     end
 
     # Register Spree calculators
+    Rails.application.reloader.to_prepare do
+      Openfoodnetwork::Application.config.spree.calculators.shipping_methods = [
+        Calculator::FlatPercentItemTotal,
+        Calculator::FlatRate,
+        Calculator::FlexiRate,
+        Calculator::PerItem,
+        Calculator::PriceSack,
+        Calculator::Weight
+      ]
+    end
+    
     initializer 'spree.register.calculators' do |app|
       app.config.spree.calculators.shipping_methods = [
         Calculator::FlatPercentItemTotal,

--- a/config/application.rb
+++ b/config/application.rb
@@ -213,5 +213,7 @@ module Openfoodnetwork
     config.action_controller.include_all_helpers = false
 
     config.generators.template_engine = :haml
+
+    config.autoloader = :zeitwerk
   end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -8,3 +8,8 @@
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
 # end
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector.inflect(
+    "stripe_sca" => "StripeSCA"
+  )
+end


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/7946

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We'll want to be careful with this, but I think it should solve the issue of the random errors popping up complaining about Single Table Inheritance. I just had to remove a `require` statement in a spree preferences module since it's now unnecessary and seemed to cause an issue if it was included. 


#### What should we test?
<!-- List which features should be tested and how. -->
<s>Green build should catch anything disastrous.... :trollface:</s>

We should double check that calculators on shipping/payment methods are working as expected. Completing an order with a shipping and payment method that each have an attached calculator should be sufficient. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Upgraded to Rails 6.0 default (Zeitwerk) for autoloading
<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
