### PR TITLE
Display tax rate for shipping in alternative invoice model

### DIFF
--- a/app/services/tax_rate_finder.rb
+++ b/app/services/tax_rate_finder.rb
@@ -20,9 +20,15 @@ class TaxRateFinder
     case originator
     when Spree::TaxRate
       [originator]
+    when Spree::ShippingMethod
+      shipping_method_fee_tax_rates(originator, adjustable)
     when EnterpriseFee
       enterprise_fee_tax_rates(originator, adjustable)
     end
+  end
+
+  def shipping_method_fee_tax_rates(shipping_method, _adjustable)
+    shipping_method.tax_category ? shipping_method.tax_category.tax_rates : []
   end
 
   def enterprise_fee_tax_rates(enterprise_fee, adjustable)

--- a/spec/services/tax_rate_finder_spec.rb
+++ b/spec/services/tax_rate_finder_spec.rb
@@ -8,9 +8,14 @@ describe TaxRateFinder do
     let(:tax_rate) {
       create(:tax_rate, amount: 0.2, calculator: Calculator::DefaultTax.new, zone: zone)
     }
+    let(:tax_rate_shipping) {
+      create(:tax_rate, amount: 0.05, calculator: Calculator::DefaultTax.new, zone: zone)
+    }
     let(:tax_category) { create(:tax_category, tax_rates: [tax_rate]) }
+    let(:tax_category_shipping) { create(:tax_category, tax_rates: [tax_rate_shipping]) }
     let(:zone) { create(:zone_with_member) }
-    let(:shipment) { create(:shipment) }
+    let(:shipping_method) { create(:shipping_method, tax_category: tax_category_shipping) }
+    let(:shipment) { create(:shipment_with, :shipping_method, shipping_method: shipping_method) }
     let(:line_item) { create(:line_item) }
     let(:enterprise_fee) { create(:enterprise_fee, tax_category: tax_category) }
     let(:order) { create(:order_with_taxes, zone: zone) }
@@ -20,6 +25,11 @@ describe TaxRateFinder do
     it "finds the tax rate of a shipping fee" do
       rates = subject.tax_rates(tax_rate, shipment)
       expect(rates).to eq [tax_rate]
+    end
+
+    it "finds the tax rate of a shipping_method fee" do
+      rates = subject.tax_rates(shipping_method, shipment)
+      expect(rates).to eq [tax_rate_shipping]
     end
 
     it "deals with soft-deleted tax rates" do


### PR DESCRIPTION
#### What? Why?

Not sure of this one. Seems to correct the initial issue, but I'm wondering if I chose the right way to fix it. Adjustments are pretty complex, I'd be happy to have a review from @Matt-Yorkley on this one. 


Closes #7934


#### What should we test?
Well explained in issues #7932 and #7934:

1. Set a tax category for "Shipping"
2. Set a tax rate for "Shipping", with a given value. Select "included in the price"
3. Create a shipping method and associate it with the "Shipping" tax category
4. Create an order with the respective shipping method
5. Make sure the billing/shipping address fall into the respective Zone (for the Tax Rate)
6. Check the orders invoice and the order edit page, making sure the shipping tax has been included in the price -> this should show all your settings are correct
7. Click the Adjustments tab or visit /admin/orders/<order_number>/adjustments and notice that the Tax included in shipping fee is not displayed
8. As super admin, select the option "Use the alternative invoice model" under /admin/invoice_settings/edit
9. As admin, visit the order and click Print invoice
10. Shipping / Tax rate table entry should have the appropriate value.

<img width="757" alt="Capture d’écran 2022-02-11 à 09 21 41" src="https://user-images.githubusercontent.com/296452/153559143-9f8df0ac-c4d5-4385-bd0c-249f7e911089.png">



#### Release notes

Display tax rate for shipping in alternative invoice model

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.
