### PR TITLE
Move Matomo event tracking for login modal into Authentication service

### DIFF
--- a/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
+++ b/app/assets/javascripts/darkswarm/services/authentication_service.js.coffee
@@ -21,6 +21,9 @@ angular.module('Darkswarm').factory "AuthenticationService", (Navigation, $modal
       @selectedPath = path || @selectedPath
       Navigation.navigate @selectedPath
 
+      if window._paq
+        window._paq.push(['trackEvent', 'Signin/Signup', 'Login Modal View', window.location.href])
+
     # Opens the /login tab if returning from email confirmation,
     # the /signup tab if opened from the enterprise registration page,
     # otherwise opens whichever tab is selected in the URL params ('/login', '/signup', or '/forgot')

--- a/app/assets/javascripts/templates/login.html.haml
+++ b/app/assets/javascripts/templates/login.html.haml
@@ -42,7 +42,3 @@
           tabindex: "4",
           type: "submit",
           value: "{{'label_login' | t}}"}
-:javascript
-  if (window._paq) {
-    window._paq.push(['trackEvent', 'Signin/Signup', 'Login Modal View', window.location.href]);
-  }


### PR DESCRIPTION
#### What? Why?

Part of #8699 

One less inline script. Simple.

#### What should we test?

The Matomo event tracking on opening the login modal should work as before, like this: https://github.com/openfoodfoundation/openfoodnetwork/pull/8289#issuecomment-961301095

#### Release notes

Changelog Category: Technical changes
