### PR TITLE
Improve shipped email design

### DIFF
--- a/app/views/spree/shipment_mailer/shipped_email.html.haml
+++ b/app/views/spree/shipment_mailer/shipped_email.html.haml
@@ -1,22 +1,18 @@
-%p
+%h3
   = t('.dear_customer')
-%p
+%p.lead
   = t('.instructions', distributor: @shipment.order.distributor.name)
 
 %p
-  = "============================================================"
-  %br
-  = t('.shipment_summary')
-  %br
-  = "============================================================"
+  %strong
+    = t('.shipment_summary')
 
-%p
+%p{ style: "font-family: monospace, serif;" }
   - @shipment.manifest.each do |item|
     = item.variant.sku
     = item.variant.product.name
     = item.variant.options_text
-  %br
-  = "============================================================"
+    %br
 
 - if @shipment.tracking
   %p
@@ -26,5 +22,5 @@
   %p
     = t('.track_link', url: @shipment.tracking_url)
 
-%p
+%p.lead
   = t('.thanks')

--- a/spec/mailers/previews/shipment_preview.rb
+++ b/spec/mailers/previews/shipment_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'open_food_network/scope_variant_to_hub'
+
+module Spree
+  class ShipmentPreview < ActionMailer::Preview
+    def shipped
+      ShipmentMailer.shipped_email(Shipment.last)
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Closes #8506 

 - Add the shipped email preview to the app, available via `http://localhost:3000/rails/mailers/spree/shipment/shipped`
 - Improve shipped email design by adding classes which are used in others email, line breaks and monospace font

**_Before:_**

<img width="638" alt="Capture d’écran 2021-11-30 à 16 54 55" src="https://user-images.githubusercontent.com/296452/144083202-fea46acc-2294-4c2d-abd5-abbdcb8e9c6d.png">

**_After:_**
<img width="624" alt="Capture d’écran 2021-11-30 à 17 01 46" src="https://user-images.githubusercontent.com/296452/144083220-ebcc19fa-5173-4cf2-910d-186166a7dd8c.png">



#### What should we test?

Test the shipped email



#### Release notes
Improve shipped email design
Changelog Category: User facing changes

