### PR TITLE
Make flaky system spec reliable

### DIFF
--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -219,7 +219,15 @@ describe '
       fill_in "order_bill_address_attributes_address1", with: "xxx"
       fill_in "order_bill_address_attributes_city", with: "xxx"
       fill_in "order_bill_address_attributes_zipcode", with: "xxx"
-      select "Australia", from: "order_bill_address_attributes_country_id"
+
+      # The country is already selected and we avoid re-selecting it here
+      # because it would trigger an API call which we would need to wait for
+      # while we have no visual indicator for the wait.
+      #
+      # Ideally, we would implement a visual cue like disable the state field
+      # while the data is fetched from the API.
+      #
+      # select "Australia", from: "order_bill_address_attributes_country_id"
       select "Victoria", from: "order_bill_address_attributes_state_id"
       fill_in "order_bill_address_attributes_phone", with: "xxx"
 


### PR DESCRIPTION

#### What? Why?

Closes #8449

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

It was failing 50% of the time since it was converted into a system spec. The input selection was going too fast and we were still waiting for an API call to set the state values (depending on the country) while the state Victoria was selected.


#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes

