### PR TITLE
Make split checkout buttons sticky on step 3

### DIFF
--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -74,7 +74,7 @@
 - if any_terms_required?(@order.distributor)
   = render partial: "terms_and_conditions", locals: { f: f }
 
-%div.checkout-submit.medium-6
+%div.checkout-submit.medium-6.checkout-step3
   = f.submit t("split_checkout.step3.submit"), name: "confirm_order", class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
   %a.button.cancel{href: main_app.cart_path}
     = t("split_checkout.step3.cancel")

--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -71,10 +71,11 @@
     
     = render 'spree/orders/summary', order: @order
 
-- if any_terms_required?(@order.distributor)
-  = render partial: "terms_and_conditions", locals: { f: f }
-
-%div.checkout-submit.medium-6.checkout-step3
-  = f.submit t("split_checkout.step3.submit"), name: "confirm_order", class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
-  %a.button.cancel{href: main_app.cart_path}
-    = t("split_checkout.step3.cancel")
+.checkout-step3{"data-controller": "sticky", "data-sticky-target": "container"}
+  - if any_terms_required?(@order.distributor)
+    = render partial: "terms_and_conditions", locals: { f: f }
+  .medium-6
+    .checkout-submit
+      = f.submit t("split_checkout.step3.submit"), name: "confirm_order", class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
+      %a.button.cancel{href: main_app.cart_path}
+        = t("split_checkout.step3.cancel")

--- a/app/views/split_checkout/edit.html.haml
+++ b/app/views/split_checkout/edit.html.haml
@@ -19,7 +19,7 @@
   .sub-header.show-for-medium-down
     = render partial: "shopping_shared/order_cycles"
 
-  .row{ "data-controller": "guest-checkout", "data-guest-checkout-distributor-value": @order.distributor.id }
+  %div{ "data-controller": "guest-checkout", "data-guest-checkout-distributor-value": @order.distributor.id }
     %div{ style: "display: #{spree_current_user ? 'block' : 'none'}", "data-guest-checkout-target": "checkout" }
       = render partial: "checkout"
 

--- a/app/webpacker/controllers/sticky_controller.js
+++ b/app/webpacker/controllers/sticky_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "stimulus";
+
+// This add a `sticked` class to the element (`container`) when the user scrolls down
+// or up until the element is `sticked`.
+// The class is then removed once the element is no more `sticked`.
+// The element should have a `data-sticky-target` attribute with `container` as value.
+// This is only functionnal with a sticked element at the bottom. We could improve that point
+// by adding a `data-position` attribute with `top|bottom|left|right` as value and
+// modify the code below to handle the different positions.
+export default class extends Controller {
+  static targets = ["container"];
+
+  connect() {
+    this.containerTarget.style.position = "sticky";
+    this.containerTarget.style.bottom = "-1px";
+    const observer = new IntersectionObserver(
+      ([e]) => {
+        e.target.classList.toggle("sticked", e.intersectionRatio < 1);
+      },
+      { threshold: [1] }
+    );
+    observer.observe(this.containerTarget);
+  }
+}

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -188,8 +188,9 @@
 
     @media screen and (max-width: 700px) {
       &.sticked {
-        width: 100%;
         width: auto;
+        margin-left: -15px;
+        margin-right: -15px;
         box-shadow: 0 0px 10px 0px rgba(0, 0, 0, 0.33);
                 
         .checkout-submit {

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -172,6 +172,10 @@
       margin-top: 0;
       margin-bottom: 0;
       padding-top: 2rem;
+
+      .button {
+        margin-bottom: 1rem;
+      }
     }
 
     &.sticked {

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -165,6 +165,38 @@
     }
   }
 
+  .checkout-step3 {
+    padding-left: 15px;
+    padding-right: 15px;
+    .checkout-submit {
+      margin-top: 0;
+      margin-bottom: 0;
+      padding-top: 2rem;
+    }
+
+    &.sticked {
+      background-color: $white;
+      box-shadow: 0 -6px 12px -6px rgba(0, 0, 0, 0.33);
+      border-left: 1px solid $light-grey;
+      border-right: 1px solid $light-grey;
+      border-top: 1px solid $light-grey;
+    }
+
+    @media screen and (max-width: 700px) {
+      &.sticked {
+        width: 100%;
+        width: auto;
+        box-shadow: 0 0px 10px 0px rgba(0, 0, 0, 0.33);
+                
+        .checkout-submit {
+          width: 100%;
+          padding-left: 15px;
+          padding-right: 15px;
+        }
+      }
+    }
+  }
+
   .checkout-submit {
     margin-top: 5rem;
     margin-bottom: 5rem;


### PR DESCRIPTION
#### What? Why?

Closes #8630

![2021-12-21 15 41 06](https://user-images.githubusercontent.com/296452/146949527-a9e6b241-7161-4a8b-83c4-3ce28a8db1c1.gif)
![2021-12-21 15 41 47](https://user-images.githubusercontent.com/296452/146949535-ecc887c5-1708-4921-b74c-f49346220ad6.gif)




#### What should we test?
The button should be sticked on step 3 (only) for both desktop and mobile view.


#### Release notes
Split Checkout: Make submit buttons on step 3 always visible

Changelog Category: User facing changes