### PR TITLE
Revert "Bump aws-sdk to 2.2.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'oauth2', '~> 1.4.7' # Used for Stripe Connect
 gem 'pagy', '~> 5.1'
 
 gem 'angularjs-rails', '1.8.0'
-gem 'aws-sdk', '2.2.0'
+gem 'aws-sdk', '1.67.0'
 gem 'bugsnag'
 gem 'haml'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,12 +154,11 @@ GEM
     awesome_nested_set (3.4.0)
       activerecord (>= 4.0.0, < 7.0)
     awesome_print (1.9.2)
-    aws-sdk (2.2.0)
-      aws-sdk-resources (= 2.2.0)
-    aws-sdk-core (2.2.0)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.2.0)
-      aws-sdk-core (= 2.2.0)
+    aws-sdk (1.67.0)
+      aws-sdk-v1 (= 1.67.0)
+    aws-sdk-v1 (1.67.0)
+      json (~> 1.4)
+      nokogiri (~> 1)
     bcrypt (3.1.16)
     bigdecimal (3.0.2)
     bindex (0.8.1)
@@ -344,7 +343,6 @@ GEM
     immigrant (0.3.6)
       activerecord (>= 3.0)
     ipaddress (0.8.3)
-    jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -699,7 +697,7 @@ DEPENDENCIES
   angularjs-rails (= 1.8.0)
   awesome_nested_set
   awesome_print
-  aws-sdk (= 2.2.0)
+  aws-sdk (= 1.67.0)
   bigdecimal (= 3.0.2)
   bootsnap
   bugsnag


### PR DESCRIPTION
#### What? Why?

Closes #8414
Revert the `aws-sdk` upgrade since it seems to break the use we have with `paperclip`: 
https://stackoverflow.com/questions/22826432/error-uninitialized-constant-aws-nameerror
Paperclip version should be higher than 4.3.0 (i guess it should be then 5 at least) 




#### What should we test?
Image upload on server that actually use the AWS storage (fr-staging)



#### Release notes
Revert a gem upgrade that broke image upload when using AWS

Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
