### PR TITLE
Patch keyword arguments syntax in Paperclip error handling

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -36,4 +36,11 @@ module UpdatedUrlGenerator
   end
 end
 
+module PaperclipImageErrors
+  def mark_invalid(record, attribute, types)
+    record.errors.add attribute, :invalid, **options.merge(:types => types.join(', '))
+  end
+end
+
 Paperclip::UrlGenerator.prepend(UpdatedUrlGenerator)
+Paperclip::Validators::AttachmentPresenceValidator.prepend(PaperclipImageErrors)


### PR DESCRIPTION
#### What? Why?

Closes #8877

Fixes an issue with Paperclip validations.

#### What should we test?

I think this can only be triggered when uploading something in image upload that isn't a valid image file type. Like... try uploading a CSV file when it prompts for an image file.

#### Release notes


Changelog Category: Technical changes
