### PR TITLE
Display variant quantity on the quantity column on the edit order page in backoffice

### DIFF
--- a/app/views/spree/admin/orders/_shipment_manifest.html.haml
+++ b/app/views/spree/admin/orders/_shipment_manifest.html.haml
@@ -10,8 +10,7 @@
       %td.item-price.align-center
         = line_item.single_money.to_html
       %td.item-qty-show.align-center
-        - item.states.each do |state,count|
-          = "#{count} x #{t(state.humanize.downcase, scope: [:spree, :shipment_states], default: [:missing, "none"])}"
+        = item.quantity
       - unless shipment.shipped?
         %td.item-qty-edit.hidden
           = quantity_field_tag(item)

--- a/spec/features/admin/order_spec.rb
+++ b/spec/features/admin/order_spec.rb
@@ -148,7 +148,7 @@ feature '
 
     expect(page).to_not have_content "Loading..."
     within("tr.stock-item", text: order.products.first.name) do
-      expect(page).to have_text("#{max_quantity} x")
+      expect(page).to have_text("#{max_quantity}")
     end
     expect(order.reload.line_items.first.quantity).to eq(max_quantity)
   end
@@ -169,7 +169,7 @@ feature '
     end
 
     within("tr.stock-item", text: order.products.first.name) do
-      expect(page).to have_text("1000 x")
+      expect(page).to have_text("1000")
     end
     expect(order.reload.line_items.first.quantity).to eq(1000)
   end
@@ -202,7 +202,7 @@ feature '
       expect(page).to have_selector("table.stock-contents")
 
       within("tr.stock-item") do
-        expect(page).to have_text("50 x")
+        expect(page).to have_text("50")
       end
 
       order = Spree::Order.last


### PR DESCRIPTION


#### What? Why?
This column was confused, and was understood like a simply quantity column not the item quantity separated according to its "state"

Closes #4582



#### What should we test?
As an admin, check that in the order products list (displayed in `/admin/orders/[ORDER_ID]/edit`) the column quantity is relevant and displays only the Quantity (yes, mindblowing) of the variant.

**Before**

<img width="957" alt="Capture d’écran 2021-08-27 à 14 17 54" src="https://user-images.githubusercontent.com/296452/131126639-91c32b36-217b-4d00-86e1-1c814f14eff7.png">

**After**
<img width="971" alt="Capture d’écran 2021-08-27 à 14 18 11" src="https://user-images.githubusercontent.com/296452/131126650-65a8dd97-bcd0-4e51-b77c-de0f33c02770.png">




#### Release notes
Display the variant quantity in its associated column when editing an order in the backoffice.

Changelog Category: Technical changes
