### PR TITLE
Bump aws-sdk to 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'oauth2', '~> 1.4.7' # Used for Stripe Connect
 gem 'pagy', '~> 4.11'
 
 gem 'angularjs-rails', '1.8.0'
-gem 'aws-sdk', '1.67.0'
+gem 'aws-sdk', '2.2.0'
 gem 'bugsnag'
 gem 'haml'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,11 +154,12 @@ GEM
     awesome_nested_set (3.4.0)
       activerecord (>= 4.0.0, < 7.0)
     awesome_print (1.9.2)
-    aws-sdk (1.67.0)
-      aws-sdk-v1 (= 1.67.0)
-    aws-sdk-v1 (1.67.0)
-      json (~> 1.4)
-      nokogiri (~> 1)
+    aws-sdk (2.2.0)
+      aws-sdk-resources (= 2.2.0)
+    aws-sdk-core (2.2.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.2.0)
+      aws-sdk-core (= 2.2.0)
     bcrypt (3.1.16)
     bigdecimal (3.0.2)
     bindex (0.8.1)
@@ -343,6 +344,7 @@ GEM
     immigrant (0.3.6)
       activerecord (>= 3.0)
     ipaddress (0.8.3)
+    jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -696,7 +698,7 @@ DEPENDENCIES
   angularjs-rails (= 1.8.0)
   awesome_nested_set
   awesome_print
-  aws-sdk (= 1.67.0)
+  aws-sdk (= 2.2.0)
   bigdecimal (= 3.0.2)
   bootsnap
   bugsnag


### PR DESCRIPTION
#### What? Why?

It looks like we can't quite bump to aws-sdk-v3 yet, but this might be a good intermediate step. It'll unblock upgrades on the `json` gem which will unblock other upgrades...

#### What should we test?
<!-- List which features should be tested and how. -->

Uploading (and showing) images hosted on S3 should work.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Bumped aws-sdk to 2.2.0

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
