### PR TITLE
Bump json gem back up to 2.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (4.2.1)
       railties (>= 3.2.16)
-    json (1.8.6)
+    json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     json_spec (1.1.5)


### PR DESCRIPTION
#### What? Why?

This was reverted in a gem update just now. We've got a weird problem with resolution of this gem verison in general related to the ActiveStorage / Paperclip issue.

#### What should we test?

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
