### PR TITLE
Split checkout: fix loading of saved addresses

### DIFF
--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -14,7 +14,7 @@ module CheckoutCallbacks
     prepend_before_action :require_distributor_chosen
 
     before_action :load_order, :associate_user, :load_saved_addresses, :load_saved_credit_cards
-    before_action :load_shipping_methods, :load_countries, if: -> { params[:step] == "details" }
+    before_action :load_shipping_methods, if: -> { params[:step] == "details" }
 
     before_action :ensure_order_not_completed
     before_action :ensure_checkout_allowed
@@ -47,15 +47,6 @@ module CheckoutCallbacks
 
   def load_shipping_methods
     @shipping_methods = Spree::ShippingMethod.for_distributor(@order.distributor).order(:name)
-  end
-
-  def load_countries
-    @countries = available_countries.map { |c| [c.name, c.id] }
-    @countries_with_states = available_countries.map { |c|
-      [c.id, c.states.map { |s|
-               [s.name, s.id]
-             }]
-    }
   end
 
   def redirect_to_shop?

--- a/app/helpers/spree/base_helper.rb
+++ b/app/helpers/spree/base_helper.rb
@@ -17,6 +17,24 @@ module Spree
       end.sort { |a, b| a.name <=> b.name }
     end
 
+    def countries
+      available_countries.map { |c| [c.name, c.id] }
+    end
+
+    def states_for_country(country)
+      country.states.map do |state|
+        [state.name, state.id]
+      end
+    end
+
+    def countries_with_states
+      available_countries.map { |c|
+        [c.id, c.states.map { |s|
+          [s.name, s.id]
+        }]
+      }
+    end
+
     def pretty_time(time)
       [I18n.l(time.to_date, format: :long),
        time.strftime("%l:%M %p")].join(" ")

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -25,7 +25,7 @@
         = bill_address.text_field :phone, { placeholder: t("split_checkout.step1.your_details.phone.placeholder") }
         = f.error_message_on "bill_address.phone"
 
-    %div.checkout-substep{ "data-controller": "dependant-select", "data-dependant-select-options-value": @countries_with_states }
+    %div.checkout-substep{ "data-controller": "dependant-select", "data-dependant-select-options-value": countries_with_states }
       -# BILLING ADDRESS
       %div.checkout-title
         = t("split_checkout.step1.billing_address.title")
@@ -45,9 +45,11 @@
         = bill_address.text_field :city, { placeholder: t("split_checkout.step1.address.city.placeholder") }
         = f.error_message_on "bill_address.city"
 
+      - bill_address_country = @order.bill_address.country || DefaultCountry.country
+
       %div.checkout-input
         = bill_address.label :state_id, t("split_checkout.step1.address.state_id.label")
-        = bill_address.select :state_id, @countries_with_states, { }, { "data-dependant-select-target": "select" }
+        = bill_address.select :state_id, states_for_country(bill_address_country), { selected: @order.bill_address&.state_id }, { "data-dependant-select-target": "select" }
 
       %div.checkout-input
         = bill_address.label :zipcode, t("split_checkout.step1.address.zipcode.label")
@@ -56,7 +58,7 @@
 
       %div.checkout-input
         = bill_address.label :country_id, t("split_checkout.step1.address.country_id.label")
-        = bill_address.select :country_id, @countries, { selected: @order.bill_address.country_id || DefaultCountry.id }, {"data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange"}
+        = bill_address.select :country_id, countries, { selected: bill_address_country.id }, { "data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange" }
 
       - if spree_current_user||true
         %div.checkout-input
@@ -121,9 +123,11 @@
           = ship_address.text_field :city, { placeholder: t("split_checkout.step1.address.city.placeholder") }
           = f.error_message_on "ship_address.city"
 
+        - ship_address_country = @order.ship_address.country || DefaultCountry.country
+
         %div.checkout-input
           = ship_address.label :state_id, t("split_checkout.step1.address.state_id.label")
-          = ship_address.select :state_id, @countries_with_states, { }, { "data-dependant-select-target": "select" }
+          = ship_address.select :state_id, states_for_country(ship_address_country), { selected: @order.ship_address&.state_id }, { "data-dependant-select-target": "select" }
 
         %div.checkout-input
           = ship_address.label :zipcode, t("split_checkout.step1.address.zipcode.label")
