### PR TITLE
Skip some before_actions when processing payment intent from Stripe

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -161,13 +161,12 @@ class CheckoutController < ::BaseController
   def valid_payment_intent_provided?
     return false unless params["payment_intent"]&.starts_with?("pi_")
 
-    return false unless @payment = Spree::Payment.where(
+    return false unless payment = Spree::Payment.where(
       response_code: params["payment_intent"],
       state: "requires_authorization"
     ).first
 
-    @order ||= @payment.order
-    @order.state == "payment" && @payment.order == @order
+    payment.order.state == "payment"
   end
 
   def handle_redirect_from_stripe

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -149,11 +149,12 @@ class CheckoutController < ::BaseController
 
   def valid_payment_intent_provided?
     return false unless params["payment_intent"]&.starts_with?("pi_")
+    return false unless @order.state == "payment"
 
-    last_payment = OrderPaymentFinder.new(@order).last_payment
-    @order.state == "payment" &&
-      last_payment&.state == "requires_authorization" &&
-      last_payment&.response_code == params["payment_intent"]
+    @order.payments.where(
+      response_code: params["payment_intent"],
+      state: "requires_authorization"
+    ).present?
   end
 
   def handle_redirect_from_stripe

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -218,6 +218,30 @@ describe CheckoutController, type: :controller do
             get :edit, params: { payment_intent: "pi_123" }
           }.to change { Customer.count }.by(1)
         end
+
+        context "current_order_cycle is nil" do
+          before do
+            allow(controller).to receive(:current_order_cycle) { nil }
+          end
+
+          it "still processes the payment and completes the order" do
+            get :edit, params: { payment_intent: "pi_123" }
+            expect(order.completed?).to be true
+            expect(response).to redirect_to order_path(order)
+          end
+        end
+
+        context "current_distributor is nil" do
+          before do
+            allow(controller).to receive(:current_distributor) { nil }
+          end
+
+          it "still processes the payment and completes the order" do
+            get :edit, params: { payment_intent: "pi_123" }
+            expect(order.completed?).to be true
+            expect(response).to redirect_to order_path(order)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/7692

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
When returning from Stripe, we were previously checking for a `current_distributor` and `current_order_cycle`; we're able to process the payment intent without these, and we still check for other things, like the OrderCycle being open and there being sufficient stock. 


#### What should we test?
<!-- List which features should be tested and how. -->
I believe you could trigger this by changing your order cycle in a different window while SCA-authorizing the payment in another window; that's most likely not how the bug was happening in reality though. 


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fixed a bug where a payment could be taken in Stripe but not marked as complete in OFN
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
