### PR TITLE
Include items from resumed orders when mailing producers

### DIFF
--- a/app/mailers/producer_mailer.rb
+++ b/app/mailers/producer_mailer.rb
@@ -65,7 +65,7 @@ class ProducerMailer < Spree::BaseMailer
       from_order_cycle(order_cycle).
       sorted_by_name_and_unit_value.
       merge(Spree::Product.with_deleted.in_supplier(producer)).
-      merge(Spree::Order.by_state('complete'))
+      merge(Spree::Order.by_state(["complete", "resumed"]))
   end
 
   def total_from_line_items(line_items)

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -111,7 +111,7 @@ describe ProducerMailer, type: :mailer do
       order.finalize!
       order.cancel
       order.resume
-      order.save
+      order.save!
       order
     end
 

--- a/spec/mailers/producer_mailer_spec.rb
+++ b/spec/mailers/producer_mailer_spec.rb
@@ -26,6 +26,7 @@ describe ProducerMailer, type: :mailer do
   let(:p3) { create(:product, name: "Banana", price: 34.56, supplier: s1) }
   let(:p4) { create(:product, name: "coffee", price: 45.67, supplier: s1) }
   let(:p5) { create(:product, name: "Daffodil", price: 56.78, supplier: s1) }
+  let(:p6) { create(:product, name: "Eggs", price: 67.89, supplier: s1) }
   let(:order_cycle) { create(:simple_order_cycle) }
   let!(:incoming_exchange) {
     order_cycle.exchanges.create! sender: s1, receiver: d1, incoming: true,
@@ -101,6 +102,22 @@ describe ProducerMailer, type: :mailer do
 
   it "does not include canceled orders" do
     expect(mail.body.encoded).not_to include p5.name
+  end
+
+  context "when a cancelled order has been resumed" do
+    let!(:order_resumed) do
+      order = create(:order, distributor: d1, order_cycle: order_cycle, state: 'complete')
+      order.line_items << create(:line_item, variant: p6.variants.first)
+      order.finalize!
+      order.cancel
+      order.resume
+      order.save
+      order
+    end
+
+    it "includes items from resumed orders" do
+      expect(mail.body.encoded).to include p6.name
+    end
   end
 
   it "includes the total" do


### PR DESCRIPTION
#### What? Why?

Closes #8320 

Resumed orders were not included in the scope when emailing producers for an OC.

#### What should we test?
<!-- List which features should be tested and how. -->

Resumed orders should be included when using the "notify producers" button.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed an issue where resumed orders were not included when emailing producers

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
