### PR TITLE
SplitCheckout: add already opened cart message on summary step when distributor allow order changes

### DIFF
--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -2,6 +2,7 @@
 
 module CheckoutCallbacks
   extend ActiveSupport::Concern
+  include EnterprisesHelper
 
   included do
     # We need pessimistic locking to avoid race conditions.
@@ -13,7 +14,8 @@ module CheckoutCallbacks
     prepend_before_action :require_order_cycle
     prepend_before_action :require_distributor_chosen
 
-    before_action :load_order, :associate_user, :load_saved_addresses, :load_saved_credit_cards
+    before_action :load_order, :associate_user, :load_saved_addresses, :load_saved_credit_cards,
+                  :load_already_ordered
     before_action :load_shipping_methods, if: -> { params[:step] == "details" }
 
     before_action :ensure_order_not_completed
@@ -50,6 +52,10 @@ module CheckoutCallbacks
       for_distributor(@order.distributor).
       display_on_checkout.
       order(:name)
+  end
+
+  def load_already_ordered
+    @already_ordered = show_bought_items?
   end
 
   def redirect_to_shop?

--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -2,7 +2,7 @@
 
 module CheckoutCallbacks
   extend ActiveSupport::Concern
-  include EnterprisesHelper
+  helper EnterprisesHelper
 
   included do
     # We need pessimistic locking to avoid race conditions.
@@ -14,8 +14,7 @@ module CheckoutCallbacks
     prepend_before_action :require_order_cycle
     prepend_before_action :require_distributor_chosen
 
-    before_action :load_order, :associate_user, :load_saved_addresses, :load_saved_credit_cards,
-                  :load_already_ordered
+    before_action :load_order, :associate_user, :load_saved_addresses, :load_saved_credit_cards
     before_action :load_shipping_methods, if: -> { params[:step] == "details" }
 
     before_action :ensure_order_not_completed
@@ -52,10 +51,6 @@ module CheckoutCallbacks
       for_distributor(@order.distributor).
       display_on_checkout.
       order(:name)
-  end
-
-  def load_already_ordered
-    @already_ordered = show_bought_items?
   end
 
   def redirect_to_shop?

--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -2,7 +2,6 @@
 
 module CheckoutCallbacks
   extend ActiveSupport::Concern
-  helper EnterprisesHelper
 
   included do
     # We need pessimistic locking to avoid race conditions.

--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -14,6 +14,7 @@ class SplitCheckoutController < ::BaseController
   helper 'terms_and_conditions'
   helper 'checkout'
   helper 'spree/orders'
+  helper EnterprisesHelper
   helper OrderHelper
 
   before_action :set_checkout_redirect

--- a/app/views/split_checkout/_already_ordered.html.haml
+++ b/app/views/split_checkout/_already_ordered.html.haml
@@ -1,0 +1,3 @@
+.already-ordered
+  .panel.medium-6
+    = t("split_checkout.already_ordered.message_html", cart: link_to(t('split_checkout.already_ordered.cart'), "#{main_app.cart_path}#bought-products"))

--- a/app/views/split_checkout/_checkout.html.haml
+++ b/app/views/split_checkout/_checkout.html.haml
@@ -1,5 +1,5 @@
 %checkout.row#checkout
   .small-12.medium-12.columns
     = render partial: "split_checkout/tabs"
-    = render partial: "split_checkout/already_ordered" if @already_ordered
+    = render partial: "split_checkout/already_ordered" if @already_ordered && checkout_step?(:summary)
     = render partial: "split_checkout/form"

--- a/app/views/split_checkout/_checkout.html.haml
+++ b/app/views/split_checkout/_checkout.html.haml
@@ -1,4 +1,5 @@
 %checkout.row#checkout
   .small-12.medium-12.columns
     = render partial: "split_checkout/tabs"
+    = render partial: "split_checkout/already_ordered" if @already_ordered
     = render partial: "split_checkout/form"

