### PR TITLE
Break up system tests into two jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,8 @@ jobs:
           - "spec/lib"
           - "spec/migrations"
           - "spec/serializers"
-          - "spec/system"
+          - "spec/system/admin"
+          - "spec/system/consumer"
           - "engines/*/spec"
       fail-fast: false
     steps:
@@ -65,7 +66,7 @@ jobs:
           bundle exec rake db:create
           bundle exec rake db:schema:load
 
-      - name: Run controller tests
+      - name: Run tests
         run: bundle exec rspec --profile -- ${{ matrix.specs }}
 
       - name: Archive failed tests screenshots


### PR DESCRIPTION
#### What? Why?

Breaks up system tests into two jobs so we can run them concurrently. At the moment that node takes twice as long as any others, so this should help trim the total build time. We can look at rebalancing it later when we've finished migrating everything.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Break system tests up into two groups

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes