### PR TITLE
OC notifications

### DIFF
--- a/app/jobs/order_cycle_notification_job.rb
+++ b/app/jobs/order_cycle_notification_job.rb
@@ -7,5 +7,6 @@ class OrderCycleNotificationJob < ActiveJob::Base
     order_cycle.suppliers.each do |supplier|
       ProducerMailer.order_cycle_report(supplier, order_cycle).deliver_now
     end
+    order_cycle.update_columns mails_sent: true
   end
 end

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -281,7 +281,9 @@ class OrderCycle < ApplicationRecord
 
   def reset_processed_at
     return unless orders_close_at.present? && orders_close_at_was.present?
+    return unless orders_close_at > orders_close_at_was
 
-    self.processed_at = nil if orders_close_at > orders_close_at_was
+    self.processed_at = nil
+    self.mails_sent = false
   end
 end

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -151,7 +151,7 @@ class OrderCycle < ApplicationRecord
   def clone!
     oc = dup
     oc.name = I18n.t("models.order_cycle.cloned_order_cycle_name", order_cycle: oc.name)
-    oc.orders_open_at = oc.orders_close_at = nil
+    oc.orders_open_at = oc.orders_close_at = oc.mails_sent = oc.processed_at = nil
     oc.coordinator_fee_ids = coordinator_fee_ids
     # rubocop:disable Layout/LineLength
     oc.preferred_product_selection_from_coordinator_inventory_only = preferred_product_selection_from_coordinator_inventory_only

--- a/app/views/admin/order_cycles/edit.html.haml
+++ b/app/views/admin/order_cycles/edit.html.haml
@@ -2,12 +2,12 @@
 - content_for :page_actions do
   - if can? :notify_producers, @order_cycle
     %li
-      - processed = @order_cycle.processed_at.present?
+      - mails_sent = @order_cycle.mails_sent?
       - url = main_app.notify_producers_admin_order_cycle_path
       - confirm_msg = "#{t('.notify_producers_tip')} #{t(:are_you_sure)}"
       %a.button.icon-email.with-tip{ href: url, data: { method: 'post', confirm: confirm_msg }, 'data-powertip': t('.notify_producers_tip') }
-        = processed ? t('.re_notify_producers') : t(:notify_producers)
-        - if processed
+        = mails_sent ? t('.re_notify_producers') : t(:notify_producers)
+        - if mails_sent
           .badge.icon-ok.success
 
 - content_for :page_title do

--- a/db/migrate/20220112102539_add_mails_sent_to_order_cycles.rb
+++ b/db/migrate/20220112102539_add_mails_sent_to_order_cycles.rb
@@ -1,0 +1,5 @@
+class AddMailsSentToOrderCycles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :order_cycles, :mails_sent, :boolean, default: false
+  end
+end

--- a/db/migrate/20220114110920_update_order_cycle_mails.rb
+++ b/db/migrate/20220114110920_update_order_cycle_mails.rb
@@ -1,0 +1,12 @@
+class UpdateOrderCycleMails < ActiveRecord::Migration[6.1]
+  class MigrationOrderCycle < ActiveRecord::Base
+    self.table_name = "order_cycles"
+  end
+
+  def up
+    MigrationOrderCycle.
+      where(automatic_notifications: true).
+      where.not(processed_at: nil).
+      update_all(mails_sent: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_17_094141) do
+ActiveRecord::Schema.define(version: 2022_01_12_102539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -295,6 +295,7 @@ ActiveRecord::Schema.define(version: 2021_12_17_094141) do
     t.datetime "updated_at", null: false
     t.datetime "processed_at"
     t.boolean "automatic_notifications", default: false
+    t.boolean "mails_sent", default: false
   end
 
   create_table "producer_properties", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_12_102539) do
+ActiveRecord::Schema.define(version: 2022_01_14_110920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/jobs/order_cycle_notification_job_spec.rb
+++ b/spec/jobs/order_cycle_notification_job_spec.rb
@@ -10,8 +10,14 @@ describe OrderCycleNotificationJob do
     allow(ProducerMailer).to receive(:order_cycle_report).twice.and_return(mail)
   end
 
-  it 'sends a mail to each supplier' do
+  it "sends a mail to each supplier" do
     OrderCycleNotificationJob.perform_now order_cycle.id
     expect(ProducerMailer).to have_received(:order_cycle_report).twice
+  end
+
+  it "records that mails have been sent for the order cycle" do
+    expect do
+      OrderCycleNotificationJob.perform_now(order_cycle.id)
+    end.to change{ order_cycle.reload.mails_sent? }.from(false).to(true)
   end
 end

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -373,7 +373,7 @@ describe OrderCycle do
     oc = create(:simple_order_cycle,
                 coordinator_fees: [create(:enterprise_fee, enterprise: coordinator)],
                 preferred_product_selection_from_coordinator_inventory_only: true,
-                automatic_notifications: true)
+                automatic_notifications: true, processed_at: Time.zone.now, mails_sent: true)
     ex1 = create(:exchange, order_cycle: oc)
     ex2 = create(:exchange, order_cycle: oc)
     oc.clone!
@@ -385,6 +385,8 @@ describe OrderCycle do
     expect(occ.coordinator).not_to be_nil
     expect(occ.preferred_product_selection_from_coordinator_inventory_only).to be true
     expect(occ.automatic_notifications).to eq(oc.automatic_notifications)
+    expect(occ.processed_at).to eq(nil)
+    expect(occ.mails_sent).to eq(nil)
     expect(occ.coordinator).to eq(oc.coordinator)
 
     expect(occ.coordinator_fee_ids).not_to be_empty


### PR DESCRIPTION
#### What? Why?

Closes #8707, #8713

Separates two flags (`processed_at` and `mails_sent`) for these two different processes; handling automatic processing when an OC closes and sending of email notifications. They were previously sharing one flag (just the `processed_at` column) and it's wasn't really sufficient. This lead to some OCs being marked as having their emails sent when actually they hadn't.

Also; cloning an OC was not resetting the state, so a cloned OC that had ended was still marked as having been processed when actually it was a new OC.

Does that make sense? I slept badly and need more coffee...

Also improves test coverage in a couple of key places.

#### What should we test?
<!-- List which features should be tested and how. -->

Lets go for this: 

1. An OC that has automatic notifications **disabled**. Place an order and close the OC. Wait for the `OrderCycleClosingJob` to run (it runs every ~5 minutes) or just trigger the `OrderCycleClosingJob` from the console. Expected outcome: emails are not sent, and when you go to the OC edit page the button does not say "re-send" notifications and doesn't have the green check mark. Bonus test: click the send emails button and then go back to the edit page for that OC. The UI should now show the emails have been sent.
2. An OC that has automatic notifications **enabled**. Basically same as above, but the emails should get sent and the OC edit page should reflect that.
3. Cloning an OC that has had it's emails sent should "reset" it so it doesn't show as having emails sent.

#### Release notes
<!-- Write a one liner description of the change to be included in the release notes.
Every PR is worth mentioning, because you did it for a reason. -->

Fixed some UI issues with new automatic notifications feature

<!-- Please select one for your PR and delete the other. -->
Changelog Category: User facing changes
