### PR TITLE
Split checkout backend

### DIFF
--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module CheckoutCallbacks
+  extend ActiveSupport::Concern
+
+  included do
+    # We need pessimistic locking to avoid race conditions.
+    # Otherwise we fail on duplicate indexes or end up with negative stock.
+    prepend_around_action CurrentOrderLocker, only: [:edit, :update]
+
+    prepend_before_action :check_hub_ready_for_checkout
+    prepend_before_action :check_order_cycle_expiry
+    prepend_before_action :require_order_cycle
+    prepend_before_action :require_distributor_chosen
+
+    before_action :load_order, :associate_user, :load_saved_addresses
+    before_action :load_shipping_methods, :load_countries, if: -> { checkout_step == "details"}
+
+    before_action :ensure_order_not_completed
+    before_action :ensure_checkout_allowed
+    before_action :handle_insufficient_stock
+    before_action :check_authorization
+    before_action :enable_embedded_shopfront
+  end
+
+  private
+
+  def load_order
+    @order = current_order
+
+    redirect_to(main_app.shop_path) && return if redirect_to_shop?
+    redirect_to_cart_path && return unless valid_order_line_items?
+  end
+
+  def load_saved_addresses
+    finder = OpenFoodNetwork::AddressFinder.new(@order.email, @order.customer, spree_current_user)
+
+    @order.bill_address = finder.bill_address
+    @order.ship_address = finder.ship_address
+  end
+
+  def load_shipping_methods
+    @shipping_methods = Spree::ShippingMethod.for_distributor(@order.distributor).order(:name)
+  end
+
+  def load_countries
+    @countries = available_countries.map { |c| [c.name, c.id] }
+    @countries_with_states = available_countries.map { |c| [c.id, c.states.map { |s| [s.name, s.id] }] }
+  end
+
+  def redirect_to_shop?
+    !@order ||
+      !@order.checkout_allowed? ||
+      @order.completed?
+  end
+
+  def redirect_to_cart_path
+    respond_to do |format|
+      format.html do
+        redirect_to main_app.cart_path
+      end
+
+      format.json do
+        render json: { path: main_app.cart_path }, status: :bad_request
+      end
+    end
+  end
+
+  def valid_order_line_items?
+    @order.insufficient_stock_lines.empty? &&
+      OrderCycleDistributedVariants.new(@order.order_cycle, @order.distributor).
+        distributes_order_variants?(@order)
+  end
+
+  def ensure_order_not_completed
+    redirect_to main_app.cart_path if @order.completed?
+  end
+
+  def ensure_checkout_allowed
+    redirect_to main_app.cart_path unless @order.checkout_allowed?
+  end
+
+  def check_authorization
+    authorize!(:edit, current_order, session[:access_token])
+  end
+end

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -39,6 +39,8 @@ class SplitCheckoutController < ::BaseController
 
     redirect_to_step unless checkout_step
 
+    OrderWorkflow.new(@order).next if @order.cart?
+
     # This is only required because of spree_paypal_express. If we implement
     # a version of paypal that uses this controller, and more specifically
     # the #action_failed method, then we can remove this call

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -15,7 +15,6 @@ class SplitCheckoutController < ::BaseController
   # Otherwise we fail on duplicate indexes or end up with negative stock.
   prepend_around_action CurrentOrderLocker, only: [:edit, :update]
 
-  prepend_before_action :set_checkout_step
   prepend_before_action :check_hub_ready_for_checkout
   prepend_before_action :check_order_cycle_expiry
   prepend_before_action :require_order_cycle
@@ -37,7 +36,7 @@ class SplitCheckoutController < ::BaseController
   def edit
     return handle_redirect_from_stripe if valid_payment_intent_provided?
 
-    redirect_to_step unless @checkout_step
+    redirect_to_step unless checkout_step
 
     # This is only required because of spree_paypal_express. If we implement
     # a version of paypal that uses this controller, and more specifically
@@ -68,8 +67,8 @@ class SplitCheckoutController < ::BaseController
 
   private
 
-  def set_checkout_step
-    @checkout_step = params[:step]
+  def checkout_step
+    @checkout_step ||= params[:step]
   end
 
   def order_params

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -82,9 +82,11 @@ class SplitCheckoutController < ::BaseController
   end
 
   def advance_order_state
-    return if @order.confirmation? || @order.complete?
+    return if @order.complete?
 
