### PR TITLE
Fix the issue with 'at' in enterprise twitter and instagram

### DIFF
--- a/app/assets/javascripts/templates/partials/follow.html.haml
+++ b/app/assets/javascripts/templates/partials/follow.html.haml
@@ -2,7 +2,7 @@
   %p.modal-header {{'follow' | t}}
   .follow-icons
     %span{"ng-if" => "::enterprise.twitter"}
-      %a{"ng-href" => "http://twitter.com/{{::enterprise.twitter}}", target: "_blank"}
+      %a{"ng-href" => "http://www.twitter.com/{{::enterprise.twitter}}", target: "_blank"}
         %i.ofn-i_041-twitter
 
     %span{"ng-if" => "::enterprise.facebook"}
@@ -14,5 +14,5 @@
         %i.ofn-i_042-linkedin
 
     %span{"ng-if" => "::enterprise.instagram"}
-      %a{"ng-href" => "http://instagram.com/{{::enterprise.instagram}}", target: "_blank"}
+      %a{"ng-href" => "http://www.instagram.com/{{::enterprise.instagram}}", target: "_blank"}
         %i.ofn-i_043-instagram

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -290,6 +290,14 @@ class Enterprise < ApplicationRecord
     strip_url self[:linkedin]
   end
 
+  def twitter
+    correct_social_url self[:twitter]
+  end
+
+  def instagram
+    correct_social_url self[:instagram]
+  end
+
   def inventory_variants
     if prefers_product_selection_from_inventory_only?
       Spree::Variant.visible_for(self)
@@ -418,6 +426,10 @@ class Enterprise < ApplicationRecord
 
   def strip_url(url)
     url&.sub(%r{(https?://)?}, '')
+  end
+
+  def correct_social_url(url)
+    url&.include?("@") ? url.delete!("@") : url
   end
 
   def set_unused_address_fields

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -291,11 +291,11 @@ class Enterprise < ApplicationRecord
   end
 
   def twitter
-    correct_social_url self[:twitter]
+    correct_twitter_url self[:twitter]
   end
 
   def instagram
-    correct_social_url self[:instagram]
+    correct_instagram_url self[:instagram]
   end
 
   def inventory_variants
@@ -428,8 +428,12 @@ class Enterprise < ApplicationRecord
     url&.sub(%r{(https?://)?}, '')
   end
 
-  def correct_social_url(url)
-    url&.delete("@")
+  def correct_instagram_url(url)
+    url && strip_url(url).sub(%r{www.instagram.com/}, '').delete("@")
+  end
+
+  def correct_twitter_url(url)
+    url && strip_url(url).sub(%r{www.twitter.com/}, '').delete("@")
   end
 
   def set_unused_address_fields

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -429,7 +429,7 @@ class Enterprise < ApplicationRecord
   end
 
   def correct_social_url(url)
-    url&.include?("@") ? url.delete!("@") : url
+    url&.delete("@")
   end
 
   def set_unused_address_fields

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -561,13 +561,20 @@ describe Enterprise do
       build_stubbed(:distributor_enterprise,
                     website: "http://www.google.com",
                     facebook: "www.facebook.com/roger",
-                    linkedin: "https://linkedin.com")
+                    linkedin: "https://linkedin.com",
+                    instagram: "@insgram_user",
+                    twitter: "@twitter_user")
     }
 
     it "strips http from url fields" do
       expect(distributor.website).to eq("www.google.com")
       expect(distributor.facebook).to eq("www.facebook.com/roger")
       expect(distributor.linkedin).to eq("linkedin.com")
+    end
+
+    it "strips @ from url fields" do
+      expect(distributor.instagram).to eq("insgram_user")
+      expect(distributor.twitter).to eq("twitter_user")
     end
   end
 

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -562,8 +562,8 @@ describe Enterprise do
                     website: "http://www.google.com",
                     facebook: "www.facebook.com/roger",
                     linkedin: "https://linkedin.com",
-                    instagram: "@insgram_user",
-                    twitter: "@twitter_user")
+                    instagram: "https://www.instagram.com/@insgram_user",
+                    twitter: "www.twitter.com/@twitter_user")
     }
 
     it "strips http from url fields" do
@@ -572,7 +572,7 @@ describe Enterprise do
       expect(distributor.linkedin).to eq("linkedin.com")
     end
 
-    it "strips @ from url fields" do
+    it "strips @, http and domain address from url fields" do
       expect(distributor.instagram).to eq("insgram_user")
       expect(distributor.twitter).to eq("twitter_user")
     end

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -125,8 +125,8 @@ describe "Registration", js: true do
       fill_in 'enterprise_website', with: 'www.shop.com'
       fill_in 'enterprise_facebook', with: 'FaCeBoOk'
       fill_in 'enterprise_linkedin', with: 'LiNkEdIn'
-      fill_in 'enterprise_twitter', with: '@TwItTeR'
-      fill_in 'enterprise_instagram', with: '@InStAgRaM'
+      fill_in 'enterprise_twitter', with: 'TwItTeR'
+      fill_in 'enterprise_instagram', with: 'InStAgRaM'
       click_button "Continue"
       expect(page).to have_content 'Finished!'
 
@@ -135,8 +135,8 @@ describe "Registration", js: true do
       expect(e.website).to eq "www.shop.com"
       expect(e.facebook).to eq "FaCeBoOk"
       expect(e.linkedin).to eq "LiNkEdIn"
-      expect(e.twitter).to eq "@TwItTeR"
-      expect(e.instagram).to eq "@InStAgRaM"
+      expect(e.twitter).to eq "TwItTeR"
+      expect(e.instagram).to eq "InStAgRaM"
 
       click_link "Go to Enterprise Dashboard"
       expect(page).to have_content "CHOOSE YOUR PACKAGE"

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -125,8 +125,8 @@ describe "Registration", js: true do
       fill_in 'enterprise_website', with: 'www.shop.com'
       fill_in 'enterprise_facebook', with: 'FaCeBoOk'
       fill_in 'enterprise_linkedin', with: 'LiNkEdIn'
-      fill_in 'enterprise_twitter', with: 'TwItTeR'
-      fill_in 'enterprise_instagram', with: 'InStAgRaM'
+      fill_in 'enterprise_twitter', with: 'https://www.twitter.com/@TwItTeR'
+      fill_in 'enterprise_instagram', with: 'www.instagram.com/InStAgRaM'
       click_button "Continue"
       expect(page).to have_content 'Finished!'
 


### PR DESCRIPTION
#### What? Why?

Closes #6558 

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->
Twitter and Instagram links were not being properly set (@ is kept in URL).

**Steps to reproduce.**
1. Create (register) a new entity -> click on the `Register here` btn on the `http://localhost:3000/abc/shop#/contact`;
2. Fill all the fields as required till the 6th step of registration - Social;
3. Fill out the social form as below.
```
Website:
https://sarvarkhalimov.com/
=> sarvarkhalimov.com/

Facebook:
https://www.facebook.com/username 
=> www.facebook.com/username

LinkedIn:
https://www.linkedin.com/in/username/ 
=> www.linkedin.com/in/username/ 

Twitter:
@username 
=> twitter.com/@username

Instagram:
@username 
=> instagram.com/@username
```


#### What should we test?
<!-- List which features should be tested and how. -->
The aforementioned steps (_Steps to reproduce._) can be followed to test.
Currently, it removes `@`, if there is any, in Twitter or Instagram link fields.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->
Enterprise Twitter and Instagram links URL will be auto-corrected.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->
No, change doesn't depend on any additional dependencies.
