### PR TITLE
Manager can delete enterprises relationship in both direction

### DIFF
--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -342,7 +342,8 @@ module Spree
     def add_relationship_management_abilities(user)
       can [:admin, :index, :create], EnterpriseRelationship
       can [:destroy], EnterpriseRelationship do |enterprise_relationship|
-        user.enterprises.include? enterprise_relationship.parent
+        user.enterprises.include?(enterprise_relationship.parent) ||
+          user.enterprises.include?(enterprise_relationship.child)
       end
     end
 

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -328,6 +328,8 @@ describe Spree::Ability do
 
     let(:er1) { create(:enterprise_relationship, parent: s1, child: d1) }
     let(:er2) { create(:enterprise_relationship, parent: d1, child: s1) }
+    let(:er3) { create(:enterprise_relationship, parent: s2, child: d2) }
+
     let(:er_ps) {
       create(:enterprise_relationship, parent: s_related, child: s1,
                                        permissions_list: [:manage_products])
@@ -429,8 +431,12 @@ describe Spree::Ability do
         is_expected.to have_ability(:destroy, for: er1)
       end
 
+      it "should be able to destroy enterprise relationships for other enterprises that are linked as child" do
+        is_expected.to have_ability(:destroy, for: er2)
+      end
+
       it "should not be able to destroy enterprise relationships for other enterprises" do
-        is_expected.not_to have_ability(:destroy, for: er2)
+        is_expected.not_to have_ability(:destroy, for: er3)
       end
 
       it "should be able to read some reports" do
@@ -655,8 +661,12 @@ describe Spree::Ability do
         is_expected.to have_ability(:destroy, for: er2)
       end
 
+      it "should be able to destroy enterprise relationships for other enterprises that are linked as child" do
+        is_expected.to have_ability(:destroy, for: er1)
+      end
+
       it "should not be able to destroy enterprise relationships for other enterprises" do
-        is_expected.not_to have_ability(:destroy, for: er1)
+        is_expected.not_to have_ability(:destroy, for: er3)
       end
 
       it "should be able to read some reports" do


### PR DESCRIPTION


#### What? Why?
```
A permits B
B permits A
```

Manager for A and B enterprises can delete the two relations.
Closes #7963 




#### What should we test?

1. As a enterprise manager, go to `admin/enterprise_relationships`
2. You should be able to delete all relation between the enterprises you manage and producers and vice-versa. 



#### Release notes
Hub is now able to remove permissions granted by Producer

Changelog Category: User facing changes


