### PR TITLE
Fix deprecation in Paperclip

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -28,3 +28,12 @@ if Paperclip::VERSION.to_f < 3.5
 else
   Rails.logger.warn "The Paperclip::GeometryDetector patch can now be removed."
 end
+
+module UpdatedUrlGenerator
+  def escape_url(url)
+    (url.respond_to?(:escape) ? url.escape : URI::Parser.new.escape(url)).
+      gsub(/(\/.+)\?(.+\.)/, '\1%3F\2')
+  end
+end
+
+Paperclip::UrlGenerator.prepend(UpdatedUrlGenerator)


### PR DESCRIPTION
#### What? Why?

Fixes the huge volume of `warning: URI.escape is obsolete` messages.

#### What should we test?
<!-- List which features should be tested and how. -->

No `warning: URI.escape is obsolete` messages in logs (including output in the test suite). Uploaded files like PDFs should work.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed URI#escape deprecation.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
