### PR TITLE
Handle imperial units in the Bulk Order Management interface

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -152,15 +152,23 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
       return false if !lineItem.hasOwnProperty('final_weight_volume') || !(lineItem.final_weight_volume > 0)
     true
 
-  # How is this different to OptionValueNamer#name?
-  # Should it be extracted to that class or VariantUnitManager?
-  $scope.formattedValueWithUnitName = (value, unitsProduct, unitsVariant) ->
-    # A Units Variant is an API object which holds unit properies of a variant
-    if unitsProduct.hasOwnProperty("variant_unit") && (unitsProduct.variant_unit == "weight" || unitsProduct.variant_unit == "volume") && value > 0
-      scale = VariantUnitManager.getScale(value, unitsProduct.variant_unit)
-      unit_name = VariantUnitManager.getUnitName(unitsVariant.unit_value, unitsProduct.variant_unit)
-      $scope.roundToThreeDecimals(value/scale) + " " + unit_name
+  $scope.getScale = (unitsProduct, unitsVariant) ->
+    if unitsProduct.hasOwnProperty("variant_unit") && (unitsProduct.variant_unit == "weight" || unitsProduct.variant_unit == "volume")
+      VariantUnitManager.getScale(unitsVariant.unit_value, unitsProduct.variant_unit)
     else
+      null
+
+  $scope.getFormattedValueWithUnitName = (value, unitsProduct, unitsVariant, scale) ->
+    unit_name = VariantUnitManager.getUnitName(scale, unitsProduct.variant_unit)
+    $scope.roundToThreeDecimals(value) + " " + unit_name
+    else
+      ''
+
+  $scope.formattedValueWithUnitName = (value, unitsProduct, unitsVariant) ->
+    scale = $scope.getScale(unitsProduct, unitsVariant)
+    if scale
+      $scope.getFormattedValueWithUnitName(value, unitsProduct, unitsVariant, scale)
+    else 
       ''
 
   $scope.fulfilled = (sumOfUnitValues) ->

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -138,6 +138,9 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
         sum + lineItem.max_quantity * lineItem.units_variant.unit_value
     , 0
 
+  $scope.roundToThreeDecimals = (value) ->
+    Math.round(value * 1000) / 1000
+
   $scope.allFinalWeightVolumesPresent = ->
     for i,lineItem of $scope.filteredLineItems
       return false if !lineItem.hasOwnProperty('final_weight_volume') || !(lineItem.final_weight_volume > 0)
@@ -150,7 +153,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     if unitsProduct.hasOwnProperty("variant_unit") && (unitsProduct.variant_unit == "weight" || unitsProduct.variant_unit == "volume") && value > 0
       scale = VariantUnitManager.getScale(value, unitsProduct.variant_unit)
       unit_name = VariantUnitManager.getUnitName(unitsVariant.unit_value, unitsProduct.variant_unit)
-      Math.round(value/scale * 1000)/1000 + " " + unit_name
+      $scope.roundToThreeDecimals(value/scale) + " " + unit_name
     else
       ''
 
@@ -159,7 +162,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     if $scope.selectedUnitsProduct.hasOwnProperty("group_buy_unit_size") && $scope.selectedUnitsProduct.group_buy_unit_size > 0 &&
       $scope.selectedUnitsProduct.hasOwnProperty("variant_unit") &&
       ( $scope.selectedUnitsProduct.variant_unit == "weight" || $scope.selectedUnitsProduct.variant_unit == "volume" )
-        Math.round( sumOfUnitValues / $scope.selectedUnitsProduct.group_buy_unit_size * 1000)/1000
+        $scope.roundToThreeDecimals(sumOfUnitValues / $scope.selectedUnitsProduct.group_buy_unit_size)
     else
       ''
 

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -165,7 +165,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.getGroupBySizeFormattedValueWithUnitName = (value, unitsProduct, unitsVariant) ->
     scale = $scope.getScale(unitsProduct, unitsVariant)
     if scale
-      value = value / scale if scale != 28.35 && scale != 1 # divide by scale if not smallest unit
+      value = value / scale if scale != 28.35 && scale != 1 && scale != 453.6 # divide by scale if not smallest unit
       $scope.getFormattedValueWithUnitName(value, unitsProduct, unitsVariant, scale)
     else
       ''
@@ -183,7 +183,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
       $scope.selectedUnitsProduct.hasOwnProperty("variant_unit") &&
       ( $scope.selectedUnitsProduct.variant_unit == "weight" || $scope.selectedUnitsProduct.variant_unit == "volume" )
         scale = $scope.getScale($scope.selectedUnitsProduct, $scope.selectedUnitsVariant)
