### PR TITLE
Setting payment state for subscription order

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -669,11 +669,12 @@ module Spree
       shipments.each(&:cancel!)
 
       OrderMailer.cancel_email(id).deliver_later if send_cancellation_email
-      self.payment_state = 'credit_owed' unless shipped?
+      update(payment_state: updater.update_payment_state)
     end
 
     def after_resume
       shipments.each(&:resume!)
+      update(payment_state: updater.update_payment_state)
     end
 
     def use_billing?


### PR DESCRIPTION
#### What? Why?

Closes #8232 

For a subscription order that is cancelled before a payment is collected should result in a void payment state. Current work around is after cancelling the order, the admin has to click the 'Update and Recalculate Fees' to reflect the change. We want this action to take place right after the cancel is initiated. [Thread](https://openfoodnetwork.slack.com/archives/C022DJZJ1J9/p1644418446848719) on the discussion 

#### What should we test?
1) Create a subscription order
2) Ensure there is no payment that is completed for said order 
3) Cancel order
4) See that the payment state is now void
5) Resume order 
6) See that the payment state is now back to balance due


