### PR TITLE
Remove unused inline JavaScript from products/_form.html.haml

### DIFF
--- a/app/views/spree/admin/products/_form.html.haml
+++ b/app/views/spree/admin/products/_form.html.haml
@@ -58,7 +58,3 @@
   %div
 
   .clear
-
-- unless Rails.env.test?
-  :javascript
-    $('.select2-container').css({width: '20em'})


### PR DESCRIPTION
#### What? Why?

Partially addresses #8699. This code, which was introduced in 1309d80f65827a9db4b3d0cb78a1f1313b76585d, does not appear to be used. The CSS at https://github.com/openfoodfoundation/openfoodnetwork/blob/master/app/webpacker/css/admin/sections/products.scss#L6 is used instead.

I tried a few things to make sure this code wasn't used e.g. after removing the code I checked desktop and mobile views and didn't notice any change to the select menus, when they were open and closed. I changed the code temporarily to `$('.select2-container').css({width: '0px'})` and couldn't see any changes either.

#### What should we test?

Go to the edit product page and check the width of the select menus e.g. 'Variant Unit Scale' hasn't changed.

#### Release notes

Remove unused inline JavaScript from products/_form.html.haml

Changelog Category: Technical changes