### PR TITLE
Added missing translation for model name.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
   # Overridden here due to a bug in spree i18n (Issue #870, and issue #1800)
   language_name: "English" # Localised name of this language
   activerecord:
+    models:
+      spree/product: Product
     attributes:
       spree/user:
         password: "Password"


### PR DESCRIPTION
#### What? Why?

Closes #8459 

When creating a product resource the flash message contained the word "product" but not trasnalted.

Why? When translating flash messages, the controller sends a resource description as a parameter to the translation.

`successfully_created: ! '%{resource} has been successfully created!'`

That resource description is `object.class.model_name.human` -> the actual name of the model; 

How:
I added the model name for spree/product in the translation file for english. When this gets translated to other language files, the translation will take place.


#### What should we test?
- Choose a french language
- Log in.
- Go to /admin/products
- click new product
- Fill in all required field and select 'new'
- Observe the confirmation message at the top of the screen


#### Release notes

Changelog Category: User facing changes 

The title of the pull request will be included in the release notes.

