### PR TITLE
Improve the way we get the unit value (g, oz, lb, ...) in the Bulk Order Management interface

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -130,7 +130,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.getLineItemScale = (lineItem) ->
     if lineItem.units_product && lineItem.units_variant && (lineItem.units_product.variant_unit == "weight" || lineItem.units_product.variant_unit == "volume") 
-      VariantUnitManager.getScale(lineItem.units_variant.unit_value, lineItem.units_product.variant_unit)
+      lineItem.units_product.variant_unit_scale
     else
       1
 
@@ -154,7 +154,7 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.getScale = (unitsProduct, unitsVariant) ->
     if unitsProduct.hasOwnProperty("variant_unit") && (unitsProduct.variant_unit == "weight" || unitsProduct.variant_unit == "volume")
-      VariantUnitManager.getScale(unitsVariant.unit_value, unitsProduct.variant_unit)
+      unitsProduct.variant_unit_scale
     else
       null
 

--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -37,17 +37,6 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
       options.push [[I18n.t('items'), 'items']]
       options = [].concat options...
 
-    @getScale: (value, unitType) ->
-      scaledValue = null
-      validScales = []
-      unitScales = VariantUnitManager.unitScales(unitType)
-
-      validScales.unshift scale for scale in unitScales when value/scale >= 1
-      if validScales.length > 0
-        validScales[0]
-      else
-        unitScales[0]
-
     @getUnitName: (scale, unitType) ->
       if @units[unitType][scale]
         @units[unitType][scale]['name']

--- a/app/serializers/api/admin/units_product_serializer.rb
+++ b/app/serializers/api/admin/units_product_serializer.rb
@@ -3,7 +3,7 @@
 module Api
   module Admin
     class UnitsProductSerializer < ActiveModel::Serializer
-      attributes :id, :name, :group_buy_unit_size, :variant_unit
+      attributes :id, :name, :group_buy_unit_size, :variant_unit, :variant_unit_scale
     end
   end
 end

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -221,10 +221,10 @@ describe "LineItemsCtrl", ->
 
         it "returns the sum of the final_weight_volumes for line_items with both metric and imperial units", ->
           scope.filteredLineItems = [
-            { final_weight_volume: 907.2, units_product: { variant_unit: "weight" }, units_variant: { unit_value: 453.6 } }
-            { final_weight_volume: 2000, units_product: { variant_unit: "weight" }, units_variant: { unit_value: 1000 } }
-            { final_weight_volume: 56.7, units_product: { variant_unit: "weight" }, units_variant: { unit_value: 28.35 } }
-            { final_weight_volume: 2, units_product: { variant_unit: "volume" }, units_variant: { unit_value: 1.0 } }
+            { final_weight_volume: 907.2, units_product: { variant_unit: "weight", variant_unit_scale: 453.6 }, units_variant: { unit_value: 453.6 } }
+            { final_weight_volume: 2000, units_product: { variant_unit: "weight", variant_unit_scale: 1000 }, units_variant: { unit_value: 1000 } }
+            { final_weight_volume: 56.7, units_product: { variant_unit: "weight", variant_unit_scale: 28.35 }, units_variant: { unit_value: 28.35 } }
+            { final_weight_volume: 2, units_product: { variant_unit: "volume", variant_unit_scale: 1.0 }, units_variant: { unit_value: 1.0 } }
           ]
           expect(scope.sumUnitValues()).toEqual 8
 
@@ -254,7 +254,7 @@ describe "LineItemsCtrl", ->
           expect(Math.round).not.toHaveBeenCalled()
 
         it "calls Math.round() if variant_unit is 'weight' or 'volume'", ->
-          unitsProduct = { variant_unit: "weight" }
+          unitsProduct = { variant_unit: "weight", variant_unit_scale: 1 }
           scope.formattedValueWithUnitName(1,unitsProduct,unitsVariant)
           expect(Math.round).toHaveBeenCalled()
           scope.selectedUnitsVariant = { variant_unit: "volume" }
@@ -262,21 +262,18 @@ describe "LineItemsCtrl", ->
           expect(Math.round).toHaveBeenCalled()
 
         it "calls Math.round with the value multiplied by 1000", ->
