### PR TITLE
update profile link based on enterprise profile

### DIFF
--- a/app/helpers/enterprises_helper.rb
+++ b/app/helpers/enterprises_helper.rb
@@ -100,4 +100,12 @@ module EnterprisesHelper
   def subscriptions_enabled?
     spree_current_user.admin? || spree_current_user.enterprises.where(enable_subscriptions: true).any?
   end
+
+  def enterprise_url_selector(enterprise)
+    if enterprise.is_distributor
+      main_app.enterprise_shop_url(enterprise)
+    else
+      main_app.producers_url
+    end
+  end
 end

--- a/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
@@ -40,18 +40,11 @@
         %span.icon-user
         = t "your_profil_live"
     .list
-      - if @enterprise.sells == "none"
-        %a.button.bottom{href: main_app.producers_url, target: '_blank'}
-          = t "see"
-          = @enterprise.name
-          = t "live"
-          %span.icon-arrow-right
-      - else
-        %a.button.bottom{href: main_app.enterprise_shop_url(@enterprise), target: '_blank'}
-          = t "see"
-          = @enterprise.name
-          = t "live"
-          %span.icon-arrow-right
+      %a.button.bottom{href: enterprise_url(@enterprise), target: '_blank'}
+        = t "see"
+        = @enterprise.name
+        = t "live"
+        %span.icon-arrow-right
 
   .eight.columns.omega.dashboard_item.single-ent#edit
     .header

--- a/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
@@ -40,11 +40,18 @@
         %span.icon-user
         = t "your_profil_live"
     .list
-      %a.button.bottom{href: main_app.enterprise_shop_url(@enterprise), target: '_blank'}
-        = t "see"
-        = @enterprise.name
-        = t "live"
-        %span.icon-arrow-right
+      - if @enterprise.sells == "none"
+        %a.button.bottom{href: main_app.producers_url, target: '_blank'}
+          = t "see"
+          = @enterprise.name
+          = t "live"
+          %span.icon-arrow-right
+      - else
+        %a.button.bottom{href: main_app.enterprise_shop_url(@enterprise), target: '_blank'}
+          = t "see"
+          = @enterprise.name
+          = t "live"
+          %span.icon-arrow-right
 
   .eight.columns.omega.dashboard_item.single-ent#edit
     .header

--- a/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
@@ -40,7 +40,7 @@
         %span.icon-user
         = t "your_profil_live"
     .list
-      %a.button.bottom{href: enterprise_url(@enterprise), target: '_blank'}
+      %a.button.bottom{href: enterprise_url_selector(@enterprise), target: '_blank'}
         = t "see"
         = @enterprise.name
         = t "live"


### PR DESCRIPTION
#### What? Why?

Closes #6140
**OLD:** When user clicks "See [ENTERPRISE] live" button on admin page, if enterprise has no shop and it is only producer, old version was directing the user to shop list (which was giving error. 
**NEW:** With this change, if user sells nothing, the user is directed to producer list (instead of shop list)


#### What should we test?
<!-- List which features should be tested and how. -->


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
User is redirected to correct page based on enterprise profile (only producer or has shop)

Changelog Category: User facing changes



#### Dependencies
not applicable

#### Documentation updates
not applicable
