### PR TITLE
Avoid rounded with float numbers errors with javascript

### DIFF
--- a/app/assets/javascripts/admin/products/services/option_value_namer.js.coffee
+++ b/app/assets/javascripts/admin/products/services/option_value_namer.js.coffee
@@ -48,7 +48,7 @@ angular.module("admin.products").factory "OptionValueNamer", (VariantUnitManager
     option_value_value_unit_scaled: ->
       [unit_scale, unit_name] = @scale_for_unit_value()
 
-      value = @variant.unit_value / unit_scale
+      value = Math.round((@variant.unit_value / unit_scale) * 100) / 100
 
       [value, unit_name]
 

--- a/spec/javascripts/unit/admin/services/option_value_namer_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/option_value_namer_spec.js.coffee
@@ -97,6 +97,13 @@ describe "Option Value Namer", ->
           p.variant_unit_scale = scale
           v.unit_value = 100 * scale
           expect(namer.option_value_value_unit()).toEqual [100, unit]
+      
+      it "generates right values for volume with rounded values", ->
+        unit = 'L'
+        p.variant_unit = 'volume'
+        p.variant_unit_scale = 1.0
+        v.unit_value = 0.7
+        expect(namer.option_value_value_unit()).toEqual [700, 'mL']
 
       it "chooses the correct scale when value is very small", ->
         p.variant_unit = 'volume'


### PR DESCRIPTION

#### What? Why?

Closes #7504

As `0.7/0.001 = 699.9999999999999`, use `Math.round()` to avoid this.



#### What should we test?
 1. As an admin, go to `/admin/products/new`
 2. Choose `L` as Unit Size
 3. Enter `0.7` in `Value` field
 4. See that `Display as` field is well filled: 
<img width="1039" alt="Capture d’écran 2021-09-14 à 10 47 02" src="https://user-images.githubusercontent.com/296452/133226269-275676df-339c-4831-80bb-59664148fe9f.png">




#### Release notes
Resolve some rounded issue when creating a product.

Changelog Category: User facing changes 



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
