### PR TITLE
Hide old "Stripe" (StripeConnect) payment method type, keep new Stripe SCA

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -124,7 +124,7 @@ module Spree
       def load_providers
         providers = Gateway.providers.sort_by(&:name)
 
-        unless Rails.env.dev? || Rails.env.test?
+        unless Rails.env.development? || Rails.env.test?
           providers.reject! { |provider| provider.name.include? "Bogus" }
         end
 

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -101,12 +101,7 @@ module Spree
       end
 
       def load_data
-        @providers = if Rails.env.dev? || Rails.env.test?
-                       Gateway.providers.sort_by(&:name)
-                     else
-                       Gateway.providers.reject{ |p| p.name.include? "Bogus" }.sort_by(&:name)
-                     end
-        @providers.reject!{ |provider| stripe_provider?(provider) } unless show_stripe?
+        @providers = load_providers
         @calculators = PaymentMethod.calculators.sort_by(&:name)
       end
 
@@ -124,6 +119,20 @@ module Spree
           [(@payment_method.has_distributor? d) ? 0 : 1, d.name]
         end
         # rubocop:enable Style/TernaryParentheses
+      end
+
+      def load_providers
+        providers = Gateway.providers.sort_by(&:name)
+
+        unless Rails.env.dev? || Rails.env.test?
+          providers.reject! { |provider| provider.name.include? "Bogus" }
+        end
+
+        unless show_stripe?
+          providers.reject! { |provider| stripe_provider?(provider) }
+        end
+
+        providers
       end
 
       # Show Stripe as an option if enabled, or if the

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -132,6 +132,11 @@ module Spree
           providers.reject! { |provider| stripe_provider?(provider) }
         end
 
+        # This method is deprecated and will be removed soon:
+        unless @payment_method&.type == "Spree::Gateway::StripeConnect"
+          providers.reject! { |provider| provider.name.ends_with?("StripeConnect") }
+        end
+
         providers
       end
 

--- a/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/app/controllers/spree/admin/payment_methods_controller.rb
@@ -133,7 +133,8 @@ module Spree
         end
 
         # This method is deprecated and will be removed soon:
-        unless @payment_method&.type == "Spree::Gateway::StripeConnect"
+        unless @payment_method&.type == "Spree::Gateway::StripeConnect" ||
+               OpenFoodNetwork::FeatureToggle.enabled?("StripeConnect")
           providers.reject! { |provider| provider.name.ends_with?("StripeConnect") }
         end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,7 +4,6 @@ class Subscription < ApplicationRecord
   include SetUnusedAddressFields
 
   ALLOWED_PAYMENT_METHOD_TYPES = ["Spree::PaymentMethod::Check",
-                                  "Spree::Gateway::StripeConnect",
                                   "Spree::Gateway::StripeSCA"].freeze
 
   searchable_attributes :shop_id, :canceled_at, :paused_at

--- a/engines/order_management/spec/services/order_management/subscriptions/stripe_payment_setup_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/stripe_payment_setup_spec.rb
@@ -34,7 +34,7 @@ module OrderManagement
           end
 
           context "when the payment method is a stripe payment method" do
-            let(:payment_method) { create(:stripe_connect_payment_method) }
+            let(:payment_method) { create(:stripe_sca_payment_method) }
 
             context "and the card is already set (the payment source is a credit card)" do
               it "returns the pending payment with no change" do

--- a/engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb
@@ -360,9 +360,9 @@ module OrderManagement
             end
           end
 
-          context "when using the StripeConnect payment gateway" do
+          context "when using the StripeSCA payment gateway" do
             let(:payment_method) {
-              instance_double(Spree::PaymentMethod, type: "Spree::Gateway::StripeConnect")
+              instance_double(Spree::PaymentMethod, type: "Spree::Gateway::StripeSCA")
             }
             before { expect(subscription).to receive(:customer).at_least(:once) { customer } }
 

--- a/lib/open_food_network/available_payment_method_filter.rb
+++ b/lib/open_food_network/available_payment_method_filter.rb
@@ -5,12 +5,12 @@ module OpenFoodNetwork
     def filter!(payment_methods)
       if stripe_enabled?
         payment_methods.to_a.reject! do |payment_method|
