### PR TITLE
Update code for active storage and rake task

### DIFF
--- a/app/models/spree/image.rb
+++ b/app/models/spree/image.rb
@@ -30,7 +30,7 @@ module Spree
 
     # used by admin products autocomplete
     def mini_url
-      attachment.url(:mini, false)
+      url_for(attachment.variant(resize: "48x48#"))
     end
 
     def find_dimensions

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -86,7 +86,7 @@ module Api
         return unless attachment.file?
 
         versions.each_with_object({}) do |version, urls|
-          urls[version] = attachment.url(version)
+          urls[version] = url_for(attachment)
         end
       end
     end

--- a/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
+++ b/app/serializers/api/admin/for_order_cycle/supplied_product_serializer.rb
@@ -11,7 +11,7 @@ module Api
         end
 
         def image_url
-          object.images.present? ? object.images.first.attachment.url(:mini) : nil
+          object.images.present? ? url_for(object.images.first.attachment.variant(resize: '48x48#')) : nil
         end
 
         def master_id

--- a/app/serializers/api/admin/product_serializer.rb
+++ b/app/serializers/api/admin/product_serializer.rb
@@ -14,7 +14,7 @@ module Api
 
       def image_url
         if object.images.present?
-          object.images.first.attachment.url(:product)
+          url_for(object.images.first.attachment.variant(resize: '240x240>'))
         else
           "/noimage/product.png"
         end
@@ -22,7 +22,7 @@ module Api
 
       def thumb_url
         if object.images.present?
-          object.images.first.attachment.url(:mini)
+          url_for(object.images.first.attachment.variant(resize: '48x48#'))
         else
           "/noimage/mini.png"
         end

--- a/app/serializers/api/image_serializer.rb
+++ b/app/serializers/api/image_serializer.rb
@@ -4,18 +4,18 @@ class Api::ImageSerializer < ActiveModel::Serializer
   attributes :id, :alt, :thumb_url, :small_url, :image_url, :large_url
 
   def thumb_url
-    object.attachment.url(:mini, false)
+    object.attachment.variant(resize: "48x48#")
   end
 
   def small_url
-    object.attachment.url(:small, false)
+    object.attachment.variant(resize: "227x227#")
   end
 
   def image_url
-    object.attachment.url(:product, false)
+    object.attachment.variant(resize: "240x240>")
   end
 
   def large_url
-    object.attachment.url(:large, false)
+    object.attachment.variant(resize: "600x600>")
   end
 end

--- a/app/serializers/api/variant_serializer.rb
+++ b/app/serializers/api/variant_serializer.rb
@@ -36,7 +36,7 @@ class Api::VariantSerializer < ActiveModel::Serializer
 
   def thumb_url
     if object.product.images.present?
-      object.product.images.first.attachment.url(:mini)
+      url_for(object.product.images.first.attachment.variant(resize: "48x48#"))
     else
       "/noimage/mini.png"
     end

--- a/app/views/admin/terms_of_service_files/show.html.haml
+++ b/app/views/admin/terms_of_service_files/show.html.haml
@@ -5,7 +5,7 @@
 
 .admin-current-terms-of-service
   - if @current_file
-    %p= t(".current_terms_html", tos_link: link_to(t(".terms_of_service"), @current_file.attachment.url), datetime: @current_file.updated_at)
+    %p= t(".current_terms_html", tos_link: link_to(t(".terms_of_service"), url_for(@current_file.attachment)), datetime: @current_file.updated_at)
     %p= link_to t(".delete"), main_app.admin_terms_of_service_files_path, method: "delete", data: { confirm: t(".confirm_delete") }
   - else
     %p

--- a/app/views/spree/admin/images/edit.html.haml
+++ b/app/views/spree/admin/images/edit.html.haml
@@ -11,7 +11,7 @@
     .field.alpha.three.columns.align-center
       = f.label t('spree.thumbnail')
       %br/
