### PR TITLE
Initialization deprecations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,21 +55,27 @@ module Openfoodnetwork
     end
 
     initializer "spree.environment", before: :load_config_initializers do |app|
-      app.config.spree = Spree::Core::Environment.new
-      Spree::Config = app.config.spree.preferences # legacy access
+      Rails.application.reloader.to_prepare do
+        app.config.spree = Spree::Core::Environment.new
+        Spree::Config = app.config.spree.preferences # legacy access
+      end
     end
 
     initializer "spree.register.payment_methods" do |app|
-      app.config.spree.payment_methods = [
-        Spree::Gateway::Bogus,
-        Spree::Gateway::BogusSimple,
-        Spree::PaymentMethod::Check
-      ]
+      Rails.application.reloader.to_prepare do
+        app.config.spree.payment_methods = [
+          Spree::Gateway::Bogus,
+          Spree::Gateway::BogusSimple,
+          Spree::PaymentMethod::Check
+        ]
+      end
     end
 
     initializer "spree.mail.settings" do |_app|
-      Spree::Core::MailSettings.init
-      Mail.register_interceptor(Spree::Core::MailInterceptor)
+      Rails.application.reloader.to_prepare do
+        Spree::Core::MailSettings.init
+        Mail.register_interceptor(Spree::Core::MailInterceptor)
+      end
     end
 
     # filter sensitive information during logging
@@ -93,52 +99,57 @@ module Openfoodnetwork
     # TODO: move back to spree initializer once we upgrade to a more recent version
     #       of Spree
     initializer 'ofn.spree_locale_settings', before: 'spree.promo.environment' do |app|
-      Spree::Config['checkout_zone'] = ENV['CHECKOUT_ZONE']
-      Spree::Config['currency'] = ENV['CURRENCY']
+      Rails.application.reloader.to_prepare do
+        Spree::Config['checkout_zone'] = ENV['CHECKOUT_ZONE']
+        Spree::Config['currency'] = ENV['CURRENCY']
+      end
     end
 
-    # Register Spree calculators
-    Rails.application.reloader.to_prepare do
-      app = Openfoodnetwork::Application
-      app.config.spree.calculators.shipping_methods = [
-        Calculator::FlatPercentItemTotal,
-        Calculator::FlatRate,
-        Calculator::FlexiRate,
-        Calculator::PerItem,
-        Calculator::PriceSack,
-        Calculator::Weight
-      ]
+    initializer "load_spree_calculators" do |app|
+      # Register Spree calculators
+      Rails.application.reloader.to_prepare do
+        app.config.spree.calculators.shipping_methods = [
+          Calculator::FlatPercentItemTotal,
+          Calculator::FlatRate,
+          Calculator::FlexiRate,
+          Calculator::PerItem,
+          Calculator::PriceSack,
+          Calculator::Weight
+        ]
 
-      app.config.spree.calculators.add_class('enterprise_fees')
-      app.config.spree.calculators.enterprise_fees = [
-        Calculator::FlatPercentPerItem,
-        Calculator::FlatRate,
-        Calculator::FlexiRate,
-        Calculator::PerItem,
-        Calculator::PriceSack,
-        Calculator::Weight
-      ]
+        app.config.spree.calculators.add_class('enterprise_fees')
+        app.config.spree.calculators.enterprise_fees = [
+          Calculator::FlatPercentPerItem,
+          Calculator::FlatRate,
+          Calculator::FlexiRate,
+          Calculator::PerItem,
+          Calculator::PriceSack,
+          Calculator::Weight
+        ]
 
-      app.config.spree.calculators.add_class('payment_methods')
-      app.config.spree.calculators.payment_methods = [
-        Calculator::FlatPercentItemTotal,
-        Calculator::FlatRate,
-        Calculator::FlexiRate,
-        Calculator::PerItem,
-        Calculator::PriceSack
-      ]
+        app.config.spree.calculators.add_class('payment_methods')
+        app.config.spree.calculators.payment_methods = [
+          Calculator::FlatPercentItemTotal,
+          Calculator::FlatRate,
+          Calculator::FlexiRate,
+          Calculator::PerItem,
+          Calculator::PriceSack
+        ]
 
-      app.config.spree.calculators.add_class('tax_rates')
-      app.config.spree.calculators.tax_rates = [
-        Calculator::DefaultTax
-      ]
+        app.config.spree.calculators.add_class('tax_rates')
+        app.config.spree.calculators.tax_rates = [
+          Calculator::DefaultTax
+        ]
+      end
     end
 
     # Register Spree payment methods
     initializer "spree.gateway.payment_methods", :after => "spree.register.payment_methods" do |app|