--- a/app/views/split_checkout/_checkout.html.haml
+++ b/app/views/split_checkout/_checkout.html.haml
@@ -1,5 +1,5 @@
 %checkout.row#checkout
   .small-12.medium-12.columns
     = render partial: "split_checkout/tabs"
-    = render partial: "split_checkout/already_ordered" if @already_ordered && checkout_step?(:summary)
+    = render partial: "split_checkout/already_ordered" if show_bought_items? && checkout_step?(:summary)
     = render partial: "split_checkout/form"

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -58,6 +58,20 @@
   }
 }
 
+.already-ordered {
+  .panel {
+    margin-top: 3rem;
+    background-color: $grey-250;
+    border: 1px solid $tiny-blue;
+    color: $grey-700;
+    
+    &.medium-6, &.medium-10 {
+      margin-right: auto;
+      margin-left: auto;
+    }
+  }
+}
+
 .checkout-step {
   margin-top: 3rem;
 

--- a/app/webpacker/css/darkswarm/split-checkout.scss
+++ b/app/webpacker/css/darkswarm/split-checkout.scss
@@ -72,6 +72,11 @@
   }
 }
 
+.already-ordered .panel, #distributor_address.panel {
+  font-size: 0.875rem;
+  padding: 1rem;
+}
+
 .checkout-step {
   margin-top: 3rem;
 
@@ -133,9 +138,6 @@
     }
 
     #distributor_address.panel {
-      font-size: 0.875rem;
-      padding: 1rem;
-
       span {
         white-space: pre-wrap;
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1745,6 +1745,9 @@ en:
     your_details_without_number: Your details
     payment_method_without_number: Payment method
     order_summary_without_number: Order summary
+    already_ordered:
+      cart: "cart"
+      message_html: "You have an order for this order cycle already. Check the %{cart} to see the items you ordered before. You can also cancel items as long as the order cycle is open."
     step1:
       your_details:
         title: Your details

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -505,7 +505,10 @@ describe "As a consumer, I want to checkout my order", js: true do
     end
 
     context "summary step" do
-      let(:order) { create(:order_ready_for_confirmation, distributor: distributor) }
+      let(:order) {
+        create(:order_ready_for_confirmation, distributor: distributor,
+                                              order_cycle: order_cycle, user_id: user.id)
+      }
 
       describe "completing the checkout" do
         it "keeps the distributor selected for the current user after completion" do
@@ -665,6 +668,23 @@ describe "As a consumer, I want to checkout my order", js: true do
           click_on "Next - Payment method"
 
           expect(page).to have_current_path checkout_step_path(:payment)
+        end
+      end
+
+      context "with previous open orders" do
+        let!(:prev_order) {
+          create(:completed_order_with_totals,
+                 order_cycle: order_cycle, distributor: distributor, user_id: order.user_id)
+        }
+
+        before do
+          order.distributor.allow_order_changes = true
+          order.distributor.save
+        end
+
+        it "informs about previous orders" do
+          pending("issue #9007")
+          expect(page).to have_content("You have an order for this order cycle already.")
         end
       end
     end


### PR DESCRIPTION
#### What? Why?

Closes #9007
The title says it all ;)
<img width="1245" alt="Capture d’écran 2022-03-17 à 10 26 36" src="https://user-images.githubusercontent.com/296452/158781623-b8a30d24-32c0-47d5-8ec7-04944e9e5876.png">
<img width="459" alt="Capture d’écran 2022-03-17 à 10 26 48" src="https://user-images.githubusercontent.com/296452/158781636-52237fff-6319-4525-9276-83798f9b3b0c.png">


#### What should we test?
Pretty well described in the linked issue:

1. As an enterprise, under `Shop preferences` toggle the option `Customers can change / cancel orders while order cycle is open`
2. As a customer: Place an order.
3. As a customer: Place another order.
4. Notice the missing info (see pic for reference)

#### Release notes

Changelog Category: User facing changes