### PR TITLE
SplitCheckout: Display checkbox that "save as default address" on the /details page

### DIFF
--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -142,7 +142,7 @@
             = ship_address.select :state_id, states_for_country(ship_address_country), { selected: @order.ship_address&.state_id }, { "data-dependant-select-target": "select" }
 
     - if spree_current_user
-      %div.checkout-input{ "data-toggle-target": "content", style: "display: none" }
+      %div.checkout-input{ "data-toggle-target": "content", style: "display: #{display_ship_address ? 'block' : 'none'}" }
         = f.check_box :save_ship_address
         = f.label :save_ship_address, t(:checkout_default_ship_address)
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -198,11 +198,13 @@ describe "As a consumer, I want to checkout my order", js: true do
         it "display the checkbox about shipping address same as billing address when selecting a shipping method that requires ship address" do
           choose free_shipping_with_required_address.name
           check "Shipping address same as billing address?"
+          expect(page).to have_content "Save as default shipping address"
 
           click_button "Next - Payment method"
 
           expect(page).to have_content "Saving failed, please update the highlighted fields."
           expect(page).to have_content "Shipping address same as billing address?"
+          expect(page).to have_content "Save as default shipping address"
           expect(page).to have_checked_field "Shipping address same as billing address?"
         end
       end


### PR DESCRIPTION
#### What? Why?

Closes #8963

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As a connected user, proceed to checkout with at least on shipping method that is delivery
- You should see the checkboxes "Shipping address same as billing address?" and "Save as default shipping address"
- Submit the first form (ie. `/details`) with one error
- You should see the checkboxes "Shipping address same as billing address?" and "Save as default shipping address"

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
