### PR TITLE
Sync subscriptions on newly-cloned order cycles

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -277,9 +277,9 @@ class OrderCycle < ApplicationRecord
   def sync_subscriptions
     return unless open? && schedule_ids.any?
 
-    subscriptions = Subscription.where(schedule_id: schedule_ids)
-    syncer = OrderManagement::Subscriptions::ProxyOrderSyncer.new(subscriptions)
-    syncer.sync!
+    OrderManagement::Subscriptions::ProxyOrderSyncer.new(
+      Subscription.where(schedule_id: schedule_ids)
+    ).sync!
   end
 
   def orders_close_at_after_orders_open_at?

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -276,15 +276,15 @@ class OrderCycle < ApplicationRecord
   private
 
   def opening?
-    open? && orders_close_at_changed? && was_closed?
+    (open? || upcoming?) && saved_change_to_orders_close_at? && was_closed?
   end
 
   def was_closed?
-    orders_close_at_was && Time.zone.now > orders_close_at_was
+    orders_close_at_previously_was && Time.zone.now > orders_close_at_previously_was
   end
 
   def sync_subscriptions
-    return unless open? && schedule_ids.any?
+    return unless schedule_ids.any?
 
     OrderManagement::Subscriptions::ProxyOrderSyncer.new(
       Subscription.where(schedule_id: schedule_ids)

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -275,7 +275,7 @@ class OrderCycle < ApplicationRecord
   private
 
   def sync_subscriptions
-    return unless schedule_ids.any?
+    return unless open? && schedule_ids.any?
 
     subscriptions = Subscription.where(schedule_id: schedule_ids)
     syncer = OrderManagement::Subscriptions::ProxyOrderSyncer.new(subscriptions)

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -29,6 +29,7 @@ class OrderCycle < ApplicationRecord
   attr_accessor :incoming_exchanges, :outgoing_exchanges
 
   before_update :reset_processed_at, if: :will_save_change_to_orders_close_at?
+  after_save :sync_subscriptions, if: :opening?
 
   validates :name, :coordinator_id, presence: true
   validate :orders_close_at_after_orders_open_at?
@@ -273,6 +274,14 @@ class OrderCycle < ApplicationRecord
   end
 
   private
+
+  def opening?
+    open? && orders_close_at_changed? && was_closed?
+  end
+
+  def was_closed?
+    orders_close_at_was && Time.zone.now > orders_close_at_was
+  end
 
   def sync_subscriptions
     return unless open? && schedule_ids.any?

--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -280,7 +280,7 @@ class OrderCycle < ApplicationRecord
   end
 
   def was_closed?
-    orders_close_at_previously_was && Time.zone.now > orders_close_at_previously_was
+    orders_close_at_previously_was.blank? || Time.zone.now > orders_close_at_previously_was
   end
 
   def sync_subscriptions

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -550,6 +550,30 @@ describe OrderCycle do
     end
   end
 
+  describe "syncing subscriptions" do
+    let!(:oc) {
+      create(:simple_order_cycle, orders_open_at: 1.week.ago, orders_close_at: 1.day.ago)
+    }
+    let(:schedule) { create(:schedule, order_cycles: [oc]) }
+    let!(:subscription) { create(:subscription, schedule: schedule, with_items: true) }
+
+    it "syncs subscriptions when transitioning from closed to open" do
+      expect(OrderManagement::Subscriptions::ProxyOrderSyncer).to receive(:new).and_call_original
+
+      expect{
+        oc.update(orders_close_at: 1.week.from_now)
+      }.to change{ ProxyOrder.count }
+    end
+
+    it "syncs subscriptions when transitioning from closed to upcoming" do
+      expect(OrderManagement::Subscriptions::ProxyOrderSyncer).to receive(:new).and_call_original
+
+      expect {
+        oc.update(orders_open_at: 1.day.from_now, orders_close_at: 1.week.from_now)
+      }.to change{ ProxyOrder.count }
+    end
+  end
+
   describe "processed_at " do
     let!(:oc) {
       create(:simple_order_cycle, orders_open_at: 1.week.ago, orders_close_at: 1.day.ago, processed_at: 1.hour.ago)

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -572,6 +572,18 @@ describe OrderCycle do
         oc.update(orders_open_at: 1.day.from_now, orders_close_at: 1.week.from_now)
       }.to change{ ProxyOrder.count }
     end
+
+    context "when the current dates are nil" do
+      before { oc.update(orders_open_at: nil, orders_close_at: nil) }
+
+      it "syncs subscriptions when transitioning from closed to open" do
+        expect(OrderManagement::Subscriptions::ProxyOrderSyncer).to receive(:new).and_call_original
+
+        expect{
+          oc.update(orders_open_at: 1.day.ago, orders_close_at: 1.week.from_now)
+        }.to change{ ProxyOrder.count }
+      end
+    end
   end
 
   describe "processed_at " do


### PR DESCRIPTION
#### What? Why?

Closes #8890 (hopefully)

Syncs subscriptions after cloning an order cycle with schedules.

#### What should we test?



#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->


