### PR TITLE
Switch to jQuery 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,6 @@ gem 'foundation-icons-sass-rails'
 
 gem 'foundation-rails', '= 5.5.2.1'
 
-gem 'jquery-migrate-rails'
 gem 'jquery-rails', '4.4.0'
 gem 'jquery-ui-rails', '~> 4.2'
 gem "select2-rails", github: "openfoodfoundation/select2-rails", branch: "v349_with_thor_v1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,6 @@ GEM
     immigrant (0.3.6)
       activerecord (>= 3.0)
     ipaddress (0.8.3)
-    jquery-migrate-rails (1.2.1)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -736,7 +735,6 @@ DEPENDENCIES
   i18n
   i18n-js (~> 3.8.3)
   immigrant
-  jquery-migrate-rails
   jquery-rails (= 4.4.0)
   jquery-ui-rails (~> 4.2)
   json

--- a/app/assets/javascripts/admin/all.js
+++ b/app/assets/javascripts/admin/all.js
@@ -6,8 +6,7 @@
 //
 
 // jquery and angular
-//= require jquery
-//= require jquery-migrate-min
+//= require jquery2
 //= require jquery_ujs
 //= require jquery.ui.all
 //= require jquery.powertip

--- a/app/assets/javascripts/admin/spree/calculator.js
+++ b/app/assets/javascripts/admin/spree/calculator.js
@@ -1,16 +1,17 @@
 $(function() {
-  var calculator_select = $('select#calc_type')
-  var original_calc_type = calculator_select.attr('value');
+  var calculator_select = $('select#calc_type');
+  var original_calc_type = calculator_select.val();
   $('.calculator-settings-warning').hide();
-  calculator_select.change(function() {
-    if (calculator_select.attr('value') == original_calc_type) {
+
+  calculator_select.on("change", function() {
+    if (calculator_select.val() === original_calc_type) {
       $('div.calculator-settings').show();
       $('.calculator-settings-warning').hide();
       $('.calculator-settings').find('input,textarea').prop("disabled", false);
     } else {
       $('div.calculator-settings').hide();
       $('.calculator-settings-warning').show();
-      $('.calculator-settings').find('input,texttarea').prop("disabled", true);
+      $('.calculator-settings').find('input,textarea').prop("disabled", true);
     }
   });
 })

--- a/app/assets/javascripts/darkswarm/all.js.coffee
+++ b/app/assets/javascripts/darkswarm/all.js.coffee
@@ -1,4 +1,4 @@
-#= require jquery
+#= require jquery2
 #= require jquery_ujs
 #= require jquery.ui.all
 #


### PR DESCRIPTION
#### What? Why?

Switches jQuery from `1.x` to `2.x`. The previous version was mostly designed to maintain browser compatibility for browsers that were considered old at the time... which was about 9 years ago!

The performance should be better, especially in regards to javascript memory leaks...

#### What should we test?
<!-- List which features should be tested and how. -->

Maybe have a quick navigate around the app and look for new console errors? In theory a green build should tell us if anything is broken.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

