### PR TITLE
shipping fees on admin: avoid backend error when updating calculator type

### DIFF
--- a/app/assets/javascripts/admin/enterprise_fees/directives/ensure_calculator_preferences_match_type.js.coffee
+++ b/app/assets/javascripts/admin/enterprise_fees/directives/ensure_calculator_preferences_match_type.js.coffee
@@ -9,9 +9,9 @@ angular.module("admin.enterpriseFees").directive 'spreeEnsureCalculatorPreferenc
       settings = element.parent().parent().find('div.calculator-settings')
       if value == orig_calculator_type
         settings.show()
-        settings.find('input').prop 'disabled', false
+        settings.find('input, select').prop 'disabled', false
       else
         settings.hide()
-        settings.find('input').prop 'disabled', true
+        settings.find('input, select').prop 'disabled', true
       return
     return

--- a/app/assets/javascripts/admin/spree/calculator.js
+++ b/app/assets/javascripts/admin/spree/calculator.js
@@ -7,11 +7,11 @@ $(function() {
     if (calculator_select.val() === original_calc_type) {
       $('div.calculator-settings').show();
       $('.calculator-settings-warning').hide();
-      $('.calculator-settings').find('input,textarea').prop("disabled", false);
+      $('.calculator-settings').find('input,textarea,select').prop("disabled", false);
     } else {
       $('div.calculator-settings').hide();
       $('.calculator-settings-warning').show();
-      $('.calculator-settings').find('input,textarea').prop("disabled", true);
+      $('.calculator-settings').find('input,textarea,select').prop("disabled", true);
     }
   });
 })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4212,6 +4212,8 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         spree/payment:
           one: Payment
           other: Payments
+    unit: unit
+    per_unit: per unit
   datetime:
     distance_in_words:
       about_x_hours:

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -58,42 +58,46 @@ describe '
     expect(page).to have_selector "#sets_enterprise_fee_set_collection_attributes_0_calculator_attributes_preferred_flat_percent[value='12.34']"
   end
 
-  it "editing an enterprise fee" do
+  context "editing an enterprise fee" do
     # Given an enterprise fee
-    fee = create(:enterprise_fee)
-    enterprise = create(:enterprise, name: 'Foo')
+    let!(:fee) { create(:enterprise_fee) }
+    let!(:enterprise) { create(:enterprise, name: 'Foo') }
 
-    # When I go to the enterprise fees page
-    login_as_admin_and_visit admin_enterprise_fees_path
+    before do
+      # When I go to the enterprise fees page
+      login_as_admin_and_visit admin_enterprise_fees_path
+      # And I update the fields for the enterprise fee and click update
+      select 'Foo', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
+      select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
+      fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'Greetings!'
+      select 'Inherit From Product', from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
+      select 'Flat Percent', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+      click_button 'Update'
+    end
 
-    # And I update the fields for the enterprise fee and click update
-    select 'Foo', from: 'sets_enterprise_fee_set_collection_attributes_0_enterprise_id'
-    select 'Admin', from: 'sets_enterprise_fee_set_collection_attributes_0_fee_type'
-    fill_in 'sets_enterprise_fee_set_collection_attributes_0_name', with: 'Greetings!'
-    select 'Inherit From Product',
-           from: 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id'
-    select 'Flat Percent', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
-    click_button 'Update'
+    it "handle the default cases" do
+      # Then I should see the updated fields for my fee
+      expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_enterprise_id",
+                                  selected: 'Foo'
+      expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_fee_type",
+                                  selected: 'Admin fee'
+      expect(page).to have_selector "input[value='Greetings!']"
+      expect(page).to have_select 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id',
+                                  selected: 'Inherit From Product'
+      expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'
 
-    # Then I should see the updated fields for my fee
-    expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_enterprise_id",
-                                selected: 'Foo'
-    expect(page).to have_select "sets_enterprise_fee_set_collection_attributes_0_fee_type",
-                                selected: 'Admin fee'
-    expect(page).to have_selector "input[value='Greetings!']"
-    expect(page).to have_select 'sets_enterprise_fee_set_collection_attributes_0_tax_category_id',
-                                selected: 'Inherit From Product'
-    expect(page).to have_selector "option[selected]", text: 'Flat Percent (per item)'
+      fee.reload
+      expect(fee.enterprise).to eq(enterprise)
+      expect(fee.name).to eq('Greetings!')
+      expect(fee.fee_type).to eq('admin')
+      expect(fee.calculator_type).to eq("Calculator::FlatPercentPerItem")
 
-    fee.reload
-    expect(fee.enterprise).to eq(enterprise)
-    expect(fee.name).to eq('Greetings!')
-    expect(fee.fee_type).to eq('admin')
-    expect(fee.calculator_type).to eq("Calculator::FlatPercentPerItem")
+      # Sets tax_category and inherits_tax_category
+      expect(fee.tax_category).to eq(nil)
+      expect(fee.inherits_tax_category).to eq(true)
+    end
 
-    # Sets tax_category and inherits_tax_category
-    expect(fee.tax_category).to eq(nil)
-    expect(fee.inherits_tax_category).to eq(true)
+
   end
 
   it "deleting an enterprise fee" do

--- a/spec/system/admin/enterprise_fees_spec.rb
+++ b/spec/system/admin/enterprise_fees_spec.rb
@@ -97,7 +97,15 @@ describe '
       expect(fee.inherits_tax_category).to eq(true)
     end
 
+    it "handle when updating calculator type for Weight to Flat Rate" do
+      select 'Weight (per kg or lb)', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+      click_button 'Update'
 
+      select 'Flat Rate (per item)', from: 'sets_enterprise_fee_set_collection_attributes_0_calculator_type'
+      click_button 'Update'
+
+      expect(fee.reload.calculator_type).to eq("Calculator::PerItem")
+    end
   end
 
   it "deleting an enterprise fee" do

--- a/spec/system/admin/shipping_methods_spec.rb
+++ b/spec/system/admin/shipping_methods_spec.rb
@@ -71,6 +71,18 @@ describe 'shipping methods' do
       expect(page).to have_field "shipping_method_distributor_ids_#{distributor2.id}",
                                  checked: false
     end
+
+    it "handle when updating calculator type for Weight to Flat Rate" do
+      visit spree.edit_admin_shipping_method_path(@shipping_method)
+
+      select2_select 'Weight (per kg or lb)', from: 'calc_type'
+      click_button 'Update'
+
+      select2_select 'Flat Rate (per item)', from: 'calc_type'
+      click_button 'Update'
+
+      expect(@shipping_method.reload.calculator_type).to eq("Calculator::PerItem")
+    end
   end
 
   context "as an enterprise user", js: true do


### PR DESCRIPTION

#### What? Why?
Ensure that form element are well disabled to not submit them, as they're not handled by the backend

This solution is not perfect (I did not change the UX behavior which can be improve a lot, I didn't remove any angular code, ...) but this seems to be straightforward and should probably improve the UX experience.

Closes #6300




#### What should we test?
Well described in the original issue: 

##### On both `/admin/shipping_methods/9/edit` and `/admin/enterprise_fees`
 - Set a weight-based fee, on an existing shipping method, choosing kg or lb and attributing a value
 - Press Update
 - Select another Calculator, for example Flat Percent
 - Press Update: this should be ok!

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

