### PR TITLE
BOM: show custom modal on last item deletion of an order

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/variant_autocomplete.js.erb
@@ -194,9 +194,12 @@ ofnAlert = function(message) {
   $('#custom-alert').show();
 }
 
-ofnCancelOrderAlert = function(callback) {
+ofnCancelOrderAlert = function(callback, i18nKey) {
+  if (i18nKey == undefined) {
+    i18nKey = "js.admin.orders.cancel_the_order_html";
+  }
   $('#custom-confirm .message').html(
-    ` ${t("js.admin.orders.cancel_the_order_html")}
+    ` ${t(i18nKey)}
       <div class="form">
         <input type="checkbox" name="send_cancellation_email" value="1" id="send_cancellation_email" />
         <label for="send_cancellation_email">${t("js.admin.orders.cancel_the_order_send_cancelation_email")}</label>

--- a/app/views/spree/admin/orders/bulk_management.html.haml
+++ b/app/views/spree/admin/orders/bulk_management.html.haml
@@ -182,3 +182,5 @@
             %a{ ng: { href: "/admin/orders/{{line_item.order.number}}/edit" }, :class => "edit-order icon-edit no-text", 'confirm-link-click' => 'confirmRefresh()' }
           %td.actions
             %a{ 'ng-click' => "deleteLineItem(line_item)", :class => "delete-line-item icon-trash no-text" }
+
+= render 'spree/admin/shared/custom-confirm'

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -119,24 +119,18 @@ describe "LineItemsCtrl", ->
         }
         scope.line_items = [ line_item1, line_item2 ]
 
-      it "shows a different message if order will be canceled", ->
-        spyOn(window, "confirm")
+      it "show popup about order cancellation only on last item deletion", ->
+        spyOn(window, "ofnCancelOrderAlert")
         scope.deleteLineItem(line_item2)
-        expect(confirm).not.toHaveBeenCalledWith("This operation will result in one or more empty orders, which will be cancelled. Do you wish to proceed?")
+        expect(ofnCancelOrderAlert).not.toHaveBeenCalled()
         scope.deleteLineItem(line_item1)
-        expect(confirm).toHaveBeenCalledWith("This operation will result in one or more empty orders, which will be cancelled. Do you wish to proceed?")
+        expect(ofnCancelOrderAlert).toHaveBeenCalled()
 
       it "deletes the line item", ->
         spyOn(window, "confirm").and.callFake(-> return true)
         spyOn(LineItems, "delete")
         scope.deleteLineItem(line_item2)
         expect(LineItems.delete).toHaveBeenCalledWith(line_item2, jasmine.anything())
-
-      it "cancels empty order", ->
-        spyOn(window, "confirm").and.callFake(-> return true)
-        spyOn(scope, "cancelOrder").and.callFake(-> return Promise.resolve())
-        scope.deleteLineItem(line_item1)
-        expect(scope.cancelOrder).toHaveBeenCalledWith(order1)
     
     describe "deleting 'checked' line items", ->
       line_item1 = line_item2 = line_item3 = line_item4 = null
@@ -169,34 +163,11 @@ describe "LineItemsCtrl", ->
         scope.line_items = [ line_item1, line_item2, line_item3, line_item4 ]
 
       it "asks for confirmation only if orders will be canceled", ->
-        spyOn(window, "confirm")
+        spyOn(window, "ofnCancelOrderAlert")
         line_item3.checked = true
         scope.deleteLineItems(scope.line_items)
-        expect(confirm).not.toHaveBeenCalled()
         line_item1.checked = true
         scope.deleteLineItems(scope.line_items)
-        expect(confirm).toHaveBeenCalledWith("This operation will result in one or more empty orders, which will be cancelled. Do you wish to proceed?")
-
-
-      it "deletes checked line items for non-empty orders", ->
-        line_item1.checked = true
-        line_item3.checked = true
-        spyOn(window, "confirm").and.callFake(-> return true)
-        spyOn(LineItems, "delete")
-        scope.deleteLineItems(scope.line_items)
-        expect(LineItems.delete).toHaveBeenCalledWith(line_item3)
-        expect(LineItems.delete).not.toHaveBeenCalledWith(line_item1)
-        expect(LineItems.delete).not.toHaveBeenCalledWith(line_item2)
-        expect(LineItems.delete).not.toHaveBeenCalledWith(line_item4)
-
-      it "cancels all empty orders", ->
-        line_item1.checked = true
-        line_item3.checked = true
-        spyOn(window, "confirm").and.callFake(-> return true)
-        spyOn(scope, "cancelOrder").and.callFake(-> return Promise.resolve())
-        scope.deleteLineItems(scope.line_items)
-        expect(scope.cancelOrder).toHaveBeenCalledWith(order1)
-        expect(scope.cancelOrder).not.toHaveBeenCalledWith(order3)
 
     describe "check boxes for line items", ->
       line_item1 = line_item2 = null


### PR DESCRIPTION
#### What? Why?
I think the title says it all.
Closes #9028

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Well described in the original issue #9028

- Log in as enterprise user
- Go to BOM
- Delete the last item of an order
- See the same modal than in https://user-images.githubusercontent.com/6525576/150115359-75cffe86-2213-40e1-a748-f158af76b014.png with different text
- Test sending the cancellation email and not sending the cancellation email
- If you proceed with cancellation, the order should now be empty and with canceled status

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 