### PR TITLE
Make home page labels clickable

### DIFF
--- a/app/views/home/_system.html.haml
+++ b/app/views/home/_system.html.haml
@@ -8,23 +8,26 @@
           .home-icon-box
             %a.search{href: "/shops"}
           .home-icon-box-bottom
-            %h4
-              = t :system_step1
+            %a.search{href: "/shops"}
+              %h4
+                = t :system_step1
             %p.text-normal
               = t :system_step1_text
         .small-12.medium-4.columns.text-left
           .home-icon-box
             %a.shop{href: "/shops"}
           .home-icon-box-bottom
-            %h4
-              = t :system_step2
+            %a.shop{href: "/shops"}
+              %h4
+                = t :system_step2
             %p.text-normal
               = t :system_step2_text
         .small-12.medium-4.columns.text-left
           .home-icon-box
             %a.pick-up-delivery{href: "/shops"}
           .home-icon-box-bottom
-            %h4
-              = t :system_step3
+            %a.pick-up-delivery{href: "/shops"}
+              %h4
+                = t :system_step3
             %p.text-normal
               = t :system_step3_text


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/wishlist/issues/50

In addition to the icons, labels in the home page are clickable


#### Release notes
In addition to the icons, labels in the home page are clickable

Changelog Category: User facing changes

