### PR TITLE
Translate stripe error messages during payment processing

### DIFF
--- a/app/models/spree/payment/processing.rb
+++ b/app/models/spree/payment/processing.rb
@@ -260,7 +260,7 @@ module Spree
 
       def gateway_error(error)
         text = if error.is_a? ActiveMerchant::Billing::Response
-                 error.params['message'] || error.params['response_reason_text'] || error.message
+                 error_text(error)
                elsif error.is_a? ActiveMerchant::ConnectionError
                  Spree.t(:unable_to_connect_to_gateway)
                else
@@ -269,6 +269,14 @@ module Spree
         logger.error(Spree.t(:gateway_error))
         logger.error("  #{error.to_yaml}")
         raise Core::GatewayError, text
+      end
+
+      def error_text(error)
+        if (code = error.params.dig('error', 'code')) && I18n.exists?("stripe.error_code.#{code}")
+          I18n.t("stripe.error_code.#{code}")
+        else
+          error.params['message'] || error.params['response_reason_text'] || error.message
+        end
       end
 
       # Saftey check to make sure we're not accidentally performing operations on a live gateway.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,20 @@ en:
             using_producer_stock_settings_but_count_on_hand_set: "must be blank because using producer stock settings"
             on_demand_but_count_on_hand_set: "must be blank if on demand"
             limited_stock_but_no_count_on_hand: "must be specified because forcing limited stock"
+  stripe:
+    error_code:
+      incorrect_number: "The card number is incorrect."
+      invalid_number: "The card number is not a valid credit card number."
+      invalid_expiry_month: "The card's expiration month is invalid."
+      invalid_expiry_year: "The card's expiration year is invalid."
+      invalid_cvc: "The card's security code is invalid."
+      expired_card: "The card has expired."
+      incorrect_cvc: "The card's security code is incorrect."
+      incorrect_zip: "The card's zip code failed validation."
+      card_declined: "The card was declined."
+      missing: "There is no card on a customer that is being charged."
+      processing_error: "An error occurred while processing the card."
+      rate_limit: "An error occurred due to requests hitting the API too quickly. Please let us know if you're consistently running into this error."
   activemodel:
     attributes:
       order_management/reports/enterprise_fee_summary/parameters:
@@ -3461,7 +3475,6 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     there_are_no_items_for_this_order: "There are no items for this order."
     order_populator:
       out_of_stock: ! '%{item} is out of stock.'
-
     actions:
       update: "Update"
       cancel: "Cancel"


### PR DESCRIPTION
#### What? Why?
Closes #7961
Stripe error messages aren't translated. 

But, Stripe send us an error code: use it (if found it _and_ translation key does exist) to translated the error message
Populate the en.yml file with some of the most known errors




#### What should we test?
Test that stripe error messages (with different card number: https://stripe.com/docs/testing#cards-responses): 
 - are well translated if the i18n key is present (ie. the errors are translated for the current langage)
 - use the default message coming from stripe if the i18n key is not present (ie. english)



#### Release notes
Add translation for Stripe errors

Changelog Category: User facing changes

