### PR TITLE
Stripe checkout alerting

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,9 +153,11 @@ class ApplicationController < ActionController::Base
 
   def check_order_cycle_expiry
     if current_order_cycle&.closed?
+      Bugsnag.notify("Notice: order cycle closed during checkout completion", order: current_order)
       current_order.empty!
       current_order.set_order_cycle! nil
       flash[:info] = I18n.t('order_cycle_closed')
+
       redirect_to main_app.shop_path
     end
   end

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -81,14 +81,14 @@ class CheckoutController < ::BaseController
   def load_order
     @order = current_order
 
-    redirect_to(main_app.shop_path) && return if redirect_to_shop?
+    redirect_to(main_app.shop_path) && return if order_invalid_for_checkout?
     handle_invalid_stock && return unless valid_order_line_items?
 
     before_address
     setup_for_current_state
   end
 
-  def redirect_to_shop?
+  def order_invalid_for_checkout?
     !@order ||
       !@order.checkout_allowed? ||
       @order.completed?

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -81,7 +81,11 @@ class CheckoutController < ::BaseController
   def load_order
     @order = current_order
 
-    redirect_to(main_app.shop_path) && return if order_invalid_for_checkout?
+    if order_invalid_for_checkout?
+      Bugsnag.notify("Notice: invalid order loaded during Stripe processing", order: @order) if valid_payment_intent_provided?
+      redirect_to(main_app.shop_path) && return
+    end
+
     handle_invalid_stock && return unless valid_order_line_items?
 
     before_address

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -148,12 +148,14 @@ class CheckoutController < ::BaseController
   end
 
   def valid_payment_intent_provided?
-    return false unless params["payment_intent"]&.starts_with?("pi_")
+    @valid_payment_intent_provided ||= begin
+      return false unless params["payment_intent"]&.starts_with?("pi_")
 
-    last_payment = OrderPaymentFinder.new(@order).last_payment
-    @order.state == "payment" &&
-      last_payment&.state == "requires_authorization" &&
-      last_payment&.response_code == params["payment_intent"]
+      last_payment = OrderPaymentFinder.new(@order).last_payment
+      @order.state == "payment" &&
+        last_payment&.state == "requires_authorization" &&
+        last_payment&.response_code == params["payment_intent"]
+    end
   end
 
   def handle_redirect_from_stripe

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -241,7 +241,7 @@ class CheckoutController < ::BaseController
   end
 
   def checkout_failed(error = RuntimeError.new(order_error))
-    Bugsnag.notify(error)
+    Bugsnag.notify(error, order: @order)
     flash[:error] = order_error if flash.blank?
     Checkout::PostCheckoutActions.new(@order).failure
   end

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -89,9 +89,7 @@ class CheckoutController < ::BaseController
   end
 
   def order_invalid_for_checkout?
-    !@order ||
-      !@order.checkout_allowed? ||
-      @order.completed?
+    !@order || @order.completed? || !@order.checkout_allowed?
   end
 
   def valid_order_line_items?

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -102,7 +102,7 @@ describe BaseController, type: :controller do
 
   it "redirects to shopfront with message if order cycle is expired" do
     expect(controller).to receive(:current_order_cycle).and_return(oc)
-    expect(controller).to receive(:current_order).and_return(order).twice
+    expect(controller).to receive(:current_order).and_return(order).at_least(:twice)
     expect(oc).to receive(:closed?).and_return(true)
     expect(order).to receive(:empty!)
     expect(order).to receive(:set_order_cycle!).with(nil)


### PR DESCRIPTION
#### What? Why?

Related to #8296 

We're currently hitting various obscure edge cases with Stripe on a regular basis and our monitoring and alerting isn't really giving us any useful feedback at all. Any clues that might help are currently like [gold dust](https://www.youtube.com/watch?v=D-vWg0Oue6w)... :musical_note: 

This PR adds a couple of simple Bugsnag alerts in cases where something has gone wrong at the checkout, and should give us better visibility and help with related investigations.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough here.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added improved alerting around checkout errors

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
