### PR TITLE
1760-Instagram-links-validation-and-migration

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -110,6 +110,8 @@ class Enterprise < ApplicationRecord
   before_validation :set_unused_address_fields
   after_validation :ensure_owner_is_manager, if: lambda { owner_id_changed? && !owner_id.nil? }
 
+  validates :instagram, format: /\A[a-zA-Z0-9._-]{1,30}\z/, allow_blank: true
+
   after_touch :touch_distributors
   after_create :set_default_contact
   after_create :relate_to_owners_enterprises

--- a/db/migrate/20220408093837_update_enterprise_social_links.rb
+++ b/db/migrate/20220408093837_update_enterprise_social_links.rb
@@ -1,0 +1,14 @@
+class UpdateEnterpriseSocialLinks < ActiveRecord::Migration
+  INSTAGRAM_REGEX = %r{\A(?:https?://)?(?:www\.)?instagram\.com/([a-zA-Z0-9._@-]{1,30})/?\z}.freeze
+  def up
+      say_with_time "Updating enterprises..." do
+        count = 0
+        Enterprise.where("instagram IS NOT NULL").find_each do |enterprise|
+          say "Update enterprise: #{enterprise.id}"
+          enterprise[:instagram] = enterprise[:instagram].downcase.try(:gsub, INSTAGRAM_REGEX, '\1').delete('@')
+          count += 1
+        end
+        count
+      end
+    end
+  end

--- a/spec/models/enterprise_spec.rb
+++ b/spec/models/enterprise_spec.rb
@@ -153,6 +153,95 @@ describe Enterprise do
       it "sets the enterprise contact to the owner by default" do
         expect(enterprise.contact).to eq enterprise.owner
       end
+      context "prevent a wrong instagram link pattern" do
+        it "invalidates the instagram attribute https://facebook.com/user" do
+          e = build(:enterprise, instagram: 'https://facebook.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "invalidates the instagram attribute tagram.com/user" do
+          e = build(:enterprise, instagram: 'tagram.com/user')
+          expect(e).to_not be_valid
+        end
+
+        it "invalidates the instagram attribute https://instagram.com/user/preferences" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/preferences')
+          expect(e).to_not be_valid
+        end
+      end
+
+      context "accepted pattern" do
+        it "validates empty instagram attribute" do
+          e = build(:enterprise, instagram: '')
+          expect(e).to be_valid
+          expect(e.instagram).to eq ""
+        end
+
+        it "validates the instagram attribute @my-user" do
+          e = build(:enterprise, instagram: '@my-user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "my-user"
+        end
+
+        it "validates the instagram attribute user" do
+          e = build(:enterprise, instagram: 'user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute my_www5.example" do
+          e = build(:enterprise, instagram: 'my_www5.example')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "my_www5.example"
+        end
+
+        it "validates the instagram attribute http://instagram.com/user" do
+          e = build(:enterprise, instagram: 'http://instagram.com/user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute https://instagram.com/user/" do
+          e = build(:enterprise, instagram: 'https://instagram.com/user/')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute https://www.instagram.com/user" do
+          e = build(:enterprise, instagram: 'https://www.instagram.com/user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute https://www.instagram.com/@user" do
+          e = build(:enterprise, instagram: 'https://www.instagram.com/@user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute instagram.com/@user" do
+          e = build(:enterprise, instagram: 'instagram.com/@user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute Https://www.Instagram.com/@User" do
+          e = build(:enterprise, instagram: 'Https://www.Instagram.com/@User')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "validates the instagram attribute instagram.com/user" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e).to be_valid
+          expect(e.instagram).to eq "user"
+        end
+
+        it "renders the expected pattern" do
+          e = build(:enterprise, instagram: 'instagram.com/user')
+          expect(e.instagram).to eq "user"
+        end
+      end
     end
 
     describe "preferred_shopfront_taxon_order" do


### PR DESCRIPTION
#### What? Why?

Closes #1760

This PR fixes the issue with changing existing Instagram links through a database migration and notifying the user when they have input an incorrect Instagram url. This closely resembles the work done by @marthaerm on #6544. 

`20220408093837_update_enterprise_social_links.rb` has been created and it iterates through all enterprises and applies an algorithm to strip away extraneous url information provided.

The changes to `enterprise_spec.rb` encompass a variety of Instagram url variations and validates them.

The changes to `enterprise.rb` are intended to be a final check on the Instagram field. It confirms that the value is a valid username. This is after the stripping of the url has occurred. 

#### What should we test?
As noted by @marthaerm in #6544, test the validations in `enterprise_spec.rb` by providing incorrect Instagram links like the ones noted earlier in this issue.

#### Release notes

Changelog Category: User facing changes

#### Dependencies

Does not depend on another PR.
