### PR TITLE
Admin, editing order, on last item deletion modal: "Send a cancellation email to the customer" checked by default

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -198,7 +198,7 @@ ofnCancelOrderAlert = function(callback) {
   $('#custom-confirm .message').html(
     ` ${t("js.admin.orders.cancel_the_order_html")}
       <div class="form">
-        <input type="checkbox" name="send_cancellation_email" value="1" id="send_cancellation_email" />
+        <input type="checkbox" name="send_cancellation_email" value="1" id="send_cancellation_email" checked="true" />
         <label for="send_cancellation_email">${t("js.admin.orders.cancel_the_order_send_cancelation_email")}</label>
       </div>`);
   $('#custom-confirm button.confirm').unbind( "click" ).click(() => {

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -172,6 +172,7 @@ describe '
       context "it shows a second modal about last item deletion and therefore about order cancellation" do
         it "that the user can close and then nothing change" do
           expect(page).to have_content "This will cancel the current order."
+          expect(page).to have_checked_field "Send a cancellation email to the customer"
           within(".modal", visible: true) do
             click_on("Cancel")
           end
@@ -184,6 +185,7 @@ describe '
           it "and then the order is cancelled and no email is sent by default" do
             expect do
               within(".modal", visible: true) do
+                uncheck("send_cancellation_email")
                 click_on("OK")
               end
               expect(page).to have_content "Cannot add item to canceled order"
@@ -195,7 +197,6 @@ describe '
           it "and check the checkbox to send an email to the customer about its order cancellation" do
             expect do
               within(".modal", visible: true) do
-                check("send_cancellation_email")
                 click_on("OK")
               end
               expect(page).to have_content "Cannot add item to canceled order"


### PR DESCRIPTION
#### What? Why?

Closes #8985

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Delete all item of an order
- On last items deletion, a modal should appear with "Send a cancellation email to the customer" checked by default
- On clicking ok, this should send an email
- Repeat the operation, and uncheck the checkbox
- On clicking ok, this should _not_ send an email

#### Release notes


Changelog Category: User facing changes