### PR TITLE
Fixing missing translation for "Are you sure?" when deleting a product

### DIFF
--- a/app/assets/javascripts/admin/bulk_product_update.js.coffee
+++ b/app/assets/javascripts/admin/bulk_product_update.js.coffee
@@ -144,7 +144,7 @@ angular.module("ofn.admin").controller "AdminProductEditCtrl", ($scope, $timeout
     $scope.variantIdCounter
 
   $scope.deleteProduct = (product) ->
-    if confirm("Are you sure?")
+    if confirm(t('are_you_sure'))
       $http(
         method: "DELETE"
         url: "/api/v0/products/" + product.id

--- a/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
+++ b/spec/javascripts/unit/admin/bulk_product_update_spec.js.coffee
@@ -822,6 +822,7 @@ describe "AdminProductEditCtrl", ->
       $scope.dirtyProducts = {}
       $httpBackend.expectDELETE("/api/v0/products/13").respond 200, "data"
       $scope.deleteProduct $scope.products[1]
+      expect(window.confirm).toHaveBeenCalledWith "Are you sure?"
       $httpBackend.flush()
 
     it "removes the specified product from both $scope.products and $scope.dirtyProducts (if it exists there)", ->


### PR DESCRIPTION

<img width="476" alt="Screenshot 2022-01-04 at 12 28 30 AM" src="https://user-images.githubusercontent.com/62469296/147968819-e62d9e55-0699-40bb-9653-1f0ced5d14ff.png">
<img width="526" alt="Screenshot 2022-01-04 at 12 27 40 AM" src="https://user-images.githubusercontent.com/62469296/147968826-b9ea1ed1-b876-410e-ae1c-01c12c8428fb.png">
What? Why?
Closes #8629

Missing translation: "Are you sure?" when deleting a product

What should we test?
Go to /admin/products -> Delete a product and verify the confirmation message in the alert. It is should be in the account language

Release notes
Changing confirmation message in product delete for non-English languages users

Changelog Category: User facing changes