### PR TITLE
Update units when variant unit name is edited

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -431,7 +431,7 @@ module Spree
     end
 
     def update_units
-      return unless saved_change_to_variant_unit?
+      return unless saved_change_to_variant_unit? || saved_change_to_variant_unit_name?
 
       option_types.delete self.class.all_variant_unit_option_types
       option_types << variant_unit_option_type if variant_unit.present?

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -443,6 +443,30 @@ module Spree
 
         expect(product.taxons).not_to include(original_taxon)
       end
+
+      it "updates units when saved change to variant unit" do
+        product.variant_unit = 'items'
+        product.variant_unit_scale = nil
+        product.variant_unit_name = 'loaf'
+        product.save!
+
+        expect(product.variant_unit_name).to eq 'loaf'
+
+        product.update(variant_unit_name: 'bag')
+
+        expect(product.variant_unit_name).to eq 'bag'
+
+        product.variant_unit = 'weight'
+        product.variant_unit_scale = 1
+        product.variant_unit_name = 'g'
+        product.save!
+
+        expect(product.variant_unit).to eq 'weight'
+
+        product.update(variant_unit: 'volume')
+
+        expect(product.variant_unit).to eq 'volume'
+      end
     end
 
     describe "scopes" do


### PR DESCRIPTION
#### What? Why?

Closes #8495 

Made it so that when variant unit name is edited, units are updated. This makes it so that this change is reflected everywhere in the UI. 

![variant_unit_name](https://user-images.githubusercontent.com/65319144/146140059-4f71dc16-0699-4d24-b2ea-5087d92ce73e.gif)

#### What should we test?
- Changes to unit name for products sold by item should be reflected everywhere.

Changelog Category: Technical changes
