### PR TITLE
Update checkout retry logic

### DIFF
--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -206,7 +206,7 @@ module Spree
     # Makes newly entered payments invalidate previously entered payments so the most recent payment
     # is used by the gateway.
     def invalidate_old_payments
-      order.payments.with_state('checkout').where.not(id: id).each do |payment|
+      order.payments.incomplete.where.not(id: id).each do |payment|
         # Using update_column skips validations and so it skips validate_source. As we are just
         # invalidating past payments here, we don't want to validate all of them at this stage.
         payment.update_columns(

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -49,6 +49,18 @@ describe Spree::Payment do
       end
     end
 
+    context "creating a new payment alongside other incomplete payments" do
+      let(:order) { create(:order_with_totals) }
+      let!(:incomplete_payment) { create(:payment, order: order, state: "pending") }
+      let(:new_payment) { create(:payment, order: order, state: "checkout") }
+
+      it "invalidates other incomplete payments on the order" do
+        new_payment
+
+        expect(incomplete_payment.reload.state).to eq "invalid"
+      end
+    end
+
     # Regression test for https://github.com/spree/spree/pull/2224
     context 'failure' do
       it 'should transition to failed from pending state' do


### PR DESCRIPTION
#### What? Why?

Improves some of the logic around invalidating incomplete payments during checkout. Previously when a new payment object was created (which happens any time the checkout is submitted) we were setting incomplete payments in `checkout` state to `invalid`.

Looking through production data, it seems like duplicate payment objects that result from customers retrying the checkout (like if a card is rejected for being out of date and they then try again) are actually not in `checkout` state, they're in `pending` state. Which means the current logic for invalidating those duplicates will just ignore them instead of dealing with them.

Should be fixed now :crossed_fingers: 

#### What should we test?

Not sure about this one. What's the best way to get the checkout to fail during payment processing?

Submitting the checkout again after it failed once should set any incomplete/unused payment objects to `invalid`.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

