### PR TITLE
Remove dead code: Product#variants?

### DIFF
--- a/app/models/concerns/product_stock.rb
+++ b/app/models/concerns/product_stock.rb
@@ -6,20 +6,12 @@ module ProductStock
   extend ActiveSupport::Concern
 
   def on_demand
-    if variants?
-      raise 'Cannot determine product on_demand value of product with multiple variants' if variants.size > 1
+    raise 'Cannot determine product on_demand value of product with multiple variants' if variants.size > 1
 
-      variants.first.on_demand
-    else
-      master.on_demand
-    end
+    variants.first.on_demand
   end
 
   def on_hand
-    if variants?
-      variants.map(&:on_hand).reduce(:+)
-    else
-      master.on_hand
-    end
+    variants.map(&:on_hand).reduce(:+)
   end
 end

--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -251,11 +251,6 @@ module Spree
       permalink.present? ? permalink : (permalink_was || UrlGenerator.to_url(name))
     end
 
-    # the master variant is not a member of the variants array
-    def variants?
-      variants.any?
-    end
-
     def tax_category
       if self[:tax_category_id].nil?
         TaxCategory.find_by(is_default: true)

--- a/lib/spree/core/product_duplicator.rb
+++ b/lib/spree/core/product_duplicator.rb
@@ -11,9 +11,7 @@ module Spree
 
       def duplicate
         new_product = duplicate_product
-
-        # don't dup the actual variants, just the characterising types
-        new_product.option_types = product.option_types if product.variants?
+        new_product.option_types = product.option_types
 
         new_product.save!
         new_product

--- a/spec/lib/spree/core/product_duplicator_spec.rb
+++ b/spec/lib/spree/core/product_duplicator_spec.rb
@@ -9,7 +9,7 @@ describe Spree::Core::ProductDuplicator do
            taxons: [],
            product_properties: [property],
            master: variant,
-           variants?: false
+           option_types: []
   end
 
   let(:new_product) do
@@ -63,6 +63,7 @@ describe Spree::Core::ProductDuplicator do
     expect(new_product).to receive(:updated_at=).with(nil)
     expect(new_product).to receive(:deleted_at=).with(nil)
     expect(new_product).to receive(:master=).with(new_variant)
+    expect(new_product).to receive(:option_types=).with([])
 
     expect(new_variant).to receive(:sku=).with("")
     expect(new_variant).to receive(:deleted_at=).with(nil)


### PR DESCRIPTION
#### What? Why?

This method only makes sense in the context of Products which only have a "master" Variant (and no others), but we removed that option a while back.

#### What should we test?

* Clone a product and it should work as before.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
