### PR TITLE
Remove Spree.user_class

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -52,11 +52,11 @@ module Api
 
         if api_key.blank?
           # An anonymous user
-          @current_api_user = Spree.user_class.new
+          @current_api_user = Spree::User.new
           return
         end
 
-        return if @current_api_user = Spree.user_class.find_by(spree_api_key: api_key.to_s)
+        return if @current_api_user = Spree::User.find_by(spree_api_key: api_key.to_s)
 
         invalid_api_key
       end

--- a/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -20,7 +20,7 @@ module Spree
         def update
           if @order.update(order_params)
             if params[:guest_checkout] == "false"
-              @order.associate_user!(Spree.user_class.find_by(email: @order.email))
+              @order.associate_user!(Spree::User.find_by(email: @order.email))
             end
 
             refresh_shipment_rates

--- a/app/controllers/spree/admin/search_controller.rb
+++ b/app/controllers/spree/admin/search_controller.rb
@@ -8,7 +8,7 @@ module Spree
       respond_to :json
 
       def known_users
-        @users = if exact_match = Spree.user_class.find_by(email: search_params[:q])
+        @users = if exact_match = Spree::User.find_by(email: search_params[:q])
                    [exact_match]
                  else
                    spree_current_user.known_users.ransack(ransack_hash).result.limit(10)

--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -27,7 +27,7 @@ module Spree
 
     # Endpoint for queries to check if a user is already registered
     def registered_email
-      user = Spree.user_class.find_by email: params[:email]
+      user = Spree::User.find_by email: params[:email]
       render json: { registered: user.present? }
     end
 

--- a/app/mailers/spree/test_mailer.rb
+++ b/app/mailers/spree/test_mailer.rb
@@ -3,7 +3,7 @@
 module Spree
   class TestMailer < BaseMailer
     def test_email(user)
-      recipient = user.respond_to?(:id) ? user : Spree.user_class.find(user)
+      recipient = user.respond_to?(:id) ? user : Spree::User.find(user)
       subject = "#{Spree::Config[:site_name]} #{t('spree.test_mailer.test_email.subject')}"
       mail(to: recipient.email, from: from_address, subject: subject)
     end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -8,7 +8,7 @@ class Customer < ApplicationRecord
   searchable_attributes :name, :email, :code
 
   belongs_to :enterprise
-  belongs_to :user, class_name: Spree.user_class.to_s
+  belongs_to :user, class_name: "Spree::User"
   has_many :orders, class_name: "Spree::Order"
   before_destroy :check_for_orders
 

--- a/app/models/enterprise_role.rb
+++ b/app/models/enterprise_role.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EnterpriseRole < ApplicationRecord
-  belongs_to :user, class_name: Spree.user_class.to_s
+  belongs_to :user, class_name: "Spree::User"
   belongs_to :enterprise
 
   validates :user, :enterprise, presence: true

--- a/app/models/spree/ability.rb
+++ b/app/models/spree/ability.rb
@@ -16,7 +16,7 @@ module Spree
       alias_action :new_action, to: :create
       alias_action :show, to: :read
 
-      user ||= Spree.user_class.new
+      user ||= Spree::User.new
 
       if user.respond_to?(:has_spree_role?) && user.has_spree_role?('admin')
         can :manage, :all
@@ -34,8 +34,8 @@ module Spree
         can [:index, :read], Product
         can [:index, :read], ProductProperty
         can [:index, :read], Property
-        can :create, Spree.user_class
-        can [:read, :update, :destroy], Spree.user_class, id: user.id
+        can :create, Spree::User
+        can [:read, :update, :destroy], Spree::User, id: user.id
         can [:index, :read], State
         can [:index, :read], StockItem
         can [:index, :read], StockLocation

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -34,8 +34,8 @@ module Spree
 
     token_resource
 
-    belongs_to :user, class_name: Spree.user_class.to_s
-    belongs_to :created_by, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: "Spree::User"
+    belongs_to :created_by, class_name: "Spree::User"
 
     belongs_to :bill_address, class_name: 'Spree::Address'
     alias_attribute :billing_address, :bill_address
@@ -677,7 +677,7 @@ module Spree
     end
 
     def registered_email?
-      Spree.user_class.exists?(email: email)
+      Spree::User.exists?(email: email)
     end
 
     def adjustments_fetcher

--- a/app/models/spree/role.rb
+++ b/app/models/spree/role.rb
@@ -3,6 +3,6 @@
 module Spree
   class Role < ApplicationRecord
     has_and_belongs_to_many :users, join_table: 'spree_roles_users',
