### PR TITLE
SplitCheckout: Display shipping options checkboxes on invalid form submit

### DIFF
--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -89,7 +89,7 @@
           = shipping_method_form.label shipping_method.id, shipping_method.name, {for: "shipping_method_" + shipping_method.id.to_s }
           %em.light
             = payment_or_shipping_price(shipping_method, @order)
-          - display_ship_address = (shipping_method.id == selected_shipping_method.to_i && shipping_method.require_ship_address)
+          - display_ship_address = display_ship_address || (shipping_method.id == selected_shipping_method.to_i && shipping_method.require_ship_address)
           - if shipping_method.id == selected_shipping_method.to_i
             - ship_method_description = shipping_method.description
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -98,7 +98,7 @@ describe "As a consumer, I want to checkout my order", js: true do
       visit checkout_path
     end
 
-    context "actually user has an account and wants to login", :debug do
+    context "actually user has an account and wants to login" do
       let(:user) { create(:user) }
 
       it "should redirect to '/checkout/details' when user submit the login form" do


### PR DESCRIPTION
#### What? Why?

Closes #8963
This happens in certain conditions: when the selected shipping method actually required a shipping address *and* is placed before (at least) one shipping method that do not required shipping address. 
<img width="635" alt="Capture d’écran 2022-03-07 à 16 42 37" src="https://user-images.githubusercontent.com/296452/157067034-25e700b9-871f-4773-82a7-a977eecb8efb.png">



#### What should we test?
- Proceed to checkout
- Select a shipping method that requires a shipping address
- Click on "Next - Payment method" with an invalid/incomplete form
- Checkbox "Shipping address same as billing address?" should be visible
- Depending if you're connected or not, "Save as default shipping address" should be visible too

#### Release notes


Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

