### PR TITLE
Add babel-loader to JS dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@hotwired/turbo": "^7.1.0",
     "@rails/webpacker": "5.4.3",
+    "babel-loader": "^8.2.3",
     "cable_ready": "^5.0.0-pre2",
     "flatpickr": "^4.6.9",
     "moment": "^2.29.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,7 +3548,7 @@ babel-jest@^27.4.2:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
-babel-loader@^8.0.0:
+babel-loader@^8.0.0, babel-loader@^8.2.3:
   version "8.2.3"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.3.tgz#8986b40f1a64cacfcb4b8429320085ef68b1342d"
   integrity sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==


### PR DESCRIPTION
#### What? Why?

Closes #8604

Deployments are currently failing with: `ERROR in Entry module not found: Error: Cannot resolve module 'babel-loader'`.

This package should have been included by other dependencies, but it seems there's some weird issues with the package not being found and this is one of the main suggested solutions.


#### What should we test?
<!-- List which features should be tested and how. -->

Deployments should work now (they do, I just checked)

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Added explicit babel-loader dependency

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
