### PR TITLE
SplitCheckout : Improve design of the order summary table

### DIFF
--- a/app/webpacker/css/darkswarm/checkout.scss
+++ b/app/webpacker/css/darkswarm/checkout.scss
@@ -39,7 +39,9 @@ checkout {
 
   h5 {
     margin: 0;
-    padding: 0.65em;
+    padding-top: 0.65em;
+    padding-bottom: 0.65em;
+    padding-left: 0.65em;
     background: $grey-050;
 
     .label {


### PR DESCRIPTION
#### What? Why?

Closes #8852

<img width="222" alt="Capture d’écran 2022-02-11 à 11 08 58" src="https://user-images.githubusercontent.com/296452/153573313-4b263a11-3db5-4b26-823b-6c6b90fbd38c.png">


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Proceed to checkout, see the order summary table. 
- Check that each cell is well aligned.
- Proceed with split checkout and with legacy checkout

#### Release notes
SplitCheckout : Improve design of the order summary table
Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
