### PR TITLE
Ability to configure order cycles so the shop owners do not receive a copy of each order confirmation email

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -366,7 +366,9 @@ module Spree
       return if subscription.present?
 
       Spree::OrderMailer.confirm_email_for_customer(id).deliver_later(wait: 10.seconds)
-      Spree::OrderMailer.confirm_email_for_shop(id).deliver_later(wait: 10.seconds)
+      if order_cycle&.send_order_confirm_email_to_shop
+        Spree::OrderMailer.confirm_email_for_shop(id).deliver_later(wait: 10.seconds)
+      end
     end
 
     # Helper methods for checkout steps

--- a/app/services/permitted_attributes/order_cycle.rb
+++ b/app/services/permitted_attributes/order_cycle.rb
@@ -16,7 +16,7 @@ module PermittedAttributes
       [
         :name, :orders_open_at, :orders_close_at, :coordinator_id,
         :preferred_product_selection_from_coordinator_inventory_only,
-        :automatic_notifications,
+        :automatic_notifications, :send_order_confirm_email_to_shop,
         { schedule_ids: [], coordinator_fee_ids: [] }
       ]
     end

--- a/app/views/admin/order_cycles/_advanced_settings.html.haml
+++ b/app/views/admin/order_cycles/_advanced_settings.html.haml
@@ -23,6 +23,14 @@
       = f.check_box :automatic_notifications
 
   .row
+    .alpha.three.columns
+      = f.label :automatic_notifications, t('.send_order_confirm_email_to_shop')
+      .with-tip{ 'data-powertip' => t('.send_order_confirm_email_to_shop_tip') }
+        %a= t('admin.whats_this')
+    .omega.eight.columns
+      = f.check_box :send_order_confirm_email_to_shop
+
+  .row
     .sixteen.columns.alpha.omega.text-center
       %input{ type: 'submit', value: t('.save_reload') }
       %a{ href: "#", onClick: "toggleSettings()" }= t(:close)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1145,6 +1145,8 @@ en:
         preferred_product_selection_from_coordinator_inventory_only_here: Coordinator's Inventory Only
         preferred_product_selection_from_coordinator_inventory_only_all: All Available Products
         save_reload: Save and Reload Page
+        send_order_confirm_email_to_shop: Send a copy of each order to the shop
+        send_order_confirm_email_to_shop_tip: Shoppers get a confirmation email after they finalize their order. Check this checkbox to send a copy of this confirmation email to the shop
       order_cycle_top_buttons:
         advanced_settings: "Advanced Settings"
       coordinator_fees:

--- a/db/migrate/20220308134807_add_send_order_confirm_email_to_shop_to_order_cycles.rb
+++ b/db/migrate/20220308134807_add_send_order_confirm_email_to_shop_to_order_cycles.rb
@@ -1,0 +1,5 @@
+class AddSendOrderConfirmEmailToShopToOrderCycles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :order_cycles, :send_order_confirm_email_to_shop, :boolean, default: true
+  end
+end

--- a/db/migrate/20220308134807_add_send_order_confirm_email_to_shop_to_order_cycles.rb
+++ b/db/migrate/20220308134807_add_send_order_confirm_email_to_shop_to_order_cycles.rb
@@ -1,5 +1,5 @@
 class AddSendOrderConfirmEmailToShopToOrderCycles < ActiveRecord::Migration[6.1]
   def change
-    add_column :order_cycles, :send_order_confirm_email_to_shop, :boolean, default: true
+    add_column :order_cycles, :send_order_confirm_email_to_shop, :boolean, default: true, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -298,7 +298,7 @@ ActiveRecord::Schema.define(version: 2022_03_08_134807) do
     t.datetime "processed_at"
     t.boolean "automatic_notifications", default: false
     t.boolean "mails_sent", default: false
-    t.boolean "send_order_confirm_email_to_shop", default: true
+    t.boolean "send_order_confirm_email_to_shop", default: true, null: false
   end
 
   create_table "producer_properties", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_18_053107) do
+ActiveRecord::Schema.define(version: 2022_03_08_134807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -298,6 +298,7 @@ ActiveRecord::Schema.define(version: 2022_01_18_053107) do
     t.datetime "processed_at"
     t.boolean "automatic_notifications", default: false
     t.boolean "mails_sent", default: false
+    t.boolean "send_order_confirm_email_to_shop", default: true
   end
 
   create_table "producer_properties", force: :cascade do |t|

--- a/spec/controllers/admin/order_cycles_controller_spec.rb
+++ b/spec/controllers/admin/order_cycles_controller_spec.rb
@@ -227,6 +227,17 @@ module Admin
           spree_put :update, params.
             merge(order_cycle: { automatic_notifications: true })
         end
+
+        it "can update preference send_order_confirm_email_to_shop" do
+          expect(OrderCycleForm).to receive(:new).
+            with(order_cycle,
+                 { "send_order_confirm_email_to_shop" => false },
+                 anything) { form_mock }
+          allow(form_mock).to receive(:save) { true }
+
+          spree_put :update, params.
+            merge(order_cycle: { send_order_confirm_email_to_shop: false })
+        end
       end
     end
 

--- a/spec/models/order_cycle_spec.rb
+++ b/spec/models/order_cycle_spec.rb
@@ -373,7 +373,8 @@ describe OrderCycle do
     oc = create(:simple_order_cycle,
                 coordinator_fees: [create(:enterprise_fee, enterprise: coordinator)],
                 preferred_product_selection_from_coordinator_inventory_only: true,
-                automatic_notifications: true, processed_at: Time.zone.now, mails_sent: true)
+                automatic_notifications: true, send_order_confirm_email_to_shop: false,
+                processed_at: Time.zone.now, mails_sent: true)
     schedule = create(:schedule, order_cycles: [oc])
     ex1 = create(:exchange, order_cycle: oc)
     ex2 = create(:exchange, order_cycle: oc)
