### PR TITLE
Removes js: true setting from system specs

### DIFF
--- a/spec/system/admin/adjustments_spec.rb
+++ b/spec/system/admin/adjustments_spec.rb
@@ -5,7 +5,7 @@ require "system_helper"
 describe '
     As an administrator
     I want to manage adjustments on orders
-', js: true do
+' do
   include AuthenticationHelper
   include WebHelper
 

--- a/spec/system/admin/authentication_spec.rb
+++ b/spec/system/admin/authentication_spec.rb
@@ -2,7 +2,7 @@
 
 require 'system_helper'
 
-describe "Authentication", js: true do
+describe "Authentication" do
   include UIComponentHelper
   include AuthenticationHelper
   include WebHelper

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -5,7 +5,7 @@ require 'system_helper'
 describe '
   As an Administrator
   I want to be able to manage orders in bulk
-', js: true do
+' do
   include AdminHelper
   include AuthenticationHelper
   include WebHelper

--- a/spec/system/admin/bulk_product_update_spec.rb
+++ b/spec/system/admin/bulk_product_update_spec.rb
@@ -5,7 +5,7 @@ require 'system_helper'
 describe '
   As an Administrator
   I want to be able to manage products in bulk
-', js: true do
+' do
   include AdminHelper
   include AuthenticationHelper
   include WebHelper

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -13,7 +13,7 @@ describe 'Customers' do
     let(:managed_distributor2) { create(:distributor_enterprise, owner: user) }
     let(:unmanaged_distributor) { create(:distributor_enterprise) }
 
-    describe "using the customers index", js: true do
+    describe "using the customers index" do
       let!(:customer1) { create(:customer, enterprise: managed_distributor1, code: nil) }
       let!(:customer2) { create(:customer, enterprise: managed_distributor1, code: nil) }
       let!(:customer3) { create(:customer, enterprise: unmanaged_distributor) }

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -5,7 +5,7 @@ require 'system_helper'
 describe '
     As an administrator
     I want to manage enterprise fees
-', js: true do
+' do
   include WebHelper
   include AuthenticationHelper
 

--- a/spec/system/admin/enterprise_groups_spec.rb
+++ b/spec/system/admin/enterprise_groups_spec.rb
@@ -24,7 +24,7 @@ describe '
     expect(page).to have_selector 'td', text: e.name
   end
 
-  it "creating a new enterprise group", js: true do
+  it "creating a new enterprise group" do
     e1 = create(:enterprise)
     e2 = create(:enterprise)
     e3 = create(:enterprise)
@@ -95,7 +95,7 @@ describe '
     expect(page.all('td.name').map(&:text)).to eq(['A', 'B'])
   end
 
-  it "deleting an enterprise group", js: true do
+  it "deleting an enterprise group" do
     eg = create(:enterprise_group, name: 'EGEGEG')
 
     click_link 'Groups'

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -19,7 +19,7 @@ describe '
     expect(page).to have_content e.name
   end
 
-  it "creating a new enterprise", js: true do
+  it "creating a new enterprise" do
     eg1 = create(:enterprise_group, name: 'eg1')
     eg2 = create(:enterprise_group, name: 'eg2')
     payment_method = create(:payment_method)
@@ -60,7 +60,7 @@ describe '
     expect(flash_message).to eq('Enterprise "Eaterprises" has been successfully created!')
   end
 
-  it "editing an existing enterprise", js: true do
+  it "editing an existing enterprise" do
     @enterprise = create(:enterprise)
     e2 = create(:enterprise)
     eg1 = create(:enterprise_group, name: 'eg1')
@@ -270,7 +270,7 @@ describe '
       expect(s.producer_properties.first.value).to eq("Shininess")
     end
 
-    it "removes producer properties", js: true do
+    it "removes producer properties" do
       # Given a producer enterprise with a property
       s = create(:supplier_enterprise)
       pp = s.producer_properties.create! property_name: 'Certified Organic', value: 'NASAA 12345'
@@ -292,7 +292,7 @@ describe '
     end
   end
 
-  context "as an Enterprise user", js: true do
+  context "as an Enterprise user" do
     let(:supplier1) { create(:supplier_enterprise, name: 'First Supplier') }
     let(:supplier2) { create(:supplier_enterprise, name: 'Another Supplier') }
     let(:distributor1) { create(:distributor_enterprise, name: 'First Distributor') }

--- a/spec/system/admin/multilingual_spec.rb
+++ b/spec/system/admin/multilingual_spec.rb
@@ -2,7 +2,7 @@
 
 require 'system_helper'
 
-describe 'Multilingual', js: true do
+describe 'Multilingual' do
   include AuthenticationHelper
   include WebHelper
   let(:admin_role) { Spree::Role.find_or_create_by!(name: 'admin') }

--- a/spec/system/admin/order_cycles_complex_nav_check_spec.rb
+++ b/spec/system/admin/order_cycles_complex_nav_check_spec.rb
@@ -5,7 +5,7 @@ require 'system_helper'
 describe '
     As an administrator
     I want to be alerted when I navigate away from a dirty order cycle form
-', js: true do
+' do
   include AuthenticationHelper
 
   it "alert when navigating away from dirty form" do

--- a/spec/system/admin/order_print_ticket_spec.rb
+++ b/spec/system/admin/order_print_ticket_spec.rb
@@ -5,7 +5,7 @@ require "system_helper"
 describe '
     As an administrator
     I want to print a ticket for an order
-', js: true do
+' do
   include CheckoutHelper
   include AuthenticationHelper
   include ActionView::Helpers::NumberHelper

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -5,7 +5,7 @@ require "system_helper"
 describe '
     As an administrator
     I want to create and edit orders
-', js: true do
+' do
   include WebHelper
   include AuthenticationHelper
 

--- a/spec/system/admin/orders_spec.rb
+++ b/spec/system/admin/orders_spec.rb
@@ -5,7 +5,7 @@ require "system_helper"
 describe '
     As an administrator
     I want to manage orders
-', js: true do
+' do
   include AuthenticationHelper
   include WebHelper
 

--- a/spec/system/admin/overview_spec.rb
+++ b/spec/system/admin/overview_spec.rb
@@ -5,7 +5,7 @@ require 'system_helper'
 describe '
   As a backend user
   I want to be given information about the state of my enterprises, products and order cycles
-', js: true do
+' do
   include WebHelper
   include AuthenticationHelper
 

--- a/spec/system/first_system_spec.rb
+++ b/spec/system/first_system_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-describe "Visit Admin", js: true do
+describe "Visit Admin" do
   include UIComponentHelper
   include AuthenticationHelper
   include WebHelper

--- a/spec/system/flatpickr_spec.rb
+++ b/spec/system/flatpickr_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-describe "Test Flatpickr", js: true do
+describe "Test Flatpickr" do
   include AuthenticationHelper
   include WebHelper
 


### PR DESCRIPTION
#### What? Why?

Related to #7929

Some cleaning up after feature -> system migration of the test suite:
This PR removes `:js true` from all system specs, as we enable this setting [here](https://github.com/openfoodfoundation/openfoodnetwork/blob/e036e9b979e41add25ff1f06186b53486cb18af0/spec/system/support/cuprite_setup.rb#L23) by default.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Removes necessary ':js true' setting from all system specs.

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removes necessary ':js true' setting from all system specs.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
