### PR TITLE
Split checkout completion

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -8,6 +8,7 @@ class SplitCheckoutController < ::BaseController
   include OrderStockCheck
   include Spree::BaseHelper
   include CheckoutCallbacks
+  include OrderCompletion
   include CablecarResponses
 
   helper 'terms_and_conditions'
@@ -45,6 +46,7 @@ class SplitCheckoutController < ::BaseController
 
     @order.customer.touch :terms_and_conditions_accepted_at
     @order.confirm!
+    order_completion_reset @order
   end
 
   def update_order

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -221,6 +221,25 @@ describe "As a consumer, I want to checkout my order", js: true do
         expect(page).to have_content("Select a shipping method")
       end
     end
+
+    context "summary step" do
+      let(:order) { create(:order_ready_for_confirmation, distributor: distributor) }
+
+      describe "completing the checkout" do
+        it "keeps the distributor selected for the current user after completion" do
+          visit checkout_step_path(:summary)
+
+          expect(page).to have_content "Shopping @ #{distributor.name}"
+
+          click_on "Complete order"
+
+          expect(page).to have_content "Back To Store"
+          expect(order.reload.state).to eq "complete"
+
+          expect(page).to have_content "Shopping @ #{distributor.name}"
+        end
+      end
+    end
   end
 
   context "when I have an out of stock product in my cart" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -8,7 +8,7 @@ describe "As a consumer, I want to checkout my order", js: true do
 
   let!(:zone) { create(:zone_with_member) }
   let(:supplier) { create(:supplier_enterprise) }
-  let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true, allow_guest_orders: false) }
+  let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true) }
   let(:product) {
     create(:taxed_product, supplier: supplier, price: 10, zone: zone, tax_rate_amount: 0.1)
   }
@@ -53,6 +53,7 @@ describe "As a consumer, I want to checkout my order", js: true do
 
   context "guest checkout when distributor doesn't allow guest orders" do
     before do
+      distributor.update_columns allow_guest_orders: false
       visit checkout_step_path(:details)
     end
 
@@ -70,8 +71,6 @@ describe "As a consumer, I want to checkout my order", js: true do
 
   context "as a guest user" do
     before do
-      distributor.update!(allow_guest_orders: true)
-      order.update!(distributor_id: distributor.id)
       visit checkout_path
     end
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -19,7 +19,8 @@ describe "As a consumer, I want to checkout my order", js: true do
   }
   let(:order) {
     create(:order, order_cycle: order_cycle, distributor: distributor, bill_address_id: nil,
-                   ship_address_id: nil, state: "cart")
+                   ship_address_id: nil, state: "cart",
+                   line_items: [create(:line_item, variant: variant)])
   }
 
   let(:fee_tax_rate) { create(:tax_rate, amount: 0.10, zone: zone, included_in_price: true) }
@@ -45,7 +46,6 @@ describe "As a consumer, I want to checkout my order", js: true do
 
     add_enterprise_fee enterprise_fee
     set_order order
-    add_product_to_cart order, product
 
     distributor.shipping_methods << free_shipping
     distributor.shipping_methods << shipping_with_fee


### PR DESCRIPTION
#### What? Why?

#8725, take two :roll_eyes: 

- Adds more test coverage
- Implements new order factories for testing each checkout step
- Uses newly-refactored `OrderCompletion` concern in split checkout (adds `#order_completion_reset`)
- Adds tests for `#order_completion_reset`, which keeps the current hub selected after an order is completed (wasn't working before)

#### What should we test?

Green build? It's mostly spec changes here, and the one small change is covered with a system test.

#### Release notes

Split checkout completion improvements and increased test coverage

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
