### PR TITLE
Remove dead code: Order#backordered?

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -203,10 +203,6 @@ module Spree
       total.to_f > 0.0 && !skip_payment_for_subscription?
     end
 
-    def backordered?
-      shipments.any?(&:backordered?)
-    end
-
     # Returns the relevant zone (if any) to be used for taxation purposes.
     # Uses default tax zone unless there is a specific match
     def tax_zone

--- a/engines/order_management/spec/services/order_management/order/updater_spec.rb
+++ b/engines/order_management/spec/services/order_management/order/updater_spec.rb
@@ -8,8 +8,6 @@ module OrderManagement
       let(:order) { create(:order) }
       let(:updater) { OrderManagement::Order::Updater.new(order) }
 
-      before { allow(order).to receive(:backordered?) { false } }
-
       context "updating order totals" do
         before do
           2.times { create(:line_item, order: order, price: 10) }


### PR DESCRIPTION
#### What? Why?

This method is no longer used.

**Background:** this is related to an original Spree feature that allowed customers to order items which are out of stock (like pre-ordering something that will come back in stock in the future). We've previously removed all the other related code for this, as we don't use it in OFN (and the feature essentially doesn't work / isn't compatible with how we process orders).

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed unused method #backordered? from Order model

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
