### PR TITLE
Remove n+1 queries when fetching association counts on /admin/enterprises

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -143,7 +143,10 @@ module Admin
     private
 
     def load_enterprise_set
-      @enterprise_set = Sets::EnterpriseSet.new(collection) if spree_current_user.admin?
+      if spree_current_user.admin?
+        @enterprise_set = Sets::EnterpriseSet.new(collection)
+        DataPreloader.preload_enterprise_data(@enterprise_set.collection)
+      end
     end
 
     def load_countries

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -63,6 +63,8 @@ class Enterprise < ApplicationRecord
                                               tag_rule[:preferred_customer_tags].blank?
                                             }
 
+  attr_accessor :preloaded_data
+
   has_attached_file :logo,
                     styles: { medium: "300x300>", small: "180x180>", thumb: "100x100>" },
                     url: '/images/enterprises/logos/:id/:style/:basename.:extension',
@@ -377,6 +379,22 @@ class Enterprise < ApplicationRecord
     abn.present?
   end
 
+  def enterprise_fees_count
+    preloaded_data_or_default.enterprise_fees_count
+  end
+
+  def payment_methods_count
+    preloaded_data_or_default.payment_methods_count
+  end
+
+  def producer_properties_count
+    preloaded_data_or_default.producer_properties_count
+  end
+
+  def shipping_methods_count
+    preloaded_data_or_default.shipping_methods_count
+  end
+
   protected
 
   def devise_mailer
@@ -398,6 +416,11 @@ class Enterprise < ApplicationRecord
     dups = dups.where('id != ?', id) unless new_record?
 
     errors.add :name, I18n.t(:enterprise_name_error, email: dups.first.owner.email) if dups.any?
+  end
+
+  def preloaded_data_or_default
+    DataPreloader.preload_enterprise_data([self]) if preloaded_data.nil?
+    preloaded_data
   end
 
   def send_welcome_email

--- a/app/queries/batch_enterprise_enterprise_fees_count_query.rb
+++ b/app/queries/batch_enterprise_enterprise_fees_count_query.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BatchEnterpriseEnterpriseFeesCountQuery
+  def self.call(enterprise_ids)
+    EnterpriseFee.where(enterprise_id: enterprise_ids).group(:enterprise_id).count
+  end
+end

--- a/app/queries/batch_enterprise_payment_methods_count_query.rb
+++ b/app/queries/batch_enterprise_payment_methods_count_query.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BatchEnterprisePaymentMethodsCountQuery
+  def self.call(enterprise_ids)
+    Spree::PaymentMethod.joins(
+      "INNER JOIN distributors_payment_methods
+       ON distributors_payment_methods.payment_method_id = spree_payment_methods.id"
+    ).where(distributors_payment_methods: { distributor_id: enterprise_ids }).
+      group("distributor_id").
+      count
+  end
+end

--- a/app/queries/batch_enterprise_producer_properties_count_query.rb
+++ b/app/queries/batch_enterprise_producer_properties_count_query.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BatchEnterpriseProducerPropertiesCountQuery
+  def self.call(enterprise_ids)
+    ProducerProperty.where(producer_id: enterprise_ids).group(:producer_id).unscope(:order).count
+  end
+end

--- a/app/queries/batch_enterprise_shipping_methods_count_query.rb
+++ b/app/queries/batch_enterprise_shipping_methods_count_query.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BatchEnterpriseShippingMethodsCountQuery
+  def self.call(enterprise_ids)
+    Spree::ShippingMethod.joins(
+      "INNER JOIN distributors_shipping_methods
+      ON distributors_shipping_methods.shipping_method_id = spree_shipping_methods.id"
+    ).where(distributors_shipping_methods: { distributor_id: enterprise_ids }).
+      group("distributor_id").
+      count
+  end
+end

--- a/app/services/data_preloader.rb
+++ b/app/services/data_preloader.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DataPreloader
+  def self.preload_enterprise_data(enterprises)
+    enterprise_ids = enterprises.map(&:id)
+
+    return if enterprise_ids.empty?
+
+    enterprise_fees_counts = BatchEnterpriseEnterpriseFeesCountQuery.call(enterprise_ids)
+    payment_methods_counts = BatchEnterprisePaymentMethodsCountQuery.call(enterprise_ids)
+    producer_properties_counts = BatchEnterpriseProducerPropertiesCountQuery.call(enterprise_ids)
+    shipping_methods_counts = BatchEnterpriseShippingMethodsCountQuery.call(enterprise_ids)
+
+    enterprises.each do |enterprise|
+      enterprise.preloaded_data = OpenStruct.new(
+        {
+          enterprise_fees_count: enterprise_fees_counts[enterprise.id] || 0,
+          payment_methods_count: payment_methods_counts[enterprise.id] || 0,
+          producer_properties_count: producer_properties_counts[enterprise.id] || 0,
+          shipping_methods_count: shipping_methods_counts[enterprise.id] || 0
+        }
+      )
+    end
+  end
+end

