### PR TITLE
Change enterprise visibility scope

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -120,7 +120,8 @@ class Enterprise < ApplicationRecord
   after_rollback :restore_permalink
 
   scope :by_name, -> { order('name') }
-  scope :visible, -> { where(visible: true) }
+  scope :visible, -> { where(visible: "public") }
+  scope :not_hidden, -> { where.not(visible: "hidden") }
   scope :activated, -> { where("sells != 'unspecified'") }
   scope :ready_for_checkout, lambda {
     joins(:shipping_methods).
@@ -267,7 +268,7 @@ class Enterprise < ApplicationRecord
 
   def plus_relatives_and_oc_producers(order_cycles)
     oc_producer_ids = Exchange.in_order_cycle(order_cycles).incoming.pluck :sender_id
-    Enterprise.is_primary_producer.relatives_of_one_union_others(id, oc_producer_ids | [id])
+    Enterprise.not_hidden.is_primary_producer.relatives_of_one_union_others(id, oc_producer_ids | [id])
   end
 
   def relatives_including_self
@@ -399,6 +400,10 @@ class Enterprise < ApplicationRecord
 
   def can_invoice?
     abn.present?
+  end
+
+  def public?
+    visible == "public"
   end
 
   protected

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -13,8 +13,8 @@ module Api
                  :default_tag_group, :require_login, :allow_guest_orders, :allow_order_changes,
                  :logo, :promo_image, :terms_and_conditions,
                  :terms_and_conditions_file_name, :terms_and_conditions_updated_at,
-                 :preferred_invoice_order_by_supplier,
-                 :preferred_product_low_stock_display
+                 :preferred_invoice_order_by_supplier, :preferred_product_low_stock_display,
+                 :visible
 
       has_one :owner, serializer: Api::Admin::UserSerializer
       has_many :users, serializer: Api::Admin::UserSerializer

--- a/app/views/admin/enterprises/form/_primary_details.html.haml
+++ b/app/views/admin/enterprises/form/_primary_details.html.haml
@@ -42,11 +42,14 @@
     %div{'ofn-with-tip' => t('.visible_in_search_tip')}
       %a= t('admin.whats_this')
   .two.columns
-    = f.radio_button :visible, true
-    = f.label :visible, t('.visible'), value: 'true'
-  .five.columns.omega
-    = f.radio_button :visible, false
-    = f.label :visible, t('.not_visible'), value: 'false'
+    = f.radio_button :visible, "public", 'ng-model' => 'Enterprise.visible'
+    = f.label :visible, t('.visible'), value: 'public'
+  .two.columns
+    = f.radio_button :visible, "only_through_links", 'ng-model' => 'Enterprise.visible'
+    = f.label :visible, t('.not_visible'), value: 'only_through_links'
+  .four.columns.omega
+    = f.radio_button :visible, "hidden", 'ng-model' => 'Enterprise.visible'
+    = f.label :visible, t('.hidden'), value: 'hidden'
 .permalink{ ng: { controller: "permalinkCtrl" } }
   .row{ ng: { show: "Enterprise.sells == 'own' || Enterprise.sells == 'any'" } }
     .three.columns.alpha

--- a/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
+++ b/app/views/spree/admin/overview/single_enterprise_dashboard.html.haml
@@ -26,7 +26,7 @@
 #package_selection{ hidden: true }
   = render partial: "/admin/enterprises/change_type_form"
 
-- if !@enterprise.visible
+- unless @enterprise.public?
   .alert-box
     %strong
       = t "spree_admin_single_enterprise_hint"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -922,9 +922,10 @@ en:
           sells: Sells
           sells_tip: "None - enterprise does not sell to customers directly.<br />Own - Enterprise sells own products to customers.<br />Any - Enterprise can sell own or other enterprises products.<br />"
           visible_in_search: Visible in search?
-          visible_in_search_tip: Determines whether this enterprise will be visible to customers when searching the site.
-          visible: Visible
-          not_visible: Not visible
+          visible_in_search_tip: "Shops can be <br />1. publicly visible, appearing on the OFN map and listings. <br />2. Hidden on maps and listings but referenced by other shops and linked in their profile. <br />3. Completely hidden."
+          visible: Public
+          not_visible: Hidden
+          hidden: Hide all references
           permalink: Permalink (no spaces)
           permalink_tip: "This permalink is used to create the url to your shop: %{link}your-shop-name/shop"
           link_to_front: Link to shop front

--- a/db/migrate/20220410162955_change_visible_data_type_for_enterprises.rb
+++ b/db/migrate/20220410162955_change_visible_data_type_for_enterprises.rb
@@ -1,0 +1,20 @@
+class ChangeVisibleDataTypeForEnterprises < ActiveRecord::Migration[6.1]
+  class Enterprise < ActiveRecord::Base; end
+  def up
+    add_column :enterprises, :visible_tmp, :string, limit: 255, default: "public", null: false
+    Enterprise.reset_column_information
+
+    Enterprise.where(:visible => 0).update_all(visible_tmp: "only_through_links")
+    remove_column :enterprises, :visible
+    rename_column :enterprises, :visible_tmp, :visible
+  end
+
+  def down
+    add_column :enterprises, :visible_tmp, :boolean,  default: true, null: false
+    Enterprise.reset_column_information
+
+    Enterprise.where("visible != 'public'").update_all(visible_tmp: false)
+    remove_column :enterprises, :visible
+    rename_column :enterprises, :visible_tmp, :visible
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_07_051248) do
+ActiveRecord::Schema.define(version: 2022_04_10_162955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,7 +191,6 @@ ActiveRecord::Schema.define(version: 2022_04_07_051248) do
     t.string "promo_image_content_type", limit: 255
     t.integer "promo_image_file_size"
     t.datetime "promo_image_updated_at"
-    t.boolean "visible", default: true
     t.string "facebook", limit: 255
     t.string "instagram", limit: 255
     t.string "linkedin", limit: 255
@@ -213,6 +212,7 @@ ActiveRecord::Schema.define(version: 2022_04_07_051248) do
     t.datetime "terms_and_conditions_updated_at"
     t.integer "business_address_id"
     t.boolean "show_customer_names_to_suppliers", default: false, null: false
+    t.string "visible", limit: 255, default: "public", null: false
     t.index ["address_id"], name: "index_enterprises_on_address_id"
     t.index ["is_primary_producer", "sells"], name: "index_enterprises_on_is_primary_producer_and_sells"
     t.index ["name"], name: "index_enterprises_on_name", unique: true

--- a/lib/open_food_network/enterprise_issue_validator.rb
+++ b/lib/open_food_network/enterprise_issue_validator.rb
@@ -43,7 +43,7 @@ module OpenFoodNetwork
     def warnings
       warnings = []
 
-      unless @enterprise.visible
+      unless @enterprise.public?
         warnings << {
           description: I18n.t('admin.enterprise_issues.not_visible', enterprise: @enterprise.name),
           link: "<a class='button fullwidth' href='#{edit_admin_enterprise_path(@enterprise)}'>#{I18n.t(:edit)}</a>"

--- a/spec/factories/enterprise_factory.rb
+++ b/spec/factories/enterprise_factory.rb
@@ -28,6 +28,12 @@ FactoryBot.define do
     sells { "none" }
   end
 
+  factory :supplier_enterprise_hidden, parent: :enterprise do
+    is_primary_producer { true }
+    sells { "none" }
+    visible { "hidden" }
+  end
+
   factory :distributor_enterprise, parent: :enterprise do
     is_primary_producer { false }
     sells { "any" }

--- a/spec/lib/open_food_network/enterprise_issue_validator_spec.rb
+++ b/spec/lib/open_food_network/enterprise_issue_validator_spec.rb
@@ -6,7 +6,7 @@ require 'open_food_network/enterprise_issue_validator'
 module OpenFoodNetwork
   describe EnterpriseIssueValidator do
     describe "warnings" do
-      let(:enterprise_invisible) { create(:enterprise, visible: false) }
+      let(:enterprise_invisible) { create(:enterprise, visible: "only_through_links") }
       let(:warnings) { EnterpriseIssueValidator.new(enterprise_invisible).warnings }
 
       it "reports invisible enterprises" do

--- a/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
+++ b/spec/serializers/api/enterprise_shopfront_serializer_spec.rb
@@ -5,12 +5,17 @@ require 'spec_helper'
 describe Api::EnterpriseShopfrontSerializer do
   let!(:hub) { create(:distributor_enterprise, with_payment_and_shipping: true) }
   let!(:producer) { create(:supplier_enterprise) }
+  let!(:producer_hidden) { create(:supplier_enterprise_hidden) }
   let!(:relationship) { create(:enterprise_relationship, parent: hub, child: producer) }
+  let!(:relationship2) { create(:enterprise_relationship, parent: hub, child: producer_hidden) }
 
   let!(:taxon1) { create(:taxon, name: 'Meat') }
   let!(:taxon2) { create(:taxon, name: 'Veg') }
   let!(:product) {
     create(:product, supplier: producer, primary_taxon: taxon1, taxons: [taxon1, taxon2] )
+  }
+  let!(:product2) {
+    create(:product, supplier: producer_hidden, primary_taxon: taxon1, taxons: [taxon1, taxon2] )
   }
 
   let(:close_time) { 2.days.from_now }
@@ -19,6 +24,10 @@ describe Api::EnterpriseShopfrontSerializer do
   let!(:ex) {
     create(:exchange, order_cycle: oc, incoming: false,
                       sender: producer, receiver: hub)
+  }
+  let!(:ex2) {
+    create(:exchange, order_cycle: oc, incoming: false,
+                      sender: producer_hidden, receiver: hub)
   }
 
   let(:serializer) { Api::EnterpriseShopfrontSerializer.new hub }
@@ -41,7 +50,7 @@ describe Api::EnterpriseShopfrontSerializer do
     expect(serializer.serializable_hash[:hubs].to_json).to match hub.name
   end
 
-  it "serializes an array of producers" do
+  it "serializes an array of producers that are public or linked by links" do
     expect(serializer.serializable_hash[:producers]).to be_a ActiveModel::ArraySerializer
     expect(serializer.serializable_hash[:producers].to_json).to match producer.name
   end

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -201,7 +201,7 @@ describe '
     expect(page).to have_field 'enterprise_name', with: 'Eaterprises'
     @enterprise.reload
     expect(@enterprise.owner).to eq user
-    expect(page).to have_checked_field "enterprise_visible_true"
+    expect(page).to have_checked_field "enterprise_visible_public"
 
     click_link "Business Details"
     expect(page).to have_checked_field "enterprise_charges_sales_tax_true"

--- a/spec/system/admin/overview_spec.rb
+++ b/spec/system/admin/overview_spec.rb
@@ -32,7 +32,7 @@ describe '
 
       context "when visibilty is set to false" do
         before do
-          d1.visible = false
+          d1.visible = "only_through_links"
           d1.save!
         end
 

--- a/spec/system/consumer/groups_spec.rb
+++ b/spec/system/consumer/groups_spec.rb
@@ -71,10 +71,20 @@ describe 'Groups', js: true do
                                     coordinator: create(:distributor_enterprise))
       }
       let(:producer) { create(:supplier_enterprise) }