-      = link_to image_tag(@image.attachment.url(:small)), @image.attachment.url(:product)
+      = link_to image_tag(url_for(@image.attachment.variant(resize: '227x227#')), url_for(@image.attachment.variant(resize: '240x240>'))
     .nine.columns.omega
       = render partial: 'form', locals: { f: f }
     .clear

--- a/app/views/spree/admin/images/index.html.haml
+++ b/app/views/spree/admin/images/index.html.haml
@@ -32,7 +32,7 @@
           %td.no-border
             %span.handle
           %td
-            = link_to image_tag(image.attachment.url(:mini)), image.attachment.url(:product)
+            = link_to image_tag(url_for(image.attachment.variant(resize: '48x48#'))), url_for(image.attachment.variant(resize: '240x240>')
           %td= options_text_for(image)
           %td= image.alt
           %td.actions

--- a/app/views/spree/shared/_variant_thumbnail.html.haml
+++ b/app/views/spree/shared/_variant_thumbnail.html.haml
@@ -1,4 +1,4 @@
 - if variant.product.images.length == 0
   = image_tag("/noimage/mini.png")
 - else
-  = image_tag(variant.product.images.first.attachment.url(:mini))
+  = image_tag(url_for(variant.product.images.first.attachment.variant(resize: '48x48#')))

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require_relative 'boot'
 require "rails"
 [
   "active_record/railtie",
-  #"active_storage/engine",
+  "active_storage/engine",
   "action_controller/railtie",
   "action_view/railtie",
   "action_mailer/railtie",

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,6 +57,8 @@ Openfoodnetwork::Application.configure do
   #   $ bundle exec rake assets:clean
   config.assets.debug = !!ENV["DEBUG_ASSETS"]
 
+  config.active_storage.service = :amazondev
+
   # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
   # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
   #

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,6 +48,8 @@ Openfoodnetwork::Application.configure do
     reconnect_attempts: 1
   }
 
+  config.active_storage.service = :amazon
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,13 @@
+amazondev:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['S3_REGION'] %>
+  bucket: <%= ENV['S3_BUCKET_NAME_DEV'] %>
+
+amazon:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['S3_REGION'] %>
+  bucket: <%= ENV['S3_BUCKET_NAME'] %>

--- a/db/migrate/20211110065552_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211110065552_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_29_174211) do
+ActiveRecord::Schema.define(version: 2021_11_10_065552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "adjustment_metadata", force: :cascade do |t|
     t.integer "adjustment_id"
@@ -1181,6 +1209,8 @@ ActiveRecord::Schema.define(version: 2021_10_29_174211) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "adjustment_metadata", "enterprises", name: "adjustment_metadata_enterprise_id_fk"
   add_foreign_key "adjustment_metadata", "spree_adjustments", column: "adjustment_id", name: "adjustment_metadata_adjustment_id_fk", on_delete: :cascade
   add_foreign_key "coordinator_fees", "enterprise_fees", name: "coordinator_fees_enterprise_fee_id_fk"

--- a/lib/tasks/migrate_paper_clip_attachments.rake
+++ b/lib/tasks/migrate_paper_clip_attachments.rake
@@ -1,0 +1,75 @@
+namespace :migrate_paperclip do
+  desc 'Migrate the paperclip attachments'
+  task move_attachments: :environment do
+    Rails.application.eager_load!
+
+    models = ActiveRecord::Base.descendants.reject(&:abstract_class?)
+
+    models.each do |model|
+      puts 'Checking Model [' + model.to_s + '] for Paperclip attachment columns ...'
+
+      errs = []
+      err_ids = []
+
+      attachments = model.column_names.map do |c|
+        Regexp.last_match(1) if c =~ /(.+)_file_name$/
+      end.compact
+
+      attachments.each do |attachment|
+        migrate_attachment(attachment, model, errs, err_ids)
+      end
+
+      next if errs.empty?
+
+      puts ''
+      puts 'Errored attachments:'
+      puts ''
+
+      errs.each do |err|
+        puts err
+      end
+
+      puts ''
+      puts 'Errored attachments list of IDs (use for SQL statements)'
+      puts err_ids.join(',')
+      puts ''
+    end
+  end
+end
+
+private
+
+def migrate_attachment(attachment, model, errs, err_ids)
+  model.where.not("#{attachment}_file_name": nil).find_each do |instance|
+
+    bucket = Rails.env.production? ? ENV['S3_BUCKET_NAME'] : ENV['S3_BUCKET_NAME_DEV']
+    region = ENV['S3_REGION']
+
+    instance_id = instance.id
+    filename = instance.send("#{attachment}_file_name")
+    extension = File.extname(filename)
+    content_type = instance.send("#{attachment}_content_type")
+    original = CGI.unescape(filename.gsub(extension, "_original#{extension}"))
+
+    puts '  [' + model.name + ' (ID: ' +
+         instance_id.to_s + ')] ' \
+         'Copying to ActiveStorage location: ' + original
+
+    instance_path = instance_id.to_s.rjust(9, '0')
+    instance_path = instance_path.scan(/.{1,3}/).join('/')
+
+    url = "https://#{bucket}.s3.#{region}.amazonaws.com/#{model.name.downcase.pluralize}/#{attachment.pluralize}/#{instance_path}/original/#{filename}"
+
+    begin
+      instance.send(attachment.to_sym).attach(
+        io: open(url),
+        filename: filename,
+        content_type: content_type
+      )
+    rescue StandardError => e
+      puts '    ... error! ...'
+      errs.push("[#{model.name}][#{attachment}] - #{instance_id} - #{e}")
+      err_ids.push(instance_id)
+    end
+  end
+end

--- a/lib/tasks/migrate_paper_clip_data.rake
+++ b/lib/tasks/migrate_paper_clip_data.rake
@@ -1,0 +1,102 @@
+require 'open-uri'
+
+namespace :migrate_paperclip do
+  desc 'Migrate the paperclip data'
+  task move_data: :environment do
+    prepare_statements
+    Rails.application.eager_load!
+
+    models = ActiveRecord::Base.descendants.reject(&:abstract_class?)
+
+    models.each do |model|
+      puts 'Checking Model [' + model.to_s + '] for Paperclip attachment columns ...'
+
+      attachments = model.column_names.map do |c|
+        Regexp.last_match(1) if c =~ /(.+)_file_name$/
+      end.compact
+
+      if attachments.blank?
+        puts '  No Paperclip attachment columns found for [' + model.to_s + '].'
+        puts ''
+        next
+      end
+
+      puts '  Paperclip attachment columns found for [' + model.to_s + ']: ' + attachments.to_s
+
+      model.find_each.each do |instance|
+        attachments.each do |attachment|
+          next if instance.send(attachment).path.blank?
+
+          create_active_storage_records(instance, attachment, model)
+        end
+      end
+      puts ''
+    end
+  end
+end
+
+private
+
+def prepare_statements
+  get_blob_id = 'LASTVAL()'
+
+  ActiveRecord::Base.connection.raw_connection.prepare('active_storage_blob_statement', <<-SQL)
+    INSERT INTO active_storage_blobs (
+      key, filename, content_type, metadata, byte_size, checksum, created_at
+    ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
+  SQL
+
+  ActiveRecord::Base.connection.raw_connection.prepare('active_storage_attachment_statement', <<-SQL)
+    INSERT INTO active_storage_attachments (
+      name, record_type, record_id, blob_id, created_at
+    ) VALUES ($1, $2, $3, #{get_blob_id}, $4)
+  SQL
+end
+
+def create_active_storage_records(instance, attachment, model)
+  puts '    Creating ActiveStorage records for [' +
+       model.name + ' (ID: ' + instance.id.to_s + ')] ' +
+       instance.send("#{attachment}_file_name") +
+       ' (' + instance.send("#{attachment}_content_type") + ')'
+  build_active_storage_blob(instance, attachment)
+  build_active_storage_attachment(instance, attachment, model)
+end
+
+def build_active_storage_blob(instance, attachment)
+  created_at = instance.updated_at.iso8601
+  blob_key = key(instance, attachment)
+  filename = instance.send("#{attachment}_file_name")
+  content_type = instance.send("#{attachment}_content_type")
+  file_size = instance.send("#{attachment}_file_size")
+  file_checksum = checksum(instance.send(attachment))
+
+  blob_values = [blob_key, filename, content_type, file_size, file_checksum, created_at]
+
+  insert_record('active_storage_blob_statement', blob_values)
+end
+
+def build_active_storage_attachment(instance, attachment, model)
+  created_at = instance.updated_at.iso8601
+  blob_name = attachment
+  record_type = model.name
+  record_id = instance.id
+  attachment_values = [blob_name, record_type, record_id, created_at]
+
+  insert_record('active_storage_attachment_statement', attachment_values)
+end
+
+def insert_record(statement, values)
+  ActiveRecord::Base.connection.raw_connection.exec_prepared(
+    statement,
+    values
+  )
+end
+
+def key(_instance, _attachment)
+  SecureRandom.uuid
+end
+
+def checksum(attachment)
+  url = attachment.url
+  Digest::MD5.base64digest(Net::HTTP.get(URI(url)))
+end


### PR DESCRIPTION
In this PR, ActiveStorage will be activated.
1. Models and views are updated as per active storage such as exists? becomes attached?, url(:size) becomes variant(resize: "dimensions") etc.
2. The actual attachments will be copied to the ActiveStorage directory structure.
3. The rake task will loop through all models in the application, and for each model containing Paperclip attachment columns, it will then search the model's records for those with attachments. When a record with an attachment is found, the rake task will then generate the URL of the attachment, and then re-attach that file to the record with the now-enabled ActiveStorage methods, which essentially copies the file on the S3 bucket from the Paperclip path to the ActiveStorage path.

Deployment
Deploy to production, and then the second rake task:
$ rails migrate_paperclip:move_attachments


Link to issue - https://github.com/openfoodfoundation/openfoodnetwork/issues/6347


#### What should we test?
Testing instructions - we have to do a lot of unit testing, updating RSpec tests, and deploy to a staging/test server first. I would also recommend backing up/duplicating your production S3 bucket prior to performing the deployment.



#### Release notes


Deploy Branch https://github.com/openfoodfoundation/openfoodnetwork/pull/8469
The first step in deployment will be to deploy this branch to production, run the migrations, and then the rake task:

$ rails migrate_paperclip:move_data

Deploy Branch https://github.com/openfoodfoundation/openfoodnetwork/pull/8470
Next, the second branch needs to be deployed to production, and then the second rake task can be run:

$ rails migrate_paperclip:move_attachments

Once finished, the old Paperclip S3 folder can be removed and your application is now on ActiveStorage





#### Dependencies
Link to related PR - https://github.com/openfoodfoundation/openfoodnetwork/pull/8469

