### PR TITLE
Fix an issue which prevented filtering by properties and sorting by category on a shopfront.

### DIFF
--- a/app/models/spree/product.rb
+++ b/app/models/spree/product.rb
@@ -78,8 +78,7 @@ module Spree
         where(producer_properties: { property_id: property_ids }).
         or(
           where(spree_product_properties: { property_id: property_ids })
-        ).
-        distinct
+        )
     }
 
     delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight,

--- a/spec/controllers/api/v0/order_cycles_controller_spec.rb
+++ b/spec/controllers/api/v0/order_cycles_controller_spec.rb
@@ -63,12 +63,16 @@ module Api
       end
 
       context "with property filters" do
+        before do
+          product1.update!(properties: [property1, property2])
+        end
+
         it "filters by product property" do
           api_get :products, id: order_cycle.id, distributor: distributor.id,
                              q: { with_properties: [property1.id, property2.id] }
 
           expect(response.status).to eq 200
-          expect(product_ids).to include product1.id, product2.id
+          expect(product_ids).to eq [product1.id, product2.id]
           expect(product_ids).to_not include product3.id
         end
 
@@ -87,7 +91,7 @@ module Api
                                q: { with_properties: [supplier_property.id] }
 
             expect(response.status).to eq 200
-            expect(product_ids).to include product1.id, product2.id
+            expect(product_ids).to eq [product1.id, product2.id]
             expect(product_ids).to_not include product3.id
           end
         end

--- a/spec/services/products_renderer_spec.rb
+++ b/spec/services/products_renderer_spec.rb
@@ -9,40 +9,80 @@ describe ProductsRenderer do
   let(:customer) { create(:customer) }
   let(:products_renderer) { ProductsRenderer.new(distributor, order_cycle, customer) }
 
-  describe "sorting" do
-    let(:t1) { create(:taxon) }
-    let(:t2) { create(:taxon) }
-    let(:s1) { create(:supplier_enterprise) }
-    let(:s2) { create(:supplier_enterprise) }
-    let!(:p1) { create(:product, name: "abc", primary_taxon_id: t2.id, supplier_id: s1.id) }
-    let!(:p2) { create(:product, name: "def", primary_taxon_id: t1.id, supplier_id: s2.id) }
-    let!(:p3) { create(:product, name: "ghi", primary_taxon_id: t2.id, supplier_id: s1.id) }
-    let!(:p4) { create(:product, name: "jkl", primary_taxon_id: t1.id, supplier_id: s2.id) }
+  describe "sorting and filtering" do
+    let(:fruits) { create(:taxon) }
+    let(:cakes) { create(:taxon) }
+    let(:fruits_supplier) { create(:supplier_enterprise) }
+    let(:cakes_supplier) { create(:supplier_enterprise) }
+    let!(:product_apples) { create(:product, name: "apples", primary_taxon_id: fruits.id, supplier_id: fruits_supplier.id) }
+    let!(:product_banana_bread) { create(:product, name: "banana bread", primary_taxon_id: cakes.id, supplier_id: cakes_supplier.id) }
+    let!(:product_cherries) { create(:product, name: "cherries", primary_taxon_id: fruits.id, supplier_id: fruits_supplier.id) }
+    let!(:product_doughnuts) { create(:product, name: "doughnuts", primary_taxon_id: cakes.id, supplier_id: cakes_supplier.id) }
 
     before do
-      exchange.variants << p1.variants.first
-      exchange.variants << p2.variants.first
-      exchange.variants << p3.variants.first
-      exchange.variants << p4.variants.first
+      exchange.variants << product_apples.variants.first
+      exchange.variants << product_banana_bread.variants.first
+      exchange.variants << product_cherries.variants.first
+      exchange.variants << product_doughnuts.variants.first
     end
 
-    it "sorts products by the distributor's preferred taxon list" do
-      allow(distributor).to receive(:preferred_shopfront_taxon_order) { "#{t1.id},#{t2.id}" }
-      products = products_renderer.send(:products)
-      expect(products).to eq([p2, p4, p1, p3])
+    describe "sorting" do
+      it "sorts products by the distributor's preferred taxon list" do
+        allow(distributor).to receive(:preferred_shopfront_taxon_order) { "#{cakes.id},#{fruits.id}" }
+        products = products_renderer.send(:products)
+        expect(products).to eq([product_banana_bread, product_doughnuts, product_apples, product_cherries])
+      end
+
+      it "sorts products by the distributor's preferred producer list" do
+        allow(distributor).to receive(:preferred_shopfront_product_sorting_method) { "by_producer" }
+        allow(distributor).to receive(:preferred_shopfront_producer_order) { "#{cakes_supplier.id},#{fruits_supplier.id}" }
+        products = products_renderer.send(:products)
+        expect(products).to eq([product_banana_bread, product_doughnuts, product_apples, product_cherries])
+      end
+
+      it "alphabetizes products by name when taxon list is not set" do
+        allow(distributor).to receive(:preferred_shopfront_taxon_order) { "" }
+        products = products_renderer.send(:products)
+        expect(products).to eq([product_apples, product_banana_bread, product_cherries, product_doughnuts])
+      end
     end
 
-    it "sorts products by the distributor's preferred producer list" do
-      allow(distributor).to receive(:preferred_shopfront_product_sorting_method) { "by_producer" }
-      allow(distributor).to receive(:preferred_shopfront_producer_order) { "#{s2.id},#{s1.id}" }
-      products = products_renderer.send(:products)
-      expect(products).to eq([p2, p4, p1, p3])
-    end
+    context "filtering" do
+      it "filters products by name_or_meta_keywords_or_variants_display_as_or_variants_display_name_or_supplier_name_cont" do
+        products_renderer = ProductsRenderer.new(distributor, order_cycle, customer, { q: { name_or_meta_keywords_or_variants_display_as_or_variants_display_name_or_supplier_name_cont: "apples" } })
+        products = products_renderer.send(:products)
+        expect(products).to eq([product_apples])
+      end
 
-    it "alphabetizes products by name when taxon list is not set" do
-      allow(distributor).to receive(:preferred_shopfront_taxon_order) { "" }
-      products = products_renderer.send(:products)
-      expect(products).to eq([p1, p2, p3, p4])
+      context "when property is set" do
+        let(:property_organic) { Spree::Property.create! name: 'Organic', presentation: 'Organic' }
+        let(:property_conventional) { Spree::Property.create! name: 'Conventional', presentation: 'Conventional' }
+
+        it "filters products with a product property" do
+          product_apples.product_properties.create!({ property_id: property_organic.id, value: '1', position: 1 })
+          products_renderer = ProductsRenderer.new(distributor, order_cycle, customer, { q: { with_properties: [property_organic.id] } })
+          products = products_renderer.send(:products)
+          expect(products).to eq([product_apples])
+        end
+
+        it "filters products with a producer property" do
+          fruits_supplier.producer_properties.create!({ property_id: property_organic.id, value: '1', position: 1 })
+          products_renderer = ProductsRenderer.new(distributor, order_cycle, customer, { q: { with_properties: [property_organic.id] } })
+          products = products_renderer.send(:products)
+          expect(products).to eq([product_apples, product_cherries])
+        end
+
+        it "filters products with property when sorting is enabled" do
+          allow(distributor).to receive(:preferred_shopfront_taxon_order) { "#{fruits.id},#{cakes.id}" }
+          product_apples.product_properties.create!({ property_id: property_conventional.id, value: '1', position: 1 })
+          product_banana_bread.product_properties.create!({ property_id: property_organic.id, value: '1', position: 1 })
+          product_cherries.product_properties.create!({ property_id: property_organic.id, value: '1', position: 1 })
+          product_doughnuts.product_properties.create!({ property_id: property_organic.id, value: '1', position: 1 })
+          products_renderer = ProductsRenderer.new(distributor, order_cycle, customer, { q: { with_properties: [property_organic.id] } })
+          products = products_renderer.send(:products)
+          expect(products).to eq([product_cherries, product_banana_bread, product_doughnuts])
+        end
+      end
     end
   end
 

--- a/spec/system/consumer/shopping/products_spec.rb
+++ b/spec/system/consumer/shopping/products_spec.rb
@@ -130,7 +130,6 @@ describe "As a consumer I want to view products", js: true do
             toggle_filter property.presentation
           end
 
-          pending("Closing issue #9046")
           expect(page).to have_content variant.name.to_s
           expect(page).not_to have_content variant2.name.to_s
         end


### PR DESCRIPTION
#### What? Why?

Closes #9046

Removing the `distinct` keyword that cause SQL error when using `ORDER BY column_name=value`



#### What should we test?
- On a hub, enable sorting by category
<img width="672" alt="Capture d’écran 2022-04-12 à 17 17 46" src="https://user-images.githubusercontent.com/296452/162996043-559c0588-17e0-4732-a882-9be046e5bc00.png">

- Then, on the shopfront, filter by a property and a category. 
- You should see the concerned products:
<img width="1179" alt="Capture d’écran 2022-04-12 à 17 18 49" src="https://user-images.githubusercontent.com/296452/162996286-a21db595-d84a-49e6-ba42-34758217c2e5.png">


#### Release notes

Fix an issue which prevented filtering by properties and sorting by category on a shopfront.

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