--- a/app/views/admin/enterprises/_actions.html.haml
+++ b/app/views/admin/enterprises/_actions.html.haml
@@ -9,26 +9,26 @@
 
 - if enterprise.is_primary_producer
   = link_to_with_icon 'icon-dashboard', t('.properties'), main_app.admin_enterprise_producer_properties_path(enterprise_id: enterprise)
-  (#{enterprise.producer_properties.count})
+  (#{enterprise.producer_properties_count})
   %br/
 
 - if enterprise.is_distributor
   - if can?(:admin, Spree::PaymentMethod) && can?(:manage_payment_methods, enterprise)
     = link_to_with_icon 'icon-chevron-right', t('.payment_methods'), spree.admin_payment_methods_path(enterprise_id: enterprise.id)
-    (#{enterprise.payment_methods.count})
-    - if enterprise.payment_methods.count == 0
+    (#{enterprise.payment_methods_count})
+    - if enterprise.payment_methods_count == 0
       %span.icon-exclamation-sign{"ofn-with-tip" => t('.payment_methods_tip'), style: "font-size: 16px;color: #DA5354"}
     %br/
 
   - if can?(:admin, Spree::ShippingMethod) && can?(:manage_shipping_methods, enterprise)
     = link_to_with_icon 'icon-plane', t('.shipping_methods'), spree.admin_shipping_methods_path(enterprise_id: enterprise.id)
-    (#{enterprise.shipping_methods.count})
-    - if enterprise.shipping_methods.count == 0
+    (#{enterprise.shipping_methods_count})
+    - if enterprise.shipping_methods_count == 0
       %span.icon-exclamation-sign{"ofn-with-tip" => t('.shipping_methods_tip'), style: "font-size: 16px;color: #DA5354"}
     %br/
 
 - if can?(:admin, EnterpriseFee) && can?(:manage_enterprise_fees, enterprise)
   = link_to_with_icon 'icon-money', t('.enterprise_fees'), main_app.admin_enterprise_fees_path(enterprise_id: enterprise.id)
-  (#{enterprise.enterprise_fees.count})
-  - if enterprise.enterprise_fees.count == 0
+  (#{enterprise.enterprise_fees_count})
+  - if enterprise.enterprise_fees_count == 0
     %span.icon-warning-sign{"ofn-with-tip" => t('.enterprise_fees_tip'), style: "font-size: 16px;color: orange"}

--- a/spec/queries/batch_enterprise_enterprise_fees_count_query_spec.rb
+++ b/spec/queries/batch_enterprise_enterprise_fees_count_query_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BatchEnterpriseEnterpriseFeesCountQuery do
+  let(:enterprise1) { create(:enterprise) }
+  let(:enterprise2) { create(:enterprise) }
+
+  context "when querying enterprises that have no enterprise fees" do
+    let(:enterprise_ids) { [enterprise1.id] }
+
+    it do
+      expect(BatchEnterpriseEnterpriseFeesCountQuery.call(enterprise_ids)).to eq({})
+    end
+  end
+
+  context "when querying enterprises that have some enterprise fees" do
+    let(:enterprise_ids) { [enterprise1.id, enterprise2.id] }
+
+    before do
+      create(:enterprise_fee, enterprise: enterprise1)
+      create(:enterprise_fee, enterprise: enterprise2)
+      create(:enterprise_fee, enterprise: enterprise2)
+    end
+
+    it do
+      expect(BatchEnterpriseEnterpriseFeesCountQuery.call(enterprise_ids)).to eq(
+        {
+          enterprise1.id => 1,
+          enterprise2.id => 2
+        }
+      )
+    end
+  end
+end

--- a/spec/queries/batch_enterprise_payment_methods_count_query_spec.rb
+++ b/spec/queries/batch_enterprise_payment_methods_count_query_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BatchEnterprisePaymentMethodsCountQuery do
+  let(:enterprise1) { create(:enterprise) }
+  let(:enterprise2) { create(:enterprise) }
+
+  context "when querying enterprises that have no payment methods" do
+    let(:enterprise_ids) { [enterprise1.id] }
+
+    it do
+      expect(BatchEnterprisePaymentMethodsCountQuery.call(enterprise_ids)).to eq({})
+    end
+  end
+
+  context "when querying enterprises that have some payment methods" do
+    let(:enterprise_ids) { [enterprise1.id, enterprise2.id] }
+
+    before do
+      create(:payment_method, distributors: [enterprise1])
+      create(:payment_method, distributors: [enterprise2])
+      create(:payment_method, distributors: [enterprise2])
+    end
+
+    it do
+      expect(BatchEnterprisePaymentMethodsCountQuery.call(enterprise_ids)).to eq(
+        {
+          enterprise1.id => 1,
+          enterprise2.id => 2
+        }
+      )
+    end
+  end
+end

--- a/spec/queries/batch_enterprise_producer_properties_count_query_spec.rb
+++ b/spec/queries/batch_enterprise_producer_properties_count_query_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BatchEnterpriseProducerPropertiesCountQuery do
+  let(:enterprise1) { create(:enterprise) }
+  let(:enterprise2) { create(:enterprise) }
+
+  context "when querying enterprises that have no producer properties" do
+    let(:enterprise_ids) { [enterprise1.id] }
+
+    it do
+      expect(BatchEnterpriseProducerPropertiesCountQuery.call(enterprise_ids)).to eq({})
+    end
+  end
+
+  context "when querying enterprises that have some producer properties" do
+    let(:enterprise_ids) { [enterprise1.id, enterprise2.id] }
+
+    before do
+      create(:producer_property, producer: enterprise1, property: create(:property))
+      create(:producer_property, producer: enterprise2, property: create(:property))
+      create(:producer_property, producer: enterprise2, property: create(:property))
+    end
+
+    it do
+      expect(BatchEnterpriseProducerPropertiesCountQuery.call(enterprise_ids)).to eq(
+        {
+          enterprise1.id => 1,
+          enterprise2.id => 2
+        }
+      )
+    end
+  end
+end

--- a/spec/queries/batch_enterprise_shipping_methods_count_query_spec.rb
+++ b/spec/queries/batch_enterprise_shipping_methods_count_query_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BatchEnterpriseShippingMethodsCountQuery do
+  let(:enterprise1) { create(:enterprise) }
+  let(:enterprise2) { create(:enterprise) }
+
+  context "when querying enterprises that have no shipping methods" do
+    let(:enterprise_ids) { [enterprise1.id] }
+
+    it do
+      expect(BatchEnterpriseShippingMethodsCountQuery.call(enterprise_ids)).to eq({})
+    end
+  end
+
+  context "when querying enterprises that have some shipping methods" do
+    let(:enterprise_ids) { [enterprise1.id, enterprise2.id] }
+
+    before do
+      create(:shipping_method, distributors: [enterprise1])
+      create(:shipping_method, distributors: [enterprise2])
+      create(:shipping_method, distributors: [enterprise2])
+    end
+
+    it do
+      expect(BatchEnterpriseShippingMethodsCountQuery.call(enterprise_ids)).to eq(
+        {
+          enterprise1.id => 1,
+          enterprise2.id => 2
+        }
+      )
+    end
+  end
+end

--- a/spec/services/data_preloader_spec.rb
+++ b/spec/services/data_preloader_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DataPreloader do
+  describe "#preload_enterprise_data" do
+    let(:enterprise) { create(:enterprise) }
+
+    context "when queries for given enterprises return no data" do
+      it "sets appropriate default values for the preloaded data i.e. 0 for counts" do
+        DataPreloader.preload_enterprise_data([enterprise])
+
+        expect(enterprise.preloaded_data.enterprise_fees_count).to eq(0)
+        expect(enterprise.preloaded_data.payment_methods_count).to eq(0)
+        expect(enterprise.preloaded_data.producer_properties_count).to eq(0)
+        expect(enterprise.preloaded_data.shipping_methods_count).to eq(0)
+      end
+    end
+
+    context "when queries for given enterprises return some data" do
+      before do
+        create(:enterprise_fee, enterprise: enterprise)
+        create(:producer_property, producer: enterprise, property: create(:property))
+        create(:payment_method, distributors: [enterprise])
+        create(:shipping_method, distributors: [enterprise])
+      end
+
+      it "sets the preloaded data on the given enterprises" do
+        DataPreloader.preload_enterprise_data([enterprise])
+
+        expect(enterprise.preloaded_data.enterprise_fees_count).to eq(1)
+        expect(enterprise.preloaded_data.payment_methods_count).to eq(1)
+        expect(enterprise.preloaded_data.producer_properties_count).to eq(1)
+        expect(enterprise.preloaded_data.shipping_methods_count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the `/admin/enterprises` page is loaded the following queries are called in `app/views/admin/enterprises/_actions.html.haml` for every enterprise.

```
enterprise.enterprise_fees.count
enterprise.producer_properties.count
enterprise.payment_methods.count
enterprise.shipping_methods.count
```

This is to improve performance for #8027. Instead of running a query for each enterprise individually, for example to count the shipping methods that enterprise has, it runs a single query to count the shipping methods for all the enterprises loaded on the page all at once.

Before

```
Completed 200 OK in 3670ms (Views: 2688.4ms | ActiveRecord: 959.7ms | Allocations: 1664423)
Completed 200 OK in 3322ms (Views: 2402.5ms | ActiveRecord: 887.2ms | Allocations: 1671457)
Completed 200 OK in 3404ms (Views: 2513.2ms | ActiveRecord: 868.6ms | Allocations: 1663917)
```

After

```
Completed 200 OK in 1832ms (Views: 1397.0ms | ActiveRecord: 402.6ms | Allocations: 1014829)
Completed 200 OK in 2121ms (Views: 1600.5ms | ActiveRecord: 446.0ms | Allocations: 1023386)
Completed 200 OK in 1851ms (Views: 1408.8ms | ActiveRecord: 408.0ms | Allocations: 1015167)
```
#### What should we test?

Test that /admin/enterprises page loads faster than before.

#### Release notes

Remove n+1 queries when fetching association counts on /admin/enterprises.

Changelog Category: User facing changes 