### PR TITLE
7706 add close button to flatpickr

### DIFF
--- a/app/assets/javascripts/admin/util.js.erb
+++ b/app/assets/javascripts/admin/util.js.erb
@@ -29,7 +29,7 @@ $(document).ready(function() {
               label: Spree.translations.today
             },
             {
-              label: "CLOSE"
+              label: Spree.translations.close
             }
           ],
           label: "or",
@@ -54,7 +54,7 @@ $(document).ready(function() {
               label: Spree.translations.now
             },
             {
-              label: "CLOSE"
+              label: Spree.translations.close
             }
           ],
           label: "or",

--- a/app/assets/javascripts/admin/util.js.erb
+++ b/app/assets/javascripts/admin/util.js.erb
@@ -1,12 +1,21 @@
 $(document).ready(function() {
   var onClickButtons = function(index, fp) {
     var date;
+    // Memorize index used for the 'Close' button
+    // (currently it has index of 1)  
+    var closeButtonIndex = 1; 
     switch (index) {
       case 0:
         date = new Date();
         break;
+      case closeButtonIndex:
+        fp.close();
+        break;
     }
-    fp.setDate(date, true);
+    // Set the date unless clicked button was the 'Close' one
+    if (index != closeButtonIndex) {
+      fp.setDate(date, true);
+    }
   }
   window.FLATPICKR_DATE_DEFAULT = {
     altInput: true,
@@ -35,9 +44,14 @@ $(document).ready(function() {
       time_24hr: true,
       plugins: [
         ShortcutButtonsPlugin({
-          button: [{
-            label: Spree.translations.now
-          }],
+          button: [
+            {
+              label: Spree.translations.now
+            },
+            {
+              label: "CLOSE"
+            }
+          ],
           label: "or",
           onClick: onClickButtons
         }),

--- a/app/assets/javascripts/admin/util.js.erb
+++ b/app/assets/javascripts/admin/util.js.erb
@@ -24,9 +24,14 @@ $(document).ready(function() {
     locale: I18n.base_locale,
     plugins: [
         ShortcutButtonsPlugin({
-          button: [{
-            label: Spree.translations.today
-          }],
+          button: [
+            {
+              label: Spree.translations.today
+            },
+            {
+              label: "CLOSE"
+            }
+          ],
           label: "or",
           onClick: onClickButtons
         }),

--- a/app/assets/stylesheets/admin/plugins/flatpickr-customization.scss
+++ b/app/assets/stylesheets/admin/plugins/flatpickr-customization.scss
@@ -60,3 +60,9 @@ $background-blue: #5498da;
 }
 
 // scss-lint:enable SelectorFormat
+
+// customization for shortcut-buttons
+.shortcut-buttons-flatpickr-wrapper > .shortcut-buttons-flatpickr-buttons {
+  justify-content: space-between;
+  flex-grow: 1;
+}

--- a/app/views/spree/admin/shared/_translations.html.erb
+++ b/app/views/spree/admin/shared/_translations.html.erb
@@ -8,6 +8,7 @@
                               :default => 'Y-m-d H:i'),
     :today                    => Spree.t('date_picker.today'),
     :now                      => Spree.t('date_picker.now'),
+    :close                    => Spree.t('date_picker.close'),
     :add                      => I18n.t(:add, scope: :actions),
     :are_you_sure_delete      => Spree.t(:are_you_sure_delete),
     :bill_address             => I18n.t(:bill_address),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3867,6 +3867,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
       flatpickr_datetime_format: "Y-m-d H:i"
       today: "Today"
       now: "Now"
+      close: "Close"
     orders:
       error_flash_for_unavailable_items: "An item in your cart has become unavailable. Please update the selected quantities."
       edit:

--- a/spec/support/features/datepicker_helper.rb
+++ b/spec/support/features/datepicker_helper.rb
@@ -4,8 +4,7 @@ module Features
   module DatepickerHelper
     def choose_today_from_datepicker
       within(".flatpickr-calendar.open") do
-        # Now that we have added the Close button, find the first button to avoid any ambiguous match
-        find('.shortcut-buttons-flatpickr-buttons > button:nth-child(1)').click
+        find("button", text: "TODAY").click
       end
     end
 

--- a/spec/support/features/datepicker_helper.rb
+++ b/spec/support/features/datepicker_helper.rb
@@ -4,7 +4,8 @@ module Features
   module DatepickerHelper
     def choose_today_from_datepicker
       within(".flatpickr-calendar.open") do
-        find('.shortcut-buttons-flatpickr-button').click
+        # Now that we have added the Close button, find the first button to avoid any ambiguous match
+        find('.shortcut-buttons-flatpickr-buttons > button:nth-child(1)').click
       end
     end
 

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -150,21 +150,27 @@ describe '
 
       it "correctly opens the datetimepicker and closes it using the last button (the 'Close' one)" do
         login_as_admin_and_visit admin_order_cycles_path
+        test_value = Time.parse("2022-12-22 00:00")
 
         # Opens a datetimepicker
         within("tr.order-cycle-#{oc_pt.id}") do
           find('input.datetimepicker', match: :first).click
         end
 
-        # Looks for the close button and click it
+        # Sets the value to test_value then looks for the close button and click it
         within(".flatpickr-calendar.open") do
           expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-          fp_buttons_count = find_all('.shortcut-buttons-flatpickr-button').count
-          find(".shortcut-buttons-flatpickr-buttons > button:nth-child(#{fp_buttons_count})").click
+          select_datetime_from_datepicker test_value
+          find(".shortcut-buttons-flatpickr-buttons > button:nth-last-child(1)").click
         end
 
         # Should no more have opened flatpickr
         expect(page).not_to have_selector '.flatpickr-calendar.open'
+
+        # Check the value is correct
+        within("tr.order-cycle-#{oc_pt.id}") do
+          expect(find('input.datetimepicker', match: :first).value).to eq test_value.to_datetime.strftime("%Y-%m-%d %H:%M")
+        end
 
       end
     end

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -161,7 +161,7 @@ describe '
         within(".flatpickr-calendar.open") do
           expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
           select_datetime_from_datepicker test_value
-          find(".shortcut-buttons-flatpickr-buttons > button:nth-last-child(1)").click
+          find("button", text: "CLOSE").click
         end
 
         # Should no more have opened flatpickr

--- a/spec/system/admin/order_cycles/list_spec.rb
+++ b/spec/system/admin/order_cycles/list_spec.rb
@@ -129,8 +129,8 @@ describe '
       I18n.locale = :en
     end
 
-    context 'using datepickers' do
-      it "correctly opens the datepicker and changes the date field" do
+    context 'using datetimepickers' do
+      it "correctly opens the datetimepicker and changes the date field" do
         login_as_admin_and_visit admin_order_cycles_path
 
         within("tr.order-cycle-#{oc_pt.id}") do
@@ -146,6 +146,26 @@ describe '
         within("tr.order-cycle-#{oc_pt.id}") do
           expect(find('input.datetimepicker', match: :first).value).to eq '2012-01-30 00:00'
         end
+      end
+
+      it "correctly opens the datetimepicker and closes it using the last button (the 'Close' one)" do
+        login_as_admin_and_visit admin_order_cycles_path
+
+        # Opens a datetimepicker
+        within("tr.order-cycle-#{oc_pt.id}") do
+          find('input.datetimepicker', match: :first).click
+        end
+
+        # Looks for the close button and click it
+        within(".flatpickr-calendar.open") do
+          expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
+          fp_buttons_count = find_all('.shortcut-buttons-flatpickr-button').count
+          find(".shortcut-buttons-flatpickr-buttons > button:nth-child(#{fp_buttons_count})").click
+        end
+
+        # Should no more have opened flatpickr
+        expect(page).not_to have_selector '.flatpickr-calendar.open'
+
       end
     end
   end

--- a/spec/system/flatpickr_spec.rb
+++ b/spec/system/flatpickr_spec.rb
@@ -7,23 +7,25 @@ describe "Test Flatpickr", js: true do
   include WebHelper
 
   context "orders" do
-    it "opens the datepicker and closes it using the last button (the 'Close' one)" do
+    it "opens the datepicker and closes it using the 'CLOSE' button" do
       login_as_admin_and_visit 'admin/orders'
       open_datepicker('#q_completed_at_gteq')       
       # Looks for the close button and click it
       within(".flatpickr-calendar.open") do
         expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
-        find(".shortcut-buttons-flatpickr-buttons > button:nth-last-child(1)").click
+        find("button", text: "CLOSE").click
       end
       # Should no more have opened flatpickr
       expect(page).not_to have_selector '.flatpickr-calendar.open'
     end
+    
     it "opens the datepicker and sets date to today" do
       login_as_admin_and_visit 'admin/orders'
       open_datepicker('#q_completed_at_gteq')
       choose_today_from_datepicker
       check_fielddate('#q_completed_at_gteq', Date.today())       
     end
+    
     it "opens the datepicker and closes it by clicking outside" do
       login_as_admin_and_visit 'admin/orders'
       open_datepicker('#q_completed_at_gteq')
@@ -33,13 +35,15 @@ describe "Test Flatpickr", js: true do
     end
   end
   
-private
+  private
+  
   def open_datepicker(field)
     # Opens a datepicker
     find(field).click
     # Should have opened flatpickr
     expect(page).to have_selector '.flatpickr-calendar.open'
   end
+  
   def check_fielddate(field, date)
     # Check the value is correct
     expect(find(field, match: :first).value).to eq date.to_datetime.strftime("%Y-%m-%d")

--- a/spec/system/flatpickr_spec.rb
+++ b/spec/system/flatpickr_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+describe "Test Flatpickr", js: true do
+  include AuthenticationHelper
+  include WebHelper
+
+  context "orders" do
+    it "opens the datepicker and closes it using the last button (the 'Close' one)" do
+      login_as_admin_and_visit 'admin/orders'
+      open_datepicker('#q_completed_at_gteq')       
+      # Looks for the close button and click it
+      within(".flatpickr-calendar.open") do
+        expect(page).to have_selector '.shortcut-buttons-flatpickr-buttons'
+        find(".shortcut-buttons-flatpickr-buttons > button:nth-last-child(1)").click
+      end
+      # Should no more have opened flatpickr
+      expect(page).not_to have_selector '.flatpickr-calendar.open'
+    end
+    it "opens the datepicker and sets date to today" do
+      login_as_admin_and_visit 'admin/orders'
+      open_datepicker('#q_completed_at_gteq')
+      choose_today_from_datepicker
+      check_fielddate('#q_completed_at_gteq', Date.today())       
+    end
+    it "opens the datepicker and closes it by clicking outside" do
+      login_as_admin_and_visit 'admin/orders'
+      open_datepicker('#q_completed_at_gteq')
+      find("#admin-menu").click       
+      # Should no more have opened flatpickr
+      expect(page).not_to have_selector '.flatpickr-calendar.open'
+    end
+  end
+  
+private
+  def open_datepicker(field)
+    # Opens a datepicker
+    find(field).click
+    # Should have opened flatpickr
+    expect(page).to have_selector '.flatpickr-calendar.open'
+  end
+  def check_fielddate(field, date)
+    # Check the value is correct
+    expect(find(field, match: :first).value).to eq date.to_datetime.strftime("%Y-%m-%d")
+  end
+end


### PR DESCRIPTION
#### What? Why?
Closes #7706

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
After discussions it was decided to add a 'Close' button which just closes the popover.
This should make things clearer for user on how to close



#### What should we test?
<!-- List which features should be tested and how. -->
The new button has been added into datetimepicker and datepicker, so one need to test both.

As an admin go to eg Order Cycles, click on one datetime area to open the calendar, you should see a Close button on the right like illustrated in this screenshot :
<img width="356" alt="Capture d’écran 2021-10-27 à 11 16 22" src="https://user-images.githubusercontent.com/54935392/139037198-47611241-1244-40cd-ae6a-3bfe9a2fd973.png">
Clicking on it should close the popover
( A test has been added for this case in list_spec.rb in context 'using datetimepickers')

Similarly select Orders from the admin dashboard and click on eg Start date area, you should also see the Close button on the right like illustrated in this screenshot :
<img width="345" alt="Capture d’écran 2021-10-27 à 11 15 57" src="https://user-images.githubusercontent.com/54935392/139037600-8d28f8fc-b921-4071-a7df-e600f20306ef.png">
Clicking on it should close the popover
(A test has been added for this case in orders_spec.rb in context "with a complete order"

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Calendars now have a Close button to clearly indicate to the user a way to close the popover 

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