-          payment_method.type.ends_with?("StripeConnect") &&
+          payment_method.type.ends_with?("StripeSCA") &&
             stripe_configuration_incomplete?(payment_method)
         end
       else
         payment_methods.to_a.reject! do |payment_method|
-          payment_method.type.ends_with?("StripeConnect")
+          payment_method.type.ends_with?("StripeSCA")
         end
       end
     end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -753,7 +753,7 @@ describe Admin::SubscriptionsController, type: :controller do
     end
 
     context "when other payment methods exist" do
-      let!(:stripe) { create(:stripe_connect_payment_method, distributors: [shop]) }
+      let!(:stripe) { create(:stripe_sca_payment_method, distributors: [shop]) }
       let!(:paypal) {
         Spree::Gateway::PayPalExpress.create!(name: "PayPalExpress", distributor_ids: [shop.id])
       }

--- a/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders/payments/payments_controller_spec.rb
@@ -44,22 +44,6 @@ describe Spree::Admin::PaymentsController, type: :controller do
         end
       end
 
-      context "with Stripe payment where payment.process! errors out" do
-        let!(:payment_method) { create(:stripe_connect_payment_method, distributors: [shop]) }
-        before do
-          allow_any_instance_of(Spree::Payment).
-            to receive(:process_offline!).
-            and_raise(Spree::Core::GatewayError.new("Payment Gateway Error"))
-        end
-
-        it "redirects to new payment page with flash error" do
-          spree_post :create, payment: params, order_id: order.number
-
-          redirects_to_new_payment_page_with_flash_error("Payment Gateway Error")
-          expect(order.reload.payments.last.state).to eq "checkout"
-        end
-      end
-
       context "with StripeSCA payment" do
         let!(:payment_method) { create(:stripe_sca_payment_method, distributors: [shop]) }
 

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -113,8 +113,11 @@ module Spree
         let!(:enterprise1) { create(:distributor_enterprise, owner: user) }
         let!(:enterprise2) { create(:distributor_enterprise, owner: create(:user)) }
         let!(:payment_method) {
-          create(:stripe_sca_payment_method, distributor_ids: [enterprise1.id, enterprise2.id],
-                                                 preferred_enterprise_id: enterprise2.id)
+          create(
+            :stripe_sca_payment_method,
+            distributor_ids: [enterprise1.id, enterprise2.id],
+            preferred_enterprise_id: enterprise2.id
+          )
         }
 
         before { allow(controller).to receive(:spree_current_user) { user } }

--- a/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -108,12 +108,12 @@ module Spree
         end
       end
 
