### PR TITLE
Allow methods which skip callbacks in Rubocop

### DIFF
--- a/.rubocop_styleguide.yml
+++ b/.rubocop_styleguide.yml
@@ -19,6 +19,15 @@ AllCops:
 #
 # Cop settings that have been agreed upon by the OFN community
 
+Rails/SkipsModelValidations:
+  AllowedMethods:
+    - "touch"
+    - "touch_all"
+    - "update_all"
+    - "update_attribute"
+    - "update_column"
+    - "update_columns"
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
#### What? Why?

There are plenty of places where we use methods which skip callbacks for perfectly good reasons. This rule isn't a helpful indication of what devs should or shouldn't be doing, as it ignores all context.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Updated Rubocop rule on use of methods which skip validations

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
