### PR TITLE
Line item descriptions

### DIFF
--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -39,6 +39,8 @@ module Spree
     before_destroy :update_inventory_before_destroy
     after_destroy :update_order
 
+    after_commit :persist_full_description, on: [:create, :update]
+
     delegate :product, :unit_description, :display_name, to: :variant
 
     attr_accessor :skip_stock_check, :target_shipment # Allows manual skipping of Stock::AvailabilityValidator
@@ -250,6 +252,10 @@ module Spree
       elsif variant.andand.unit_value.present?
         self.final_weight_volume = variant.andand.unit_value * quantity
       end
+    end
+
+    def persist_full_description
+      update_columns(full_description: full_name) if full_description.blank?
     end
   end
 end

--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -45,9 +45,9 @@ module VariantUnits
 
     # Used like "product.name - full_name", preferably using product_and_full_name method above.
     # This returns, for a product with name "Bread":
-    #     Bread - 1kg                     # if display_name blank
-    #     Bread - Spelt Sourdough, 1kg    # if display_name is "Spelt Sourdough, 1kg"
-    #     Bread - 1kg Spelt Sourdough     # if unit_to_display is "1kg Spelt Sourdough"
+    #     Bread - 1kg                     # if display_name blank and unit_to_display is "1kg"
+    #     Bread - Spelt Sourdough, 1kg    # if display_name is "Spelt Sourdough, 1kg" and unit_to_display is "1kg"
+    #     Bread - 1kg Spelt Sourdough     # if unit_to_display is "1kg Spelt Sourdough" and display_name is "1kg"
     #     Bread - Spelt Sourdough (1kg)   # if display_name is "Spelt Sourdough" and unit_to_display is "1kg"
     def full_name
       return unit_to_display if display_name.blank?

--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -27,7 +27,6 @@ module VariantUnits
 
     def presentation(option_value)
       return display_as if has_attribute?(:display_as) && display_as.present?
-
       return variant.display_as if variant_display_as?
 
       option_value.presentation
@@ -66,7 +65,6 @@ module VariantUnits
 
     def unit_to_display
       return display_as if has_attribute?(:display_as) && display_as.present?
-
       return variant.display_as if variant_display_as?
 
       options_text

--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -26,8 +26,6 @@ module VariantUnits
     end
 
     def presentation(option_value)
-      return option_value.presentation unless option_value.option_type.name == "unit_weight"
-
       return display_as if has_attribute?(:display_as) && display_as.present?
 
       return variant.display_as if variant_display_as?

--- a/db/migrate/20210829190419_add_full_description_to_line_items.rb
+++ b/db/migrate/20210829190419_add_full_description_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddFullDescriptionToLineItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_line_items, :full_description, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_203927) do
+ActiveRecord::Schema.define(version: 2021_08_29_190419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -496,6 +496,7 @@ ActiveRecord::Schema.define(version: 2021_06_17_203927) do
     t.decimal "distribution_fee", precision: 10, scale: 2
     t.decimal "final_weight_volume", precision: 10, scale: 2
     t.integer "tax_category_id"
+    t.string "full_description", limit: 255
     t.index ["order_id"], name: "index_line_items_on_order_id"
     t.index ["variant_id"], name: "index_line_items_on_variant_id"
   end


### PR DESCRIPTION
#### What? Why?

Adapts line item naming so that the `full_name` is persisted at database level when a line item is created.

#### The problem

In reports (and probably in the API) we need to display the `LineItem#full_name` attribute, but it's actually a convoluted _method_ that triggers 5 different queries and joins multiple tables, with branching conditionals in the app code that can't be translated into SQL.

If we're pulling that data in a reports context with a large dataset where we're showing (for example) 6000 line items, it would require instanciating +6000 objects, then triggering 6000 x 5 (30,000) additional queries just to show those fields, which are essentially just a string like `Carrots (500g)` :see_no_evil: 

#### Solutions

Instead if we persist that string in the line items table when a line item is created, then we can just fetch the value directly with no additional queries :+1:

The alternative options to this are: 
- a) don't ever show that field in any reports (untenable)
- b) try to replicate the output of that method via insanely complex SQL (I tried this and it's not viable).

If anyone has any ideas for a different approach, I'm all ears :smile:

This PR is step one of a two part process, step two involves a data migration.

#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
