### PR TITLE
Move paypal controller

### DIFF
--- a/app/controllers/payment_gateways/paypal_controller.rb
+++ b/app/controllers/payment_gateways/paypal_controller.rb
@@ -80,10 +80,10 @@ module PaymentGateways
         SetExpressCheckoutRequestDetails: {
           InvoiceID: order.number,
           BuyerEmail: order.email,
-          ReturnURL: spree.confirm_paypal_url(
+          ReturnURL: payment_gateways_confirm_paypal_url(
             payment_method_id: params[:payment_method_id], utm_nooverride: 1
           ),
-          CancelURL: spree.cancel_paypal_url,
+          CancelURL: payment_gateways_cancel_paypal_url,
           SolutionType: payment_method.preferred_solution.presence || "Mark",
           LandingPage: payment_method.preferred_landing_page.presence || "Billing",
           cppheaderimage: payment_method.preferred_logourl.presence || "",

--- a/app/controllers/payment_gateways/paypal_controller.rb
+++ b/app/controllers/payment_gateways/paypal_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Spree
+module PaymentGateways
   class PaypalController < ::BaseController
     include OrderStockCheck
 

--- a/app/services/checkout/paypal_redirect.rb
+++ b/app/services/checkout/paypal_redirect.rb
@@ -3,6 +3,8 @@
 # Provides the redirect path if a redirect to the payment gateway is needed
 module Checkout
   class PaypalRedirect
+    include Rails.application.routes.url_helpers
+
     def initialize(params)
       @params = params
     end
@@ -15,13 +17,7 @@ module Checkout
       payment_method = Spree::PaymentMethod.find(payment_method_id)
       return unless payment_method.is_a?(Spree::Gateway::PayPalExpress)
 
-      spree_routes_helper.paypal_express_path(payment_method_id: payment_method.id)
-    end
-
-    private
-
-    def spree_routes_helper
-      Spree::Core::Engine.routes.url_helpers
+      payment_gateways_paypal_express_path(payment_method_id: payment_method.id)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,6 @@ Openfoodnetwork::Application.routes.draw do
     get "/paypal", to: "paypal#express", as: :paypal_express
     get "/paypal/confirm", to: "paypal#confirm", as: :confirm_paypal
     get "/paypal/cancel", to: "paypal#cancel", as: :cancel_paypal
-    get "/paypal/notify", to: "paypal#notify", as: :notify_paypal
   end
 
   constraints SplitCheckoutConstraint.new do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,6 @@ Openfoodnetwork::Application.routes.draw do
   get '/checkout', to: 'checkout#edit'
   put '/checkout', to: 'checkout#update', as: :update_checkout
   get '/checkout/:state', to: 'checkout#edit', as: :checkout_state
-  get '/checkout/paypal_payment/:order_id', to: 'checkout#paypal_payment', as: :paypal_payment
 
   get 'embedded_shopfront/shopfront_session', to: 'application#shopfront_session'
   post 'embedded_shopfront/enable', to: 'application#enable_embedded_styles'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,13 @@ Openfoodnetwork::Application.routes.draw do
     resources :callbacks, only: [:index]
     resources :webhooks, only: [:create]
   end
+  
+  namespace :payment_gateways do
+    get "/paypal", to: "paypal#express", as: :paypal_express
+    get "/paypal/confirm", to: "paypal#confirm", as: :confirm_paypal
+    get "/paypal/cancel", to: "paypal#cancel", as: :cancel_paypal
+    get "/paypal/notify", to: "paypal#notify", as: :notify_paypal
+  end
 
   constraints SplitCheckoutConstraint.new do
     get '/checkout', to: 'split_checkout#edit'

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -169,8 +169,6 @@ Spree::Core::Engine.routes.draw do
   resources :products
 
   # Used by spree_paypal_express
-  get '/content/cvv', :to => 'content#cvv', :as => :cvv
-  get '/content/*path', :to => 'content#show', :as => :content
   get '/paypal', :to => "paypal#express", :as => :paypal_express
   get '/paypal/confirm', :to => "paypal#confirm", :as => :confirm_paypal
   get '/paypal/cancel', :to => "paypal#cancel", :as => :cancel_paypal

--- a/config/routes/spree.rb
+++ b/config/routes/spree.rb
@@ -167,10 +167,4 @@ Spree::Core::Engine.routes.draw do
   end
 
   resources :products
-
-  # Used by spree_paypal_express
-  get '/paypal', :to => "paypal#express", :as => :paypal_express
-  get '/paypal/confirm', :to => "paypal#confirm", :as => :confirm_paypal
-  get '/paypal/cancel', :to => "paypal#cancel", :as => :cancel_paypal
-  get '/paypal/notify', :to => "paypal#notify", :as => :notify_paypal
 end

--- a/spec/controllers/payment_gateways/paypal_controller_spec.rb
+++ b/spec/controllers/payment_gateways/paypal_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-module Spree
+module PaymentGateways
   describe PaypalController, type: :controller do
     context '#cancel' do
       it 'redirects back to checkout' do

--- a/spec/requests/checkout/paypal_spec.rb
+++ b/spec/requests/checkout/paypal_spec.rb
@@ -55,7 +55,7 @@ describe "checking out an order with a paypal express payment method", type: :re
       expect(order.all_adjustments.payment_fee.count).to eq 1
       expect(order.all_adjustments.payment_fee.first.amount).to eq 1.5
 
-      get spree.confirm_paypal_path, params: params
+      get payment_gateways_confirm_paypal_path, params: params
 
       # Processing was successful, order is complete
       expect(response).to redirect_to order_path(order, token: order.token)

--- a/spec/support/request/paypal_helper.rb
+++ b/spec/support/request/paypal_helper.rb
@@ -10,7 +10,7 @@ module PaypalHelper
       set_express_checkout: paypal_response,
       express_checkout_url: options[:redirect]
     )
-    allow_any_instance_of(Spree::PaypalController).to receive(:provider).
+    allow_any_instance_of(PaymentGateways::PaypalController).to receive(:provider).
       and_return(paypal_provider)
   end
 

--- a/spec/system/consumer/shopping/checkout_paypal_spec.rb
+++ b/spec/system/consumer/shopping/checkout_paypal_spec.rb
@@ -72,7 +72,7 @@ describe "Check out with Paypal", js: true do
       # jump straight to being redirected back to OFN with a "confirmed" payment.
       stub_paypal_response(
         success: true,
-        redirect: spree.confirm_paypal_path(
+        redirect: payment_gateways_confirm_paypal_path(
           payment_method_id: paypal.id, token: "t123", PayerID: 'p123'
         )
       )


### PR DESCRIPTION
#### What? Why?

Moves the Paypal controller (responsible for handling the process of redirecting to Paypal and then handling the response when the user is redirected back from Paypal to OFN) out of the `controllers/spree` namespace and into a new `controllers/payment_gateways` namespace.

This will be followed (in another PR) by a new Stripe controller for handling redirects from Stripe back to OFN, so we can extract all of the Stripe-specific logic (and _responsibilities_!) out of the `CheckoutController#edit` action :tada:

This came up as part of the payment backend work for split checkout https://github.com/openfoodfoundation/openfoodnetwork/pull/8503 and also the move towards saner Stripe payment handling as mentioned [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/8485).

Soundtrack: [Basilisk](https://www.youtube.com/watch?v=F3XxD8cbJB0) :musical_note: 

#### What should we test?
<!-- List which features should be tested and how. -->

Paying with Paypal at the checkout, both when the payment is authorized by the user successfully and when it is cancelled by the user in Paypal should work as normal.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Refactored Paypal controller routes

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes