### PR TITLE
Update TAB behavior for the login modal

### DIFF
--- a/app/assets/javascripts/templates/login.html.haml
+++ b/app/assets/javascripts/templates/login.html.haml
@@ -14,7 +14,7 @@
         %input.title.input-text{name: "email",
           type: "email",
           id: "email",
-          tabindex: 1,
+          tabindex: "1",
           inputmode: "email",
           "ng-model" => "spree_user.email"}
     .row
@@ -24,7 +24,7 @@
           type: "password",
           id: "password",
           autocomplete: "off",
-          tabindex: 2,
+          tabindex: "2",
           inputmode: "password",
           "ng-model" => "spree_user.password"}
     .row
@@ -33,12 +33,13 @@
         type: "checkbox",
         id: "remember_me",
         value: "1",
+        tabindex: "3",
         "ng-model" => "spree_user.remember_me"}
         %label{for: "remember_me"} {{'remember_me' | t}}
     .row
       .large-12.columns
         %input.button.primary{name: "commit",
-          tabindex: "3",
+          tabindex: "4",
           type: "submit",
           value: "{{'label_login' | t}}"}
 :javascript

--- a/spec/support/request/ui_component_helper.rb
+++ b/spec/support/request/ui_component_helper.rb
@@ -109,4 +109,10 @@ module UIComponentHelper
     expand_active_table_node(name)
     page.find(".active_table_node a", text: name.to_s).click
   end
+
+  def fill_in_using_keyboard
+    page.find('#email').send_keys(user.email, :tab, user.password, :tab, :space)
+    expect(page.find('#remember_me')).to be_checked
+    page.find('#remember_me').send_keys(:tab, :enter)
+  end
 end

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -48,6 +48,13 @@ describe "Authentication", js: true do
           expect(page).to be_logged_in_as user
         end
 
+        context "using keyboard" do
+          it "logging in successfully" do
+            fill_in_using_keyboard
+            expect(page).to be_logged_in_as user
+          end
+        end
+
         describe "signing up" do
           before do
             select_login_tab "Sign up"


### PR DESCRIPTION
#### What? Why?

Closes #8479 

After entering the password, the focus should jump to the "remember me" checkbox when pressing the <'TAB'> key.
Pressing <'TAB'> again should jump to the "login" button. More reference is in the issue decription.


#### What should we test?
Login flow and remember me feature.

#### Release notes
N/a

#### Dependencies
No.

#### Documentation updates
Not required.