### PR TITLE
Fix untranslated flash message

### DIFF
--- a/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
+++ b/app/assets/javascripts/admin/resources/services/order_cycles.js.coffee
@@ -43,7 +43,7 @@ angular.module("admin.resources").factory 'OrderCycles', ($q, $injector, OrderCy
             angular.extend(@byID[orderCycle.id], orderCycle)
             angular.extend(@pristineByID[orderCycle.id], orderCycle)
           form.$setPristine() if form?
-          StatusMessage.display('success', "Order cycles have been updated.")
+          StatusMessage.display('success', t('order_cycles_bulk_update_notice'))
         , (response) =>
           if response.data.errors?
             StatusMessage.display('failure', response.data.errors[0])


### PR DESCRIPTION
#### What? Why?

Closes #9018
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
Messages when editing order cycles were not translated.

#### What should we test?

1. Choose a language other than English.
2. Log in.
3. Go to /admin/order_cycles
4. Change the open or close time of an order cycle
5. Save changes
6. Observe the confirmation message at the bottom of the screen

#### Release notes

Changelog Category: User facing changes

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->

#### Screenshots
I have selected Spanish

**Before:**
![localhost_3000_admin_order_cycles](https://user-images.githubusercontent.com/47295890/159447046-b5ad83d0-de80-434a-b2ab-37a098468b18.png)

**After:**
![localhost_3000_admin_order_cycles (1)](https://user-images.githubusercontent.com/47295890/159447106-be2f5684-f822-4b34-9d27-44e3eb8484de.png)