-        sumOfUnitValues = sumOfUnitValues / scale if scale == 28.35 # divide by scale if smallest unit
+        sumOfUnitValues = sumOfUnitValues / scale if scale == 28.35 || scale == 453.6 # divide by scale if smallest unit
         $scope.roundToThreeDecimals(sumOfUnitValues / $scope.selectedUnitsProduct.group_buy_unit_size * $scope.selectedUnitsVariant.unit_value)
     else
       ''

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -161,6 +161,12 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.getFormattedValueWithUnitName = (value, unitsProduct, unitsVariant, scale) ->
     unit_name = VariantUnitManager.getUnitName(scale, unitsProduct.variant_unit)
     $scope.roundToThreeDecimals(value) + " " + unit_name
+
+  $scope.getGroupBySizeFormattedValueWithUnitName = (value, unitsProduct, unitsVariant) ->
+    scale = $scope.getScale(unitsProduct, unitsVariant)
+    if scale
+      value = value / scale if scale != 28.35 && scale != 1 # divide by scale if not smallest unit
+      $scope.getFormattedValueWithUnitName(value, unitsProduct, unitsVariant, scale)
     else
       ''
 

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -168,7 +168,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     if $scope.selectedUnitsProduct.hasOwnProperty("group_buy_unit_size") && $scope.selectedUnitsProduct.group_buy_unit_size > 0 &&
       $scope.selectedUnitsProduct.hasOwnProperty("variant_unit") &&
       ( $scope.selectedUnitsProduct.variant_unit == "weight" || $scope.selectedUnitsProduct.variant_unit == "volume" )
-        $scope.roundToThreeDecimals(sumOfUnitValues / $scope.selectedUnitsProduct.group_buy_unit_size)
+        $scope.roundToThreeDecimals(sumOfUnitValues / $scope.selectedUnitsProduct.group_buy_unit_size * $scope.selectedUnitsVariant.unit_value)
     else
       ''
 

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -128,14 +128,20 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.selectedUnitsProduct = unitsProduct
     $scope.selectedUnitsVariant = unitsVariant
 
+  $scope.getScale = (lineItem) ->
+    if lineItem.units_product && lineItem.units_variant && (lineItem.units_product.variant_unit == "weight" || lineItem.units_product.variant_unit == "volume") 
+      VariantUnitManager.getScale(lineItem.units_variant.unit_value, lineItem.units_product.variant_unit)
+    else
+      1
+
   $scope.sumUnitValues = ->
-    sum = $scope.filteredLineItems?.reduce (sum,lineItem) ->
-      sum + lineItem.final_weight_volume
+    sum = $scope.filteredLineItems?.reduce (sum, lineItem) ->
+      sum + $scope.roundToThreeDecimals(lineItem.final_weight_volume / $scope.getScale(lineItem))
     , 0
 
   $scope.sumMaxUnitValues = ->
     sum = $scope.filteredLineItems?.reduce (sum,lineItem) ->
-        sum + lineItem.max_quantity * lineItem.units_variant.unit_value
+      sum + lineItem.max_quantity * $scope.roundToThreeDecimals(lineItem.units_variant.unit_value / $scope.getScale(lineItem))
     , 0
 
   $scope.roundToThreeDecimals = (value) ->

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -182,6 +182,8 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     if $scope.selectedUnitsProduct.hasOwnProperty("group_buy_unit_size") && $scope.selectedUnitsProduct.group_buy_unit_size > 0 &&
       $scope.selectedUnitsProduct.hasOwnProperty("variant_unit") &&
       ( $scope.selectedUnitsProduct.variant_unit == "weight" || $scope.selectedUnitsProduct.variant_unit == "volume" )
+        scale = $scope.getScale($scope.selectedUnitsProduct, $scope.selectedUnitsVariant)
+        sumOfUnitValues = sumOfUnitValues / scale if scale == 28.35 # divide by scale if smallest unit
         $scope.roundToThreeDecimals(sumOfUnitValues / $scope.selectedUnitsProduct.group_buy_unit_size * $scope.selectedUnitsVariant.unit_value)
     else
       ''

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -128,7 +128,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     $scope.selectedUnitsProduct = unitsProduct
     $scope.selectedUnitsVariant = unitsVariant
 
