### PR TITLE
Handle checkout as guest feature on split checkout

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -85,7 +85,13 @@ class SplitCheckoutController < ::BaseController
     @order_params ||= Checkout::Params.new(@order, params).call
   end
 
+  def redirect_to_guest
+    redirect_to checkout_step_path(:guest)
+  end
+
   def redirect_to_step
+    return redirect_to_guest unless spree_current_user
+
     case @order.state
     when "cart", "address", "delivery"
       redirect_to checkout_step_path(:details)

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -94,7 +94,7 @@ class SplitCheckoutController < ::BaseController
   end
 
   def redirect_to_step
-    return redirect_to_guest unless spree_current_user
+    return redirect_to_guest if !spree_current_user && !params[:step]
 
     case @order.state
     when "cart", "address", "delivery"

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -16,7 +16,9 @@ class SplitCheckoutController < ::BaseController
   helper OrderHelper
 
   def edit
-    redirect_to_step unless params[:step]
+    return redirect_to_step unless params[:step]
+
+    return redirect_to_guest if !@order.distributor.allow_guest_orders? && params[:step] != "guest"
   end
 
   def update

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -22,6 +22,8 @@ class SplitCheckoutController < ::BaseController
   end
 
   def update
+    return redirect_to_guest if !spree_current_user && !@order.distributor.allow_guest_orders?
+
     if confirm_order || update_order
       clear_invalid_payments
       advance_order_state

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -18,7 +18,9 @@ class SplitCheckoutController < ::BaseController
   def edit
     return redirect_to_step unless params[:step]
 
-    return redirect_to_guest if !@order.distributor.allow_guest_orders? && params[:step] != "guest"
+    return redirect_to_guest if !spree_current_user &&
+                                !@order.distributor.allow_guest_orders? &&
+                                params[:step] != "guest"
   end
 
   def update

--- a/app/views/split_checkout/_checkout.html.haml
+++ b/app/views/split_checkout/_checkout.html.haml
@@ -1,4 +1,4 @@
 %checkout.row#checkout
   .small-12.medium-12.columns
-    = render partial: "split_checkout/tabs"
+    = render partial: "split_checkout/tabs" unless checkout_step?(:guest)
     = render partial: "split_checkout/form"

--- a/app/views/split_checkout/_guest.html.haml
+++ b/app/views/split_checkout/_guest.html.haml
@@ -1,0 +1,12 @@
+.medium-10
+  %div.checkout-guest-title
+    = t :checkout_headline
+
+  %div.checkout-submit{ class: "#{@order.distributor.allow_guest_orders? ? 'checkout-submit-inline' : 'medium-6' }" }
+    %a.primary.button{href: main_app.login_path}
+      = t :label_login
+    -if @order.distributor.allow_guest_orders?
+      %span.checkout-submit-or
+        or
+      %a.button.cancel{href: main_app.checkout_step_path(:details)}
+        = t :checkout_as_guest

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -174,6 +174,34 @@
         color: $black;
       }
     }
+
+    &.checkout-submit-inline {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+
+      @media screen and (max-width: 700px) {
+        flex-direction: column;
+      }
+
+      .checkout-submit-or {
+        margin-left: 20px;
+        margin-right: 20px;
+        text-transform: uppercase;
+        color: $min-accessible-grey;
+
+        @media screen and (max-width: 700px) {
+          display: none;
+        }
+      }
+    }
+  }
+
+  .checkout-guest-title {
+    font-size: 1.5rem;
+    @include headingFont;
+    text-align: center;
+    color: $min-accessible-grey;
   }
 }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Openfoodnetwork::Application.routes.draw do
   constraints SplitCheckoutConstraint.new do
     get '/checkout', to: 'split_checkout#edit'
 
-    constraints step: /(details|payment|summary)/ do
+    constraints step: /(guest|details|payment|summary)/ do
       get '/checkout/:step', to: 'split_checkout#edit', as: :checkout_step
       put '/checkout/:step', to: 'split_checkout#update', as: :checkout_update
     end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -8,7 +8,7 @@ describe "As a consumer, I want to checkout my order", js: true do
 
   let!(:zone) { create(:zone_with_member) }
   let(:supplier) { create(:supplier_enterprise) }
-  let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true) }
+  let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true, allow_guest_orders: false) }
   let(:product) {
     create(:taxed_product, supplier: supplier, price: 10, zone: zone, tax_rate_amount: 0.1)
   }
@@ -53,6 +53,8 @@ describe "As a consumer, I want to checkout my order", js: true do
 
   context "as a guest user" do
     before do
+      distributor.update!(allow_guest_orders: true)
+      order.update!(distributor_id: distributor.id)
       visit checkout_path
     end
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -64,6 +64,13 @@ describe "As a consumer, I want to checkout my order", js: true do
       expect(page).to have_no_content("Checkout as guest")
     end
 
+    it "should be redirected if user enter the url" do
+      order.update(state: "payment")
+      get checkout_step_path(:details)
+      expect(response).to have_http_status(:redirect)
+      expect(page).to have_current_path("/checkout/guest")
+    end
+
     it "should redirect to the login page when clicking the login button" do
       click_on "Login"
       expect(page).to have_current_path "/"
