### PR TITLE
Adds test for valid_email2 email validation

### DIFF
--- a/spec/features/admin/customers_spec.rb
+++ b/spec/features/admin/customers_spec.rb
@@ -343,13 +343,21 @@ feature 'Customers' do
           end
 
           it "creates customers when the email provided is valid" do
-            # When an invalid email is used
+            # When an invalid email without domain is used it is checked by a regex, in the UI
             expect{
               click_link('New Customer')
-              fill_in 'email', with: "not_an_email"
+              fill_in 'email', with: "email_with_no_domain@"
               click_button 'Add Customer'
               expect(page).to have_selector "#new-customer-dialog .error",
                                             text: "Please enter a valid email address"
+            }.to_not change{ Customer.of(managed_distributor1).count }
+
+            # When an invalid email with domain is used it is checked by the "valid_email2" gem #7886
+            expect{
+              fill_in 'email', with: "invalid_email_with_no_complete_domain@incomplete"
+              click_button 'Add Customer'
+              expect(page).to have_selector "#new-customer-dialog .error",
+                                            text: "Email is invalid"
             }.to_not change{ Customer.of(managed_distributor1).count }
 
             # When an existing email is used


### PR DESCRIPTION
#### What? Why?

Relates to #7945

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Checking for missing test cases to improve test coverage on release testing.
Realized we could benefit from coverage on the recently added `valid_email2` gem.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Adds an assertion to make sure the `valid_email2` gem is validating emails when creating new customers.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->

Depends on the `valid_email2` gem.
