### PR TITLE
Only shows order that actually have at least one line_item V2

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -106,6 +106,10 @@ module Spree
     before_save :update_payment_fees!, if: :complete?
 
     # -- Scopes
+    scope :not_empty, -> {
+      joins(:line_items).group(:id).having("count(spree_line_items.id) > 0")
+    }
+
     scope :managed_by, lambda { |user|
       if user.has_spree_role?('admin')
         where(nil)

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -107,7 +107,7 @@ module Spree
 
     # -- Scopes
     scope :not_empty, -> {
-      joins(:line_items).group(:id).having("count(spree_line_items.id) > 0")
+      left_outer_joins(:line_items).where.not(spree_line_items: { id: nil })
     }
 
     scope :managed_by, lambda { |user|

--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -23,7 +23,8 @@ class SearchOrders
   end
 
   def search_query
-    base_query = ::Permissions::Order.new(current_user).editable_orders
+    base_query = ::Permissions::Order.new(current_user).editable_orders.not_empty
+
     return base_query unless params[:shipping_method_id]
 
     base_query

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -144,15 +144,18 @@ feature '
         completed_at: 1.day.ago,
         line_items_count: 1
       )
+      empty_order = create(:order, distributor: distributor, order_cycle: order_cycle)
       login_as_admin_and_visit spree.admin_orders_path
       expect(page).to have_content complete_order.number
       expect(page).to have_no_content incomplete_order.number
+      expect(page).to have_no_content empty_order.number
 
       uncheck 'Only show complete orders'
       page.find('a.icon-search').click
 
       expect(page).to have_content complete_order.number
       expect(page).to have_content incomplete_order.number
+      expect(page).to have_no_content empty_order.number
     end
   end
 

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -119,7 +119,7 @@ feature '
 
   context "with incomplete order" do
     scenario "can edit order" do
-      incomplete_order = create(:order, distributor: distributor, order_cycle: order_cycle)
+      incomplete_order = create(:order_with_line_items, distributor: distributor, order_cycle: order_cycle, line_items_count: 1)
 
       login_as_admin_and_visit spree.admin_orders_path
       uncheck 'Only show complete orders'
@@ -133,15 +133,16 @@ feature '
 
   context "test the 'Only show the complete orders' checkbox" do
     scenario "display or not incomplete order" do
-      incomplete_order = create(:order, distributor: distributor, order_cycle: order_cycle)
+      incomplete_order = create(:order_with_line_items, distributor: distributor, order_cycle: order_cycle, line_items_count: 1)
       complete_order = create(
-        :order,
+        :order_with_line_items,
         distributor: distributor,
         order_cycle: order_cycle,
         user: user,
         state: 'complete',
         payment_state: 'balance_due',
-        completed_at: 1.day.ago
+        completed_at: 1.day.ago,
+        line_items_count: 1
       )
       login_as_admin_and_visit spree.admin_orders_path
       expect(page).to have_content complete_order.number

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -849,6 +849,16 @@ describe Spree::Order do
         expect(Spree::Order.not_state(:canceled)).not_to include o
       end
     end
+
+    describe "not_empty" do
+      let!(:order_with_line_items) { create(:order_with_line_items, line_items_count: 1) }
+      let!(:order_without_line_items) { create(:order) }
+
+      it "returns only orders which have line items" do
+        expect(Spree::Order.not_empty).to include order_with_line_items
+        expect(Spree::Order.not_empty).to_not include order_without_line_items
+      end
+    end
   end
 
   describe "sending confirmation emails" do

--- a/spec/requests/api/orders_spec.rb
+++ b/spec/requests/api/orders_spec.rb
@@ -51,6 +51,10 @@ describe 'api/v0/orders', type: :request do
           }
           let!(:li4) { create(:line_item_with_shipment, order: order_dist_1_credit_owed) }
 