-                                    class_name: Spree.user_class.to_s
+                                    class_name: "Spree::User"
   end
 end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -33,9 +33,6 @@ Spree::Image.set_attachment_attribute(:path, ENV['ATTACHMENT_PATH']) if ENV['ATT
 Spree::Image.set_attachment_attribute(:url, ENV['ATTACHMENT_URL']) if ENV['ATTACHMENT_URL']
 Spree::Image.set_storage_attachment_attributes
 
-# Spree 2.0 recommends explicitly setting this here when using spree_auth_devise
-Spree.user_class = 'Spree::User'
-
 # TODO Work out why this is necessary
 # Seems like classes within OFN module become 'uninitialized' when server reloads
 # unless the empty module is explicity 'registered' here. Something to do with autoloading?

--- a/lib/spree/core.rb
+++ b/lib/spree/core.rb
@@ -12,18 +12,6 @@ require 'ransack'
 require 'state_machines'
 
 module Spree
-  mattr_accessor :user_class
-
-  def self.user_class
-    if @@user_class.is_a?(Class)
-      raise "Spree.user_class MUST be a String object, not a Class object."
-    end
-
-    return unless @@user_class.is_a?(String)
-
-    @@user_class.constantize
-  end
-
   # Used to configure Spree.
   #
   # Example:

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     "xxxx#{Time.now.to_i}#{rand(1000)}#{n}xxxxxxxxxxxxx"
   end
 
-  factory :user, class: Spree.user_class do
+  factory :user, class: Spree::User do
     transient do
       enterprises { [] }
     end
@@ -14,7 +14,7 @@ FactoryBot.define do
     login { email }
     password { 'secret' }
     password_confirmation { password }
-    if Spree.user_class.attribute_method? :authentication_token
+    if Spree::User.attribute_method? :authentication_token
       authentication_token {
         generate(:user_authentication_token)
       }

--- a/spec/mailers/test_mailer_spec.rb
+++ b/spec/mailers/test_mailer_spec.rb
@@ -13,7 +13,7 @@ describe Spree::TestMailer do
   end
 
   it "confirm_email accepts a user id as an alternative to a User object" do
-    expect(Spree.user_class).to receive(:find).with(user.id).and_return(user)
+    expect(Spree::User).to receive(:find).with(user.id).and_return(user)
     expect {
       Spree::TestMailer.test_email(user.id).deliver_now
     }.to_not raise_error

--- a/spec/models/spree/ability_spec.rb
+++ b/spec/models/spree/ability_spec.rb
@@ -40,9 +40,9 @@ describe Spree::Ability do
     let(:resource) { Object.new }
     let(:resource_shipment) { Spree::Shipment.new }
     let(:resource_product) { Spree::Product.new }
-    let(:resource_user) { Spree.user_class.new }
+    let(:resource_user) { Spree::User.new }
     let(:resource_order) { Spree::Order.new }
-    let(:fakedispatch_user) { Spree.user_class.new }
+    let(:fakedispatch_user) { Spree::User.new }
     let(:fakedispatch_ability) { Spree::Ability.new(fakedispatch_user) }
 
     context 'with admin user' do
@@ -97,7 +97,7 @@ describe Spree::Ability do
       end
 
       context 'requested by other user' do
-        before(:each) { resource.user = Spree.user_class.new }
+        before(:each) { resource.user = Spree::User.new }
         it_should_behave_like 'create only'
       end
 
@@ -185,7 +185,7 @@ describe Spree::Ability do
         it_should_behave_like 'no index allowed'
       end
       context 'requested by other user' do
-        let(:resource) { Spree.user_class.new }
+        let(:resource) { Spree::User.new }
         it_should_behave_like 'create only'
       end
     end

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -17,7 +17,7 @@ describe "spree/admin/orders/edit.html.haml" do
   before do
     controller.singleton_class.class_eval do
       def current_ability
-        Spree::Ability.new(Spree.user_class.new)
+        Spree::Ability.new(Spree::User.new)
       end
     end
 

--- a/spec/views/spree/admin/orders/index.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/index.html.haml_spec.rb
@@ -15,7 +15,7 @@ describe "spree/admin/orders/index.html.haml" do
   before do
     controller.singleton_class.class_eval do
       def current_ability
-        Spree::Ability.new(Spree.user_class.new)
+        Spree::Ability.new(Spree::User.new)
       end
     end
 


### PR DESCRIPTION
#### What? Why?

This construct was previously used in Spree to switch out the user class with a dummy class in certain places in the test suite. We don't use this any more, so it's just mess.

:fire:

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed unused method #user_class

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
