### PR TITLE
Split checkout: specify a min width for radio input that improve the rendering on iOS

### DIFF
--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -136,6 +136,10 @@
       display: flex;
       align-items: center;
 
+      input[type=radio] {
+        min-width: 12px;
+      }
+
       label {
         margin-top: 0.3rem;
       }


### PR DESCRIPTION
#### What? Why?

Closes #8793 

Seems that some trouble appears on mobile view with iOS/Safari. Could not exactly reproduced the bug, but this PR add a `min-width` for the radio input that improve the rendering of this page.


#### What should we test?
Select a shipping / payment method with a long name on an iPhone / Safari system with the split checkout activated and see that it is correctly rendering.

#### Release notes


The title of the pull request will be included in the release notes.
