### PR TITLE
Fix split checkout guest user login

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/auth.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/auth.js.coffee
@@ -3,3 +3,9 @@ angular.module('Darkswarm').directive 'auth', (AuthenticationService) ->
   link: (scope, elem, attrs) ->
     elem.bind "click", ->
       AuthenticationService.open '/' + attrs.auth
+
+    window.addEventListener "login:modal:open", ->
+      AuthenticationService.open '/login'
+
+    scope.$on "$destroy", ->
+      window.removeEventListener "login:modal:open"

--- a/app/views/split_checkout/_checkout.html.haml
+++ b/app/views/split_checkout/_checkout.html.haml
@@ -1,4 +1,4 @@
 %checkout.row#checkout
   .small-12.medium-12.columns
-    = render partial: "split_checkout/tabs" unless checkout_step?(:guest)
+    = render partial: "split_checkout/tabs"
     = render partial: "split_checkout/form"

--- a/app/views/split_checkout/_guest.html.haml
+++ b/app/views/split_checkout/_guest.html.haml
@@ -1,12 +1,13 @@
-.medium-10
-  %div.checkout-guest-title
-    = t :checkout_headline
+.checkout-step
+  .medium-10
+    %div.checkout-guest-title
+      = t :checkout_headline
 
-  %div.checkout-submit{ class: "#{@order.distributor.allow_guest_orders? ? 'checkout-submit-inline' : 'medium-6' }" }
-    %a.primary.button{href: main_app.login_path}
-      = t :label_login
-    -if @order.distributor.allow_guest_orders?
-      %span.checkout-submit-or
-        or
-      %a.button.cancel{href: main_app.checkout_step_path(:details)}
-        = t :checkout_as_guest
+    %div.checkout-submit{ class: "#{@order.distributor.allow_guest_orders? ? 'checkout-submit-inline' : 'medium-6' }" }
+      %a.primary.button{ href: main_app.login_path }
+        = t :label_login
+      -if @order.distributor.allow_guest_orders?
+        %span.checkout-submit-or
+          or
+        %button.button.cancel{ "data-action": "click->guest-checkout#guestSelected" }
+          = t :checkout_as_guest

--- a/app/views/split_checkout/_guest.html.haml
+++ b/app/views/split_checkout/_guest.html.haml
@@ -4,7 +4,7 @@
       = t :checkout_headline
 
     %div.checkout-submit{ class: "#{@order.distributor.allow_guest_orders? ? 'checkout-submit-inline' : 'medium-6' }" }
-      %a.primary.button{ href: main_app.login_path }
+      %button.button.primary{ "data-action": "click->guest-checkout#login" }
         = t :label_login
       -if @order.distributor.allow_guest_orders?
         %span.checkout-submit-or

--- a/app/views/split_checkout/edit.html.haml
+++ b/app/views/split_checkout/edit.html.haml
@@ -19,6 +19,12 @@
   .sub-header.show-for-medium-down
     = render partial: "shopping_shared/order_cycles"
 
-  = render partial: "checkout"
+  .row{ "data-controller": "guest-checkout", "data-guest-checkout-distributor-value": @order.distributor.id }
+    %div{ style: "display: #{spree_current_user ? 'block' : 'none'}", "data-guest-checkout-target": "checkout" }
+      = render partial: "checkout"
+
+    - unless spree_current_user
+      %div{ style: "display: block", "data-guest-checkout-target": "guest" }
+        = render partial: "guest"
 
 = render partial: "shared/footer"

--- a/app/webpacker/controllers/guest_checkout_controller.js
+++ b/app/webpacker/controllers/guest_checkout_controller.js
@@ -15,6 +15,10 @@ export default class extends Controller {
     }
   }
 
