### PR TITLE
SplitCheckout: handle navigation between steps

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -492,6 +492,7 @@ Metrics/ClassLength:
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/checkout_controller.rb'
     - 'app/controllers/payment_gateways/paypal_controller.rb'
+    - 'app/controllers/split_checkout_controller.rb'
     - 'app/controllers/spree/admin/orders_controller.rb'
     - 'app/controllers/spree/admin/payment_methods_controller.rb'
     - 'app/controllers/spree/admin/payments_controller.rb'

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -17,7 +17,7 @@ class SplitCheckoutController < ::BaseController
   helper OrderHelper
 
   def edit
-    redirect_to_step unless params[:step]
+    redirect_to_step_based_on_order unless params[:step]
   end
 
   def update
@@ -116,7 +116,7 @@ class SplitCheckoutController < ::BaseController
     @order_params ||= Checkout::Params.new(@order, params, spree_current_user).call
   end
 
-  def redirect_to_step
+  def redirect_to_step_based_on_order
     case @order.state
     when "cart", "address", "delivery"
       redirect_to checkout_step_path(:details)
@@ -127,5 +127,15 @@ class SplitCheckoutController < ::BaseController
     else
       redirect_to order_path(@order)
     end
+  end
+
+  def redirect_to_step
+    case params[:step]
+    when "details"
+      return redirect_to checkout_step_path(:payment)
+    when "payment"
+      return redirect_to checkout_step_path(:summary)
+    end
+    redirect_to_step_based_on_order
   end
 end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -425,6 +425,26 @@ describe "As a consumer, I want to checkout my order", js: true do
           end
         end
       end
+
+      context "handle the navigation when the order is ready for confirmation" do
+        it "redirect to summary step" do
+          visit "/checkout"
+
+          expect(page).to have_current_path checkout_step_path(:summary)
+        end
+
+        it "handle the navigation between each step by clicking on tab or button to submit the form" do
+          visit checkout_step_path(:summary)
+
+          click_on "Your details"
+
+          expect(page).to have_current_path checkout_step_path(:details)
+
+          click_on "Next - Payment method"
+
+          expect(page).to have_current_path checkout_step_path(:payment)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
#### What? Why?
Handle two types of redirection: one is based on the order step itself, the other is based on the current step passed through the params

Closes #8889



#### What should we test?
We should test navigation between steps for different order.state (ie. is the order in details, payment or summary/confirmation state):
 - the tab should redirect to the previous concerned step
 - the _next/submit_ button at the bottom should redirect to the next step
 - the _cancel/previous_ button at the bottom should redirect to the previous step
 - when not specifying any step (ie. going on `/checkout`), should redirect to the order.state

#### Release notes



Changelog Category: Technical changes
