### PR TITLE
Packing reports filtering

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -5,6 +5,7 @@ require 'spree/core/s3_support'
 class Enterprise < ApplicationRecord
   SELLS = %w(unspecified none own any).freeze
   ENTERPRISE_SEARCH_RADIUS = 100
+
   searchable_attributes :sells, :is_primary_producer
   searchable_associations :properties
   searchable_scopes :is_primary_producer, :is_distributor, :is_hub, :activated, :visible,

--- a/app/models/spree/line_item.rb
+++ b/app/models/spree/line_item.rb
@@ -9,14 +9,17 @@ module Spree
     include LineItemStockChanges
 
     searchable_attributes :price, :quantity, :order_id, :variant_id, :tax_category_id
-    searchable_associations :order, :variant, :tax_category, :option_values
+    searchable_associations :order, :order_cycle, :variant, :product, :supplier, :tax_category, :option_values
     searchable_scopes :with_tax, :without_tax
 
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items
+    has_one :order_cycle, through: :order
+
     belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant"
+    has_one :product, through: :variant
+    has_one :supplier, through: :product
     belongs_to :tax_category, class_name: "Spree::TaxCategory"
 
-    has_one :product, through: :variant
     has_many :adjustments, as: :adjustable, dependent: :destroy
 
     has_and_belongs_to_many :option_values, join_table: 'spree_option_values_line_items',

--- a/app/views/admin/reports/_date_range_form.html.haml
+++ b/app/views/admin/reports/_date_range_form.html.haml
@@ -2,8 +2,8 @@
   = label_tag nil, t(:date_range)
   %br
   = label_tag nil, t(:start), :class => 'inline'
-  = text_field_tag "q[completed_at_gt]", params.dig(:q, :completed_at_gt), :class => 'datetimepicker datepicker-from'
+  = text_field_tag "q[order_completed_at_gt]", params.dig(:q, :order_completed_at_gt), :class => 'datetimepicker datepicker-from'
   %span.range-divider
     %i.icon-arrow-right
-  = text_field_tag "q[completed_at_lt]", params.dig(:q, :completed_at_lt), :class => 'datetimepicker datepicker-to'
+  = text_field_tag "q[order_completed_at_lt]", params.dig(:q, :order_completed_at_lt), :class => 'datetimepicker datepicker-to'
   = label_tag nil, t(:end), :class => 'inline'

--- a/app/views/admin/reports/packing.html.haml
+++ b/app/views/admin/reports/packing.html.haml
@@ -4,7 +4,7 @@
   .row
     .alpha.two.columns= label_tag nil, t(:report_hubs)
     .omega.fourteen.columns
-      = collection_select("q", "distributor_id_in", @distributors, :id, :name, {selected: params.dig(:q, :distributor_id_in)}, {class: "select2 fullwidth", multiple: true})
+      = collection_select("q", "order_distributor_id_in", @distributors, :id, :name, {selected: params.dig(:q, :order_distributor_id_in)}, {class: "select2 fullwidth", multiple: true})
 
   .row
     .alpha.two.columns= label_tag nil, t(:report_producers)

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -31,7 +31,7 @@ module Reporting
       @renderer ||= ReportRenderer.new(self)
     end
 
-    def scoped_orders_relation
+    def ransacked_orders_relation
       visible_orders_relation.ransack(ransack_params).result
     end
 

--- a/lib/reporting/report_template.rb
+++ b/lib/reporting/report_template.rb
@@ -35,6 +35,10 @@ module Reporting
       visible_orders_relation.ransack(ransack_params).result
     end
 
+    def ransacked_line_items_relation
+      visible_line_items_relation.ransack(ransack_params).result
+    end
+
     def visible_orders_relation
       ::Permissions::Order.new(current_user).
         visible_orders.complete.not_state(:canceled).

--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -12,8 +12,8 @@ module Reporting
 
         def report_query
           Queries::QueryBuilder.new(primary_model, grouping_fields).
-            scoped_to_orders(ransacked_orders_relation).
-            scoped_to_line_items(visible_line_items_relation).
+            scoped_to_orders(visible_orders_relation).
+            scoped_to_line_items(ransacked_line_items_relation).
             with_managed_orders(managed_orders_relation).
             joins_order_and_distributor.
             joins_order_customer.

