### PR TITLE
Fix debounce on variant search dropdown

### DIFF
--- a/app/assets/javascripts/admin/utils/directives/variant_autocomplete.js.coffee
+++ b/app/assets/javascripts/admin/utils/directives/variant_autocomplete.js.coffee
@@ -10,10 +10,10 @@ angular.module("admin.utils").directive "variantAutocomplete", ($timeout) ->
         element.select2
           placeholder: t('admin.orders.select_variant')
           minimumInputLength: 3
-          quietMillis: 300
           ajax:
             url: Spree.routes.variants_search
             datatype: "json"
+            quietMillis: 500 # debounce
             data: (term, page) ->
               q: term
               distributor_id: scope.distributor_id


### PR DESCRIPTION

#### What? Why?

This wasn't applied correctly so there was zero debounce, leading to a big excess of pointless requests whilst typing in the variant search dropdown.

#### What should we test?
<!-- List which features should be tested and how. -->

If you try the "add variants" dropdown in the new subscription page it should be obvious that each letter typed in the box triggers a new request (check the network tab). After this, there should be a short delay, and only the last value will be sent in a single request (after half a second).

![Screenshot from 2021-11-04 20-45-21](https://user-images.githubusercontent.com/9029026/140417520-19bc3299-4e61-4873-85b3-fb7b8a817e36.png)


#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed debounce on variant search dropdowns

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes