### PR TITLE
Fix display of "inventory only" radio buttons

### DIFF
--- a/app/views/admin/enterprises/form/_inventory_settings.html.haml
+++ b/app/views/admin/enterprises/form/_inventory_settings.html.haml
@@ -12,8 +12,8 @@
 .row
   .alpha.eleven.columns
     .five.columns.alpha
-      = radio_button :enterprise, :preferred_product_selection_from_inventory_only, "0", { 'ng-model' => 'Enterprise.preferred_product_selection_from_inventory_only' }
+      = radio_button :enterprise, :preferred_product_selection_from_inventory_only, false
       = label :enterprise, :preferred_product_selection_from_inventory_only, t('.preferred_product_selection_from_inventory_only_yes')
     .six.columns.omega
-      = radio_button :enterprise, :preferred_product_selection_from_inventory_only, "1", { 'ng-model' => 'Enterprise.preferred_product_selection_from_inventory_only' }
+      = radio_button :enterprise, :preferred_product_selection_from_inventory_only, true
       = label :enterprise, :preferred_product_selection_from_inventory_only, t('.preferred_product_selection_from_inventory_only_no')

--- a/spec/features/admin/enterprises_spec.rb
+++ b/spec/features/admin/enterprises_spec.rb
@@ -183,6 +183,11 @@ feature '
     choose "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
     choose "enterprise_enable_subscriptions_true"
 
+    accept_alert do
+      click_link "Inventory Settings"
+    end
+    expect(page).to have_checked_field "enterprise_preferred_product_selection_from_inventory_only_false"
+
     click_button 'Update'
 
     expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully updated!')


### PR DESCRIPTION
#### What? Why?

Addresses UI issue described in https://github.com/openfoodfoundation/openfoodnetwork/issues/8256#issuecomment-931241157

Previously the two radio buttons were not showing which option was set; both options were blank even if one had been selected.

#### What should we test?
<!-- List which features should be tested and how. -->

When an inventory setting is set in the enterprise "Inventory Settings" tab, it should correctly show which setting is currently in use. Note: the default value is `false`.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed display of "inventory only" setting in enterprise edit page

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes