### PR TITLE
Updating properties specs

### DIFF
--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -110,15 +110,17 @@ describe '
     accept_alert do
       click_link "Primary Details"
     end
-    uncheck 'enterprise_is_primary_producer'
+    uncheck 'enterprise_is_primary_producer' # unchecking...
     choose 'None'
     expect(page).not_to have_selector "#enterprise_fees"
     expect(page).not_to have_selector "#payment_methods"
     expect(page).not_to have_selector "#shipping_methods"
-    check 'enterprise_is_primary_producer'
+    expect(page).not_to have_selector "#properties" # ...hides the Properties tab
+    check 'enterprise_is_primary_producer' # checking...
     expect(page).to have_selector "#enterprise_fees"
     expect(page).not_to have_selector "#payment_methods"
     expect(page).not_to have_selector "#shipping_methods"
+    expect(page).to have_selector "#properties"  # ...displays the Properties tab
     uncheck 'enterprise_is_primary_producer'
     choose 'Own'
     expect(page).to have_selector "#enterprise_fees"

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -8,6 +8,8 @@ describe '
 ' do
   include WebHelper
   include AuthenticationHelper
+  include ShopWorkflow
+  include UIComponentHelper
 
   it "viewing an enterprise" do
     e = create(:enterprise)
@@ -110,17 +112,19 @@ describe '
     accept_alert do
       click_link "Primary Details"
     end
-    uncheck 'enterprise_is_primary_producer' # unchecking...
+    # Unchecking hides the Properties tab
+    uncheck 'enterprise_is_primary_producer'
     choose 'None'
     expect(page).not_to have_selector "#enterprise_fees"
     expect(page).not_to have_selector "#payment_methods"
     expect(page).not_to have_selector "#shipping_methods"
-    expect(page).not_to have_selector "#properties" # ...hides the Properties tab
-    check 'enterprise_is_primary_producer' # checking...
+    expect(page).not_to have_selector "#properties"
+    # Checking displays the Properties tab
+    check 'enterprise_is_primary_producer'
     expect(page).to have_selector "#enterprise_fees"
     expect(page).not_to have_selector "#payment_methods"
     expect(page).not_to have_selector "#shipping_methods"
-    expect(page).to have_selector "#properties"  # ...displays the Properties tab
+    expect(page).to have_selector "#properties"
     uncheck 'enterprise_is_primary_producer'
     choose 'Own'
     expect(page).to have_selector "#enterprise_fees"
@@ -450,6 +454,69 @@ describe '
 
       expect(page).to have_content 'Enterprise "First Supplier" has been successfully updated!'
       expect(supplier1.producer_properties.reload).to be_empty
+    end
+
+    describe "setting ordering preferences" do
+      let(:taxon) { create(:taxon, name: "Tricky Taxon") }
+      let(:property) { create(:property, presentation: "Fresh and Fine") }
+      let(:user) { create(:user, enterprise_limit: 1) }
+      let(:oc1) {
+        create(:simple_order_cycle, distributors: [distributor1],
+                                    coordinator: create(:distributor_enterprise), orders_close_at: 2.days.from_now)
+      }
+      let(:product) {
+        create(:simple_product, supplier: supplier1, primary_taxon: taxon, properties: [property], name: "Beans")
+      }
+      let(:variant) { product.variants.first }
+      let(:exchange1) { oc1.exchanges.to_enterprises(distributor1).outgoing.first }
+      let(:order) { create(:order, distributor: distributor1) }
+
+      before do
+        exchange1.update_attribute :pickup_time, "monday"
+        add_variant_to_order_cycle(exchange1, variant)
+      end
+
+      context "sorting by category" do
+        before do
+          visit edit_admin_enterprise_path(distributor1)
+
+          within(".side_menu") do
+            click_link "Shop Preferences"
+          end
+          
+          choose "enterprise_preferred_shopfront_product_sorting_method_by_category"
+          find("#s2id_autogen7").click
+          find(".select2-result-label", text: "Tricky Taxon").click
+          click_button 'Update'
+          expect(flash_message).to eq('Enterprise "First Distributor" has been successfully updated!')
+        end
+
+        it "sets the preference correctly" do
+          expect(distributor1.preferred_shopfront_product_sorting_method).to eql("by_category")
+          expect(distributor1.preferred_shopfront_taxon_order).to eql(taxon.id.to_s)
+        end
+      end
+
+      context "sorting by producer" do
+        before do
+          visit edit_admin_enterprise_path(distributor1)
+
+          within(".side_menu") do
+            click_link "Shop Preferences"
+          end
+          
+          choose "enterprise_preferred_shopfront_product_sorting_method_by_producer"
+          find("#s2id_autogen8").click
+          find(".select2-result-label", text: "First Supplier").click
+          click_button 'Update'
+          expect(flash_message).to eq('Enterprise "First Distributor" has been successfully updated!')
+        end
+
+        it "sets the preference correctly" do
+          expect(distributor1.preferred_shopfront_product_sorting_method).to eql("by_producer")
+          expect(distributor1.preferred_shopfront_producer_order).to eql(supplier1.id.to_s)
+        end
+      end
     end
   end
 end

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -9,16 +9,27 @@ describe "As a consumer I want to view products", js: true do
   include UIComponentHelper
 
   describe "Viewing a product" do
