### PR TITLE
Use the last payment method instead of the first for the Payment Method Report

### DIFF
--- a/app/helpers/spree/reports_helper.rb
+++ b/app/helpers/spree/reports_helper.rb
@@ -6,7 +6,7 @@ module Spree
   module ReportsHelper
     def report_payment_method_options(orders)
       orders.map do |order|
-        payment_method = order.payments.first&.payment_method
+        payment_method = order.payments.last&.payment_method
 
         next unless payment_method
 

--- a/lib/open_food_network/order_cycle_management_report.rb
+++ b/lib/open_food_network/order_cycle_management_report.rb
@@ -94,7 +94,7 @@ module OpenFoodNetwork
        order.email,
        ba&.phone,
        order.shipping_method&.name,
-       order.payments.first&.payment_method&.name,
+       order.payments.last&.payment_method&.name,
        order.total,
        balance(order)]
     end

--- a/spec/helpers/spree/admin/reports_helper_spec.rb
+++ b/spec/helpers/spree/admin/reports_helper_spec.rb
@@ -7,7 +7,7 @@ describe Spree::ReportsHelper, type: :helper do
     let(:order_with_payments) { create(:order_ready_to_ship) }
     let(:order_without_payments) { create(:order_with_line_items) }
     let(:orders) { [order_with_payments, order_without_payments] }
-    let(:payment_method) { order_with_payments.payments.first.payment_method }
+    let(:payment_method) { order_with_payments.payments.last.payment_method }
 
     it "returns payment method select options for given orders" do
       select_options = helper.report_payment_method_options([order_with_payments])


### PR DESCRIPTION
#### What? Why?

Closes #8547

We now display the *last* payment method done in the "Order Cycle Management" > "Payment Methods Report" (`/admin/reports/order_cycle_management`) report:

##### The order:
<img width="990" alt="Capture d’écran 2022-01-19 à 10 00 12" src="https://user-images.githubusercontent.com/296452/150098425-684905a7-10d8-4943-b562-5fe4458c11a4.png">

##### Before the PR:
<img width="1444" alt="Capture d’écran 2022-01-19 à 10 01 52" src="https://user-images.githubusercontent.com/296452/150098454-ae5130f1-86f1-4dfb-8f73-434598779b3b.png">

##### After the PR:
<img width="1459" alt="Capture d’écran 2022-01-19 à 10 01 57" src="https://user-images.githubusercontent.com/296452/150098476-52e9790f-e007-4ed1-8068-0056de4bee2d.png">




#### What should we test?
1. Edit payment method for an order by adding one
2. See that in the "Payment Methods Report"  (`/admin/reports/order_cycle_management`) the value in the column "Payment Method" is the last for this order.

#### Release notes

Use the last payment method instead of the first for the Payment Method Report

Changelog Category: User facing changes