### PR TITLE
Fixed inconsistency with display of unit name for products sold by item

### DIFF
--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -71,6 +71,8 @@ module VariantUnits
 
       return variant.display_as if variant_display_as?
 
+      return product.variant_unit_name if product.variant_unit_scale.nil? 
+
       options_text
     end
 

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -594,6 +594,13 @@ module Spree
           expect(v.unit_to_display).to eq("ponies")
           expect(v1.unit_to_display).to eq("ponies")
         end
+
+        it "displays variant unit name if no unit scale" do
+          p = create(:simple_product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: 'items_unit')
+          v = build_stubbed(:variant, product: p)
+
+          expect(v.unit_to_display).to eq("items_unit")
+        end
       end
 
       describe "setting the variant's weight from the unit value" do


### PR DESCRIPTION
#### What? Why?

Closes #8495 

This PR fixes the bug where an update to the "Unit name" for products with the "Variant unit" set as "Items" does not reflect in shop front.

**Before :** 

![Screenshot 2021-11-18 at 12 43 01 PM](https://user-images.githubusercontent.com/65319144/142369465-558ff9a4-d7fb-422d-9dab-818acd6d9211.png)

**After :**

![Screenshot 2021-11-18 at 12 43 58 PM](https://user-images.githubusercontent.com/65319144/142369508-14f53e3d-1e6b-45e2-833b-0a43e289a7fa.png)

#### What should we test?

- Pricer per unit and Variant unit should be the same in shopfront after an update to unit name in back office.

#### Release notes
- Fixed inconsistency with update of unit name for product sold per item in shopfront.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes 