-    OrderWorkflow.new(@order).advance_to_confirmation
+    workflow_options = raw_params.slice(:shipping_method_id)
+
+    OrderWorkflow.new(@order).advance_to_confirmation(workflow_options)
   end
 
   def checkout_step

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -54,7 +54,7 @@ class SplitCheckoutController < ::BaseController
       advance_order_state
       redirect_to_step
     else
-      flash[:error] = "Saving failed, please update the highlighted fields"
+      flash.now[:error] = "Saving failed, please update the highlighted fields"
       render :edit
     end
   end

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -92,12 +92,21 @@ class SplitCheckoutController < ::BaseController
   end
 
   def order_params
-    params.require(:order).permit(
+    return @order_params unless @order_params.nil?
+
+    @order_params = params.require(:order).permit(
       :email, :shipping_method_id, :special_instructions,
       bill_address_attributes: PermittedAttributes::Address.attributes,
       ship_address_attributes: PermittedAttributes::Address.attributes,
       payments_attributes: [:payment_method_id]
     )
+
+    if @order_params[:payments_attributes]
+      # Set payment amount
+      @order_params[:payments_attributes].first[:amount] = @order.total
+    end
+
+    @order_params
   end
 
   def redirect_to_step

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -150,7 +150,6 @@ class SplitCheckoutController < ::BaseController
     redirect_to_cart_path && return unless valid_order_line_items?
 
     before_address
-    setup_for_current_state
   end
 
   def redirect_to_shop?
@@ -177,11 +176,6 @@ class SplitCheckoutController < ::BaseController
     end
   end
 
-  def setup_for_current_state
-    method_name = :"before_#{@order.state}"
-    __send__(method_name) if respond_to?(method_name, true)
-  end
-
   def before_address
     associate_user
 
@@ -189,10 +183,6 @@ class SplitCheckoutController < ::BaseController
 
     @order.bill_address = finder.bill_address
     @order.ship_address = finder.ship_address
-  end
-
-  def before_payment
-    current_order.payments.destroy_all if request.put?
   end
 
   def valid_payment_intent_provided?

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -20,7 +20,8 @@ class SplitCheckoutController < ::BaseController
   prepend_before_action :require_order_cycle
   prepend_before_action :require_distributor_chosen
 
-  before_action :load_order, :load_shipping_methods, :load_countries
+  before_action :load_order
+  before_action :load_shipping_methods, :load_countries, if: -> { checkout_step == "details"}
 
   before_action :ensure_order_not_completed
   before_action :ensure_checkout_allowed

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -49,16 +49,11 @@ class SplitCheckoutController < ::BaseController
 
   def update
     if @order.update(order_params)
-      OrderWorkflow.new(@order).advance_to_payment
+      OrderWorkflow.new(@order).advance_to_confirmation
 
-      if @order.state == "payment"
-        redirect_to checkout_step_path(:payment)
-      else
-        render :edit
-      end
+      redirect_to_step
     else
       flash[:error] = "Saving failed, please update the highlighted fields"
-
       render :edit
     end
   end
@@ -87,14 +82,15 @@ class SplitCheckoutController < ::BaseController
   end
 
   def redirect_to_step
-    if @order.state == "payment"
-      if true# order.has_no_payment_method_chosen?
-        redirect_to checkout_step_path(:payment)
-      else
-        redirect_to checkout_step_path(:summary)
-      end
-    else
+    case @order.state
+    when "cart", "address", "delivery"
       redirect_to checkout_step_path(:details)
+    when "payment"
+      redirect_to checkout_step_path(:payment)
+    when "confirmation"
+      redirect_to checkout_step_path(:summary)
+    else
+      redirect_to order_path(@order)
     end
   end
 

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -51,6 +51,7 @@ class SplitCheckoutController < ::BaseController
 
   def update
     if confirm_order || update_order
+      clear_invalid_payments
       advance_order_state
       redirect_to_step
     else
@@ -68,6 +69,10 @@ class SplitCheckoutController < ::BaseController
   end
 
   private
+
+  def clear_invalid_payments
+    @order.payments.with_state(:invalid).delete_all
+  end
 
   def confirm_order
     return unless @order.confirmation? && params[:confirm_order]

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -7,29 +7,10 @@ class SplitCheckoutController < ::BaseController
 
   include OrderStockCheck
   include Spree::BaseHelper
+  include CheckoutCallbacks
 
   helper 'terms_and_conditions'
   helper 'checkout'
-
-  # We need pessimistic locking to avoid race conditions.
-  # Otherwise we fail on duplicate indexes or end up with negative stock.
-  prepend_around_action CurrentOrderLocker, only: [:edit, :update]
-
-  prepend_before_action :check_hub_ready_for_checkout
-  prepend_before_action :check_order_cycle_expiry
-  prepend_before_action :require_order_cycle
-  prepend_before_action :require_distributor_chosen
-
-  before_action :load_order, :associate_user, :load_saved_addresses
-  before_action :load_shipping_methods, :load_countries, if: -> { checkout_step == "details"}
-
-  before_action :ensure_order_not_completed
-  before_action :ensure_checkout_allowed
-  before_action :handle_insufficient_stock
-
-  before_action :check_authorization
-  before_action :enable_embedded_shopfront
-
   helper 'spree/orders'
   helper OrderHelper
 
@@ -126,65 +107,6 @@ class SplitCheckoutController < ::BaseController
     else
       redirect_to order_path(@order)
     end
-  end
-
-  def check_authorization
-    authorize!(:edit, current_order, session[:access_token])
-  end
-
-  def ensure_checkout_allowed
-    redirect_to main_app.cart_path unless @order.checkout_allowed?
-  end
-
-  def ensure_order_not_completed
-    redirect_to main_app.cart_path if @order.completed?
-  end
-
-  def load_shipping_methods
-    @shipping_methods = Spree::ShippingMethod.for_distributor(@order.distributor).order(:name)
-  end
-
-  def load_countries
-    @countries = available_countries.map { |c| [c.name, c.id] }
-    @countries_with_states = available_countries.map { |c| [c.id, c.states.map { |s| [s.name, s.id] }] }
-  end
-
-  def load_order
-    @order = current_order
-
-    redirect_to(main_app.shop_path) && return if redirect_to_shop?
-    redirect_to_cart_path && return unless valid_order_line_items?
-  end
-
-  def redirect_to_shop?
-    !@order ||
-      !@order.checkout_allowed? ||
-      @order.completed?
-  end
-
-  def valid_order_line_items?
-    @order.insufficient_stock_lines.empty? &&
-      OrderCycleDistributedVariants.new(@order.order_cycle, @order.distributor).
-        distributes_order_variants?(@order)
-  end
-
-  def redirect_to_cart_path
-    respond_to do |format|
-      format.html do
-        redirect_to main_app.cart_path
-      end
-
-      format.json do
-        render json: { path: main_app.cart_path }, status: :bad_request
-      end
-    end
-  end
-
-  def load_saved_addresses
-    finder = OpenFoodNetwork::AddressFinder.new(@order.email, @order.customer, spree_current_user)
-
-    @order.bill_address = finder.bill_address
-    @order.ship_address = finder.ship_address
   end
 
   def valid_payment_intent_provided?

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -20,14 +20,13 @@ class SplitCheckoutController < ::BaseController
   prepend_before_action :require_order_cycle
   prepend_before_action :require_distributor_chosen
 
-  before_action :load_order
+  before_action :load_order, :associate_user, :load_saved_addresses
   before_action :load_shipping_methods, :load_countries, if: -> { checkout_step == "details"}
 
   before_action :ensure_order_not_completed
   before_action :ensure_checkout_allowed
   before_action :handle_insufficient_stock
 
-  before_action :associate_user
   before_action :check_authorization
   before_action :enable_embedded_shopfront
 
@@ -155,8 +154,6 @@ class SplitCheckoutController < ::BaseController
 
     redirect_to(main_app.shop_path) && return if redirect_to_shop?
     redirect_to_cart_path && return unless valid_order_line_items?
-
-    before_address
   end
 
   def redirect_to_shop?
@@ -183,9 +180,7 @@ class SplitCheckoutController < ::BaseController
     end
   end
 
-  def before_address
-    associate_user
-
+  def load_saved_addresses
     finder = OpenFoodNetwork::AddressFinder.new(@order.email, @order.customer, spree_current_user)
 
     @order.bill_address = finder.bill_address

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -122,4 +122,8 @@ module CheckoutHelper
       "{{ #{price} | localizeCurrency }}"
     end
   end
+
+  def checkout_step?(step)
+    params[:step] == step.to_s
+  end
 end

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -123,6 +123,15 @@ module CheckoutHelper
     end
   end
 
+  def payment_or_shipping_price(method, order)
+    price = method.compute_amount(order)
+    if price.zero?
+      t('checkout_method_free')
+    else
+      Spree::Money.new(price, currency: order.currency)
+    end
+  end
+
   def checkout_step
     params[:step]
   end

--- a/app/helpers/checkout_helper.rb
+++ b/app/helpers/checkout_helper.rb
@@ -123,7 +123,11 @@ module CheckoutHelper
     end
   end
 
+  def checkout_step
+    params[:step]
+  end
+
   def checkout_step?(step)
-    params[:step] == step.to_s
+    checkout_step == step.to_s
   end
 end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -20,6 +20,9 @@ module Spree
         order.update_totals
         order.payment_required?
       }
