### PR TITLE
Set default_url_options in all environments

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,3 +5,5 @@ SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 OFN_REDIS_URL="redis://localhost:6379/1"
 OFN_REDIS_JOBS_URL="redis://localhost:6379/2"
+
+SITE_URL="0.0.0.0:3000"

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,5 @@
 # Override locally with `.env.test.local`
 
 SECRET_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+SITE_URL="test.host"

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Openfoodnetwork
 
     config.after_initialize do
       # We need this here because the test env file loads before the Spree engine is loaded
-      Spree::Core::Engine.routes.default_url_options[:host] = 'test.host' if Rails.env == 'test'
+      Spree::Core::Engine.routes.default_url_options[:host] = ENV["SITE_URL"] if Rails.env == 'test'
     end
 
     # We reload the routes here

--- a/config/application.rb
+++ b/config/application.rb
@@ -230,6 +230,8 @@ module Openfoodnetwork
 
     config.generators.template_engine = :haml
 
+    Rails.application.routes.default_url_options[:host] = ENV["SITE_URL"]
+
     config.autoloader = :zeitwerk
 
     config.action_view.form_with_generates_ids = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,3 @@ Openfoodnetwork::Application.configure do
 
   config.active_job.queue_adapter = :test
 end
-
-# Allows us to use _url helpers in Rspec
-Rails.application.routes.default_url_options[:host] = 'test.host'

--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -46,7 +46,7 @@ Capybara.configure do |config|
 end
 
 # Override setting in Spree engine: Spree::Core::MailSettings
-ActionMailer::Base.default_url_options[:host] = 'test.host'
+ActionMailer::Base.default_url_options[:host] = ENV["SITE_URL"]
 
 FactoryBot.use_parent_strategy = false
 


### PR DESCRIPTION
#### What? Why?

Extracting these two commits from elsewhere, as they were needed in two other PRs where they were not the main purpose of the PR.

For various reasons, `Rails.application.routes.default_url_options[:host]` needs to be explicitly set across all environments in a consistent way. We haven't been doing this up to now, and it's led to all kinds of weirdness. It's basically the base URL/domain that the site is running on and is needed in route-building whenever `*_url` helper methods are used (instead of just `*_path`, which doesn't use the full URL).

This PR standardises the setting of that attribute, mainly across dev and testing environments.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Set default_url_options[:host] in a standardised way across environments

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