@@ -132,7 +136,7 @@
 
         %div.checkout-input
           = ship_address.label :country_id, t("split_checkout.step1.address.country_id.label")
-          = ship_address.select :country_id, @countries, { selected: @order.ship_address.country_id || DefaultCountry.id }, {"data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange"}
+          = ship_address.select :country_id, countries, { selected: ship_address_country.id }, { "data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange" }
 
     - if spree_current_user
       %div.checkout-input{ "data-toggle-target": "content", style: "display: none" }

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -25,7 +25,7 @@
         = bill_address.text_field :phone, { placeholder: t("split_checkout.step1.your_details.phone.placeholder") }
         = f.error_message_on "bill_address.phone"
 
-    %div.checkout-substep{ "data-controller": "dependant-select", "data-dependant-select-options-value": countries_with_states }
+    %div.checkout-substep
       -# BILLING ADDRESS
       %div.checkout-title
         = t("split_checkout.step1.billing_address.title")
@@ -45,20 +45,21 @@
         = bill_address.text_field :city, { placeholder: t("split_checkout.step1.address.city.placeholder") }
         = f.error_message_on "bill_address.city"
 
-      - bill_address_country = @order.bill_address.country || DefaultCountry.country
-
-      %div.checkout-input
-        = bill_address.label :state_id, t("split_checkout.step1.address.state_id.label")
-        = bill_address.select :state_id, states_for_country(bill_address_country), { selected: @order.bill_address&.state_id }, { "data-dependant-select-target": "select" }
-
       %div.checkout-input
         = bill_address.label :zipcode, t("split_checkout.step1.address.zipcode.label")
         = bill_address.text_field :zipcode, { placeholder: t("split_checkout.step1.address.zipcode.placeholder") }
         = f.error_message_on "bill_address.zipcode"
 
-      %div.checkout-input
-        = bill_address.label :country_id, t("split_checkout.step1.address.country_id.label")
-        = bill_address.select :country_id, countries, { selected: bill_address_country.id }, { "data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange" }
+      %div{ "data-controller": "dependant-select", "data-dependant-select-options-value": countries_with_states }
+        - bill_address_country = @order.bill_address.country || DefaultCountry.country
+
+        %div.checkout-input
+          = bill_address.label :country_id, t("split_checkout.step1.address.country_id.label")
+          = bill_address.select :country_id, countries, { selected: bill_address_country.id }, { "data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange" }
+
+        %div.checkout-input
+          = bill_address.label :state_id, t("split_checkout.step1.address.state_id.label")
+          = bill_address.select :state_id, states_for_country(bill_address_country), { selected: @order.bill_address&.state_id }, { "data-dependant-select-target": "select" }
 
       - if spree_current_user||true
         %div.checkout-input
@@ -123,20 +124,21 @@
           = ship_address.text_field :city, { placeholder: t("split_checkout.step1.address.city.placeholder") }
           = f.error_message_on "ship_address.city"
 
-        - ship_address_country = @order.ship_address.country || DefaultCountry.country
-
-        %div.checkout-input
-          = ship_address.label :state_id, t("split_checkout.step1.address.state_id.label")
-          = ship_address.select :state_id, states_for_country(ship_address_country), { selected: @order.ship_address&.state_id }, { "data-dependant-select-target": "select" }
-
         %div.checkout-input
           = ship_address.label :zipcode, t("split_checkout.step1.address.zipcode.label")
           = ship_address.text_field :zipcode, { placeholder: t("split_checkout.step1.address.zipcode.placeholder") }
           = f.error_message_on "ship_address.zipcode"
 
