### PR TITLE
Drop jquery_ujs

### DIFF
--- a/app/assets/javascripts/darkswarm/all.js.coffee
+++ b/app/assets/javascripts/darkswarm/all.js.coffee
@@ -1,5 +1,4 @@
 #= require jquery2
-#= require jquery_ujs
 #= require jquery.ui.all
 #
 #= require angular

--- a/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
+++ b/app/assets/javascripts/darkswarm/controllers/credit_cards_controller.js.coffee
@@ -1,4 +1,4 @@
-angular.module('Darkswarm').controller "CreditCardsCtrl", ($scope, CreditCard, CreditCards, $controller) ->
+angular.module('Darkswarm').controller "CreditCardsCtrl", ($scope, $http, CreditCard, CreditCards, $controller) ->
   angular.extend this, $controller('FieldsetMixin', {$scope: $scope})
 
   $scope.savedCreditCards = CreditCards.saved
@@ -12,3 +12,11 @@ angular.module('Darkswarm').controller "CreditCardsCtrl", ($scope, CreditCard, C
 
   $scope.allow_name_change = true
   $scope.disable_fields = false
+
+  $scope.deleteCard = (id) ->
+    $http(
+      method: "DELETE"
+      url: "/credit_cards/#{id}"
+    ).finally ->
+      window.location.reload()
+

--- a/app/controllers/spree/credit_cards_controller.rb
+++ b/app/controllers/spree/credit_cards_controller.rb
@@ -54,10 +54,11 @@ module Spree
       else
         flash[:error] = I18n.t(:card_could_not_be_removed)
       end
-      redirect_to spree.account_path(anchor: 'cards')
+
+      head :ok
     rescue Stripe::CardError
       flash[:error] = I18n.t(:card_could_not_be_removed)
-      redirect_to spree.account_path(anchor: 'cards')
+      head :unprocessable_entity
     end
 
     private

--- a/app/views/spree/users/_saved_cards.html.haml
+++ b/app/views/spree/users/_saved_cards.html.haml
@@ -12,5 +12,5 @@
     %td.is-default
       %input{ type: 'radio', name: 'default_card', ng: { model: 'card.is_default', click: 'confirmSetDefault(card, $event)', value: "true"} }
     %td.actions
-      %a{"rel" => "nofollow", "data-method" => "delete", "ng-href" => "{{card.delete_link}}" }
+      %button.tiny.alert.no-margin{ "ng-click": "deleteCard(card.id)" }
         = t(:delete)

--- a/app/webpacker/css/shared/variables/layout.scss
+++ b/app/webpacker/css/shared/variables/layout.scss
@@ -4,3 +4,6 @@ $tablet_breakpoint: 768px;
 $phablet_breakpoint: 640px;
 $mobile_breakpoint: 480px;
 
+.no-margin {
+  margin: 0;
+}

--- a/spec/controllers/spree/credit_cards_controller_spec.rb
+++ b/spec/controllers/spree/credit_cards_controller_spec.rb
@@ -146,7 +146,7 @@ describe Spree::CreditCardsController, type: :controller do
         expect(controller).to_not receive(:destroy_at_stripe)
         spree_delete :destroy, params
         expect(flash[:error]).to eq I18n.t(:card_could_not_be_removed)
-        expect(response).to redirect_to spree.account_path(anchor: 'cards')
+        expect(response.status).to eq 200
       end
     end
 
@@ -178,7 +178,7 @@ describe Spree::CreditCardsController, type: :controller do
           it "doesn't delete the card" do
             expect{ spree_delete :destroy, params }.to_not change(Spree::CreditCard, :count)
             expect(flash[:error]).to eq I18n.t(:card_could_not_be_removed)
-            expect(response).to redirect_to spree.account_path(anchor: 'cards')
+            expect(response.status).to eq 422
           end
         end
 
@@ -192,7 +192,7 @@ describe Spree::CreditCardsController, type: :controller do
             expect{ spree_delete :destroy, params }.to change(Spree::CreditCard, :count).by(-1)
             expect(flash[:success]).to eq I18n.t(:card_has_been_removed,
                                                  number: "x-#{card.last_digits}")
-            expect(response).to redirect_to spree.account_path(anchor: 'cards')
+            expect(response.status).to eq 200
           end
 
           context "the card is the default card and there are existing authorizations for the user" do

--- a/spec/system/consumer/account/cards_spec.rb
+++ b/spec/system/consumer/account/cards_spec.rb
@@ -90,7 +90,7 @@ describe "Credit Cards", js: true do
 
       # Allows deletion of cards
       within(".card#card#{default_card.id}") do
-        click_link I18n.t(:delete)
+        click_button I18n.t(:delete)
       end
 
       expect(page).to have_content I18n.t(:card_has_been_removed,


### PR DESCRIPTION
#### What? Why?

Removes unused `jquery_ujs` from non-admin pages. This is effectively replaced by `mrujs` and to some extent `hotwire/turbo`.

:fire::fire::fire:

Soundtrack: [Ghostwriter](https://www.youtube.com/watch?v=rVqAdIMQZlk) :musical_note: 

#### What should we test?
<!-- List which features should be tested and how. -->

Double check that deletion of credit cards in the `/account` page is working (there was a small issue there, but I'm 99% sure it's fixed now).

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Removed deprecated jquery_ujs

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