@@ -386,6 +387,7 @@ describe OrderCycle do
     expect(occ.coordinator).not_to be_nil
     expect(occ.preferred_product_selection_from_coordinator_inventory_only).to be true
     expect(occ.automatic_notifications).to eq(oc.automatic_notifications)
+    expect(occ.send_order_confirm_email_to_shop).to eq(oc.send_order_confirm_email_to_shop)
     expect(occ.processed_at).to eq(nil)
     expect(occ.mails_sent).to eq(nil)
     expect(occ.coordinator).to eq(oc.coordinator)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -171,9 +171,24 @@ describe Spree::Order do
 
     it "sends confirmation emails to both the user and the shop owner" do
       mailer = double(:mailer, deliver_later: true)
+      oc = double(:order_cycle)
+      allow(oc).to receive(:send_order_confirm_email_to_shop) { true }
+      allow(order).to receive(:order_cycle) { oc }
 
       expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return(mailer)
       expect(Spree::OrderMailer).to receive(:confirm_email_for_shop).and_return(mailer)
+
+      order.finalize!
+    end
+
+    it "sends confirmation emails only to the user" do
+      mailer = double(:mailer, deliver_later: true)
+      oc = double(:order_cycle)
+      allow(oc).to receive(:send_order_confirm_email_to_shop) { false }
+      allow(order).to receive(:order_cycle) { oc }
+
+      expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return(mailer)
+      expect(Spree::OrderMailer).not_to receive(:confirm_email_for_shop)
 
       order.finalize!
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -169,30 +169,6 @@ describe Spree::Order do
       expect(order.shipment_state).to eq 'ready'
     end
 
-    it "sends confirmation emails to both the user and the shop owner" do
-      mailer = double(:mailer, deliver_later: true)
-      oc = double(:order_cycle)
-      allow(oc).to receive(:send_order_confirm_email_to_shop) { true }
-      allow(order).to receive(:order_cycle) { oc }
-
-      expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return(mailer)
-      expect(Spree::OrderMailer).to receive(:confirm_email_for_shop).and_return(mailer)
-
-      order.finalize!
-    end
-
-    it "sends confirmation emails only to the user" do
-      mailer = double(:mailer, deliver_later: true)
-      oc = double(:order_cycle)
-      allow(oc).to receive(:send_order_confirm_email_to_shop) { false }
-      allow(order).to receive(:order_cycle) { oc }
-
-      expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return(mailer)
-      expect(Spree::OrderMailer).not_to receive(:confirm_email_for_shop)
-
-      order.finalize!
-    end
-
     it "should freeze all adjustments" do
       allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_later
       adjustments = double
@@ -890,10 +866,26 @@ describe Spree::Order do
     let!(:distributor) { create(:distributor_enterprise) }
     let!(:order) { create(:order, distributor: distributor) }
 
-    it "sends confirmation emails" do
+    it "sends confirmation emails to both the user and the shop owner" do
       mailer = double(:mailer, deliver_later: true)
+      oc = double(:order_cycle)
+      allow(oc).to receive(:send_order_confirm_email_to_shop) { true }
+      allow(order).to receive(:order_cycle) { oc }
+
       expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return(mailer)
       expect(Spree::OrderMailer).to receive(:confirm_email_for_shop).and_return(mailer)
+
+      order.deliver_order_confirmation_email
+    end
+
+    it "sends confirmation emails only to the user" do
+      mailer = double(:mailer, deliver_later: true)
+      oc = double(:order_cycle)
+      allow(oc).to receive(:send_order_confirm_email_to_shop) { false }
+      allow(order).to receive(:order_cycle) { oc }
+
+      expect(Spree::OrderMailer).to receive(:confirm_email_for_customer).and_return(mailer)
+      expect(Spree::OrderMailer).not_to receive(:confirm_email_for_shop)
 
       order.deliver_order_confirmation_email
     end


### PR DESCRIPTION
#### What? Why?

Closes openfoodfoundation/openfoodnetwork#8978

#### What should we test?

- Create Order cycle
- Go to advance settings and uncheck "SEND A COPY OF EACH ORDER TO THE SHOP"
- Go the the shopfront and create an order
- Shopper should still receive the confirmation email, but shop owner should not
- Duplicate the OC
- Configuration should be kept the same (unchecked)
- check again the checkbox
- Create an order within this duplicated order_cycle
- Both Shopper and shop owner should now receive a copy
 
#### Release notes

Changelog Category: Admin change

#### Documentation updates

If needed we could describe this feature in the wiki page regadring order cycle, but it seems self explanatory
