### PR TITLE
Fixed rename of taxons

### DIFF
--- a/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
+++ b/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
@@ -40,8 +40,8 @@ handle_rename = (e, data) ->
   node = data.rslt.obj
   name = data.rslt.new_name
 
-  url = Spree.url(base_url).clone()
-  url.pathname = url.pathname + '/' + node.attr("id")
+  url =  $.extend(true, {}, base_url)
+  url = url['href'] + '/' + node.attr("id")
 
   $.ajax
     type: "POST",

--- a/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
+++ b/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
@@ -40,7 +40,7 @@ handle_rename = (e, data) ->
   node = data.rslt.obj
   name = data.rslt.new_name
 
-  url =  $.extend(true, {}, base_url)
+  url = Object.assign(base_url, {})
   url = url['href'] + '/' + node.attr("id")
 
   $.ajax

--- a/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
+++ b/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
@@ -41,12 +41,12 @@ handle_rename = (e, data) ->
   name = data.rslt.new_name
 
   url = Object.assign(base_url, {})
-  url = url['href'] + '/' + node.attr("id")
+  url.pathname = url.pathname + '/' + node.attr("id")
 
   $.ajax
     type: "POST",
     dataType: "json",
-    url: url.toString(),
+    url: url.pathname.toString(),
     data: {_method: "put", "taxon[name]": name },
     error: handle_ajax_error
 


### PR DESCRIPTION
#### What? Why?

Closes #9031

Currently, right click on the taxon and selecting Rename does not work. This is a fix for the renaming of a taxon in a tree, not necessarily the name of the entire tree. 


#### What should we test?
As a superadmin:
- Visit /admin/taxonomies/<taxon_id>/edit
- Right click on the taxon (not the name of the tree)
- Select Rename and change the name
- Click Update, or on the "Back to Taxonomies list"
- Check whether the change took effect -> see that it now updates the name of the taxon

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

Fixed Rename of Taxon Functionality 

