### PR TITLE
Fix product import on existing, empty unit_type and variant_unit

### DIFF
--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -73,7 +73,7 @@ module ProductImport
                                            'variant_unit_scale', 'primary_taxon_id')
       )
       new_variant.save
-      if entry.attributes['unit_type'].present? || entry.attributes['variant_unit_name'].present?
+      if new_variant.persisted?
         if entry.attributes['on_demand'].present?
           new_variant.on_demand = entry.attributes['on_demand']
         end

--- a/app/models/product_import/entry_validator.rb
+++ b/app/models/product_import/entry_validator.rb
@@ -73,11 +73,13 @@ module ProductImport
                                            'variant_unit_scale', 'primary_taxon_id')
       )
       new_variant.save
-      if entry.attributes['on_demand'].present?
-        new_variant.on_demand = entry.attributes['on_demand']
-      end
-      if entry.attributes['on_hand'].present?
-        new_variant.on_hand = entry.attributes['on_hand']
+      if entry.attributes['unit_type'].present? || entry.attributes['variant_unit_name'].present?
+        if entry.attributes['on_demand'].present?
+          new_variant.on_demand = entry.attributes['on_demand']
+        end
+        if entry.attributes['on_hand'].present?
+          new_variant.on_hand = entry.attributes['on_hand']
+        end
       end
 
       new_variant.product_id = product_id

--- a/spec/models/product_import/entry_validator_spec.rb
+++ b/spec/models/product_import/entry_validator_spec.rb
@@ -55,6 +55,54 @@ describe ProductImport::EntryValidator do
     )
   end
 
+  describe "variant validation" do
+    let(:potatoes) {
+      create(
+        :simple_product,
+        supplier: enterprise,
+        on_hand: '100',
+        name: 'Potatoes',
+        unit_value: 1000,
+        variant_unit_scale: 1000,
+        variant_unit: 'weight'
+      )
+    }
+
+    let(:potato_variant) do
+      ProductImport::SpreadsheetEntry.new(
+        unscaled_units: "1",
+        units: "1",
+        unit_type: "",
+        variant_unit_name: "",
+        name: potatoes.name,
+        display_name: 'Potatoes',
+        enterprise: enterprise,
+        enterprise_id: enterprise.id,
+        producer: enterprise,
+        producer_id: enterprise.id,
+      )
+    end
+
+    before do
+      allow(import_settings).to receive(:dig)
+      allow(spreadsheet_data).to receive(:tax_index)
+      allow(spreadsheet_data).to receive(:shipping_index)
+      allow(spreadsheet_data).to receive(:categories_index)
+      allow(entry_validator).to receive(:enterprise_validation)
+      allow(entry_validator).to receive(:tax_and_shipping_validation)
+      allow(entry_validator).to receive(:variant_of_product_validation)
+      allow(entry_validator).to receive(:category_validation)
+      allow(entry_validator).to receive(:shipping_presence_validation)
+      allow(entry_validator).to receive(:product_validation)
+    end
+
+    it "validates a product" do
+      entries = [potato_variant]
+      entry_validator.validate_all(entries)
+      expect(potato_variant.errors.count).to eq 1
+    end
+  end
+
   describe "inventory validation" do
     before do
       allow(entry_validator).to receive(:import_into_inventory?) { true }


### PR DESCRIPTION
#### What? Why?

Closes #8773 

Importing product file with empty `unit_type` and`variant_unit_name` columns on already existing products was failing without any error notice to the user.


#### What should we test?

- Visit `/admin/product_import` page.
- Fill out product list template (.csv) leaving `unit_type` and`variant_unit_name` columns empty and product `name` column to already existing product name.
- Select your .csv file, upload and import.
> Corresponding error notification appears.

![PR_import](https://user-images.githubusercontent.com/60043698/153757191-a5d2d045-0d91-4709-84b3-0b0dbc1e06a9.gif)


#### Release notes

Changelog Category: User facing changes