### PR TITLE
Convert variant.weight into decimal if integer or 0.0 if nil

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -79,6 +79,8 @@ module Spree
     after_create :create_stock_items
     after_create :set_position
 
+    before_save :convert_variant_weight_to_decimal
+
     around_destroy :destruction
 
     # default variant scope only lists non-deleted variants
@@ -242,6 +244,10 @@ module Spree
       return unless (product&.variant_unit == "items" && unit_value.nil?) || unit_value&.nan?
 
       self.unit_value = 1.0
+    end
+
+    def convert_variant_weight_to_decimal
+      self.weight = weight.to_d
     end
   end
 end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -525,6 +525,38 @@ module Spree
           expect(product.master).to be_valid
         end
       end
+
+      context "when the product's unit is non-weight" do
+        before do
+          product.update_attribute :variant_unit, 'volume'
+          product.reload
+          variant.reload
+        end
+
+        it "sets weight to decimal before save if it's integer" do
+          variant.weight = 1
+          variant.save!
+          expect(variant.weight).to eq 1.0
+        end
+
+        it "sets weight to 0.0 before save if it's nil" do
+          variant.weight = nil
+          variant.save!
+          expect(variant.weight).to eq 0.0
+        end
+
+        it "sets weight to 0.0 if input is a non numerical string" do
+          variant.weight = "BANANAS!"
+          variant.save!
+          expect(variant.weight).to eq 0.0
+        end
+
+        it "sets weight to correct decimal value if input is numerical string" do
+          variant.weight = "2"
+          variant.save!
+          expect(variant.weight).to eq 2.0
+        end
+      end
     end
 
     describe "unit value/description" do


### PR DESCRIPTION
#### What? Why?

Closes #7398 

In some instances, when the variant weight field is left empty in variant edit form, a snail is triggered. This PR fixes that by converting nil entires into 0.0 and integers into decimals before saving. 

Change in action : 

![weight](https://user-images.githubusercontent.com/65319144/151344052-e69fc804-41f9-4efa-a20a-a36fa4dd2f5b.gif)

#### What should we test?
- When a user saves an empty weight field in the variant edit form, it should save as 0.0. In case a user inputs an integer, it should be converted into a decimal.

#### Release notes
- Converts nil values in weight field on variant edit page to 0.0 or decimal to integer.

<!-- Please select one for your PR and delete the other. -->
Changelog Category: Technical Changes