### PR TITLE
Ignore StateMachines warnings in console output

### DIFF
--- a/config/initializers/state_machines.rb
+++ b/config/initializers/state_machines.rb
@@ -1,0 +1,2 @@
+# Ignore noisy StateMachines warnings.
+StateMachines::Machine.ignore_method_conflicts = true


### PR DESCRIPTION
#### What? Why?

```
Warning:Instance method "open" is already defined in Object, use generic helper instead
or set StateMachines::Machine.ignore_method_conflicts = true.
```

We *already* ignore this warning anyway (and always have), so this just removes the console noise.

Also means we can now run rake tasks without any superfluous warnings. Clean output! :tada:

#### What should we test?
<!-- List which features should be tested and how. -->

No test. 

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improve rake console output

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

