### PR TITLE
Docker: upgrade nodeJs from 10 to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,10 @@ RUN sh -c "echo 'deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main'
     apt-get update && \
     apt-get install -yqq --no-install-recommends postgresql-client-9.5 libpq-dev
 
-# Install node & yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && \
-    apt-get install -y nodejs yarn
+# Install NodeJs and yarn
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get install --no-install-recommends -y nodejs \
+    && npm install -g yarn
 
 # Install Chrome
 RUN wget --quiet -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \


### PR DESCRIPTION
Upgrade nodeJs form 10 to 12, because some package have been upgraded and now needs node >= 12