### PR TITLE
Fixed missing translation: "Shipping method"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
   activerecord:
     models:
       spree/product: Product
+      spree/shipping_method: Shipping Method
     attributes:
       spree/user:
         password: "Password"


### PR DESCRIPTION
#### What? Why?

Closes #9017

When editing a shipping method, the confirmation message at the top of the screen is not fully translated. It starts with untranslated "Shipping method". This change fixes it so that the words "Shipping method" are properly translated for all languages and this pop-up message does not just work for English users. 



#### What should we test?
- Choose a language other than English (for this example it is German)
- Log in
- Go to /admin/shipping_methods/
- If a shipping method does not exist, add one
- Click the 'edit' icon of a shipping method
- Make a change and click 'Speichern' ('update' in German)
- Observe the confirmation message at the top of the screen
- It should say "Versandart" ('shipping method' in German) 

#### Release notes

Changelog Category: User facing changes

Correctly translate "Shipping method" in flash message 