### PR TITLE
Remove dead code: session[:guest_token]

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -34,11 +34,6 @@ module Spree
     def create
       @user = Spree::User.new(user_params)
       if @user.save
-
-        if current_order
-          session[:guest_token] = nil
-        end
-
         redirect_back_or_default(main_app.root_url)
       else
         render :new

--- a/lib/spree/core/controller_helpers/order.rb
+++ b/lib/spree/core/controller_helpers/order.rb
@@ -59,11 +59,9 @@ module Spree
 
         def associate_user
           @order ||= current_order
-          if spree_current_user && @order && (@order.user.blank? || @order.email.blank?)
-            @order.associate_user!(spree_current_user)
-          end
+          return unless spree_current_user && @order && (@order.user.blank? || @order.email.blank?)
 
-          session[:guest_token] = nil
+          @order.associate_user!(spree_current_user)
         end
 
         # Recover incomplete orders from other sessions after logging in.


### PR DESCRIPTION
#### What? Why?

This `session[:guest_token]` doesn't seem to ever be assigned anywhere in the codebase, and it doesn't seem to be read at any point either..? There are various places where `current_order.token` is used and `session[:access_token]` is used, but not this.

As far as I can tell; it was part of an old version of Spree and related to the `spree_auth_devise` gem (which we no longer use). 

Looks perfectly safe to remove, but then again [it might be a trap](https://www.youtube.com/watch?v=f--QTXpb0QI)... :musical_note: 

:fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed unused session[:guest_token] code

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

