### PR TITLE
Fix rendering problem with multiple flash messages in the admin section

### DIFF
--- a/app/assets/stylesheets/admin/components/messages.scss
+++ b/app/assets/stylesheets/admin/components/messages.scss
@@ -27,24 +27,31 @@
   }
 }
 
-.flash {
+.flash-container {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
-  padding: 16px;
-  text-align: center;
   z-index: 1000;
-  font-size: 120%;
-  color: $color-1;
-  font-weight: 600;
 
-  &.notice  { background-color: rgba($color-notice,  0.8) }
-  &.success { background-color: rgba($color-success, 0.8) }
-  &.error   { background-color: rgba($color-error,   0.8) }
+  .flash {
+    padding: 18px;
+    text-align: center;  
+    font-size: 120%;
+    color: $color-1;
+    font-weight: 600;
+  
+    &.notice  { background-color: rgba($color-notice,  0.8) }
+    &.success { background-color: rgba($color-success, 0.8) }
+    &.error   { background-color: rgba($color-error,   0.8) }
+
+    // Adjust heights to fit main layout dimension (header, navbar...)
+    &:nth-child(2) { padding: 24px; }
+    &:nth-child(3) { padding: 20px; }
+  }
 }
 
-.notice {
+.notice:not(.flash) {
   padding: 1rem;
   margin-bottom: 1.5rem;
   background-color: $spree-light-blue;

--- a/app/views/spree/layouts/_admin_body.html.haml
+++ b/app/views/spree/layouts/_admin_body.html.haml
@@ -2,12 +2,13 @@
 = render "layouts/i18n_script"
 
 #wrapper{ data: { hook: '' } }
-  - if flash[:error]
-    .flash.error= flash[:error]
-  - if notice
-    .flash.notice= notice
-  - if flash[:success]
-    .flash.success= flash[:success]
+  .flash-container
+    - if flash[:error]
+      .flash.error= flash[:error]
+    - if notice
+      .flash.notice= notice
+    - if flash[:success]
+      .flash.success= flash[:success]
 
   = render partial: "spree/layouts/admin/progress_spinner"
 


### PR DESCRIPTION
#### What? Why?

Closes #8442 

#### What should we test?
For a developper : Adds following in any controller action
```
flash[:error] = "This is a flash error message"
flash[:success] = "Yeah success !"
flash[:notice] = "And a notice one"
```

For a non developper, see "Step to reproduce" in #8442

It is now correctly displayed (one bellow each other)

I also adjusted the flash message height so it fit to the header and main nav height (cause flash message is a bit transparent otherwise it looks weird)

![image](https://user-images.githubusercontent.com/17404254/143566422-5e4afc93-c84b-4f84-ac73-649d9663843a.png)




