### PR TITLE
Fix image uploads by patching aws-sdk

### DIFF
--- a/config/initializers/aws_sdk.rb
+++ b/config/initializers/aws_sdk.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: false
+
+if AWS::VERSION == "1.67.0"
+  module AWS
+    module Core
+      module Signers
+        # @api private
+        class S3
+          module URI
+            def self.escape(string)
+              ::URI::RFC2396_Parser.new.escape(string)
+            end
+          end
+        end
+      end
+    end
+  end
+else
+  Rails.logger.warn "The aws-sdk patch needs updating or removing."
+end

--- a/spec/models/spree/image_spec.rb
+++ b/spec/models/spree/image_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+
+module Spree
+  describe Image do
+    include FileHelper
+
+    let(:file) { Rack::Test::UploadedFile.new(black_logo_file, 'image/png') }
+    let(:product) { create(:product) }
+
+    describe "using local storage" do
+      it "stores a new image" do
+        image = Spree::Image.create!(
+          attachment: file,
+          viewable: product.master,
+        )
+
+        attachment = image.attachment
+        expect(attachment.exists?).to eq true
+        expect(attachment.file?).to eq true
+        expect(attachment.url).to match /logo-black\.png\?[0-9]+$/
+      end
+    end
+
+    describe "using AWS S3" do
+      let(:s3_config) {
+        {
+          url: ":s3_alias_url",
+          storage: :s3,
+          s3_credentials: {
+            access_key_id: "A...A",
+            secret_access_key: "H...H",
+          },
+          s3_headers: { "Cache-Control" => "max-age=31557600" },
+          bucket: "ofn",
+          s3_protocol: "https",
+          s3_host_alias: "ofn.s3.us-east-1.amazonaws.com",
+
+          # This is for easier testing:
+          path: "/:id/:style/:basename.:extension",
+        }
+      }
+      around do |example|
+        original_config = Spree::Image.attachment_definitions
+        test_config = original_config.dup
+        test_config[:attachment].merge!(s3_config)
+        Spree::Image.attachment_definitions = test_config
+
+        example.run
+
+        Spree::Image.attachment_definitions = original_config
+      end
+
+      it "saves a new image when none is present" do
+        pending "patch for aws-sdk to encode URIs"
+
+        stub_request(:put, %r"https://ofn.s3.amazonaws.com/[0-9]+/(original|mini|small|product|large)/logo-black.png").
+          to_return(status: 200, body: "", headers: {})
+        stub_request(:head, %r"https://ofn.s3.amazonaws.com/[0-9]+/product/logo-black.png").
+          to_return(status: 200, body: "", headers: {})
+        image = Spree::Image.create!(
+          attachment: file,
+          viewable: product.master,
+        )
+
+        attachment = image.attachment
+        expect(attachment.exists?).to eq true
+        expect(attachment.file?).to eq true
+        expect(attachment.url).to match /logo-black\.png\?[0-9]+$/
+      end
+    end
+  end
+end

--- a/spec/models/spree/image_spec.rb
+++ b/spec/models/spree/image_spec.rb
@@ -19,7 +19,7 @@ module Spree
         attachment = image.attachment
         expect(attachment.exists?).to eq true
         expect(attachment.file?).to eq true
-        expect(attachment.url).to match /logo-black\.png\?[0-9]+$/
+        expect(attachment.url).to match %r"^/spree/products/[0-9]+/product/logo-black\.png\?[0-9]+$"
       end
     end
 
@@ -41,24 +41,22 @@ module Spree
           path: "/:id/:style/:basename.:extension",
         }
       }
-      around do |example|
-        original_config = Spree::Image.attachment_definitions
-        test_config = original_config.dup
-        test_config[:attachment].merge!(s3_config)
-        Spree::Image.attachment_definitions = test_config
 
-        example.run
-
-        Spree::Image.attachment_definitions = original_config
+      before do
+        attachment_definition = Spree::Image.attachment_definitions[:attachment]
+        allow(Spree::Image).to receive(:attachment_definitions).and_return(
+          attachment: attachment_definition.merge(s3_config)
+        )
       end
 
       it "saves a new image when none is present" do
-        pending "patch for aws-sdk to encode URIs"
+        upload_pattern = %r"^https://ofn.s3.amazonaws.com/[0-9]+/(original|mini|small|product|large)/logo-black.png$"
+        download_pattern = %r"^https://ofn.s3.amazonaws.com/[0-9]+/product/logo-black.png$"
+        public_url_pattern = %r"^https://ofn.s3.us-east-1.amazonaws.com/[0-9]+/product/logo-black.png\?[0-9]+$"
 
-        stub_request(:put, %r"https://ofn.s3.amazonaws.com/[0-9]+/(original|mini|small|product|large)/logo-black.png").
-          to_return(status: 200, body: "", headers: {})
-        stub_request(:head, %r"https://ofn.s3.amazonaws.com/[0-9]+/product/logo-black.png").
-          to_return(status: 200, body: "", headers: {})
+        stub_request(:put, upload_pattern).to_return(status: 200, body: "", headers: {})
+        stub_request(:head, download_pattern).to_return(status: 200, body: "", headers: {})
+
         image = Spree::Image.create!(
           attachment: file,
           viewable: product.master,
@@ -67,7 +65,7 @@ module Spree
         attachment = image.attachment
         expect(attachment.exists?).to eq true
         expect(attachment.file?).to eq true
-        expect(attachment.url).to match /logo-black\.png\?[0-9]+$/
+        expect(attachment.url).to match public_url_pattern
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #8824.
Replaces #8825.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Ruby 3 removed the method `URI.decode` and our old version of aws-sdk still uses it. We can't upgrade aws-sdk because of our Paperclip version. So until we've done #6347 we need a monkey patch for aws-sdk.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. Go to admin / Products.
2. Click on the image icon of a product.
3. Click on Upload an image.
4. Choose an image file from your computer.
5. Check that the image uploaded correctly.
6. Clone the product.
7. Check the image on the cloned product.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


