### PR TITLE
Navigation is included only for super admin users

### DIFF
--- a/app/views/admin/terms_of_service_files/show.html.haml
+++ b/app/views/admin/terms_of_service_files/show.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = t(".title")

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = Spree.t(:general_settings)

--- a/app/views/spree/admin/payment_methods/edit.html.haml
+++ b/app/views/spree/admin/payment_methods/edit.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = t('.editing_payment_method')

--- a/app/views/spree/admin/payment_methods/index.html.haml
+++ b/app/views/spree/admin/payment_methods/index.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = t('.payment_methods')

--- a/app/views/spree/admin/payment_methods/new.html.haml
+++ b/app/views/spree/admin/payment_methods/new.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = t('.new_payment_method')

--- a/app/views/spree/admin/shipping_methods/edit.html.haml
+++ b/app/views/spree/admin/shipping_methods/edit.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = t('.editing_shipping_method')

--- a/app/views/spree/admin/shipping_methods/index.html.haml
+++ b/app/views/spree/admin/shipping_methods/index.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = t('.shipping_methods')

--- a/app/views/spree/admin/shipping_methods/new.html.haml
+++ b/app/views/spree/admin/shipping_methods/new.html.haml
@@ -1,4 +1,5 @@
-= render 'spree/admin/shared/configuration_menu'
+- if spree_current_user.admin?
+  = render 'spree/admin/shared/configuration_menu'
 
 - content_for :page_title do
   = t('.new_shipping_method')


### PR DESCRIPTION
#### What? Why?

Closes #8546

I previously added navigation for pages (#8395). This created another issue that navigation is shown also to regular users. In this PR I am checking if the user is super admin then shows the navigation. In addition pages mentioned in the issue, I included the super admin user check to all pages which I previously added navigation. 



#### Release notes
Show navigation if user is super admin


Changelog Category: User facing changes

**Before**

https://user-images.githubusercontent.com/37421564/144409729-e434cf56-607c-4456-ba92-b2524bd25553.mov

**After**


https://user-images.githubusercontent.com/37421564/144409848-379aaa7a-1d99-4248-8422-71236b0d965e.mov


