### PR TITLE
Add order cycle coordinator to the list of enterprises with fees for order cycle incoming products form

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/controllers/order_cycle_exchanges_controller.js.coffee
@@ -18,7 +18,7 @@ angular.module('admin.orderCycles')
       OrderCycle.exchangeDirection(exchange)
 
     $scope.enterprisesWithFees = ->
-      $scope.enterprises[id] for id in OrderCycle.participatingEnterpriseIds() when $scope.enterpriseFeesForEnterprise(id).length > 0
+      $scope.enterprises[id] for id in [OrderCycle.participatingEnterpriseIds()..., [OrderCycle.order_cycle.coordinator_id]...] when $scope.enterpriseFeesForEnterprise(id).length > 0
 
     $scope.removeExchange = ($event, exchange) ->
       $event.preventDefault()

--- a/spec/javascripts/unit/admin/order_cycles/controllers/order_cycle_exchanges_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/order_cycles/controllers/order_cycle_exchanges_controller_spec.js.coffee
@@ -17,6 +17,8 @@ describe 'AdminOrderCycleExchangesCtrl', ->
       absUrl: ->
         'example.com/admin/order_cycles/27/edit'
     OrderCycle =
+      order_cycle:
+        coordinator_id: 4
       exchangeSelectedVariants: jasmine.createSpy('exchangeSelectedVariants').and.returnValue('variants selected')
       exchangeDirection: jasmine.createSpy('exchangeDirection').and.returnValue('exchange direction')
       removeExchange: jasmine.createSpy('removeExchange')
@@ -48,10 +50,12 @@ describe 'AdminOrderCycleExchangesCtrl', ->
       1: {id: 1, name: 'Eaterprises'}
       2: {id: 2, name: 'Pepper Tree Place'}
       3: {id: 3, name: 'South East'}
+      4: {id: 4, name: 'coordinator'}
     OrderCycle.participatingEnterpriseIds = jasmine.createSpy('participatingEnterpriseIds').and.returnValue([2])
     EnterpriseFee.enterprise_fees = [ {enterprise_id: 2} ] # Pepper Tree Place has a fee
     expect(scope.enterprisesWithFees()).toEqual([
-      {id: 2, name: 'Pepper Tree Place'}
+      {id: 2, name: 'Pepper Tree Place'},
+      {id: 4, name: 'coordinator'}
       ])
 
   it 'Removes order cycle exchanges', ->


### PR DESCRIPTION
#### What? Why?
Add order cycle coordinator to the list of enterprises with fees, thus coordinator can choose to add its own fee for a specific supplier

Closes #5472

#### What should we test?

 - Hub `A` is coordinator of an order cycle and has `B` as supplier.
 - When creating order cycle and adding incoming products, `A` can add its own fees to a specific supplier into the 'Incoming products' section:

<img width="1134" alt="Capture d’écran 2021-07-28 à 11 42 12" src="https://user-images.githubusercontent.com/296452/127301209-5160c860-4329-491b-83e6-c223917a6b58.png">

On the screenshot above, 'Mary's Online Shop' is the coordinator of the current order cycle, and 'Fred's Farm' is one if its supplier.
_**NB**_: Before this PR, coordinator could only choose 'Fred's Farm' fee.


#### Release notes
Add order cycle coordinator to the list of of the enterprises fees that could be added to the supplier in the order cycle incoming products form.

@filipefurtad0 feel free to edit this release note, as I can't make it more clear... And it's not! haha

Changelog Category: User facing changes


