### PR TITLE
SplitCheckout: filter shipping method with tag

### DIFF
--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -2,6 +2,7 @@
 
 module CheckoutCallbacks
   extend ActiveSupport::Concern
+  include EnterprisesHelper
 
   included do
     # We need pessimistic locking to avoid race conditions.
@@ -46,10 +47,7 @@ module CheckoutCallbacks
   end
 
   def load_shipping_methods
-    @shipping_methods = Spree::ShippingMethod.
-      for_distributor(@order.distributor).
-      display_on_checkout.
-      order(:name)
+    @shipping_methods = available_shipping_methods
   end
 
   def redirect_to_shop?


### PR DESCRIPTION
#### What? Why?

Closes #8999
Use the helper `EnterpriseHelper` to retrieve all the needed shipping methods


#### What should we test?
Well explained in the orginal notes: 

- Set a tag hide_sm as default rule to hide shipping methods
- Add the tag to a given shipping method
- Visit the checkout and notice the shipping method still appears

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
