### PR TITLE
Remove unused code for currency select menu which no longer exists

### DIFF
--- a/app/helpers/spree/admin/general_settings_helper.rb
+++ b/app/helpers/spree/admin/general_settings_helper.rb
@@ -3,14 +3,6 @@
 module Spree
   module Admin
     module GeneralSettingsHelper
-      def currency_options
-        currencies = ::Money::Currency.table.map do |_code, details|
-          iso = details[:iso_code]
-          [iso, "#{details[:name]} (#{iso})"]
-        end
-        options_from_collection_for_select(currencies, :first, :last, Spree::Config[:currency])
-      end
-
       def all_units
         ["g", "oz", "lb", "kg", "T", "mL", "L", "kL"]
       end

--- a/app/views/spree/admin/general_settings/edit.html.haml
+++ b/app/views/spree/admin/general_settings/edit.html.haml
@@ -97,6 +97,3 @@
         = button Spree.t('actions.update'), 'icon-refresh'
         %span.or= Spree.t(:or)
         = link_to_with_icon 'icon-remove', Spree.t('actions.cancel'), edit_admin_general_settings_url, :class => 'button'
-
-:javascript
-  $('#currency').select2();


### PR DESCRIPTION
#### What? Why?

This partially addresses #8699 by removing inline JavaScript. This code was for the old currency select menu which was removed in 4839b7bd631d462001c8cf4b612f244dfadacaac

#### What should we test?

Passing tests probably enough for this one.

#### Release notes

Remove unused code for currency select menu which no longer exists

Changelog Category: Technical changes