### PR TITLE
Display unit value and unit name when products with unit type "item"

### DIFF
--- a/app/services/variant_units/variant_and_line_item_naming.rb
+++ b/app/services/variant_units/variant_and_line_item_naming.rb
@@ -71,7 +71,7 @@ module VariantUnits
 
       return variant.display_as if variant_display_as?
 
-      return product.variant_unit_name if product.variant_unit_scale.nil? 
+      return option_value_name if product.variant_unit_scale.nil?
 
       options_text
     end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -595,11 +595,13 @@ module Spree
           expect(v1.unit_to_display).to eq("ponies")
         end
 
-        it "displays variant unit name if no unit scale" do
+        it "displays variant unit name and unit value if no unit scale" do
           p = create(:simple_product, variant_unit: 'items', variant_unit_scale: nil, variant_unit_name: 'items_unit')
-          v = build_stubbed(:variant, product: p)
+          v = build_stubbed(:variant, product: p, unit_value: 5)
+          v1 = build_stubbed(:variant, product: p, unit_value: 10)
 
-          expect(v.unit_to_display).to eq("items_unit")
+          expect(v.unit_to_display).to eq("5 items_unit")
+          expect(v1.unit_to_display).to eq("10 items_unit")
         end
       end
 


### PR DESCRIPTION
#### What? Why?

After #8500 , It was observed that only unit name was being displayed for products being sold by item. This PR makes it so that full details are displayed. 

![image](https://user-images.githubusercontent.com/65319144/144812482-ada0bf18-ab08-4151-8f0d-8eedc37d2846.png)

#### What should we test?
- Wherever unit_to_display method is used, the number of items sold as well as the unit name should be displayed properly for products with unit_type 'items'.
- Changes to unit name must be reflected everywhere unit_to_display method is used.

#### Release notes
- Fixed Inconsistency in unit names, values for products sold by item.

Changelog Category: User facing changes 
