### PR TITLE
Change visibilities of hubs on group page

### DIFF
--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -94,7 +94,8 @@
                   .small-12.columns
                     .active_table
                       %hub.active_table_node.row.animate-repeat{id: "{{hub.hash}}",
-                      "ng-repeat" => "hub in filteredEnterprises = (Enterprises.hubs | searchEnterprises:query | taxons:activeTaxons | shipping:shippingTypes | properties:activeProperties:'distributed_properties' | orderBy:['-active', '+orders_close_at'])",
+                      "ng-repeat" => "hub in filteredEnterprises = (Enterprises.hubs | searchEnterprises:query | taxons:activeTaxons | shipping:shippingTypes | properties:activeProperties:'distributed_properties' | orderBy:['+orders_close_at'])",
+                      "ng-if" => "hub.visible",
                       "ng-class" => "{'is_profile' : hub.category == 'hub_profile', 'closed' : !open(), 'open' : open(), 'inactive' : !hub.active, 'current' : current()}",
                       "ng-controller" => "HubNodeCtrl"}
                         .small-12.columns

--- a/spec/features/consumer/groups_spec.rb
+++ b/spec/features/consumer/groups_spec.rb
@@ -57,29 +57,54 @@ feature 'Groups', js: true do
     end
   end
 
-  describe "shops" do
+  describe "hubs" do
     describe "filtering by product property" do
-      let!(:group) { create(:enterprise_group, enterprises: [d1, d2], on_front_page: true) }
+      let!(:group) {
+        create(:enterprise_group, enterprises: [d1, d2, d3, d4], on_front_page: true)
+      }
       let!(:order_cycle) {
-        create(:simple_order_cycle, distributors: [d1, d2],
+        create(:simple_order_cycle, distributors: [d1, d2, d3],
+                                    coordinator: create(:distributor_enterprise))
+      }
+      let!(:closed_order_cycle) {
+        create(:closed_order_cycle, distributors: [d4],
                                     coordinator: create(:distributor_enterprise))
       }
       let(:producer) { create(:supplier_enterprise) }
-      let(:d1) { create(:distributor_enterprise, with_payment_and_shipping: true) }
-      let(:d2) { create(:distributor_enterprise, with_payment_and_shipping: true) }
+      let(:d1) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: true) }
+      let(:d2) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: true) }
+      let(:d3) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: false) }
+      let(:d4) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: true) }
       let(:p1) { create(:simple_product, supplier: producer) }
       let(:p2) { create(:simple_product, supplier: create(:supplier_enterprise)) }
+      let(:p3) { create(:simple_product, supplier: create(:supplier_enterprise)) }
+      let(:p4) { create(:simple_product, supplier: create(:supplier_enterprise)) }
       let(:ex_d1) { order_cycle.exchanges.outgoing.where(receiver_id: d1).first }
       let(:ex_d2) { order_cycle.exchanges.outgoing.where(receiver_id: d2).first }
+      let(:ex_d3) { order_cycle.exchanges.outgoing.where(receiver_id: d3).first }
+      let(:ex_d4) { closed_order_cycle.exchanges.outgoing.where(receiver_id: d4).first }
 
       before do
         producer.set_producer_property 'Organic', 'NASAA 12345'
         p2.set_property 'Local', 'XYZ 123'
+        p3.set_property 'Not vibsible', 'Not vibsible'
+        p4.set_property 'No active order cycle', 'No active order cycle'
 
         ex_d1.variants << p1.variants.first
         ex_d2.variants << p2.variants.first
+        ex_d3.variants << p3.variants.first
+        ex_d4.variants << p4.variants.first
 
         visit group_path(group, anchor: "/hubs")
+      end
+
+      it "adjusts visibilities of enterprises depending on their status" do
+        expect(page).to     have_css('hub', text: d1.name)
+        expect(page).to_not have_css('hub.inactive', text: d1.name)
+        expect(page).to     have_css('hub', text: d2.name)
+        expect(page).to_not have_css('hub.inactive', text: d2.name)
+        expect(page).to_not have_text d3.name
+        expect(page).to     have_css('hub.inactive', text: d4.name)
       end
 
       it "filters" do


### PR DESCRIPTION
#### What? Why?

Closes #5106

Hubs on group page for consumers are displayed unconditionally.
But they should only appear under the following conditions: Visible.

In addition, those that are active should only be filled with red color
when they have open order cycles.


#### What should we test?

- Enterprises whose visible attribute set to false, should not bi displayed.
- Enterprises which have open orders should be colored in red, other enterprises should not.


#### Release notes
Visibility of enterprise as a hub should more precisely reflect its status.

Changelog Category: User facing changes