### PR TITLE
7853 deprecation warnings 1

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -62,8 +62,7 @@ module Spree
         if params[:user][:password].present?
           # this logic needed b/c devise wants to log us out after password changes
           Spree::User.reset_password_by_token(params[:user])
-          sign_in(@user, event: :authentication,
-                         bypass: true)
+          bypass_sign_in(@user)
         end
         redirect_to spree.account_url, notice: Spree.t(:account_updated)
       else

--- a/app/models/spree/payment.rb
+++ b/app/models/spree/payment.rb
@@ -183,9 +183,11 @@ module Spree
 
     def validate_source
       if source && !skip_source_validation && !source.valid?
-        source.errors.each do |field, error|
-          field_name = I18n.t("activerecord.attributes.#{source.class.to_s.underscore}.#{field}")
-          errors.add(Spree.t(source.class.to_s.demodulize.underscore), "#{field_name} #{error}")
+        source.errors.each do |error|
+          field_name =
+            I18n.t("activerecord.attributes.#{source.class.to_s.underscore}.#{error.attribute}")
+          errors.add(Spree.t(source.class.to_s.demodulize.underscore),
+                     "#{field_name} #{error.message}")
         end
       end
       errors.blank?

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,5 +3,5 @@ require 'rubygems'
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 require 'bootsnap/setup'

--- a/lib/spree/localized_number.rb
+++ b/lib/spree/localized_number.rb
@@ -44,7 +44,7 @@ module Spree
 
     def self.valid_localizable_number?(number)
       return true unless number.is_a?(String) || number.respond_to?(:to_d)
-      return false if number =~ /[.,]\d{2}[.,]/
+      return false if number.to_s =~ /[.,]\d{2}[.,]/
 
       true
     end

--- a/spec/controllers/api/v0/enterprises_controller_spec.rb
+++ b/spec/controllers/api/v0/enterprises_controller_spec.rb
@@ -75,7 +75,7 @@ describe Api::V0::EnterprisesController, type: :controller do
     end
 
     describe "submitting a valid image" do
-      let!(:logo) { fixture_file_upload("files/logo.png", "image/png") }
+      let!(:logo) { fixture_file_upload("logo.png", "image/png") }
       before do
         allow(Enterprise)
           .to receive(:find_by).with({ permalink: enterprise.id.to_s }) { enterprise }

--- a/spec/system/consumer/registration_spec.rb
+++ b/spec/system/consumer/registration_spec.rb
@@ -17,7 +17,7 @@ describe "Registration", js: true do
       Spree::State.create!({ name: "Berat", abbr: "BRA", country: albania })
       Spree::Country.create!({ name: "Chad", iso3: "TCD", iso: "TD", iso_name: "CHAD",
                                numcode: "148" })
-      AddressGeocoder.any_instance.stub(:geocode)
+      allow_any_instance_of(AddressGeocoder).to receive(:geocode)
     end
 
     after do


### PR DESCRIPTION
#### What? Why?

Closes parts of #7853

This PR just fixes some of the deprecatin warnings found througout the application.

Note: Most of the `file.exists?` deprecation warnings are unrelated to our application and are from the gems we use.

#### What should we test?
- Run the related spec files and see if the deprecation warnings still exist.
- Green build

#### Release notes
- Fixes some deprecation warnings.
<!-- Please select one for your PR and delete the other. -->

Changelog Category:  Technical changes
