### PR TITLE
Credit card brand formatting

### DIFF
--- a/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/admin/payments/services/stripe_elements.js.coffee
@@ -17,7 +17,7 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
           console.error(JSON.stringify(response.error))
         else
           secrets.token = response.token.id
-          secrets.cc_type = @mapTokenApiCardBrand(response.token.card.brand)
+          secrets.cc_type = response.token.card.brand
           secrets.card = response.token.card
           submit()
 
@@ -33,27 +33,9 @@ angular.module("admin.payments").factory 'AdminStripeElements', ($rootScope, Sta
           console.error(JSON.stringify(response.error))
         else
           secrets.token = response.paymentMethod.id
-          secrets.cc_type = @mapPaymentMethodsApiCardBrand(response.paymentMethod.card.brand)
+          secrets.cc_type = response.paymentMethod.card.brand
           secrets.card = response.paymentMethod.card
           submit()
-
-    # Maps the brand returned by Stripe's tokenAPI to that required by activemerchant
-    mapTokenApiCardBrand: (cardBrand) ->
-      switch cardBrand
-        when 'MasterCard' then return 'master'
-        when 'Visa' then return 'visa'
-        when 'American Express' then return 'american_express'
-        when 'Discover' then return 'discover'
-        when 'JCB' then return 'jcb'
-        when 'Diners Club' then return 'diners_club'
-
-    # Maps the brand returned by Stripe's paymentMethodsAPI to that required by activemerchant
-    mapPaymentMethodsApiCardBrand: (cardBrand) ->
-      switch cardBrand
-        when 'mastercard' then return 'master'
-        when 'amex' then return 'american_express'
-        when 'diners' then return 'diners_club'
-        else return cardBrand # a few brands are equal, for example, visa
 
     # It doesn't matter if any of these are nil, all are optional.
     makeCardData: (secrets) ->

--- a/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/stripe_elements.js.coffee
@@ -16,7 +16,7 @@ angular.module('Darkswarm').factory 'StripeElements', ($rootScope, Messages) ->
           @reportError(response.error, t("error") + ": #{response.error.message}")
         else
           secrets.token = response.token.id
-          secrets.cc_type = @mapTokenApiCardBrand(response.token.card.brand)
+          secrets.cc_type = response.token.card.brand
           secrets.card = response.token.card
           submit()
       .catch (response) =>
@@ -37,7 +37,7 @@ angular.module('Darkswarm').factory 'StripeElements', ($rootScope, Messages) ->
           @reportError(response.error, t("error") + ": #{response.error.message}")
         else
           secrets.token = response.paymentMethod.id
-          secrets.cc_type = @mapPaymentMethodsApiCardBrand(response.paymentMethod.card.brand)
+          secrets.cc_type = response.paymentMethod.card.brand
           secrets.card = response.paymentMethod.card
           submit()
       .catch (response) =>
@@ -55,24 +55,6 @@ angular.module('Darkswarm').factory 'StripeElements', ($rootScope, Messages) ->
     triggerAngularDigest: ->
       # $evalAsync is improved way of triggering a digest without calling $apply
       $rootScope.$evalAsync()
-
-    # Maps the brand returned by Stripe's tokenAPI to that required by activemerchant
-    mapTokenApiCardBrand: (cardBrand) ->
-      switch cardBrand
-        when 'MasterCard' then return 'master'
-        when 'Visa' then return 'visa'
-        when 'American Express' then return 'american_express'
-        when 'Discover' then return 'discover'
-        when 'JCB' then return 'jcb'
-        when 'Diners Club' then return 'diners_club'
-
-    # Maps the brand returned by Stripe's paymentMethodsAPI to that required by activemerchant
-    mapPaymentMethodsApiCardBrand: (cardBrand) ->
-      switch cardBrand
-        when 'mastercard' then return 'master'
-        when 'amex' then return 'american_express'
-        when 'diners' then return 'diners_club'
-        else return cardBrand # a few brands are equal, for example, visa
 
     # It doesn't matter if any of these are nil, all are optional.
     makeCardData: (secrets) ->

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -7,7 +7,6 @@ module Spree
 
     has_many :payments, as: :source
 
-    before_validation :reformat_card_type!
     before_save :set_last_digits
 
     attr_accessor :verification_value
@@ -118,8 +117,8 @@ module Spree
 
     private
 
-    def reformat_card_type!(type = nil)
-      self[:cc_type] = active_merchant_card_type(type || cc_type)
+    def reformat_card_type!(type)
+      self[:cc_type] = active_merchant_card_type(type)
     end
 
     # ActiveMerchant requires certain credit card brand names to be stored in a specific format.

--- a/app/models/spree/credit_card.rb
+++ b/app/models/spree/credit_card.rb
@@ -7,6 +7,7 @@ module Spree
 
     has_many :payments, as: :source
 
+    before_validation :reformat_card_type!
     before_save :set_last_digits
 
     attr_accessor :verification_value
@@ -39,20 +40,8 @@ module Spree
       end
     end
 
-    # cc_type is set by jquery.payment, which helpfully provides different
-    # types from Active Merchant. Converting them is necessary.
     def cc_type=(type)
-      real_type = case type
-                  when 'mastercard', 'maestro'
-                    'master'
-                  when 'amex'
-                    'american_express'
-                  when 'dinersclub'
-                    'diners_club'
-                  else
-                    type
-                  end
-      self[:cc_type] = real_type
+      reformat_card_type!(type)
     end
 
     def set_last_digits
@@ -128,6 +117,27 @@ module Spree
     end
 
     private
+
+    def reformat_card_type!(type = nil)
+      self[:cc_type] = active_merchant_card_type(type || cc_type)
+    end
+
+    # ActiveMerchant requires certain credit card brand names to be stored in a specific format.
+    # See: https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/credit_card.rb#L89
+    def active_merchant_card_type(type)
+      card_type = type.to_s.downcase
+
+      case card_type
+      when "mastercard", "maestro", "master card"
+        "master"
+      when "amex", "american express"
+        "american_express"
+      when "dinersclub", "diners club"
+        "diners_club"
+      else
+        card_type
+      end
+    end
 
     def expiry_not_in_the_past
       return unless year.present? && month.present?

--- a/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
+++ b/spec/javascripts/unit/darkswarm/services/stripe_elements_spec.js.coffee
@@ -34,7 +34,7 @@ describe 'StripeElements Service', ->
         StripeElements.requestToken(secrets, submit)
         $rootScope.$digest() # required for #then to by called
         expect(secrets.token).toEqual "token"
-        expect(secrets.cc_type).toEqual "master"
+        expect(secrets.cc_type).toEqual "MasterCard"
         expect(submit).toHaveBeenCalled()
 
     describe "with unsatifactory data", ->
@@ -52,19 +52,3 @@ describe 'StripeElements Service', ->
           expect(Loading.clear).toHaveBeenCalled()
           expect(RailsFlashLoader.loadFlash).toHaveBeenCalledWith({error: "Error: There was a problem"})
           expect(Bugsnag.notify).toHaveBeenCalled()
-
-  describe 'mapTokenApiCardBrand', ->
-    it "maps the brand returned by Stripe's tokenAPI to that required by activemerchant", ->
-      expect(StripeElements.mapTokenApiCardBrand('MasterCard')).toEqual "master"
-      expect(StripeElements.mapTokenApiCardBrand('Visa')).toEqual "visa"
-      expect(StripeElements.mapTokenApiCardBrand('American Express')).toEqual "american_express"
-      expect(StripeElements.mapTokenApiCardBrand('Discover')).toEqual "discover"
-      expect(StripeElements.mapTokenApiCardBrand('JCB')).toEqual "jcb"
-      expect(StripeElements.mapTokenApiCardBrand('Diners Club')).toEqual "diners_club"
-
-  describe 'mapPaymentMethodsApiCardBrand', ->
-    it "maps the brand returned by Stripe's paymentMethodsAPI to that required by activemerchant", ->
-      expect(StripeElements.mapPaymentMethodsApiCardBrand('mastercard')).toEqual "master"
-      expect(StripeElements.mapPaymentMethodsApiCardBrand('amex')).toEqual "american_express"
-      expect(StripeElements.mapPaymentMethodsApiCardBrand('diners')).toEqual "diners_club"
-      expect(StripeElements.mapPaymentMethodsApiCardBrand('visa')).toEqual "visa"


### PR DESCRIPTION
#### What? Why?

Refactors / DRYs payments code around (re)formatting of credit card brand names.

Came up as part of payments backend work in https://github.com/openfoodfoundation/openfoodnetwork/pull/8503

A significant amount of mess is being thrown out here, and there's a really nice clarification of responsibilities :partying_face:

:fire::fire::fire:

Soundtrack: [Disco Inferno](https://www.youtube.com/watch?v=pG8TyIEAqps) :musical_note: 

#### What should we test?
<!-- List which features should be tested and how. -->

This PR cleans up some code which translates input for a credit card's brand name (from Stripe for example), which could be in a format like `American Express`, but on our end we need to save it as `american_express`.

I guess we could do a quick check that saving credit cards with Stripe is working correctly? In theory it also applies to anywhere a card can be saved with Stripe (which is a few places), but they have test coverage already.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Refactored logic around storing credit card brand names in a valid ActiveMerchant format

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes