### PR TITLE
Fix order cycle advanced settings close button so it uses new remote toggle StimulusJs controller instead of old toggleSettings method

### DIFF
--- a/app/views/admin/order_cycles/_advanced_settings.html.haml
+++ b/app/views/admin/order_cycles/_advanced_settings.html.haml
@@ -22,7 +22,7 @@
     .omega.eight.columns
       = f.check_box :automatic_notifications
 
-  .row
+  .row{ "data-controller": "remote-toggle", "data-remote-toggle-selector-value": "#advanced_settings" }
     .sixteen.columns.alpha.omega.text-center
       %input{ type: 'submit', value: t('.save_reload') }
-      %a{ href: "#", onClick: "toggleSettings()" }= t(:close)
+      %a{ href: "#", "data-action": "click->remote-toggle#toggle" }= t(:close)


### PR DESCRIPTION
#### What? Why?

When replacing the old inline JS with a StimulusJs controller for #8699 I didn't notice that there was a close button inside the advanced settings panel too. This fixes the button so it doesn't use the old toggleSettings method which has been replaced by the StimulusJs controller. I didn't add a new test because I'm not sure it would be very valuable, there is coverage at [spec/javascripts/stimulus/remote_toggle_controller_test.js](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/spec/javascripts/stimulus/remote_toggle_controller_test.js) already.

Closes #9012

#### What should we test?

1. Visit an edit order cycle page.
2. Click the 'Advanced Settings' button.
3. Check the 'Close' button inside the advanced settings panel works.

#### Release notes

Changelog Category: User facing changes 