+      go_to_state :confirmation, if: ->(order) {
+        Flipper.enabled? :split_checkout, order.user
+      }
       go_to_state :complete
     end
 

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -81,17 +81,16 @@ module Spree
     before_validation :associate_customer, unless: :customer_id?
     before_validation :ensure_customer, unless: :customer_is_valid?
 
-    validates :customer, presence: true, if: :require_customer?
-    validate :products_available_from_new_distribution, if: lambda {
-      distributor_id_changed? || order_cycle_id_changed?
-    }
-    validate :disallow_guest_order
-
     attr_accessor :use_billing
 
     before_create :link_by_email
     after_create :create_tax_charge!
 
+    validates :customer, presence: true, if: :require_customer?
+    validate :products_available_from_new_distribution, if: lambda {
+      distributor_id_changed? || order_cycle_id_changed?
+    }
+    validate :disallow_guest_order
     validates :email, presence: true,
                       format: /\A([\w.%+\-']+)@([\w\-]+\.)+(\w{2,})\z/i,
                       if: :require_email

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -94,6 +94,7 @@ module Spree
     validates :email, presence: true,
                       format: /\A([\w.%+\-']+)@([\w\-]+\.)+(\w{2,})\z/i,
                       if: :require_email
+    validates :payments, presence: true, if: ->(order) { order.confirmation? && payment_required? }
 
     make_permalink field: :number
 

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -67,6 +67,10 @@ module Spree
                 transition to: :cart, unless: :completed?
               end
 
+              event :confirm do
+                transition to: :complete, from: :confirmation
+              end
+
               before_transition from: :cart, do: :ensure_line_items_present
 
               before_transition to: :delivery, do: :create_proposed_shipments

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -44,6 +44,8 @@ class OrderWorkflow
 
       after_transition_hook(options)
     end
+
+    order.state == target_state
   end
 
   def advance_order!(options)

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -27,8 +27,12 @@ class OrderWorkflow
     advance_to_state("payment", advance_order_options)
   end
 
-  def advance_to_confirmation
-    advance_to_state("confirmation", advance_order_options)
+  def advance_to_confirmation(options = {})
+    if options[:shipping_method_id]
+      order.select_shipping_method(options[:shipping_method_id])
+    end
+
+    advance_to_state("confirmation")
   end
 
   private
@@ -38,7 +42,7 @@ class OrderWorkflow
     { shipping_method_id: shipping_method_id }
   end
 
-  def advance_to_state(target_state, options)
+  def advance_to_state(target_state, options = {})
     until order.state == target_state
       break unless order.next
 

--- a/app/services/order_workflow.rb
+++ b/app/services/order_workflow.rb
@@ -27,6 +27,10 @@ class OrderWorkflow
     advance_to_state("payment", advance_order_options)
   end
 
+  def advance_to_confirmation
+    advance_to_state("confirmation", advance_order_options)
+  end
+
   private
 
   def advance_order_options

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -80,7 +80,7 @@
           "data-toggle-show": shipping_method.require_ship_address
         = shipping_method_form.label shipping_method.id, shipping_method.name, {for: "shipping_method_" + shipping_method.id.to_s }
         %em.light
-          = payment_method_price(shipping_method, @order)
+          = payment_or_shipping_price(shipping_method, @order)
 
 
   %div.checkout-input{ "data-toggle-target": "content", style: "display: none" }

--- a/app/views/split_checkout/_form.html.haml
+++ b/app/views/split_checkout/_form.html.haml
@@ -2,5 +2,5 @@
   = inject_saved_credit_cards
 
 %div.checkout-step.medium-6
-  = form_with url: checkout_update_path(@checkout_step), model: @order, method: :put do |f|
-    = render "split_checkout/#{@checkout_step}", f: f
+  = form_with url: checkout_update_path(checkout_step), model: @order, method: :put do |f|
+    = render "split_checkout/#{checkout_step}", f: f

--- a/app/views/split_checkout/_payment.html.haml
+++ b/app/views/split_checkout/_payment.html.haml
@@ -11,7 +11,7 @@
         checked: (payment_method.id == selected_payment_method),
         "data-action": "paymentmethod#selectPaymentMethod",
         "data-paymentmethod-description": "#{payment_method.description}"
-      = f.label payment_method.id, "#{payment_method.name} (#{payment_method_price(payment_method, @order)})", {for: "payment_method_" + payment_method.id.to_s }
+      = f.label payment_method.id, "#{payment_method.name} (#{payment_or_shipping_price(payment_method, @order)})", {for: "payment_method_" + payment_method.id.to_s }
 
   %div
     .panel{"data-paymentmethod-target": "panel", style: "display: none"} 

--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -103,13 +103,13 @@
 
 %div.checkout-substep
   %div.checkout-input
-    = f.check_box :accept_terms, {id: 'accept_terms', "checked": "#{all_terms_and_conditions_already_accepted?}"}
+    = f.check_box :accept_terms, {id: 'accept_terms', name: "accept_terms", "checked": "#{all_terms_and_conditions_already_accepted?}"}
     = f.label :accept_terms, t('split_checkout.step3.terms_and_conditions.message_html', terms_and_conditions_link: link_to( t("split_checkout.step3.terms_and_conditions.link_text"), @order.distributor.terms_and_conditions.url, target: '_blank'), tos_link: link_to_platform_terms), {for: "accept_terms"}
 
   %div.checkout-input
   = t("split_checkout.step3.agree")
 
 %div.checkout-submit
-  = f.submit t("split_checkout.step3.submit"), class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
+  = f.submit t("split_checkout.step3.submit"), name: "confirm_order", class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
   %a.button.cancel{href: main_app.cart_path}
     = t("split_checkout.step3.cancel")

--- a/app/views/split_checkout/_tabs.html.haml
+++ b/app/views/split_checkout/_tabs.html.haml
@@ -1,12 +1,12 @@
 %div.flex
-  %div.columns.three.text-center.checkout-tab{"class": [("selected" if @checkout_step == "details"), ("success" unless @checkout_step == "details")]}
+  %div.columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:details)), ("success" unless checkout_step?(:details))]}
     %span
