### PR TITLE
Add digest gem explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "pg", "~> 1.2.3"
 
 gem 'acts_as_list', '1.0.4'
 gem 'cancancan', '~> 1.15.0'
+gem 'digest'
 gem 'ffaker'
 gem 'highline', '2.0.3' # Necessary for the install generator
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,7 @@ GEM
     devise-token_authenticatable (1.1.0)
       devise (>= 4.0.0, < 5.0.0)
     diff-lcs (1.4.4)
+    digest (3.1.0)
     docile (1.4.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -719,6 +720,7 @@ DEPENDENCIES
   devise-i18n
   devise-token_authenticatable
   dfc_provider!
+  digest
   dotenv-rails
   factory_bot_rails (= 6.2.0)
   ffaker


### PR DESCRIPTION
#### What? Why?

This was previously part of the standard lib in Ruby, but is being transitioned to an external gem. Fixes console warning:

`warning: already initialized constant Digest::REQUIRE_MUTEX`

#### What should we test?

Green build.

#### Release notes

Added digest gem (now extracted from Ruby)

Changelog Category: Technical changes