-      context "on a StripeConnect payment method" do
+      context "on a StripeSCA payment method" do
         let!(:user) { create(:user, enterprise_limit: 2) }
         let!(:enterprise1) { create(:distributor_enterprise, owner: user) }
         let!(:enterprise2) { create(:distributor_enterprise, owner: create(:user)) }
         let!(:payment_method) {
-          create(:stripe_connect_payment_method, distributor_ids: [enterprise1.id, enterprise2.id],
+          create(:stripe_sca_payment_method, distributor_ids: [enterprise1.id, enterprise2.id],
                                                  preferred_enterprise_id: enterprise2.id)
         }
 
@@ -124,7 +124,7 @@ module Spree
             {
               id: payment_method.id,
               payment_method: {
-                type: "Spree::Gateway::StripeConnect",
+                type: "Spree::Gateway::StripeSCA",
                 preferred_enterprise_id: enterprise1.id
               }
             }

--- a/spec/helpers/enterprises_helper_spec.rb
+++ b/spec/helpers/enterprises_helper_spec.rb
@@ -262,14 +262,14 @@ describe EnterprisesHelper, type: :helper do
       end
     end
 
-    context "when StripeConnect payment methods are present" do
+    context "when Stripe payment methods are present" do
       let!(:pm3) {
-        create(:stripe_connect_payment_method, distributors: [distributor],
-                                               preferred_enterprise_id: distributor.id)
+        create(:stripe_sca_payment_method, distributors: [distributor],
+                                           preferred_enterprise_id: distributor.id)
       }
       let!(:pm4) {
-        create(:stripe_connect_payment_method, distributors: [distributor],
-                                               preferred_enterprise_id: some_other_distributor.id)
+        create(:stripe_sca_payment_method, distributors: [distributor],
+                                           preferred_enterprise_id: some_other_distributor.id)
       }
       let(:available_payment_methods) { helper.available_payment_methods }
 

--- a/spec/jobs/subscription_confirm_job_spec.rb
+++ b/spec/jobs/subscription_confirm_job_spec.rb
@@ -190,23 +190,6 @@ describe SubscriptionConfirmJob do
           job.send(:confirm_order!, order)
         end
       end
-
-      context "Stripe Connect" do
-        let(:stripe_connect_payment_method) { create(:stripe_connect_payment_method) }
-        let(:stripe_connect_payment) {
-          create(:payment, amount: 10, payment_method: stripe_connect_payment_method)
-        }
-
-        before do
-          allow(order).to receive(:pending_payments) { [stripe_connect_payment] }
-          allow(stripe_connect_payment_method).to receive(:purchase) { true }
-        end
-
-        it "runs the charges in offline mode" do
-          job.send(:confirm_order!, order)
-          expect(stripe_connect_payment_method).to have_received(:purchase)
-        end
-      end
     end
 
     context "when payments need to be processed" do

--- a/spec/lib/stripe/profile_storer_spec.rb
+++ b/spec/lib/stripe/profile_storer_spec.rb
@@ -4,41 +4,28 @@ require 'spec_helper'
 
 module Stripe
   describe ProfileStorer do
+    include StripeStubs
+
     describe "create_customer_from_token" do
-      let(:payment) { create(:payment) }
-      let(:stripe_payment_method) { create(:stripe_connect_payment_method) }
+      let(:stripe_payment_method) { create(:stripe_sca_payment_method) }
+      let(:card) { create(:credit_card, gateway_payment_profile_id: card_id) }
+      let(:payment) { create(:payment, source: card, payment_method: stripe_payment_method) }
       let(:profile_storer) { Stripe::ProfileStorer.new(payment, stripe_payment_method.provider) }
 
       let(:customer_id) { "cus_A123" }
       let(:card_id) { "card_2342" }
-      let(:customer_response_mock) { { status: 200, body: customer_response_body } }
+      let(:customer_response_mock) {
+        { status: 200, body: JSON.generate(id: customer_id, sources: { data: [{ id: "1" }] }) }
+      }
 
       before do
         Stripe.api_key = "sk_test_12345"
 
-        stub_request(:post, "https://api.stripe.com/v1/customers")
-          .with(basic_auth: ["sk_test_12345", ""], body: { email: payment.order.email })
-          .to_return(customer_response_mock)
-      end
-
-      context "when called from Stripe Connect" do
-        let(:customer_response_body) {
-          JSON.generate(id: customer_id, default_card: card_id, sources: { data: [{ id: "1" }] })
-        }
-
-        it "fetches the customer id and the card id from the correct response fields" do
-          profile_storer.create_customer_from_token
-
-          expect(payment.source.gateway_customer_profile_id).to eq customer_id
-          expect(payment.source.gateway_payment_profile_id).to eq card_id
-        end
+        stub_customers_post_request(email: payment.order.email, response: customer_response_mock)
+        stub_payment_method_attach_request(payment_method: card_id, customer: customer_id)
       end
 
       context "when called from Stripe SCA" do
-        let(:customer_response_body) {
-          JSON.generate(customer: customer_id, id: card_id, sources: { data: [{ id: "1" }] })
-        }
-
         it "fetches the customer id and the card id from the correct response fields" do
           profile_storer.create_customer_from_token
 

--- a/spec/models/spree/gateway_tagging_spec.rb
+++ b/spec/models/spree/gateway_tagging_spec.rb
@@ -45,9 +45,9 @@ module Spree
       it_behaves_like "taggable", "Spree::PaymentMethod"
     end
 
-    describe Gateway::StripeConnect do
+    describe Gateway::StripeSCA do
       subject do
-        # StripeConnect needs an owner to be valid.
+        # StripeSCA needs an owner to be valid.
         valid_subject.tap { |m| m.preferred_enterprise_id = shop.id }
       end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1213,7 +1213,7 @@ describe Spree::Order do
     let!(:enterprise) { create(:enterprise) }
     let!(:order) { create(:order, distributor: enterprise) }
     let!(:payment_method) {
-      create(:stripe_connect_payment_method, distributor_ids: [enterprise.id])
+      create(:stripe_sca_payment_method, distributor_ids: [enterprise.id])
     }
     let!(:payment) { create(:payment, order: order, payment_method: payment_method) }
 

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -920,8 +920,8 @@ describe Spree::Payment do
       context "to Stripe payments" do
         let(:shop) { create(:enterprise) }
         let(:payment_method) {
-          create(:stripe_connect_payment_method, distributor_ids: [create(:distributor_enterprise).id],
-                                                 preferred_enterprise_id: shop.id)
+          create(:stripe_sca_payment_method, distributor_ids: [create(:distributor_enterprise).id],
+                                             preferred_enterprise_id: shop.id)
         }
         let(:payment) {
           create(:payment, order: order, payment_method: payment_method, amount: order.total)

--- a/spec/support/request/stripe_stubs.rb
+++ b/spec/support/request/stripe_stubs.rb
@@ -28,11 +28,11 @@ module StripeStubs
   end
 
   # Attaches the payment method to the customer in the hub's stripe account
-  def stub_payment_method_attach_request
+  def stub_payment_method_attach_request(payment_method: "pm_123", customer: "cus_A123")
     stub_request(:post,
-                 "https://api.stripe.com/v1/payment_methods/pm_123/attach")
-      .with(body: { customer: "cus_A123" })
-      .to_return(hub_payment_method_response_mock({ pm_id: "pm_123" }))
+                 "https://api.stripe.com/v1/payment_methods/#{payment_method}/attach")
+      .with(body: { customer: customer })
+      .to_return(hub_payment_method_response_mock({ pm_id: payment_method }))
   end
 
   def stub_retrieve_payment_method_request(payment_method_id = "pm_1234")

--- a/spec/system/admin/subscriptions_spec.rb
+++ b/spec/system/admin/subscriptions_spec.rb
@@ -220,7 +220,7 @@ describe 'Subscriptions' do
       }
       let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
       let!(:payment_method) {
-        create(:stripe_connect_payment_method, name: 'Credit Card', distributors: [shop])
+        create(:stripe_sca_payment_method, name: 'Credit Card', distributors: [shop])
       }
       let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
 
