### PR TITLE
Revoke transaction fee if payment is cancelled

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -138,7 +138,7 @@ module Spree
     end
 
     def ensure_correct_adjustment
-      revoke_adjustment_eligibility if ['failed', 'invalid'].include?(state)
+      revoke_adjustment_eligibility if ['failed', 'invalid', 'void'].include?(state)
       return if adjustment.try(:finalized?)
 
       if adjustment

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -356,6 +356,22 @@ describe Spree::Payment do
             payment.void_transaction!
           end
         end
+
+        context "if payment has any adjustment" do
+          let!(:order) { create(:order) }
+          let!(:payment_method) { create(:payment_method, calculator: ::Calculator::FlatRate.new(preferred_amount: 10)) }
+
+          it "should create another adjustment and revoke the previous one" do
+            payment = create(:payment, order: order, payment_method: payment_method)
+            expect(order.all_adjustments.payment_fee.eligible.length).to eq(1)
+
+            payment.void_transaction!
+            expect(order.all_adjustments.payment_fee.eligible.length).to eq(0)
+
+            payment = create(:payment, order: order, payment_method: payment_method)
+            expect(order.all_adjustments.payment_fee.eligible.length).to eq(1)
+          end
+        end
       end
 
       context "#credit" do


### PR DESCRIPTION
#### What? Why?

Closes #3584

Revoke adjustment when cancelling a payment.


#### What should we test?
This is very well explained in the linked issue #3584 

As enterprise manager:

_Voiding payment that has been captured:_

1. Create an order selecting the payment method earlier.
2. Complete the order without capturing payment. Check that the transaction fee is correct.
3. Capture payment. Check that the transaction fee is still correct.
4. Void the payment.
5. Add another payment. Notice in "Order Details" that there are now two transaction fees charged.

_Voiding payment that was not captured:_

1. Create another order.
2. Complete the order without capturing payment.
3. Mark the uncaptured payment void.
4. Add another payment to the order. Notice in "Order Details" that there are now two transaction fees charged.



#### Release notes
Revoke transaction fee if payment is cancelled

Changelog Category: User facing changes
