### PR TITLE
Gracefully handle admin UI failure on updating enterprise notifications

### DIFF
--- a/app/controllers/admin/enterprises_controller.rb
+++ b/app/controllers/admin/enterprises_controller.rb
@@ -234,8 +234,10 @@ module Admin
     end
 
     def update_enterprise_notifications
-      if params.key? :receives_notifications
-        @enterprise.update_contact params[:receives_notifications]
+      user_id = params[:receives_notifications].to_i
+
+      if user_id.positive? && @enterprise.user_ids.include?(user_id)
+        @enterprise.update_contact(user_id)
       end
     end
 

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -174,8 +174,6 @@ describe Admin::EnterprisesController, type: :controller do
       end
 
       it "updates the contact for notifications" do
-        pending "parameter sanitation: https://github.com/openfoodfoundation/openfoodnetwork/issues/8925"
-
         allow(controller).to receive_messages spree_current_user: distributor_manager
         params = {
           id: distributor,

--- a/spec/controllers/admin/enterprises_controller_spec.rb
+++ b/spec/controllers/admin/enterprises_controller_spec.rb
@@ -162,6 +162,30 @@ describe Admin::EnterprisesController, type: :controller do
         expect(distributor.users).to_not include user
       end
 
+      it "updates the contact for notifications" do
+        allow(controller).to receive_messages spree_current_user: distributor_manager
+        params = {
+          id: distributor,
+          receives_notifications: distributor_manager.id,
+        }
+
+        expect { spree_post :update, params }.
+          to change { distributor.contact }.to(distributor_manager)
+      end
+
+      it "updates the contact for notifications" do
+        pending "parameter sanitation: https://github.com/openfoodfoundation/openfoodnetwork/issues/8925"
+
+        allow(controller).to receive_messages spree_current_user: distributor_manager
+        params = {
+          id: distributor,
+          receives_notifications: "? object:null ?",
+        }
+
+        expect { spree_post :update, params }.
+          to_not change { distributor.contact }
+      end
+
       it "updates enterprise preferences" do
         allow(controller).to receive_messages spree_current_user: distributor_manager
         update_params = { id: distributor,


### PR DESCRIPTION
#### What? Why?

Closes #8925 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

It looks like some JS component can submit an invalid value as user id for an enterprise contact and it causes a server error.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Edit an enterprise.
- Update the user who receives notifications.
- Then update it again but this time, after you selected user and before you save, remove that user from the enterprise (e.g. remove a manager).
- The notification setting should not be updated and no error should be shown.

We could implement some user feedback here but I expect this case to be so rare that it's not worth it.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

