### PR TITLE
Remove old config comments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,4 @@ Openfoodnetwork::Application.configure do
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
-
-  # force ssl site-wide
-  # config.middleware.insert_before ActionDispatch::Static, "Rack::SSL"
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -69,7 +69,4 @@ Openfoodnetwork::Application.configure do
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
-
-  # force ssl site-wide
-  # config.middleware.insert_before ActionDispatch::Static, "Rack::SSL"
 end


### PR DESCRIPTION

#### What? Why?

SSL is enforced via `config.force_ssl = true` in the same files. We
don't need that comment any more.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

