### PR TITLE
Moves/Updates admin into system (cont. III)

### DIFF
--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -180,8 +180,9 @@ describe '
     shop_message_input = page.find("text-angular#enterprise_preferred_shopfront_message div[id^='taTextElement']")
     shop_message_input.native.send_keys('This is my shopfront message.')
     expect(page).to have_checked_field "enterprise_preferred_shopfront_order_cycle_order_orders_close_at"
-    choose "enterprise_preferred_shopfront_order_cycle_order_orders_open_at"
-    choose "enterprise_enable_subscriptions_true"
+    #using "find" as fields outside of the screen and are not visible  
+    find(:xpath, '//*[@id="enterprise_preferred_shopfront_order_cycle_order_orders_open_at"]').trigger("click")
+    find(:xpath, '//*[@id="enterprise_enable_subscriptions_true"]').trigger("click")
 
     accept_alert do
       click_link "Inventory Settings"

--- a/spec/system/admin/schedules_spec.rb
+++ b/spec/system/admin/schedules_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'system_helper'
 
 describe 'Schedules', js: true do
   include AuthenticationHelper

--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -46,9 +46,12 @@ describe 'shipping methods' do
     end
 
     it "deleting a shipping method" do
-      visit_delete spree.admin_shipping_method_path(@shipping_method)
-
-      expect(flash_message).to eq "Successfully Removed"
+      visit spree.admin_shipping_methods_path
+        
+      accept_alert 'Are you sure?' do
+        page.find('a.delete-resource').click
+      end
+      expect(page).not_to have_content(@shipping_method)
       expect(Spree::ShippingMethod.where(id: @shipping_method.id)).to be_empty
     end
 

--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'system_helper'
 
 describe 'shipping methods' do
   include WebHelper

--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -55,19 +55,6 @@ describe 'shipping methods' do
       expect(Spree::ShippingMethod.where(id: @shipping_method.id)).to be_empty
     end
 
-    it "deleting a shipping method referenced by an order" do
-      order = create(:order)
-      shipment = create(:shipment)
-      shipment.add_shipping_method(@shipping_method, true)
-      order.shipments << shipment
-      order.save!
-
-      visit_delete spree.admin_shipping_method_path(@shipping_method)
-
-      expect(page).to have_content "That shipping method cannot be deleted as it is referenced by an order: #{order.number}."
-      expect(Spree::ShippingMethod.find(@shipping_method.id)).not_to be_nil
-    end
-
     it "checking a single distributor is checked by default" do
       first_distributor = Enterprise.first
       visit spree.new_admin_shipping_method_path


### PR DESCRIPTION
#### What? Why?

Continues #8440

Updates/moves several admin/enterprise feature specs into system. 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Aside from the required updates https://github.com/openfoodfoundation/openfoodnetwork/pull/8450/commits/182ef9eb3ee1ce62db54d6b626c874784ab4e4e8 and https://github.com/openfoodfoundation/openfoodnetwork/pull/8450/commits/a946b93fb92cc10cd135aa916909b68f44ad917c, an example was removed in https://github.com/openfoodfoundation/openfoodnetwork/pull/8450/commits/a946b93fb92cc10cd135aa916909b68f44ad917c as it concerned hard-deletion of a shipping method. This cannot be achieved from the UI - it is only possible to soft delete items using the trash-bin icon.

Enterprises_spec.rb was updated 6a33ad4 as it seemed to fail before. 

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes