### PR TITLE
Restrict Dependabot to update only the lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: lockfile-only


### PR DESCRIPTION

#### What? Why?

Because of merging #8709 accidentally.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This enables us to specify versions in the Gemfile and package.json and
Dependabot won't suggest updates we excluded that way.

We could remove some restrictions from the lockfiles after this but our current Gemfile.lock is a bit broken (json version conflict).

#### What should we test?
No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.