+  login() {
+    window.dispatchEvent(new Event("login:modal:open"))
+  }
+
   showCheckout() {
     this.checkoutTarget.style.display = "block";
     this.guestTarget.style.display = "none";

--- a/app/webpacker/controllers/guest_checkout_controller.js
+++ b/app/webpacker/controllers/guest_checkout_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["checkout", "guest"];
+  static values = {
+    distributor: String,
+    session: { type: String, default: "guest-checkout" }
+  };
+
+  connect() {
+    if(!this.hasGuestTarget) { return }
+
+    if(this.usingGuestCheckout()) {
+      this.showCheckout();
+    }
+  }
+
+  showCheckout() {
+    this.checkoutTarget.style.display = "block";
+    this.guestTarget.style.display = "none";
+  }
+
+  guestSelected() {
+    this.showCheckout();
+    sessionStorage.setItem(this.sessionValue, this.distributorValue);
+  }
+
+  usingGuestCheckout() {
+    return sessionStorage.getItem(this.sessionValue) === this.distributorValue
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Openfoodnetwork::Application.routes.draw do
   constraints SplitCheckoutConstraint.new do
     get '/checkout', to: 'split_checkout#edit'
 
-    constraints step: /(guest|details|payment|summary)/ do
+    constraints step: /(details|payment|summary)/ do
       get '/checkout/:step', to: 'split_checkout#edit', as: :checkout_step
       put '/checkout/:step', to: 'split_checkout#update', as: :checkout_update
     end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -53,26 +53,18 @@ describe "As a consumer, I want to checkout my order", js: true do
 
   context "guest checkout when distributor doesn't allow guest orders" do
     before do
-      visit checkout_path
+      visit checkout_step_path(:details)
     end
 
     it "should display the split checkout login page" do
-      expect(page).to have_content distributor.name
       expect(page).to have_content("Ok, ready to checkout?")
       expect(page).to have_content("Login")
       expect(page).to have_no_content("Checkout as guest")
     end
 
-    it "should be redirected if user enter the url" do
-      order.update(state: "payment")
-      get checkout_step_path(:details)
-      expect(response).to have_http_status(:redirect)
-      expect(page).to have_content("Ok, ready to checkout?")
-    end
-
     it "should redirect to the login page when clicking the login button" do
       click_on "Login"
-      expect(page).to have_content("Login")
+      expect(page).to have_current_path "/"
     end
   end
 
@@ -83,7 +75,7 @@ describe "As a consumer, I want to checkout my order", js: true do
       visit checkout_path
     end
 
-    it "should display the split checkout login/guest page" do
+    it "should display the split checkout login/guest form" do
       expect(page).to have_content distributor.name
       expect(page).to have_content("Ok, ready to checkout?")
       expect(page).to have_content("Login")
@@ -126,7 +118,7 @@ describe "As a consumer, I want to checkout my order", js: true do
       it "should allow visit '/checkout/details'" do
         order.update(state: "payment")
         visit checkout_step_path(:details)
-        expect(page).to have_button("Next - Payment method")
+        expect(page).to have_current_path("/checkout/details")
       end
     end
   end
@@ -236,8 +228,10 @@ describe "As a consumer, I want to checkout my order", js: true do
     before do
       variant.update!(on_demand: false, on_hand: 0)
     end
+
     it "returns me to the cart with an error message" do
       visit checkout_path
+
       expect(page).not_to have_selector 'closing', text: "Checkout now"
       expect(page).to have_selector 'closing', text: "Your shopping cart"
       expect(page).to have_content "An item in your cart has become unavailable"

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -62,9 +62,9 @@ describe "As a consumer, I want to checkout my order", js: true do
       expect(page).to have_no_content("Checkout as guest")
     end
 
-    it "should redirect to the login page when clicking the login button" do
+    it "should show the login modal when clicking the login button" do
       click_on "Login"
-      expect(page).to have_current_path "/"
+      expect(page).to have_selector ".login-modal"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

Closes #8719

- Moves guest checkout logic to the frontend
- Enables opening of login modal without having to go through Angular
- Fixes login modal redirecting when used in during guest checkout

#### What should we test?

Using the split checkout as a guest should work and the login modal should not take the user away from the page

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes