### PR TITLE
Fix Stripe payment authorizing for closed order cycles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,17 +139,6 @@ class ApplicationController < ActionController::Base
       !current_distributor.ready_for_checkout?
   end
 
-  def check_order_cycle_expiry
-    if current_order_cycle&.closed?
-      Bugsnag.notify("Notice: order cycle closed during checkout completion", order: current_order)
-      current_order.empty!
-      current_order.set_order_cycle! nil
-      flash[:info] = I18n.t('order_cycle_closed')
-
-      redirect_to main_app.shop_path
-    end
-  end
-
   # All render calls within the block will be performed with the specified format
   # Useful for rendering html within a JSON response, particularly if the specified
   # template or partial then goes on to render further partials without specifying

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -12,7 +12,6 @@ class BaseController < ApplicationController
   include OrderCyclesHelper
 
   before_action :set_locale
-  before_action :check_order_cycle_expiry
 
   private
 

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -19,14 +19,14 @@ module OrderStockCheck
   end
 
   def check_order_cycle_expiry
-    if current_order_cycle&.closed?
-      Bugsnag.notify("Notice: order cycle closed during checkout completion", order: current_order)
-      current_order.empty!
-      current_order.set_order_cycle! nil
-      flash[:info] = I18n.t('order_cycle_closed')
+    return unless current_order_cycle&.closed?
 
-      redirect_to main_app.shop_path
-    end
+    Bugsnag.notify("Notice: order cycle closed during checkout completion", order: current_order)
+    current_order.empty!
+    current_order.set_order_cycle! nil
+
+    flash[:info] = I18n.t('order_cycle_closed')
+    redirect_to main_app.shop_path
   end
 
   private

--- a/app/controllers/concerns/order_stock_check.rb
+++ b/app/controllers/concerns/order_stock_check.rb
@@ -18,6 +18,17 @@ module OrderStockCheck
     redirect_to main_app.cart_path
   end
 
+  def check_order_cycle_expiry
+    if current_order_cycle&.closed?
+      Bugsnag.notify("Notice: order cycle closed during checkout completion", order: current_order)
+      current_order.empty!
+      current_order.set_order_cycle! nil
+      flash[:info] = I18n.t('order_cycle_closed')
+
+      redirect_to main_app.shop_path
+    end
+  end
+
   private
 
   def sufficient_stock?

--- a/app/controllers/payment_gateways/paypal_controller.rb
+++ b/app/controllers/payment_gateways/paypal_controller.rb
@@ -8,6 +8,7 @@ module PaymentGateways
     before_action :destroy_orphaned_paypal_payments, only: :confirm
     before_action :load_checkout_order, only: [:express, :confirm]
     before_action :handle_insufficient_stock, only: [:express, :confirm]
+    before_action :check_order_cycle_expiry, only: [:express, :confirm]
     before_action :permit_parameters!
 
     after_action :reset_order_when_complete, only: :confirm

--- a/app/controllers/payment_gateways/stripe_controller.rb
+++ b/app/controllers/payment_gateways/stripe_controller.rb
@@ -7,6 +7,7 @@ module PaymentGateways
 
     before_action :load_checkout_order, only: :confirm
     before_action :validate_payment_intent, only: :confirm
+    before_action :check_order_cycle_expiry, only: :confirm
     before_action :validate_stock, only: :confirm
 
     def confirm

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -99,17 +99,4 @@ describe BaseController, type: :controller do
       controller.current_order(true)
     end
   end
-
-  it "redirects to shopfront with message if order cycle is expired" do
-    expect(controller).to receive(:current_order_cycle).and_return(oc)
-    expect(controller).to receive(:current_order).and_return(order).at_least(:twice)
-    expect(oc).to receive(:closed?).and_return(true)
-    expect(order).to receive(:empty!)
-    expect(order).to receive(:set_order_cycle!).with(nil)
-
-    get :index
-
-    expect(response).to redirect_to shop_url
-    expect(flash[:info]).to eq I18n.t('order_cycle_closed')
-  end
 end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -25,6 +25,20 @@ describe CheckoutController, type: :controller do
     expect(response).to redirect_to shop_path
   end
 
+  it "redirects to shopfront with message if order cycle is expired" do
+    allow(controller).to receive(:current_distributor).and_return(distributor)
+    expect(controller).to receive(:current_order_cycle).and_return(order_cycle).at_least(:once)
+    expect(controller).to receive(:current_order).and_return(order).at_least(:once)
+    expect(order_cycle).to receive(:closed?).and_return(true)
+    expect(order).to receive(:empty!)
+    expect(order).to receive(:set_order_cycle!).with(nil)
+
+    get :edit
+
+    expect(response).to redirect_to shop_url
+    expect(flash[:info]).to eq I18n.t('order_cycle_closed')
+  end
+
   it "redirects home with message if hub is not ready for checkout" do
     allow(distributor).to receive(:ready_for_checkout?) { false }
     allow(order).to receive_messages(distributor: distributor, order_cycle: order_cycle)


### PR DESCRIPTION
#### What? Why?

Closes  #8635

Previously, callbacks in our controllers (and specifically for the checkout) were checking if the current order cycle of the user's current order had closed, and if so: cancelling the current action and bouncing the user to the shop page with an "order cycle has closed" type message.

This was completely incompatible with the off-session Stripe payment authorization flow for orders processed via the backoffice or subscriptions, where the order can be completed (and stock already reduced) but the payment can still be awaiting (asychronous) authorization after the fact. In this case the order cycle may well have closed before the user authorizes the payment but it doesn't matter; the payment should still be successfully authorized anyway.

Now that the Stripe processing logic has been extracted to it's own controller, it's now possible (and easy) to make the necessary changes to ensure we don't interrupt processing of payment authorizations on orders with closed order cycles. Woot :partying_face: 

Soundtrack: [Lazy Eye](https://www.youtube.com/watch?v=igS2xaNlY80) :musical_note: 

#### What should we test?

- Place an order via backoffice or subscription with Stripe and a card which requires 3D authorization
- The order should be completed and the payment should be in "requires authorization" state (or whatever it's called)
- The user should get an email with an authorization link
- Close the order cycle!
- Click the email link to authorize the Stripe payment
- It should work and the payment should get authorized

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

