### PR TITLE
SplitCheckout: adjust display of long shipping method or payment method label

### DIFF
--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -72,7 +72,7 @@
     - ship_method_description = nil
 
     - @shipping_methods.each do |shipping_method|
-      %div.checkout-input
+      %div.checkout-input.checkout-input-radio
         = fields_for shipping_method do |shipping_method_form|
           = shipping_method_form.radio_button :name, shipping_method.id,
             id: "shipping_method_#{shipping_method.id}",

--- a/app/views/split_checkout/_payment.html.haml
+++ b/app/views/split_checkout/_payment.html.haml
@@ -5,7 +5,7 @@
 
     - selected_payment_method = @order.payments&.with_state(:checkout)&.first&.payment_method_id
     - available_payment_methods.each do |payment_method| 
-      %div.checkout-input
+      %div.checkout-input.checkout-input-radio
         = f.radio_button :payment_method_id, payment_method.id,
           id: "payment_method_#{payment_method.id}",
           name: "order[payments_attributes][][payment_method_id]",

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -131,6 +131,15 @@
       color: $teal-400;
       text-decoration: underline;
     }
+
+    &.checkout-input-radio {
+      display: flex;
+      align-items: center;
+
+      label {
+        margin-top: 0.3rem;
+      }
+    }
   }
 
   .checkout-input span.formError, div.error.card-errors {


### PR DESCRIPTION
#### What? Why?

Closes #6139

###### Before
<img width="365" alt="Capture d’écran 2022-01-13 à 10 33 16" src="https://user-images.githubusercontent.com/296452/149309944-e944838e-03af-42ea-b992-67a99560403a.png">
<img width="366" alt="Capture d’écran 2022-01-13 à 10 42 27" src="https://user-images.githubusercontent.com/296452/149309997-2f833394-adc1-4975-920b-6123885b6515.png">


###### After
<img width="644" alt="Capture d’écran 2022-01-13 à 10 39 56" src="https://user-images.githubusercontent.com/296452/149309983-58af82a7-8c43-407a-94fa-af065ac14b1e.png">
<img width="355" alt="Capture d’écran 2022-01-13 à 10 42 37" src="https://user-images.githubusercontent.com/296452/149310008-5101692d-379b-48bf-8082-a8198a234937.png">


#### What should we test?
As a consumer, proceed to checkout (with a distributor that fill long shipping method and payment method label), and check that the display is nice, on both desktop and mobile view. 



#### Release notes
SplitCheckout: adjust display of long shipping method or payment method label
Changelog Category: User facing changes
