### PR TITLE
SplitCheckout: preselect the shipping/payment method if the only one available

### DIFF
--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -74,6 +74,7 @@
     - display_ship_address = false
     - ship_method_description = nil
 
+    - selected_shipping_method ||= @shipping_methods[0].id if @shipping_methods.length == 1
     - @shipping_methods.each do |shipping_method|
       %div.checkout-input.checkout-input-radio
         = fields_for shipping_method do |shipping_method_form|

--- a/app/views/split_checkout/_payment.html.haml
+++ b/app/views/split_checkout/_payment.html.haml
@@ -4,6 +4,7 @@
       = t("split_checkout.step2.payment_method.title")
 
     - selected_payment_method = @order.payments&.with_state(:checkout)&.first&.payment_method_id
+    - selected_payment_method ||= available_payment_methods[0].id if available_payment_methods.length == 1
     - available_payment_methods.each do |payment_method| 
       %div.checkout-input.checkout-input-radio
         = f.radio_button :payment_method_id, payment_method.id,

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -242,6 +242,27 @@ describe "As a consumer, I want to checkout my order", js: true do
       end
     end
 
+    context "payment method step" do
+      let(:order) { create(:order_ready_for_payment, distributor: distributor) }
+
+      it "preselect the payment method if only one is available" do
+        visit checkout_step_path(:payment)
+
+        expect(page).to have_checked_field "payment_method_#{payment_method.id}"
+      end
+
+      context "with more than one payment method" do
+        let!(:payment_method2) { create(:payment_method, distributors: [distributor]) }
+
+        it "don't preselect the payment method if more than one is available" do
+          visit checkout_step_path(:payment)
+
+          expect(page).to have_field "payment_method_#{payment_method.id}", checked: false
+          expect(page).to have_field "payment_method_#{payment_method2.id}", checked: false
+        end
+      end
+    end
+
     context "summary step" do
       let(:order) { create(:order_ready_for_confirmation, distributor: distributor) }
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -201,6 +201,25 @@ describe "As a consumer, I want to checkout my order", js: true do
           end
         end
       end
+
+      describe "pre-selecting a shipping method" do
+        it "preselect a shipping method if only one is available" do
+          order.distributor.update! shipping_methods: [free_shipping]
+
+          visit checkout_step_path(:details)
+
+          expect(page).to have_checked_field "shipping_method_#{free_shipping.id}"
+        end
+
+        it "don't preselect a shipping method if more than one is available" do
+          order.distributor.update! shipping_methods: [free_shipping, shipping_with_fee]
+
+          visit checkout_step_path(:details)
+
+          expect(page).to have_field "shipping_method_#{free_shipping.id}", checked: false
+          expect(page).to have_field "shipping_method_#{shipping_with_fee.id}", checked: false
+        end
+      end
     end
 
     describe "not filling out delivery details" do


### PR DESCRIPTION
#### What? Why?

Closes #8827



#### What should we test?
 - Add product to card, proceed to checkout
 - With a hub with only one shipping method and/or one payment method, those two options should be pre-checked in the interface
 - Check if more than one, for a guest user none are preselected, and for a connected user, the previous is selected

#### Release notes

<!-- Please select one for your PR and delete the other. -->
SplitCheckout: preselect the shipping/payment method if it's the only one is available

Changelog Category: User facing changes