### PR TITLE
Adds puffing-billy to the stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,6 +163,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'test-prof'
   gem 'webmock'
+  gem 'puffing-billy'
   # See spec/spec_helper.rb for instructions
   # gem 'perftools.rb'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,7 @@ GEM
       ruby-rc4 (>= 0.1.5)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
+    cookiejar (0.3.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -254,12 +255,24 @@ GEM
       railties (>= 3.2)
     dry-inflector (0.2.1)
     e2mmap (0.1.0)
+    em-http-request (1.1.7)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-socksify (0.3.2)
+      eventmachine (>= 1.0.0.beta.4)
+    em-synchrony (1.0.6)
+      eventmachine (>= 1.0.0.beta.1)
     erubi (1.10.0)
     et-orbi (1.2.4)
       tzinfo
-    excon (0.81.0)
-    execjs (2.7.0)
-    factory_bot (6.2.0)
+    eventmachine (1.2.7)
+    eventmachine_httpserver (0.2.1)
+    excon (0.92.1)
+    execjs (2.8.1)
+    factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
@@ -327,7 +340,8 @@ GEM
     highline (2.0.3)
     hiredis (0.6.3)
     htmlentities (4.3.4)
-    i18n (1.8.10)
+    http_parser.rb (0.6.0)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     i18n-js (3.9.0)
       i18n (>= 0.6.6)
@@ -432,6 +446,14 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
+    puffing-billy (3.0.2)
+      addressable (~> 2.5)
+      em-http-request (~> 1.1, >= 1.1.0)
+      em-synchrony
+      eventmachine (~> 1.2)
+      eventmachine_httpserver
+      http_parser.rb (~> 0.6.0)
+      multi_json
     puma (5.6.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -761,6 +783,7 @@ DEPENDENCIES
   pg (~> 1.2.3)
   pry (~> 0.13.0)
   pry-byebug (~> 3.9.0)
+  puffing-billy
   puma
   rack-mini-profiler (< 3.0.0)
   rack-rewrite

--- a/spec/features/consumer/split_checkout_feature_spec.rb
+++ b/spec/features/consumer/split_checkout_feature_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "As a consumer, I want to checkout my order", js: true, billy: true do
+describe "As a consumer, I want to checkout my order", js: true, payments: true, billy: true do
   include ShopWorkflow
   include SplitCheckoutHelper
   include FileHelper
@@ -92,9 +92,6 @@ describe "As a consumer, I want to checkout my order", js: true, billy: true do
           fill_out_card_details
           proceed_to_summary
         end
-
-        #it " fills in card data and saves a Stripe card" do
-        #end
       end
     end
 

--- a/spec/features/consumer/split_checkout_feature_spec.rb
+++ b/spec/features/consumer/split_checkout_feature_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "As a consumer, I want to checkout my order", js: true, billy: true do
+  include ShopWorkflow
+  include SplitCheckoutHelper
+  include FileHelper
+  include StripeHelper
+  include StripeStubs
+  include PaypalHelper
+  include AuthenticationHelper
+
+  let!(:zone) { create(:zone_with_member) }
+  let(:supplier) { create(:supplier_enterprise) }
+  let(:distributor) { create(:distributor_enterprise, charges_sales_tax: true) }
+  let(:product) {
+    create(:taxed_product, supplier: supplier, price: 10, zone: zone, tax_rate_amount: 0.1)
+  }
+  let(:variant) { product.variants.first }
+  let!(:order_cycle) {
+    create(:simple_order_cycle, suppliers: [supplier], distributors: [distributor],
+                                coordinator: create(:distributor_enterprise), variants: [variant])
+  }
+  let(:order) {
+    create(:order, order_cycle: order_cycle, distributor: distributor, bill_address_id: nil,
+                   ship_address_id: nil, state: "cart",
+                   line_items: [create(:line_item, variant: variant)])
+  }
+
+  let(:fee_tax_rate) { create(:tax_rate, amount: 0.10, zone: zone, included_in_price: true) }
+  let(:fee_tax_category) { create(:tax_category, tax_rates: [fee_tax_rate]) }
+  let(:enterprise_fee) { create(:enterprise_fee, amount: 1.23, tax_category: fee_tax_category) }
+
+  let(:free_shipping_with_required_address) {
+    create(:shipping_method, require_ship_address: true, name: "A Free Shipping with required address")
+  }
+  let(:free_shipping) {
+    create(:shipping_method, require_ship_address: false, name: "Free Shipping", description: "yellow",
+                             calculator: Calculator::FlatRate.new(preferred_amount: 0.00))
+  }
+  let(:shipping_tax_rate) { create(:tax_rate, amount: 0.25, zone: zone, included_in_price: true) }
+  let(:shipping_tax_category) { create(:tax_category, tax_rates: [shipping_tax_rate]) }
+  let(:shipping_with_fee) {
+    create(:shipping_method, require_ship_address: true, tax_category: shipping_tax_category,
+                             name: "Shipping with Fee", description: "blue",
+                             calculator: Calculator::FlatRate.new(preferred_amount: 4.56))
+  }
+
+  let!(:stripe_account) { create(:stripe_account, enterprise: distributor) }
+  let!(:stripe_sca_payment_method) {
+    create(:stripe_sca_payment_method, distributors: [distributor], name: "Stripe SCA")
+  }
+  let(:free_shipping_without_required_address) {
+    create(:shipping_method, require_ship_address: false, name: "Z Free Shipping without required address")
+  }
+
+  let(:shipping_backoffice_only) {
+    create(:shipping_method, require_ship_address: true, name: "Shipping Backoffice Only", display_on: "back_end")
+  }
+
+  before do
+    allow(Flipper).to receive(:enabled?).with(:split_checkout).and_return(true)
+    allow(Flipper).to receive(:enabled?).with(:split_checkout, anything).and_return(true)
+
+    add_enterprise_fee enterprise_fee
+    set_order order
+
+    distributor.shipping_methods.push(free_shipping_with_required_address, free_shipping, shipping_with_fee, free_shipping_without_required_address)
+  end
+
+  context "as a logged in user" do
+    let(:user) { create(:user) }
+
+    before do
+      login_as(user)
+      visit checkout_path
+    end
+
+    context "payment step" do
+      let(:order) { create(:order_ready_for_payment, distributor: distributor)}
+
+      context "checking out with Stripe SCA" do
+        before do
+          setup_stripe
+          visit checkout_step_path(:payment)
+        end
+
+        it "selects Stripe SCA and proceeds to payment step" do
+          byebug
+          choose stripe_sca_payment_method.name
+          fill_out_card_details
+          proceed_to_summary
+        end
+
+        #it " fills in card data and saves a Stripe card" do
+        #end
+      end
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,10 @@ RSpec.configure do |config|
     Capybara.javascript_driver = :chrome
   end
 
+  config.before :each, payments: true do
+    stub_stripe!
+  end
+
   # Patch `puffing-billy`'s proxy so that it doesn't try to stop
   # eventmachine's reactor if it's not running.
   # taken from https://github.com/oesmith/puffing-billy/issues/253

--- a/spec/support/request/stripe_helper.rb
+++ b/spec/support/request/stripe_helper.rb
@@ -33,4 +33,52 @@ module StripeHelper
     Stripe.publishable_key = "pk_test_12345"
     Spree::Config.set(stripe_connect_enabled: true)
   end
+
+  # from puffing-billy setup
+  def stub_stripe_token_request!(success: true)
+    if success
+      stub_success_token
+    else
+      stub_failed_token
+    end
+  end
+
+  private
+
+  def stub_success_token
+    proxy.stub('https://api.stripe.com:443/v1/tokens').
+      and_return(Proc.new { |params|
+      { :code => 200, :text => "#{params['callback'][0]}({
+        'id': 'tok_2Z0Jh5UWnSrAeL',
+        'livemode': false,
+        'created': 1379062337,
+        'used': false,
+        'object': 'token',
+        'type': 'card'
+      },
+      200)" } })
+  end
+
+  def stub_failed_token
+    proxy.stub('https://api.stripe.com:443/v1/tokens').
+      and_return(Proc.new { |params|
+      { :code => 200, :text => "#{params['callback'][0]}({
+        'error': {
+          'message': 'Your card number is incorrect.',
+          'type': 'card_error',
+          'param': 'number',
+          'code': 'incorrect_number'
+        }
+      }
+      , 402)" } })
+  end
+
+  #def stub_stripe!
+  #  allow(controller).to receive(:current_order).and_return(order)
+  #  stub_successful_capture_request(order: order)
+  #  allow(controller).to receive(:spree_current_user).and_return(user)
+  #end
 end
+
+
+


### PR DESCRIPTION
#### What? Why?

Closes #8957

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds puffing-billy gem the stack to test interactions between the browser and external sites, to improve Stripe test coverage.
This includes:
- adding the gem to the gemfile following [this approach](https://github.com/openfoodfoundation/openfoodnetwork/pull/9015#issuecomment-1073037743) to overcome [unmet dependencies](https://github.com/openfoodfoundation/openfoodnetwork/issues/6347) - done :heavy_check_mark: 
- adding the required settings to make it work with capybara/selenium - feature spec - done :heavy_check_mark: 
- adding the required settings to make it work with capybara/cuprite - WIP :warning:
- add a proof of concept
  - feature spec? WIP :warning:
  - system spec?

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Ideally, a proof of concept spec should be green, to validate this approach. This could also be part of #8957
- Green build

#### Release notes

Adds puffing-billy to the stack

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
