### PR TITLE
Add missing super admin subnavigation fixes #7937

### DIFF
--- a/app/views/admin/enterprise_fees/index.html.haml
+++ b/app/views/admin/enterprise_fees/index.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 = content_for :page_title do
   = t('.title')
 

--- a/app/views/admin/terms_of_service_files/show.html.haml
+++ b/app/views/admin/terms_of_service_files/show.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t(".title")
 

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -1,4 +1,4 @@
-= render :partial => 'spree/admin/shared/configuration_menu'
+= render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = Spree.t(:general_settings)

--- a/app/views/spree/admin/payment_methods/edit.html.haml
+++ b/app/views/spree/admin/payment_methods/edit.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.editing_payment_method')
   %i.icon-arrow-right

--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.payment_methods')
 

--- a/app/views/spree/admin/payment_methods/new.html.haml
+++ b/app/views/spree/admin/payment_methods/new.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.new_payment_method')
 - content_for :page_actions do

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.editing_shipping_method')
 - content_for :page_actions do

--- a/app/views/spree/admin/shipping_methods/index.html.haml
+++ b/app/views/spree/admin/shipping_methods/index.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.shipping_methods')
 - content_for :page_actions do

--- a/app/views/spree/admin/shipping_methods/new.html.haml
+++ b/app/views/spree/admin/shipping_methods/new.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.new_shipping_method')
 - content_for :page_actions do


### PR DESCRIPTION
#### What? Why?

Closes #7937

Fixes missing super admin sub-navigation for all sections within configuration.

#### What should we test?

Navigate through all sections of the configuration section within the admin area.

#### Release notes

Fixes missing super admin sub-navigation for all sections within configuration.
Changelog Category: User facing changes

#### Dependencies

None.

#### Documentation updates

None.