### PR TITLE
Fix order dependent reports spec

### DIFF
--- a/spec/factories/country_factory.rb
+++ b/spec/factories/country_factory.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :country, class: Spree::Country do
-    iso_name { 'UNITED STATES' }
-    name { 'United States of America' }
-    iso { 'US' }
-    iso3 { 'USA' }
-    numcode { 840 }
+    iso_name { "AUSTRALIA" }
+    name { "Australia" }
+    iso { "AU" }
+    iso3 { "AUS" }
+    numcode { 36 }
   end
 end

--- a/spec/factories/state_factory.rb
+++ b/spec/factories/state_factory.rb
@@ -2,14 +2,8 @@
 
 FactoryBot.define do
   factory :state, class: Spree::State do
-    name { 'Alabama' }
-    abbr { 'AL' }
-    country do |country|
-      if usa = Spree::Country.find_by(numcode: 840)
-        country = usa
-      else
-        country.association(:country)
-      end
-    end
+    name { "Victoria" }
+    abbr { "Vic" }
+    country
   end
 end

--- a/spec/support/seeds.rb
+++ b/spec/support/seeds.rb
@@ -7,7 +7,7 @@
 # leaves them there when deleting the rest (see spec/spec_helper.rb).
 # You can add more entries here if you need them for your tests.
 
-if Spree::Country.where(nil).empty?
+if Spree::Country.where(name: "Australia").empty?
   Spree::Country.create!({ "name" => "Australia", "iso3" => "AUS", "iso" => "AU",
                            "iso_name" => "AUSTRALIA", "numcode" => "36" })
   country = Spree::Country.find_by(name: 'Australia')


### PR DESCRIPTION
#### What? Why?

Closes #8238

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Depending on the order of spec execution, it was possible that a factory
created the default state "Alabama" with the default country "USA"
instead of using the usual seed data of "Victoria" in "Australia". Some
specs rely on "Victoria" though and we now make sure that it's created
even if another spec created another country first.

In addition, I changed the default state and country created by factories to Victoria instead of Alabama.

#### What should we test?
<!-- List which features should be tested and how. -->

No further test.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Stabilised specs depending on the default country in the database.

