### PR TITLE
Add overflow handling on pagination

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -9,3 +9,7 @@ Pagy::VARS[:items]  = 100
 require 'pagy/extras/items'
 Pagy::VARS[:items_param] = :per_page
 Pagy::VARS[:max_items]   = 100
+
+# For handling requests for non-existant pages eg: page 35 when there are only 4 pages of results
+require 'pagy/extras/overflow'
+Pagy::VARS[:overflow] = :empty_page


### PR DESCRIPTION
#### What? Why?

Fixes an issues where pages that don't exist can be requested via pagination arguments and the response isn't handled nicely.

After this, if a non-existent page is requested, it returns an empty array for the results instead of an error.

#### What should we test?
<!-- List which features should be tested and how. -->

A small subset of shopfronts seem to get stuck on the loading spinner when they try to load the last page of products. My current working theory is that it's only affecting shops that hide some products using tags. This means the "scroll more" feature tries to request say page 5, but the result set only has 4 pages of products as some of them are hidden from the current user. So page 5 doesn't actually exist, which results in this error. That's my best guess at the moment :man_shrugging: 

I can't currently find any shops on Staging where this can be replicated...

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed a pagination overflow issue for results pages that are outside the range of existing results

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes


