### PR TITLE
Revoke transaction fee if there is an amount to be credited in order

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -147,7 +147,7 @@ module Spree
         adjustment.originator = payment_method
         adjustment.label = adjustment_label
         adjustment.save
-      elsif payment_method.present?
+      elsif amount.positive? && payment_method.present?
         payment_method.create_adjustment(adjustment_label, self, true)
         adjustment.reload
       end

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -147,7 +147,7 @@ module Spree
         adjustment.originator = payment_method
         adjustment.label = adjustment_label
         adjustment.save
-      elsif amount.positive? && payment_method.present?
+      elsif !processing_refund? && payment_method.present?
         payment_method.create_adjustment(adjustment_label, self, true)
         adjustment.reload
       end
@@ -162,6 +162,10 @@ module Spree
     end
 
     private
+
+    def processing_refund?
+      amount.negative?
+    end
 
     # Don't charge fees for invalid or failed payments.
     # This is called twice for failed payments, because the persistence of the 'failed'

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -414,7 +414,7 @@ describe Spree::Payment do
           it "should not applied any transaction fees" do
             payment.credit!
             expect(payment.adjustment.finalized?).to eq(false)
-            expect(order.all_adjustments.payment_fee.eligible.length).to eq(0)
+            expect(order.all_adjustments.payment_fee.length).to eq(0)
           end
         end
 

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -413,7 +413,7 @@ describe Spree::Payment do
 
           it "should not applied any transaction fees" do
             payment.credit!
-            expect(payment.adjustment.try(:finalized?)).to eq(false)
+            expect(payment.adjustment.finalized?).to eq(false)
             expect(order.all_adjustments.payment_fee.eligible.length).to eq(0)
           end
         end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -407,8 +407,8 @@ describe Spree::Payment do
 
         context "if payment method has any payment fees" do
           before do
-            payment.order.stub outstanding_balance: 10
-            payment.stub credit_allowed: 200
+            expect(payment.order).to receive(:outstanding_balance).at_least(:once) { 10 }
+            expect(payment).to receive(:credit_allowed) { 200 }
           end
 
           it "should not applied any transaction fees" do

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -405,6 +405,19 @@ describe Spree::Payment do
           end
         end
 
+        context "if payment method has any payment fees" do
+          before do
+            payment.order.stub outstanding_balance: 10
+            payment.stub credit_allowed: 200
+          end
+
+          it "should not applied any transaction fees" do
+            payment.credit!
+            expect(payment.adjustment.try(:finalized?)).to eq(false)
+            expect(order.all_adjustments.payment_fee.eligible.length).to eq(0)
+          end
+        end
+
         context "when outstanding_balance is equal to payment amount" do
           before do
             payment.order.stub outstanding_balance: payment.amount


### PR DESCRIPTION
#### What? Why?

Closes #3490 

It seems, the revoking of transaction fee for certain situations is handled by :

```Ruby
    def ensure_correct_adjustment
      revoke_adjustment_eligibility if ['failed', 'invalid', 'void'].include?(state) 
      return if adjustment.try(:finalized?)

      if adjustment
        adjustment.originator = payment_method
        adjustment.label = adjustment_label
        adjustment.save
      elsif payment_method.present?
        payment_method.create_adjustment(adjustment_label, self, true)
        adjustment.reload
      end
    end
```
<s>But I'm facing a a problem : 
**Once I add `|| can_credit?` to the ` revoke_adjustment_eligibility if ['failed', 'invalid', 'void'].include?(state) ` condition, only the first credit is succesful without a transaction fee applied and all subsequent credits have the fee applied.** 

And even though 'credit' seems to be a valid state, adding it to the state conditions seems to have no effect. </s>

We  can ensure that the payment method fee adjustment is not created by adding the condition  `return if order.payment_state == 'credit_owed` to the `ensure_correct_adjustment` method.

#### What should we test?
- There should be no transaction fee/payment method fee applied for crediting an amount.

#### Release notes
- Transaction fee is not applied when crediting an order.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical changes
