### PR TITLE
When creating a product, preselect the supplier if there is only one

### DIFF
--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -9,5 +9,9 @@ module Admin
         {}
       end
     end
+
+    def select_only_item(size)
+      size == 1 ? 1 : nil
+    end
   end
 end

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -11,7 +11,7 @@
           = f.field_container :supplier do
             = f.label :supplier_id, t(".supplier")
             %span.required *
-            = f.collection_select(:supplier_id, @producers, :id, :name, {:include_blank => true}, {:class => "select2 fullwidth"})
+            = f.collection_select(:supplier_id, @producers, :id, :name, {:include_blank => true, :selected => select_only_item(@producers.size)}, {:class => "select2 fullwidth"})
             = f.error_message_on :supplier
         .eight.columns.omega
           = f.field_container :name do


### PR DESCRIPTION
#### What? Why?

Closes #8176

This is an enhancement to improve user experience. This change introduces the pre-selection of supplier if there is only one available during the product creation process.

#### What should we test?

#### Release notes
When creating a new product, pre-select the supplier if there is only one supplier

Changelog Category: User facing changes 