### PR TITLE
Added the Active Storage and a rake task for migrating paperclip data…

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require_relative 'boot'
 require "rails"
 [
   "active_record/railtie",
-  #"active_storage/engine",
+  "active_storage/engine",
   "action_controller/railtie",
   "action_view/railtie",
   "action_mailer/railtie",

--- a/db/migrate/20211110065552_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211110065552_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_29_174211) do
+ActiveRecord::Schema.define(version: 2021_11_10_065552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "adjustment_metadata", force: :cascade do |t|
     t.integer "adjustment_id"
@@ -1181,6 +1209,8 @@ ActiveRecord::Schema.define(version: 2021_10_29_174211) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "adjustment_metadata", "enterprises", name: "adjustment_metadata_enterprise_id_fk"
   add_foreign_key "adjustment_metadata", "spree_adjustments", column: "adjustment_id", name: "adjustment_metadata_adjustment_id_fk", on_delete: :cascade
   add_foreign_key "coordinator_fees", "enterprise_fees", name: "coordinator_fees_enterprise_fee_id_fk"

--- a/lib/tasks/migrate_paper_clip_data.rake
+++ b/lib/tasks/migrate_paper_clip_data.rake
@@ -1,0 +1,103 @@
+require 'open-uri'
+
+namespace :migrate_paperclip do
+  desc 'Migrate the paperclip data'
+  task move_data: :environment do
+    prepare_statements
+    Rails.application.eager_load!
+
+    models = ActiveRecord::Base.descendants.reject(&:abstract_class?)
+
+    models.each do |model|
+      puts 'Checking Model [' + model.to_s + '] for Paperclip attachment columns ...'
+
+      attachments = model.column_names.map do |c|
+        Regexp.last_match(1) if c =~ /(.+)_file_name$/
+      end.compact
+
+      if attachments.blank?
+        puts '  No Paperclip attachment columns found for [' + model.to_s + '].'
+        puts ''
+        next
+      end
+
+      puts '  Paperclip attachment columns found for [' + model.to_s + ']: ' + attachments.to_s
+
+      model.find_each.each do |instance|
+        attachments.each do |attachment|
+          next if instance.send(attachment).path.blank?
+
+          create_active_storage_records(instance, attachment, model)
+        end
+      end
+      puts ''
+    end
+  end
+end
+
+private
+
+def prepare_statements
+  get_blob_id = 'LASTVAL()'
+
+  ActiveRecord::Base.connection.raw_connection.prepare('active_storage_blob_statement', <<-SQL)
+    INSERT INTO active_storage_blobs (
+      key, filename, content_type, metadata, byte_size, checksum, created_at
+    ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
+  SQL
+
+  ActiveRecord::Base.connection.raw_connection.prepare('active_storage_attachment_statement', <<-SQL)
+    INSERT INTO active_storage_attachments (
+      name, record_type, record_id, blob_id, created_at
+    ) VALUES ($1, $2, $3, #{get_blob_id}, $4)
+  SQL
+end
+
+def create_active_storage_records(instance, attachment, model)
+  puts '    Creating ActiveStorage records for [' +
+       model.name + ' (ID: ' + instance.id.to_s + ')] ' +
+       instance.send("#{attachment}_file_name") +
+       ' (' + instance.send("#{attachment}_content_type") + ')'
+  build_active_storage_blob(instance, attachment)
+  build_active_storage_attachment(instance, attachment, model)
+end
+
+def build_active_storage_blob(instance, attachment)
+  created_at = instance.updated_at.iso8601
+  blob_key = key(instance, attachment)
+  filename = instance.send("#{attachment}_file_name")
+  content_type = instance.send("#{attachment}_content_type")
+  file_size = instance.send("#{attachment}_file_size")
+  file_checksum = checksum(instance.send(attachment))
+
+  blob_values = [blob_key, filename, content_type, file_size, file_checksum, created_at]
+
+  insert_record('active_storage_blob_statement', blob_values)
+end
+
+def build_active_storage_attachment(instance, attachment, model)
+  created_at = instance.updated_at.iso8601
+  blob_name = attachment
+  record_type = model.name
+  record_id = instance.id
+
+  attachment_values = [blob_name, record_type, record_id, created_at]
+
+  insert_record('active_storage_attachment_statement', attachment_values)
+end
+
+def insert_record(statement, values)
+  ActiveRecord::Base.connection.raw_connection.exec_prepared(
+    statement,
+    values
+  )
+end
+
+def key(_instance, _attachment)
+  SecureRandom.uuid
+end
+
+def checksum(attachment)
+  url = attachment.url
+  Digest::MD5.base64digest(Net::HTTP.get(URI(url)))
+end


### PR DESCRIPTION
… to active storage

#### 
1. Enabled Active storage feature for store the attachments.
2. Created a rake task to migrate paperclip data to active storage.

Closes #[the issue number this PR is related to]

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->



#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes | Technical changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
