### PR TITLE
Send cancellation email by default when cancelling an order

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -65,7 +65,7 @@ module Spree
 
       def fire
         event = params[:e]
-        @order.send_cancellation_email = params[:send_cancellation_email] == "true"
+        @order.send_cancellation_email = params[:send_cancellation_email] != "false"
         if @order.public_send(event.to_s)
           flash[:success] = Spree.t(:order_updated)
         else

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -208,6 +208,22 @@ describe '
     end
   end
 
+  context "user can cancel an order" do
+    before do
+      login_as_admin_and_visit spree.edit_admin_order_path(order)
+    end
+
+    it "by clicking on the cancel button" do
+      expect do
+        accept_alert do
+          click_button "Cancel"
+        end
+        expect(page).to have_content "Order updated"
+        expect(order.reload.state).to eq("canceled")
+      end.to have_enqueued_mail(Spree::OrderMailer, :cancel_email)
+    end
+  end
+
   it "can't add more items than are available" do
     # Move the order back to the cart state
     order.state = 'cart'


### PR DESCRIPTION
#### What? Why?

Closes #9043

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. As customer place an order
  2. As shop manager cancel the order on page admin/orders/Rxyz/edit OR
  3. or, as a customer cancel the order on page account#/orders (only available if the shop allows to edit and cancel orders)
4. Observe that email is sent

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
