### PR TITLE
Fix Webpacker container configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     command: ./bin/webpack-dev-server
     volumes:
       - .:/usr/src/app
+      - gems:/bundles
     ports:
       - '3035:3035'
     environment:


### PR DESCRIPTION
#### What? Why?

There was an error locally while running the `webpacker` container locally. It is now requiring the `i18n-js` gem but this gem is not accessible to this container. We just need to add the gems volume to the container configuration.


#### What should we test?

Just run the docker congfiguration locally and control that the webpacker container is not crashing.


#### Release notes

- Fix Webpacker container configuration on Docker setup

Changelog Category: Technical changes
