### PR TITLE
Fix infinite loop when printing invoices for orders not in completed

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -84,8 +84,7 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, $timeout, Reque
     $scope.selected_orders.length = 0
     $scope.orders.forEach (order) ->
       $scope.checkboxes[order.id] = $scope.select_all
-      if $scope.select_all && order.state == "complete"
-        $scope.selected_orders.push order.id
+      $scope.selected_orders.push order.id if $scope.select_all
 
   $scope.$watch 'sortOptions', (sort) ->
     return unless sort && sort.predicate != ""

--- a/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/orders_controller.js.coffee
@@ -84,7 +84,8 @@ angular.module("admin.orders").controller "ordersCtrl", ($scope, $timeout, Reque
     $scope.selected_orders.length = 0
     $scope.orders.forEach (order) ->
       $scope.checkboxes[order.id] = $scope.select_all
-      $scope.selected_orders.push order.id if $scope.select_all
+      if $scope.select_all && order.state == "complete"
+        $scope.selected_orders.push order.id
 
   $scope.$watch 'sortOptions', (sort) ->
     return unless sort && sort.predicate != ""

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -23,8 +23,14 @@
   = render partial: 'per_page_controls'
 
   - if Spree::Config[:enable_invoices?]
-    %button.invoices-modal{'ng-controller' => 'bulkInvoiceCtrl', 'ng-click' => 'createBulkInvoice()', 'ng-disabled' => 'selected_orders.length == 0'}
+    %button.invoices-modal{'ng-controller' => 'bulkInvoiceCtrl', 'ng-click' => 'createBulkInvoice()', 'ng-disabled' => 'selected_orders.length == 0 || !q.completed_at_not_null'}
       = t('.print_invoices')
+      %question-mark-with-tooltip{"question-mark-with-tooltip": "_",
+      "question-mark-with-tooltip-append-to-body": "true",
+      "question-mark-with-tooltip-placement": "top",
+      "question-mark-with-tooltip-animation": true,
+      style: "margin-left: 5px",
+      key: "'js.admin.print_invoice_tooltip'"}
 
 %table#listing_orders.index.responsive{width: "100%", 'ng-init' => 'initialise()', 'ng-show' => "!RequestMonitor.loading && orders.length > 0" }
   %colgroup
@@ -49,7 +55,7 @@
   %tbody
     %tr{ng: {repeat: 'order in orders track by order.id', class: {even: "'even'", odd: "'odd'"}}, 'ng-class' => "{'state-{{order.state}}': true, 'row-loading': rowStatus[order.id] == 'loading'}"}
       %td.align-center
-        %input{type: 'checkbox', 'ng-model' => 'checkboxes[order.id]', 'ng-change' => 'toggleSelection(order.id)', 'ng-hide' => 'order.state != "complete"'}
+        %input{type: 'checkbox', 'ng-model' => 'checkboxes[order.id]', 'ng-change' => 'toggleSelection(order.id)'}
       %td.align-center
         {{order.distributor_name}}
       %td.align-center

--- a/app/views/spree/admin/orders/index.html.haml
+++ b/app/views/spree/admin/orders/index.html.haml
@@ -49,7 +49,7 @@
   %tbody
     %tr{ng: {repeat: 'order in orders track by order.id', class: {even: "'even'", odd: "'odd'"}}, 'ng-class' => "{'state-{{order.state}}': true, 'row-loading': rowStatus[order.id] == 'loading'}"}
       %td.align-center
-        %input{type: 'checkbox', 'ng-model' => 'checkboxes[order.id]', 'ng-change' => 'toggleSelection(order.id)'}
+        %input{type: 'checkbox', 'ng-model' => 'checkboxes[order.id]', 'ng-change' => 'toggleSelection(order.id)', 'ng-hide' => 'order.state != "complete"'}
       %td.align-center
         {{order.distributor_name}}
       %td.align-center

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2708,6 +2708,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         Perhaps it has become unavailable or the shop is closing.
     admin:
       unit_price_tooltip: "The unit price increases transparency by allowing your customers to easily compare prices between different products and packaging sizes. Note, that the final unit price displayed in the shopfront might differ as it is includes taxes & fees."
+      print_invoice_tooltip: "Choose 'ONLY SHOW COMPLETE ORDERS' to enable bulk printing of invoices"
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
       modals:
         got_it: "Got it"


### PR DESCRIPTION
#### What? Why?

Closes #5708

**ISSUE:** If an order is not in completed state, the user can select the order with checkbox and click `Print Invoices` button. In this case, user see an endless-spinner.

**SOLUTION:** 
- **Single Selection Case**: If the order is not in completed state, the checkbox is hidden. 
- **Select All Case**: In `toggleAll` function, the order is not included in `selected_orders` so when user click select all checkbox, the order is not selected.

#### What should we test?

#### Release notes
Fixes the bug when user tries to print not completed orders

Changelog Category: User facing changes



#### Dependencies

#### Documentation updates
