### PR TITLE
Use :harmony option with Uglifier when minimizing javascript

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Openfoodnetwork::Application.configure do
   # config.assets.precompile += %w( search.js )
 
   require 'uglifier'
-  config.assets.js_compressor = Uglifier.new(mangle: false)
+  config.assets.js_compressor = Uglifier.new(mangle: false, harmony: true)
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Openfoodnetwork::Application.configure do
   # config.assets.precompile += %w( search.js )
 
   require 'uglifier'
-  config.assets.js_compressor = Uglifier.new(mangle: false)
+  config.assets.js_compressor = Uglifier.new(mangle: false, harmony: true)
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
#### What? Why?

Resolves a bug where the asset pipeline tries to minify assets that have already been minified by Webpack.

#### What should we test?
<!-- List which features should be tested and how. -->

Deployments should succeed without any asset precompiling errors.

I already deployed it here: https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/servers/au-staging/deploys/372 :heavy_check_mark:

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed asset compiling issue with Ugifier and Webpack

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

