### PR TITLE
Split Checkout: Show "Save card for future use" checkbox only on "Enter new card details" option selected

### DIFF
--- a/app/views/split_checkout/payment/_stripe_sca.html.haml
+++ b/app/views/split_checkout/payment/_stripe_sca.html.haml
@@ -7,26 +7,27 @@
         options_for_select(stripe_card_options(@saved_credit_cards) + [[t('split_checkout.step2.form.stripe.create_new_card'), ""]], @selected_card),
         { "data-action": "change->stripe-cards#onSelectCard", "data-stripe-cards-target": "select" }
 
-  .checkout-input{"data-stripe-cards-target": "stripeelements"}
-    - if @saved_credit_cards.none?
-      %label
-        = t('split_checkout.step2.form.stripe.use_new_card')
-
-    %div{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}" }
-      .stripe-card
-        = hidden_field_tag "order[payments_attributes][][source_attributes][first_name]", @order.bill_address.first_name
-        = hidden_field_tag "order[payments_attributes][][source_attributes][last_name]", @order.bill_address.last_name
-        = hidden_field_tag "order[payments_attributes][][source_attributes][month]", nil, { "data-stripe-target": "expMonth" }
-        = hidden_field_tag "order[payments_attributes][][source_attributes][year]", nil, { "data-stripe-target": "expYear" }
-        = hidden_field_tag "order[payments_attributes][][source_attributes][cc_type]", nil, { "data-stripe-target": "brand" }
-        = hidden_field_tag "order[payments_attributes][][source_attributes][last_digits]", nil, { "data-stripe-target": "last4" }
-        = hidden_field_tag "order[payments_attributes][][source_attributes][gateway_payment_profile_id]", nil, { "data-stripe-target": "pmId" }
-        %div.card-element{ "data-stripe-target": "cardElement" }
-      
-      %div.error.card-errors{ "data-stripe-target": "cardErrors" }
-
-  - if spree_current_user
+  %div{"data-stripe-cards-target": "stripeelements"}
     .checkout-input
-      = check_box_tag "order[payments_attributes][][source_attributes][save_requested_by_customer]", 1, false
-      = label :save_requested_by_customer, t('split_checkout.step2.form.stripe.save_card'), { for: "save_requested_by_customer" }
-    
+      - if @saved_credit_cards.none?
+        %label
+          = t('split_checkout.step2.form.stripe.use_new_card')
+
+      %div{ "data-controller": "stripe", "data-stripe-key": "#{Stripe.publishable_key}" }
+        .stripe-card
+          = hidden_field_tag "order[payments_attributes][][source_attributes][first_name]", @order.bill_address.first_name
+          = hidden_field_tag "order[payments_attributes][][source_attributes][last_name]", @order.bill_address.last_name
+          = hidden_field_tag "order[payments_attributes][][source_attributes][month]", nil, { "data-stripe-target": "expMonth" }
+          = hidden_field_tag "order[payments_attributes][][source_attributes][year]", nil, { "data-stripe-target": "expYear" }
+          = hidden_field_tag "order[payments_attributes][][source_attributes][cc_type]", nil, { "data-stripe-target": "brand" }
+          = hidden_field_tag "order[payments_attributes][][source_attributes][last_digits]", nil, { "data-stripe-target": "last4" }
+          = hidden_field_tag "order[payments_attributes][][source_attributes][gateway_payment_profile_id]", nil, { "data-stripe-target": "pmId" }
+          %div.card-element{ "data-stripe-target": "cardElement" }
+        
+        %div.error.card-errors{ "data-stripe-target": "cardErrors" }
+
+    - if spree_current_user
+      .checkout-input
+        = check_box_tag "order[payments_attributes][][source_attributes][save_requested_by_customer]", 1, false
+        = label :save_requested_by_customer, t('split_checkout.step2.form.stripe.save_card'), { for: "save_requested_by_customer" }
+      


### PR DESCRIPTION
#### What? Why?

Closes #8623

<img width="691" alt="Capture d’écran 2021-12-23 à 14 23 59" src="https://user-images.githubusercontent.com/296452/147246965-dbee23c0-a8ea-41f8-82bb-41f2e6726ef5.png">
<img width="673" alt="Capture d’écran 2021-12-23 à 14 24 03" src="https://user-images.githubusercontent.com/296452/147246970-923713bc-db59-4531-8c66-bc5341ccde81.png">


#### What should we test?
As a customer with saved cards, proceed to checkout:

1. Go to step 2
2. Select a stripe (with existing cards) payment method
3. Select the default card. Notice the checkbox "Save card for future use" _is not_ present
4. Select "or enter new card details below". Notice the checkbox "Save card for future use" _is_ present



#### Release notes
Split Checkout: Show "Save card for future use" checkbox only on "Enter new card details" option selected

Changelog Category: User facing changes