### PR TITLE
Split checkout: default address saving

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -749,18 +749,7 @@ module Spree
     def save_default_addresses
       return unless save_bill_address || save_ship_address
 
-      if save_bill_address
-        customer.bill_address_id = bill_address_id
-        user&.bill_address_id = bill_address_id
-      end
-
-      if save_ship_address
-        customer.ship_address_id = ship_address_id
-        user&.ship_address_id = ship_address_id
-      end
-
-      customer.save
-      user&.save
+      DefaultAddressUpdater.new(self).call
     end
   end
 end

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -104,7 +104,7 @@ module Spree
     before_save :update_shipping_fees!, if: :complete?
     before_save :update_payment_fees!, if: :complete?
 
-    after_save_commit :save_default_addresses
+    after_save_commit DefaultAddressUpdater
 
     # -- Scopes
     scope :not_empty, -> {
@@ -744,12 +744,6 @@ module Spree
       return unless pending_payments.any?
 
       pending_payments.first.update_attribute :amount, total
-    end
-
-    def save_default_addresses
-      return unless save_bill_address || save_ship_address
-
-      DefaultAddressUpdater.new(self).call
     end
   end
 end

--- a/app/services/checkout/params.rb
+++ b/app/services/checkout/params.rb
@@ -24,6 +24,7 @@ module Checkout
     def apply_strong_parameters
       @order_params = params.require(:order).permit(
         :email, :shipping_method_id, :special_instructions, :existing_card_id,
+        :save_bill_address, :save_ship_address,
         bill_address_attributes: ::PermittedAttributes::Address.attributes,
         ship_address_attributes: ::PermittedAttributes::Address.attributes,
         payments_attributes: [

--- a/app/services/default_address_updater.rb
+++ b/app/services/default_address_updater.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class DefaultAddressUpdater
+  def self.after_commit(order)
+    return unless order.save_bill_address || order.save_ship_address
+
+    new(order).call
+  end
+
   def initialize(order)
     @order = order
   end

--- a/app/services/default_address_updater.rb
+++ b/app/services/default_address_updater.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DefaultAddressUpdater
+  def initialize(order)
+    @order = order
+  end
+
+  def call
+    assign_bill_addresses
+    assign_ship_addresses
+
+    customer.save
+    user&.save
+  end
+
+  private
+
+  attr_reader :order
+
+  delegate :save_ship_address, :save_bill_address, :customer, :user,
+           :bill_address_id, :ship_address_id, to: :order
+
+  def assign_bill_addresses
+    return unless save_bill_address
+
+    customer.bill_address_id = bill_address_id
+    user&.bill_address_id = bill_address_id
+  end
+
+  def assign_ship_addresses
+    return unless save_ship_address
+
+    customer.ship_address_id = ship_address_id
+    user&.ship_address_id = ship_address_id
+  end
+end

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -60,8 +60,8 @@
 
       - if spree_current_user||true
         %div.checkout-input
-          = f.check_box :checkout_default_bill_address
-          = f.label :checkout_default_bill_address, t(:checkout_default_bill_address)
+          = f.check_box :save_bill_address
+          = f.label :save_bill_address, t(:checkout_default_bill_address)
 
   %div.checkout-substep{ "data-controller": "toggle shippingmethod" }
     - selected_shipping_method = @order.shipping_method&.id || params[:shipping_method_id]
@@ -136,8 +136,8 @@
 
     - if spree_current_user
       %div.checkout-input{ "data-toggle-target": "content", style: "display: none" }
-        = f.check_box :default_ship_address, { id: "default_ship_address", name: "default_ship_address" }
-        = f.label :default_ship_address, t(:checkout_default_ship_address), { for: "default_ship_address" }
+        = f.check_box :save_ship_address
+        = f.label :save_ship_address, t(:checkout_default_ship_address)
 
     .div.checkout-input
       = f.label :special_instructions, t(:checkout_instructions)

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -82,6 +82,22 @@ describe SplitCheckoutController, type: :controller do
           expect(response).to redirect_to checkout_step_path(:payment)
           expect(order.reload.state).to eq "payment"
         end
+
+        describe "saving default addresses" do
+          it "updates default bill address on user and customer" do
+            put :update, params: params.merge({ order: { save_bill_address: true } })
+
+            expect(order.customer.bill_address).to eq(order.bill_address)
+            expect(order.user.bill_address).to eq(order.bill_address)
+          end
+
+          it "updates default ship address on user and customer" do
+            put :update, params: params.merge({ order: { save_ship_address: true } })
+
+            expect(order.customer.ship_address).to eq(order.ship_address)
+            expect(order.user.ship_address).to eq(order.ship_address)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Enables saving the shipping or billing address as default address with split checkout.

#### What should we test?

Checking either of the "save as default billing/shipping address" checkboxes should save the respective address.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
