### PR TITLE
Fix about us paragraph breaks

### DIFF
--- a/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprise_registration_service.js.coffee
@@ -61,7 +61,9 @@ angular.module('Darkswarm').factory "EnterpriseRegistrationService", ($http, Reg
       enterprise = {}
       excluded = [ 'address', 'country', 'id' ]
       for key, value of @enterprise when key not in excluded
-        enterprise[key] = value
+        if (key == 'long_description')
+          enterprise[key] = value.replace(/(?:\r\n|\r|\n)/g, '<br>')
+        else enterprise[key] = value
       enterprise.address_attributes = @enterprise.address if @enterprise.address?
       enterprise.address_attributes.country_id = @enterprise.country.id if @enterprise.country?
       enterprise


### PR DESCRIPTION
#### What? Why?

Closes #3309 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
On about us step save, it replaces any return carriage with `<br>` for the long description text. When viewed in the enterprise about us page, it should display the same formatting  

![Screen Shot 2021-10-23 at 2 40 14 PM](https://user-images.githubusercontent.com/45666083/138568467-f3b67928-1bec-485b-84fb-653f7927ffab.png)

<img width="863" alt="Screen Shot 2021-10-23 at 2 40 33 PM" src="https://user-images.githubusercontent.com/45666083/138568468-c2b8ee16-c249-4a49-81f1-93b747cb28ed.png">

#### What should we test?
Create a new enterprise and in the about page step, add some description in the long description with return carriages. In the enterprise dashboard, navigate to the about page and it should display the same formatting that you typed out in the about step. 
