### PR TITLE
Fix sorting admin orders by total

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -12,7 +12,7 @@ module Spree
     include Balance
 
     searchable_attributes :number, :state, :shipment_state, :payment_state, :distributor_id,
-                          :order_cycle_id, :email
+                          :order_cycle_id, :email, :total
     searchable_associations :shipping_method, :bill_address
     searchable_scopes :complete, :incomplete
 

--- a/spec/controllers/api/v0/orders_controller_spec.rb
+++ b/spec/controllers/api/v0/orders_controller_spec.rb
@@ -21,18 +21,18 @@ module Api
       let!(:order_cycle2) { create(:simple_order_cycle, coordinator: coordinator2) }
       let!(:order1) do
         create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now,
-                       distributor: distributor, billing_address: create(:address) )
+                       distributor: distributor, billing_address: create(:address), total: 5.0)
       end
       let!(:order2) do
         create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now,
-                       distributor: distributor2, billing_address: create(:address) )
+                       distributor: distributor2, billing_address: create(:address), total: 10.0)
       end
       let!(:order3) do
         create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now,
-                       distributor: distributor, billing_address: create(:address) )
+                       distributor: distributor, billing_address: create(:address), total: 1.0 )
       end
       let!(:order4) do
-        create(:completed_order_with_fees, order_cycle: order_cycle2, distributor: distributor2)
+        create(:completed_order_with_fees, order_cycle: order_cycle2, distributor: distributor2, total: 15.0)
       end
       let!(:order5) { create(:order, state: 'cart', completed_at: nil) }
       let!(:line_item1) do
@@ -120,6 +120,19 @@ module Api
                       as: :json
 
           expect(json_response['orders']).to eq serialized_orders([order4, order3, order2, order1])
+        end
+      end
+
+      context 'sorting' do
+        before do
+          allow(controller).to receive(:spree_current_user) { admin_user }
+        end
+
+        it 'can sort orders by total' do
+          get :index, params: { q: { completed_at_not_null: true, s: 'total desc' } },
+              as: :json
+
+          expect(json_response['orders']).to eq serialized_orders([order4, order2, order1, order3])
         end
       end
 


### PR DESCRIPTION
#### What? Why?

Closes #8161 

- Bug: clicking on "Total" column on an admin table would not result in a sorted table.
- Validate bug: add new test on sorting orders.
- Solution: mark "Total" as a searchable field in backend api/v0/orders.


#### What should we test?
<!-- List which features should be tested and how. -->

1. Visit /admin/orders page
1. Click "Total" to check the rows are now sorted by "Total".
1. Option: select/de-select the "Show only complete orders option" to have more rows to test.




#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Fix sorting admin/orders by "Total"

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes


