### PR TITLE
Remove Stripe Connect

### DIFF
--- a/db/migrate/20210927092807_migrate_stripe_account_owner_to_stripe_sca.rb
+++ b/db/migrate/20210927092807_migrate_stripe_account_owner_to_stripe_sca.rb
@@ -1,0 +1,17 @@
+class MigrateStripeAccountOwnerToStripeSca < ActiveRecord::Migration[6.1]
+  def up
+    replace_preferences_key("/spree/gateway/stripe_connect", "/spree/gateway/stripe_sca")
+  end
+
+  private
+
+  def replace_preferences_key(from_pattern, to_pattern)
+    updated_pref_key = "replace( pref.key, '" + from_pattern + "', '" + to_pattern + "')"
+    execute(
+      "UPDATE spree_preferences pref SET key = " + updated_pref_key + "
+        WHERE pref.key like '" + from_pattern + "%'
+          AND NOT EXISTS (SELECT 1 FROM spree_preferences existing_pref
+                           WHERE existing_pref.key = " + updated_pref_key + ")"
+    )
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #7869 

Removes Stripe connect from codebase with necessary migrations.


#### What should we test?

- It should not be possible to select StripeConnect to create new payment method.
- All StripeConnect payment methods type should be changed to StripeSCA
- All migrated StripeConnect payments should retain account owner.

#### Release notes

- Removed Stripe Connect payment method.

Changelog Category: User facing changes 
