### PR TITLE
Enterprise fee must be linked with an enterprise: add validations

### DIFF
--- a/app/models/enterprise_fee.rb
+++ b/app/models/enterprise_fee.rb
@@ -21,6 +21,7 @@ class EnterpriseFee < ApplicationRecord
 
   validates :fee_type, inclusion: { in: FEE_TYPES }
   validates :name, presence: true
+  validates :enterprise_id, presence: true
 
   before_save :ensure_valid_tax_category_settings
 

--- a/app/views/admin/enterprise_fees/index.html.haml
+++ b/app/views/admin/enterprise_fees/index.html.haml
@@ -29,7 +29,7 @@
         %tr{ ng: { repeat: 'enterprise_fee in enterprise_fees | filter:query' } }
           %td
             = f.ng_hidden_field :id
-            %ofn-select{ :id => angular_id(:enterprise_id), data: 'enterprises', include_blank: true, ng: { model: 'enterprise_fee.enterprise_id' } }
+            %ofn-select{ :id => angular_id(:enterprise_id), data: 'enterprises', ng: { model: 'enterprise_fee.enterprise_id' } }
             %input{ type: "hidden", name: angular_name(:enterprise_id), ng: { value: "enterprise_fee.enterprise_id" } }
           %td= f.ng_select :fee_type, enterprise_fee_type_options, 'enterprise_fee.fee_type'
           %td= f.ng_text_field :name, { placeholder: t('.name_placeholder') }

--- a/spec/features/admin/enterprise_fees_spec.rb
+++ b/spec/features/admin/enterprise_fees_spec.rb
@@ -181,7 +181,7 @@ feature '
       click_link "Manage Enterprise Fees"
       expect(page).to have_select('sets_enterprise_fee_set_collection_attributes_0_enterprise_id',
                                   selected: 'Second Distributor',
-                                  options: ['', 'First Distributor', 'Second Distributor'])
+                                  options: ['First Distributor', 'Second Distributor'])
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Add 2 validation / errorproof options:
 - Add rails validation on `enterprise_id`  on `enterprise_fee` model
 - Do not add a blank option on the select: ie. user can select a blank enterprise in the form

Closes #7919 

###### Add validation for the model
![2021-07-27 14 56 48](https://user-images.githubusercontent.com/296452/127158726-17b0df19-63e0-4d63-bd08-8b047aa6a9e5.gif)

###### Do not let the use select a blank option
<img width="250" alt="Capture d’écran 2021-07-27 à 14 57 21" src="https://user-images.githubusercontent.com/296452/127158756-387b5ac1-4aff-405c-9871-e41206c54023.png">

#### What should we test?
###### Can't select a blank enterprise (non-sense)
On `/admin/enterprise_fees?enterprise_id=[ID]` see that you can't select a blank enterprise (demo here: https://github.com/openfoodfoundation/openfoodnetwork/issues/7919#issuecomment-879787426)

###### But you can select a enterprise
Confirm that you can select an enterprise, and create a enterprise fee with this form.


#### Release notes
Validation on enterprise fees form that a enterprise is actually selected
Changelog Category: User facing changes

