### PR TITLE
Track event via matomo when submitting signup form

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/login_controller.js.coffee
@@ -11,6 +11,8 @@ angular.module('Darkswarm').controller "LoginCtrl", ($scope, $timeout, $location
   $scope.submit = ->
     Loading.message = t 'logging_in'
     $http.post("/user/spree_user/sign_in", {spree_user: $scope.spree_user}).then (response)->
+      if window._paq
+        window._paq.push(['trackEvent', 'Signin/Signup', 'Login Submit Success', $location.absUrl()]);
       if Redirections.after_login
         $window.location.href = $window.location.origin + Redirections.after_login
       else

--- a/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/authentication/signup_controller.js.coffee
@@ -11,5 +11,7 @@ angular.module('Darkswarm').controller "SignupCtrl", ($scope, $http, $window, $l
     $http.post("/user/spree_user", {spree_user: $scope.spree_user, return_url: $location.absUrl()}).then (response)->
       $scope.errors = {email: null, password: null}
       $scope.messages = t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
+      if window._paq
+        window._paq.push(['trackEvent', 'Signin/Signup', 'Signup Submit Success', $location.absUrl()]);
     .catch (response) ->
       $scope.errors = response.data

--- a/app/assets/javascripts/templates/login.html.haml
+++ b/app/assets/javascripts/templates/login.html.haml
@@ -41,4 +41,7 @@
           tabindex: "3",
           type: "submit",
           value: "{{'label_login' | t}}"}
-
+:javascript
+  if (window._paq) {
+    window._paq.push(['trackEvent', 'Signin/Signup', 'Login Modal View', window.location.href]);
+  }


### PR DESCRIPTION
#### What? Why?
This PR push events to matomo (if present) on login/signup modal view, login submit success and signup submit success. 

1. Signin/Signup Modal View (ie. the generic one)
**Event Category**: SignIn/Signup
**Event Action**: Modal View
**Event Name**: the current url

2. Login Submit Success
**Event Category**: SignIn/Signup
**Event Action**: Login Submit Success
**Event Name**: the current url

3. Signup Submit Success
**Event Category**: SignIn/Signup
**Event Action**: Signup Submit Success
**Event Name**: the current url

Event are well tracked through the Matomo app (don't know why all the page views/events are tracked twice, not related to this PR):

<img width="636" alt="Capture d’écran 2021-10-12 à 11 34 15" src="https://user-images.githubusercontent.com/296452/136932767-d5f77284-8cf7-4f02-9f29-255d9b7d2370.png">


Closes #7409

#### What should we test?

1. Test the login and signup when Matomo is not configured.
2. Test the login and signup once Matomo is configured.
3. Visit http://localhost:3000/register/auth#/signup?after_login=%2Fregister and see that page is ok (can login/signup)

<img width="1056" alt="Capture d’écran 2021-10-06 à 10 46 15" src="https://user-images.githubusercontent.com/296452/136170475-d6dbaf23-64ce-4f7a-8348-0fb03161a7ad.png">



#### Release notes

Track signup event

Changelog Category: Technical changes


