### PR TITLE
Adds additional test coverage on step 1

### DIFF
--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -51,6 +51,6 @@ module SplitCheckoutHelper
 
   def proceed_to_payment
     click_button "Next - Payment method"
-    expect(page).to have_current_path("/checkout/payment")
+    expect(page).to have_button("Next - Order summary")
   end
 end

--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -46,7 +46,7 @@ module SplitCheckoutHelper
   end
 
   def fill_out(notes)
-    fill_in 'Any comments or special instructions?', with: "#{notes}"
+    fill_in 'Any comments or special instructions?', with: notes.to_s
   end
 
   def proceed_to_payment

--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -44,4 +44,13 @@ module SplitCheckoutHelper
       select "New South Wales", from: "State"
     end
   end
+
+  def fill_out(notes)
+    fill_in 'Any comments or special instructions?', with: "#{notes}"
+  end
+
+  def proceed_to_payment
+    click_button "Next - Payment method"
+    expect(page).to have_current_path("/checkout/payment")
+  end
 end

--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -45,8 +45,8 @@ module SplitCheckoutHelper
     end
   end
 
-  def fill_out(notes)
-    fill_in 'Any comments or special instructions?', with: notes.to_s
+  def fill_notes(text)
+    fill_in 'Any comments or special instructions?', with: text.to_s
   end
 
   def proceed_to_payment

--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -14,35 +14,28 @@ module SplitCheckoutHelper
   end
 
   def fill_out_details
-    # Section: Your Details
-    within(:xpath, './/div[@class="checkout-substep"][1]') do
-      fill_in "First Name", with: "Will"
-      fill_in "Last Name", with: "Marshall"
-      fill_in "Email", with: "test@test.com"
-      fill_in "Phone", with: "0468363090"
-    end
+    fill_in "First Name", with: "Will"
+    fill_in "Last Name", with: "Marshall"
+    fill_in "Email", with: "test@test.com"
+    fill_in "Phone", with: "0468363090"
   end
 
   def fill_out_billing_address
-    # Section: Your Billing Address
-    within(:xpath, './/div[@class="checkout-substep"][2]') do
-      fill_in "Address", with: "Rue de la Vie, 77"
-      fill_in "City", with: "Melbourne"
-      fill_in "Postcode", with: "3066"
-      select "Australia", from: "Country"
-      select "Victoria", from: "State"
-    end
+    fill_in "order_bill_address_attributes_address1", with: "Rue de la Vie, 77"
+    fill_in "order_bill_address_attributes_address2", with: "2nd floor"
+    fill_in "order_bill_address_attributes_city", with: "Melbourne"
+    fill_in "order_bill_address_attributes_zipcode", with: "3066"
+    select "Australia", from: "order_bill_address_attributes_country_id"
+    select "Victoria", from: "order_bill_address_attributes_state_id"
   end
 
   def fill_out_shipping_address
-    # Section: Delivery Address
-    within(:xpath, './/div[@class="checkout-substep"][3]') do
-      fill_in "Address", with: "Rue de la Vie, 66"
-      fill_in "City", with: "Perth"
-      fill_in "Postcode", with: "2899"
-      select "Australia", from: "Country"
-      select "New South Wales", from: "State"
-    end
+    fill_in "order_ship_address_attributes_address1", with: "Rue de la Vie, 66"
+    fill_in "order_ship_address_attributes_address2", with: "3rd floor"
+    fill_in "order_ship_address_attributes_city", with: "Perth"
+    fill_in "order_ship_address_attributes_zipcode", with: "6603"
+    select "Australia", from: "order_ship_address_attributes_country_id"
+    select "New South Wales", from: "order_ship_address_attributes_state_id"
   end
 
   def fill_notes(text)

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -154,7 +154,7 @@ describe "As a consumer, I want to checkout my order", js: true do
         end
 
         it "redirects the user to the Payment Method step" do
-          fill_out("SpEcIaL NoTeS")
+          fill_notes("SpEcIaL NoTeS")
           proceed_to_payment
         end
       end
@@ -208,7 +208,7 @@ describe "As a consumer, I want to checkout my order", js: true do
           it "fills in shipping details and redirects the user to the Payment Method step,
           when submiting the form" do
             fill_out_shipping_address
