### PR TITLE
Split checkout: handle the link for "Back to Payment method" button in the summary page

### DIFF
--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -77,5 +77,5 @@
   .medium-6
     .checkout-submit
       = f.submit t("split_checkout.step3.submit"), name: "confirm_order", class: "button primary", disabled: @terms_and_conditions_accepted == false || @platform_tos_accepted == false
-      %a.button.cancel{href: main_app.cart_path}
+      %a.button.cancel{href: main_app.checkout_step_path(:payment)}
         = t("split_checkout.step3.cancel")

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -260,6 +260,16 @@ describe "As a consumer, I want to checkout my order", js: true do
         end
       end
 
+      describe "navigation available" do
+        it "redirect to Payment method step by clicking on 'Back to payment method' button" do
+          visit checkout_step_path(:summary)
+
+          click_on "Back to Payment method"
+
+          expect(page).to have_content "You can review and confirm your order in the next step which includes the final costs."
+        end
+      end
+
       describe "terms and conditions" do
         context "when none are required" do
           it "doesn't show checkbox or links" do


### PR DESCRIPTION
#### What? Why?
Update to the right link the "Back to Payment method" button + create a spec as well
Closes #8853



#### What should we test?
With the split checkout enabled,

1. Go through the checkout flow till you reach the `/summary` page
2. Click "Back to payment method"
3. See that you're on the `/payment` page now



#### Release notes

Split checkout: handle the link for "Back to Payment method" button in the summary page
Changelog Category: User facing changes
The title of the pull request will be included in the release notes.
