### PR TITLE
SplitCheckout: as guest user, after login should redirect to the first step of checkout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_checkout_redirect
-    return unless URI(request.referer.to_s).path == main_app.checkout_path
+    referer_path = URI(request.referer.to_s).path
+    return unless referer_path == main_app.checkout_path ||
+                  referer_path == main_app.checkout_step_path(:details)
 
     session["spree_user_return_to"] = main_app.checkout_path
   end

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -16,6 +16,8 @@ class SplitCheckoutController < ::BaseController
   helper 'spree/orders'
   helper OrderHelper
 
+  before_action :set_checkout_redirect
+
   def edit
     redirect_to_step unless params[:step]
   end

--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -46,4 +46,11 @@ module SplitCheckoutHelper
     click_button "Next - Payment method"
     expect(page).to have_button("Next - Order summary")
   end
+
+  def expect_to_be_on_first_step
+    expect(page).to have_content("1 - Your details")
+    expect(page).to have_selector("div.checkout-tab.selected", text: "1 - Your details")
+    expect(page).to have_content("2 - Payment method")
+    expect(page).to have_content("3 - Order summary")
+  end
 end

--- a/spec/system/consumer/shopping/checkout_auth_spec.rb
+++ b/spec/system/consumer/shopping/checkout_auth_spec.rb
@@ -66,12 +66,8 @@ describe "As a consumer I want to check out my cart", js: true do
           end
 
           context "and populating user details on (#{checkout_type})", if: checkout_type.eql?("split_checkout") do
-            it "currently redirects to the homepage" do
-              # currently redirects to the homepage due to bug #8894
-              expect(page).to have_content("Logged in successfully")
-            end
             it "should allow proceeding to the next step" do
-              pending("bug fix for #8894")
+              expect(page).to have_content("Logged in successfully")
               click_button "Next - Payment method"
               expect(page).to have_button("Next - Order summary")
             end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -103,10 +103,7 @@ describe "As a consumer, I want to checkout my order", js: true do
     it "should display the split checkout details page" do
       click_on "Checkout as guest"
       expect(page).to have_content distributor.name
-      expect(page).to have_content("1 - Your details")
-      expect(page).to have_selector("div.checkout-tab.selected", text: "1 - Your details")
-      expect(page).to have_content("2 - Payment method")
-      expect(page).to have_content("3 - Order summary")
+      expect_to_be_on_first_step
     end
 
     it "should display error when fields are empty" do

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -9,6 +9,7 @@ describe "As a consumer, I want to checkout my order", js: true do
   include StripeHelper
   include StripeStubs
   include PaypalHelper
+  include AuthenticationHelper
 
   let!(:zone) { create(:zone_with_member) }
   let(:supplier) { create(:supplier_enterprise) }
@@ -91,6 +92,23 @@ describe "As a consumer, I want to checkout my order", js: true do
   context "as a guest user" do
     before do
       visit checkout_path
+    end
+
+    context "actually user has an account and wants to login", :debug do
+      let(:user) { create(:user) }
+
+      it "should redirect to '/checkout/details' when user submit the login form" do
+        expect(page).to have_content("Ok, ready to checkout?")
+
+        click_on "Login"
+        within ".login-modal" do
+          fill_in_and_submit_login_form(user)
+        end
+
+        expect_logged_in
+        expect(page).not_to have_selector ".login-modal"
+        expect_to_be_on_first_step
+      end
     end
 
     it "should display the split checkout login/guest form" do


### PR DESCRIPTION
#### What? Why?

Closes #8894 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

- As guest user, proceed to checkout
- You should see the "Ok, ready to checkout?" page (with at least the login button)
- Click on login, should open the modal, fill the form and then proceed to login
- You should be redirected to the first step of the checkout and logged-in


#### Release notes

Changelog Category: Technical changes
