### PR TITLE
[Split Checkout] Adds tests on payments

### DIFF
--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -267,10 +267,12 @@ describe "As a consumer, I want to checkout my order", js: true do
     context "payment method step" do
       let(:order) { create(:order_ready_for_payment, distributor: distributor) }
 
-      it "preselect the payment method if only one is available" do
-        visit checkout_step_path(:payment)
+      context "with one payment method" do
+        it "preselect the payment method if only one is available" do
+          visit checkout_step_path(:payment)
 
-        expect(page).to have_checked_field "payment_method_#{payment_method.id}"
+          expect(page).to have_checked_field "payment_method_#{payment_method.id}"
+        end
       end
 
       context "with more than one payment method" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -297,7 +297,6 @@ describe "As a consumer, I want to checkout my order", js: true do
 
       describe "choosing" do
         shared_examples "different payment methods" do |pay_method|
-
           context "checking out with #{pay_method}", if: pay_method.eql?("Stripe SCA") == false do
             before do
               visit checkout_step_path(:payment)
@@ -313,7 +312,6 @@ describe "As a consumer, I want to checkout my order", js: true do
               expect(page).to have_content "Paying via: #{pay_method}"
               expect(order.reload.state).to eq "complete"
             end
-
           end
 
           context "for Stripe SCA", if: pay_method.eql?("Stripe SCA") do
@@ -330,14 +328,14 @@ describe "As a consumer, I want to checkout my order", js: true do
             end
           end
         end
-        
+
         describe "shared examples" do
-            let!(:payment_method3) { create(:payment_method, distributors: [distributor], name: "Cash") }
-          
+          let!(:cash) { create(:payment_method, distributors: [distributor], name: "Cash") }
+
           context "Cash" do
             it_behaves_like "different payment methods", "Cash"
           end
-          
+
           context "Paypal" do
             let!(:paypal) do
               Spree::Gateway::PayPalExpress.create!(
@@ -359,7 +357,7 @@ describe "As a consumer, I want to checkout my order", js: true do
 
             it_behaves_like "different payment methods", "Paypal"
           end
-          
+
           context "Stripe SCA" do
             let!(:stripe_account) { create(:stripe_account, enterprise: distributor) }
             let!(:stripe_sca_payment_method) {

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -292,6 +292,30 @@ describe "As a consumer, I want to checkout my order", js: true do
           expect(page).to have_content "Select a payment method"
         end
       end
+
+      describe "choosing" do
+        shared_examples "bewteen different payment methods" do |pay_method|
+          let!(:payment_method3) { create(:payment_method, distributors: [distributor], name: "Cash") }
+          let!(:payment_method4) { create(:payment_method, distributors: [distributor], name: "BoGuS") }
+
+          before do
+            visit checkout_step_path(:payment)
+          end
+
+          context "like #{pay_method}" do
+            it "selects it and proceeds to the summary step" do        
+              choose "#{pay_method}"
+              click_on "Next - Order summary"
+              expect(page).to have_content "Shopping @ #{distributor.name}"
+            end
+          end
+        end
+        describe "shared examples" do
+          context "legacy checkout" do
+            it_behaves_like "bewteen different payment methods", "Cash"
+          end
+        end
+      end
     end
 
     context "summary step" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -131,7 +131,6 @@ describe "As a consumer, I want to checkout my order", js: true do
       visit checkout_path
     end
 
-
     context "details step" do
       describe "filling out delivery details" do
         before do
@@ -281,7 +280,7 @@ describe "As a consumer, I want to checkout my order", js: true do
         before do
           visit checkout_step_path(:payment)
         end
-        
+
         it "don't preselect the payment method if more than one is available" do
           expect(page).to have_field "payment_method_#{payment_method.id}", checked: false
           expect(page).to have_field "payment_method_#{payment_method2.id}", checked: false
@@ -296,15 +295,21 @@ describe "As a consumer, I want to checkout my order", js: true do
       describe "choosing" do
         shared_examples "bewteen different payment methods" do |pay_method|
           let!(:payment_method3) { create(:payment_method, distributors: [distributor], name: "Cash") }
-          let!(:payment_method4) { create(:payment_method, distributors: [distributor], name: "BoGuS") }
+          let!(:paypal) do
+            Spree::Gateway::PayPalExpress.create!(
+              name: "Paypal",
+              environment: "test",
+              distributor_ids: [distributor.id]
+            )
+          end
 
           before do
             visit checkout_step_path(:payment)
           end
 
           context "like #{pay_method}" do
-            it "selects it and proceeds to the summary step" do        
-              choose "#{pay_method}"
+            it "selects it and proceeds to the summary step" do
+              choose pay_method.to_s
               click_on "Next - Order summary"
               expect(page).to have_content "Shopping @ #{distributor.name}"
             end
@@ -313,6 +318,7 @@ describe "As a consumer, I want to checkout my order", js: true do
         describe "shared examples" do
           context "legacy checkout" do
             it_behaves_like "bewteen different payment methods", "Cash"
+            it_behaves_like "bewteen different payment methods", "Paypal"
           end
         end
       end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -264,7 +264,7 @@ describe "As a consumer, I want to checkout my order", js: true do
       end
     end
 
-    context "payment method step" do
+    context "payment step" do
       let(:order) { create(:order_ready_for_payment, distributor: distributor) }
 
       context "with one payment method" do
@@ -278,11 +278,18 @@ describe "As a consumer, I want to checkout my order", js: true do
       context "with more than one payment method" do
         let!(:payment_method2) { create(:payment_method, distributors: [distributor]) }
 
-        it "don't preselect the payment method if more than one is available" do
+        before do
           visit checkout_step_path(:payment)
-
+        end
+        
+        it "don't preselect the payment method if more than one is available" do
           expect(page).to have_field "payment_method_#{payment_method.id}", checked: false
           expect(page).to have_field "payment_method_#{payment_method2.id}", checked: false
+        end
+
+        it "requires choosing a payment method" do
+          click_on "Next - Order summary"
+          expect(page).to have_content "Select a payment method"
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Contributes to #8667 by adding coverage on payment method selection.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Adds Cash, Paypal and Stripe SCA UI tests on the payment step  (step 2 - Payment)
- Covers order completion with Cash and Paypal (step 3 - Summary)

These can perhaps be extended in other dedicated spec files, for example on:
~~`spec/system/consumer/shopping/checkout_paypal_spec.rb`~~ -> added in commit https://github.com/openfoodfoundation/openfoodnetwork/pull/8772/commits/1f6157dd7c67694ccd345044c65b9cf729e3329c
`spec/system/consumer/shopping/checkout_stripe_spec.rb`

#### What should we test?

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds tests on payment methods for split checkout.
