### PR TITLE
Use our defined rubocop version on CI

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -11,6 +11,8 @@ jobs:
       - name: rubocop
         uses: reviewdog/action-rubocop@v2
         with:
+          rubocop_version: gemfile
+          rubocop_extensions: rubocop-rails:gemfile
           reporter: github-pr-check
           level: error
           fail_on_error: true


### PR DESCRIPTION

#### What? Why?

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The default is to use the latest version. That's often fine because we
keep our version up-to-date but it may not always be. It's also great if
builds are re-producible.

This came up while working on the new API. This commit was cherry-picked from #8326.

#### What should we test?

Just CI.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
