### PR TITLE
Checkout address handling

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -148,12 +148,14 @@ class CheckoutController < ::BaseController
   end
 
   def valid_payment_intent_provided?
-    return false unless params["payment_intent"]&.starts_with?("pi_")
+    @valid_payment_intent_provided ||= begin
+      return false unless params["payment_intent"]&.starts_with?("pi_")
 
-    last_payment = OrderPaymentFinder.new(@order).last_payment
-    @order.state == "payment" &&
-      last_payment&.state == "requires_authorization" &&
-      last_payment&.response_code == params["payment_intent"]
+      last_payment = OrderPaymentFinder.new(@order).last_payment
+      @order.state == "payment" &&
+        last_payment&.state == "requires_authorization" &&
+        last_payment&.response_code == params["payment_intent"]
+    end
   end
 
   def handle_redirect_from_stripe

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -84,6 +84,8 @@ class CheckoutController < ::BaseController
     redirect_to(main_app.shop_path) && return if redirect_to_shop?
     handle_invalid_stock && return unless valid_order_line_items?
 
+    return if valid_payment_intent_provided?
+
     before_address
     setup_for_current_state
   end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -210,6 +210,12 @@ describe CheckoutController, type: :controller do
           expect(response).to redirect_to order_path(order)
         end
 
+        it "does not attempt to load different addresses" do
+          expect(OpenFoodNetwork::AddressFinder).to_not receive(:new)
+
+          get :edit, params: { payment_intent: "pi_123" }
+        end
+
         it "creates a customer record" do
           order.update_columns(customer_id: nil)
           Customer.delete_all


### PR DESCRIPTION
#### What? Why?

Related to Stripe problems previously explored in https://github.com/openfoodfoundation/openfoodnetwork/issues/7952#issuecomment-883545593 and https://github.com/openfoodfoundation/openfoodnetwork/pull/8233

I'm pretty sure this is responsible for at least some (but maybe not all) of the problems reported in #8296 

Should fix some edge cases with failing Stripe payments, where the errors shown in Bugsnag refer to address fields being blank (when they actually were filled out correctly at the checkout), and the backtrace shows the checkout was being loaded after a Stripe redirect (referencing `#handle_redirect_from_stripe`). Here's an example from French Production: https://app.bugsnag.com/open-food-france/coopcircuits/errors/60f11496903af700075b686d?filters[event.since]=7d&filters[error.status]=open&event_id=618a7041008972185a600000

Review note: see further details in the second commit message. 

Side note: ultimately we should move all this Stripe-response-processing into it's own controller, and have Stripe redirect back to _that_, instead of just throwing all these requests at the `checkout#edit` action.

Soundtrack: [Oh My Gosh!](https://www.youtube.com/watch?v=gOEHefkds2w) :musical_note: 

#### What should we test?
<!-- List which features should be tested and how. -->

I think these issues can sometimes occur when using Stripe at the checkout in cases where either:
- the user is a guest
- the user is registered but hasn't previously placed an order
- the user is registered but hasn't previously saved an address

If a previously saved address isn't found (not including the billing and shipping addresses on the current order), the addresses on the order can get partially _cleared_, which means the order doesn't get completed because the addresses become invalid.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed address issue in checkout with Stripe payment processing

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
