### PR TITLE
Fix keyword args deprecations

### DIFF
--- a/lib/spree/core/delegate_belongs_to.rb
+++ b/lib/spree/core/delegate_belongs_to.rb
@@ -72,7 +72,7 @@ module DelegateBelongsTo
         raise 'Illegal or unimplemented association type.'
       end
 
-      __send__(type, association, opts) if reflect_on_association(association).nil?
+      __send__(type, association, **opts) if reflect_on_association(association).nil?
     end
 
     private

--- a/lib/spree/i18n.rb
+++ b/lib/spree/i18n.rb
@@ -16,8 +16,8 @@ module Spree
 
       options = args.extract_options!
       options[:scope] = [*options[:scope]].unshift(:spree).uniq
-      args << options
-      super(*args)
+
+      super(*args, **options)
     end
 
     alias_method :t, :translate


### PR DESCRIPTION
#### What? Why?

Fixes some (very frequent) deprecation warnings for keyword arguments syntax:
```
/home/runner/work/openfoodnetwork/openfoodnetwork/lib/spree/core/delegate_belongs_to.rb:75: 
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

/home/runner/work/openfoodnetwork/openfoodnetwork/lib/spree/i18n.rb:20: 
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

We still have a few more instances of this warning message, but coming from gem code...

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated some deprecated keyword arguments syntax

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