-  $scope.getScale = (lineItem) ->
+  $scope.getLineItemScale = (lineItem) ->
     if lineItem.units_product && lineItem.units_variant && (lineItem.units_product.variant_unit == "weight" || lineItem.units_product.variant_unit == "volume") 
       VariantUnitManager.getScale(lineItem.units_variant.unit_value, lineItem.units_product.variant_unit)
     else
@@ -136,12 +136,12 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.sumUnitValues = ->
     sum = $scope.filteredLineItems?.reduce (sum, lineItem) ->
-      sum + $scope.roundToThreeDecimals(lineItem.final_weight_volume / $scope.getScale(lineItem))
+      sum + $scope.roundToThreeDecimals(lineItem.final_weight_volume / $scope.getLineItemScale(lineItem))
     , 0
 
   $scope.sumMaxUnitValues = ->
     sum = $scope.filteredLineItems?.reduce (sum,lineItem) ->
-      sum + lineItem.max_quantity * $scope.roundToThreeDecimals(lineItem.units_variant.unit_value / $scope.getScale(lineItem))
+      sum + lineItem.max_quantity * $scope.roundToThreeDecimals(lineItem.units_variant.unit_value / $scope.getLineItemScale(lineItem))
     , 0
 
   $scope.roundToThreeDecimals = (value) ->

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -149,7 +149,8 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
     # A Units Variant is an API object which holds unit properies of a variant
     if unitsProduct.hasOwnProperty("variant_unit") && (unitsProduct.variant_unit == "weight" || unitsProduct.variant_unit == "volume") && value > 0
       scale = VariantUnitManager.getScale(value, unitsProduct.variant_unit)
-      Math.round(value/scale * 1000)/1000 + " " + VariantUnitManager.getUnitName(scale, unitsProduct.variant_unit)
+      unit_name = VariantUnitManager.getUnitName(unitsVariant.unit_value, unitsProduct.variant_unit)
+      Math.round(value/scale * 1000)/1000 + " " + unit_name
     else
       ''
 

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -70,7 +70,7 @@
       .three.columns
         .text-center
           = t("admin.orders.bulk_management.group_buy_unit_size")
-        .text-center {{ formattedValueWithUnitName( selectedUnitsProduct.group_buy_unit_size, selectedUnitsProduct, selectedUnitsVariant ) }}
+        .text-center {{ getGroupBySizeFormattedValueWithUnitName(selectedUnitsProduct.group_buy_unit_size , selectedUnitsProduct, selectedUnitsVariant ) }}
       .three.columns
         .text-center
           = t("admin.orders.bulk_management.total_qtt_ordered")

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -261,24 +261,24 @@ describe "LineItemsCtrl", ->
           scope.formattedValueWithUnitName(1,unitsProduct,unitsVariant)
           expect(Math.round).toHaveBeenCalled()
 
-        it "calls Math.round with the quotient of scale and value, multiplied by 1000", ->
+        it "calls Math.round with the value multiplied by 1000", ->
           unitsProduct = { variant_unit: "weight" }
           spyOn(VariantUnitManager, "getScale").and.returnValue 5
           scope.formattedValueWithUnitName(10, unitsProduct,unitsVariant)
-          expect(Math.round).toHaveBeenCalledWith 10/5 * 1000
+          expect(Math.round).toHaveBeenCalledWith 10 * 1000
 
         it "returns the result of Math.round divided by 1000, followed by the result of getUnitName", ->
           unitsProduct = { variant_unit: "weight" }
           spyOn(VariantUnitManager, "getScale").and.returnValue 1000
           spyOn(VariantUnitManager, "getUnitName").and.returnValue "kg"
-          expect(scope.formattedValueWithUnitName(2000,unitsProduct,unitsVariant)).toEqual "2 kg"
+          expect(scope.formattedValueWithUnitName(2,unitsProduct,unitsVariant)).toEqual "2 kg"
 
         it "handle correclty the imperial units", ->
           unitsProduct = { variant_unit: "weight" }
           unitsVariant = { unit_value: "453.6" }
           spyOn(VariantUnitManager, "getScale").and.returnValue 1000
           spyOn(VariantUnitManager, "getUnitName").and.returnValue "lb"
-          expect(scope.formattedValueWithUnitName(2000, unitsProduct, unitsVariant)).toEqual "2 lb"
+          expect(scope.formattedValueWithUnitName(2, unitsProduct, unitsVariant)).toEqual "2 lb"
 
 
       describe "updating the price upon updating the weight of a line item", ->

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -171,7 +171,13 @@ describe "LineItemsCtrl", ->
 
         it "returns the quantity of fulfilled group buy units", ->
           scope.selectedUnitsProduct = { variant_unit: "weight", group_buy_unit_size: 1000 }
