### PR TITLE
Include language metatags in html template when more than one language available

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,17 @@ module ApplicationHelper
     OpenFoodNetwork::FeatureToggle.enabled?(feature, user)
   end
 
+  def language_meta_tags
+    return if I18n.available_locales.one?
+
+    I18n.available_locales.map do |locale|
+      tag.link(
+        hreflang: locale.to_s.gsub("_", "-").downcase,
+        href: "#{request.protocol}#{request.host_with_port}/locales/#{locale}"
+      )
+    end.join("\n").html_safe
+  end
+
   def ng_form_for(name, *args, &block)
     options = args.extract_options!
 

--- a/app/views/layouts/darkswarm.html.haml
+++ b/app/views/layouts/darkswarm.html.haml
@@ -14,6 +14,7 @@
       = favicon_link_tag "/favicon-staging.ico"
     %link{href: "https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700", rel: "stylesheet", type: "text/css"}
     %link{href: asset_pack_path("media/fonts/OFN-v2.woff"), rel: "preload", as: "font", crossorigin: "anonymous"}
+    = language_meta_tags
 
     = stylesheet_pack_tag "darkswarm", "data-turbo-track": "reload"
     = javascript_pack_tag "application", "data-turbo-track": "reload"

--- a/app/views/layouts/registration.html.haml
+++ b/app/views/layouts/registration.html.haml
@@ -9,6 +9,7 @@
     - else
       = favicon_link_tag "/favicon-staging.ico"
     %link{href: "https://fonts.googleapis.com/css?family=Roboto:400,300italic,400italic,300,700,700italic|Oswald:300,400,700", rel: "stylesheet", type: "text/css"}
+    = language_meta_tags
 
     = stylesheet_pack_tag "darkswarm"
     = javascript_include_tag "darkswarm/all"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ApplicationHelper, type: :helper do
+  describe "#language_meta_tags" do
+    let(:request) { double("request", host_with_port: "test.host", protocol: "http://") }
+    before do
+      allow(helper).to receive(:request).and_return(request)
+    end
+
+    context "when there is more than one available locale" do
+      before do
+        allow(I18n).to receive(:available_locales) { ["en", "es", "pt"] }
+      end
+
+      it "displays a language tag for each available locale" do
+        expect(language_meta_tags).to include('<link hreflang="en" href="http://test.host/locales/en">')
+        expect(language_meta_tags).to include('<link hreflang="es" href="http://test.host/locales/es">')
+        expect(language_meta_tags).to include('<link hreflang="pt" href="http://test.host/locales/pt">')
+      end
+    end
+
+    context "when there is only one available locale" do
+      before do
+        allow(I18n).to receive(:available_locales) { ["en"] }
+      end
+
+      it "doesn't include any language tags" do
+        expect(language_meta_tags).to be_nil
+      end
+    end
+
+    context "when the availables locales have regional variations" do
+      before do
+        allow(I18n).to receive(:available_locales) { ["fr_CA", "en_CA"] }
+      end
+
+      it "includes the region code in the :hreflang attribute" do
+        expect(language_meta_tags).to include('<link hreflang="fr-ca" href="http://test.host/locales/fr_CA">')
+        expect(language_meta_tags).to include('<link hreflang="en-ca" href="http://test.host/locales/en_CA">')
+      end
+    end
+  end
+end

--- a/spec/views/layouts/darkswarm.html.haml_spec.rb
+++ b/spec/views/layouts/darkswarm.html.haml_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "layouts/darkswarm.html.haml" do
+  helper InjectionHelper
+  helper I18nHelper
+  helper ShopHelper
+
+  before do
+    allow(view).to receive_messages(
+      current_order: nil,
+      spree_current_user: nil
+    )
+  end
+
+  it "displays language tags when there is more than one available locale" do
+    render
+
+    expect(rendered).to include('<link hreflang="en" href="http://test.host/locales/en">')
+    expect(rendered).to include('<link hreflang="es" href="http://test.host/locales/es">')
+    expect(rendered).to include('<link hreflang="pt" href="http://test.host/locales/pt">')
+  end
+end

--- a/spec/views/layouts/registration.html.haml_spec.rb
+++ b/spec/views/layouts/registration.html.haml_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "layouts/registration.html.haml" do
+  helper InjectionHelper
+  helper I18nHelper
+  helper ShopHelper
+
+  before do
+    allow(view).to receive_messages(
+      current_order: nil,
+      spree_current_user: nil
+    )
+  end
+
+  it "displays language tags when there is more than one available locale" do
+    render
+
+    expect(rendered).to include('<link hreflang="en" href="http://test.host/locales/en">')
+    expect(rendered).to include('<link hreflang="es" href="http://test.host/locales/es">')
+    expect(rendered).to include('<link hreflang="pt" href="http://test.host/locales/pt">')
+  end
+end


### PR DESCRIPTION
#### What? Why?

This is to help Google find pages in all languages, it is based on their docs here https://developers.google.com/search/docs/advanced/crawling/localized-versions

Closes #8902

#### What should we test?

1. Go to an instance with more than one available language.
2. View the page source of a public page and check there is a `<link hreflang...` tag for each language.

#### Release notes

Changelog Category: Technical changes