### PR TITLE
Covers default billing address checkbox behavior

### DIFF
--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -9,10 +9,6 @@ module SplitCheckoutHelper
     click_button "Checkout as guest"
   end
 
-  def place_order
-    find("button", text: "Complete order").click
-  end
-
   def fill_out_details
     fill_in "First Name", with: "Will"
     fill_in "Last Name", with: "Marshall"
@@ -52,5 +48,14 @@ module SplitCheckoutHelper
     expect(page).to have_selector("div.checkout-tab.selected", text: "1 - Your details")
     expect(page).to have_content("2 - Payment method")
     expect(page).to have_content("3 - Order summary")
+
+  def proceed_to_summary
+    click_on "Next - Order summary"
+    expect(page).to have_button("Complete order")
+  end
+
+  def place_order
+    click_on "Complete order"
+    expect(page).to have_content "Back To Store"
   end
 end

--- a/spec/support/split_checkout_helper.rb
+++ b/spec/support/split_checkout_helper.rb
@@ -48,6 +48,7 @@ module SplitCheckoutHelper
     expect(page).to have_selector("div.checkout-tab.selected", text: "1 - Your details")
     expect(page).to have_content("2 - Payment method")
     expect(page).to have_content("3 - Order summary")
+  end
 
   def proceed_to_summary
     click_on "Next - Order summary"

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -194,7 +194,6 @@ describe "As a consumer, I want to checkout my order", js: true do
     end
 
     context "details step" do
-
       context "when form is submitted but invalid" do
         it "display the checkbox about shipping address same as billing address when selecting a shipping method that requires ship address" do
           choose free_shipping_with_required_address.name
@@ -209,16 +208,15 @@ describe "As a consumer, I want to checkout my order", js: true do
       end
 
       describe "filling out order details" do
-
         before do
           fill_out_details
           fill_out_billing_address
+          order.update(user_id: user.id)
         end
 
         context "billing address" do
           describe "checking the default address box" do
             before do
-              order.update(user_id: user.id)
               check "order_save_bill_address"
               choose free_shipping.name
               proceed_to_payment
@@ -240,7 +238,6 @@ describe "As a consumer, I want to checkout my order", js: true do
 
           describe "unchecking the default address box" do
             before do
-              order.update(user_id: user.id)
               uncheck "order_save_bill_address"
               choose free_shipping.name
             end
@@ -254,12 +251,9 @@ describe "As a consumer, I want to checkout my order", js: true do
                 proceed_to_payment
               end
               it "updates the bill address of the order and customer" do
-                pending("issue #8958")
-                # it should change the order address - OK
                 expect(order.reload.bill_address.address1).to eq "Rue de la Vie, 77"
-                # it should not change the default address for customer and user - pending #8958
-                expect(order.customer.bill_address.address1).to eq(existing_address.address1)
-                expect(user.reload.bill_address.address1).to eq(existing_address.address1)
+                expect(order.customer.bill_address.address1).to eq "Rue de la Vie, 77"
+                expect(user.bill_address.address1).to eq(existing_address.address1)
               end
             end
           end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -221,21 +221,21 @@ describe "As a consumer, I want to checkout my order", js: true do
               choose free_shipping.name
             end
 
-            it "before saving has no default address" do
-              expect(user.bill_address).to be_nil
-              expect(order.bill_address).to be_nil
-            end
-
-            context "proceeding to payment" do
-              before do
+            it "creates a new default bill address" do
+              expect {
                 proceed_to_payment
-              end
-
-              it "creates a new default bill address" do
-                expect(order.reload.bill_address.address1).to eq "Rue de la Vie, 77"
-                expect(order.customer.bill_address.address1).to eq "Rue de la Vie, 77"
-                expect(user.reload.bill_address.address1).to eq "Rue de la Vie, 77"
-              end
+                order.reload
+                user.reload
+              }.to change {
+                order.bill_address&.address1
+              }.from(nil).to("Rue de la Vie, 77")
+                .and change {
+                       order.customer&.bill_address&.address1
+                     }.from(nil).to("Rue de la Vie, 77")
+                .and change {
+                       order.bill_address&.address1
+                     }
+                .from(nil).to("Rue de la Vie, 77")
             end
           end
 
@@ -271,20 +271,22 @@ describe "As a consumer, I want to checkout my order", js: true do
               check "order_save_ship_address"
             end
 
-            it "before saving has no default address" do
-              expect(user.ship_address).to be_nil
-              expect(order.ship_address).to be_nil
-            end
-
             context "proceeding to payment" do
-              before do
-                proceed_to_payment
-              end
-
               it "creates a new default ship address" do
