### PR TITLE
Synchronise processing of subscriptions and avoid duplicate order creation

### DIFF
--- a/app/jobs/subscription_placement_job.rb
+++ b/app/jobs/subscription_placement_job.rb
@@ -4,8 +4,7 @@ require 'order_management/subscriptions/summarizer'
 
 class SubscriptionPlacementJob < ActiveJob::Base
   def perform
-    ids = proxy_orders.pluck(:id)
-    ProxyOrder.where(id: ids).each do |proxy_order|
+    proxy_orders.each do |proxy_order|
       place_order_for(proxy_order)
     end
 
@@ -23,6 +22,7 @@ class SubscriptionPlacementJob < ActiveJob::Base
     ProxyOrder.not_canceled.where(placed_at: nil)
       .joins(:order_cycle).merge(OrderCycle.active)
       .joins(:subscription).merge(Subscription.not_canceled.not_paused)
+      .order(:id)
   end
 
   def place_order_for(proxy_order)

--- a/app/services/place_proxy_order.rb
+++ b/app/services/place_proxy_order.rb
@@ -13,8 +13,6 @@ class PlaceProxyOrder
   def call
     return unless initialise_order
 
-    mark_as_processed
-
     summarizer.record_order(order)
     return summarizer.record_issue(:complete, order) if order.completed?
 
@@ -43,6 +41,9 @@ class PlaceProxyOrder
       summarizer.record_subscription_issue(subscription)
       return false
     end
+
+    mark_as_processed
+
     true
   rescue StandardError => e
     Bugsnag.notify(e, subscription: subscription, proxy_order: proxy_order)

--- a/app/services/place_proxy_order.rb
+++ b/app/services/place_proxy_order.rb
@@ -11,7 +11,7 @@ class PlaceProxyOrder
   end
 
   def call
-    return unless initialise_order
+    return unless place_order
 
     summarizer.record_order(order)
     return summarizer.record_issue(:complete, order) if order.completed?
@@ -31,6 +31,14 @@ class PlaceProxyOrder
 
   attr_reader :proxy_order, :subscription, :summarizer, :logger, :stock_changes_loader, :changes
   attr_accessor :order
+
+  def place_order
+    proxy_order.with_lock do
+      return if proxy_order.placed_at.present?
+
+      initialise_order
+    end
+  end
 
   def initialise_order
     logger.info("Placing Order for Proxy Order #{proxy_order.id}")

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -214,8 +214,6 @@ describe SubscriptionPlacementJob do
         breakpoint.unlock
         threads.each(&:join)
       }.to change {
-        pending "The current code places two orders!"
-
         Spree::Order.count
       }.by(1)
     end

--- a/spec/jobs/subscription_placement_job_spec.rb
+++ b/spec/jobs/subscription_placement_job_spec.rb
@@ -171,4 +171,53 @@ describe SubscriptionPlacementJob do
       end
     end
   end
+
+  describe "parallisation", concurrency: true do
+    let(:shop) { create(:distributor_enterprise) }
+    let(:order_cycle) {
+      create(
+        :simple_order_cycle,
+        coordinator: shop,
+        orders_open_at: 1.minute.ago,
+        orders_close_at: 10.minutes.from_now
+      )
+    }
+    let(:schedule) { create(:schedule, order_cycles: [order_cycle]) }
+    let(:subscription) { create(:subscription, shop: shop, schedule: schedule) }
+    let!(:proxy_order) {
+      create(:proxy_order, subscription: subscription, order_cycle: order_cycle)
+    }
+    let(:breakpoint) { Mutex.new }
+
+    it "doesn't place duplicate orders" do
+      # Pause jobs when placing proxy order:
+      breakpoint.lock
+      allow(PlaceProxyOrder).to(
+        receive(:new).and_wrap_original do |method, *args|
+          breakpoint.synchronize {}
+          method.call(*args)
+        end
+      )
+
+      expect {
+        # Start two jobs in parallel:
+        threads = [
+          Thread.new { SubscriptionPlacementJob.new.perform },
+          Thread.new { SubscriptionPlacementJob.new.perform },
+        ]
+
+        # Wait for both to jobs to pause.
+        # This can reveal a race condition.
+        sleep 1
+
+        # Resume and complete both jobs:
+        breakpoint.unlock
+        threads.each(&:join)
+      }.to change {
+        pending "The current code places two orders!"
+
+        Spree::Order.count
+      }.by(1)
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #8606

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

We place subscription orders every five minutes. We've got so many subscriptions now though that the process can take longer than five minutes. When two processes are running at the same time they can process one subscription twice and place two orders.

I added database locking to avoid processing the same subscription twice at the same time.

#### What should we test?
<!-- List which features should be tested and how. -->

Subscription orders are still placed.

I don't think that it's feasible to test the original issue. I added a spec though and we need to check production once deployed.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes

Avoid duplicate placing of subscription orders.
