### PR TITLE
Add locale to stripe elements options to display stripe error messages in globale interface chosen language

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/stripe_elements.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/stripe_elements.js.coffee
@@ -9,7 +9,7 @@ angular.module('Darkswarm').directive "stripeElements", ($injector, StripeElemen
     if $injector.has('stripeObject')
       stripe = $injector.get('stripeObject')
 
-      card = stripe.elements().create 'card',
+      card = stripe.elements({ locale: I18n.base_locale }).create 'card',
         hidePostalCode: true
         style:
           base:

--- a/app/webpacker/controllers/stripe_controller.js
+++ b/app/webpacker/controllers/stripe_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
 
     // Initialize Stripe JS
     this.stripe = Stripe(this.data.get("key"));
-    this.stripeElement = this.stripe.elements().create("card", {
+    this.stripeElement = this.stripe.elements({ locale: I18n.base_locale }).create("card", {
       style: this.constructor.styles,
       hidePostalCode: true
     });


### PR DESCRIPTION
#### What? Why?

Closes #8488


List of supported language by stripe elements:
https://stripe.com/docs/js/appendix/supported_locales


<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

Simply test that the stripe card form displays both label and error messages in the same language than the global interface for both _split checkout_ and _normal checkout_.
Test with an unsupported locale by stripe (see the supported ones: https://stripe.com/docs/js/appendix/supported_locales), like `cy` for example. It should fallback to the english version.

<img width="402" alt="Capture d’écran 2022-01-17 à 15 09 15" src="https://user-images.githubusercontent.com/296452/149785561-bd90341b-4b57-47d6-ab10-64b66130ad25.png">
<img width="402" alt="Capture d’écran 2022-01-17 à 15 09 09" src="https://user-images.githubusercontent.com/296452/149785571-01e2b95e-8e3f-4658-b365-c26f337d61e9.png">
<img width="393" alt="Capture d’écran 2022-01-17 à 15 08 55" src="https://user-images.githubusercontent.com/296452/149785590-8957b55f-7dae-480c-b7c3-b8d635742621.png">
<img width="609" alt="Capture d’écran 2022-01-17 à 15 14 27" src="https://user-images.githubusercontent.com/296452/149785693-e5e7a685-16f0-40a7-aee7-ed960bb4e71a.png">
<img width="611" alt="Capture d’écran 2022-01-17 à 15 14 13" src="https://user-images.githubusercontent.com/296452/149785703-42fbc6a2-212f-4cd4-9989-8f2baa5d9735.png">


#### Release notes

Add locale to stripe elements options to display messages in chosen language

Changelog Category: User facing changes


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
