### PR TITLE
Avoid flaky race conditions in product import spec

### DIFF
--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -724,6 +724,12 @@ describe "Product Import", js: true do
   end
 
   def expect_import_completed
-    expect(page).to have_content I18n.t('admin.product_import.save_results.final_results')
+    # The step pages are hidden and shown by AngularJS and we get a false
+    # positive when querying for the content of a hidden step.
+    #
+    #   expect(page).to have_content I18n.t('admin.product_import.save_results.final_results')
+    #
+    # Being more explicit seems to work:
+    expect(page).to have_selector("h5", text: "Import final results")
   end
 end

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -722,6 +722,8 @@ describe "Product Import", js: true do
     #   expect(page).to have_content I18n.t('admin.product_import.save_results.final_results')
     #
     # Being more explicit seems to work:
-    expect(page).to have_selector("h5", text: "Import final results")
+    using_wait_time 60 do
+      expect(page).to have_selector("h5", text: "Import final results")
+    end
   end
 end

--- a/spec/system/admin/product_import_spec.rb
+++ b/spec/system/admin/product_import_spec.rb
@@ -685,8 +685,6 @@ describe "Product Import", js: true do
         # Save file.
         proceed_with_save
 
-        # Be extra patient.
-        expect_progress_percentages "33%", "67%", "100%"
         expect_import_completed
 
         # Check that all rows are saved.
@@ -711,12 +709,6 @@ describe "Product Import", js: true do
     proceed_with_save
     expect(page).to have_selector 'div.save-results', visible: true
     expect_import_completed
-  end
-
-  def expect_progress_percentages(*percentages)
-    percentages.each do |percentage|
-      page.has_selector? ".progress-interface", text: percentage # Waits for progress bar
-    end
   end
 
   def proceed_with_save


### PR DESCRIPTION

#### What? Why?

Closes #7685

We had some false expectations which made the spec become very flaky. If this spec is still flaky, we need to increase the wait time for the product import.
<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how. -->

Just specs pass.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

Avoid flaky race conditions in product import spec

