### PR TITLE
Apply recommended framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -219,7 +219,7 @@ module Openfoodnetwork
     # Apply framework defaults. New recommended defaults are successively added with each Rails version and
     # include the defaults from previous versions. For more info see:
     # https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults
-    config.load_defaults 5.2
+    config.load_defaults 6.0
     config.action_view.form_with_generates_remote_forms = false
     config.active_record.belongs_to_required_by_default = false
     config.active_record.cache_versioning = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -220,6 +220,9 @@ module Openfoodnetwork
     # include the defaults from previous versions. For more info see:
     # https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults
     config.load_defaults 5.2
+    config.action_view.form_with_generates_remote_forms = false
+    config.active_record.belongs_to_required_by_default = false
+    config.active_record.cache_versioning = false
 
     config.active_support.escape_html_entities_in_json = true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -235,10 +235,6 @@ module Openfoodnetwork
 
     Rails.application.routes.default_url_options[:host] = ENV["SITE_URL"]
 
-    config.autoloader = :zeitwerk
-
     Rails.autoloaders.main.ignore(Rails.root.join('app/webpacker'))
-
-    config.action_view.form_with_generates_ids = true
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -216,6 +216,11 @@ module Openfoodnetwork
     config.assets.precompile += ['qz/*']
     config.assets.precompile += ['*.jpg', '*.jpeg', '*.png', '*.gif' '*.svg']
 
+    # Apply framework defaults. New recommended defaults are successively added with each Rails version and
+    # include the defaults from previous versions. For more info see:
+    # https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults
+    config.load_defaults 5.2
+
     config.active_support.escape_html_entities_in_json = true
 
     config.active_job.queue_adapter = :sidekiq

--- a/config/application.rb
+++ b/config/application.rb
@@ -219,10 +219,11 @@ module Openfoodnetwork
     # Apply framework defaults. New recommended defaults are successively added with each Rails version and
     # include the defaults from previous versions. For more info see:
     # https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults
-    config.load_defaults 6.0
+    config.load_defaults 6.1
     config.action_view.form_with_generates_remote_forms = false
     config.active_record.belongs_to_required_by_default = false
     config.active_record.cache_versioning = false
+    config.active_record.has_many_inversing = false
 
     config.active_support.escape_html_entities_in_json = true
 

--- a/spec/controllers/user_confirmations_controller_spec.rb
+++ b/spec/controllers/user_confirmations_controller_spec.rb
@@ -72,7 +72,7 @@ describe UserConfirmationsController, type: :controller do
       performing_deliveries do
         expect do
           spree_post :create, spree_user: { email: unconfirmed_user.email }
-        end.to enqueue_job ActionMailer::DeliveryJob
+        end.to enqueue_job ActionMailer::MailDeliveryJob
 
         expect(enqueued_jobs.last.to_s).to match "confirmation_instructions"
       end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -11,7 +11,7 @@ describe Enterprise do
       it "sends a welcome email" do
         expect do
           create(:enterprise, owner: user)
-        end.to enqueue_job ActionMailer::DeliveryJob
+        end.to enqueue_job ActionMailer::MailDeliveryJob
 
         expect(enqueued_jobs.last.to_s).to match "welcome"
       end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -88,7 +88,7 @@ describe Spree::User do
       performing_deliveries do
         expect do
           create(:user, email: 'new_user@example.com', confirmation_sent_at: nil, confirmed_at: nil)
-        end.to enqueue_job ActionMailer::DeliveryJob
+        end.to enqueue_job ActionMailer::MailDeliveryJob
       end
 
       expect(enqueued_jobs.last.to_s).to match "confirmation_instructions"
@@ -116,7 +116,7 @@ describe Spree::User do
 
       expect do
         create(:user, confirmed_at: nil).confirm
-      end.to enqueue_job ActionMailer::DeliveryJob
+      end.to enqueue_job ActionMailer::MailDeliveryJob
 
       expect(enqueued_jobs.last.to_s).to match "signup_confirmation"
     end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -126,7 +126,7 @@ describe "Managing users" do
           # The `a` element doesn't have an href, so we can't use click_link.
           find("a", text: "Resend").click
           expect(page).to have_text "Resend done"
-        end.to enqueue_job ActionMailer::DeliveryJob
+        end.to enqueue_job ActionMailer::MailDeliveryJob
       end
     end
   end

--- a/spec/system/consumer/account/settings_spec.rb
+++ b/spec/system/consumer/account/settings_spec.rb
@@ -28,7 +28,7 @@ describe "Account Settings", js: true do
       performing_deliveries do
         expect do
           click_button I18n.t(:update)
-        end.to enqueue_job ActionMailer::DeliveryJob
+        end.to enqueue_job ActionMailer::MailDeliveryJob
       end
 
       expect(enqueued_jobs.last.to_s).to match "new@email.com"

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -91,7 +91,7 @@ describe "Authentication", js: true do
               expect do
                 click_signup_button
                 expect(page).to have_content I18n.t('devise.user_registrations.spree_user.signed_up_but_unconfirmed')
-              end.to enqueue_job ActionMailer::DeliveryJob
+              end.to enqueue_job ActionMailer::MailDeliveryJob
             end
           end
         end
@@ -113,7 +113,7 @@ describe "Authentication", js: true do
             expect do
               click_reset_password_button
               expect(page).to have_reset_password
-            end.to enqueue_job ActionMailer::DeliveryJob
+            end.to enqueue_job ActionMailer::MailDeliveryJob
 
             expect(enqueued_jobs.last.to_s).to match "reset_password_instructions"
           end


### PR DESCRIPTION
#### What? Why?

Applies framework defaults. These are recommended configuration options which are added to successively with each Rails version. They generally make improvements and enhancements, but in some cases can introduce breaking changes, so they're opt-in. I manually disabled a couple of them which broke the build. Further notes in the commit messages :ok_hand:

Previous discussion: https://github.com/openfoodfoundation/openfoodnetwork/pull/8070#discussion_r751200512

Documentation here: https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults

#### What should we test?
<!-- List which features should be tested and how. -->

I'm not sure what we could test specifically here, other than what gets done in a general release test.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Applied Rails framework defaults

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
