### PR TITLE
Searching variants should order results by variant display name

### DIFF
--- a/lib/open_food_network/scope_variants_for_search.rb
+++ b/lib/open_food_network/scope_variants_for_search.rb
@@ -36,7 +36,8 @@ module OpenFoodNetwork
         includes(option_values: :option_type).
         ransack(search_params.merge(m: 'or')).
         result.
-        order("display_name")
+        includes(:product).
+        order("products_spree_variants.name, display_name, display_as, products_spree_variants.variant_unit_name")
     end
 
     def distributor

--- a/lib/open_food_network/scope_variants_for_search.rb
+++ b/lib/open_food_network/scope_variants_for_search.rb
@@ -34,7 +34,9 @@ module OpenFoodNetwork
     def query_scope
       Spree::Variant.where(is_master: false).
         includes(option_values: :option_type).
-        ransack(search_params.merge(m: 'or')).result
+        ransack(search_params.merge(m: 'or')).
+        result.
+        order("display_name")
     end
 
     def distributor

--- a/lib/open_food_network/scope_variants_for_search.rb
+++ b/lib/open_food_network/scope_variants_for_search.rb
@@ -36,10 +36,9 @@ module OpenFoodNetwork
         includes(option_values: :option_type).
         ransack(search_params.merge(m: 'or')).
         result.
+        order("spree_products.name, display_name, display_as, spree_products.variant_unit_name").
         includes(:product).
-        merge(Spree::Product.order(:name)).
-        order(:display_name, :display_as).
-        merge(Spree::Product.order(:variant_unit_name))
+        joins(:product)
     end
 
     def distributor

--- a/lib/open_food_network/scope_variants_for_search.rb
+++ b/lib/open_food_network/scope_variants_for_search.rb
@@ -37,7 +37,9 @@ module OpenFoodNetwork
         ransack(search_params.merge(m: 'or')).
         result.
         includes(:product).
-        order("products_spree_variants.name, display_name, display_as, products_spree_variants.variant_unit_name")
+        merge(Spree::Product.order(:name)).
+        order(:display_name, :display_as).
+        merge(Spree::Product.order(:variant_unit_name))
     end
 
     def distributor

--- a/spec/lib/open_food_network/scope_variants_to_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_to_search_spec.rb
@@ -61,5 +61,20 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
         expect(result).to_not include v1, v2, v3
       end
     end
+
+    context "searching products starting with the same 3 caracters" do
+      let(:params) { { q: "pro" } }
+      it "returns variants ordered by display_name" do
+        v1.display_name = "Product 1 - b"
+        v2.display_name = "Product 1 - a"
+        v3.display_name = "Product 1 - c"
+        v4.display_name = "Product 1"
+        v1.save!
+        v2.save!
+        v3.save!
+        v4.save!
+        expect(result.map(&:display_name)).to eq ["Product 1", "Product 1 - a", "Product 1 - b", "Product 1 - c"]
+      end
+    end
   end
 end

--- a/spec/lib/open_food_network/scope_variants_to_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_to_search_spec.rb
@@ -65,15 +65,16 @@ describe OpenFoodNetwork::ScopeVariantsForSearch do
     context "searching products starting with the same 3 caracters" do
       let(:params) { { q: "pro" } }
       it "returns variants ordered by display_name" do
-        v1.display_name = "Product 1 - b"
-        v2.display_name = "Product 1 - a"
-        v3.display_name = "Product 1 - c"
-        v4.display_name = "Product 1"
-        v1.save!
-        v2.save!
-        v3.save!
-        v4.save!
-        expect(result.map(&:display_name)).to eq ["Product 1", "Product 1 - a", "Product 1 - b", "Product 1 - c"]
+        p1.name = "Product b"
+        p2.name = "Product a"
+        p3.name = "Product c"
+        p4.name = "Product 1"
+        p1.save!
+        p2.save!
+        p3.save!
+        p4.save!
+        expect(result.map(&:name)).
+          to eq(["Product 1", "Product a", "Product b", "Product c"])
       end
     end
   end

--- a/spec/lib/open_food_network/scope_variants_to_search_spec.rb
+++ b/spec/lib/open_food_network/scope_variants_to_search_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'open_food_network/scope_variants_for_search'
+require 'spec_helper'
 
 describe OpenFoodNetwork::ScopeVariantsForSearch do
   let!(:p1) { create(:simple_product, name: 'Product 1') }


### PR DESCRIPTION
#### What? Why?

Closes #8507

Order variant search by `display_name` of a variant.


#### What should we test?
 1. Go to orders / new order / select a distributor and OC. Make sure you have some products with multiple variants whose names start the same way, like "Bread - wheat 1kg", "Bread - wheat 2kg", "Bread - spelt 1kg", etc.
 2. Start typing "Brea" and see the results are ordered by display_name.
 3. Redo the process again and see the results is the same





#### Release note
Searching variants should order results by variant display name
Changelog Category: User facing changes
