### PR TITLE
Removes signup string from private shop login screen

### DIFF
--- a/app/views/shop/messages/_customer_required.html.haml
+++ b/app/views/shop/messages/_customer_required.html.haml
@@ -6,7 +6,7 @@
       %p
       - if spree_current_user.nil?
         %p
-          = t('.require_login_html', login: ('<a auth="login" data-action="click->login-modal#call">' + t('.login') + '</a>').html_safe, signup: ('<a auth="signup" data-action="click->login-modal#call">' + t('.signup') + '</a>').html_safe)
+          = t('.require_login_3_html', login: ('<a data-action="click->login-modal#call">' + t('.login') + '</a>').html_safe)
         %p
           = t('.require_login_2_html', contact: link_to(t('.contact'), '#contact'), enterprise: current_distributor.name)
       - else

--- a/app/views/shop/messages/_customer_required.html.haml
+++ b/app/views/shop/messages/_customer_required.html.haml
@@ -6,7 +6,7 @@
       %p
       - if spree_current_user.nil?
         %p
-          = t('.require_login_3_html', login: ('<a data-action="click->login-modal#call">' + t('.login') + '</a>').html_safe)
+          = t('.require_login_link_html', login: ('<a data-action="click->login-modal#call">' + t('.login') + '</a>').html_safe)
         %p
           = t('.require_login_2_html', contact: link_to(t('.contact'), '#contact'), enterprise: current_distributor.name)
       - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1487,10 +1487,9 @@ en:
     messages:
       customer_required:
         login: "login"
-        signup: "signup"
         contact: "contact"
         require_customer_login: "Only approved customers can access this shop."
-        require_login_html: "If you're already an approved customer, %{login} or %{signup} to proceed."
+        require_login_3_html: "If you're already an approved customer, %{login} to proceed."
         require_login_2_html: "Want to start shopping here? Please %{contact} %{enterprise} and ask about joining."
         require_customer_html: "If you'd like to start shopping here, please %{contact} %{enterprise} to ask about joining."
       select_oc:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1489,7 +1489,7 @@ en:
         login: "login"
         contact: "contact"
         require_customer_login: "Only approved customers can access this shop."
-        require_login_3_html: "If you're already an approved customer, %{login} to proceed."
+        require_login_link_html: "If you're already an approved customer, %{login} to proceed."
         require_login_2_html: "Want to start shopping here? Please %{contact} %{enterprise} and ask about joining."
         require_customer_html: "If you'd like to start shopping here, please %{contact} %{enterprise} to ask about joining."
       select_oc:

--- a/spec/system/consumer/authentication_spec.rb
+++ b/spec/system/consumer/authentication_spec.rb
@@ -156,6 +156,25 @@ describe "Authentication", js: true do
       end
     end
 
+    describe "Logging in from the private shop page" do
+      let(:distributor) { create(:distributor_enterprise, require_login: true) }
+      let!(:order_cycle) {
+        create(:simple_order_cycle, distributors: [distributor],
+                                    coordinator: create(:distributor_enterprise))
+      }
+      before do
+        visit enterprise_shop_path(distributor)
+      end
+
+      it "clicking login triggers the login modal" do
+        within "#shop-tabs" do
+          find("a", text: "login").click
+        end
+        expect(page).to have_selector("a.active", text: "Login")
+        expect(page).to have_button("Login")
+      end
+    end
+
     describe "after following email confirmation link" do
       it "shows confirmed message in modal" do
         visit root_path(anchor: "/login", validation: "confirmed")

--- a/spec/system/consumer/shopping/shopping_spec.rb
+++ b/spec/system/consumer/shopping/shopping_spec.rb
@@ -543,7 +543,7 @@ describe "As a consumer I want to shop with a distributor", js: true do
         it "tells us to login" do
           visit shop_path
           expect(page).to have_content "Only approved customers can access this shop."
-          expect(page).to have_content "login or signup"
+          expect(page).to have_content "login to proceed"
           expect(page).to have_no_content product.name
           expect(page).not_to have_selector "ordercycle"
         end


### PR DESCRIPTION
#### What? Why?

Closes #8860.
Replaces #8861 (and closes #8858).

Removes signup string from private shop login screen.
Adds a test case for the login modal.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The signup option on this screen does not provide much value, as discussed [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/8861#issuecomment-1036036589). This PR removes it.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- The text displayed on shops set to require logged in customers should only mention the login option. See also Steps to Reproduce on #8860.

Before:
![image](https://user-images.githubusercontent.com/49817236/153579178-583d87b2-07cf-43d4-a6eb-8d1fad29a6af.png)

After:
![image](https://user-images.githubusercontent.com/49817236/153579029-4a37b932-f26c-436c-8334-f27e6abaf268.png)



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Removes signup string from private shop login screen.