### PR TITLE
Search enterprises through name + city and state_name

### DIFF
--- a/app/assets/javascripts/darkswarm/controllers/enterprises_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/enterprises_controller.js.coffee
@@ -1,4 +1,4 @@
-angular.module('Darkswarm').controller "EnterprisesCtrl", ($scope, $rootScope, $timeout, $location, Enterprises, Search, $document, HashNavigation, FilterSelectorsService, EnterpriseModal, enterpriseMatchesNameQueryFilter, distanceWithinKmFilter) ->
+angular.module('Darkswarm').controller "EnterprisesCtrl", ($scope, $rootScope, $timeout, $location, Enterprises, Search, $document, HashNavigation, FilterSelectorsService, EnterpriseModal, enterpriseMatchesQueryFilter, distanceWithinKmFilter) ->
   $scope.Enterprises = Enterprises
   $scope.producers_to_filter = Enterprises.producers
   $scope.filterSelectors = FilterSelectorsService.createSelectors()
@@ -55,8 +55,8 @@ angular.module('Darkswarm').controller "EnterprisesCtrl", ($scope, $rootScope, $
 
   $scope.filterEnterprises = ->
     es = Enterprises.hubs
-    $scope.nameMatches = enterpriseMatchesNameQueryFilter(es, true)
-    noNameMatches = enterpriseMatchesNameQueryFilter(es, false)
+    $scope.nameMatches = enterpriseMatchesQueryFilter(es, true)
+    noNameMatches = enterpriseMatchesQueryFilter(es, false)
     $scope.distanceMatches = distanceWithinKmFilter(noNameMatches, 50)
 
 

--- a/app/assets/javascripts/darkswarm/filters/enterpriseMatchesNameQuery.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/enterpriseMatchesNameQuery.js.coffee
@@ -1,4 +1,0 @@
-angular.module('Darkswarm').filter 'enterpriseMatchesNameQuery', ->
-  (enterprises, matches_name_query) ->
-    enterprises.filter (enterprise) ->
-      enterprise.matches_name_query == matches_name_query

--- a/app/assets/javascripts/darkswarm/filters/enterpriseMatchesQuery.js.coffee
+++ b/app/assets/javascripts/darkswarm/filters/enterpriseMatchesQuery.js.coffee
@@ -1,0 +1,4 @@
+angular.module('Darkswarm').filter 'enterpriseMatchesQuery', ->
+  (enterprises, matches_query) ->
+    enterprises.filter (enterprise) ->
+      enterprise.matches_query == matches_query

--- a/app/assets/javascripts/darkswarm/services/enterprises.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/enterprises.js.coffee
@@ -53,8 +53,8 @@ angular.module('Darkswarm').factory 'Enterprises', (enterprises, ShopsResource, 
 
     flagMatching: (query) ->
       for enterprise in @enterprises
-        enterprise.matches_name_query = if query? && query.length > 0
-          Matcher.match([enterprise.name], query)
+        enterprise.matches_query = if query? && query.length > 0
+          Matcher.match([enterprise.name, enterprise.address?.state_name, enterprise.address?.city], query)
         else
           false
 

--- a/spec/javascripts/unit/darkswarm/services/enterprise_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/enterprise_spec.js.coffee
@@ -25,6 +25,7 @@ describe "Enterprises service", ->
     {id: 6, visible: true, name: 'f', category: "producer_shop", hubs: [{id: 2}]},
     {id: 7, visible: true, name: 'g', category: "producer", hubs: [{id: 2}]}
     {id: 8, visible: true, name: 'h', category: "producer", hubs: [{id: 2}], latitude: 76.26, longitude: -42.66 }
+    {id: 9, visible: true, name: 'i', category: "hub", address: {state_name: "state", city: "city"}}
   ]
   H1: 0
   beforeEach ->
@@ -77,19 +78,22 @@ describe "Enterprises service", ->
     expect(Enterprises.producers).toContain Enterprises.enterprises[5]
     expect(Enterprises.producers).toContain Enterprises.enterprises[6]
 
-  describe "flagging enterprises with names matching a query", ->
+  describe "flagging enterprises with names, city or state matching a query", ->
     it "flags enterprises when a query is provided", ->
       Enterprises.flagMatching 'c'
-      expect(e.matches_name_query).toBe true for e in enterprises when e.name == 'c'
-      expect(e.matches_name_query).toBe false for e in enterprises when e.name != 'c'
+      expect(e.matches_query).toBe true for e in enterprises when e.name == 'c' || e.address?.city == 'city'
+      expect(e.matches_query).toBe false for e in enterprises when e.name != 'c' && e.address?.city != 'city'
+      Enterprises.flagMatching 'state'
+      expect(e.matches_query).toBe true for e in enterprises when e.address?.state_name == "state"
+      expect(e.matches_query).toBe false for e in enterprises when e.address?.state_name != "state"
 
     it "clears flags when query is null", ->
       Enterprises.flagMatching null
-      expect(e.matches_name_query).toBe false for e in enterprises
+      expect(e.matches_query).toBe false for e in enterprises
 
     it "clears flags when query is blank", ->
       Enterprises.flagMatching ''
-      expect(e.matches_name_query).toBe false for e in enterprises
+      expect(e.matches_query).toBe false for e in enterprises
 
   describe "calculating the distance of enterprises from a location", ->
     describe "when a query is provided", ->


### PR DESCRIPTION
#### What? Why?

Closes #6689 

The idea here is to search, match and filter enterprise in the `/shops` page with name, city and state_name of the address. 



#### What should we test?
1. As a visitor, go to `/shops`
2. Filtering enterprise should work with name, city and state name

<img width="1135" alt="Capture d’écran 2021-11-12 à 15 59 40" src="https://user-images.githubusercontent.com/296452/141487509-f4c0f495-6871-45ae-ae42-8c55e7903de8.png">

<img width="1142" alt="Capture d’écran 2021-11-12 à 15 59 46" src="https://user-images.githubusercontent.com/296452/141487525-88fd4fab-b2f9-4ce7-a303-01385965b993.png">
<img width="1176" alt="Capture d’écran 2021-11-12 à 15 59 51" src="https://user-images.githubusercontent.com/296452/141487534-be6d4e9c-fe3d-49d9-84ab-e4c178497633.png">



#### Release notes
Filtering enterprise by name, city and state in the `/shops` page

Changelog Category: User facing changes