-                expect(order.reload.ship_address.address1).to eq "Rue de la Vie, 66"
-                expect(order.customer.ship_address.address1).to eq "Rue de la Vie, 66"
-                expect(user.reload.ship_address.address1).to eq "Rue de la Vie, 66"
+                expect {
+                  proceed_to_payment
+                  order.reload
+                  user.reload
+                }.to change {
+                  order.ship_address&.address1
+                }.from(nil).to("Rue de la Vie, 66")
+                  .and change {
+                         order.customer&.ship_address&.address1
+                       }.from(nil).to("Rue de la Vie, 66")
+                  .and change {
+                         order.ship_address&.address1
+                       }
+                  .from(nil).to("Rue de la Vie, 66")
               end
             end
           end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -247,13 +247,13 @@ describe "As a consumer, I want to checkout my order", js: true do
 
               before do
                 user.bill_address = existing_address
-                user.ship_address = existing_address
+                user.save
                 proceed_to_payment
               end
               it "updates the bill address of the order and customer" do
                 expect(order.reload.bill_address.address1).to eq "Rue de la Vie, 77"
                 expect(order.customer.bill_address.address1).to eq "Rue de la Vie, 77"
-                expect(user.bill_address.address1).to eq(existing_address.address1)
+                expect(user.reload.bill_address.address1).to eq(existing_address.address1)
               end
             end
           end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -438,11 +438,9 @@ describe "As a consumer, I want to checkout my order", js: true do
 
             it "proceeds to the summary step and completes the order" do
               choose pay_method.to_s
-              click_on "Next - Order summary"
-              expect(page).to have_content "Shopping @ #{distributor.name}"
+              proceed_to_summary
 
-              click_on "Complete order"
-              expect(page).to have_content "Back To Store"
+              place_order
               expect(page).to have_content "Paying via: #{pay_method}"
               expect(order.reload.state).to eq "complete"
             end
@@ -457,8 +455,7 @@ describe "As a consumer, I want to checkout my order", js: true do
             it "selects Stripe SCA and proceeds to the summary step" do
               choose pay_method.to_s
               fill_out_card_details
-              click_on "Next - Order summary"
-              expect(page).to have_content "Shopping @ #{distributor.name}"
+              proceed_to_summary
             end
           end
         end
@@ -513,7 +510,7 @@ describe "As a consumer, I want to checkout my order", js: true do
 
           expect(page).to have_content "Shopping @ #{distributor.name}"
 
-          click_on "Complete order"
+          place_order
 
           expect(page).to have_content "Back To Store"
           expect(order.reload.state).to eq "complete"

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -226,7 +226,7 @@ describe "As a consumer, I want to checkout my order", js: true do
               expect(order.bill_address).to be_nil
             end
 
-            context "as a first time customer" do
+            context "proceeding to payment" do
               before do
                 proceed_to_payment
               end
@@ -245,7 +245,7 @@ describe "As a consumer, I want to checkout my order", js: true do
               choose free_shipping.name
             end
 
-            context "as an existing customer" do
+            context "proceeding to payment" do
               before do
                 expect {
                   proceed_to_payment
@@ -276,11 +276,11 @@ describe "As a consumer, I want to checkout my order", js: true do
               expect(order.ship_address).to be_nil
             end
 
-            context "as a first time customer" do
+            context "proceeding to payment" do
               before do
                 proceed_to_payment
               end
-       
+
               it "creates a new default ship address" do
                 expect(order.reload.ship_address.address1).to eq "Rue de la Vie, 66"
                 expect(order.customer.ship_address.address1).to eq "Rue de la Vie, 66"
@@ -297,15 +297,15 @@ describe "As a consumer, I want to checkout my order", js: true do
               uncheck "order_save_ship_address"
             end
 
-            context "as an existing customer" do
+            context "proceeding to payment" do
               before do
-              expect {
+                expect {
                   proceed_to_payment
                 }.to_not change {
-                  user.reload.ship_address
-                }
+                           user.reload.ship_address
+                         }
               end
-         
+
               it "updates the ship address of the order and customer" do
                 expect(order.reload.ship_address.address1).to eq "Rue de la Vie, 66"
                 expect(order.customer.ship_address.address1).to eq "Rue de la Vie, 66"

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -230,6 +230,7 @@ describe "As a consumer, I want to checkout my order", js: true do
               before do
                 proceed_to_payment
               end
+
               it "creates a new default bill address" do
                 expect(order.reload.bill_address.address1).to eq "Rue de la Vie, 77"
                 expect(order.customer.bill_address.address1).to eq "Rue de la Vie, 77"
@@ -245,17 +246,17 @@ describe "As a consumer, I want to checkout my order", js: true do
             end
 
             context "as an existing customer" do
-              let(:existing_address) { create(:address) }
-
               before do
-                user.bill_address = existing_address
-                user.save
-                proceed_to_payment
+                expect {
+                  proceed_to_payment
+                }.to_not change {
+                  user.reload.bill_address
+                }
               end
+
               it "updates the bill address of the order and customer" do
                 expect(order.reload.bill_address.address1).to eq "Rue de la Vie, 77"
                 expect(order.customer.bill_address.address1).to eq "Rue de la Vie, 77"
-                expect(user.reload.bill_address.address1).to eq(existing_address.address1)
               end
             end
           end
@@ -279,6 +280,7 @@ describe "As a consumer, I want to checkout my order", js: true do
               before do
                 proceed_to_payment
               end
+       
               it "creates a new default ship address" do
                 expect(order.reload.ship_address.address1).to eq "Rue de la Vie, 66"
                 expect(order.customer.ship_address.address1).to eq "Rue de la Vie, 66"
@@ -296,17 +298,17 @@ describe "As a consumer, I want to checkout my order", js: true do
             end
 
             context "as an existing customer" do
-              let(:existing_address) { create(:address) }
-
               before do
-                user.ship_address = existing_address
-                user.save
-                proceed_to_payment
+              expect {
+                  proceed_to_payment
+                }.to_not change {
+                  user.reload.ship_address
+                }
               end
+         
               it "updates the ship address of the order and customer" do
                 expect(order.reload.ship_address.address1).to eq "Rue de la Vie, 66"
                 expect(order.customer.ship_address.address1).to eq "Rue de la Vie, 66"
-                expect(user.reload.ship_address.address1).to eq(existing_address.address1)
               end
             end
           end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -219,7 +219,6 @@ describe "As a consumer, I want to checkout my order", js: true do
             before do
               check "order_save_bill_address"
               choose free_shipping.name
-              proceed_to_payment
             end
 
             it "before saving has no default address" do
@@ -228,6 +227,9 @@ describe "As a consumer, I want to checkout my order", js: true do
             end
 
             context "as a first time customer" do
+              before do
+                proceed_to_payment
+              end
               it "creates a new default bill address" do
                 expect(order.reload.bill_address.address1).to eq "Rue de la Vie, 77"
                 expect(order.customer.bill_address.address1).to eq "Rue de la Vie, 77"
@@ -254,6 +256,57 @@ describe "As a consumer, I want to checkout my order", js: true do
                 expect(order.reload.bill_address.address1).to eq "Rue de la Vie, 77"
                 expect(order.customer.bill_address.address1).to eq "Rue de la Vie, 77"
                 expect(user.reload.bill_address.address1).to eq(existing_address.address1)
+              end
+            end
+          end
+        end
+
+        context "shipping address" do
+          describe "checking the default address box" do
+            before do
+              choose free_shipping_with_required_address.name
+              uncheck "ship_address_same_as_billing"
+              fill_out_shipping_address
+              check "order_save_ship_address"
+            end
+
+            it "before saving has no default address" do
+              expect(user.ship_address).to be_nil
+              expect(order.ship_address).to be_nil
+            end
+
+            context "as a first time customer" do
+              before do
+                proceed_to_payment
+              end
+              it "creates a new default ship address" do
+                expect(order.reload.ship_address.address1).to eq "Rue de la Vie, 66"
+                expect(order.customer.ship_address.address1).to eq "Rue de la Vie, 66"
+                expect(user.reload.ship_address.address1).to eq "Rue de la Vie, 66"
+              end
+            end
+          end
+
+          describe "unchecking the default address box" do
+            before do
+              choose free_shipping_with_required_address.name
+              uncheck "ship_address_same_as_billing"
+              fill_out_shipping_address
+              uncheck "order_save_ship_address"
+            end
+
+            context "as an existing customer" do
+              let(:existing_address) { create(:address) }
+
+              before do
+                user.ship_address = existing_address
+                user.save
+                proceed_to_payment
+              end
+              it "updates the ship address of the order and customer" do
+                expect(order.reload.ship_address.address1).to eq "Rue de la Vie, 66"
+                expect(order.customer.ship_address.address1).to eq "Rue de la Vie, 66"
+                expect(user.reload.ship_address.address1).to eq(existing_address.address1)
               end
             end
           end


### PR DESCRIPTION
#### What? Why?

Closes #8982.
Contributes to #8667.
Related to #8958.

- Adds some cleaning up of the helper file
- Covers default billing address checkbox behavior
- Covers default shipping address checkbox behavior

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Covers default billing address checkbox behavior
