### PR TITLE
Migrate Pin gateway payments to Check

### DIFF
--- a/db/migrate/20210910085912_migrate_pin_payment_to_cash.rb
+++ b/db/migrate/20210910085912_migrate_pin_payment_to_cash.rb
@@ -1,0 +1,5 @@
+class MigratePinPaymentToCash < ActiveRecord::Migration[6.1]
+  def change
+    execute "UPDATE spree_payment_methods SET type = 'Spree::PaymentMethod::Check' WHERE type = 'Spree::Gateway::Pin'"
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #7799 

Migrates Spree::Gateway::Pin to Spree::PaymentMethod::Check so that EnterpriseFee Summary does not throw a 500 error when a payment type = Spree::Gateway::Pin is encountered. 


#### What should we test?
- Test if enterprise fee reports work.
- Before staging, check that at least one Pin payment method exists. After running this migration, there should be no Pin payment methods. 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
