### PR TITLE
Fix payment method fee bug for all calculator types

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -7,7 +7,7 @@ module Spree
       before_action :load_data
       before_action :validate_payment_method_provider, only: [:create]
       before_action :load_hubs, only: [:new, :edit, :update]
-      before_action :validate_calculator_preferred_amount, only: [:update]
+      before_action :validate_calculator_preferred_value, only: [:update]
 
       respond_to :html
 
@@ -177,13 +177,9 @@ module Spree
         end
       end
 
-      def validate_calculator_preferred_amount
-        preferred_amount = params.dig(:payment_method_check, :calculator_attributes,
-                                      :preferred_amount)
-        return if preferred_amount.nil? || Float(preferred_amount,
-                                                 exception: false)
+      def validate_calculator_preferred_value
 
-        flash[:error] = I18n.t(:calculator_preferred_amount_error)
+        flash[:error] = I18n.t(:calculator_preferred_value_error)
         redirect_to spree.edit_admin_payment_method_path(@payment_method)
       end
     end

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -157,11 +157,14 @@ module Spree
           call.to_h.with_indifferent_access
       end
 
+      def gateway_params
+        raw_params[ActiveModel::Naming.param_key(@payment_method)] || {}
+      end
+
       # Merge payment method params with gateway params like :gateway_stripe_connect
       # Also, remove password if present and blank
       def update_params
         @update_params ||= begin
-          gateway_params = raw_params[ActiveModel::Naming.param_key(@payment_method)] || {}
           params_for_update = base_params.merge(gateway_params)
 
           params_for_update.each do |key, value|

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -178,9 +178,28 @@ module Spree
       end
 
       def validate_calculator_preferred_value
+        return if calculator_preferred_values.all? do |value|
+          preferred_value_from_params = gateway_params.dig(:calculator_attributes, value)
+          preferred_value_from_params.nil? || Float(preferred_value_from_params,
+                                                    exception: false)
+        end
 
         flash[:error] = I18n.t(:calculator_preferred_value_error)
         redirect_to spree.edit_admin_payment_method_path(@payment_method)
+      end
+
+      def calculator_preferred_values
+        [
+          :preferred_amount,
+          :preferred_flat_percent,
+          :preferred_flat_percent,
+          :preferred_first_item,
+          :preferred_additional_item,
+          :preferred_max_items,
+          :preferred_normal_amount,
+          :preferred_discount_amount,
+          :preferred_minimal_amount
+        ]
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2322,7 +2322,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   calculator_values: "Calculator values"
   calculator_settings_warning: "If you are changing the calculator type, you must save first before you can edit the calculator settings"
   calculator_preferred_unit_error: "must be kg or lb"
-  calculator_preferred_amount_error: "Invalid input. Please use only numbers. For example: 10, 5.5, -20"
+  calculator_preferred_value_error: "Invalid input. Please use only numbers. For example: 10, 5.5, -20"
   flat_percent_per_item: "Flat Percent (per item)"
   flat_rate_per_item: "Flat Rate (per item)"
   flat_rate_per_order: "Flat Rate (per order)"


### PR DESCRIPTION
#### What? Why?

Related to #6942
Related to #8144
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

This will take care of validating the payment fee input for paypal and cash payment methods and all calculators.

#### What should we test?
<!-- List which features should be tested and how. -->
Input a non-number value in the fields of a payment method edit form and try to click on update. You should see a flash error message instead of a 500 error.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Validate payment method fee input for all calculator types

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes