### PR TITLE
Displays fee names instead of fee types in the shopfront piechart tooltip

### DIFF
--- a/app/models/spree/variant.rb
+++ b/app/models/spree/variant.rb
@@ -170,6 +170,10 @@ module Spree
       OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle).fees_by_type_for self
     end
 
+    def fees_by_name_for(distributor, order_cycle)
+      OpenFoodNetwork::EnterpriseFeeCalculator.new(distributor, order_cycle).fees_by_name_for self
+    end
+
     def option_value(opt_name)
       option_values.detect { |o| o.option_type.name == opt_name }.try(:presentation)
     end

--- a/lib/open_food_network/enterprise_fee_calculator.rb
+++ b/lib/open_food_network/enterprise_fee_calculator.rb
@@ -40,6 +40,14 @@ module OpenFoodNetwork
       end.select { |_fee_type, amount| amount > 0 }
     end
 
+    def fees_by_name_for(variant)
+      per_item_enterprise_fee_applicators_for(variant).each_with_object({}) do |applicator, fees|
+        fees[applicator.enterprise_fee.fee_name.to_sym] ||= 0
+        fees[applicator.enterprise_fee.fee_name.to_sym] += calculate_fee_for variant,
+                                                                             applicator.enterprise_fee
+      end.select { |_fee_name, amount| amount > 0 }
+    end
+
     def create_line_item_adjustments_for(line_item)
       variant = line_item.variant
 


### PR DESCRIPTION
#### What? Why?

Closes #8899 and partially #8907

Displays fee names instead of fee types in the shopfront piechart tooltip.


#### What should we test?

- Setup enterprise fees on products announced in the OC;
- visit this products shopfront;
- click on the price breakdown piechart to see fee breakdown by names (not by fees);

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
