### PR TITLE
If an order has out of stock line items display them and let admins remove them

### DIFF
--- a/app/views/spree/admin/orders/_form.html.haml
+++ b/app/views/spree/admin/orders/_form.html.haml
@@ -2,6 +2,9 @@
   - if @line_item.try(:errors).present?
     = render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item }
 
+  - if !@order.completed? && @order.insufficient_stock_lines.any?
+    = render 'spree/admin/orders/insufficient_stock_lines', insufficient_stock_lines: @order.insufficient_stock_lines
+
   = render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order }
 
   = render :partial => "spree/admin/orders/_form/adjustments", :locals => { :adjustments => @order.line_item_adjustments, :title => t(".line_item_adjustments")}

--- a/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
+++ b/app/views/spree/admin/orders/_insufficient_stock_lines.html.haml
@@ -1,0 +1,39 @@
+%div.insufficient-stock-items
+  %fieldset.no-border-bottom
+    %legend
+      = t("spree.orders.line_item.out_of_stock")
+
+  %table
+    %colgroup
+      %col{ :style => "width: 10%;" }
+      %col{ :style => "width: 30%;" }
+      %col{ :style => "width: 15%;" }
+      %col{ :style => "width: 15%;" }
+      %col{ :style => "width: 15%;" }
+      %col{ :style => "width: 15%;" }
+
+    %thead
+      %th{ :colspan => "2" }
+        = Spree.t(:item_description)
+      %th
+        = Spree.t(:price)
+      %th
+        = Spree.t(:quantity)
+      %th
+        = Spree.t(:total)
+      %th.orders-actions.actions
+
+    - insufficient_stock_lines.each do |line_item|
+      %tr.insufficient-stock-item
+        %td
+          = render 'spree/shared/variant_thumbnail', variant: line_item.variant
+        %td
+          = line_item.variant.product_and_full_name
+        %td.align-center
+          = line_item.single_money.to_html
+        %td.align-center
+          = line_item.quantity
+        %td.align-center
+          = line_item.money.to_html
+        %td.actions
+          = link_to_delete line_item, { url: main_app.admin_bulk_line_item_path(line_item), no_text: true }

--- a/app/webpacker/css/admin/sections/orders.scss
+++ b/app/webpacker/css/admin/sections/orders.scss
@@ -33,6 +33,16 @@
   }
 }
 
+.insufficient-stock-items {
+  legend {
+    color: $color-error;
+  }
+
+  table tr:last-child th {
+    border-bottom: 1px solid $admin-table-border;
+  }
+}
+
 // Customize orduct add fieldset
 #add-line-item {
   fieldset {

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -448,6 +448,27 @@ describe '
           end
         end
       end
+
+      context "when an incomplete order has some line items with insufficient stock" do
+        let(:incomplete_order) do
+          create(:order_with_line_items, user: user, distributor: distributor,
+                                         order_cycle: order_cycle)
+        end
+
+        it "displays the out of stock line items and they can be deleted from the order" do
+          incomplete_order.line_items.first.variant.update!(on_demand: false, on_hand: 0)
+
+          visit spree.edit_admin_order_path(incomplete_order)
+
+          within ".insufficient-stock-items" do
+            expect(page).to have_content incomplete_order.products.first.name
+            accept_alert 'Are you sure?' do
+              find("a.delete-resource").click
+            end
+            expect(page).to_not have_content incomplete_order.products.first.name
+          end
+        end
+      end
     end
 
     it "creating an order with distributor and order cycle" do

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -22,21 +22,76 @@ describe "spree/admin/orders/edit.html.haml" do
     end
 
     allow(view).to receive_messages spree_current_user: create(:user)
-
-    order = create(:completed_order_with_fees)
-    order.distributor = create(:distributor_enterprise)
-    assign(:order, order)
-    assign(:shops, [order.distributor])
-    assign(:order_cycles, [])
   end
 
-  describe "order values" do
-    it "displays order shipping costs, transaction fee and order total" do
-      render
+  context "when order is complete" do
+    let(:order) { create(:completed_order_with_fees) }
 
-      expect(rendered).to have_content("Shipping Method\nUPS Ground $6.00")
-      expect(rendered).to have_content("Transaction fee:\n\n$10.00")
-      expect(rendered).to have_content("Order Total\n$36.00")
+    before do
+      order.distributor = create(:distributor_enterprise)
+      assign(:order, order)
+      assign(:shops, [order.distributor])
+      assign(:order_cycles, [])
+    end
+
+    describe "order values" do
+      it "displays order shipping costs, transaction fee and order total" do
+        render
+
+        expect(rendered).to have_content("Shipping Method\nUPS Ground $6.00")
+        expect(rendered).to have_content("Transaction fee:\n\n$10.00")
+        expect(rendered).to have_content("Order Total\n$36.00")
+      end
+    end
+
+    context "when some line items are out of stock" do
+      let!(:out_of_stock_line_item) do
+        line_item = order.line_items.first
+        line_item.variant.update!(on_demand: false, on_hand: 0)
+        line_item
+      end
+
+      it "doesn't display a table of out of stock line items" do
+        render
+
+        expect(rendered).to_not have_content "Out of Stock"
+        expect(rendered).to_not have_selector ".insufficient-stock-items",
+                                              text: out_of_stock_line_item.variant.display_name
+      end
+    end
+  end
+
+  context "when order is incomplete" do
+    let(:order) { create(:order_with_line_items) }
+
+    before do
+      assign(:order, order)
+      assign(:shops, [order.distributor])
+      assign(:order_cycles, [])
+    end
+
+    context "when some line items are out of stock" do
+      let!(:out_of_stock_line_item) do
+        line_item = order.line_items.first
+        line_item.variant.update!(on_demand: false, on_hand: 0)
+        line_item
+      end
+
+      it "displays a table of out of stock line items" do
+        render
+
+        expect(rendered).to have_content "Out of Stock"
+        expect(rendered).to have_selector ".insufficient-stock-items",
+                                          text: out_of_stock_line_item.variant.display_name
+      end
+    end
+
+    context "when all line items are in stock" do
+      it "doesn't display a table of out of stock line items" do
+        render
+
+        expect(rendered).to_not have_content "Out of Stock"
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

For #8178. Before only customers could delete out of stock line items and out of stock line items would not be displayed when an order was viewed in the admin area. This changes things so the out of stock line items are displayed in the admin area and gives the admin the ability to delete them.

#### What should we test?

1. First follow the _Steps to reproduce_ in the issue #8178.
2. Then make sure the out of stock line item is visible on the edit order page in the admin area.
3. Then make sure you can delete the out of stock line item.

#### Release notes

If an order has out of stock line items display them and let admins remove them.

Changelog Category: User facing changes

![insufficient-stock-lines](https://user-images.githubusercontent.com/101088/139487654-5d33b853-2d9b-4a9a-9307-b0653731e723.gif)
