### PR TITLE
Fix menu indicator on bulk order page

### DIFF
--- a/app/helpers/spree/admin/navigation_helper.rb
+++ b/app/helpers/spree/admin/navigation_helper.rb
@@ -9,6 +9,8 @@ module Spree
       #   * :route to override automatically determining the default route
       #   * :match_path as an alternative way to control when the tab is active,
       #       /products would match /admin/products, /admin/products/5/variants etc.
+      #   * :except_paths to reject subpaths that have their own menu,
+      #       e.g. match_path = '/admin/orders', except_paths = ['/admin/orders/bulk_management']
       def tab(*args)
         options = { label: args.first.to_s }
         if args.last.is_a?(Hash)
@@ -36,9 +38,9 @@ module Spree
         end
 
         selected = if options[:match_path]
-                     request.
-                       fullpath.
-                       starts_with?("#{main_app.root_path}admin#{options[:match_path]}")
+                     PathChecker
+                       .new(request.fullpath, self)
+                       .active_path?(options[:match_path], options[:except_paths])
                    else
                      args.include?(controller.controller_name.to_sym)
                    end

--- a/app/services/path_checker.rb
+++ b/app/services/path_checker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: false
+
+class PathChecker
+  def initialize(fullpath, view_context)
+    @fullpath = fullpath
+    @view_context = view_context
+  end
+
+  def active_path?(match_path, except_paths = nil)
+    root_path = @view_context.main_app.root_path
+    active = @fullpath.starts_with?("#{root_path}admin#{match_path}")
+    return false unless active
+    return true if except_paths.blank?
+
+    except_paths.each do |path|
+      return false if @fullpath.starts_with?("#{root_path}admin#{path}")
+    end
+
+    true
+  end
+end

--- a/app/views/spree/admin/shared/_order_sub_menu.html.haml
+++ b/app/views/spree/admin/shared/_order_sub_menu.html.haml
@@ -1,6 +1,6 @@
 - content_for :sub_menu do
   %ul#sub_nav.inline-menu
-    = tab :orders, :match_path => '/orders'
+    = tab :orders, match_path: '/orders', except_paths: ['/orders/bulk_management']
     = tab :bulk_order_management, :match_path => '/orders/bulk_management'
     - if subscriptions_enabled?
       = tab :subscriptions, :match_path => '/subscriptions', url: main_app.admin_subscriptions_path

--- a/spec/services/path_checker_spec.rb
+++ b/spec/services/path_checker_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe PathChecker do
+  describe "#active_path?" do
+    let(:view_context) { double("view context") }
+
+    before do
+      allow(view_context).to receive_message_chain("main_app.root_path") { "/" }
+    end
+
+    context "when fullpath starts with match_path and except_paths is blank" do
+      it "returns true" do
+        checker = described_class.new("/admin/products", view_context)
+        expect(checker.active_path?("/products")).to be true
+        expect(checker.active_path?("/products", nil)).to be true
+        expect(checker.active_path?("/products", [])).to be true
+
+        checker = described_class.new("/admin/products/5/variants", view_context)
+        expect(checker.active_path?("/products")).to be true
+        expect(checker.active_path?("/products", nil)).to be true
+        expect(checker.active_path?("/products", [])).to be true
+      end
+    end
+
+    context "when fullpath doesn't start with match_path" do
+      it "returns false" do
+        checker = described_class.new("/admin/products", view_context)
+        expect(checker.active_path?("/orders")).to be false
+      end
+    end
+
+    context "when fullpath starts with match_path and doesn't start with any of except_paths" do
+      it "returns true" do
+        checker = described_class.new("/admin/products", view_context)
+        expect(checker.active_path?("/products", ["/orders/bulk_management"])).to be true
+      end
+    end
+
+    context "when fullpath starts with match_path also with one of except_paths" do
+      it "returns false" do
+        checker = described_class.new("/admin/orders/bulk_management", view_context)
+        expect(checker.active_path?("/orders", ["/orders/bulk_management"])).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #8011

The indicator is added if the current full path starts with the path in button. In this case, `/orders/bulk_management` starts with `/orders`. My approach is to add `except_paths` option to allow sub-paths which have their own menu to be excluded.

I also separated the path checking logic into another class to make it easier to test, and added some test cases. This is an approach I learnt from this screencast: http://railscasts.com/episodes/101-refactoring-out-helper-object. I'm willing to discuss more if it's not suitable for this project.

#### Screenshots

Normally, sub-paths still activate the menu indicator for the main path's menu.
![product_edit](https://user-images.githubusercontent.com/57126452/137513736-6e6c501c-cf2c-4423-8829-b7a09723db9f.PNG)

When there are `except_paths`, the indicator will only be on the sub-path menu.
![bulk_order](https://user-images.githubusercontent.com/57126452/137513745-053a2e2e-b1d3-4167-b29f-8a80d3fbecf9.PNG)


