### PR TITLE
Change instructions to move release notes to the title of a new pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,39 @@
 #### What? Why?
 
-Closes #[the issue number this PR is related to]
+Closes # <!-- Insert issue number here. -->
 
 <!-- Explain why this change is needed and the solution you propose.
-Provide context for others to understand it. -->
+     Provide context for others to understand it. -->
 
 
 
 #### What should we test?
-<!-- List which features should be tested and how. -->
+<!-- List which features should be tested and how.
+     This can be similar to the Steps to Reproduce in the issue.
+     Also think of other parts of the app which could be affected
+     by your change. -->
 
-
+- Visit ... page.
+- 
 
 #### Release notes
-<!-- Write a one liner description of the change to be included in the release notes.
-Every PR is worth mentioning, because you did it for a reason. -->
 
 <!-- Please select one for your PR and delete the other. -->
+
 Changelog Category: User facing changes | Technical changes
 
+<!-- Choose a pull request title above which explains your change to a
+     a user of the Open Food Network app. -->
+
+The title of the pull request will be included in the release notes.
 
 
 #### Dependencies
 <!-- Does this PR depend on another one?
-Add the link or remove this section. -->
+     Add the link or remove this section. -->
 
 
 
 #### Documentation updates
 <!-- Are there any wiki pages that need updating after merging this PR?
-List them here or remove this section. -->
+     List them here or remove this section. -->


### PR DESCRIPTION

#### What? Why?

Github can generate release notes from titles automatically. That's much easier than us copying the text from each pull request.

Also changed:

- Converted instructions for the issue number to a comment to make pasting the issue number easier.
- More detail for testing instructions. Many people don't fill them out correctly.
- Formatting of comments for better readability.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

No test needed.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

If we all agree on this new process, we need to update the docs for releasing:

https://github.com/openfoodfoundation/openfoodnetwork/wiki/Releasing