### PR TITLE
Missing navigation for super admin users only included

### DIFF
--- a/app/views/admin/enterprise_fees/index.html.haml
+++ b/app/views/admin/enterprise_fees/index.html.haml
@@ -1,3 +1,6 @@
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
+
 = content_for :page_title do
   = t('.title')
 
@@ -29,7 +32,7 @@
         %tr{ ng: { repeat: 'enterprise_fee in enterprise_fees | filter:query' } }
           %td
             = f.ng_hidden_field :id
-            %ofn-select{ :id => angular_id(:enterprise_id), data: 'enterprises', ng: { model: 'enterprise_fee.enterprise_id' } }
+            %ofn-select{ :id => angular_id(:enterprise_id), data: 'enterprises', ng: { model: 'enterprise_fee.enterprise_id' }, style: "width: 90%" }
             %input{ type: "hidden", name: angular_name(:enterprise_id), ng: { value: "enterprise_fee.enterprise_id" } }
           %td= f.ng_select :fee_type, enterprise_fee_type_options, 'enterprise_fee.fee_type'
           %td= f.ng_text_field :name, { placeholder: t('.name_placeholder') }

--- a/app/views/admin/terms_of_service_files/show.html.haml
+++ b/app/views/admin/terms_of_service_files/show.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t(".title")
 

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -1,4 +1,4 @@
-= render :partial => 'spree/admin/shared/configuration_menu'
+= render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = Spree.t(:general_settings)

--- a/app/views/spree/admin/payment_methods/edit.html.haml
+++ b/app/views/spree/admin/payment_methods/edit.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.editing_payment_method')
   %i.icon-arrow-right

--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.payment_methods')
 

--- a/app/views/spree/admin/payment_methods/new.html.haml
+++ b/app/views/spree/admin/payment_methods/new.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.new_payment_method')
 - content_for :page_actions do

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.editing_shipping_method')
 - content_for :page_actions do

--- a/app/views/spree/admin/shipping_methods/index.html.haml
+++ b/app/views/spree/admin/shipping_methods/index.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.shipping_methods')
 - content_for :page_actions do

--- a/app/views/spree/admin/shipping_methods/new.html.haml
+++ b/app/views/spree/admin/shipping_methods/new.html.haml
@@ -1,3 +1,5 @@
+= render 'spree/admin/shared/configuration_menu'
+
 - content_for :page_title do
   = t('.new_shipping_method')
 - content_for :page_actions do

--- a/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/payment_methods/index.html.haml_spec.rb
@@ -6,6 +6,7 @@ describe "spree/admin/payment_methods/index.html.haml" do
   include AuthenticationHelper
   helper Spree::Admin::NavigationHelper
   helper Spree::Admin::BaseHelper
+  helper Spree::Core::Engine.routes.url_helpers
 
   before do
     ActionView::Base.class_eval do
@@ -20,6 +21,7 @@ describe "spree/admin/payment_methods/index.html.haml" do
              create(:payment_method),
              create(:payment_method)
            ])
+    allow(controller).to receive(:controller_name).and_return("tests")
   end
 
   describe "payment methods index page" do


### PR DESCRIPTION
#### What? Why?

Closes #7937

Some of the super admin pages were missing navigation sidebar. Sidebar is included in every relevant pages only for super admin and with styling to prevent main content overlapping with sidebar.
Please see the screenshots in the next comment



#### What should we test?

Navigate through all sections of the configuration section within the admin area.



#### Release notes
Navigation is included in all relevant pages for improved and consistent user experience for super admins

Changelog Category: User facing changes 
