### PR TITLE
SplitCheckout - Handle submit on step2 

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -70,7 +70,7 @@ class SplitCheckoutController < ::BaseController
   end
 
   def validate_payment!
-    return true if params.dig(:order, :payments_attributes).present?
+    return true if params.dig(:order, :payments_attributes, 0, :payment_method_id).present?
 
     @order.errors.add :payment_method, I18n.t('split_checkout.errors.select_a_payment_method')
   end

--- a/app/views/split_checkout/_payment.html.haml
+++ b/app/views/split_checkout/_payment.html.haml
@@ -11,7 +11,8 @@
           name: "order[payments_attributes][][payment_method_id]",
           checked: (payment_method.id == selected_payment_method),
           "data-action": "paymentmethod#selectPaymentMethod",
-          "data-paymentmethod-id": "paymentmethod#{payment_method.id}"
+          "data-paymentmethod-id": "paymentmethod#{payment_method.id}",
+          "data-paymentmethod-target": "input"
         = f.label :payment_method_id, "#{payment_method.name} (#{payment_or_shipping_price(payment_method, @order)})", for: "payment_method_#{payment_method.id}"
 
     = f.error_message_on :payment_method, standalone: true

--- a/app/views/split_checkout/payment/_stripe_sca.html.haml
+++ b/app/views/split_checkout/payment/_stripe_sca.html.haml
@@ -12,7 +12,7 @@
       %label
         = t('split_checkout.step2.form.stripe.use_new_card')
 
-    %div.stripe-card{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}" }
+    %div.stripe-card{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}", "data-stripe-target": "stripeElementsForm" }
       = hidden_field_tag "order[payments_attributes][][source_attributes][first_name]", @order.bill_address.first_name
       = hidden_field_tag "order[payments_attributes][][source_attributes][last_name]", @order.bill_address.last_name
       = hidden_field_tag "order[payments_attributes][][source_attributes][month]", nil, { "data-stripe-target": "expMonth" }

--- a/app/views/split_checkout/payment/_stripe_sca.html.haml
+++ b/app/views/split_checkout/payment/_stripe_sca.html.haml
@@ -12,17 +12,18 @@
       %label
         = t('split_checkout.step2.form.stripe.use_new_card')
 
-    %div.stripe-card{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}", "data-stripe-target": "stripeElementsForm" }
-      = hidden_field_tag "order[payments_attributes][][source_attributes][first_name]", @order.bill_address.first_name
-      = hidden_field_tag "order[payments_attributes][][source_attributes][last_name]", @order.bill_address.last_name
-      = hidden_field_tag "order[payments_attributes][][source_attributes][month]", nil, { "data-stripe-target": "expMonth" }
-      = hidden_field_tag "order[payments_attributes][][source_attributes][year]", nil, { "data-stripe-target": "expYear" }
-      = hidden_field_tag "order[payments_attributes][][source_attributes][cc_type]", nil, { "data-stripe-target": "brand" }
-      = hidden_field_tag "order[payments_attributes][][source_attributes][last_digits]", nil, { "data-stripe-target": "last4" }
-      = hidden_field_tag "order[payments_attributes][][source_attributes][gateway_payment_profile_id]", nil, { "data-stripe-target": "pmId" }
-
-      %div.card-element{ "data-stripe-target": "cardElement" }
-      %div.card-errors{ "data-stripe-target": "cardErrors" }
+    %div{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}", "data-stripe-target": "stripeElementsForm" }
+      .stripe-card
+        = hidden_field_tag "order[payments_attributes][][source_attributes][first_name]", @order.bill_address.first_name
+        = hidden_field_tag "order[payments_attributes][][source_attributes][last_name]", @order.bill_address.last_name
+        = hidden_field_tag "order[payments_attributes][][source_attributes][month]", nil, { "data-stripe-target": "expMonth" }
+        = hidden_field_tag "order[payments_attributes][][source_attributes][year]", nil, { "data-stripe-target": "expYear" }
+        = hidden_field_tag "order[payments_attributes][][source_attributes][cc_type]", nil, { "data-stripe-target": "brand" }
+        = hidden_field_tag "order[payments_attributes][][source_attributes][last_digits]", nil, { "data-stripe-target": "last4" }
+        = hidden_field_tag "order[payments_attributes][][source_attributes][gateway_payment_profile_id]", nil, { "data-stripe-target": "pmId" }
+        %div.card-element{ "data-stripe-target": "cardElement" }
+      
+      %div.error.card-errors{ "data-stripe-target": "cardErrors" }
 
   - if spree_current_user
     .checkout-input

