### PR TITLE
Fixes translation/rendering inconsistency on Country label (step 3)

### DIFF
--- a/app/views/split_checkout/_summary_address.html.haml
+++ b/app/views/split_checkout/_summary_address.html.haml
@@ -31,6 +31,6 @@
 
 %div.summary
   %span.summary-label
-    = t("split_checkout.step1.billing_address.country.label")
+    = t("split_checkout.step1.address.country_id.label")
   %span.summary-value
     = address.country


### PR DESCRIPTION
#### What? Why?

Closes #8729 ?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Fixes the rendering of the Country label on step 3 of the split checkout.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As superdmin:
- Enable `split_checkout` feature on the feature toggle

As a customer visit the checkout page on step 3:
- The `Country` word should label the country info for both shipping and billing addresses.
- It should be translatable: switch locales and verify it is correctly displayed in other languages

![image](https://user-images.githubusercontent.com/49817236/149636334-ca3f9e51-461c-4712-81f1-65911fe825f7.png)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Fixes translation/rendering inconsistency on Country label (step 3)