-      let(:d1) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: true) }
-      let(:d2) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: true) }
-      let(:d3) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: false) }
-      let(:d4) { create(:distributor_enterprise, with_payment_and_shipping: true, visible: true) }
+      let(:d1) {
+        create(:distributor_enterprise, with_payment_and_shipping: true, visible: "public")
+      }
+      let(:d2) {
+        create(:distributor_enterprise, with_payment_and_shipping: true, visible: "public")
+      }
+      let(:d3) {
+        create(:distributor_enterprise,
+               with_payment_and_shipping: true,
+               visible: "only_through_links")
+      }
+      let(:d4) {
+        create(:distributor_enterprise, with_payment_and_shipping: true, visible: "public")
+      }
       let(:p1) { create(:simple_product, supplier: producer) }
       let(:p2) { create(:simple_product, supplier: create(:supplier_enterprise)) }
       let(:p3) { create(:simple_product, supplier: create(:supplier_enterprise)) }


### PR DESCRIPTION
#### What? Why?

Closes #8896 
Be able to make an enterprise invisible on other enterprises profiles. 
There is a migration script that transforms Enterprise.visible from a boolean field to a text field so that we can support the variations(public, hidden, invisible) needed

#### What should we test?
- go to admin/enterprise and see that we have three options for visible in search
![Screen Shot 2022-04-14 at 7 54 12 PM](https://user-images.githubusercontent.com/45666083/163495003-26a2a3c9-86f9-4158-a801-41240c2640a1.png)

- invisible enterprises are hidden on maps and listings and not referenced by other shops and linked in their profile(producers tab for now) 
- hidden enterprises that were not visible are now marked as hidden should be hidden in maps and listings but can be referenced by other profiles linked in their profile
- public enterprises that were visible are now marked as public should be available in maps, listings and be referenced by other profiles linked in their profile

