### PR TITLE
Use the user in the request to check flipper constraint for split checkout urls

### DIFF
--- a/app/constraints/split_checkout_constraint.rb
+++ b/app/constraints/split_checkout_constraint.rb
@@ -2,7 +2,7 @@
 
 class SplitCheckoutConstraint
   def matches?(request)
-    Flipper.enabled? :split_checkout, current_user(request)
+    OpenFoodNetwork::FeatureToggle.enabled? :split_checkout, current_user(request)
   end
 
   def current_user(request)

--- a/app/constraints/split_checkout_constraint.rb
+++ b/app/constraints/split_checkout_constraint.rb
@@ -6,6 +6,6 @@ class SplitCheckoutConstraint
   end
 
   def current_user(request)
-    @spree_current_user ||= request.env['warden'].user
+    request.env['warden'].user
   end
 end


### PR DESCRIPTION
#### What? Why?
 - `@spree_current_user` seemed to be memoized. Directly use the user stored in the request via `request.env['warden'].user`

plus

 - use the `OpenFoodNetwork::FeatureToggle ` proxy.


Closes #8769

#### What should we test?

###### Initial conditions
 - _User_1_ is connected and have access to split checkout via the interface `Spree::User;1`, as seen on screenshot below.
 - _Guest_ is not connected, and therefore should not have access to the Split checkout.
<img width="614" alt="Capture d’écran 2022-02-11 à 10 34 45" src="https://user-images.githubusercontent.com/296452/153568145-1d64ec7c-d155-476b-8be2-12c03433bd94.png">

###### Steps to reproduce
 - With _User_1_, prepare a cart and proceed to checkout. See that `/checkout/details` is the split checkout. 
 - With _Guest_, prepare a cart and proceed to checkout. See that `/checkout/details` is _not_ the split checkout.

_Context_: https://github.com/openfoodfoundation/openfoodnetwork/issues/8769#issuecomment-1035989023


#### Release notes
Use the user in the request to check flipper constraint for split checkout urls

Changelog Category: Technical changes
