### PR TITLE
Fix platform terms of service checkbox

### DIFF
--- a/app/views/checkout/_platform_terms_of_service.html.haml
+++ b/app/views/checkout/_platform_terms_of_service.html.haml
@@ -1,4 +1,4 @@
 %p
-  %input{ type: "checkbox", id: "platform_tos_accepted", ng: { model: "platform_tos_accepted", init: "platform_tos_accepted = #{platform_tos_already_accepted?}" } }
+  %input{ type: "checkbox", id: "accept_terms", ng: { model: "platform_tos_accepted", init: "platform_tos_accepted = #{platform_tos_already_accepted?}" } }
   %label.small{for: "platform_tos_accepted"}
     = t(".message_html", tos_link: link_to_platform_terms)

--- a/spec/features/consumer/shopping/checkout_spec.rb
+++ b/spec/features/consumer/shopping/checkout_spec.rb
@@ -219,10 +219,10 @@ feature "As a consumer I want to check out my cart", js: true do
           expect(page).to have_button("Place order now", disabled: true)
         end
 
-        check "Terms of service"
+        check "accept_terms"
         expect(page).to have_button("Place order now", disabled: false)
 
-        uncheck "Terms of service"
+        uncheck "accept_terms"
         expect(page).to have_button("Place order now", disabled: true)
       end
 
@@ -244,10 +244,10 @@ feature "As a consumer I want to check out my cart", js: true do
             expect(page).to have_button("Place order now", disabled: false)
           end
 
-          uncheck "Terms of service"
+          uncheck "accept_terms"
           expect(page).to have_button("Place order now", disabled: true)
 
-          check "Terms of service"
+          check "accept_terms"
           expect(page).to have_button("Place order now", disabled: false)
         end
       end
@@ -279,10 +279,10 @@ feature "As a consumer I want to check out my cart", js: true do
         end
 
         # Both Ts&Cs and TOS appear in the one label for the one checkbox.
-        check "Terms and Conditions"
+        check "accept_terms"
         expect(page).to have_button("Place order now", disabled: false)
 
-        uncheck "Terms of service"
+        uncheck "accept_terms"
         expect(page).to have_button("Place order now", disabled: true)
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #7999 

There's little bit of angular code that sends the request for checkout processing, and it was pulling the checkbox value based on the element's ID, which didn't match what was in the markup. So the value wasn't being passed in the params.

#### What should we test?
<!-- List which features should be tested and how. -->

Accepting terms and conditions should work, and should mean the checkbox is checked when the user comes back to the checkout.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed terms and conditions checkbox value not being saved in some cases

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes