### PR TITLE
Strip subdomains from session cookie host

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ env:
   TIMEZONE: UTC
   COVERAGE: true
   RSPEC_RETRY_RETRY_COUNT: 3
+  RAILS_ENV: test
 
 jobs:
   test-controllers-and-serializers:

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,7 @@ module Openfoodnetwork
       SessionCookieUpgrader, {
         old_key: "_session_id",
         new_key: "_ofn_session_id",
-        domain: "." + ENV["SITE_URL"].delete_prefix("www.")
+        domain: ".#{ENV['SITE_URL'].gsub(/^(www\.)|^(app\.)|^(staging\.)|^(stg\.)/, '')}"
       }
     ) if Rails.env.staging? || Rails.env.production?
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,9 +3,15 @@
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
+
+domain = if Rails.env.staging? || Rails.env.production?
+           ".#{ENV['SITE_URL'].gsub(/^(www\.)|^(app\.)|^(staging\.)|^(stg\.)/, '')}"
+         else
+           :all
+         end
+
 Openfoodnetwork::Application.config.session_store(
   :active_record_store,
   key: "_ofn_session_id",
-  domain: :all,
-  tld_length: 2
+  domain: domain
 )


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/8126

When migrating session cookies, the domain should be used without the subdomain. `www.` was being stripped correctly, but other prefixes like `staging.` where not, so the session was broken in staging.

#### What should we test?
<!-- List which features should be tested and how. -->

Login should work in staging. For a proper test you should stage a version of master prior to #8090 and manually delete whatever session cookies are present, then follow the testing steps from #8090, making sure you start with a cookie labelled `_session_id`, then stage this PR.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Adjusted session cookie migration

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes