### PR TITLE
Create a new method pdf_stylesheet_pack_tag that actually include CSS in PDF files

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,4 +48,13 @@ module ApplicationHelper
     classes << "off-canvas" unless @hide_menu
     classes << @shopfront_layout
   end
+
+  def pdf_stylesheet_pack_tag(source)
+    if running_in_development?
+      options = { media: "all", host: "#{Webpacker.dev_server.host}:#{Webpacker.dev_server.port}" }
+      stylesheet_pack_tag(source, **options)
+    else
+      wicked_pdf_stylesheet_pack_tag(source)
+    end
+  end
 end

--- a/app/views/spree/admin/orders/invoice.html.haml
+++ b/app/views/spree/admin/orders/invoice.html.haml
@@ -1,4 +1,4 @@
-= wicked_pdf_stylesheet_pack_tag "mail"
+= pdf_stylesheet_pack_tag "mail"
 
 %table{:width => "100%"}
   %tbody

--- a/app/views/spree/admin/orders/invoice2.html.haml
+++ b/app/views/spree/admin/orders/invoice2.html.haml
@@ -1,4 +1,4 @@
-= wicked_pdf_stylesheet_pack_tag "mail"
+= pdf_stylesheet_pack_tag "mail"
 
 %table{:width => "100%"}
   %tbody


### PR DESCRIPTION
#### What? Why?
It appears that, at least on my local environnement (maybe due to macos?), but not on server, PDF file were not render with CSS, that produce a pdf file without any style:

<img width="748" alt="Capture d’écran 2022-02-04 à 16 23 10" src="https://user-images.githubusercontent.com/296452/153179016-8648b0b7-f67d-4484-a445-a9316d5fe968.png">

This PR introduce a new method that take into account the Webpacker server if is running (ie. development env). Use the default method otherwise (production, staging env.)

Source: https://stackoverflow.com/a/60541688
Context: https://github.com/openfoodfoundation/openfoodnetwork/issues/7934#issuecomment-1030122958

#### What should we test?
We should test each PDF file generation. Of course, I think of the "print invoice" button inside an order, but there should be some others places I can't think of. PDF should be _the same_ as previous, ie. with style.

<img width="453" alt="Capture d’écran 2022-02-09 à 11 26 04" src="https://user-images.githubusercontent.com/296452/153179323-858c947e-7164-4b79-80bb-f4b14b77bad3.png">


#### Release notes
Improve PDF generation for development environment. 

Changelog Category: Technical changes
