### PR TITLE
Cancel empty orders on BOM page

### DIFF
--- a/app/serializers/api/admin/order_serializer.rb
+++ b/app/serializers/api/admin/order_serializer.rb
@@ -7,7 +7,7 @@ module Api
                  :edit_path, :state, :payment_state, :shipment_state,
                  :payments_path, :ready_to_ship, :ready_to_capture, :created_at,
                  :distributor_name, :special_instructions, :display_outstanding_balance,
-                 :item_total, :adjustment_total, :payment_total, :total
+                 :item_total, :adjustment_total, :payment_total, :total, :item_count
 
       has_one :distributor, serializer: Api::Admin::IdSerializer
       has_one :order_cycle, serializer: Api::Admin::IdSerializer
@@ -67,6 +67,10 @@ module Api
 
       def completed_at
         object.completed_at.blank? ? "" : I18n.l(object.completed_at, format: '%B %d, %Y')
+      end
+
+      def item_count
+        object.line_items.count
       end
 
       private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2748,6 +2748,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     admin:
       unit_price_tooltip: "The unit price increases transparency by allowing your customers to easily compare prices between different products and packaging sizes. Note, that the final unit price displayed in the shopfront might differ as it is includes taxes & fees."
       enterprise_limit_reached: "You have reached the standard limit of enterprises per account. Write to %{contact_email} if you need to increase it."
+      deleting_item_will_cancel_order: "This operation will result in one or more empty orders, which will be cancelled. Do you wish to proceed?"
       modals:
         got_it: "Got it"
         close: "Close"
@@ -3245,6 +3246,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   last: "Last"
 
   spree:
+    order_updated: "Order Updated"
     add_country: "Add country"
     add_state: "Add state"
     adjustment: "Adjustment"

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -670,8 +670,10 @@ describe '
           within("tr#li_#{li2.id} td.bulk") do
             check "bulk"
           end
-          find("div#bulk-actions-dropdown").click
-          find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
+          page.driver.accept_modal :confirm do
+            find("div#bulk-actions-dropdown").click   
+            find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
+          end
           expect(page).to have_selector "tr#li_#{li1.id}"
           expect(page).to have_no_selector "tr#li_#{li2.id}"
         end
@@ -693,8 +695,10 @@ describe '
           check "toggle_bulk"
           fill_in "quick_search", with: o1.number
           expect(page).to have_no_selector "tr#li_#{li2.id}"
-          find("div#bulk-actions-dropdown").click
-          find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
+          page.driver.accept_modal :confirm do
+            find("div#bulk-actions-dropdown").click
+            find("div#bulk-actions-dropdown div.menu_item", text: "Delete Selected" ).click
+          end
           expect(page).to have_no_selector "tr#li_#{li1.id}"
           expect(page).to have_selector "#quick_search"
           fill_in "quick_search", with: ''


### PR DESCRIPTION
#### What? Why?

Closes #8131 

Deleting all line items from an order on BOM (bulk order management) page will open a confirm modal. If accepted, the order will be canceled.
Obs:
* Applicable for deleting a single line item using the trash icon or for deleting multiple items at once with the "Actions" dropdown (see issue #8131)
* Multiple orders can be cancelled at once. In this scenario a single confirmation modal will be opened.
* A single generic message is being used in both scenarios: "This operation will result in one or more empty orders, which will be cancelled. Do you wish to proceed?" This can be changed if needed.
* Currently it's not possible to see what order(s) will be canceled when deleting line items. Further layout changes might be needed for this functionality

#### What should we test?
Deleting all items from an order should cause the confirm modal to open, and if accepted the order should be canceled.
* must be applicable for both scenarios described in #8131 (delete trash icon and "Actions" dropdown)
* must be able to delete multiple orders at once

#### Release notes
Removing all line items from an order in BOM page will cause order to be cancelled.

Changelog Category: User facing changes
