### PR TITLE
Add appropriate distributors and suppliers to the packing report

### DIFF
--- a/app/controllers/spree/admin/reports_controller.rb
+++ b/app/controllers/spree/admin/reports_controller.rb
@@ -75,6 +75,9 @@ module Spree
         @report_types = report_types[:packing]
         @report_type = params[:report_type]
 
+        # Add distributors/suppliers distributing/supplying products I distribute/supply
+        add_appropriate_distributors_and_suppliers
+
         # -- Build Report with Order Grouper
         @report = OpenFoodNetwork::PackingReport.new spree_current_user, raw_params, render_content?
         @table = order_grouper_table
@@ -116,12 +119,8 @@ module Spree
       def orders_and_fulfillment
         raw_params[:q] ||= orders_and_fulfillment_default_filters
 
-        # -- Prepare Form Options
-        permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
-        # My distributors and any distributors distributing products I supply
-        @distributors = permissions.visible_enterprises_for_order_reports.is_distributor
-        # My suppliers and any suppliers supplying products I distribute
-        @suppliers = permissions.visible_enterprises_for_order_reports.is_primary_producer
+        # Add distributors/suppliers distributing/supplying products I distribute/supply
+        add_appropriate_distributors_and_suppliers
 
         @order_cycles = my_order_cycles
 
@@ -217,6 +216,15 @@ module Spree
         @header = header
         @table = table
         # Rendering HTML is the default.
+      end
+
+      def add_appropriate_distributors_and_suppliers
+        # -- Prepare Form Options
+        permissions = OpenFoodNetwork::Permissions.new(spree_current_user)
+        # My distributors and any distributors distributing products I supply
+        @distributors = permissions.visible_enterprises_for_order_reports.is_distributor
+        # My suppliers and any suppliers supplying products I distribute
+        @suppliers = permissions.visible_enterprises_for_order_reports.is_primary_producer
       end
 
       def csv_report(header, table)


### PR DESCRIPTION
#### What? Why?

Add the distributors/suppliers  that are distributing/supplying products the current user is distributing/supplying for the two reports: `orders_and_fullfillment` (already done but made some refactoring) and `packing` (that's new)

As the `orders_and_fullfillment` report already had the right filled distributors and suppliers, use the same method: `add_appropriate_distributors_and_suppliers`

Closes #7959



#### What should we test?
As an enterprise manager that sell product to its shop _and_ to another shop, when you go to `/admin/reports/packing` and `/admin/reports/orders_and_fulfillment` you should see for both `hubs` and `producers` select the same options:

###### Distributors
<img width="397" alt="Capture d’écran 2021-07-28 à 09 32 04" src="https://user-images.githubusercontent.com/296452/127282346-96d74af0-f3c0-47bc-aaa4-366ed8397bba.png">

###### Suppliers
<img width="374" alt="Capture d’écran 2021-07-28 à 09 32 07" src="https://user-images.githubusercontent.com/296452/127282339-4768d791-5a20-4f12-b4eb-8b482a97940e.png">


**_NB_**: before this PR, the distributors and suppliers were well filled for `orders_and_fullfillment` report but not for `packing` one. Nice to know for testing before applying the PR ;)


#### Release notes
Add the right hubs and suppliers options for the packing report.

Changelog Category: User facing changes

