### PR TITLE
Migrate StripeConnect to StripeSCA

### DIFF
--- a/db/migrate/20210806112144_rename_stripe_connect_payment_methods_to_stripe_sca.rb
+++ b/db/migrate/20210806112144_rename_stripe_connect_payment_methods_to_stripe_sca.rb
@@ -1,0 +1,7 @@
+class RenameStripeConnectPaymentMethodsToStripeSca < ActiveRecord::Migration[6.1]
+  def change
+    Spree::PaymentMethod
+      .where(type: "Spree::Gateway::StripeConnect")
+      .update_all(type: "Spree::Gateway::StripeSCA")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_203927) do
+ActiveRecord::Schema.define(version: 2021_08_06_112144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
#### What? Why?

Part of #7872 

This PR migrates StripeConnect to StripaSCA via Rails migration

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

#### Dependencies
#7978 