-      app.config.spree.payment_methods << Spree::Gateway::StripeConnect
-      app.config.spree.payment_methods << Spree::Gateway::StripeSCA
-      app.config.spree.payment_methods << Spree::Gateway::PayPalExpress
+      Rails.application.reloader.to_prepare do
+        app.config.spree.payment_methods << Spree::Gateway::StripeConnect
+        app.config.spree.payment_methods << Spree::Gateway::StripeSCA
+        app.config.spree.payment_methods << Spree::Gateway::PayPalExpress
+      end
     end
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -152,17 +152,6 @@ module Openfoodnetwork
       end
     end
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(
-      #{config.root}/app/models/concerns
-      #{config.root}/app/presenters
-      #{config.root}/app/jobs
-    )
-
     initializer "ofn.reports" do |app|
       module ::Reporting; end
       loader = Zeitwerk::Loader.new

--- a/config/initializers/content_config.rb
+++ b/config/initializers/content_config.rb
@@ -1,1 +1,3 @@
-ContentConfig = ContentConfiguration.new
+Rails.application.config.to_prepare do
+  ContentConfig = ContentConfiguration.new
+end

--- a/config/initializers/db2fog.rb
+++ b/config/initializers/db2fog.rb
@@ -1,15 +1,17 @@
 require_relative 'spree'
 
-# See: https://github.com/itbeaver/db2fog
-DB2Fog.config = {
-    :aws_access_key_id     => Spree::Config[:s3_access_key],
-    :aws_secret_access_key => Spree::Config[:s3_secret],
-    :directory             => ENV['S3_BACKUPS_BUCKET'],
-    :provider              => 'AWS'
-}
+Rails.application.reloader.to_prepare do
+  # See: https://github.com/openfoodfoundation/db2fog
+  DB2Fog.config = {
+      :aws_access_key_id     => Spree::Config[:s3_access_key],
+      :aws_secret_access_key => Spree::Config[:s3_secret],
+      :directory             => ENV['S3_BACKUPS_BUCKET'],
+      :provider              => 'AWS'
+  }
 
-region = ENV['S3_BACKUPS_REGION'] || ENV['S3_REGION']
+  region = ENV['S3_BACKUPS_REGION'] || ENV['S3_REGION']
 
-# If no region is defined we leave this config key undefined (instead of nil),
-# so that db2fog correctly applies it's default
-DB2Fog.config[:region] = region if region
+  # If no region is defined we leave this config key undefined (instead of nil),
+  # so that db2fog correctly applies it's default
+  DB2Fog.config[:region] = region if region
+end

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,2 +1,4 @@
-Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
-Money.default_currency = Money::Currency.new(ENV.fetch('CURRENCY'))
+Rails.application.reloader.to_prepare do
+  Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
+  Money.default_currency = Money::Currency.new(ENV.fetch('CURRENCY'))
+end

--- a/config/initializers/serializers.rb
+++ b/config/initializers/serializers.rb
@@ -1,2 +1,4 @@
-ActiveModel::ArraySerializer.root = false
-ActiveModel::Serializer.root = false
+Rails.application.reloader.to_prepare do
+  ActiveModel::ArraySerializer.root = false
+  ActiveModel::Serializer.root = false
+end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -8,33 +8,35 @@
 
 require 'spree/core'
 
-Spree.config do |config|
-  config.site_url = ENV['SITE_URL'] if ENV['SITE_URL']
-  config.site_name = ENV['SITE_NAME'] if ENV['SITE_NAME']
-  config.shipping_instructions = true
-  config.address_requires_state = true
-  config.admin_interface_logo = '/default_images/ofn-logo.png'
+Rails.application.reloader.to_prepare do
+  Spree.config do |config|
+    config.site_url = ENV['SITE_URL'] if ENV['SITE_URL']
+    config.site_name = ENV['SITE_NAME'] if ENV['SITE_NAME']
+    config.shipping_instructions = true
+    config.address_requires_state = true
+    config.admin_interface_logo = '/default_images/ofn-logo.png'
 
-  # S3 settings
-  config.s3_bucket = ENV['S3_BUCKET'] if ENV['S3_BUCKET']
-  config.s3_access_key = ENV['S3_ACCESS_KEY'] if ENV['S3_ACCESS_KEY']
-  config.s3_secret = ENV['S3_SECRET'] if ENV['S3_SECRET']
-  config.use_s3 = true if ENV['S3_BUCKET']
-  config.s3_headers = ENV['S3_HEADERS'] if ENV['S3_HEADERS']
-  config.s3_protocol = ENV.fetch('S3_PROTOCOL', 'https')
-end
+    # S3 settings
+    config.s3_bucket = ENV['S3_BUCKET'] if ENV['S3_BUCKET']
+    config.s3_access_key = ENV['S3_ACCESS_KEY'] if ENV['S3_ACCESS_KEY']
+    config.s3_secret = ENV['S3_SECRET'] if ENV['S3_SECRET']
+    config.use_s3 = true if ENV['S3_BUCKET']
+    config.s3_headers = ENV['S3_HEADERS'] if ENV['S3_HEADERS']
+    config.s3_protocol = ENV.fetch('S3_PROTOCOL', 'https')
+  end
 
