### PR TITLE
Reduce expensive tax recalculation calls

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -310,6 +310,8 @@ module Spree
     # Creates new tax charges if there are any applicable rates. If prices already
     # include taxes then price adjustments are created instead.
     def create_tax_charge!
+      return if state.in?(["cart", "address", "delivery"]) && Flipper.enabled?(:split_checkout)
+
       clear_legacy_taxes!
 
       Spree::TaxRate.adjust(self, line_items)


### PR DESCRIPTION
#### What? Why?

With the split checkout changes we can cut out a large number of expensive tax recalculations that get performed prior to the checkout. This should have a big impact on performance (and request speed) when processing changes to the cart during shopping, especially with large numbers of taxed items in a cart. Should also reduce deadlocks and general pressure on the database.

This can only really be enabled once we've merged the split checkout, hence the feature toggle.

#### What should we test?

Green build?

#### Release notes

Reduce tax calculation overhead (split checkout only)

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->