+          scope.selectedUnitsVariant = { unit_value: 1 }
           expect(scope.fulfilled(1500)).toEqual 1.5
+
+        it "returns the quantity of fulfilled group buy units by volume", ->
+          scope.selectedUnitsProduct = { variant_unit: "volume", group_buy_unit_size: 5000 }
+          scope.selectedUnitsVariant = { unit_value: 1000 }
+          expect(scope.fulfilled(5)).toEqual 1
 
       describe "allFinalWeightVolumesPresent()", ->
         it "returns false if the unit_value of any item in filteredLineItems does not exist", ->

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -228,34 +228,35 @@ describe "LineItemsCtrl", ->
 
         beforeEach ->
           spyOn(Math,"round").and.callThrough()
+        unitsVariant = { unit_value: "1" }
 
         it "returns '' if selectedUnitsVariant has no property 'variant_unit'", ->
           expect(scope.formattedValueWithUnitName(1,{})).toEqual ''
 
         it "returns '', and does not call Math.round if variant_unit is 'items'", ->
-          unitsVariant = { variant_unit: "items" }
-          expect(scope.formattedValueWithUnitName(1,unitsVariant)).toEqual ''
+          unitsProduct = { variant_unit: "items" }
+          expect(scope.formattedValueWithUnitName(1,unitsProduct,unitsVariant)).toEqual ''
           expect(Math.round).not.toHaveBeenCalled()
 
         it "calls Math.round() if variant_unit is 'weight' or 'volume'", ->
-          unitsVariant = { variant_unit: "weight" }
-          scope.formattedValueWithUnitName(1,unitsVariant)
+          unitsProduct = { variant_unit: "weight" }
+          scope.formattedValueWithUnitName(1,unitsProduct,unitsVariant)
           expect(Math.round).toHaveBeenCalled()
           scope.selectedUnitsVariant = { variant_unit: "volume" }
-          scope.formattedValueWithUnitName(1,unitsVariant)
+          scope.formattedValueWithUnitName(1,unitsProduct,unitsVariant)
           expect(Math.round).toHaveBeenCalled()
 
         it "calls Math.round with the quotient of scale and value, multiplied by 1000", ->
-          unitsVariant = { variant_unit: "weight" }
+          unitsProduct = { variant_unit: "weight" }
           spyOn(VariantUnitManager, "getScale").and.returnValue 5
-          scope.formattedValueWithUnitName(10, unitsVariant)
+          scope.formattedValueWithUnitName(10, unitsProduct,unitsVariant)
           expect(Math.round).toHaveBeenCalledWith 10/5 * 1000
 
         it "returns the result of Math.round divided by 1000, followed by the result of getUnitName", ->
-          unitsVariant = { variant_unit: "weight" }
+          unitsProduct = { variant_unit: "weight" }
           spyOn(VariantUnitManager, "getScale").and.returnValue 1000
           spyOn(VariantUnitManager, "getUnitName").and.returnValue "kg"
-          expect(scope.formattedValueWithUnitName(2000,unitsVariant)).toEqual "2 kg"
+          expect(scope.formattedValueWithUnitName(2000,unitsProduct,unitsVariant)).toEqual "2 kg"
 
       describe "updating the price upon updating the weight of a line item", ->
         beforeEach ->

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -213,6 +213,15 @@ describe "LineItemsCtrl", ->
           ]
           expect(scope.sumUnitValues()).toEqual 30
 
