### PR TITLE
Show order total in Delivery/Payment Method reports instead of first …

### DIFF
--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -95,7 +95,7 @@ module OpenFoodNetwork
        ba&.phone,
        order.shipping_method&.name,
        order.payments.first&.payment_method&.name,
-       order.payments.first&.amount,
+       order.total,
        balance(order)]
     end
 
@@ -110,7 +110,7 @@ module OpenFoodNetwork
        sa.phone,
        order.shipping_method&.name,
        order.payments.first&.payment_method&.name,
-       order.payments.first&.amount,
+       order.total,
        balance(order),
        has_temperature_controlled_items?(order),
        order.special_instructions]

--- a/spec/lib/open_food_network/order_cycle_management_report_spec.rb
+++ b/spec/lib/open_food_network/order_cycle_management_report_spec.rb
@@ -173,7 +173,7 @@ module OpenFoodNetwork
                                                 order.billing_address.phone,
                                                 order.shipment.shipping_method.name,
                                                 nil,
-                                                nil,
+                                                order.total,
                                                 -order.total
                                               ]])
           end
@@ -200,7 +200,7 @@ module OpenFoodNetwork
                                                 order.ship_address.phone,
                                                 order.shipment.shipping_method.name,
                                                 nil,
-                                                nil,
+                                                order.total,
                                                 -order.total,
                                                 false,
                                                 order.special_instructions


### PR DESCRIPTION
…payment

#### What? Why?

Closes #8019

In this PR I make it so that in Order Cycle Management reports, under the amount column, the order **TOTAL** is shown. Previously it was the **FIRST** payment in `admin/orders/{order_id}/payments` being shown.



#### What should we test?
- After order is edited and order total is changed, it should be reflected in Order Cycle Management reports under Amount column.

#### Release notes
- Updated Order Cycle Management reports to show order total.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
