### PR TITLE
Place the localize button above the map/below the address

### DIFF
--- a/app/views/registration/steps/_details.html.haml
+++ b/app/views/registration/steps/_details.html.haml
@@ -44,18 +44,18 @@
                 %span.error{ ng: { show: "details.zipcode.$error.required && submitted" } }
                   = t(".postcode_field_error")
           .row
-            .small-12.medium-4.large-4.columns
-              .field
-                %label{ for: 'enterprise_state' }= t(".state_field")
-                %select.chunky{ id: 'enterprise_state', name: 'state', ng: { model: 'enterprise.address.state_id', options: 's.id as s.abbr for s in enterprise.country.states', show: 'countryHasStates()', required: 'countryHasStates()' } }
-                %span.error{ ng: { show: "details.state.$error.required && submitted" } }
-                  = t(".state_field_error")
             .small-12.medium-8.large-8.columns
               .field
                 %label{ for: 'enterprise_country' }= t(".country_field")
                 %select.chunky{ id: 'enterprise_country', name: 'country', required: true, ng: { init: "setDefaultCountry(#{DefaultCountry.id})", model: 'enterprise.country', options: 'c as c.name for c in countries' } }
                 %span.error{ ng: { show: "details.country.$error.required && submitted" } }
                   = t(".country_field_error")
+            .small-12.medium-4.large-4.columns
+              .field
+                %label{ for: 'enterprise_state' }= t(".state_field")
+                %select.chunky{ id: 'enterprise_state', name: 'state', ng: { model: 'enterprise.address.state_id', options: 's.id as s.abbr for s in enterprise.country.states', show: 'countryHasStates()', required: 'countryHasStates()' } }
+                %span.error{ ng: { show: "details.state.$error.required && submitted" } }
+                  = t(".state_field_error")
 
       = render 'registration/steps/location_map' if using_google_maps?
 

--- a/app/views/registration/steps/_location_map.html.haml
+++ b/app/views/registration/steps/_location_map.html.haml
@@ -1,13 +1,14 @@
 %div
+  .center
+    %input.button.primary{ type: "button", value: "{{'registration.steps.details.locate_address' | t}}", ng: { click: "locateAddress()" } }
   .center{ ng: {if: "latLong"}}
     %strong {{'registration.steps.details.drag_pin' | t}}
+    
   .small-12.medium-9.large-12.columns.end
     .map-container--registration{id: "registration-map", ng: {if: "!!map"}}
       %ui-gmap-google-map{ center: "map.center", zoom: "map.zoom"}
         %ui-gmap-marker{idKey: 1, coords: "latLong", options: '{ draggable: true}'}
 
-  .center
-    %input.button.primary{ type: "button", value: "{{'registration.steps.details.locate_address' | t}}", ng: { click: "locateAddress()" } }
   .center{ ng: {if: "latLong"}}
     .field
       %input{ type: 'checkbox', id: 'confirm_address', name: 'confirm_address', ng: { click: 'toggleAddressConfirmed()' } }


### PR DESCRIPTION
#### What? Why?

This modification places the localize button above the map/below the address as proposed in [#51](https://github.com/openfoodfoundation/product-pipe/issues/51).

#### What should we test?
The registration process works as before.

#### Release notes
Place the localize button above the map/below the address.

Changelog Category: User facing changes

#### Dependencies
None.

#### Documentation updates
User guides need updated screenshots (outdated anyways).
[https://guide.openfoodnetwork.org/basic-features/register-and-create-your-profile](https://guide.openfoodnetwork.org/basic-features/register-and-create-your-profile)