### PR TITLE
Add all variants for only one distributor

### DIFF
--- a/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
+++ b/app/assets/javascripts/admin/order_cycles/services/order_cycle.js.coffee
@@ -1,4 +1,4 @@
-angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, $timeout, StatusMessage, Panels) ->
+angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, $timeout, StatusMessage, Panels, Enterprise) ->
   OrderCycleResource = $resource '/admin/order_cycles/:action_name/:order_cycle_id.json', {}, {
     'index':  { method: 'GET', isArray: true}
     'new'   : { method: 'GET', params: { action_name: "new" } }
@@ -50,7 +50,14 @@ angular.module('admin.orderCycles').factory 'OrderCycle', ($resource, $window, $
         (callback || angular.noop)()
 
     addDistributor: (new_distributor_id, callback) ->
-      this.order_cycle.outgoing_exchanges.push({ enterprise_id: new_distributor_id, incoming: false, active: true, variants: {}, enterprise_fees: [] })
+      exchange = { enterprise_id: new_distributor_id, incoming: false, active: true, variants: {}, enterprise_fees: [] }
+      if (Enterprise.hub_enterprises.length == 1)
+        editable = this.order_cycle["editable_variants_for_outgoing_exchanges"][new_distributor_id] || []
+        variants = this.incomingExchangesVariants()
+        for variant in variants when variant in editable
+          exchange.variants[variant] = true
+
+      this.order_cycle.outgoing_exchanges.push(exchange)
       $timeout ->
         (callback || angular.noop)()
 


### PR DESCRIPTION
#### What? Why?

Closes #8887 
Add all variants for only one distributor in outgoing screen

#### What should we test?
On page: /admin/order_cycles/new If I'm coordinating an OC for only one distributor and several producers, I want to see all products selected by default

