### PR TITLE
Add test and change order_cycle#show to redirect to edit page.

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -26,7 +26,9 @@ module Admin
 
     def show
       respond_to do |format|
-        format.html
+        format.html do
+          redirect_to edit_admin_order_cycle_path(@order_cycle)
+        end
         format.json do
           render_as_json @order_cycle, current_user: spree_current_user
         end

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -104,6 +104,20 @@ module Admin
       end
     end
 
+    describe "show" do
+      context 'a distributor manages an order cycle' do
+        let(:distributor) { create(:distributor_enterprise, owner: distributor_owner) }
+        let(:oc) { create(:simple_order_cycle, coordinator: distributor) }
+
+        context "distributor navigates to order cycle show page" do
+          it 'redirects to edit page' do
+            get :show, params: { id: oc.id }
+            expect(response).to redirect_to edit_admin_order_cycle_path(oc.id)
+          end
+        end
+      end
+    end
+
     describe "create" do
       let(:shop) { create(:distributor_enterprise) }
 


### PR DESCRIPTION
#### What? Why?

Closes #6943

This change is need because when you copy and paste part of a URL to go to an order cycle, you may see a server error.
The solution is to redirect the user to edit page if they navigate to a show page.

#### What should we test?
Navigate to edit an order cycle.
Delete the /edit from the URL so that it looks like this: https://openfoodnetwork.org.au/admin/order_cycles/6791
You should be redirected to the edit page.

#### Release notes
User is redirected to edit page if they navigate to order_cycle#show.

Changelog Category: User facing changes
