### PR TITLE
Raise JavaScript errors within system specs

### DIFF
--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -13,7 +13,8 @@ Capybara.register_driver(:cuprite) do |app|
       # Don't load scripts from external sources, like google maps or stripe
       url_whitelist: ["http://localhost", "http://0.0.0.0", "http://127.0.0.1"],
       inspector: true,
-      headless: true
+      headless: true,
+      js_errors: true,
     }
   )
 end


### PR DESCRIPTION

#### What? Why?

Re-raising console errors helps us to find subtle bugs.

Some feature specs may raise JS errors which we will now discover when we migrate them to system specs. This may mean a little bit of additional effort within the migration to system specs but we want to fix those errors anyway and this approach means that we can do it bit by bit.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build only.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Automated system tests now fail on JavaScript console errors.

