### PR TITLE
Remove dalli gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem 'angularjs-file-upload-rails', '~> 2.4.1'
 gem 'bigdecimal', '3.0.2'
 gem 'bootsnap', require: false
 gem 'custom_error_message', github: 'jeremydurham/custom-err-msg'
-gem 'dalli'
 gem 'geocoder'
 gem 'gmaps4rails'
 gem 'mimemagic', '> 0.3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,6 @@ GEM
     cuprite (0.13)
       capybara (>= 2.1, < 4)
       ferrum (~> 0.11.0)
-    dalli (3.0.2)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
     database_cleaner-active_record (2.0.0)
@@ -715,7 +714,6 @@ DEPENDENCIES
   compass-rails
   cuprite
   custom_error_message!
-  dalli
   database_cleaner
   db2fog!
   ddtrace


### PR DESCRIPTION
#### What? Why?

Follow-up for PR https://github.com/openfoodfoundation/openfoodnetwork/pull/8370

Dalli is a wrapper around `memcached`, which we previously removed. :fire:


#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Remove unused dalli gem

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
