### PR TITLE
Fix Angular interpolation for translations with apostrophes

### DIFF
--- a/app/views/shared/menu/_cart_sidebar.html.haml
+++ b/app/views/shared/menu/_cart_sidebar.html.haml
@@ -49,6 +49,8 @@
 
     %div.fullwidth
       %a.edit-cart.button.large.dark.left{href: main_app.cart_path, "ng-disabled" => "Cart.dirty || Cart.empty()", "ng-class" => "{ dirty: Cart.dirty }"}
-        = "{{ Cart.dirty ? '#{t(:cart_updating)}' : (Cart.empty() ? '#{t(:cart_empty)}' : '#{t('.edit_cart')}' ) }}"
+        %div{ ng: { if: "Cart.dirty" } }= t(:cart_updating)
+        %div{ ng: { if: "!Cart.dirty && Cart.empty()" } }= t(:cart_empty)
+        %div{ ng: { if: "!Cart.dirty && !Cart.empty()" } }= t('.edit_cart')
       %a.checkout.button.large.bright.right{href: main_app.checkout_path, "ng-disabled" => "Cart.dirty || Cart.empty()"}
         = t '.checkout'


### PR DESCRIPTION
#### What? Why?

The translations here contain apostrophes in the Welsh versions, and they were not playing nicely with this mix of nested Angular and Ruby interpolation. 

#### What should we test?

Deploying on a server with Welsh should be fine (UK Staging).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
