### PR TITLE
Delete linked coordinators fees when deleting an order cycle

### DIFF
--- a/app/models/order_cycle.rb
+++ b/app/models/order_cycle.rb
@@ -10,7 +10,8 @@ class OrderCycle < ApplicationRecord
   belongs_to :coordinator, class_name: 'Enterprise'
 
   has_many :coordinator_fee_refs, class_name: 'CoordinatorFee'
-  has_many :coordinator_fees, through: :coordinator_fee_refs, source: :enterprise_fee
+  has_many :coordinator_fees, through: :coordinator_fee_refs, source: :enterprise_fee,
+                              dependent: :destroy
 
   has_many :exchanges, dependent: :destroy
 

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -401,6 +401,20 @@ module Admin
           expect(flash[:error]).to eq I18n.t('admin.order_cycles.destroy_errors.schedule_present')
         end
       end
+
+      describe "when an order cycle has any coordinator_fees", :debug do
+        let(:enterprise_fee1) { create(:enterprise_fee) }
+
+        before do
+          oc.coordinator_fees << enterprise_fee1
+        end
+
+        it "displays an error message when we attempt to delete it" do
+          get :destroy, params: { id: oc.id }
+          expect(OrderCycle.find_by(id: oc.id)).to be nil
+          expect(response).to redirect_to admin_order_cycles_path
+        end
+      end
     end
   end
 end

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -402,17 +402,30 @@ module Admin
         end
       end
 
-      describe "when an order cycle has any coordinator_fees", :debug do
+      describe "when an order cycle has any coordinator_fees" do
         let(:enterprise_fee1) { create(:enterprise_fee) }
 
         before do
           oc.coordinator_fees << enterprise_fee1
         end
 
-        it "displays an error message when we attempt to delete it" do
+        it "actually delete the order cycle" do
           get :destroy, params: { id: oc.id }
           expect(OrderCycle.find_by(id: oc.id)).to be nil
           expect(response).to redirect_to admin_order_cycles_path
+        end
+
+        describe "when the order_cycle was previously cloned" do
+          let(:cloned) { oc.clone! }
+
+          it "actually delete the order cycle" do
+            get :destroy, params: { id: cloned.id }
+
+            expect(OrderCycle.find_by(id: cloned.id)).to be nil
+            expect(OrderCycle.find_by(id: oc.id)).to_not be nil
+            expect(EnterpriseFee.find_by(id: enterprise_fee1.id)).to_not be nil
+            expect(response).to redirect_to admin_order_cycles_path
+          end
         end
       end
     end


### PR DESCRIPTION
#### What? Why?
There was a `InvalidForeignKey` when deleting a cloned OrderCycle, due to existing `coordinators_fees`. This PR adds a `dependent: :destroy` on `coordinator_fees` for an `order_cycle`

Closes #5903

#### What should we test?

 - Clone an order cycle (with coordinator fees)
 - Delete the new created order cycle
 - This should be possible without any error


#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.

