### PR TITLE
Archive failed tests screenshots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,15 @@ jobs:
       - name: Run controller tests
         run: bundle exec rspec --profile -- ${{ matrix.specs }}
 
+      - name: Archive failed tests screenshots
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: failed-tests-screenshots
+          path: tmp/capybara/screenshots/*.png
+          retention-days: 7
+          if-no-files-found: ignore
+
   test-the-rest:
     runs-on: ubuntu-18.04
     services:


### PR DESCRIPTION
#### What? Why?

The aim of this PR is to add the availability to see screenshot taken by capybara/cuprite each time a test fail. It could be really helpful to debug/understand each test failed. 




#### What should we test?
🟢 Green build. For each build failed, it add a section to the Actions view: 
<img width="588" alt="Capture d’écran 2021-10-21 à 09 50 20" src="https://user-images.githubusercontent.com/296452/138234815-84350087-0fb2-464a-86a8-2d502d0a6daa.png">

See here: https://github.com/jibees/openfoodnetwork/actions/runs/1366872884



#### Release notes
Add new GH action that upload the screenshot taken each time a test on continuous integration fails. 

Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
