### PR TITLE
Fix deprecated syntax for live() function

### DIFF
--- a/app/views/admin/producer_properties/index.html.haml
+++ b/app/views/admin/producer_properties/index.html.haml
@@ -18,8 +18,8 @@
 :javascript
   var properties = #{raw(@properties.to_json)};
 
-  $("#producer_properties input.autocomplete").live("keydown", function() {
-    already_auto_completed = $(this).is('ac_input');
+  $("#producer_properties").on("keydown", "input.autocomplete", function() {
+    var already_auto_completed = $(this).is('ac_input');
     if (!already_auto_completed) {
       $(this).autocomplete({source: properties});
       $(this).focus();

--- a/app/views/spree/admin/product_properties/index.html.haml
+++ b/app/views/spree/admin/product_properties/index.html.haml
@@ -61,8 +61,9 @@
 
 :javascript
   var properties = #{raw(@properties.to_json)};
-  $("#product_properties input.autocomplete").live("keydown", function(){
-    already_auto_completed = $(this).is('ac_input');
+
+  $("#product_properties").on("keydown", "input.autocomplete", function(){
+    var already_auto_completed = $(this).is('ac_input');
     if (!already_auto_completed) {
       $(this).autocomplete({source: properties});
       $(this).focus();


### PR DESCRIPTION
#### What? Why?

Closes #8033 

Fixes a bit of deprecated syntax causing this Bugsnag: https://app.bugsnag.com/yaycode/open-food-network-js-uk/errors/6113beea69ef30000706df7e?event_id=6113beea007fa62b1b5c0000&i=sk&m=nw

Relevant docs here: https://jquery.com/upgrade-guide/1.9/#live-removed

#### What should we test?
<!-- List which features should be tested and how. -->

The autocomplete functionality when adding a product property to a product in admin product page (properties tab) should work.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed minor bug in product property autocomplete.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes