### PR TITLE
Ensure line items are correctly scoped for producers

### DIFF
--- a/app/services/permissions/order.rb
+++ b/app/services/permissions/order.rb
@@ -10,7 +10,9 @@ module Permissions
       @search_params = search_params
     end
 
-    # Find orders that the user can see
+    # Find orders that the user can see. This includes any order where the producer has permissions
+    # and has at least *one* of their supplied products in the order. Additional scoping may be
+    # needed for queries showing line items per producer.
     def visible_orders
       orders = Spree::Order.
         with_line_items_variants_and_products_outer.

--- a/lib/reporting/queries/query_builder.rb
+++ b/lib/reporting/queries/query_builder.rb
@@ -26,6 +26,12 @@ module Reporting
         )
       end
 
+      def scoped_to_line_items(line_items_relation)
+        reflect query.where(
+          line_item_table[:id].in(Arel.sql(line_items_relation.to_sql))
+        )
+      end
+
       def with_managed_orders(orders_relation)
         reflect query.
           outer_join(managed_orders_alias).

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -41,6 +41,12 @@ module Reporting
         select(:id).distinct
     end
 
+    def visible_line_items_relation
+      ::Permissions::Order.new(current_user).
+        visible_line_items.
+        select(:id).distinct
+    end
+
     def managed_orders_relation
       ::Enterprise.managed_by(current_user).select(:id).distinct
     end

--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -13,6 +13,7 @@ module Reporting
         def report_query
           Queries::QueryBuilder.new(primary_model, grouping_fields).
             scoped_to_orders(scoped_orders_relation).
+            scoped_to_line_items(visible_line_items_relation).
             with_managed_orders(managed_orders_relation).
             joins_order_and_distributor.
             joins_order_customer.


### PR DESCRIPTION
#### What? Why?

Closes #8473 

#### What should we test?
<!-- List which features should be tested and how. -->

For orders which contain items from multiple producers, only those supplied by the current user should be shown.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed supplied items visibility issue in packing reports

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
