### PR TITLE
Avoid superfluous permalink check on site load

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/permalink_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/permalink_controller.js.coffee
@@ -9,6 +9,10 @@ angular.module("admin.enterprises")
     $scope.checking = false
 
     $scope.$watch "Enterprise.permalink", (newValue, oldValue) ->
+      if newValue == initialPermalink
+        $scope.availability = ""
+        return
+
       $scope.checking = true
       pendingRequest = PermalinkChecker.check(newValue)
 

--- a/app/assets/javascripts/admin/enterprises/services/permalink_checker.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/services/permalink_checker.js.coffee
@@ -34,7 +34,7 @@ angular.module("admin.enterprises").factory 'PermalinkChecker', ($q, $http) ->
           deferredRequest.reject()
 
       deferredRequest.promise.finally ->
-        request = deferredRequest.promise = null;
+        request = deferredRequest.promise = null
 
       deferredRequest.promise
 


### PR DESCRIPTION
#### What? Why?

Related to #7393.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

I noticed some unnecessary API calls when loading the enterprise edit page. The original value of the enterprise's permalink was checked for conflicts even though it's already in the database.


#### What should we test?
<!-- List which features should be tested and how. -->

* Edit an enterprise.
* Change the permalink.
* Permalink conflicts (same as another enterprise) should be displayed.


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Optimised page load when editing an enterprise.



