### PR TITLE
Clarify use of order tokens

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -28,7 +28,7 @@ class CartController < BaseController
   end
 
   def check_authorization
-    session[:access_token] ||= params[:token]
+    session[:access_token] ||= params[:order_token]
     order = Spree::Order.find_by(number: params[:id]) || current_order
 
     if order

--- a/app/controllers/payment_gateways/paypal_controller.rb
+++ b/app/controllers/payment_gateways/paypal_controller.rb
@@ -192,7 +192,7 @@ module PaymentGateways
     end
 
     def completion_route(order)
-      main_app.order_path(order, token: order.token)
+      main_app.order_path(order, order_token: order.token)
     end
 
     def address_required?

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -19,7 +19,7 @@ class PaymentsController < BaseController
   private
 
   def require_logged_in
-    return if session[:access_token] || params[:token] || spree_current_user
+    return if session[:access_token] || spree_current_user
 
     flash[:error] = I18n.t("spree.orders.edit.login_to_view_order")
     redirect_to main_app.root_path(anchor: "login?after_login=#{request.env['PATH_INFO']}")

--- a/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -75,14 +75,10 @@ module Spree
         end
 
         def check_authorization
-          load_order
-          session[:access_token] ||= params[:token]
-
-          resource = @order
           action = params[:action].to_sym
           action = :edit if action == :show # show route renders :edit for this controller
 
-          authorize! action, resource, session[:access_token]
+          authorize! action, @order
         end
 
         def set_guest_checkout_status

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -113,7 +113,7 @@ module Spree
     end
 
     def check_authorization
-      session[:access_token] ||= params[:token]
+      session[:access_token] ||= params[:order_token]
       order = Spree::Order.find_by(number: params[:id]) || current_order
 
       if order
@@ -154,7 +154,7 @@ module Spree
     end
 
     def require_order_authentication
-      return if session[:access_token] || params[:token] || spree_current_user
+      return if session[:access_token] || params[:order_token] || spree_current_user
 
       flash[:error] = I18n.t("spree.orders.edit.login_to_view_order")
       redirect_to main_app.root_path(anchor: "login?after_login=#{request.env['PATH_INFO']}")

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -26,12 +26,12 @@ describe Spree::OrdersController, type: :controller do
       let(:current_user) { nil }
 
       it "loads page" do
-        get :show, params: { id: order.number, token: order.token }
+        get :show, params: { id: order.number, order_token: order.token }
         expect(response.status).to eq 200
       end
 
       it "stores order token in session as 'access_token'" do
-        get :show, params: { id: order.number, token: order.token }
+        get :show, params: { id: order.number, order_token: order.token }
         expect(session[:access_token]).to eq(order.token)
       end
     end

--- a/spec/requests/checkout/paypal_spec.rb
+++ b/spec/requests/checkout/paypal_spec.rb
@@ -58,7 +58,7 @@ describe "checking out an order with a paypal express payment method", type: :re
       get payment_gateways_confirm_paypal_path, params: params
 
       # Processing was successful, order is complete
-      expect(response).to redirect_to order_path(order, token: order.token)
+      expect(response).to redirect_to order_path(order, order_token: order.token)
       expect(order.reload.complete?).to be true
 
       # We have only one payment, and one transaction fee

--- a/spec/system/consumer/shopping/orders_spec.rb
+++ b/spec/system/consumer/shopping/orders_spec.rb
@@ -48,7 +48,7 @@ describe "Order Management", js: true do
         expect(page).to_not be_confirmed_order_page
 
         # Can load the page with token
-        visit order_path(order, token: order.token)
+        visit order_path(order, order_token: order.token)
         expect(page).to be_confirmed_order_page
 
         # Can load the page even without the token, after loading the page with


### PR DESCRIPTION
#### What? Why?

Clarifies use of access tokens used for viewing order details as a guest user.

There are 4 or 5 different places in the app where we reference a `:token` and `params[:token]` for completely different purposes (they're not even vaguely the same token). :scream: 

Examples:
- `params[:token]` is used to allow guest users to view order details when they have completed checkout but are (obviously) not logged in. This is often used alongside `session[:access_token]` (they're effectively the same thing, in different data stores)
- `params[:token]` is used in API controllers for the user's API key
- `params[:token]` is used in a paypal controller action for a unique paypal token which is not the same as an order token (and gets saved on the payment's source object)
- `params[:token]` is used in a couple of Stripe Connect and Stripe card-saving actions and hold a unique token which is not an order token

This PR is an attempt to clarify the places in the app where we use `params[:token]` specifically in relation to *orders*, for allowing guest users (who are not logged in) to view details of an order they have placed (like after checkout completion), and to differentiate this usage from the various other places where `params[:token]` can actually be used for something entirely different. 

Review note: I left some more extensive notes in the commit messages. The second and third commits are ripping things out which look like they shouldn't be there.

Soundtrack: [Flies](https://www.youtube.com/watch?v=cF01Ou3_Wfo) :musical_note: 

#### What should we test?
<!-- List which features should be tested and how. -->

Place an order as a guest.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Clarify use of order tokens for guest users

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes