### PR TITLE
Split admin system tests into two groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,8 @@ jobs:
           - "spec/lib"
           - "spec/migrations"
           - "spec/serializers"
-          - "spec/system/admin"
+          - "spec/system/admin/[a-o0-9]*_spec.rb"
+          - "spec/system/admin/[p-z]*_spec.rb"
           - "spec/system/consumer"
           - "engines/*/spec"
       fail-fast: false


### PR DESCRIPTION
#### What? Why?

Breaks up admin system tests into two CI jobs, in line with the previous feature test setup. Should cut the current build time roughly in half.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Split admin system tests into two groups

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
