### PR TITLE
Reports/Order Cycle Management: filter by shipping method

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -126,7 +126,7 @@ module OpenFoodNetwork
 
     def filter_to_shipping_method(orders)
       if params[:shipping_method_in].present?
-        orders.joins(shipments: :shipping_rates).where(spree_shipping_rates: { shipping_method_id: params[:shipping_method_in] })
+        orders.joins(shipments: :shipping_rates).where(spree_shipping_rates: { selected: true, shipping_method_id: params[:shipping_method_in] })
       else
         orders
       end


### PR DESCRIPTION
#### What? Why?



_Note for developper:_ I used the same code as:
https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/services/search_orders.rb#L31


Closes #5168



#### What should we test?
1. Go to `/admin/reports/order_cycle_management`
2. You should be able to filter order by shipping method.
###### Before

###### Filter by: Pickup Fredo's Farm Hub
<img width="900" alt="Capture d’écran 2021-07-28 à 17 12 00" src="https://user-images.githubusercontent.com/296452/127347730-4d946a8d-c98e-493d-8418-884f9521e82d.png">

###### Filter by: Home Delivery Fredo's Farm Hub
<img width="908" alt="Capture d’écran 2021-07-28 à 17 12 07" src="https://user-images.githubusercontent.com/296452/127347747-4b9541d4-4e32-40bd-b84b-18508f1963b7.png">


##### After
###### No filter
<img width="912" alt="Capture d’écran 2021-07-28 à 17 08 44" src="https://user-images.githubusercontent.com/296452/127347261-ede19db0-af8b-4eb9-a9d3-34bf6517a394.png">

###### Filter by: Pickup Fredo's Farm Hub
<img width="901" alt="Capture d’écran 2021-07-28 à 17 08 51" src="https://user-images.githubusercontent.com/296452/127347276-519a1253-99d1-4fef-abff-151c9982f81f.png">

###### Filter by: Home Delivery Fredo's Farm Hub
<img width="918" alt="Capture d’écran 2021-07-28 à 17 09 01" src="https://user-images.githubusercontent.com/296452/127347285-7ad4e9ed-c21b-474a-ade5-da58712c9dea.png">


#### Release notes
Filter by shipping method in the Order Cycle Management report.

Changelog Category: User facing changes


