### PR TITLE
Eager load the EnterpriseRelationship :permissions association on the enterprise permissions page

### DIFF
--- a/app/controllers/admin/enterprise_relationships_controller.rb
+++ b/app/controllers/admin/enterprise_relationships_controller.rb
@@ -8,7 +8,7 @@ module Admin
         managed_by(spree_current_user).by_name
       @all_enterprises = Enterprise.includes(:shipping_methods, :payment_methods).by_name
       @enterprise_relationships = EnterpriseRelationship.
-        includes(:parent, :child).
+        includes(:parent, :child, :permissions).
         by_name.involving_enterprises @my_enterprises
     end
 


### PR DESCRIPTION
For #8028. This removes n+1 queries fetching the permissions for each `EnterpriseRelationship`.

Before:

```
Completed 200 OK in 529ms (Views: 351.5ms | ActiveRecord: 108.1ms | Allocations: 507757)
Completed 200 OK in 661ms (Views: 474.7ms | ActiveRecord: 110.5ms | Allocations: 515593)
Completed 200 OK in 510ms (Views: 339.1ms | ActiveRecord: 104.0ms | Allocations: 508074)
```

After:

```
Completed 200 OK in 368ms (Views: 261.5ms | ActiveRecord: 41.2ms | Allocations: 436223)
Completed 200 OK in 484ms (Views: 307.6ms | ActiveRecord: 53.9ms | Allocations: 443757)
Completed 200 OK in 374ms (Views: 266.1ms | ActiveRecord: 42.0ms | Allocations: 436234)
```

The `./spec/features/consumer/shopping/shopping_spec.rb:480` test failed in the [build](https://github.com/cillian/openfoodnetwork/runs/3442418752) but I don't think it's related.

#### What should we test?

Go to Admin > Enterprises > Permissions and check if it loads faster than before.

#### Release notes

Eager load the EnterpriseRelationship :permissions association on the enterprise permissions page

Changelog Category: User facing changes