### PR TITLE
Improve permissions query building

### DIFF
--- a/lib/open_food_network/permissions.rb
+++ b/lib/open_food_network/permissions.rb
@@ -60,21 +60,23 @@ module OpenFoodNetwork
     end
 
     def editable_products
-      permitted_enterprise_products_ids = product_ids_supplied_by(
-        related_enterprises_granting(:manage_products)
-      )
-      Spree::Product.where(
-        id: managed_enterprise_products.select(:id) | permitted_enterprise_products_ids
+      return Spree::Product.all if admin?
+
+      Spree::Product.where(supplier_id: @user.enterprises).or(
+        Spree::Product.where(supplier_id: related_enterprises_granting(:manage_products))
       )
     end
 
     def visible_products
-      permitted_enterprise_products_ids = product_ids_supplied_by(
-        related_enterprises_granting(:manage_products) |
-          related_enterprises_granting(:add_to_order_cycle)
-      )
+      return Spree::Product.all if admin?
+
       Spree::Product.where(
-        id: managed_enterprise_products.select(:id) | permitted_enterprise_products_ids
+        supplier_id: @user.enterprises
+      ).or(
+        Spree::Product.where(
+          supplier_id: related_enterprises_granting(:manage_products) |
+            related_enterprises_granting(:add_to_order_cycle)
+        )
       )
     end
 


### PR DESCRIPTION
#### What? Why?

For larger queries and especially where filtering and paginating, these simpler product queries are way more efficient. It cuts out some very large subqueries with large lists of product ids.


#### What should we test?

A simple test is loading the admin products page as a superadmin user. Page load dropped from 2.5 seconds to 0.8 seconds for me, with production data.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
