### PR TITLE
8694 improve subscriptions index perfomance by eager loading tags, suppliers and exchanges.

### DIFF
--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -18,6 +18,7 @@ module Admin
           if view_context.subscriptions_setup_complete?(@shops)
             @order_cycles = OrderCycle.joins(:schedules).managed_by(spree_current_user).includes([:distributors, :cached_incoming_exchanges])
             @payment_methods = Spree::PaymentMethod.managed_by(spree_current_user).includes(:taggings)
+            @payment_method_tags = payment_method_tags_by_id
             @shipping_methods = Spree::ShippingMethod.managed_by(spree_current_user)
           else
             @shop = @shops.first

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -24,7 +24,7 @@ module Admin
             render :setup_explanation
           end
         end
-        format.json { render_as_json @collection, ams_prefix: params[:ams_prefix] }
+        format.json { render_as_json @collection, ams_prefix: params[:ams_prefix], payment_method_tags: payment_method_tags_by_id }
       end
     end
 
@@ -164,6 +164,22 @@ module Admin
     def subscription_params
       @subscription_params ||= PermittedAttributes::Subscription.new(params).call.
         to_h.with_indifferent_access
+    end
+
+    def payment_method_tags_by_id
+      payment_method_tags = ::ActsAsTaggableOn::Tag.
+        joins(:taggings).
+        includes(:taggings).
+        where(taggings: { taggable_type: "Spree::PaymentMethod",
+                          taggable_id: Spree::PaymentMethod.from(Enterprise.managed_by(spree_current_user).
+                          select('enterprises.id').find_by_id(params[:enterprise_id])),
+                          context: 'tags' })
+
+      payment_method_tags.each_with_object({}) do |tag, hash|
+        payment_method_id = tag.taggings.first.taggable_id
+        hash[payment_method_id] ||= []
+        hash[payment_method_id] << tag.name
+      end
     end
   end
 end

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -17,7 +17,7 @@ module Admin
         format.html do
           if view_context.subscriptions_setup_complete?(@shops)
             @order_cycles = OrderCycle.joins(:schedules).managed_by(spree_current_user)
-            @payment_methods = Spree::PaymentMethod.managed_by(spree_current_user)
+            @payment_methods = Spree::PaymentMethod.managed_by(spree_current_user).includes(:taggings)
             @shipping_methods = Spree::ShippingMethod.managed_by(spree_current_user)
           else
             @shop = @shops.first

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -16,7 +16,7 @@ module Admin
       respond_to do |format|
         format.html do
           if view_context.subscriptions_setup_complete?(@shops)
-            @order_cycles = OrderCycle.joins(:schedules).managed_by(spree_current_user)
+            @order_cycles = OrderCycle.joins(:schedules).managed_by(spree_current_user).includes([:distributors, :cached_incoming_exchanges])
             @payment_methods = Spree::PaymentMethod.managed_by(spree_current_user).includes(:taggings)
             @shipping_methods = Spree::ShippingMethod.managed_by(spree_current_user)
           else
@@ -172,7 +172,7 @@ module Admin
         includes(:taggings).
         where(taggings: { taggable_type: "Spree::PaymentMethod",
                           taggable_id: Spree::PaymentMethod.from(Enterprise.managed_by(spree_current_user).
-                          select('enterprises.id').find_by_id(params[:enterprise_id])),
+                          select('enterprises.id').find_by(id: params[:enterprise_id])),
                           context: 'tags' })
 
       payment_method_tags.each_with_object({}) do |tag, hash|

--- a/app/serializers/api/admin/payment_method/base_serializer.rb
+++ b/app/serializers/api/admin/payment_method/base_serializer.rb
@@ -7,11 +7,19 @@ module Api
         attributes :id, :name, :type, :tag_list, :tags
 
         def tag_list
-          object.tag_list.join(",")
+          payment_method_tag_list.join(",")
         end
 
         def tags
-          object.tag_list.map{ |t| { text: t } }
+          payment_method_tag_list.map{ |t| { text: t } }
+        end
+
+        private
+
+        def payment_method_tag_list
+          return object.tag_list unless options[:payment_method_tags]
+
+          options.dig(:payment_method_tags, object.id) || []
         end
       end
     end

--- a/app/serializers/api/admin/payment_method_serializer.rb
+++ b/app/serializers/api/admin/payment_method_serializer.rb
@@ -7,9 +7,9 @@ module Api
 
       def method_serializer
         if object.type == 'Spree::Gateway::StripeSCA'
-          Api::Admin::PaymentMethod::StripeSerializer.new(object)
+          Api::Admin::PaymentMethod::StripeSerializer.new(object, options)
         else
-          Api::Admin::PaymentMethod::BaseSerializer.new(object)
+          Api::Admin::PaymentMethod::BaseSerializer.new(object, options)
         end
       end
     end

--- a/app/views/admin/subscriptions/_data.html.haml
+++ b/app/views/admin/subscriptions/_data.html.haml
@@ -2,7 +2,7 @@
 = admin_inject_json_ams_array "admin.subscriptions", "shops", @shops, Api::Admin::IdNameSerializer if @shops
 = admin_inject_json_ams_array "admin.subscriptions", "customers", @customers, Api::Admin::IdEmailSerializer if @customers
 = admin_inject_json_ams_array "admin.subscriptions", "schedules", @schedules, Api::Admin::IdNameSerializer if @schedules
-= admin_inject_json_ams_array "admin.subscriptions", "paymentMethods", @payment_methods, Api::Admin::PaymentMethodSerializer if @payment_methods
+= admin_inject_json_ams_array "admin.subscriptions", "paymentMethods", @payment_methods, Api::Admin::PaymentMethodSerializer, { payment_method_tags: @payment_method_tags } if @payment_methods
 = admin_inject_json_ams_array "admin.subscriptions", "shippingMethods", @shipping_methods, Api::Admin::IdNameSerializer if @shipping_methods
 = admin_inject_json_ams_array "admin.subscriptions", "orderCycles", @order_cycles, Api::Admin::BasicOrderCycleSerializer if @order_cycles
 = admin_inject_available_countries(module: "admin.subscriptions")

--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
     "storybook": "start-storybook"
   },
   "jest": {
-    "testRegex": ["spec/javascripts/.*_test\\.js"],
-    "transformIgnorePatterns": ["/node_modules/(?!(stimulus)/)"]
+    "testRegex": [
+      "spec/javascripts/.*_test\\.js"
+    ],
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(stimulus)/)"
+    ]
   },
   "devDependencies": {
     "@storybook/addon-controls": "^6.4.13",


### PR DESCRIPTION
#### What? Why?

Addresses #8694 partially

Recently we've had a server outage due to N+1 queries bottlenecking the server. This PR cut's down the queries by 75% and should dramatically improve loading time and resource usage!

#### What should we test?
- Visit `Admin::Subscriptions#index` page.
- Check for N+1 queries of `taggings` and `exchanges`

#### Release notes

- Optimize N+1 queries in `Admin::Subscriptions#index`

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

