### PR TITLE
Enterprise can access permissions from enterprise edit page

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/side_menu_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/side_menu_controller.js.coffee
@@ -16,6 +16,7 @@ angular.module("admin.enterprises")
       { name: 'shipping_methods', label: t('shipping_methods'), icon_class: "icon-truck", show: "showShippingMethods()" }
       { name: 'payment_methods', label: t('payment_methods'), icon_class: "icon-money", show: "showPaymentMethods()" }
       { name: 'enterprise_fees', label: t('enterprise_fees'), icon_class: "icon-tasks", show: "showEnterpriseFees()" }
+      { name: 'enterprise_permissions', label: t('enterprise_permissions'), icon_class: "icon-plug" }
       { name: 'inventory_settings', label: t('inventory_settings'), icon_class: "icon-list-ol", show: "enterpriseIsShop()" }
       { name: 'tag_rules', label: t('tag_rules'), icon_class: "icon-random", show: "enterpriseIsShop()" }
       { name: 'shop_preferences', label: t('shop_preferences'), icon_class: "icon-shopping-cart", show: "enterpriseIsShop()" }
@@ -44,3 +45,5 @@ angular.module("admin.enterprises")
 
     $scope.enterpriseIsShop = ->
       $scope.Enterprise.sells != "none"
+
+    $scope.menu.redirect_function('enterprise_permissions', '/admin/enterprise_relationships')

--- a/app/assets/javascripts/admin/side_menu/services/side_menu.js.coffee
+++ b/app/assets/javascripts/admin/side_menu/services/side_menu.js.coffee
@@ -30,3 +30,14 @@ angular.module("admin.side_menu")
         for item in @items when item.name is name
           return item
         null
+
+      redirect_function: (elementID , href) =>
+        window.addEventListener 'load', ->
+          element = document.getElementById(elementID)
+          if !element
+            return
+          element.addEventListener 'click', ->
+            window.location.replace(href)
+            return
+          return
+

--- a/app/views/admin/enterprises/_form.html.haml
+++ b/app/views/admin/enterprises/_form.html.haml
@@ -47,6 +47,9 @@
   %legend {{menu.selected.label}}
   = render 'admin/enterprises/form/enterprise_fees', f: f
 
+%fieldset.alpha.no-border-bottom{ ng: { show: "menu.selected.name=='enterprise_permissions'" } }
+  %legend {{menu.selected.label}}
+
 %fieldset.alpha.no-border-bottom{ ng: { show: "menu.selected.name=='inventory_settings'" } }
   %legend {{menu.selected.label}}
   = render 'admin/enterprises/form/inventory_settings', f: f

--- a/app/webpacker/css/admin/plugins/font-awesome.scss
+++ b/app/webpacker/css/admin/plugins/font-awesome.scss
@@ -441,6 +441,9 @@ a .icon-flip-vertical:before {
 .icon-home:before {
   content: "\f015";
 }
+.icon-plug:before {
+  content: "\f1e6";
+}
 .icon-file-alt:before {
   content: "\f016";
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,7 +324,7 @@ en:
   producers_join: Australian producers are now welcome to join the Open Food Network. #FIXME
   charges_sales_tax: Charges GST?
   business_address: "Business Address"
-  Invoice_item_sorting: "Invoice sorting"
+  enterprise_permissions: "Enterprise Permissions"
   print_invoice: "Print Invoice"
   print_ticket: "Print Ticket"
   select_ticket_printer: "Select printer for tickets"
@@ -880,6 +880,8 @@ en:
           manage_fees: Manage Enterprise Fees
           no_fees_yet: You don't have any enterprise fees yet.
           create_button: Create One Now
+        enterprise_permissions:
+          enterprise_relationships: Enterprise Relationships
         images:
           logo: Logo
           promo_image_placeholder: 'This image is displayed in "About Us"'


### PR DESCRIPTION
#### What? Why?

Closes #8908 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `admin/enterprises/{enterprise_name}/edit` page.
- There should be an `Enterprise Permissions` option in the side menu with a `plug` icon. Click on it.
- Once in the `Enterprise Permissions' menu, there should be a button named `Enterprise Relationships`
- When you click on the button mentioned above, it should take you to Admin enterprise relationships page

#### Release notes
- Added link to Enterprise Relationships in Enterprise edit page.

Changelog Category: User facing changes
