### PR TITLE
Avoid opening tabs when navigating away from page

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/hub_node_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/hub_node_controller.js.coffee
@@ -9,6 +9,8 @@ Darkswarm.controller "HubNodeCtrl", ($scope, HashNavigation, CurrentHub, $http, 
   # Toggles shopfront tabs open/closed. Fetches enterprise details from the api, diplays them and adds them
   # to $scope.enterprise_details, or simply displays the details again if previously fetched
   $scope.toggle = (event) ->
+    return if event.target.closest("a")
+
     if $scope.open()
       $scope.toggle_tab(event)
       return

--- a/app/assets/javascripts/darkswarm/controllers/producer_node_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/producer_node_controller.js.coffee
@@ -9,6 +9,8 @@ Darkswarm.controller "ProducerNodeCtrl", ($scope, HashNavigation, $anchorScroll,
   # Toggles shopfront tabs open/closed. Fetches enterprise details from the api, diplays them and adds them
   # to $scope.enterprise_details, or simply displays the details again if previously fetched
   $scope.toggle = (event) ->
+    return if event.target.closest("a")
+
     if $scope.open()
       $scope.toggle_tab(event)
       return


### PR DESCRIPTION
#### What? Why?

Fixes a long-standing mini bug that creates little Javascript console errors. Also stops pointless requests being sent to the server.

Relevant Bugsnag: https://app.bugsnag.com/yaycode/open-food-network-js-australia/errors/6107571122c69d0007a7246c?event_id=61075711007f8a053b6d0000&i=sk&m=nw

#### What should we test?
<!-- List which features should be tested and how. -->

On the shops page and producers page; the pull-down tabs for enterprises should work as before when clicking in the space in the tab, but when the link with the enterprise's name is clicked, the tab doesn't toggle open/closed at the same time as navigating away from the page.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved toggling of tabs on shops and producers pages

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
