### PR TITLE
Modify assets builder to get CSS inside emails when running in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,6 +68,7 @@ Openfoodnetwork::Application.configure do
   # Show emails using Letter Opener
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_url_options = { host: "0.0.0.0:3000" }
+  config.action_mailer.asset_host = "http://localhost:3000"
 
   config.log_level = ENV.fetch("DEV_LOG_LEVEL", :debug)
 


### PR DESCRIPTION
#### What? Why?
Specify the assets host for the action mailer to get the assets when running in development with webpacker running as well.

Closes #8882




#### What should we test?
 - We should dev test this one, by sending an email and see if the mail contains the assets and the design seems to be coherent (for example the screenshot below, confirmation email)
 - We should also test in staging that the email are actually send with CSS / design too
 
<img width="606" alt="Capture d’écran 2022-02-14 à 14 55 35" src="https://user-images.githubusercontent.com/296452/153877295-1f963175-f9cb-42d3-bf83-87d06a1798dd.png">

#### Release notes
Modify assets builder to get CSS inside emails when running in development mode.

Changelog Category: Technical changes


The title of the pull request will be included in the release notes.
