### PR TITLE
 Clarifies context in checkout_paypal_spec and implements the tests as shared example

### DIFF
--- a/spec/system/consumer/shopping/checkout_paypal_spec.rb
+++ b/spec/system/consumer/shopping/checkout_paypal_spec.rb
@@ -46,26 +46,15 @@ describe "Check out with Paypal", js: true do
     add_product_to_cart order, product
   end
 
-  context "as a guest" do
-    it "fails with an error message" do
-      visit checkout_path
-      checkout_as_guest
-      fill_out_form(free_shipping.name, paypal.name, save_default_addresses: false)
-
-      stub_paypal_response success: false
-
-      place_order
-      expect(page).to have_content "PayPal failed."
-    end
-  end
-
   context "as a registered user" do
-    before { login_as user }
-
-    it "completes the checkout after successful Paypal payment" do
+    before do
+      login_as user
       visit checkout_path
       fill_out_details
       fill_out_form(free_shipping.name, paypal.name, save_default_addresses: false)
+    end
+
+    it "completes the checkout after successful Paypal payment" do
 
       # Normally the checkout would redirect to Paypal, a form would be filled out there, and the
       # user would be redirected back to #confirm_paypal_path. Here we skip the PayPal part and
@@ -83,6 +72,13 @@ describe "Check out with Paypal", js: true do
 
       expect(order.reload.state).to eq "complete"
       expect(order.payments.count).to eq 1
+    end
+
+    it "fails with an error message" do
+      stub_paypal_response success: false
+
+      place_order
+      expect(page).to have_content "PayPal failed."
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

This came up [here](https://openfoodnetwork.slack.com/archives/C02TZ6X00/p1645615153328839).

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

This PR aims to clarify the context in which a Paypal error message appears to the user. It should work for both guest and logged in users. Also, for both user types, checkout should be possible. This is now tested under a shared example.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Clarifies context in checkout_paypal_spec and implements the tests as shared examples.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