+        it "returns the sum of the final_weight_volumes for line_items with both metric and imperial units", ->
+          scope.filteredLineItems = [
+            { final_weight_volume: 907.2, units_product: { variant_unit: "weight" }, units_variant: { unit_value: 453.6 } }
+            { final_weight_volume: 2000, units_product: { variant_unit: "weight" }, units_variant: { unit_value: 1000 } }
+            { final_weight_volume: 56.7, units_product: { variant_unit: "weight" }, units_variant: { unit_value: 28.35 } }
+            { final_weight_volume: 2, units_product: { variant_unit: "volume" }, units_variant: { unit_value: 1.0 } }
+          ]
+          expect(scope.sumUnitValues()).toEqual 8
+
       describe "sumMaxUnitValues()", ->
         it "returns the sum of the product of unit_value and maxOf(max_quantity, pristine quantity) for specified line_items", ->
           scope.filteredLineItems = [

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -258,6 +258,14 @@ describe "LineItemsCtrl", ->
           spyOn(VariantUnitManager, "getUnitName").and.returnValue "kg"
           expect(scope.formattedValueWithUnitName(2000,unitsProduct,unitsVariant)).toEqual "2 kg"
 
+        it "handle correclty the imperial units", ->
+          unitsProduct = { variant_unit: "weight" }
+          unitsVariant = { unit_value: "453.6" }
+          spyOn(VariantUnitManager, "getScale").and.returnValue 1000
+          spyOn(VariantUnitManager, "getUnitName").and.returnValue "lb"
+          expect(scope.formattedValueWithUnitName(2000, unitsProduct, unitsVariant)).toEqual "2 lb"
+
+
       describe "updating the price upon updating the weight of a line item", ->
         beforeEach ->
           LineItems.pristineByID = { 1: { price: 2.00, quantity: 1, final_weight_volume: 2000 } }

--- a/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
@@ -21,6 +21,10 @@ describe "VariantUnitManager", ->
       expect(VariantUnitManager.getScale(0.4,"weight")).toEqual 1
       expect(VariantUnitManager.getScale(0.0004,"volume")).toEqual 0.001
 
+    it "returns the right unit when using imperial units", ->
+      expect(VariantUnitManager.getScale(453.6, "weight")).toEqual 453.6
+      expect(VariantUnitManager.getScale(28.35, "weight")).toEqual 28.35
+
   describe "getUnitName", ->
     it "returns the unit name based on the scale and unit type (weight/volume) provided", ->
       expect(VariantUnitManager.getUnitName(1, "weight")).toEqual "g"

--- a/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
@@ -4,7 +4,7 @@ describe "VariantUnitManager", ->
   beforeEach ->
     module "admin.products"
     module ($provide)->
-      $provide.value "availableUnits", "g,kg,T,mL,L,kL"
+      $provide.value "availableUnits", "g,kg,T,mL,L,kL,lb,oz"
       null
 
   beforeEach inject (_VariantUnitManager_) ->
@@ -29,6 +29,8 @@ describe "VariantUnitManager", ->
       expect(VariantUnitManager.getUnitName(0.001, "volume")).toEqual "mL"
       expect(VariantUnitManager.getUnitName(1, "volume")).toEqual "L"
       expect(VariantUnitManager.getUnitName(1000, "volume")).toEqual "kL"
+      expect(VariantUnitManager.getUnitName(453.6, "weight")).toEqual "lb"
+      expect(VariantUnitManager.getUnitName(28.35, "weight")).toEqual "oz"
 
   describe "unitScales", ->
     it "returns a sorted set of scales for unit type weight", ->
@@ -46,6 +48,8 @@ describe "VariantUnitManager", ->
     it "returns an array of options", ->
       expect(VariantUnitManager.variantUnitOptions()).toEqual [
         ["Weight (g)", "weight_1"],
+        ["Weight (oz)", "weight_28.35" ],
+        ["Weight (lb)", "weight_453.6" ]
         ["Weight (kg)", "weight_1000"],
         ["Weight (T)", "weight_1000000"],
         ["Volume (mL)", "volume_0.001"],


### PR DESCRIPTION
#### What? Why?

Closes #8171

Imperial units seems to be completly forget for this interface. The aim of this PR is to handle correctly imperial units for the whole BOM interface. 

_NB_
The `BULK UNIT SIZE` in the page `/admin/products/french-beans/group_buy_options` is a bit tricky. 
 - If the unit system used is the metric one, the unit used in this interface should be `g` or `L` (no matter of the product unit, that could be `kg` or `g`)
 - If the unit system used is the imperial one, the unit used in this interface should be the one of the product (ie. `oz` or `lb`)

We should somehow edit the `https://guide.openfoodnetwork.org/basic-features/products-1/group-buy-for-bulk-ordering` page

#### What should we test?
First of all, the _how to reproduce_ from the linked issue #8171 . The interface should now be fixed:

<img width="1205" alt="Capture d’écran 2021-12-03 à 15 25 54" src="https://user-images.githubusercontent.com/296452/144618637-2cc49845-f4ff-4190-b698-33e72bbbca74.png">


I think it could be a good idea to test the BOM interface with the product/variants set with imperial units _before_ and _after_ the PR.



#### Release notes
Handle imperial units in the Bulk Order Management interface
Changelog Category: User facing changes
