### PR TITLE
6942 fix payment method fee bug

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -7,6 +7,7 @@ module Spree
       before_action :load_data
       before_action :validate_payment_method_provider, only: [:create]
       before_action :load_hubs, only: [:new, :edit, :update]
+      before_action :validate_calculator_preferred_amount, only: [:update]
 
       respond_to :html
 
@@ -172,6 +173,16 @@ module Spree
 
           params_for_update
         end
+      end
+
+      def validate_calculator_preferred_amount
+        preferred_amount = params.dig(:payment_method_check, :calculator_attributes,
+                                      :preferred_amount)
+        return if preferred_amount.nil? || Float(preferred_amount,
+                                                 exception: false)
+
+        flash[:error] = I18n.t(:calculator_preferred_amount_error)
+        redirect_to spree.edit_admin_payment_method_path(@payment_method)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2308,6 +2308,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   calculator_values: "Calculator values"
   calculator_settings_warning: "If you are changing the calculator type, you must save first before you can edit the calculator settings"
   calculator_preferred_unit_error: "must be kg or lb"
+  calculator_preferred_amount_error: "Invalid input. Please use only numbers. For example: 10, 5.5, -20"
   flat_percent_per_item: "Flat Percent (per item)"
   flat_rate_per_item: "Flat Rate (per item)"
   flat_rate_per_order: "Flat Rate (per order)"


### PR DESCRIPTION
#### What? Why?

Related to #6942

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This validates the payment method fee and shows a flash message to the user if they input a value that isn't a number.

#### What should we test?
<!-- List which features should be tested and how. -->
Edit a cash payment method and set the payment method fee to be a non-number value like 'hello' and try to submit the form.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Validate payment method  fee input
<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes