### PR TITLE
Adds basic coverage on tag functionality on payment methods

### DIFF
--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -672,9 +672,9 @@ describe "As a consumer, I want to checkout my order", js: true do
         end
       end
 
-      describe "hidding a payment method with a default rule" do
+      describe "hiding a payment method with a default rule" do
         let!(:tagged_customer) { create(:customer, user: user, enterprise: distributor) }
-        let!(:hidden_payment) {
+        let!(:hidden_method) {
           create(:payment_method, distributors: [distributor], name: "Hidden", tag_list: "hide_pm")
         }
         before do
@@ -688,7 +688,7 @@ describe "As a consumer, I want to checkout my order", js: true do
 
         context "with no exceptions set to a customer" do
           it "hides the payment method" do
-            expect(page).not_to have_content hidden_payment.name
+            expect(page).not_to have_content hidden_method.name
           end
         end
 
@@ -702,8 +702,9 @@ describe "As a consumer, I want to checkout my order", js: true do
             tagged_customer.update_attribute(:tag_list, "show_pm")
             visit checkout_step_path(:payment)
           end
+
           it "displays the payment method" do
-            expect(page).to have_content hidden_payment.name
+            expect(page).to have_content hidden_method.name
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

Relates to #8667. 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds basic coverage on tag functionality on payment methods
Coverage on shipping method tagging is already included in #9004 :heavy_check_mark: 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds basic coverage on tag functionality on payment methods
