### PR TITLE
Validate the presence of first/last name if there is no company

### DIFF
--- a/app/models/spree/address.rb
+++ b/app/models/spree/address.rb
@@ -15,7 +15,9 @@ module Spree
 
     validates :address1, :city, :country, :phone, presence: true
     validates :company, presence: true, unless: -> { first_name.blank? || last_name.blank? }
-    validates :firstname, :lastname, presence: true, unless: -> { company.present? }
+    validates :firstname, :lastname, presence: true, if: -> do
+      company.blank? || company == 'unused'
+    end
     validates :zipcode, presence: true, if: :require_zipcode?
 
     validate :state_validate

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -68,9 +68,9 @@ describe "As a consumer, I want to checkout my order", js: true do
     it "should display error when fields are empty" do
       click_button "Next - Payment method"
       expect(page).to have_content("Saving failed, please update the highlighted fields")
-      expect(page).to have_css 'span.field_with_errors label', count: 4
-      expect(page).to have_css 'span.field_with_errors input', count: 4
-      expect(page).to have_css 'span.formError', count: 5
+      expect(page).to have_css 'span.field_with_errors label', count: 6
+      expect(page).to have_css 'span.field_with_errors input', count: 6
+      expect(page).to have_css 'span.formError', count: 7
     end
 
     it "should validate once each needed field is filled" do


### PR DESCRIPTION
No company = company is blank or company is "unused"

#### What? Why?
What I've found: https://github.com/openfoodfoundation/openfoodnetwork/issues/8691#issuecomment-1008884971
Closes #8691 

Note sure of this one, needs a review from @Matt-Yorkley and @apricot12 at least:
 - Maybe we should add some testing notes
 - Does any _company_ field is used for an order form?

Automatic testing will be done thanks to #8683 

#### What should we test?
Test that in the split checkout, the first name and the last name are well validated: they cannot be empty.

<img width="659" alt="Capture d’écran 2022-01-10 à 14 59 00" src="https://user-images.githubusercontent.com/296452/148778034-3cd46223-3a92-4e09-8b4f-3de59c001186.png">


#### Release notes
Split checkout: validate first name and last name of the order

Changelog Category: User facing changes