### PR TITLE
Orphaned adjustments handing

### DIFF
--- a/app/models/spree/adjustment.rb
+++ b/app/models/spree/adjustment.rb
@@ -100,6 +100,11 @@ module Spree
     def update_adjustment!(calculable = nil, force: false)
       return amount if immutable? && !force
 
+      if calculable.nil? && adjustable.nil?
+        self.delete
+        return 0.0
+      end
+
       if originator.present?
         amount = originator.compute_amount(calculable || adjustable)
         update_columns(

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -64,6 +64,23 @@ module Spree
         expect(adjustment).not_to receive(:update_columns)
         adjustment.update_adjustment!
       end
+
+      context "where the adjustable has been deleted" do
+        let(:line_item) { create(:line_item, price: 10) }
+        let!(:adjustment) { create(:adjustment, adjustable: line_item) }
+
+        it "returns zero" do
+          line_item.delete
+          expect(adjustment.reload.update_adjustment!).to eq 0.0
+        end
+
+        it "removes orphaned adjustments" do
+          expect {
+            line_item.delete
+            adjustment.reload.update_adjustment!
+          }.to change{ Spree::Adjustment.count }.by -1
+        end
+      end
     end
 
     context "adjustment state" do

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -21,10 +21,11 @@ module Spree
     context "#update_adjustment!" do
       context "when originator present" do
         let(:originator) { instance_double(EnterpriseFee, compute_amount: 10.0) }
+        let(:adjustable) { instance_double(LineItem) }
 
         before do
           allow(adjustment).to receive_messages originator: originator, label: 'adjustment',
-                                                amount: 0
+                                                adjustable: adjustable, amount: 0
         end
 
         it "should do nothing when closed" do


### PR DESCRIPTION

#### What? Why?

Closes #7844

Deals with edge cases where an adjustment is left referencing a deleted item. Rough description here: https://github.com/openfoodfoundation/openfoodnetwork/issues/7844#issuecomment-920807392

I couldn't actually find any places where an adjustment would actually get left in this orphaned state. It's possible this irregularity is caused by deadlocks, it seems to be rare.

I would have preferred to deal with this at the database level with a simpler option for maintaining referential integrity in these cases (like cascading deletes), but it turns out you can't really use those kinds of strategies with polymorphic associations.


#### What should we test?
<!-- List which features should be tested and how. -->

I'm not sure how to manually test this, as I haven't managed to replicate the issue manually.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added some defenesive code for orphaned adjustments edge case

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
