### PR TITLE
Order cycle navigation fix

### DIFF
--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -10,6 +10,9 @@ Openfoodnetwork::Application.routes.draw do
     end
 
     resources :bulk_line_items
+    
+    # Redirect html requests for show path to edit path
+    get '/order_cycles/:id', to: redirect('/admin/order_cycles/%{id}/edit'), constraints: { format: 'html' }
 
     resources :order_cycles do
       post :bulk_update, on: :collection, as: :bulk_update


### PR DESCRIPTION
#### What? Why?

Closes #6943 

Manually navigating to an order cycle was throwing a server error.  Router-level redirection added to redirect from `/order_cycles/:id`, to:  `/order_cycles/:id/edit`, for html requests.

