### PR TITLE
Cancel payments on stock shortages

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -119,7 +119,7 @@ class CheckoutController < ::BaseController
     # The checkout could not complete due to stock running out. We void any pending (incomplete)
     # Stripe payments here as the order will need to be changed and resubmitted (or abandoned).
     @order.payments.incomplete.each do |payment|
-      payment.void!
+      payment.void_transaction!
       payment.adjustment&.update_columns(eligible: false, state: "finalized")
     end
     flash[:notice] = I18n.t("checkout.payment_cancelled_due_to_stock")

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -126,7 +126,7 @@ describe CheckoutController, type: :controller do
         end
 
         it "cancels the payment and resets the order to cart" do
-          expect(payment).to receive(:void!).and_call_original
+          expect(payment).to receive(:void_transaction!).and_call_original
 
           spree_post :edit
 

--- a/spec/features/admin/payments_stripe_spec.rb
+++ b/spec/features/admin/payments_stripe_spec.rb
@@ -140,12 +140,8 @@ feature '
       let(:payment) { OrderPaymentFinder.new(order.reload).last_payment }
 
       before do
-        stub_payment_intent_get_request stripe_account_header: false
-        stub_successful_capture_request order: order
-
-        payment.update response_code: "pi_123", amount: order.total
-        payment.purchase!
-
+        payment.update response_code: "pi_123", amount: order.total, state: "completed"
+        stub_payment_intent_get_request response: { intent_status: "succeeded" }, stripe_account_header: false
         stub_refund_request
       end
 


### PR DESCRIPTION
#### What? Why?

Closes #7922 

Payments should now be correctly voided via `ActiveMerchant` when checkout fails due to stock shortages.

#### What should we test?
<!-- List which features should be tested and how. -->

Payments with Stripe should be cancelled in Stripe when checkout fails because of stock running out during checkout.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed issue with payments when checkout fails due to stock shortages.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes