### PR TITLE
Add customer information to mail when we notify producers when required 

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -77,7 +77,7 @@ class ProducerMailer < Spree::BaseMailer
   end
 
   def set_customer_data(line_items)
-    return unless @producer.preferred_show_customer_names_to_suppliers
+    return unless @coordinator.preferred_show_customer_names_to_suppliers
     line_items.map do |line_item|
       {
         sku: line_item.variant.sku,

--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -38,6 +38,7 @@ class ProducerMailer < Spree::BaseMailer
     @receival_instructions = @order_cycle.receival_instructions_for(@producer)
     @total = total_from_line_items(line_items)
     @tax_total = tax_total_from_line_items(line_items)
+    @customer_line_items = set_customer_data(line_items)
   end
 
   def subject
@@ -73,5 +74,19 @@ class ProducerMailer < Spree::BaseMailer
 
   def tax_total_from_line_items(line_items)
     Spree::Money.new line_items.to_a.sum(&:included_tax)
+  end
+
+  def set_customer_data(line_items)
+    return unless @producer.preferred_show_customer_names_to_suppliers
+    line_items.map do |line_item|
+      {
+        sku: line_item.variant.sku,
+        supplier_name: line_item.product.supplier.name,
+        product_and_full_name: line_item.product_and_full_name,
+        quantity: line_item.quantity,
+        first_name: line_item.order.billing_address.first_name,
+        last_name: line_item.order.billing_address.last_name
+      }
+    end.sort_by { |line_item| [line_item[:last_name].downcase, line_item[:first_name].downcase] }
   end
 end

--- a/app/views/producer_mailer/order_cycle_report.html.haml
+++ b/app/views/producer_mailer/order_cycle_report.html.haml
@@ -59,6 +59,39 @@
           #{@total}
         %td.text-right
           #{@tax_total}
+- if @customer_line_items
+  %p
+    = t :producer_mail_order_customer_text
+  %table.order-summary.customer-order
+    %thead
+      %tr
+        %th
+          = t :sku
+        %th
+          = t :supplier
+        %th
+          = t :product
+        %th.text-right
+          = t :quantity
+        %th.text-right
+          = t :first_name
+        %th.text-right
+          = t :last_name
+    %tbody
+      - @customer_line_items.each do |line_item|
+        %tr
+          %td
+            #{line_item[:sku]}
+          %td
+            #{raw(line_item[:supplier_name])}
+          %td
+            #{raw(line_item[:product_and_full_name])}
+          %td.text-right
+            #{line_item[:quantity]}
+          %td
+            #{raw(line_item[:first_name])}
+          %td
+            #{raw(line_item[:last_name])}
 %p
   = t :producer_mail_text_after
 %p

--- a/app/views/producer_mailer/order_cycle_report.text.haml
+++ b/app/views/producer_mailer/order_cycle_report.text.haml
@@ -20,6 +20,13 @@ Orders summary
 \
 #{t :total}: #{@total}
 \
+- if @customer_grouped_line_items
+  = t :producer_mail_order_customer_text
+  \
+  - @customer_line_items.each do |line_item|
+    #{line_item[:sku]} - #{raw(line_item[:supplier_name])} - #{raw(line_item[:product_and_full_name])} (QTY: #{line_item[:quantity]})  - #{raw(line_item[:first_name])} #{raw(line_item[:last_name])}
+\
+\
 = t :producer_mail_text_after
 
 #{t :producer_mail_signoff},

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1730,6 +1730,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   producer_mail_delivery_instructions: "Stock pickup/delivery instructions:"
   producer_mail_text_after: ""
   producer_mail_signoff: "Thanks and best wishes"
+  producer_mail_order_customer_text: "Here is a summary of the orders grouped by customers"
 
   shopping_oc_closed: Orders are closed
   shopping_oc_closed_description: "Please wait until the next cycle opens (or contact us directly to see if we can accept any late orders)"

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -129,7 +129,9 @@ describe ProducerMailer, type: :mailer do
   end
 
   context 'when flag preferred_show_customer_names_to_suppliers is true' do
-    let(:s1) { create(:supplier_enterprise, preferred_show_customer_names_to_suppliers: true) }
+    before do
+      order_cycle.coordinator.set_preference(:show_customer_names_to_suppliers, true)
+    end
 
     it "adds customer names table" do
       expect(body_as_html(mail).find(".order-summary.customer-order")).to_not be_nil
@@ -155,7 +157,9 @@ describe ProducerMailer, type: :mailer do
   end
 
   context 'when flag preferred_show_customer_names_to_suppliers is false' do
-    let(:s1) { create(:supplier_enterprise, preferred_show_customer_names_to_suppliers: false) }
+    before do
+      order_cycle.coordinator.set_preference(:show_customer_names_to_suppliers, false)
+    end
 
     it "does not add customer names table" do
       expect { body_as_html(mail).find(".order-summary.customer-order") }.to raise_error(Capybara::ElementNotFound)


### PR DESCRIPTION
#### What? Why?
Solves Issue - #6303 
Closes #6303

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
In the producer_mailer.rb file add code to accomodate for Table where line items are shown along with customer last name and first name.


#### What should we test?
Notify Producer email in Edit Order Cycle. Make sure that in the enterprise shop preferences , `Customer Names in Reports` is enabled. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Show Line items grouped by customer in Notify Producers email when flag `preferred_show_customer_names_to_suppliers` is set

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 


<img width="914" alt="Screenshot 2021-08-10 at 9 58 22 AM" src="https://user-images.githubusercontent.com/9512872/128808345-b81d3320-f055-4586-bf4a-6bc13a368f01.png">



