### PR TITLE
API: add the tax_category_id for each ajustements of an order

### DIFF
--- a/app/serializers/api/adjustment_serializer.rb
+++ b/app/serializers/api/adjustment_serializer.rb
@@ -4,6 +4,15 @@ module Api
   class AdjustmentSerializer < ActiveModel::Serializer
     attributes :id, :amount, :label, :eligible,
                :adjustable_type, :adjustable_id,
-               :originator_type, :originator_id
+               :originator_type, :originator_id,
+               :tax_category_id
+
+    def tax_category_id
+      if object.originator_type == "Spree::TaxRate"
+        object.originator.tax_category_id
+      else
+        object.tax_category_id
+      end
+    end
   end
 end


### PR DESCRIPTION

#### What? Why?
The aim of this PR is to add the `tax_category_id` of each ajustements of an order through the API. 

Notes:
 - This tax_category_id could be null
 - Special case if the originator is a `Spree::TaxRate` then use the `tax_category_id` from the originator

#### What should we test?
1. Create an order with ajustement with tax category (both shipment and _manual_ ajustement): 

<img width="918" alt="Capture d’écran 2021-10-26 à 16 39 29" src="https://user-images.githubusercontent.com/296452/138902214-0e1ffd39-73b3-42d9-b972-19f916322cbe.png">

2. Request the API through: `/api/v0/orders/[ORDER_ID].json?token=[TOKEN_ID]` and see that ajustements have a `tax_category_id` that reference the right tax rate:

```json
"adjustments": [
        {
            "id": 137,
            "amount": "0.0",
            "label": "Transaction fee",
            "eligible": true,
            "adjustable_type": "Spree::Payment",
            "adjustable_id": 29,
            "originator_type": "Spree::PaymentMethod",
            "originator_id": 5,
            "tax_category_id": null
        },
        {
            "id": 138,
            "amount": "2.0",
            "label": "Shipping",
            "eligible": true,
            "adjustable_type": "Spree::Shipment",
            "adjustable_id": 17,
            "originator_type": "Spree::ShippingMethod",
            "originator_id": 6,
            "tax_category_id": null
        },
        {
            "id": 144,
            "amount": "-0.33",
            "label": "Refund 20% 20.0% (Included in price)",
            "eligible": true,
            "adjustable_type": "Spree::Shipment",
            "adjustable_id": 17,
            "originator_type": "Spree::TaxRate",
            "originator_id": 1,
            "tax_category_id": 1
        },
        {
            "id": 509,
            "amount": "1.0",
            "label": "Ajustement de 1",
            "eligible": true,
            "adjustable_type": "Spree::Order",
            "adjustable_id": 24,
            "originator_type": null,
            "originator_id": null,
            "tax_category_id": 2
        }
    ],
```



#### Release notes
API: add `tax_category_id` to ajustements of an order. 

Changelog Category: User facing changes