--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -12,7 +12,7 @@ module Reporting
 
         def report_query
           Queries::QueryBuilder.new(primary_model, grouping_fields).
-            scoped_to_orders(scoped_orders_relation).
+            scoped_to_orders(ransacked_orders_relation).
             scoped_to_line_items(visible_line_items_relation).
             with_managed_orders(managed_orders_relation).
             joins_order_and_distributor.

--- a/spec/controllers/api/v0/reports/packing_report_spec.rb
+++ b/spec/controllers/api/v0/reports/packing_report_spec.rb
@@ -6,7 +6,7 @@ describe Api::V0::ReportsController, type: :controller do
   let(:params) {
     {
       report_type: 'packing',
-      q: { created_at_lt: Time.zone.now }
+      q: { order_created_at_lt: Time.zone.now }
     }
   }
 

--- a/spec/lib/reports/packing/packing_report_spec.rb
+++ b/spec/lib/reports/packing/packing_report_spec.rb
@@ -127,23 +127,36 @@ describe "Packing Reports" do
         expect(report_contents).to_not include line_item3.product.name
       end
 
-      context "filtering by order cycle" do
+      context "filtering results" do
         let(:order_cycle2) { create(:simple_order_cycle) }
         let(:order4) {
           create(:completed_order_with_totals, distributor: distributor, order_cycle: order_cycle2,
                                                line_items_count: 0)
         }
         let(:line_item4) { build(:line_item_with_shipment) }
-        let(:params) { { order_cycle_id_in: order_cycle.id } }
 
         before do
           order4.line_items << line_item4
           order4.finalize!
+          line_item4.variant.product.update(supplier: create(:supplier_enterprise))
         end
 
-        it "only shows results from the selected order cycle" do
-          expect(report_contents).to include line_item.product.name
-          expect(report_contents).to_not include line_item4.product.name
+        context "filtering by order cycle" do
+          let(:params) { { order_cycle_id_in: [order_cycle.id] } }
+
+          it "only shows results from the selected order cycle" do
+            expect(report_contents).to include line_item.product.name
+            expect(report_contents).to_not include line_item4.product.name
+          end
+        end
+
+        context "filtering by supplier" do
+          let(:params) { { supplier_id_in: [line_item.supplier.id] } }
+
+          it "only shows results from the selected supplier" do
+            expect(report_contents).to include line_item.product.name
+            expect(report_contents).to_not include line_item4.product.name
+          end
         end
       end
     end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -822,4 +822,36 @@ module Spree
       end
     end
   end
+
+  describe "searching with ransack" do
+    let(:order_cycle1) { create(:order_cycle) }
+    let(:order_cycle2) { create(:order_cycle) }
+    let(:product1) { create(:product, supplier: create(:supplier_enterprise)) }
+    let(:product2) { create(:product, supplier: create(:supplier_enterprise)) }
+    let!(:line_item1) { create(:line_item, variant: product1.variants.first) }
+    let!(:line_item2) { create(:line_item, variant: product2.variants.first) }
+
+    let(:search_result) { Spree::LineItem.ransack(query).result }
+
+    before do
+      line_item1.order.update_attribute :order_cycle, order_cycle1
+      line_item2.order.update_attribute :order_cycle, order_cycle2
+    end
+
+    context "searching by supplier" do
+      let(:query) { { supplier_id_eq: line_item1.variant.product.supplier_id } }
+
+      it "filters results" do
+        expect(search_result.to_a).to eq [line_item1]
+      end
+    end
+
+    context "searching by order_cycle" do
+      let(:query) { { order_cycle_id_eq: order_cycle1.id } }
+
+      it "filters results" do
+        expect(search_result.to_a).to eq [line_item1]
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #8539 

Updates filtering on packing reports to fix an issue with filtering by supplier (which was not working) and updates general searching options on the `LineItem` class.

Soundtrack: [Leftovers](https://www.youtube.com/watch?v=ou2M5VSNvjo) :musical_note: 

#### What should we test?
<!-- List which features should be tested and how. -->

Filtering results by supplier should now work correctly in packing reports. It'll be worth checking the order cycle filters as well :ok_hand:

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed filtering by producers in packing reports

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
