### PR TITLE
Maps and AMS conditional loading

### DIFF
--- a/app/views/enterprises/shop.html.haml
+++ b/app/views/enterprises/shop.html.haml
@@ -8,6 +8,10 @@
 - content_for :injection_data do
   - cache(*CacheService::FragmentCaching.ams_shop(@enterprise)) do
     = inject_enterprise_shopfront(@enterprise)
+  - cache(*CacheService::FragmentCaching.ams_all_taxons) do
+    = inject_taxons
+  - cache(*CacheService::FragmentCaching.ams_all_properties) do
+    = inject_properties
 
 %shop.darkswarm
   - if @shopfront_layout == 'embedded'

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -5,6 +5,9 @@
 - content_for(:image) do
   = @group.logo.url
 
+- content_for :scripts do
+  = render partial: "shared/google_maps_js"
+
 - content_for :injection_data do
   = inject_available_countries
   = inject_group_enterprises

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -9,6 +9,10 @@
   = inject_available_countries
   = inject_group_enterprises
   = inject_open_street_map_config
+  - cache(*CacheService::FragmentCaching.ams_all_taxons) do
+    = inject_taxons
+  - cache(*CacheService::FragmentCaching.ams_all_properties) do
+    = inject_properties
 
 #group-page.row.pad-top.footer-pad{"ng-controller" => "GroupPageCtrl"}
   .small-12.columns.pad-top

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -42,13 +42,10 @@
 
     - if Spree::Config.stripe_connect_enabled
       = render "shared/stripe_js"
-
-    - if !ContentConfig.open_street_map_enabled
-      %script{src: "//maps.googleapis.com/maps/api/js?libraries=places,geometry#{ ENV['GOOGLE_MAPS_API_KEY'] ? '&key=' + ENV['GOOGLE_MAPS_API_KEY'] : ''} "}
-
     = javascript_include_tag "darkswarm/all"
     = javascript_include_tag "web/all"
     = render "layouts/i18n_script"
+
     = yield :scripts
 
     = inject_current_hub

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -54,10 +54,6 @@
     = inject_current_hub
     = inject_current_user
     = inject_rails_flash
-    - cache(*CacheService::FragmentCaching.ams_all_taxons) do
-      = inject_taxons
-    - cache(*CacheService::FragmentCaching.ams_all_properties) do
-      = inject_properties
     = inject_current_order
     = inject_currency_config
     = yield :injection_data

--- a/app/views/map/index.html.haml
+++ b/app/views/map/index.html.haml
@@ -5,5 +5,9 @@
   = inject_available_countries
   = inject_enterprise_shopfront_list
   = inject_open_street_map_config
+  - cache(*CacheService::FragmentCaching.ams_all_taxons) do
+    = inject_taxons
+  - cache(*CacheService::FragmentCaching.ams_all_properties) do
+    = inject_properties
 
 = render partial: "shared/map"

--- a/app/views/map/index.html.haml
+++ b/app/views/map/index.html.haml
@@ -1,6 +1,9 @@
 - content_for(:title) do
   = t :map_title
 
+- content_for :scripts do
+  = render partial: "shared/google_maps_js"
+
 - content_for :injection_data do
   = inject_available_countries
   = inject_enterprise_shopfront_list

--- a/app/views/producers/index.html.haml
+++ b/app/views/producers/index.html.haml
@@ -4,6 +4,10 @@
 - content_for :injection_data do
   - cache @enterprises do
     = inject_enterprises(@enterprises)
+  - cache(*CacheService::FragmentCaching.ams_all_taxons) do
+    = inject_taxons
+  - cache(*CacheService::FragmentCaching.ams_all_properties) do
+    = inject_properties
 
 .producers{"ng-controller" => "EnterprisesCtrl", "ng-cloak" => true}
   .row

--- a/app/views/producers/index.html.haml
+++ b/app/views/producers/index.html.haml
@@ -1,6 +1,9 @@
 - content_for(:title) do
   = t :producers_title
 
+- content_for :scripts do
+  = render partial: "shared/google_maps_js"
+
 - content_for :injection_data do
   - cache @enterprises do
     = inject_enterprises(@enterprises)

--- a/app/views/registration/index.html.haml
+++ b/app/views/registration/index.html.haml
@@ -1,6 +1,9 @@
 - content_for(:title) do
   = t :register_title
 
+- content_for :scripts do
+  = render partial: "shared/google_maps_js"
+
 - content_for :injection_data do
   = inject_spree_api_key
   = inject_available_countries

--- a/app/views/shared/_google_maps_js.html.haml
+++ b/app/views/shared/_google_maps_js.html.haml
@@ -1,0 +1,2 @@
+- if !ContentConfig.open_street_map_enabled
+  %script{src: "//maps.googleapis.com/maps/api/js?libraries=places,geometry#{ ENV['GOOGLE_MAPS_API_KEY'] ? '&key=' + ENV['GOOGLE_MAPS_API_KEY'] : ''} "}

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -1,6 +1,9 @@
 - content_for(:title) do
   = t :shops_title
 
+- content_for :scripts do
+  = render partial: "shared/google_maps_js"
+
 - content_for :injection_data do
   - cache(*CacheService::FragmentCaching.ams_shops) do
     = inject_enterprises(@enterprises)

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -4,6 +4,10 @@
 - content_for :injection_data do
   - cache(*CacheService::FragmentCaching.ams_shops) do
     = inject_enterprises(@enterprises)
+  - cache(*CacheService::FragmentCaching.ams_all_taxons) do
+    = inject_taxons
+  - cache(*CacheService::FragmentCaching.ams_all_properties) do
+    = inject_properties
 
 #panes
   #shops.pane


### PR DESCRIPTION
#### What? Why?

For the Google Maps Javascript and all the Taxons and Properties AMS data; loads/injects them only on the pages where they're used, instead of all pages.

#### What should we test?
<!-- List which features should be tested and how. -->

A quick check of the Geocoding when searching enterprises in the `/shops` page would be good. Also things like properties filters when searching for enterprises in `/shops` and searching for products in `/shop`.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved efficiency of loading AMS data and external maps scripts

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes