### PR TITLE
Remove custom errors gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem 'acts-as-taggable-on', '~> 8.1'
 gem 'angularjs-file-upload-rails', '~> 2.4.1'
 gem 'bigdecimal', '3.0.2'
 gem 'bootsnap', require: false
-gem 'custom_error_message', github: 'jeremydurham/custom-err-msg'
 gem 'geocoder'
 gem 'gmaps4rails'
 gem 'mimemagic', '> 0.3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,4 @@
 GIT
-  remote: https://github.com/jeremydurham/custom-err-msg.git
-  revision: 3a8ec9dddc7a5b0aab7c69a6060596de300c68f4
-  specs:
-    custom_error_message (1.1.1)
-
-GIT
   remote: https://github.com/openfoodfoundation/db2fog.git
   revision: 5b63343847452f52aa42f7fc169d6ab3af57cda3
   branch: rails-6
@@ -734,7 +728,6 @@ DEPENDENCIES
   combine_pdf
   compass-rails
   cuprite
-  custom_error_message!
   database_cleaner
   db2fog!
   ddtrace

--- a/config/initializers/custom_errors.rb
+++ b/config/initializers/custom_errors.rb
@@ -1,0 +1,22 @@
+# This patch customises ActiveModel error messages, as previously handled by the custom_error_messages gem
+# See: https://github.com/jeremydurham/custom-err-msg
+
+module ActiveModel
+  class Error
+    def self.full_message(attribute, message, base)
+      return message if attribute == :base
+
+      attr_name = attribute.to_s.tr(".", "_").humanize
+      attr_name = base.class.human_attribute_name(attribute, {
+        default: attr_name,
+        base: base,
+      })
+
+      if message.start_with?("^")
+        I18n.t("errors.format.full_message", default: "%{message}", message: message[1..-1], attribute: attr_name)
+      else
+        I18n.t("errors.format", default: "%{attribute} %{message}", message: message, attribute: attr_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What? Why?

Prep for Ruby 3.x and Rails 7. This gem was adding a couple of monkey-patches on error classes to change the message output, but it's wildly outdated. It's not compatible with modern Rails. It's a bit of a horror-show actually: https://github.com/jeremydurham/custom-err-msg

This PR drops the gem from the Gemfile and reproduces the bare minimum of the customisations we need to display our error messages in the way the test suite expects them to be displayed.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build should be enough here. We have lots of places where we test the content of error messages.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Dropped custom_error_messages gem

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
