### PR TITLE
[Split-Checkout] Hides "Save as default billing address" from guest-checkout

### DIFF
--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -62,7 +62,7 @@
           = bill_address.select :state_id, states_for_country(bill_address_country), { selected: @order.bill_address&.state_id }, { "data-dependant-select-target": "select" }
 
       - if spree_current_user
-        %div.checkout-input{ "data-toggle-target": "content", style: "display: none" }
+        %div.checkout-input
           = f.check_box :save_bill_address
           = f.label :save_bill_address, t(:checkout_default_bill_address)
 

--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -61,8 +61,8 @@
           = bill_address.label :state_id, t("split_checkout.step1.address.state_id.label")
           = bill_address.select :state_id, states_for_country(bill_address_country), { selected: @order.bill_address&.state_id }, { "data-dependant-select-target": "select" }
 
-      - if spree_current_user||true
-        %div.checkout-input
+      - if spree_current_user
+        %div.checkout-input{ "data-toggle-target": "content", style: "display: none" }
           = f.check_box :save_bill_address
           = f.label :save_bill_address, t(:checkout_default_bill_address)
 

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -162,10 +162,21 @@ describe "As a consumer, I want to checkout my order", js: true do
     context "on the 'details' step" do
       before do
         visit checkout_step_path(:details)
+        click_on "Checkout as guest"
       end
 
       it "should allow visit '/checkout/details'" do
         expect(page).to have_current_path("/checkout/details")
+      end
+
+      it 'does not show the save as default bill address checkbox' do
+        expect(page).not_to have_content "Save as default billing address"
+      end
+
+      it 'does not show the save as default ship address checkbox' do
+        choose free_shipping_with_required_address.name
+        uncheck "ship_address_same_as_billing"
+        expect(page).not_to have_content "Save as default shipping address"
       end
 
       it_behaves_like "when I have an out of stock product in my cart"


### PR DESCRIPTION
#### What? Why?

Closes #9022.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds a spec and a fix (hopefully) on the cases in which the default address checkbox should appear in the UI.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

With the split-checkout feature enabled:

- As a guest
  - Add items to the cart
  - Visit checkout
  - On the Details step
  - The "Save as default billing address" should not be visible

- As a logged-in user
  - Add items to the cart
  - Visit checkout
  - On the Details step
  - The "Save as default billing address" should be visible

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
