### PR TITLE
Adds coverage on previous open orders (/summary step)

### DIFF
--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -667,6 +667,24 @@ describe "As a consumer, I want to checkout my order", js: true do
           expect(page).to have_current_path checkout_step_path(:payment)
         end
       end
+
+      context "with previous open orders" do
+        let!(:prev_order) {
+          create(:completed_order_with_totals, order_cycle: order.order_cycle, distributor: distributor,
+                                               user: order.user)
+        }
+
+        before do
+          order.distributor.allow_order_changes = true
+          order.distributor.save
+          visit checkout_step_path(:summary)
+        end
+
+        it "informs about previous orders" do
+          byebug
+          expect(page).to have_content("You have an order for this order cycle already.")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Contributes to ##8667.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds coverage on previous open orders on the `/summary` step.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds coverage on previous open orders (/summary step).
