### PR TITLE
Show orders with line items + finalized orders

### DIFF
--- a/app/services/search_orders.rb
+++ b/app/services/search_orders.rb
@@ -24,6 +24,7 @@ class SearchOrders
 
   def search_query
     base_query = ::Permissions::Order.new(current_user).editable_orders.not_empty
+                    .or(::Permissions::Order.new(current_user).editable_orders.finalized)
 
     return base_query unless params[:shipping_method_id]
 

--- a/spec/services/search_orders_spec.rb
+++ b/spec/services/search_orders_spec.rb
@@ -8,6 +8,8 @@ describe SearchOrders do
   let!(:order2) { create(:order_with_line_items, distributor: distributor, line_items_count: 2) }
   let!(:order3) { create(:order_with_line_items, distributor: distributor, line_items_count: 1) }
   let!(:order_empty) { create(:order, distributor: distributor) }
+  let!(:order_empty_but_complete) { create(:order, distributor: distributor, state: :complete) }
+  let!(:order_empty_but_canceled) { create(:order, distributor: distributor, state: :canceled) }
 
   let(:enterprise_user) { distributor.owner }
 
@@ -16,7 +18,10 @@ describe SearchOrders do
     let(:service) { SearchOrders.new(params, enterprise_user) }
 
     it 'returns orders' do
-      expect(service.orders.count).to eq 3
+      expect(service.orders.count).to eq 5
+      service.orders.each do |order|
+        expect(order.id).not_to eq(order_empty.id)
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #8221 

The aim of this PR is to return by the API (and then display in the `/admin/orders` interface) the following orders: 

 - the ones that contains at least one line item (whatever theirs state)
 - the _finalized_ orders. Ie. the orders with state : complete canceled resumed awaiting_return returned



#### What should we test?

1. Create an order
2. Delete all line items using BOM
3. see the order does not appear anymore on /admin/orders

Order with no line items _AND_ with state not finalized (ie. `address`, `cart`, `payment`) must not be display 



#### Release notes
In the `/admin/orders` display all the finalized orders and the not empty orders.

Changelog Category: User facing changes
