### PR TITLE
Remove unused icons from Spree::Taxon

### DIFF
--- a/app/models/spree/taxon.rb
+++ b/app/models/spree/taxon.rb
@@ -2,8 +2,6 @@
 
 module Spree
   class Taxon < ApplicationRecord
-    include Spree::Core::S3Support
-
     acts_as_nested_set dependent: :destroy
 
     belongs_to :taxonomy, class_name: 'Spree::Taxonomy', touch: true
@@ -13,15 +11,6 @@ module Spree
     before_create :set_permalink
 
     validates :name, presence: true
-
-    has_attached_file :icon,
-                      styles: { mini: '32x32>', normal: '128x128>' },
-                      default_style: :mini,
-                      url: '/spree/taxons/:id/:style/:basename.:extension',
-                      path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
-                      default_url: '/assets/default_taxon.png'
-
-    supports_s3 :icon
 
     # Indicate which filters should be used for this taxon
     def applicable_filters

--- a/app/views/spree/admin/taxonomies/_taxon.html.haml
+++ b/app/views/spree/admin/taxonomies/_taxon.html.haml
@@ -2,6 +2,6 @@
   %ul
     - taxon.children.each do |child|
       %li{id: "#{child.id}", rel: "taxon"}
-        %a{href: "#", style: "background-image: url(#{child.icon.url});"}= child.name
+        %a{href: "#"}= child.name
         - if child.children.length > 0
           = render partial: 'taxon', locals: { taxon: child }

--- a/db/migrate/20220407051248_remove_icon_from_spree_taxons.rb
+++ b/db/migrate/20220407051248_remove_icon_from_spree_taxons.rb
@@ -1,0 +1,8 @@
+class RemoveIconFromSpreeTaxons < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :spree_taxons, :icon_file_name, :string
+    remove_column :spree_taxons, :icon_content_type, :string
+    remove_column :spree_taxons, :icon_file_size, :integer
+    remove_column :spree_taxons, :icon_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_21_165207) do
+ActiveRecord::Schema.define(version: 2022_04_07_051248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -976,10 +976,6 @@ ActiveRecord::Schema.define(version: 2022_02_21_165207) do
     t.datetime "updated_at", null: false
     t.integer "lft"
     t.integer "rgt"
-    t.string "icon_file_name", limit: 255
-    t.string "icon_content_type", limit: 255
-    t.integer "icon_file_size"
-    t.datetime "icon_updated_at"
     t.text "description"
     t.string "meta_title", limit: 255
     t.string "meta_description", limit: 255


### PR DESCRIPTION
#### What? Why?

Prepares for #6347.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->
The icons are not used any more

And it's better to remove this clutter before migrating those files to
Active Storage.

We are keeping the icon files in storage as a backup. The whole folder
`/spree/taxons` can be deleted when desired. But storage is cheap.



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Edit taxons as admin and observe no changes to before.
- Look at the product properties in the shop front and observe no changes either.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
