### PR TITLE
Fix snail on shipping method fees

### DIFF
--- a/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -7,6 +7,7 @@ module Spree
       before_action :set_shipping_category, only: [:create, :update]
       before_action :set_zones, only: [:create, :update]
       before_action :load_hubs, only: [:new, :edit, :create, :update]
+      before_action :check_shipping_fee_input, only: [:update]
 
       # Sort shipping methods by distributor name
       def collection
@@ -91,6 +92,15 @@ module Spree
           :tax_category_id, distributor_ids: [],
                             calculator_attributes: PermittedAttributes::Calculator.attributes
         )
+      end
+
+      def check_shipping_fee_input
+        shipping_amount = permitted_resource_params.dig('calculator_attributes', 'preferred_amount')
+
+        unless shipping_amount.nil? || Float(shipping_amount, exception: false) 
+          flash[:error] = I18n.t(:calculator_preferred_value_error) 
+          return redirect_to location_after_save      
+        end
       end
     end
   end

--- a/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -31,6 +31,16 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
       expect(shipping_method.reload.calculator.preferred_currency).to eq "EUR"
     end
 
+    it "diplay error message on update if preferred_amount input is invalid" do
+      shipping_method.calculator = create(:calculator_flat_rate, calculable: shipping_method)
+      params[:shipping_method][:calculator_attributes][:preferred_amount] = "\'20.0'"
+
+      spree_post :update, params
+
+      expect(flash[:error]).to match I18n.t(:calculator_preferred_value_error) 
+      expect(response).to redirect_to spree.edit_admin_shipping_method_path(shipping_method)
+    end
+
     it "updates preferred_per_unit of a Weight calculator" do
       shipping_method.calculator = create(:weight_calculator, calculable: shipping_method)
       params[:shipping_method][:calculator_attributes][:preferred_per_unit] = 10


### PR DESCRIPTION
**What? Why?**

This PR fixes snail when editing non-numeric characters on shipping method fees.

Closes #8249

**Release notes**
fix: Fix snail when editing non-numeric characters on shipping method fees

**Dependencies**

**Documentation updates**
