### PR TITLE
Fix order_path issue in cart page

### DIFF
--- a/app/helpers/spree/orders_helper.rb
+++ b/app/helpers/spree/orders_helper.rb
@@ -30,7 +30,7 @@ module Spree
     end
 
     def changeable_orders_link_path
-      changeable_orders.one? ? order_path(changeable_orders.first) : spree.account_path
+      changeable_orders.one? ? main_app.order_path(changeable_orders.first) : spree.account_path
     end
 
     def shop_changeable_orders_alert_html

--- a/spec/features/consumer/shopping/cart_spec.rb
+++ b/spec/features/consumer/shopping/cart_spec.rb
@@ -315,6 +315,16 @@ feature "full-page cart", js: true do
         expect(page).to have_no_content item1.variant.name
         expect(page).to have_content item2.variant.name
       end
+
+      context "with a single editable order" do # Regression test for #8191
+        before do
+          prev_order2.destroy
+        end
+
+        it "doesn't throw an error" do
+          expect{ visit main_app.cart_path }.to_not raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #8191

The `order_path` route wasn't being inferred correctly from this Spree controller, causing fatal errors to be thrown when rendering the cart page if the number of editable orders (for the current user, with the current hub) was precisely **one**.

```
ActionView::Template::Error: undefined method `order_path'
```

#### What should we test?
<!-- List which features should be tested and how. -->

Quick test of the reproducible steps in https://github.com/openfoodfoundation/openfoodnetwork/issues/8191

I've also added a regression test that fails before this change and succeeds after.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed a cart display issue where hubs allow editable orders

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