-      = link_to_if (@checkout_step != "details"), t("split_checkout.your_details"), main_app.checkout_step_path(:details), {} do
+      = link_to_unless checkout_step?(:details), t("split_checkout.your_details"), main_app.checkout_step_path(:details) do
         = t("split_checkout.your_details")
-  %div.columns.three.text-center.checkout-tab{"class": [("selected" if @checkout_step == "payment"), ("success" if @checkout_step == "summary")]}
+  %div.columns.three.text-center.checkout-tab{"class": [("selected" if checkout_step?(:payment)), ("success" if checkout_step?(:summary))]}
     %span
-      = link_to_if (@checkout_step != "payment"), t("split_checkout.payment_method"), main_app.checkout_step_path(:payment), {} do
+      = link_to_if checkout_step?(:summary), t("split_checkout.payment_method"), main_app.checkout_step_path(:payment) do
         = t("split_checkout.payment_method")
-  %div.columns.three.text-center.checkout-tab{"class": ("selected" if @checkout_step == "summary")}
+  %div.columns.three.text-center.checkout-tab{"class": ("selected" if checkout_step?(:summary))}
     %span
-      = t("split_checkout.order_summary")      
+      = t("split_checkout.order_summary")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3929,6 +3929,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       awaiting_return: awaiting return
       canceled: cancelled
       cart: cart
+      confirmation: "confirmation"
       complete: complete
       confirm: confirm
       delivery: delivery


### PR DESCRIPTION
#### What? Why?

- Adds a new `confirmation` order state. This is currently only used when the feature toggle for the spit checkout is activated, otherwise it's skipped.
- Updates the split checkout controller and order workflow

Most of the basic functionality is working at this point, but there are various bits that still need some work:
- Handing of shipping/billing address logic and UX (like "use billing address as shipping address" and saving as default address etc)
- Handling of Stripe/Paypal logic and entering card details (frontend and backend)
- Lots of tests!
- Some errors and validations UX improvements for example if the user doesn't select a shipping or payment method
- Terms and Conditions checkbox handling (frontend and backend)

#### What should we test?
<!-- List which features should be tested and how. -->

There isn't really anything to test here, it's not enabled. It'll be used by the split checkout (which is still WIP / toggled off). Maybe a quick check that the normal checkout flow still works as before (but that would already be covered by both the test suite and by a release test)?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated split checkout processing (behind feature toggle)

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes