### PR TITLE
Allow AddressFinder to return nil bill/ship address

### DIFF
--- a/lib/open_food_network/address_finder.rb
+++ b/lib/open_food_network/address_finder.rb
@@ -66,11 +66,11 @@ module OpenFoodNetwork
     end
 
     def fallback_bill_address
-      last_used_bill_address&.clone || Spree::Address.default
+      last_used_bill_address&.clone
     end
 
     def fallback_ship_address
-      last_used_ship_address&.clone || Spree::Address.default
+      last_used_ship_address&.clone
     end
 
     def last_used_bill_address

--- a/spec/lib/open_food_network/address_finder_spec.rb
+++ b/spec/lib/open_food_network/address_finder_spec.rb
@@ -59,7 +59,7 @@ module OpenFoodNetwork
         before { allow(finder).to receive(:last_used_bill_address) { nil } }
 
         it "returns a new empty address" do
-          expect(finder.send(:fallback_bill_address)).to eq Spree::Address.default
+          expect(finder.send(:fallback_bill_address)).to eq nil
         end
       end
     end
@@ -79,8 +79,8 @@ module OpenFoodNetwork
       context "when no last_used_ship_address is found" do
         before { allow(finder).to receive(:last_used_ship_address) { nil } }
 
-        it "returns a new empty address" do
-          expect(finder.send(:fallback_ship_address)).to eq Spree::Address.default
+        it "returns nil" do
+          expect(finder.send(:fallback_ship_address)).to eq nil
         end
       end
     end


### PR DESCRIPTION
Previously it returned Spree::Address.default, which could not be saved without errors.

#### What? Why?

Closes #[the issue number this PR is related to]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
