### PR TITLE
Adds spec on open order information, on split-checkout

### DIFF
--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -505,7 +505,10 @@ describe "As a consumer, I want to checkout my order", js: true do
     end
 
     context "summary step" do
-      let(:order) { create(:order_ready_for_confirmation, distributor: distributor) }
+      let(:order) {
+        create(:order_ready_for_confirmation, distributor: distributor,
+                                              order_cycle: order_cycle, user_id: user.id)
+      }
 
       describe "completing the checkout" do
         it "keeps the distributor selected for the current user after completion" do
@@ -665,6 +668,23 @@ describe "As a consumer, I want to checkout my order", js: true do
           click_on "Next - Payment method"
 
           expect(page).to have_current_path checkout_step_path(:payment)
+        end
+      end
+
+      context "with previous open orders" do
+        let!(:prev_order) {
+          create(:completed_order_with_totals,
+                 order_cycle: order_cycle, distributor: distributor, user_id: order.user_id)
+        }
+
+        before do
+          order.distributor.allow_order_changes = true
+          order.distributor.save
+        end
+
+        it "informs about previous orders" do
+          pending("issue #9007")
+          expect(page).to have_content("You have an order for this order cycle already.")
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Contributes to #8667
Relates to #9007

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds a pending example on displaying open order information, on split-checkout, on the `/summary` step.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds spec on open order information, on split-checkout.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

Can be changed (removing the "pending" line) once #9007 is closed.