--- a/app/views/split_checkout/payment/_stripe_sca.html.haml
+++ b/app/views/split_checkout/payment/_stripe_sca.html.haml
@@ -12,7 +12,7 @@
       %label
         = t('split_checkout.step2.form.stripe.use_new_card')
 
-    %div{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}", "data-stripe-target": "stripeElementsForm" }
+    %div{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}" }
       .stripe-card
         = hidden_field_tag "order[payments_attributes][][source_attributes][first_name]", @order.bill_address.first_name
         = hidden_field_tag "order[payments_attributes][][source_attributes][last_name]", @order.bill_address.last_name

--- a/app/webpacker/controllers/paymentmethod_controller.js
+++ b/app/webpacker/controllers/paymentmethod_controller.js
@@ -12,6 +12,14 @@ export default class extends Controller {
 
   selectPaymentMethod(event) {
     this.doSelectPaymentMethod(event.target.dataset.paymentmethodId);
+    const stripeCardsController =
+      this.application.getControllerForElementAndIdentifier(
+        document
+          .getElementById(event.target.dataset.paymentmethodId)
+          .querySelector('[data-controller="stripe-cards"]'),
+        "stripe-cards"
+      );
+    stripeCardsController.connect();
   }
 
   doSelectPaymentMethod(paymentMethodContainerId) {

--- a/app/webpacker/controllers/paymentmethod_controller.js
+++ b/app/webpacker/controllers/paymentmethod_controller.js
@@ -29,11 +29,9 @@ export default class extends Controller {
     ).forEach((e) => {
       if (e.id === paymentMethodContainerId) {
         e.style.display = "block";
-        this.addRequiredAttributeOnInputIfNeeded(e);
         this.removeDisabledAttributeOnInput(e);
       } else {
         e.style.display = "none";
-        this.removeRequiredAttributeOnInput(e);
         this.addDisabledAttributeOnInput(e);
       }
     });
@@ -52,23 +50,6 @@ export default class extends Controller {
   removeDisabledAttributeOnInput(container) {
     this.getFormElementsArray(container).forEach((i) => {
       i.disabled = false;
-    });
-  }
-
-  removeRequiredAttributeOnInput(container) {
-    this.getFormElementsArray(container).forEach((i) => {
-      if (i.required) {
-        i.dataset.required = i.required;
-        i.required = false;
-      }
-    });
-  }
-
-  addRequiredAttributeOnInputIfNeeded(container) {
-    this.getFormElementsArray(container).forEach((i) => {
-      if (i.dataset.required === "true") {
-        i.required = true;
-      }
     });
   }
 }

--- a/app/webpacker/controllers/paymentmethod_controller.js
+++ b/app/webpacker/controllers/paymentmethod_controller.js
@@ -3,15 +3,15 @@ export default class extends Controller {
   static targets = ["input"];
 
   connect() {
-    this.inputTargets.forEach((i) => {
-      if (i.checked) {
-        this.doSelectPaymentMethod(i.dataset.paymentmethodId);
+    this.inputTargets.forEach((input) => {
+      if (input.checked) {
+        this.setPaymentMethod(input.dataset.paymentmethodId);
       }
     });
   }
 
   selectPaymentMethod(event) {
-    this.doSelectPaymentMethod(event.target.dataset.paymentmethodId);
+    this.setPaymentMethod(event.target.dataset.paymentmethodId);
 
     const stripeCardSelector =
       this.application.getControllerForElementAndIdentifier(
@@ -23,33 +23,29 @@ export default class extends Controller {
     stripeCardSelector?.initSelectedCard();
   }
 
-  doSelectPaymentMethod(paymentMethodContainerId) {
+  setPaymentMethod(paymentMethodContainerId) {
     Array.from(
       document.getElementsByClassName("paymentmethod-container")
-    ).forEach((e) => {
-      if (e.id === paymentMethodContainerId) {
-        e.style.display = "block";
-        this.removeDisabledAttributeOnInput(e);
+    ).forEach((container) => {
+      const enabled = container.id === paymentMethodContainerId
+
+      if (enabled) {
+        container.style.display = "block";
+        this.toggleFieldsEnabled(container, enabled);
       } else {
-        e.style.display = "none";
-        this.addDisabledAttributeOnInput(e);
+        container.style.display = "none";
+        this.toggleFieldsEnabled(container, enabled);
       }
     });
   }
 
-  getFormElementsArray(container) {
+  toggleFieldsEnabled(container, enabled) {
+    this.subFormElements(container).forEach((field) => {
+      field.disabled = !enabled;
+    });
+  }
+
+  subFormElements(container) {
     return Array.from(container.querySelectorAll("input, select, textarea"));
-  }
-
-  addDisabledAttributeOnInput(container) {
-    this.getFormElementsArray(container).forEach((i) => {
-      i.disabled = true;
-    });
-  }
-
-  removeDisabledAttributeOnInput(container) {
-    this.getFormElementsArray(container).forEach((i) => {
-      i.disabled = false;
-    });
   }
 }

--- a/app/webpacker/controllers/paymentmethod_controller.js
+++ b/app/webpacker/controllers/paymentmethod_controller.js
@@ -12,14 +12,15 @@ export default class extends Controller {
 
   selectPaymentMethod(event) {
     this.doSelectPaymentMethod(event.target.dataset.paymentmethodId);
-    const stripeCardsController =
+
+    const stripeCardSelector =
       this.application.getControllerForElementAndIdentifier(
         document
           .getElementById(event.target.dataset.paymentmethodId)
           .querySelector('[data-controller="stripe-cards"]'),
         "stripe-cards"
       );
-    stripeCardsController.connect();
+    stripeCardSelector?.connect();
   }
 
   doSelectPaymentMethod(paymentMethodContainerId) {

--- a/app/webpacker/controllers/paymentmethod_controller.js
+++ b/app/webpacker/controllers/paymentmethod_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
           .querySelector('[data-controller="stripe-cards"]'),
         "stripe-cards"
       );
-    stripeCardSelector?.connect();
+    stripeCardSelector?.initSelectedCard();
   }
 
   doSelectPaymentMethod(paymentMethodContainerId) {

--- a/app/webpacker/controllers/paymentmethod_controller.js
+++ b/app/webpacker/controllers/paymentmethod_controller.js
@@ -1,9 +1,20 @@
 import { Controller } from "stimulus";
 export default class extends Controller {
-  static targets = ["paymentMethod"];
+  static targets = ["input"];
+
+  connect() {
+    this.inputTargets.forEach((i) => {
+      if (i.checked) {
+        this.doSelectPaymentMethod(i.dataset.paymentmethodId);
+      }
+    });
+  }
 
   selectPaymentMethod(event) {
-    const paymentMethodContainerId = event.target.dataset.paymentmethodId;
+    this.doSelectPaymentMethod(event.target.dataset.paymentmethodId);
+  }
+
+  doSelectPaymentMethod(paymentMethodContainerId) {
     Array.from(
       document.getElementsByClassName("paymentmethod-container")
     ).forEach((e) => {

--- a/app/webpacker/controllers/stripe_cards_controller.js
+++ b/app/webpacker/controllers/stripe_cards_controller.js
@@ -16,8 +16,18 @@ export default class extends Controller {
   selectCard(cardValue) {
     if (cardValue == "") {
       this.stripeelementsTarget.style.display = "block";
+      this.getFormElementsArray(this.stripeelementsTarget).forEach((i) => {
+        i.disabled = false;
+      });
     } else {
       this.stripeelementsTarget.style.display = "none";
+      this.getFormElementsArray(this.stripeelementsTarget).forEach((i) => {
+        i.disabled = true;
+      });
     }
+  }
+
+  getFormElementsArray(container) {
+    return Array.from(container.querySelectorAll("input, select, textarea"));
   }
 }

--- a/app/webpacker/controllers/stripe_cards_controller.js
+++ b/app/webpacker/controllers/stripe_cards_controller.js
@@ -6,6 +6,10 @@ export default class extends Controller {
   static targets = ["stripeelements", "select"];
 
   connect() {
+    this.initSelectedCard()
+  }
+
+  initSelectedCard() {
     if (this.hasSelectTarget) {
       this.selectCard(this.selectTarget.value);
     }

--- a/app/webpacker/controllers/stripe_cards_controller.js
+++ b/app/webpacker/controllers/stripe_cards_controller.js
@@ -6,7 +6,9 @@ export default class extends Controller {
   static targets = ["stripeelements", "select"];
 
   connect() {
-    this.selectCard(this.selectTarget.value);
+    if (this.hasSelectTarget) {
+      this.selectCard(this.selectTarget.value);
+    }
   }
 
   onSelectCard(event) {

--- a/app/webpacker/controllers/stripe_controller.js
+++ b/app/webpacker/controllers/stripe_controller.js
@@ -32,6 +32,11 @@ export default class extends Controller {
     this.stripeElement.addEventListener("change", this.updateErrors);
   }
 
+  disconnect() {
+    this.parentForm.removeEventListener("submit", this.stripeSubmit);
+    this.stripeElement.removeEventListener("change", this.updateErrors);
+  }
+
   // Before the form is submitted we send the card details directly to Stripe (via StripeJS),
   // and receive a token which represents the card object, and add that token into the form.
   stripeSubmit = (event) => {

--- a/app/webpacker/controllers/stripe_controller.js
+++ b/app/webpacker/controllers/stripe_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = [ "cardElement", "cardErrors", "expMonth", "expYear", "brand", "last4", "pmId" ];
+  static targets = [ "cardElement", "cardErrors", "expMonth", "expYear", "brand", "last4", "pmId", "stripeElementsForm" ];
   static styles = {
     base: {
       fontFamily: "Roboto, Arial, sans-serif",
@@ -23,6 +23,7 @@ export default class extends Controller {
     const brand_field = this.brandTarget;
     const last4_field = this.last4Target;
     const pm_id_field = this.pmIdTarget;
+    const stripeElementsForm = this.stripeElementsFormTarget;
 
     const stripe_element = elements.create("card", {
       style: this.constructor.styles,
@@ -42,22 +43,35 @@ export default class extends Controller {
     // Before the form is submitted we send the card details directly to Stripe (via StripeJS),
     // and receive a token which represents the card object, and add that token into the form.
     form.addEventListener("submit", event => {
-      event.preventDefault();
-      event.stopPropagation();
+      if (this.isVisible(stripeElementsForm)) {
+        event.preventDefault();
+        event.stopPropagation();
+       
+        stripe.createPaymentMethod({type: "card", card: stripe_element}).then(response => {
+          if (response.error) {
+            error_container.textContent = response.error.message;
+          } else {
+            pm_id_field.setAttribute("value", response.paymentMethod.id);
+            exp_month_field.setAttribute("value", response.paymentMethod.card.exp_month);
+            exp_year_field.setAttribute("value", response.paymentMethod.card.exp_year);
+            brand_field.setAttribute("value", response.paymentMethod.card.brand);
+            last4_field.setAttribute("value", response.paymentMethod.card.last4);
 
-      stripe.createPaymentMethod({type: "card", card: stripe_element}).then(response => {
-        if (response.error) {
-          error_container.textContent = response.error.message;
-        } else {
-          pm_id_field.setAttribute("value", response.paymentMethod.id);
-          exp_month_field.setAttribute("value", response.paymentMethod.card.exp_month);
-          exp_year_field.setAttribute("value", response.paymentMethod.card.exp_year);
-          brand_field.setAttribute("value", response.paymentMethod.card.brand);
-          last4_field.setAttribute("value", response.paymentMethod.card.last4);
-
-          form.submit();
-        }
-      });
+            form.submit();
+          }
+        });
+      }
     });
   }
+
+  isVisible(element) {
+    while (element) {
+      if (window.getComputedStyle(element).display === "none") {
+        return false;
+      }
+      element = element.parentElement;
+    }
+    return true;
+  }
+
 }

--- a/app/webpacker/controllers/stripe_controller.js
+++ b/app/webpacker/controllers/stripe_controller.js
@@ -43,35 +43,29 @@ export default class extends Controller {
     // Before the form is submitted we send the card details directly to Stripe (via StripeJS),
     // and receive a token which represents the card object, and add that token into the form.
     form.addEventListener("submit", event => {
-      if (this.isVisible(stripeElementsForm)) {
-        event.preventDefault();
-        event.stopPropagation();
-       
-        stripe.createPaymentMethod({type: "card", card: stripe_element}).then(response => {
-          if (response.error) {
-            error_container.textContent = response.error.message;
-          } else {
-            pm_id_field.setAttribute("value", response.paymentMethod.id);
-            exp_month_field.setAttribute("value", response.paymentMethod.card.exp_month);
-            exp_year_field.setAttribute("value", response.paymentMethod.card.exp_year);
-            brand_field.setAttribute("value", response.paymentMethod.card.brand);
-            last4_field.setAttribute("value", response.paymentMethod.card.last4);
+      if(!this.stripeSelected()) { return }
 
-            form.submit();
-          }
-        });
-      }
+      event.preventDefault();
+      event.stopPropagation();
+
+      stripe.createPaymentMethod({type: "card", card: stripe_element}).then(response => {
+        if (response.error) {
+          error_container.textContent = response.error.message;
+        } else {
+          pm_id_field.setAttribute("value", response.paymentMethod.id);
+          exp_month_field.setAttribute("value", response.paymentMethod.card.exp_month);
+          exp_year_field.setAttribute("value", response.paymentMethod.card.exp_year);
+          brand_field.setAttribute("value", response.paymentMethod.card.brand);
+          last4_field.setAttribute("value", response.paymentMethod.card.last4);
+
+          form.submit();
+        }
+      });
     });
   }
 
-  isVisible(element) {
-    while (element) {
-      if (window.getComputedStyle(element).display === "none") {
-        return false;
-      }
-      element = element.parentElement;
-    }
-    return true;
+  // Boolean; true if Stripe is shown / currently selected
+  stripeSelected() {
+    return !!this.cardElementTarget.offsetParent
   }
-
 }

--- a/app/webpacker/controllers/stripe_controller.js
+++ b/app/webpacker/controllers/stripe_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
     }
   };
 
-  connect() {
+  initialize() {
     this.parentForm = this.pmIdTarget.form;
 
     // Initialize Stripe JS
@@ -25,7 +25,9 @@ export default class extends Controller {
 
     // Mount Stripe Elements JS to the form field
     this.stripeElement.mount(this.cardElementTarget);
+  }
 
+  connect() {
     this.parentForm.addEventListener("submit", this.stripeSubmit);
     this.stripeElement.addEventListener("change", this.updateErrors);
   }

--- a/spec/javascripts/stimulus/paymentmethod_controller_test.js
+++ b/spec/javascripts/stimulus/paymentmethod_controller_test.js
@@ -14,13 +14,13 @@ describe("PaymentmethodController", () => {
          <input id="paymentmethod_3" data-action="click->paymentmethod#selectPaymentMethod" data-paymentmethod-id="paymentmethod3" data-paymentmethod-target="input"/>
          
          <div class="paymentmethod-container" id="paymentmethod1">
-          <input type="number" required id="input1" />
+          <input type="number" id="input1" />
           <select id="select1" >
             <option value="1">1</option>
           </select>
          </div>
          <div class="paymentmethod-container" id="paymentmethod2">
-          <input type="number" required="true" id="input2" />
+          <input type="number" id="input2" />
           <select id="select2" >
             <option value="1">1</option>
           </select>
@@ -59,39 +59,6 @@ describe("PaymentmethodController", () => {
       expect(paymentMethod1Container.style.display).toBe("none");
       expect(paymentMethod2Container.style.display).toBe("none");
       expect(paymentMethod3Container.style.display).toBe("block");
-    });
-
-    it("handle well the add/remove on 'required' attribute on each input", () => {
-      const paymentMethod1 = document.getElementById("paymentmethod_1");
-      const paymentMethod2 = document.getElementById("paymentmethod_2");
-      const paymentMethod3 = document.getElementById("paymentmethod_3");
-
-      const input1 = document.getElementById("input1");
-      const input2 = document.getElementById("input2");
-      const input3 = document.getElementById("input3");
-
-      paymentMethod1.click();
-      expect(input1.required).toBe(true);
-      expect(input2.dataset.required).toBe("true");
-      expect(input2.required).toBe(false);
-      expect(input3.required).toBe(false);
-
-      paymentMethod2.click();
-      expect(input2.required).toBe(true);
-      expect(input1.dataset.required).toBe("true");
-      expect(input1.required).toBe(false);
-      expect(input3.required).toBe(false);
-
-      paymentMethod3.click();
-      expect(input1.required).toBe(false);
-      expect(input2.required).toBe(false);
-      expect(input3.required).toBe(false);
-
-      paymentMethod1.click();
-      expect(input1.required).toBe(true);
-      expect(input2.dataset.required).toBe("true");
-      expect(input2.required).toBe(false);
-      expect(input3.required).toBe(false);
     });
 
     it("handle well the add/remove 'disabled='disabled'' attribute on each input/select", () => {

--- a/spec/javascripts/stimulus/paymentmethod_controller_test.js
+++ b/spec/javascripts/stimulus/paymentmethod_controller_test.js
@@ -9,23 +9,23 @@ describe("PaymentmethodController", () => {
   describe("#selectPaymentMethod", () => {
     beforeEach(() => {
       document.body.innerHTML = `<div data-controller="paymentmethod">
-         <span id="paymentmethod_1" data-action="click->paymentmethod#selectPaymentMethod" data-paymentmethod-id="paymentmethod1" />
-         <span id="paymentmethod_2" data-action="click->paymentmethod#selectPaymentMethod" data-paymentmethod-id="paymentmethod2" />
-         <span id="paymentmethod_3" data-action="click->paymentmethod#selectPaymentMethod" data-paymentmethod-id="paymentmethod3" />
+         <input id="paymentmethod_1" data-action="click->paymentmethod#selectPaymentMethod" data-paymentmethod-id="paymentmethod1" data-paymentmethod-target="input" />
+         <input id="paymentmethod_2" data-action="click->paymentmethod#selectPaymentMethod" data-paymentmethod-id="paymentmethod2" data-paymentmethod-target="input" checked="checked" />
+         <input id="paymentmethod_3" data-action="click->paymentmethod#selectPaymentMethod" data-paymentmethod-id="paymentmethod3" data-paymentmethod-target="input"/>
          
-         <div class="paymentmethod-container" style="display: none;" id="paymentmethod1">
+         <div class="paymentmethod-container" id="paymentmethod1">
           <input type="number" required id="input1" />
           <select id="select1" >
             <option value="1">1</option>
           </select>
          </div>
-         <div class="paymentmethod-container" style="display: block;" id="paymentmethod2">
+         <div class="paymentmethod-container" id="paymentmethod2">
           <input type="number" required="true" id="input2" />
           <select id="select2" >
             <option value="1">1</option>
           </select>
          </div>
-         <div class="paymentmethod-container" style="display: none;" id="paymentmethod3">
+         <div class="paymentmethod-container" id="paymentmethod3">
           <input type="number" id="input3" />
           <select id="select3" >
             <option value="1">1</option>

--- a/spec/javascripts/stimulus/stripe_cards_controller_test.js
+++ b/spec/javascripts/stimulus/stripe_cards_controller_test.js
@@ -13,7 +13,9 @@ describe("StripeCardsController", () => {
         <option value="1">Card #1</option>
         <option value="2">Card #2</option>
        </select>
-       <div data-stripe-cards-target="stripeelements" id="stripeelements" />
+       <div data-stripe-cards-target="stripeelements" id="stripeelements" >
+        <input type="hidden" id="input_1">
+       </div>
       </div>`;
 
     const application = Application.start();
@@ -38,18 +40,21 @@ describe("StripeCardsController", () => {
       expect(document.getElementById("stripeelements").style.display).toBe(
         "none"
       );
+      expect(document.getElementById("input_1").disabled).toBe(true);
 
       select.value = "2";
       select.dispatchEvent(new Event("change"));
       expect(document.getElementById("stripeelements").style.display).toBe(
         "none"
       );
+      expect(document.getElementById("input_1").disabled).toBe(true);
 
       select.value = "";
       select.dispatchEvent(new Event("change"));
       expect(document.getElementById("stripeelements").style.display).toBe(
         "block"
       );
+      expect(document.getElementById("input_1").disabled).toBe(false);
     });
   });
 });


### PR DESCRIPTION
#### What? Why?

The aim of this PR is simply to handle form submit on step 2. Each commits resolve a case, and the `How to test?` section should be complete on each case. 


Closes #8625

###### Error message
<img width="610" alt="Capture d’écran 2021-12-20 à 17 28 17" src="https://user-images.githubusercontent.com/296452/146800193-7a41b747-825c-4757-ae2b-f1af93df5be8.png">



#### What should we test?
Check, for every payment method, the step 2.

Pay attention to the Stripe payment method, since it can be:
1. Without any register stripe card: should create a new one, with or without error
2. With existing registered card, and create a new one
3. With existing registered card, and select an existing
4. I don't know if this case is relevant, but it can co-exist in the same page many stripe payment methods


#### Release notes
Split checkout : Handle step-2 submit

Changelog Category: User facing changes