-            fill_out("SpEcIaL NoTeS")
+            fill_notes("SpEcIaL NoTeS")
             proceed_to_payment
             # asserts whether shipping and billing addresses are the same
             ship_add_id = Spree::Order.first.ship_address_id

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -168,7 +168,6 @@ describe "As a consumer, I want to checkout my order", js: true do
           before do
             check "ship_address_same_as_billing"
           end
-          
           it "does not display the shipping address form" do
             within(:xpath, './/div[@class="checkout-substep"][3]') do
               expect(page).not_to have_field "order_ship_address_attributes_address1"
@@ -185,10 +184,20 @@ describe "As a consumer, I want to checkout my order", js: true do
           before do
             uncheck "ship_address_same_as_billing"
           end
-          
           it "displays the shipping address form" do
             within(:xpath, './/div[@class="checkout-substep"][3]') do
               expect(page).to have_field "order_ship_address_attributes_address1"
+            end
+          end
+
+          it "displays error messages when submitting incomplete billing address" do
+            click_button "Next - Payment method"
+            expect(page).to have_content "Saving failed, please update the highlighted fields."
+            within(:xpath, './/div[@class="checkout-substep"][3]') do
+              expect(page).to have_field("Address", with: "")
+              expect(page).to have_field("City", with: "")
+              expect(page).to have_field("Postcode", with: "")
+              expect(page).to have_content("can't be blank", count: 3)
             end
           end
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -58,7 +58,6 @@ describe "As a consumer, I want to checkout my order", js: true do
 
     it "should display the split checkout login page" do
       expect(page).to have_content distributor.name
-      expect(page).to have_current_path("/checkout/guest")
       expect(page).to have_content("Ok, ready to checkout?")
       expect(page).to have_content("Login")
       expect(page).to have_no_content("Checkout as guest")
@@ -68,12 +67,13 @@ describe "As a consumer, I want to checkout my order", js: true do
       order.update(state: "payment")
       get checkout_step_path(:details)
       expect(response).to have_http_status(:redirect)
-      expect(page).to have_current_path("/checkout/guest")
+      expect(page).to have_content("Ok, ready to checkout?")
     end
 
     it "should redirect to the login page when clicking the login button" do
       click_on "Login"
-      expect(page).to have_current_path "/"
+      expect(page).to have_content("Login")
+      expect(page).to have_content("Login")
     end
   end
 
@@ -86,7 +86,6 @@ describe "As a consumer, I want to checkout my order", js: true do
 
     it "should display the split checkout login/guest page" do
       expect(page).to have_content distributor.name
-      expect(page).to have_current_path("/checkout/guest")
       expect(page).to have_content("Ok, ready to checkout?")
       expect(page).to have_content("Login")
       expect(page).to have_content("Checkout as guest")
@@ -95,7 +94,6 @@ describe "As a consumer, I want to checkout my order", js: true do
     it "should display the split checkout details page" do
       click_on "Checkout as guest"
       expect(page).to have_content distributor.name
-      expect(page).to have_current_path("/checkout/details")
       expect(page).to have_content("1 - Your details")
       expect(page).to have_selector("div.checkout-tab.selected", text: "1 - Your details")
       expect(page).to have_content("2 - Payment method")
@@ -122,14 +120,14 @@ describe "As a consumer, I want to checkout my order", js: true do
       choose free_shipping.name
 
       click_button "Next - Payment method"
-      expect(page).to have_current_path("/checkout/payment")
+      expect(page).to have_button("Next - Order summary")
     end
 
     context "when order is state: 'payment'" do
       it "should allow visit '/checkout/details'" do
         order.update(state: "payment")
         visit checkout_step_path(:details)
-        expect(page).to have_current_path("/checkout/details")
+        expect(page).to have_button("Next - Payment method")
       end
     end
   end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -175,8 +175,12 @@ describe "As a consumer, I want to checkout my order", js: true do
           end
 
           it "redirects the user to the Payment Method step, when submiting the form" do
-            click_button "Next - Payment method"
-            expect(page).to have_current_path("/checkout/payment")
+            proceed_to_payment
+            # asserts whether shipping and billing addresses are the same
+            ship_add_id = Spree::Order.first.ship_address_id
+            bill_add_id = Spree::Order.first.bill_address_id
+            expect(Spree::Address.where(id: bill_add_id).pluck(:address1) ==
+              Spree::Address.where(id: ship_add_id).pluck(:address1)).to be true
           end
         end
 
