### PR TITLE
Backoffice order, using stripe payment: when card requires auth, send authorization email to guest user

### DIFF
--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -8,9 +8,7 @@ class PaymentMailer < Spree::BaseMailer
     subject = I18n.t('spree.payment_mailer.authorize_payment.subject',
                      distributor: @payment.order.distributor.name)
     I18n.with_locale valid_locale(@payment.order.user) do
-      mail(to: payment.order.user.email,
-           from: from_address,
-           subject: subject)
+      mail(to: payment.order.email, from: from_address, subject: subject)
     end
   end
 


### PR DESCRIPTION
#### What? Why?
If the user is set on the order (connected user) send the email to user.email
If this is a guest user, send the email to the order email directly

Closes #8475

As I opened #8882, I cannot test the entire process (I made a hack to test), but I'm confident about the solution I've found.


#### What should we test?

- As a hub manager, create a order for a guest user in the backoffice `/admin/orders/new`
- Create a payment with a card that requires an authorization: `4000 0027 6000 3184`
- User should receive an email
- Repeat the operation with a connected user

#### Release notes

Changelog Category: User facing changes