### PR TITLE
Remove unused controller action

### DIFF
--- a/app/controllers/spree/user_passwords_controller.rb
+++ b/app/controllers/spree/user_passwords_controller.rb
@@ -16,24 +16,6 @@ module Spree
     include I18nHelper
     before_action :set_locale
 
-    # Overridden due to bug in Devise.
-    #   respond_with resource, :location => new_session_path(resource_name)
-    # is generating bad url /session/new.user
-    #
-    # overridden to:
-    #   respond_with resource, :location => spree.login_path
-    #
-    def create
-      self.resource = resource_class.send_reset_password_instructions(raw_params[resource_name])
-
-      if resource.errors.empty?
-        set_flash_message(:notice, :send_instructions) if is_navigational_format?
-        respond_with resource, location: spree.login_path
-      else
-        respond_with_navigational(resource) { render :new }
-      end
-    end
-
     # Devise::PasswordsController allows for blank passwords.
     # Silly Devise::PasswordsController!
     # Fixes spree/spree#2190.


### PR DESCRIPTION
#### What? Why?

Removes some dead code. We have two user password controllers (`Spree::UserPasswordsController` and `UserPasswordsController`) and they both define a `#create` action but only one of them is used.

:fire::fire:

#### What should we test?

Green build? Otherwise: signing up / confirming a new user account / resetting a forgotten password...

#### Release notes

Removed unused controller action

Changelog Category: Technical changes
