### PR TITLE
Split-checkout transaction and shipping fees

### DIFF
--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -239,6 +239,9 @@ describe "As a consumer, I want to checkout my order", js: true do
                   within "#line-items" do
                     expect(page).to have_content("Shipping #{with_currency(4.56)}")
                   end
+                  if checkout_page.eql?("order confirmation")
+                    expect(page).to have_content "Your order has been processed successfully"
+                  end
                 end
               end
               
@@ -368,6 +371,9 @@ describe "As a consumer, I want to checkout my order", js: true do
           it "on the #{checkout_page} page" do
             within "#line-items" do
               expect(page).to have_content("Transaction fee #{with_currency(1.23)}")
+            end
+            if checkout_page.eql?("order confirmation")
+              expect(page).to have_content "Your order has been processed successfully"
             end
           end
         end

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -43,9 +43,11 @@ describe "As a consumer, I want to checkout my order", js: true do
                              name: "Shipping with Fee", description: "blue",
                              calculator: Calculator::FlatRate.new(preferred_amount: 4.56))
   }
-  let!(:payment_with_fee) { create(:payment_method, distributors: [distributor],
-                             name: "Payment with Fee", description: "Payment with fee",
-                             calculator: Calculator::FlatRate.new(preferred_amount: 1.23)) }
+  let!(:payment_with_fee) {
+    create(:payment_method, distributors: [distributor],
+                            name: "Payment with Fee", description: "Payment with fee",
+                            calculator: Calculator::FlatRate.new(preferred_amount: 1.23))
+  }
 
   before do
     allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
@@ -212,7 +214,7 @@ describe "As a consumer, I want to checkout my order", js: true do
             end
 
             it "displays the shipping fee" do
-              expect(page).to have_content("#{shipping_with_fee.name} " + "#{with_currency(4.56)}")
+              expect(page).to have_content("#{shipping_with_fee.name} " + with_currency(4.56).to_s)
             end
 
             it "does not display the shipping address form" do
@@ -244,7 +246,7 @@ describe "As a consumer, I want to checkout my order", js: true do
                   end
                 end
               end
-              
+
               it_behaves_like "displays the shipping fee", "order summary"
 
               context "after completing the order" do
@@ -377,7 +379,7 @@ describe "As a consumer, I want to checkout my order", js: true do
             end
           end
         end
-        
+
         it_behaves_like "displays the transaction fee", "order summary"
 
         context "after completing the order" do


### PR DESCRIPTION
#### What? Why?

Continues #8667 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds transaction and shipping fees coverage on split-checkout.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds transaction and shipping fees coverage on split-checkout