@@ -387,7 +387,7 @@ describe 'Subscriptions' do
       }
       let!(:payment_method) { create(:payment_method, distributors: [shop]) }
       let!(:stripe_payment_method) {
-        create(:stripe_connect_payment_method, name: 'Credit Card', distributors: [shop])
+        create(:stripe_sca_payment_method, name: 'Credit Card', distributors: [shop])
       }
       let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
       let!(:subscription) {
@@ -536,7 +536,7 @@ describe 'Subscriptions' do
       let!(:enterprise_fee) { create(:enterprise_fee, amount: 1.75) }
       let!(:order_cycle) { create(:simple_order_cycle, coordinator: shop) }
       let!(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
-      let!(:payment_method) { create(:stripe_connect_payment_method, distributors: [shop]) }
+      let!(:payment_method) { create(:stripe_sca_payment_method, distributors: [shop]) }
       let!(:shipping_method) { create(:shipping_method, distributors: [shop]) }
 
       before do


### PR DESCRIPTION
#### What? Why?

Starts with #7872. This PR contains commits from #8255. We decided to split that pull request to progress while we haven't solved the database migration part yet.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Some users still create payment methods with the old, unsupported, Stripe Connect type. After this PR, that's not an option any more which should help us in the removal of Stripe Connect.

#### What should we test?
<!-- List which features should be tested and how. -->

- Create a new payment method.
- Stripe SCA should be available but the old "Stripe" option (StripeConnect) should not be visible.
- Visit /admin/feature-toggle/ and add the feature `StripeConnect`, then enable it.
- You should now be able to create a "Stripe" payment method.
- Disable the feature again.
- You should be able to edit the "Stripe" payment method, keeping its type.
- If you switch from Stripe to Stripe SCA, you can't switch back to Stripe.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->

Any documentation mentioning to only use "Stripe SCA" instead of "Stripe" can now be updated.