### PR TITLE
Allow mutiple stripe form in the admin section

### DIFF
--- a/app/assets/javascripts/admin/payments/controllers/payment.js.coffee
+++ b/app/assets/javascripts/admin/payments/controllers/payment.js.coffee
@@ -8,3 +8,6 @@ angular.module("admin.payments").controller "PaymentCtrl", ($scope, Payment, Sta
     $scope.submitted = true
     StatusMessage.display 'progress', t("spree.admin.payments.source_forms.stripe.submitting_payment")
     Payment.purchase()
+
+  $scope.isSelected = (payment_method_id) ->
+    return parseInt($scope.form_data.payment_method) == payment_method_id

--- a/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
@@ -1,7 +1,7 @@
 angular.module('admin.payments').directive "stripeElements", ($injector, AdminStripeElements) ->
   restrict: 'E'
   template: "<label for='card-element'>\
-             <div id='card-element'></div>\
+             <div id='card-element' class='card-element'></div>\
              <div id='card-errors' class='error'></div>\
              </label>"
 
@@ -18,7 +18,7 @@ angular.module('admin.payments').directive "stripeElements", ($injector, AdminSt
             color: '#5c5c5c'
             '::placeholder':
               color: '#6c6c6c'
-      card.mount('#card-element')
+      card.mount(elem.find('.card-element').get(0))
 
       # Elements validates user input as it is typed. To help your customers
       # catch mistakes, you should listen to change events on the card Element

--- a/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
@@ -4,7 +4,9 @@ angular.module('admin.payments').directive "stripeElements", ($injector, AdminSt
              <div id='card-element' class='card-element'></div>\
              <div class='error card-errors'></div>\
              </label>"
-
+  scope:
+    selected: "="
+  
   link: (scope, elem, attr)->
     if $injector.has('stripeObject')
       stripe = $injector.get('stripeObject')
@@ -32,5 +34,7 @@ angular.module('admin.payments').directive "stripeElements", ($injector, AdminSt
 
         return
 
-      AdminStripeElements.stripe = stripe
-      AdminStripeElements.card = card
+      scope.$watch "selected", (value) ->
+        if (value)
+          AdminStripeElements.stripe = stripe
+          AdminStripeElements.card = card 

--- a/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
@@ -2,7 +2,7 @@ angular.module('admin.payments').directive "stripeElements", ($injector, AdminSt
   restrict: 'E'
   template: "<label for='card-element'>\
              <div id='card-element' class='card-element'></div>\
-             <div id='card-errors' class='error'></div>\
+             <div class='error card-errors'></div>\
              </label>"
 
   link: (scope, elem, attr)->
@@ -24,7 +24,7 @@ angular.module('admin.payments').directive "stripeElements", ($injector, AdminSt
       # catch mistakes, you should listen to change events on the card Element
       # and display any errors:
       card.addEventListener 'change', (event) ->
-        displayError = document.getElementById('card-errors')
+        displayError = elem.find('.card-errors').get(0)
         if event.error
           displayError.textContent = event.error.message
         else

--- a/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/directives/stripe_elements.js.coffee
@@ -1,9 +1,9 @@
 angular.module('admin.payments').directive "stripeElements", ($injector, AdminStripeElements) ->
   restrict: 'E'
-  template: "<label for='card-element'>\
-             <div id='card-element' class='card-element'></div>\
+  template: "<div >\
+             <div class='card-element'></div>\
              <div class='error card-errors'></div>\
-             </label>"
+             </div>"
   scope:
     selected: "="
   

--- a/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
@@ -1,4 +1,4 @@
-angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, StatusMessage) ->
+angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, StatusMessage, $timeout) ->
   new class AdminStripeElements
 
     # These are both set from the AdminStripeElements directive
@@ -13,7 +13,7 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
 
       @stripe.createToken(@card, cardData).then (response) =>
         if(response.error)
-          StatusMessage.display 'error', response.error.message
+          $timeout -> StatusMessage.display 'error', response.error.message
           console.error(JSON.stringify(response.error))
         else
           secrets.token = response.token.id
@@ -29,7 +29,7 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
 
       @stripe.createPaymentMethod({ type: 'card', card: @card }, @card, cardData).then (response) =>
         if(response.error)
-          StatusMessage.display 'error', response.error.message
+          $timeout -> StatusMessage.display 'error', response.error.message
           console.error(JSON.stringify(response.error))
         else
           secrets.token = response.paymentMethod.id

--- a/app/assets/javascripts/admin/utils/services/status_message.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/status_message.js.coffee
@@ -6,6 +6,7 @@ angular.module("admin.utils").factory "StatusMessage", ->
       notice:   {style: {color: 'grey'}}
       success:  {style: {color: '#9fc820'}}
       failure:  {style: {color: '#da5354'}}
+      error:   {style: {color: '#da5354'}}
 
     statusMessage:
       text: ""

--- a/app/views/spree/admin/payments/source_forms/_stripe.html.haml
+++ b/app/views/spree/admin/payments/source_forms/_stripe.html.haml
@@ -1,6 +1,7 @@
 -# = render "spree/admin/payments/source_forms/gateway", payment_method: payment_method
 .stripe
-  = render "shared/stripe_js"
+  - content_for :stripe_js, flush: true do
+    = render "shared/stripe_js"
 
   - if Stripe.publishable_key
     :javascript

--- a/app/views/spree/admin/payments/source_forms/_stripe.html.haml
+++ b/app/views/spree/admin/payments/source_forms/_stripe.html.haml
@@ -16,4 +16,4 @@
     .three.columns
       = label_tag :card_details, t(:card_details)
     .nine.columns
-      %stripe-elements
+      %stripe-elements{selected: "isSelected(#{payment_method.id})"}

--- a/app/views/spree/admin/payments/source_forms/_stripe_sca.html.haml
+++ b/app/views/spree/admin/payments/source_forms/_stripe_sca.html.haml
@@ -1,5 +1,6 @@
 .stripe
-  = render "shared/stripe_js"
+  - content_for :stripe_js, flush: true do
+    = render "shared/stripe_js"
 
   - if Stripe.publishable_key
     :javascript

--- a/app/views/spree/admin/payments/source_forms/_stripe_sca.html.haml
+++ b/app/views/spree/admin/payments/source_forms/_stripe_sca.html.haml
@@ -15,4 +15,4 @@
     .three.columns
       = label_tag :card_details, t(:card_details)
     .nine.columns
-      %stripe-elements
+      %stripe-elements{selected: "isSelected(#{payment_method.id})"}

--- a/app/views/spree/layouts/_admin_body.html.haml
+++ b/app/views/spree/layouts/_admin_body.html.haml
@@ -1,5 +1,6 @@
 = admin_inject_currency_config
 = render "layouts/i18n_script"
+= yield :stripe_js
 
 #wrapper{ data: { hook: '' } }
   - if flash[:error]


### PR DESCRIPTION
#### What? Why?

 - include only one time the stripe js 
 - Modify angularjs directive to mount the stripe element on the right (and unique) DOM element (ie. the one concerning by the directive)

Closes #7278





#### What should we test?
1. As an admin, add more than one Stripe or StripeSCA payment method
2. Go to an order payment section (such as `/admin/orders/[ORDER_ID]/payments/new`), and see multiple Stripe radio button
3. Check that each one has its own stripe form
4. Check that each stripe form handle its own stripe error

Extra note: maybe we should do a quick test of the stripe card form in the checkout as well, as I think the same code is used in the backoffice and the checkout. -Matt

<img width="515" alt="Capture d’écran 2021-11-15 à 11 52 17" src="https://user-images.githubusercontent.com/296452/141769531-89079af3-d765-4b1d-b1f9-ead0b7d29e61.png">


<img width="601" alt="Capture d’écran 2021-11-15 à 11 52 24" src="https://user-images.githubusercontent.com/296452/141769544-32edd96d-2b49-48ab-87c0-ce3203ba4550.png">

<img width="558" alt="Capture d’écran 2021-11-15 à 11 52 41" src="https://user-images.githubusercontent.com/296452/141769556-30157074-8da3-404c-816e-98f1d6bdd8b0.png">

#### Release notes
Handle multiple Stripe payment form in the admin section, under the payment section of an order

Changelog Category: User facing changes