+          let!(:order_empty) {
+            create(:order_with_line_items, line_items_count: 0)
+          }
+
           let(:user) { order_dist_1.distributor.owner }
           let(:'X-Spree-Token') do
             user.generate_spree_api_key!

--- a/spec/requests/api/orders_spec.rb
+++ b/spec/requests/api/orders_spec.rb
@@ -38,15 +38,18 @@ describe 'api/v0/orders', type: :request do
           let!(:order_dist_1) {
             create(:order_with_distributor, email: "specific_name@example.com")
           }
+          let!(:li1) { create(:line_item, order: order_dist_1) }
           let!(:order_dist_2) { create(:order_with_totals_and_distribution) }
+          let!(:li2) { create(:line_item, order: order_dist_2) }
           let!(:order_dist_1_complete) {
-            create(:order, distributor: order_dist_1.distributor, state: 'complete',
-                           completed_at: Time.zone.today - 7.days)
+            create(:completed_order_with_totals,  distributor: order_dist_1.distributor, state: 'complete',
+                                                  completed_at: Time.zone.today - 7.days, line_items_count: 1)
           }
           let!(:order_dist_1_credit_owed) {
             create(:order, distributor: order_dist_1.distributor, payment_state: 'credit_owed',
                            completed_at: Time.zone.today)
           }
+          let!(:li4) { create(:line_item_with_shipment, order: order_dist_1_credit_owed) }
 
           let(:user) { order_dist_1.distributor.owner }
           let(:'X-Spree-Token') do

--- a/spec/services/search_orders_spec.rb
+++ b/spec/services/search_orders_spec.rb
@@ -7,6 +7,7 @@ describe SearchOrders do
   let!(:order1) { create(:order_with_line_items, distributor: distributor, line_items_count: 3) }
   let!(:order2) { create(:order_with_line_items, distributor: distributor, line_items_count: 2) }
   let!(:order3) { create(:order_with_line_items, distributor: distributor, line_items_count: 1) }
+  let!(:order_empty) { create(:order, distributor: distributor) }
 
   let(:enterprise_user) { distributor.owner }
 

--- a/spec/services/search_orders_spec.rb
+++ b/spec/services/search_orders_spec.rb
@@ -16,7 +16,7 @@ describe SearchOrders do
     let(:service) { SearchOrders.new(params, enterprise_user) }
 
     it 'returns orders' do
-      expect(service.orders.count.length).to eq 3
+      expect(service.orders.count).to eq 3
     end
   end
 end

--- a/spec/services/search_orders_spec.rb
+++ b/spec/services/search_orders_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 describe SearchOrders do
   let!(:distributor) { create(:distributor_enterprise) }
-  let!(:order1) { create(:order, distributor: distributor) }
-  let!(:order2) { create(:order, distributor: distributor) }
-  let!(:order3) { create(:order, distributor: distributor) }
+  let!(:order1) { create(:order_with_line_items, distributor: distributor, line_items_count: 3) }
+  let!(:order2) { create(:order_with_line_items, distributor: distributor, line_items_count: 2) }
+  let!(:order3) { create(:order_with_line_items, distributor: distributor, line_items_count: 1) }
 
   let(:enterprise_user) { distributor.owner }
 
@@ -15,7 +15,7 @@ describe SearchOrders do
     let(:service) { SearchOrders.new(params, enterprise_user) }
 
     it 'returns orders' do
-      expect(service.orders.count).to eq 3
+      expect(service.orders.count.length).to eq 3
     end
   end
 end


### PR DESCRIPTION
#### What? Why?
Filter inside the API to shows only orders that have at least one line items
Closes #5236


This PR modify the API contract.
~~This PR should be compared to #8147~~



#### What should we test?

As an admin, go to `/admin/orders`, you should not be able to see empty (ie. with no line items) orders.



#### Release notes

 - Remove empty orders from `/admin/orders` interface
 - Do not sent empty orders from `/api/v0/orders.json`
Empty orders are defined as orders that don't have at lease one item.

Changelog Category: User facing changes & Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