@@ -184,7 +188,7 @@ describe "As a consumer, I want to checkout my order", js: true do
           before do
             uncheck "ship_address_same_as_billing"
           end
-          it "displays the shipping address form" do
+          it "displays the shipping address form and the option to save it as default" do
             within(:xpath, './/div[@class="checkout-substep"][3]') do
               expect(page).to have_field "order_ship_address_attributes_address1"
             end
@@ -206,6 +210,11 @@ describe "As a consumer, I want to checkout my order", js: true do
             fill_out_shipping_address
             fill_out("SpEcIaL NoTeS")
             proceed_to_payment
+            # asserts whether shipping and billing addresses are the same
+            ship_add_id = Spree::Order.first.ship_address_id
+            bill_add_id = Spree::Order.first.bill_address_id
+            expect(Spree::Address.where(id: bill_add_id).pluck(:address1) ==
+             Spree::Address.where(id: ship_add_id).pluck(:address1)).to be false
           end
         end
       end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -226,12 +226,12 @@ describe "As a consumer, I want to checkout my order", js: true do
         click_button "Next - Payment method"
         expect(page).to have_content("Saving failed, please update the highlighted fields")
         within(:xpath, './/div[@class="checkout-substep"][1]') do
-          expect(page).to have_field("First Name", with: "") # needs to display error, issue #8691
-          expect(page).to have_field("Last Name", with: "") # needs to display error, issue #8691
+          expect(page).to have_field("First Name", with: "")
+          expect(page).to have_field("Last Name", with: "")
           expect(page).to have_field("Email", with: "")
           expect(page).to have_content("is invalid")
           expect(page).to have_field("Phone number", with: "")
-          expect(page).to have_content("can't be blank", count: 2) # update count: 4 after closing #8691
+          expect(page).to have_content("can't be blank", count: 4)
         end
         within(:xpath, './/div[@class="checkout-substep"][2]') do
           expect(page).to have_field("Address", with: "")

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -73,7 +73,6 @@ describe "As a consumer, I want to checkout my order", js: true do
     it "should redirect to the login page when clicking the login button" do
       click_on "Login"
       expect(page).to have_content("Login")
-      expect(page).to have_content("Login")
     end
   end
 
@@ -167,9 +166,7 @@ describe "As a consumer, I want to checkout my order", js: true do
             check "ship_address_same_as_billing"
           end
           it "does not display the shipping address form" do
-            within(:xpath, './/div[@class="checkout-substep"][3]') do
-              expect(page).not_to have_field "order_ship_address_attributes_address1"
-            end
+            expect(page).not_to have_field "order_ship_address_attributes_address1"
           end
 
           it "redirects the user to the Payment Method step, when submiting the form" do
@@ -187,20 +184,16 @@ describe "As a consumer, I want to checkout my order", js: true do
             uncheck "ship_address_same_as_billing"
           end
           it "displays the shipping address form and the option to save it as default" do
-            within(:xpath, './/div[@class="checkout-substep"][3]') do
-              expect(page).to have_field "order_ship_address_attributes_address1"
-            end
+            expect(page).to have_field "order_ship_address_attributes_address1"
           end
 
           it "displays error messages when submitting incomplete billing address" do
             click_button "Next - Payment method"
             expect(page).to have_content "Saving failed, please update the highlighted fields."
-            within(:xpath, './/div[@class="checkout-substep"][3]') do
-              expect(page).to have_field("Address", with: "")
-              expect(page).to have_field("City", with: "")
-              expect(page).to have_field("Postcode", with: "")
-              expect(page).to have_content("can't be blank", count: 3)
-            end
+            expect(page).to have_field("Address", with: "")
+            expect(page).to have_field("City", with: "")
+            expect(page).to have_field("Postcode", with: "")
+            expect(page).to have_content("can't be blank", count: 3)
           end
 
           it "fills in shipping details and redirects the user to the Payment Method step,
@@ -225,23 +218,16 @@ describe "As a consumer, I want to checkout my order", js: true do
       it "should display error when fields are empty" do
         click_button "Next - Payment method"
         expect(page).to have_content("Saving failed, please update the highlighted fields")
