### PR TITLE
Allow users with enterprise permissions to change notification settings

### DIFF
--- a/app/views/admin/enterprises/form/_users.html.haml
+++ b/app/views/admin/enterprises/form/_users.html.haml
@@ -1,5 +1,5 @@
 - owner_email = @enterprise.andand.owner.andand.email || ""
-- full_permissions = (spree_current_user.admin? || spree_current_user == @enterprise.andand.owner)
+- full_permissions = can?(:edit, @enterprise) 
 
 .row
   .three.columns.alpha

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -286,6 +286,27 @@ feature '
     end
   end
 
+  context "as an Enterprise manager", js: true do
+    let(:enterprise_manager) { create(:user) }
+    let(:enterprise) { create(:enterprise, users: [:enterprise_manager]) }
+
+    before do
+      login_as enterprise_manager
+      visit admin_enterprises_path
+
+      it "allows me to edit notifications" do
+        expect(page).to have_content enterprise.name
+
+        accept_alert do
+          within(".side_menu") { click_link "Users" }
+        end
+
+        select2_select enterprise_manager.email, from: 'receives_notifications_dropdown'
+        expect(page).to have_no_selector '.select2-drop-mask' # Ensure select2 has finished
+      end
+    end
+  end
+
   context "as an Enterprise user", js: true do
     let(:supplier1) { create(:supplier_enterprise, name: 'First Supplier') }
     let(:supplier2) { create(:supplier_enterprise, name: 'Another Supplier') }


### PR DESCRIPTION
#### What? Why?

Closes #7964 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->
A user with permissions for an enterprise should see editable fields on the Users tab of the enterprise


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where users with permissions for an enterprise could not change notification settings
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