@@ -116,6 +123,14 @@ describe "As a consumer, I want to checkout my order", js: true do
 
       click_button "Next - Payment method"
       expect(page).to have_current_path("/checkout/payment")
+    end
+
+    context "when order is state: 'payment'" do
+      it "should allow visit '/checkout/details'" do
+        order.update(state: "payment")
+        visit checkout_step_path(:details)
+        expect(page).to have_current_path("/checkout/details")
+      end
     end
   end
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -19,7 +19,7 @@ describe "As a consumer, I want to checkout my order", js: true do
   }
   let(:order) {
     create(:order, order_cycle: order_cycle, distributor: distributor, bill_address_id: nil,
-                   ship_address_id: nil)
+                   ship_address_id: nil, state: "cart")
   }
 
   let(:fee_tax_rate) { create(:tax_rate, amount: 0.10, zone: zone, included_in_price: true) }
@@ -49,6 +49,25 @@ describe "As a consumer, I want to checkout my order", js: true do
 
     distributor.shipping_methods << free_shipping
     distributor.shipping_methods << shipping_with_fee
+  end
+
+  context "guest checkout when distributor doesn't allow guest orders" do
+    before do
+      visit checkout_path
+    end
+
+    it "should display the split checkout login page" do
+      expect(page).to have_content distributor.name
+      expect(page).to have_current_path("/checkout/guest")
+      expect(page).to have_content("Ok, ready to checkout?")
+      expect(page).to have_content("Login")
+      expect(page).to have_no_content("Checkout as guest")
+    end
+
+    it "should redirect to the login page when clicking the login button" do
+      click_on "Login"
+      expect(page).to have_current_path "/"
+    end
   end
 
   context "as a guest user" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -56,7 +56,16 @@ describe "As a consumer, I want to checkout my order", js: true do
       visit checkout_path
     end
 
-    it "should display the split checkout page" do
+    it "should display the split checkout login/guest page" do
+      expect(page).to have_content distributor.name
+      expect(page).to have_current_path("/checkout/guest")
+      expect(page).to have_content("Ok, ready to checkout?")
+      expect(page).to have_content("Login")
+      expect(page).to have_content("Checkout as guest")
+    end
+
+    it "should display the split checkout details page" do
+      click_on "Checkout as guest"
       expect(page).to have_content distributor.name
       expect(page).to have_current_path("/checkout/details")
       expect(page).to have_content("1 - Your details")
@@ -66,6 +75,7 @@ describe "As a consumer, I want to checkout my order", js: true do
     end
 
     it "should display error when fields are empty" do
+      click_on "Checkout as guest"
       click_button "Next - Payment method"
       expect(page).to have_content("Saving failed, please update the highlighted fields")
       expect(page).to have_css 'span.field_with_errors label', count: 4
@@ -74,6 +84,7 @@ describe "As a consumer, I want to checkout my order", js: true do
     end
 
     it "should validate once each needed field is filled" do
+      click_on "Checkout as guest"
       fill_in "First Name", with: "Jane"
       fill_in "Last Name", with: "Doe"
       fill_in "Phone number", with: "07987654321"


### PR DESCRIPTION
#### What? Why?

Closes #8668

This PR handles the _checkout as guest feature_ on the new split checkout.

No design specifications found, screenshots must be reviewed by @openfoodfoundation/train-drivers-product-owners :

<img width="1183" alt="Capture d’écran 2022-01-05 à 16 30 59" src="https://user-images.githubusercontent.com/296452/148245237-60dbfcaa-9e0f-434d-91c7-ae0c2fef9c66.png">

<img width="344" alt="Capture d’écran 2022-01-05 à 16 30 54" src="https://user-images.githubusercontent.com/296452/148245250-76a147ac-4cc5-479a-8182-e6383a6f9054.png">

<img width="1220" alt="Capture d’écran 2022-01-05 à 16 43 10" src="https://user-images.githubusercontent.com/296452/148246071-9cac3fa5-8a5b-4d4b-96c4-e2cb04d78f31.png">


#### What should we test?
##### As anonymous user, when distributor authorize checkout as guest
1. Add product to cart
2. Go to checkout, then you must be redirected to `/checkout/guest`
3. Then you can either _Login_ or _Checkout as guest_
4. _Checkout as guest_ redirect to `/checkout/details`

##### As anonymous user, when distributor _doesn't_ authorize checkout as guest
1. Add product to cart
2. Go to checkout, then you must be redirected to `/checkout/guest`
3. Then you can only _Login_
4. Each URL under `/checkout` (such as  `/checkout/details`) redirects to `/checkout/guest`

##### As connected user
1. Add product to cart
2. Go to checkout, then you must be redirected to `/checkout/details`



#### Release notes
Handle checkout as guest feature on split checkout
Changelog Category: User facing changes



#### Dependencies
<!-- Does this PR depend on another one?
Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
List them here or remove this section. -->
