### PR TITLE
Flatpickr only use language and not locale

### DIFF
--- a/app/assets/javascripts/admin/util.js.erb
+++ b/app/assets/javascripts/admin/util.js.erb
@@ -12,7 +12,7 @@ $(document).ready(function() {
     altInput: true,
     altFormat: Spree.translations.flatpickr_date_format,
     dateFormat: "Y-m-d",
-    locale: I18n.locale,
+    locale: I18n.base_locale,
     plugins: [
         ShortcutButtonsPlugin({
           button: [{

--- a/app/views/layouts/_i18n_script.html.haml
+++ b/app/views/layouts/_i18n_script.html.haml
@@ -1,5 +1,6 @@
 :javascript
   I18n.default_locale = "#{I18n.default_locale}";
+  I18n.base_locale = "#{I18n.locale.to_s.split('_').first}";
   I18n.locale = "#{I18n.locale}";
   I18n.fallbacks = true;
   moment.locale([I18n.locale, 'en']);


### PR DESCRIPTION
#### What? Why?

Flatpickr can be configured by passing a _locale_ but it's more only a language than a locale.
Create and use a small attribute onto `I18n` javascript object.


Closes #7928




#### What should we test?
1. Set up a locale like `fr_CA`
2. Login as admin and choose French on the homepage
3. Visit `admin/orders/bulk_management`
4. Open the console and notice there is no error, and the date(time)picker is well configured in `fr` language



#### Release notes
Use the right language for date(time)picker when configured locale contains also country

Changelog Category: User facing changes

