### PR TITLE
Style all standard select as the text input in the backoffice

### DIFF
--- a/app/assets/stylesheets/admin/products.scss
+++ b/app/assets/stylesheets/admin/products.scss
@@ -86,9 +86,6 @@ table#listing_products.bulk {
     input, select {
       width: 100%;
     }
-    select {
-      margin-bottom: 0.5em;
-    }
   }
 
   td.left-actions {

--- a/app/assets/stylesheets/admin/shared/forms.scss
+++ b/app/assets/stylesheets/admin/shared/forms.scss
@@ -283,3 +283,8 @@ fieldset {
 .form-buttons {
   text-align: center;
 }
+
+select {
+  @extend input[type="text"];
+  background-color: white;
+}


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/17404254/145272354-cf34584b-6041-4982-87ad-82b037caad7e.png)


### After

![image](https://user-images.githubusercontent.com/17404254/145272406-e181c901-bcb0-4a51-aec3-1e21b80956d2.png)

### How to test

As an admin manager, test the look and feel of as many as possible select input in the admin section.