### PR TITLE
API: Add customer_id as an attribute to the GET /orders/ORDER_ID endpoint

### DIFF
--- a/app/serializers/api/order_detailed_serializer.rb
+++ b/app/serializers/api/order_detailed_serializer.rb
@@ -10,7 +10,7 @@ module Api
 
     has_many :payments, serializer: Api::PaymentSerializer
 
-    attributes :adjustments
+    attributes :adjustments, :customer_id
 
     def adjustments
       adjustments = object.all_adjustments.where(


### PR DESCRIPTION
#### What? Why?

Closes # <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
 - As an API consumer, request for an order made by a registered or unregistered user with endpoint : `/api/v0/orders/[ORDER_ID].json`
 - You should see a `customer_id` attribute (even if the `user_id` is null, this is the case for an unregistered user)
 - Then, request the customer endpoint, to confirm the customer is the right one, with endpoint: `/api/v1/customers/[CUSTOMER_ID].json`. You must have the feature toggle `api_v1` activated.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
