### PR TITLE
Place the localize button above the map/below the address

### DIFF
--- a/app/views/registration/steps/_location_map.html.haml
+++ b/app/views/registration/steps/_location_map.html.haml
@@ -1,13 +1,14 @@
 %div
+  .center
+    %input.button.primary{ type: "button", value: "{{'registration.steps.details.locate_address' | t}}", ng: { click: "locateAddress()" } }
   .center{ ng: {if: "latLong"}}
     %strong {{'registration.steps.details.drag_pin' | t}}
+    
   .small-12.medium-9.large-12.columns.end
     .map-container--registration{id: "registration-map", ng: {if: "!!map"}}
       %ui-gmap-google-map{ center: "map.center", zoom: "map.zoom"}
         %ui-gmap-marker{idKey: 1, coords: "latLong", options: '{ draggable: true}'}
 
-  .center
-    %input.button.primary{ type: "button", value: "{{'registration.steps.details.locate_address' | t}}", ng: { click: "locateAddress()" } }
   .center{ ng: {if: "latLong"}}
     .field
       %input{ type: 'checkbox', id: 'confirm_address', name: 'confirm_address', ng: { click: 'toggleAddressConfirmed()' } }


### PR DESCRIPTION
#### What? Why?

This modification places the localize button above the map/below the address as proposed in [#51](https://github.com/openfoodfoundation/product-pipe/issues/51).

#### What should we test?
The registration process works as before.

#### Release notes
Place the localize button above the map/below the address.

Changelog Category: User facing changes

#### Dependencies
None.

#### Documentation updates
User guides need updated screenshots (outdated anyways).
[https://guide.openfoodnetwork.org/basic-features/register-and-create-your-profile](https://guide.openfoodnetwork.org/basic-features/register-and-create-your-profile)