### PR TITLE
Edit order: on last item deletion, cancel the order and conditionally send cancellation email to consumer

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -82,7 +82,15 @@ adjustItems = function(shipment_number, variant_id, quantity){
   var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
 
   if (quantity == 0 && inventory_units.length == shipment.inventory_units.length) {
-    ofnAlert(t("js.admin.orders.cannot_remove_last_item"));
+    ofnCancelOrderAlert((confirm, sendEmailCancellation) => {
+      if (confirm) {
+        doAdjustItems(shipment_number, variant_id, quantity, inventory_units, () => {
+          var redirectTo = new URL(Spree.routes.cancel_order.toString());
+          redirectTo.searchParams.append("send_cancellation_email", sendEmailCancellation);
+          window.location.href = redirectTo.toString();
+        });
+      }
+    });
     return;
   }
   doAdjustItems(shipment_number, variant_id, quantity, inventory_units, () => {
@@ -184,6 +192,24 @@ initConfirm = function() {
 ofnAlert = function(message) {
   $('#custom-alert .message').text(message);
   $('#custom-alert').show();
+}
+
+ofnCancelOrderAlert = function(callback) {
+  $('#custom-confirm .message').html(
+    ` ${t("js.admin.orders.cancel_the_order_html")}
+      <div class="form">
+        <input type="checkbox" name="send_cancellation_email" value="1" id="send_cancellation_email" />
+        <label for="send_cancellation_email">${t("js.admin.orders.cancel_the_order_send_cancelation_email")}</label>
+      </div>`);
+  $('#custom-confirm button.confirm').unbind( "click" ).click(() => {
+    $('#custom-confirm').hide();
+    callback(true, $('#send_cancellation_email').is(':checked'));
+  });
+  $('#custom-confirm button.cancel').click(() => {
+    $('#custom-confirm').hide();
+    callback(false)
+  });
+  $('#custom-confirm').show();
 }
 
 ofnConfirm = function(callback) {

--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -85,7 +85,12 @@ adjustItems = function(shipment_number, variant_id, quantity){
     ofnAlert(t("js.admin.orders.cannot_remove_last_item"));
     return;
   }
+  doAdjustItems(shipment_number, variant_id, quantity, inventory_units, () => {
+    window.location.reload();
+  });
+}
 
+doAdjustItems = function(shipment_number, variant_id, quantity, inventory_units, callback) {
   var url = Spree.routes.orders_api + "/" + order_number + "/shipments/" + shipment_number;
 
   var new_quantity = 0;
@@ -106,7 +111,7 @@ adjustItems = function(shipment_number, variant_id, quantity){
       url: Spree.url(url),
       data: { variant_id: variant_id, quantity: new_quantity }
     }).done(function( msg ) {
-      window.location.reload();
+      callback();
     });
   }
 }

--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -65,6 +65,7 @@ module Spree
 
       def fire
         event = params[:e]
+        @order.send_cancellation_email = params[:send_cancellation_email] == "true"
         if @order.public_send(event.to_s)
           flash[:success] = Spree.t(:order_updated)
         else

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -106,6 +106,7 @@ module Spree
 
     after_save_commit DefaultAddressUpdater
 
+    attribute :send_cancellation_email, type: :boolean, default: true
     # -- Scopes
     scope :not_empty, -> {
       left_outer_joins(:line_items).where.not(spree_line_items: { id: nil })
@@ -658,7 +659,7 @@ module Spree
     def after_cancel
       shipments.each(&:cancel!)
 
-      OrderMailer.cancel_email(id).deliver_later
+      OrderMailer.cancel_email(id).deliver_later if send_cancellation_email
       self.payment_state = 'credit_owed' unless shipped?
     end
 

--- a/app/views/spree/admin/shared/_routes.html.erb
+++ b/app/views/spree/admin/shared/_routes.html.erb
@@ -9,6 +9,7 @@
     :variants_search       => spree.admin_search_variants_url(:format => 'json'),
     :taxons_search         => main_app.api_v0_taxons_url(:format => 'json'),
     :orders_api            => main_app.api_v0_orders_url,
-    :states_search         => main_app.api_v0_states_url(:format => 'json')
+    :states_search         => main_app.api_v0_states_url(:format => 'json'),
+    :cancel_order          => spree.fire_admin_order_url(id: @order ? @order.number : "", e: 'cancel')
   }.to_json %>;
 </script>

--- a/app/webpacker/css/admin/orders.scss
+++ b/app/webpacker/css/admin/orders.scss
@@ -148,5 +148,9 @@ table.index td.actions {
 	.message {
 		font-size: $h5-size;
 		padding: 1.2em 0;
+
+		.form {
+			padding: 1.2em 0;
+		}
 	}
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3416,6 +3416,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
     tracking: "Tracking"
     tracking_number: "Tracking Number"
     order_total: "Order Total"
+    order_updated: "Order updated"
     customer_details: "Customer Details"
     customer_details_updated: "Customer Details updated"
     customer_search: "Customer Search"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3030,7 +3030,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
           invalid: "invalid"
         quantity_adjusted: "Insufficient stock available. Line item updated to maximum available quantity."
         quantity_unchanged: "Quantity unchanged from previous amount."
-        cannot_remove_last_item: "Cannot remove last item from order. Please cancel order instead."
+        cancel_the_order_html: "This will cancel the current order.<br />Are you sure you want to proceed?"
+        cancel_the_order_send_cancelation_email: "Send a cancellation email to the customer"
       resend_user_email_confirmation:
         resend: "Resend"
         sending: "Resend..."


### PR DESCRIPTION
#### What? Why?

Closes #8477
<img width="516" alt="Capture d’écran 2022-01-19 à 11 39 39" src="https://user-images.githubusercontent.com/296452/150864076-729f8ce1-3e68-4f93-913e-3a0316dfc826.png">


#### What should we test?
The acceptance criteria are well described in the issue #8477. This PR take only into account the `/orders/[ORDER_NUMBER]/edit` page (and not the BOM page, that will have its own separated PR)

We should also test that cancelling an order as a consumer do not change any behavior (specially around email sending that should always been sent I guess). 

#### Release notes

As an admin;, when editing an order: on last item deletion, cancel the order and conditionally send cancellation email to consumer

Changelog Category: User facing changes
