### PR TITLE
Missing translation: table headers in product import validation table #8458

### DIFF
--- a/app/models/product_import/product_importer.rb
+++ b/app/models/product_import/product_importer.rb
@@ -107,7 +107,11 @@ module ProductImport
     end
 
     def table_headings
-      @entries.first.displayable_attributes.keys.map(&:humanize) if @entries.first
+      return unless @entries.first
+
+      @entries.first.displayable_attributes.keys.map do |key|
+        I18n.t "admin.product_import.product_headings.#{key}"
+      end
     end
 
     def products_created_count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,7 +200,7 @@ en:
       logged_in_succesfully: "Logged in successfully"
     sessions:
       signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."      
+      already_signed_out: "Signed out successfully."
     user_passwords:
       spree_user:
         updated_not_active: "Your password has been reset, but your email has not been confirmed yet."
@@ -750,6 +750,21 @@ en:
         import_again: Upload Another File
         view_products: Go To Products Page
         view_inventory: Go To Inventory Page
+      product_headings:
+        producer: Producer
+        sku: SKU
+        name: Name
+        display_name: Display Name
+        category: Category
+        description: Description
+        units: Units
+        unit_type: Unit Type
+        variant_unit_name: Variant Unit Name
+        price: Price
+        on_hand: On Hand
+        on_demand: On Demand
+        shipping_category: Shipping Category
+        tax_category: Tax Category
 
     variant_overrides:
       loading_flash:
@@ -1771,7 +1786,7 @@ en:
     step2:
       payment_method:
         title: Payment method
-      form: 
+      form:
         card_number:
           label: Card number
           placeholder: e.g. 4242 4242 4242 4242
@@ -2450,7 +2465,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
   new_order_cycle: "New Order Cycle"
   new_order_cycle_tooltip: "Open shop for a certain time period"
   select_a_coordinator_for_your_order_cycle: "Select a coordinator for your order cycle"
-  notify_producers: 'Notify producers'  
+  notify_producers: 'Notify producers'
   edit_order_cycle: "Edit Order Cycle"
   roles: "Roles"
   update: "Update"


### PR DESCRIPTION
#### What? Why?

Closes  #8458 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

I added translation for product heading that will match the translation. The translation for other languages should be added after merging this pull request. 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->
Test the import products while using other language than English.

1. Select a language other than English
2. Log in
3. Go to /admin/product_import (products - import)
4. Choose the csv-file you have prepared and klick 'upload'
5. Follow the instructions until you end up at the validation screen

#### Release notes

Use translation when displaying the products list on the product import validation page. 

Changelog Category: User facing changes