-    let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true) }
+    let(:taxon) { create(:taxon, name: "Tricky Taxon") }
+    let(:property) { create(:property, presentation: "Fresh and Fine") }
+    let(:taxon2) { create(:taxon, name: "Delicious Dandelion") }
+    let(:property2) { create(:property, presentation: "Berry Bio") }
+    let(:user) { create(:user, enterprise_limit: 1) }
+    let(:distributor) { create(:distributor_enterprise, with_payment_and_shipping: true, owner: user, name: "Testing Farm") }
     let(:supplier) { create(:supplier_enterprise) }
     let(:oc1) {
       create(:simple_order_cycle, distributors: [distributor],
                                   coordinator: create(:distributor_enterprise), orders_close_at: 2.days.from_now)
     }
-    let(:product) { create(:simple_product, supplier: supplier) }
+    let(:product) {
+      create(:simple_product, supplier: supplier, primary_taxon: taxon, properties: [property], name: "Beans")
+    }
+    let(:product2) {
+      create(:product, supplier: supplier, primary_taxon: taxon2, properties: [property2], name: "Chickpeas")
+    }
     let(:variant) { product.variants.first }
-    let(:order) { create(:order, distributor: distributor) }
+    let(:variant2) { product2.variants.first }
     let(:exchange1) { oc1.exchanges.to_enterprises(distributor).outgoing.first }
+    let(:order) { create(:order, distributor: distributor) }
 
     before do
       set_order order
@@ -79,6 +90,48 @@ describe "As a consumer I want to view products", js: true do
         within(".reveal-modal") do
           expect(html).to include("<p>Safe</p>")
           expect(html).not_to include("<script>alert('Dangerous!');</script>")
+        end
+      end
+    end
+
+    describe "filtering" do
+      before do
+        exchange1.update_attribute :pickup_time, "monday"
+        add_variant_to_order_cycle(exchange1, variant)
+        add_variant_to_order_cycle(exchange1, variant2)
+      end
+
+      context "product taxonomies" do
+
+        before do
+          visit shop_path
+        end
+
+        it "filters out variants according to the selected taxon" do
+
+          expect(page).to have_content variant.name.to_s
+          expect(page).to have_content variant2.name.to_s
+
+          within "#shop-tabs .taxon-selectors" do
+            expect(page).to have_content "Tricky Taxon"
+            toggle_filter taxon.name
+          end
+          
+          expect(page).to have_content variant.name.to_s
+          expect(page).not_to have_content variant2.name.to_s
+        end
+
+        it "filters out variants according to the selected property" do
+          expect(page).to have_content variant.name.to_s
+          expect(page).to have_content variant2.name.to_s
+
+          within "#shop-tabs .sticky-shop-filters-container .property-selectors" do
+            expect(page).to have_content "Fresh and Fine"
+            toggle_filter property.presentation
+          end
+
+          expect(page).to have_content variant.name.to_s
+          expect(page).not_to have_content variant2.name.to_s
         end
       end
     end

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -102,13 +102,13 @@ describe "As a consumer I want to view products", js: true do
       end
 
       context "product taxonomies" do
-
         before do
+          distributor.preferred_shopfront_product_sorting_method = "by_category"
+          distributor.preferred_shopfront_taxon_order = taxon.id.to_s
           visit shop_path
         end
 
         it "filters out variants according to the selected taxon" do
-
           expect(page).to have_content variant.name.to_s
           expect(page).to have_content variant2.name.to_s
 
@@ -116,7 +116,7 @@ describe "As a consumer I want to view products", js: true do
             expect(page).to have_content "Tricky Taxon"
             toggle_filter taxon.name
           end
-          
+
           expect(page).to have_content variant.name.to_s
           expect(page).not_to have_content variant2.name.to_s
         end
@@ -130,6 +130,7 @@ describe "As a consumer I want to view products", js: true do
             toggle_filter property.presentation
           end
 
+          pending("Closing issue #9046")
           expect(page).to have_content variant.name.to_s
           expect(page).not_to have_content variant2.name.to_s
         end


### PR DESCRIPTION
#### What? Why?

Adds a regression test case on bug #9046.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- I've found no system tests on the toggling of properties and taxons for the shopfront. This PR addresses this. 
- It also introduces a change (updated:) on a spec to cover for the side-menu behavior, which should display the `Properties` tab _only if_ the enterprise is a producer 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Updates specs around product Properties.

#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->

It relates to bug #9046.
