### PR TITLE
Run rubocop with reviewdog

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,16 @@
+name: Linters
+on: [push, pull_request]
+jobs:
+  rubocop:
+    name: runner / rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - uses: ruby/setup-ruby@v1
+      - name: rubocop
+        uses: reviewdog/action-rubocop@v2
+        with:
+          reporter: github-pr-check
+          level: error
+          fail_on_error: true


### PR DESCRIPTION
#### What? Why?

Run Rubocop with GH Actions on each `push` and `pull_request`

<img width="804" alt="Capture d’écran 2021-11-24 à 09 35 31" src="https://user-images.githubusercontent.com/296452/143203067-932c30be-8b08-40d8-a98d-6c4c87e6b58e.png">



#### Release notes
Add an automatic run of a Ruby linter

Changelog Category: Technical changes

