### PR TITLE
Fragment-Cache producers AMS data

### DIFF
--- a/app/views/producers/index.html.haml
+++ b/app/views/producers/index.html.haml
@@ -2,7 +2,8 @@
   = t :producers_title
 
 - content_for :injection_data do
-  = inject_enterprises(@enterprises)
+  - cache @enterprises do
+    = inject_enterprises(@enterprises)
 
 .producers{"ng-controller" => "EnterprisesCtrl", "ng-cloak" => true}
   .row

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Openfoodnetwork::Application.configure do
   config.cache_classes = !!ENV["PROFILE"]
 
   # :file_store is used by default when no cache store is specifically configured.
-  if !!ENV["PROFILE"]
+  if !!ENV["PROFILE"] || !!ENV["DEV_CACHING"]
     config.cache_store = :redis_cache_store, {
       driver: :hiredis,
       url: ENV.fetch("OFN_REDIS_URL", "redis://localhost:6379/1"),
@@ -23,7 +23,7 @@ Openfoodnetwork::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = !!ENV["PROFILE"]
+  config.action_controller.perform_caching = !!ENV["PROFILE"] || !!ENV["DEV_CACHING"]
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
#### What? Why?

Reduces response time (and brutal CPU load) on the `/producers` page by around 80% when the data hasn't changed, by caching the full output of the AMS array generated by `InjectionHelper#inject_enterprises`.

Also adds a nice toggle for enabling caching in dev.

#### What should we test?
<!-- List which features should be tested and how. -->

Visiting the `/producers` page should be noticeably faster (_after_ the first page visit). Updating enterprise data invalidates the cache, meaning the page will be slow again for one page load, then back to fast, but more importantly; changes are always reflected in the page so the data is never stale.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added basic caching to /producers page AMS data

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
