### PR TITLE
Open modal on login/signup links for a "Visible to Registered Customers Only" shop page

### DIFF
--- a/app/views/shop/messages/_customer_required.html.haml
+++ b/app/views/shop/messages/_customer_required.html.haml
@@ -1,12 +1,12 @@
 .content{ "darker-background" => true }
   .row.footer-pad
-    .small-12.columns
+    .small-12.columns{ "data-controller": "login-modal" }
       %strong
         = t '.require_customer_login'
       %p
       - if spree_current_user.nil?
         %p
-          = t('.require_login_html', login: ('<a auth="login">' + t('.login') + '</a>').html_safe, signup: ('<a auth="signup">' + t('.signup') + '</a>').html_safe)
+          = t('.require_login_html', login: ('<a auth="login" data-action="click->login-modal#call">' + t('.login') + '</a>').html_safe, signup: ('<a auth="signup" data-action="click->login-modal#call">' + t('.signup') + '</a>').html_safe)
         %p
           = t('.require_login_2_html', contact: link_to(t('.contact'), '#contact'), enterprise: current_distributor.name)
       - else


### PR DESCRIPTION
#### What? Why?

Closes #8855
Add action to links on that page that seems to be forgotten. 

_Notes_: 
 - we should add some feature tests around this feature --> https://github.com/openfoodfoundation/openfoodnetwork/issues/8858
 - we should improve the feature by open the right tab (either login nor signup) directly --> https://github.com/openfoodfoundation/openfoodnetwork/issues/8860

_Context_: https://github.com/openfoodfoundation/openfoodnetwork/pull/8808


#### What should we test?

For shopfronts that choose 'Visible to Registered Customers Only' option under 'Publicly Visible Shopfront' option in Shop Preferences of Enterprise Settings, this view is shown in the shops Home message when the the shop is open.

Click on the 'login' or 'signup' buttons: it must open the modal.
<img width="1167" alt="Capture d’écran 2022-02-10 à 10 17 24" src="https://user-images.githubusercontent.com/296452/153375869-81a3d90d-9176-406b-92a9-201486f8d4aa.png">



#### Release notes
Open modal on login/signup links for a "Visible to Registered Customers Only" shop page

Changelog Category: User facing changes
The title of the pull request will be included in the release notes.