-        %div.checkout-input
-          = ship_address.label :country_id, t("split_checkout.step1.address.country_id.label")
-          = ship_address.select :country_id, countries, { selected: ship_address_country.id }, { "data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange" }
+        %div
+          - ship_address_country = @order.ship_address.country || DefaultCountry.country
+
+          %div.checkout-input
+            = ship_address.label :country_id, t("split_checkout.step1.address.country_id.label")
+            = ship_address.select :country_id, countries, { selected: ship_address_country.id }, { "data-dependant-select-target": "source", "data-action": "dependant-select#handleSelectChange" }
+
+          %div.checkout-input
+            = ship_address.label :state_id, t("split_checkout.step1.address.state_id.label")
+            = ship_address.select :state_id, states_for_country(ship_address_country), { selected: @order.ship_address&.state_id }, { "data-dependant-select-target": "select" }
 
     - if spree_current_user
       %div.checkout-input{ "data-toggle-target": "content", style: "display: none" }

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -129,7 +129,7 @@
           = ship_address.text_field :zipcode, { placeholder: t("split_checkout.step1.address.zipcode.placeholder") }
           = f.error_message_on "ship_address.zipcode"
 
-        %div
+        %div{ "data-controller": "dependant-select", "data-dependant-select-options-value": countries_with_states }
           - ship_address_country = @order.ship_address.country || DefaultCountry.country
 
           %div.checkout-input

--- a/app/webpacker/controllers/dependant_select_controller.js
+++ b/app/webpacker/controllers/dependant_select_controller.js
@@ -13,15 +13,25 @@ export default class extends Controller {
   }
 
   populateSelect(sourceId) {
-    const allOptions = this.optionsValue;
-    const options = allOptions.find((option) => option[0] === sourceId)[1];
-    const selectBox = this.selectTarget;
-    selectBox.innerHTML = "";
-    options.forEach((item) => {
-      const opt = document.createElement("option");
-      opt.value = item[1];
-      opt.innerHTML = item[0];
-      selectBox.appendChild(opt);
+    this.removeCurrentOptions()
+
+    this.dependantOptionsFor(sourceId).forEach((item) => {
+      this.addOption(item[0], item[1])
     });
+  }
+
+  removeCurrentOptions() {
+    this.selectTarget.innerHTML = ""
+  }
+
+  addOption(label, value) {
+    const newOption = document.createElement("option")
+    newOption.innerHTML = label
+    newOption.value = value
+    this.selectTarget.appendChild(newOption)
+  }
+
+  dependantOptionsFor(sourceId) {
+    return this.optionsValue.find((option) => option[0] === sourceId)[1]
   }
 }

--- a/app/webpacker/controllers/dependant_select_controller.js
+++ b/app/webpacker/controllers/dependant_select_controller.js
@@ -4,10 +4,6 @@ export default class extends Controller {
   static targets = ["source", "select"];
   static values = { options: Array };
 
-  connect() {
-    this.populateSelect(parseInt(this.sourceTarget.value));
-  }
-
   handleSelectChange() {
     this.populateSelect(parseInt(this.sourceTarget.value));
   }

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -223,6 +223,25 @@ describe "As a consumer, I want to checkout my order", js: true do
       end
     end
 
+    context "with a saved address" do
+      let!(:address_state) do
+        create(:state, name: "Testville", abbr: "TST", country: DefaultCountry.country )
+      end
+      let(:saved_address) do
+        create(:bill_address, state: address_state, zipcode: "TST01" )
+      end
+
+      before do
+        user.update_columns bill_address_id: saved_address.id
+      end
+
+      xit "pre-fills address details" do
+        visit checkout_path
+        expect(page).to have_select "order_bill_address_attributes_state_id", selected: "Testville"
+        expect(page).to have_field "order_bill_address_attributes_zipcode", with: "TST01"
+      end
+    end
+
     context "summary step" do
       let(:order) { create(:order_ready_for_confirmation, distributor: distributor) }
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -235,7 +235,7 @@ describe "As a consumer, I want to checkout my order", js: true do
         user.update_columns bill_address_id: saved_address.id
       end
 
-      xit "pre-fills address details" do
+      it "pre-fills address details" do
         visit checkout_path
         expect(page).to have_select "order_bill_address_attributes_state_id", selected: "Testville"
         expect(page).to have_field "order_bill_address_attributes_zipcode", with: "TST01"


### PR DESCRIPTION
#### What? Why?

Fixes a couple of issues with saved addresses not being pre-filled correctly in split checkout.

Side note: we should throw some _caching_ on to these helper methods which fetch and format arrays of countries/states options, but I'm not adding it in this PR.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Selecting a country in the shipping address form should update the states dropdown in the shipping address form
- The states dropdowns should be filled correctly when loading a saved address (not just picking the first item in the dropdown)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
