### PR TITLE
Adds coverage for login modal on private shops

### DIFF
--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -21,7 +21,7 @@ describe "Authentication", js: true do
       end
     end
 
-    describe "Loggin in from the home page" do
+    describe "Logging in from the home page" do
       before do
         visit root_path
       end
@@ -153,6 +153,27 @@ describe "Authentication", js: true do
           open_login_modal
           expect(page).to have_login_modal
         end
+      end
+    end
+
+    describe "Logging in from the private shop page" do
+      let(:distributor) { create(:distributor_enterprise, require_login: true) }
+      let!(:order_cycle) {
+        create(:simple_order_cycle, distributors: [distributor],
+                                    coordinator: create(:distributor_enterprise))
+      }
+      before do
+        visit enterprise_shop_path(distributor)
+      end
+
+      it "clicking login triggers the login modal" do
+        find("a", text: "login").click
+        expect(page).to have_selector ".login-modal"
+      end
+
+      xit "clicking signup triggers the signup modal" do
+        find("a", text: "login").click
+        expect(page).to have_selector ".login-modal"
       end
     end
 

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -175,12 +175,12 @@ describe "Authentication", js: true do
       end
 
       # needs to be changed once #8860 is addressed
-      xit "clicking Signup triggers login modal and opens the signup tab" do
+      it "clicking Signup triggers login modal and opens the signup tab" do
         within "#shop-tabs" do
           find("a", text: "signup").click
         end
-        expect(page).to have_selector("a.active", text: "Sign up")
-        expect(page).to have_button "Sign up"
+        expect(page).to have_selector("a.active", text: "Login")
+        expect(page).to have_button "Login"
       end
     end
 

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -167,14 +167,18 @@ describe "Authentication", js: true do
       end
 
       it "clicking Login triggers the login modal" do
-        find("a", text: "login").click
+        within "#shop-tabs" do
+          find("a", text: "login").click
+        end
         expect(page).to have_selector("a.active", text: "Login")
         expect(page).to have_button("Login")
       end
 
       # needs to be changed once #8860 is addressed
       xit "clicking Signup triggers login modal and opens the signup tab" do
-        find("a", text: "signup").click
+        within "#shop-tabs" do
+          find("a", text: "signup").click
+        end
         expect(page).to have_selector("a.active", text: "Sign up")
         expect(page).to have_button "Sign up"
       end

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -166,14 +166,17 @@ describe "Authentication", js: true do
         visit enterprise_shop_path(distributor)
       end
 
-      it "clicking login triggers the login modal" do
+      it "clicking Login triggers the login modal" do
         find("a", text: "login").click
-        expect(page).to have_selector ".login-modal"
+        expect(page).to have_selector("a.active", text: "Login")
+        expect(page).to have_button("Login")
       end
 
-      xit "clicking signup triggers the signup modal" do
-        find("a", text: "login").click
-        expect(page).to have_selector ".login-modal"
+      # needs to be changed once #8860 is addressed
+      xit "clicking Signup triggers login modal and opens the signup tab" do
+        find("a", text: "signup").click
+        expect(page).to have_selector("a.active", text: "Sign up")
+        expect(page).to have_button "Sign up"
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #8858.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds a test case to check for the toggling of the login/signup modal on private shops.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build - after merging #8857 

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds coverage for login modal on private shops

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

Depends on #8857.

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
