### PR TITLE
Splitcheckout: Don't save bill|ship address when associated checkbox is not checked during checkout process

### DIFF
--- a/app/services/default_address_updater.rb
+++ b/app/services/default_address_updater.rb
@@ -27,14 +27,14 @@ class DefaultAddressUpdater
            :bill_address_id, :ship_address_id, to: :order
 
   def assign_bill_addresses
-    return unless save_bill_address
+    return if save_bill_address == "0"
 
     customer.bill_address_id = bill_address_id
     user&.bill_address_id = bill_address_id
   end
 
   def assign_ship_addresses
-    return unless save_ship_address
+    return if save_ship_address == "0"
 
     customer.ship_address_id = ship_address_id
     user&.ship_address_id = ship_address_id

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -85,14 +85,14 @@ describe SplitCheckoutController, type: :controller do
 
         describe "saving default addresses" do
           it "updates default bill address on user and customer" do
-            put :update, params: params.merge({ order: { save_bill_address: true } })
+            put :update, params: params.merge({ order: { save_bill_address: "1" } })
 
             expect(order.customer.bill_address).to eq(order.bill_address)
             expect(order.user.bill_address).to eq(order.bill_address)
           end
 
           it "updates default ship address on user and customer" do
-            put :update, params: params.merge({ order: { save_ship_address: true } })
+            put :update, params: params.merge({ order: { save_ship_address: "1" } })
 
             expect(order.customer.ship_address).to eq(order.ship_address)
             expect(order.user.ship_address).to eq(order.ship_address)

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -84,11 +84,27 @@ describe SplitCheckoutController, type: :controller do
         end
 
         describe "saving default addresses" do
+          it "don't updates default bill address on user" do
+            expect {
+              put :update, params: params.merge({ order: { save_bill_address: "0" } })
+            }.to_not change {
+              order.user.reload.bill_address
+            }
+          end
+
           it "updates default bill address on user and customer" do
             put :update, params: params.merge({ order: { save_bill_address: "1" } })
 
             expect(order.customer.bill_address).to eq(order.bill_address)
             expect(order.user.bill_address).to eq(order.bill_address)
+          end
+
+          it "don't updates default ship address on user" do
+            expect {
+              put :update, params: params.merge({ order: { save_bill_address: "0" } })
+            }.to_not change {
+              order.user.reload.ship_address
+            }
           end
 
           it "updates default ship address on user and customer" do


### PR DESCRIPTION
#### What? Why?

Closes #8958
This PR improve the check before saving or not the bill/shop address: default value for checkbox are `0` and `1`

> The checked_value defaults to 1 while the default unchecked_value is set to 0 which is convenient for boolean values.

_Source:_ 
https://apidock.com/rails/ActionView/Helpers/FormHelper/check_box



#### What should we test?


- Proceed to checkout with an existing user
- Change billing address
- Uncheck "Save as default billing address" 
- Check on `/admin/customers` that user billing address did not change

#### Release notes


Changelog Category: User facing changes 
The title of the pull request will be included in the release notes.
