### PR TITLE
Migrate Migs to Check

### DIFF
--- a/db/migrate/20210927091723_update_migs_gateway_to_check.rb
+++ b/db/migrate/20210927091723_update_migs_gateway_to_check.rb
@@ -1,0 +1,5 @@
+class UpdateMigsGatewayToCheck < ActiveRecord::Migration[6.1]
+  def change
+    execute "UPDATE spree_payment_methods SET type = 'Spree::PaymentMethod::Check' WHERE type = 'Spree::Gateway::Migs'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_203927) do
+ActiveRecord::Schema.define(version: 2021_09_27_091723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
#### What? Why?

Related to #7799.

Updates all Migs payment method types to Check to prevent snail on running reports.

#### What should we test?

- Test if enterprise fee reports work.
- Before staging, check that at least one Migs payment method exists. After running this migration, there should be no Migs payment methods.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
