### PR TITLE
[Split Checkout] Move setting of payment total during checkout into OrderUpdater

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -96,9 +96,7 @@ class CheckoutController < ::BaseController
   def checkout_workflow(shipping_method_id)
     while @order.state != "complete"
       if @order.state == "payment"
-        @order.updater.update_totals
-        @order.updater.update_pending_payment
-
+        update_payment_total
         return if redirect_to_payment_gateway
 
         return action_failed if @order.errors.any?
@@ -111,6 +109,11 @@ class CheckoutController < ::BaseController
     end
 
     update_response
+  end
+
+  def update_payment_total
+    @order.updater.update_totals
+    @order.updater.update_pending_payment
   end
 
   def redirect_to_payment_gateway

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -96,6 +96,9 @@ class CheckoutController < ::BaseController
   def checkout_workflow(shipping_method_id)
     while @order.state != "complete"
       if @order.state == "payment"
+        @order.updater.update_totals
+        @order.updater.update_pending_payment
+
         return if redirect_to_payment_gateway
 
         return action_failed if @order.errors.any?

--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -734,16 +734,5 @@ module Spree
       adjustment.update_adjustment!(force: true)
       updater.update_totals_and_states
     end
-
-    # object_params sets the payment amount to the order total, but it does this
-    # before the shipping method is set. This results in the customer not being
-    # charged for their order's shipping. To fix this, we refresh the payment
-    # amount here.
-    def set_payment_amount!
-      update_totals
-      return unless pending_payments.any?
-
-      pending_payments.first.update_attribute :amount, total
-    end
   end
 end

--- a/app/models/spree/order/checkout.rb
+++ b/app/models/spree/order/checkout.rb
@@ -81,7 +81,6 @@ module Spree
               after_transition to: :complete, do: :finalize!
               after_transition to: :resumed,  do: :after_resume
               after_transition to: :canceled, do: :after_cancel
-              after_transition to: :payment, do: :set_payment_amount!
             end
           end
 

--- a/engines/order_management/app/services/order_management/order/updater.rb
+++ b/engines/order_management/app/services/order_management/order/updater.rb
@@ -35,6 +35,14 @@ module OrderManagement
         end
 
         persist_totals
+        update_pending_payment
+      end
+
+      def update_pending_payment
+        return unless order.state.in? ["payment", "confirmation"]
+        return unless order.pending_payments.any?
+
+        order.pending_payments.first.update_attribute :amount, order.total
       end
 
       # Updates the following Order total values:

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -165,6 +165,7 @@ describe SplitCheckoutController, type: :controller do
 
           expect(order.state).to eq "confirmation"
           expect(order.payments.first.adjustment.amount).to eq 1.23
+          expect(order.payments.first.amount).to eq order.item_total + order.adjustment_total
           expect(order.adjustment_total).to eq 1.23
           expect(order.total).to eq order.item_total + order.adjustment_total
         end

--- a/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -7,20 +7,10 @@ module Spree
     describe ReturnAuthorizationsController, type: :controller do
       include AuthenticationHelper
 
-      let(:order) do
-        create(:order, :with_line_item, :completed,
-               distributor: create(:distributor_enterprise) )
-      end
+      let(:order) { create(:shipped_order, distributor: create(:distributor_enterprise)) }
 
       before do
         controller_login_as_admin
-
-        # Pay the order
-        order.payments.first.complete
-        order.update_order!
-
-        # Ship the order
-        order.shipment.ship!
       end
 
       it "creates and updates a return authorization" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1335,54 +1335,6 @@ describe Spree::Order do
     end
   end
 
-  describe '#set_payment_amount!' do
-    let(:order) do
-      shipment = build(:shipment_with, :shipping_method, shipping_method: build(:shipping_method))
-      build(:order, shipments: [shipment])
-    end
-
-    context 'after transitioning to payment' do
-      before do
-        order.state = 'delivery' # payment's previous state
-
-        allow(order).to receive(:payment_required?) { true }
-      end
-
-      it 'calls #set_payment_amount! and updates totals' do
-        expect(order).to receive(:set_payment_amount!)
-        expect(order).to receive(:update_totals).at_least(:once)
-
-        order.next
-      end
-
-      context "payment's amount" do
-        let(:failed_payment) { create(:payment, order: order, state: 'failed', amount: 100) }
-
-        before do
-          allow(order).to receive(:total) { 120 }
-        end
-
-        it 'is not updated for failed payments' do
-          failed_payment
-
-          order.next
-
-          expect(failed_payment.reload.amount).to eq 100
-        end
-
-        it 'is updated only for pending payments' do
-          pending_payment = create(:payment, order: order, state: 'pending', amount: 80)
-          failed_payment
-
-          order.next
-
-          expect(failed_payment.reload.amount).to eq 100
-          expect(pending_payment.reload.amount).to eq 120
-        end
-      end
-    end
-  end
-
   describe "#ensure_updated_shipments" do
     before { Spree::Shipment.create!(order: order) }
 

--- a/spec/services/process_payment_intent_spec.rb
+++ b/spec/services/process_payment_intent_spec.rb
@@ -129,6 +129,8 @@ describe ProcessPaymentIntent do
 
         it "completes the order, but with failed payment state recorded" do
           service.call!
+          order.reload
+
           expect(order.state).to eq("complete")
           expect(order.payment_state).to eq("failed")
           expect(order).to have_received(:deliver_order_confirmation_email)


### PR DESCRIPTION
#### What? Why?

Closes #8792

Refactors payment-amount-setting logic to encompass diverging requirements for how both the current checkout and the split checkout create payments with fees included in the total.

**Review Notes**

The underlying issue here was related to the split checkout creating the payment object before the payment fees had been applied, or to put it another way: the order total at the point the payment was created did not yet have the payment fee included in it.

I was a bit confused initially as it "just works" in the current checkout and it was difficult to see how the current checkout solves that problem. The answer was that it goes back and changes the payment's amount after the fact in a convoluted and obscure way that was tightly coupled to the current checkout's needs but didn't work well with the new checkout code and was difficult to change/adapt. Part of the reason it does that is that in the _current_ checkout the payment is also created before the point that shipping fees are added (which isn't the case with the split checkout). Effectively when the payment is crated it gets assigned an _incorrect_ total, and that total gets revised later on. The responsibility for handling this odd process was also spread around in multiple places. :see_no_evil: 

One of the main factors influencing the alternative solution I've implemented here is that in the new split checkout the user can *go back* and select a different payment method before the checkout is completed, which potentially changes what fees the payment has, and replaces the (not yet complete) order's payment. The previous logic was tied to the order's state changes in a linear way which implied the order would only pass into payment state once, and the payment method would never be changed afterwards.

Soundtrack: [China Town](https://www.youtube.com/watch?v=7vJFJL63Fqw) :musical_note: 

#### What should we test?

I've made a fairly serious change to some critical bits of code here (even though the changes look really small on the surface). In theory it's all heavily covered by lots of existing of tests, but this potentially impacts:
- orders with fees placed in the split checkout
- orders with fees placed in the current checkout
- orders with fees placed in the backoffice and subscriptions

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

