### PR TITLE
Catch JS error on OC page

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/filters/visible_variants.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/filters/visible_variants.js.coffee
@@ -1,3 +1,7 @@
 angular.module("admin.orderCycles").filter "visibleVariants", ->
   return (variants, exchange, rules) ->
-    return (variant for variant in variants when variant.id in rules[exchange.enterprise_id])
+    enterprise_rules = rules[exchange.enterprise_id]
+    if enterprise_rules
+      (variant for variant in variants when variant.id in enterprise_rules)
+    else
+      []

--- a/app/controllers/admin/enterprise_fees_controller.rb
+++ b/app/controllers/admin/enterprise_fees_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open_food_network/order_cycle_permissions'
+
 module Admin
   class EnterpriseFeesController < Admin::ResourceController
     before_action :load_enterprise_fee_set, only: :index


### PR DESCRIPTION
#### What? Why?

Related to #7393

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Calling `when variant.id in enterprise_rules` raised an error when `enterprise_rules` was null.

Fixing this then revealed a missing require statement in a controller.



#### What should we test?
<!-- List which features should be tested and how. -->

Green build. This is covered by specs.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Avoid a Javascript error on the order cycles edit page.

