### PR TITLE
Hide loading html components on product index

### DIFF
--- a/app/views/spree/admin/products/index.html.haml
+++ b/app/views/spree/admin/products/index.html.haml
@@ -5,9 +5,10 @@
 %div{ ng: { app: 'ofn.admin', controller: 'AdminProductEditCtrl', init: 'initialise()' } }
 
   = render 'spree/admin/products/index/filters'
-  = render 'spree/admin/products/index/actions'
-  = render 'spree/admin/products/index/indicators'
-  = render 'spree/admin/products/index/products'
+  %div{ 'ng-cloak' => true }
+    = render 'spree/admin/products/index/actions'
+    = render 'spree/admin/products/index/indicators'
+    = render 'spree/admin/products/index/products'
 
-  %div{'ng-show' => "!RequestMonitor.loading && products.length > 0" }
-    = render partial: 'admin/shared/angular_pagination'
+    %div{'ng-show' => "!RequestMonitor.loading && products.length > 0" }
+      = render partial: 'admin/shared/angular_pagination'


### PR DESCRIPTION
when loading product index, for a brief period some of the html elements are displayed before Angular get initialized and hide them

#### how to test
go to product index, refresh the page and make sure the display is clean : only filters and loading message are displayed, then the table appears