### PR TITLE
Update Docker configuration to support sidekiq and webpacker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,16 +28,29 @@ services:
     depends_on:
       - db
       - redis
+      - webpack
     environment:
       OFN_DB_HOST: db
       OFN_REDIS_URL: redis://redis/
       OFN_REDIS_JOBS_URL: redis://redis
+      WEBPACKER_DEV_SERVER_HOST: webpack
     command: >
       bash -c "wait-for-it -t 30 db:5432 &&
                rm -f tmp/pids/server.pid &&
                (bundle check || bundle install)
                yarn install &&
                bundle exec rails s -p 3000 -b '0.0.0.0'"
+  webpack:
+    build: .
+    command: ./bin/webpack-dev-server
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - '3035:3035'
+    environment:
+      NODE_ENV: development
+      RAILS_ENV: development
+      WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
   worker:
     tty: true
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     command: >
       bash -c "wait-for-it -t 30 db:5432 &&
                (bundle check || bundle install)
-               bundle exec rake jobs:work"
+               bundle exec sidekiq -q mailers -q default"
 volumes:
   gems:
   postgres:


### PR DESCRIPTION
#### What? Why?

The Docker configuration was obsolete since we are using Sidekiq for jobs and Webpacker for Javascript bundle.
Let's update it then in order to setup Docker environment smoothly. 


#### What should we test?
We should just test that the Docker configuration is running properly locally. Just by using the `docker-compose run --build` command. More details about Docker can be find in the docker/DOCKER,md file.


#### Release notes
- Update Docker configuration to support webpacker and sidekiq

Changelog Category: Technical changes
