### PR TITLE
Handle select/unselect all orders in the admin orders page

### DIFF
--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -32,7 +32,7 @@
   %thead
     %tr
       %th
-        %input{type: 'checkbox', 'ng-click' => 'toggleAll()', 'ng-model' => 'select_all'}
+        %input{type: 'checkbox', 'ng-change' => 'toggleAll()', 'ng-model' => 'select_all'}
       %th
         = t(:products_distributor)
         %th

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -62,6 +62,25 @@ feature '
       expect(page).to_not have_content order4.number
     end
 
+    context "select/unselect all orders" do
+      scenario "by clicking on the checkbox in the table header" do
+        order2 = create(:order_with_credit_payment, user: user, distributor: distributor,
+                  order_cycle: order_cycle)
+        order3 = create(:order_with_credit_payment, user: user, distributor: distributor,
+                  order_cycle: order_cycle)
+        order4 = create(:order_with_credit_payment, user: user, distributor: distributor,
+                  order_cycle: order_cycle)
+
+        login_as_admin_and_visit spree.admin_orders_path
+        # select all orders
+        page.find("#listing_orders thead th:first-child input[type=checkbox]").click
+        expect(page.find("#listing_orders tbody tr td:first-child input[type=checkbox]")).to be_checked
+        # unselect all orders
+        page.find("#listing_orders thead th:first-child input[type=checkbox]").click
+        expect(page.find("#listing_orders tbody tr td:first-child input[type=checkbox]")).to_not be_checked
+      end
+    end
+
     context "with a capturable order" do
       before do
         order.finalize! # ensure order has a payment to capture


### PR DESCRIPTION
#### What? Why?

Closes #8087


_Technical explanation_: Change `ng-click` to `ng-change` to capture `ng-model` updated value & create a feature test for this feature
![2021-08-20 15 20 47](https://user-images.githubusercontent.com/296452/130239627-dfdca07b-d20d-4575-958a-7273dc45d264.gif)


#### What should we test?
As admin

1. Visit the /orders page
2. Check the top-left check box , see that all orders are selected
3. Un-check the top-left check box, see that orders are all unselected


#### Release notes
Handle the select/unselect all orders in the /admin/orders page with the checkbox.

Changelog Category: User facing changes


