### PR TITLE
Split checkout: Display "Update" button on the order table page unless order is complete

### DIFF
--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -22,7 +22,7 @@
       = render 'bought' if show_bought_items? && @order.cart?
 
       %tfoot#edit-cart
-        = render 'spree/orders/form/cart_actions_row' if @order.cart?
+        = render 'spree/orders/form/cart_actions_row' unless @order.complete?
 
         %tr
           %td.text-right{colspan:"3"}

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -154,11 +154,7 @@ describe "As a consumer, I want to checkout my order", js: true do
         expect(page).to have_current_path("/checkout/payment")
       end
 
-      context "when I have an out of stock product in my cart" do
-        pending("awaiting closure bug #8940") do
-          it_behaves_like "when I have an out of stock product in my cart"
-        end
-      end
+      it_behaves_like "when I have an out of stock product in my cart"
     end
   end
 


### PR DESCRIPTION
#### What? Why?

With the split checkout, we can access the `/cart` between the different steps: for this cases, cart actions should be displayed (and not only for the `cart` state)
Closes #8940 



#### What should we test?
###### With split_checkout feature toggle activated:
 - Proceed to checkout with a product that `on hand`
 - As an admin, set the stock of the product to `0`
 - Between each steps, you should be redirected to the `/cart` page with an "Update" button

###### With legacy checkout:
 - Proceed to checkout with a product that `on hand`
 - As an admin, set the stock of the product to `0`
 - Fill the form, and click on the submit button
 - you should be redirected to the `/cart` page with an "Update" button

This modification comes from an issue around the split checkout, but could impact the legacy checkout system: ie. the code is shared between split/legacy checkout.
I've tested this page for both split and legacy checkout and I didn't find any issue, but maybe I've missed some place where this page/table is used.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