-          unitsProduct = { variant_unit: "weight" }
-          spyOn(VariantUnitManager, "getScale").and.returnValue 5
+          unitsProduct = { variant_unit: "weight", variant_unit_scale: 5 }
           scope.formattedValueWithUnitName(10, unitsProduct,unitsVariant)
           expect(Math.round).toHaveBeenCalledWith 10 * 1000
 
         it "returns the result of Math.round divided by 1000, followed by the result of getUnitName", ->
-          unitsProduct = { variant_unit: "weight" }
-          spyOn(VariantUnitManager, "getScale").and.returnValue 1000
+          unitsProduct = { variant_unit: "weight", variant_unit_scale: 1000 }
           spyOn(VariantUnitManager, "getUnitName").and.returnValue "kg"
           expect(scope.formattedValueWithUnitName(2,unitsProduct,unitsVariant)).toEqual "2 kg"
 
         it "handle correclty the imperial units", ->
-          unitsProduct = { variant_unit: "weight" }
+          unitsProduct = { variant_unit: "weight", variant_unit_scale: 1000 }
           unitsVariant = { unit_value: "453.6" }
-          spyOn(VariantUnitManager, "getScale").and.returnValue 1000
           spyOn(VariantUnitManager, "getUnitName").and.returnValue "lb"
           expect(scope.formattedValueWithUnitName(2, unitsProduct, unitsVariant)).toEqual "2 lb"
 

--- a/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/variant_unit_manager_spec.js.coffee
@@ -10,21 +10,6 @@ describe "VariantUnitManager", ->
   beforeEach inject (_VariantUnitManager_) ->
     VariantUnitManager = _VariantUnitManager_
 
-  describe "getScale", ->
-    it "returns the largest scale for which value/scale is greater than 1", ->
-      expect(VariantUnitManager.getScale(1.2,"weight")).toEqual 1.0
-      expect(VariantUnitManager.getScale(1000,"weight")).toEqual 1000.0
-      expect(VariantUnitManager.getScale(0.0012,"volume")).toEqual 0.001
-      expect(VariantUnitManager.getScale(1001,"volume")).toEqual 1000.0
-
-    it "returns the smallest unit available when value is smaller", ->
-      expect(VariantUnitManager.getScale(0.4,"weight")).toEqual 1
-      expect(VariantUnitManager.getScale(0.0004,"volume")).toEqual 0.001
-
-    it "returns the right unit when using imperial units", ->
-      expect(VariantUnitManager.getScale(453.6, "weight")).toEqual 453.6
-      expect(VariantUnitManager.getScale(28.35, "weight")).toEqual 28.35
-
   describe "getUnitName", ->
     it "returns the unit name based on the scale and unit type (weight/volume) provided", ->
       expect(VariantUnitManager.getUnitName(1, "weight")).toEqual "g"

--- a/spec/system/admin/bulk_order_management_spec.rb
+++ b/spec/system/admin/bulk_order_management_spec.rb
@@ -817,15 +817,15 @@ describe '
 
         within "div#group_buy_calculation" do
           expect(page).to have_text "Group Buy Unit Size"
-          expect(page).to have_text "5 kg"
+          expect(page).to have_text "5000 g"
           expect(page).to have_text "Total Quantity Ordered"
-          expect(page).to have_text "4 kg"
+          expect(page).to have_text "4000 g"
           expect(page).to have_text "Max Quantity Ordered"
-          expect(page).to have_text "9 kg"
+          expect(page).to have_text "9000 g"
           expect(page).to have_text "Current Fulfilled Units"
-          expect(page).to have_text "0.8"
+          expect(page).to have_text "800"
           expect(page).to have_text "Max Fulfilled Units"
-          expect(page).to have_text "1.8"
+          expect(page).to have_text "1800"
           expect(page).to have_selector "div.shared_resource", visible: true
           within "div.shared_resource" do
             expect(page).to have_selector "span", text: "Shared Resource?"


### PR DESCRIPTION
#### What? Why?
This PR change the UnitsProductSerializer to embed the `variant_unit_scale` and use it in the Bulk Order Managment interface to retrieve scale of a product
Closes #8965

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Well...

 - We should obviously test the steps that triggered the bug (having a product with more that 100 as its unit value).
 - But we also should test the interface as well, and confirmed that #8565 is still valid

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

