### PR TITLE
Ask checkboxes are removed from two pages

### DIFF
--- a/app/views/admin/customers/index.html.haml
+++ b/app/views/admin/customers/index.html.haml
@@ -71,9 +71,6 @@
             %th.bill_address{ 'ng-show' => 'columns.bill_address.visible' }=t('admin.customers.index.bill_address')
             %th.ship_address{ 'ng-show' => 'columns.ship_address.visible' }=t('admin.customers.index.ship_address')
             %th.balance{ 'ng-show' => 'columns.balance.visible' }=t('admin.customers.index.balance')
-            %th.actions
-              Ask?&nbsp;
-              %input{ :type => 'checkbox', 'ng-model' => "confirmDelete" }
         %tbody
           %tr.customer{ 'ng-repeat' => "customer in filteredCustomers = ( customers | filter:quickSearch | orderBy: sorting.predicate:sorting.reverse ) | limitTo:customerLimit track by customer.id", 'ng-class-even' => "'even'", 'ng-class-odd' => "'odd'", :id => "c_{{customer.id}}" }
             -# %td.bulk

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -154,9 +154,6 @@
             %th.price{ 'ng-show' => 'columns.price.visible' }
               = "#{t('admin.price')} (#{Spree::Money.currency_symbol})"
             %th.actions
-            %th.actions
-              = t("admin.orders.bulk_management.ask")
-              %input{ :type => 'checkbox', 'ng-model' => "confirmDelete" }
 
         %tr.line_item{ ng: { repeat: "line_item in filteredLineItems = ( line_items | filter:quickSearch | variantFilter:selectedUnitsProduct:selectedUnitsVariant:sharedResource | orderBy:sorting.predicate:sorting.reverse )", 'class-even' => "'even'", 'class-odd' => "'odd'", attr: { id: "li_{{line_item.id}}" } } }
           %td.bulk


### PR DESCRIPTION
#### What? Why?

Closes #8223 

There is Ask checkbox in two pages. These checkboxes don't have any functionality. Therefore I searched them in the code base and only found in two pages. Both of them are removed from views.
- `admin/orders/bulk_management`
- `admin/customers`



#### What should we test?


#### Release notes
Checkboxes which don't have any functionalities are removed

Changelog Category: User facing changes