### PR TITLE
Add "Product" translation in product created confirmation message

### DIFF
--- a/app/controllers/spree/admin/base_controller.rb
+++ b/app/controllers/spree/admin/base_controller.rb
@@ -66,6 +66,12 @@ module Spree
         Spree.t(event_sym, resource: resource_desc)
       end
 
+      def flash_message_for_w_res(resource_name, object, event_sym)
+        resource_desc  = resource_name
+        resource_desc += " \"#{object.name}\"" if object.respond_to?(:name) && object.name.present?
+        Spree.t(event_sym, resource: resource_desc)
+      end
+
       # Index request for JSON needs to pass a CSRF token in order to prevent JSON Hijacking
       def check_json_authenticity
         return unless request.format.js? || request.format.json?

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -29,7 +29,7 @@ module Spree
 
           @object.attributes = permitted_resource_params
           if @object.save
-            flash[:success] = flash_message_for(@object, :successfully_created)
+            flash[:success] = flash_message_for_w_res(t(:product), @object, :successfully_created)
             if params[:button] == "add_another"
               redirect_to spree.new_admin_product_path
             else


### PR DESCRIPTION
#### What? Why?

Closes #8459 

Added a new function to **base_controller.rb**, _flash_message_for_w_resource_ that looks at the resource name and applies the newly translated resource name to the resource_desc; this fix could be applied to numerous Missing Translation bugs in the issues page. I changed the function call for _create_ in **products_controller.rb** to implement this change and pass in the translated product (using t[:product]) to the resource name and continue the function as before. I added this function to base_controller to minimize the interference with other code items and isolate this issue. 

This change was necessary since the previous **base_controller** function, _flash_message_for_, did not apply the translated resource name and only applied the English version directly, so there had to be a t() included to the resource name to access the yaml translations.

#### What should we test?
Since we isolated this issue only to **products_controller.rb**, we made a new function in **base_controller.rb**; we just need to test if the function create is acting inappropriately.

#### Attachments
Video Replicating the error with fix:
https://user-images.githubusercontent.com/49418660/145761466-7f5403d4-156a-4f76-bccc-74468726e5b7.MOV

Image of Error Fix (Correctly translating "Product" to "Produkt"):
![IMG_8280](https://user-images.githubusercontent.com/49418660/145761546-16f1d53d-9abb-4f64-a161-b98b774a3a75.JPEG)