-# Read mail configuration from ENV vars at boot time and ensure the values are
-# applied correctly in Spree::Config.
-MailConfiguration.apply!
+  # Read mail configuration from ENV vars at boot time and ensure the values are
+  # applied correctly in Spree::Config.
+  MailConfiguration.apply!
 
-# Attachments settings
-Spree::Image.set_attachment_attribute(:path, ENV['ATTACHMENT_PATH']) if ENV['ATTACHMENT_PATH']
-Spree::Image.set_attachment_attribute(:url, ENV['ATTACHMENT_URL']) if ENV['ATTACHMENT_URL']
-Spree::Image.set_storage_attachment_attributes
+  # Attachments settings
+  Spree::Image.set_attachment_attribute(:path, ENV['ATTACHMENT_PATH']) if ENV['ATTACHMENT_PATH']
+  Spree::Image.set_attachment_attribute(:url, ENV['ATTACHMENT_URL']) if ENV['ATTACHMENT_URL']
+  Spree::Image.set_storage_attachment_attributes
 
-# TODO Work out why this is necessary
-# Seems like classes within OFN module become 'uninitialized' when server reloads
-# unless the empty module is explicity 'registered' here. Something to do with autoloading?
-module OpenFoodNetwork
+  # TODO Work out why this is necessary
+  # Seems like classes within OFN module become 'uninitialized' when server reloads
+  # unless the empty module is explicity 'registered' here. Something to do with autoloading?
+  module OpenFoodNetwork
+  end
 end

--- a/config/initializers/state_machines.rb
+++ b/config/initializers/state_machines.rb
@@ -1,2 +1,4 @@
-# Ignore noisy StateMachines warnings.
-StateMachines::Machine.ignore_method_conflicts = true
+Rails.application.reloader.to_prepare do
+  # Ignore noisy StateMachines warnings.
+  StateMachines::Machine.ignore_method_conflicts = true
+end

--- a/config/initializers/storybook.rb
+++ b/config/initializers/storybook.rb
@@ -9,6 +9,7 @@ if Rails.env.development?
     end
   end
 
-  ViewComponent::Storybook::StoriesController.before_action(PermissiveCORSHeaders)
+  Rails.application.reloader.to_prepare do
+    ViewComponent::Storybook::StoriesController.before_action(PermissiveCORSHeaders)
+  end
 end
-

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -10,7 +10,9 @@ module Stripe
   end
 end
 
-Stripe.api_key = ENV['STRIPE_INSTANCE_SECRET_KEY']
-Stripe.publishable_key = ENV['STRIPE_INSTANCE_PUBLISHABLE_KEY']
-Stripe.client_id = ENV['STRIPE_CLIENT_ID']
-Stripe.endpoint_secret = ENV['STRIPE_ENDPOINT_SECRET']
+Rails.application.reloader.to_prepare do
+  Stripe.api_key = ENV['STRIPE_INSTANCE_SECRET_KEY']
+  Stripe.publishable_key = ENV['STRIPE_INSTANCE_PUBLISHABLE_KEY']
+  Stripe.client_id = ENV['STRIPE_CLIENT_ID']
+  Stripe.endpoint_secret = ENV['STRIPE_ENDPOINT_SECRET']
+end

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,8 +1,10 @@
-WickedPdf.config = {
-  #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
-  #:layout => "pdf.html",
-  :exe_path => `bundle exec which wkhtmltopdf`.chomp
-}
+Rails.application.reloader.to_prepare do
+  WickedPdf.config = {
+    #:wkhtmltopdf => '/usr/local/bin/wkhtmltopdf',
+    #:layout => "pdf.html",
+    :exe_path => `bundle exec which wkhtmltopdf`.chomp
+  }
+end
 
 # A monkey-patch to remove WickedPdf's monkey-patch, as it clashes with ViewComponents.
 class WickedPdf


### PR DESCRIPTION
#### What? Why?

Fixes some deprecation warnings around class loading during initialization (in preparation for Rails 7):

```
DEPRECATION WARNING: Initialization autoloaded the constant User.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload User, for example,
the expected changes won't be reflected in that stale Class object.

This autoloaded constant has been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
```

#### What should we test?
<!-- List which features should be tested and how. -->

Green build?

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Improved class loading during app initialization

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
