### PR TITLE
Sets OC-times in relation to the Zone time

### DIFF
--- a/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
+++ b/spec/features/admin/order_cycles/complex_creating_specific_time_spec.rb
@@ -10,8 +10,8 @@ feature '
   include AuthenticationHelper
   include WebHelper
 
-  let(:order_cycle_opening_time) { Time.zone.local(2040, 11, 0o6, 0o6, 0o0, 0o0) }
-  let(:order_cycle_closing_time) { Time.zone.local(2040, 11, 13, 17, 0o0, 0o0) }
+  let(:order_cycle_opening_time) { 1.day.from_now(Time.zone.now) }
+  let(:order_cycle_closing_time) { 2.day.from_now(Time.zone.now) }
 
   scenario "creating an order cycle with full interface", js: true do
     # Given coordinating, supplying and distributing enterprises with some products with variants


### PR DESCRIPTION
#### What? Why?

Closes #8091
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Changes how OC times are defined and speeds up the spec (from 1 min -> ~20 sec, on my system).

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Sets OC times relative to the Zone time.
