### PR TITLE
Use distinct to return unique product list for scope `visible_for`

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -159,7 +159,8 @@ module Spree
         joins('
           LEFT OUTER JOIN inventory_items AS o_inventory_items
             ON (o_spree_variants.id = o_inventory_items.variant_id)').
-        where('o_inventory_items.enterprise_id = (?) AND visible = (?)', enterprise, true)
+        where('o_inventory_items.enterprise_id = (?) AND visible = (?)', enterprise, true).
+        distinct
     }
 
     # -- Scopes

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -617,18 +617,26 @@ module Spree
         let(:enterprise) { create(:distributor_enterprise) }
         let!(:new_variant) { create(:variant) }
         let!(:hidden_variant) { create(:variant) }
-        let!(:visible_variant) { create(:variant) }
+
+        let!(:product) { create(:product) }
+        let!(:visible_variant1) { create(:variant, product: product) }
+        let!(:visible_variant2) { create(:variant, product: product) }
+
         let!(:hidden_inventory_item) {
           create(:inventory_item, enterprise: enterprise, variant: hidden_variant, visible: false )
         }
-        let!(:visible_inventory_item) {
-          create(:inventory_item, enterprise: enterprise, variant: visible_variant, visible: true )
+        let!(:visible_inventory_item1) {
+          create(:inventory_item, enterprise: enterprise, variant: visible_variant1, visible: true )
+        }
+        let!(:visible_inventory_item2) {
+          create(:inventory_item, enterprise: enterprise, variant: visible_variant2, visible: true )
         }
 
         let!(:products) { Spree::Product.visible_for(enterprise) }
 
         it "lists any products with variants that are listed as visible=true" do
-          expect(products).to include visible_variant.product
+          expect(products.length).to eq(1)
+          expect(products).to include product
           expect(products).to_not include new_variant.product, hidden_variant.product
         end
       end


### PR DESCRIPTION
#### What? Why?
Product were displayed twice (or more) in certain condition under order cycle incoming products admin interface


Closes #7885


#### What should we test?

1. Create a product with n variants, with n > 1
2. Add it to the inventory
3. Add it to an OC
4. Under "Advanced Settings" choose the option "Coordinators inventory only"
5. See this product appears *1* time in the incoming section of the OC -> notice the loaded variant count is also *correct* (xx / yy Variants Loaded where xx < yy)



#### Release notes
Remove duplicate product under incoming products section of an order cycle under certain conditions

Changelog Category: User facing changes

