### PR TITLE
[Split Checkout] Ensure fees are applied during checkout update

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -71,6 +71,7 @@ class SplitCheckoutController < ::BaseController
 
     @order.select_shipping_method(params[:shipping_method_id])
     @order.update(order_params)
+    @order.updater.update_totals_and_states
 
     validate_current_step!
 


### PR DESCRIPTION
#### What? Why?

Closes #8792

Ensures fees are applied/updated correctly in split checkout.

#### What should we test?

- Use the split checkout with a payment method with fees
- The order total should be correct and the fees should be applied as expected

#### Release notes

Changelog Category: Technical changes
