### PR TITLE
Pin webpack packages to respective major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "karma-chrome-launcher": "~3.1.0",
     "karma-coffee-preprocessor": "~1.0.1",
     "karma-jasmine": "~0.3.8",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "~3"
   },
   "license": "AGPL-3.0",
   "dependencies": {
@@ -35,7 +35,7 @@
     "mrujs": "^0.4.13",
     "shortcut-buttons-flatpickr": "^0.3.1",
     "stimulus": "^2.0.0",
-    "webpack": "^4.46.0",
-    "webpack-cli": "^3.3.12"
+    "webpack": "~4",
+    "webpack-cli": "~3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12745,7 +12745,7 @@ webpack-assets-manifest@^3.1.1:
     tapable "^1.0.0"
     webpack-sources "^1.0.0"
 
-webpack-cli@^3.3.12:
+webpack-cli@^3.3.12, webpack-cli@~3:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.12.tgz#94e9ada081453cd0aa609c99e500012fd3ad2d4a"
   integrity sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==
@@ -12773,7 +12773,7 @@ webpack-dev-middleware@^3.7.2, webpack-dev-middleware@^3.7.3:
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
-webpack-dev-server@^3.11.2:
+webpack-dev-server@~3:
   version "3.11.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz#695ebced76a4929f0d5de7fd73fafe185fe33708"
   integrity sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==
@@ -12850,7 +12850,7 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4, webpack@^4.46.0:
+webpack@4, webpack@^4.46.0, webpack@~4:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==


### PR DESCRIPTION
#### What? Why?

Pins our Webpack-related packages to their major versions. Hopefully Dependabot will stop trying to bump them out of these ranges now...

Syntax reference: https://github.com/npm/node-semver#advanced-range-syntax

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