-        within(:xpath, './/div[@class="checkout-substep"][1]') do
-          expect(page).to have_field("First Name", with: "")
-          expect(page).to have_field("Last Name", with: "")
-          expect(page).to have_field("Email", with: "")
-          expect(page).to have_content("is invalid")
-          expect(page).to have_field("Phone number", with: "")
-          expect(page).to have_content("can't be blank", count: 4)
-        end
-        within(:xpath, './/div[@class="checkout-substep"][2]') do
-          expect(page).to have_field("Address", with: "")
-          expect(page).to have_field("City", with: "")
-          expect(page).to have_field("Postcode", with: "")
-          expect(page).to have_content("can't be blank", count: 3)
-        end
-        within(:xpath, './/div[@class="checkout-substep"][3]') do
-          expect(page).to have_content("Select a shipping method")
-        end
+        expect(page).to have_field("First Name", with: "")
+        expect(page).to have_field("Last Name", with: "")
+        expect(page).to have_field("Email", with: "")
+        expect(page).to have_content("is invalid")
+        expect(page).to have_field("Phone number", with: "")
+        expect(page).to have_field("Address", with: "")
+        expect(page).to have_field("City", with: "")
+        expect(page).to have_field("Postcode", with: "")
+        expect(page).to have_content("can't be blank", count: 7)
+        expect(page).to have_content("Select a shipping method")
       end
     end
   end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -177,8 +177,8 @@ describe "As a consumer, I want to checkout my order", js: true do
           it "redirects the user to the Payment Method step, when submiting the form" do
             proceed_to_payment
             # asserts whether shipping and billing addresses are the same
-            ship_add_id = Spree::Order.first.ship_address_id
-            bill_add_id = Spree::Order.first.bill_address_id
+            ship_add_id = order.reload.ship_address_id
+            bill_add_id = order.reload.bill_address_id
             expect(Spree::Address.where(id: bill_add_id).pluck(:address1) ==
               Spree::Address.where(id: ship_add_id).pluck(:address1)).to be true
           end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -154,23 +154,50 @@ describe "As a consumer, I want to checkout my order", js: true do
         end
 
         it "redirects the user to the Payment Method step" do
-          fill_in 'Any comments or special instructions?', with: "SpEcIaL NoTeS"
-          click_button "Next - Payment method"
-          expect(page).to have_current_path("/checkout/payment")
+          fill_out("SpEcIaL NoTeS")
+          proceed_to_payment
         end
       end
 
-      describe "selecting a delivery shipping method and submiting the form" do
+      describe "selecting a delivery method" do
         before do
           choose shipping_with_fee.name
-          uncheck "ship_address_same_as_billing"
         end
 
-        it "redirects the user to the Payment Method step" do
-          fill_out_shipping_address
-          fill_in 'Any comments or special instructions?', with: "SpEcIaL NoTeS"
-          click_button "Next - Payment method"
-          expect(page).to have_current_path("/checkout/payment")
+        context "with same shipping and billing address" do
+          before do
+            check "ship_address_same_as_billing"
+          end
+          
+          it "does not display the shipping address form" do
+            within(:xpath, './/div[@class="checkout-substep"][3]') do
+              expect(page).not_to have_field "order_ship_address_attributes_address1"
+            end
+          end
+
+          it "redirects the user to the Payment Method step, when submiting the form" do
+            click_button "Next - Payment method"
+            expect(page).to have_current_path("/checkout/payment")
+          end
+        end
+
+        context "with different shipping and billing address" do
+          before do
+            uncheck "ship_address_same_as_billing"
+          end
+          
+          it "displays the shipping address form" do
+            within(:xpath, './/div[@class="checkout-substep"][3]') do
+              expect(page).to have_field "order_ship_address_attributes_address1"
+            end
+          end
+
+          it "fills in shipping details and redirects the user to the Payment Method step,
+          when submiting the form" do
+            fill_out_shipping_address
+            fill_out("SpEcIaL NoTeS")
+            proceed_to_payment
+          end
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #8670.

<!-- Explain why this change is needed and the solution you propose.
Provide context for others to understand it. -->

Adds additional test coverage on step 1:
- Adds coverage on the option to submit same shipping and billing address.
- Adds coverage on mandatory fields - details/billing/shipping

#### What should we test?
<!-- List which features should be tested and how. -->

Green build.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Adds coverage on the option to submit same shipping and billing address.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes


#### Dependencies
PR #8692