### PR TITLE
Adding a link to enterprise's own site from Order confirmation page.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,7 @@ class ApplicationController < ActionController::Base
   helper 'footer_links'
   helper 'discourse'
   helper 'checkout'
+  helper 'link'
   helper 'terms_and_conditions'
 
   protect_from_forgery

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GroupsHelper
+module LinkHelper
   def link_to_service(baseurl, name, html_options = {}, &block)
     return if name.blank?
 
@@ -14,9 +14,5 @@ module GroupsHelper
     else
       prefix + url
     end
-  end
-
-  def strip_url(url)
-    url&.sub(%r{^https?://}i, '')
   end
 end

--- a/app/views/spree/orders/form/_update_buttons.html.haml
+++ b/app/views/spree/orders/form/_update_buttons.html.haml
@@ -5,19 +5,17 @@
         = link_to main_app.cart_path, :class => "button expand" do
           = t(:order_back_to_cart)
       - else
-      .wrapper
-        .row
-          .columns.small-12.medium-6
-            = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop", class: "button expand" do
-              = t(:order_back_to_store)
-          .columns.small-12.medium-6
-            - if @order.distributor.website.present?
-              = link_to_service "https://", current_order.distributor.website, class: "button expand" do
-                = t(:order_back_to_website)
+        .columns.small-12.medium-6
+          = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop", class: "button expand" do
+            = t(:order_back_to_store)
+        .columns.small-12.medium-6
+          - if @order.distributor.website.present?
+            = link_to_service "https://", current_order.distributor.website, class: "button expand" do
+              = t(:order_back_to_website)
     - else
       &nbsp;
   - if order.changes_allowed?
-    .columns.show-for-medium-up.medium-3 &nbsp;
+    .columns.show-for-medium-up.medium-1 &nbsp;
     .columns.small-12.medium-3
       = link_to main_app.cancel_order_path(@order), method: :put, class: "button secondary expand", "data-confirm": t('orders_confirm_cancel') do
         %i.ofn-i_009-close

--- a/app/views/spree/orders/form/_update_buttons.html.haml
+++ b/app/views/spree/orders/form/_update_buttons.html.haml
@@ -1,12 +1,19 @@
 .row
-  .columns.small-12.medium-3
+  .columns.small-12.medium-5
     - if current_order.nil? || current_order.distributor.nil? || current_order.distributor == @order.distributor
       - if current_order&.line_items.present?
         = link_to main_app.cart_path, :class => "button expand" do
           = t(:order_back_to_cart)
       - else
-        = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop", class: "button expand" do
-          = t(:order_back_to_store)
+      .wrapper
+        .row
+          .columns.small-12.medium-6
+            = link_to "#{main_app.enterprise_shop_path(@order.distributor)}#/shop", class: "button expand" do
+              = t(:order_back_to_store)
+          .columns.small-12.medium-6
+            - if @order.distributor.website.present?
+              = link_to_service "https://", current_order.distributor.website, class: "button expand" do
+                = t(:order_back_to_website)
     - else
       &nbsp;
   - if order.changes_allowed?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1860,6 +1860,7 @@ en:
   order_hub_info: Hub Info
   order_back_to_store: Back To Store
   order_back_to_cart: Back To Cart
+  order_back_to_website: Back To Website
 
   bom_tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
 

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -2,18 +2,11 @@
 
 require 'spec_helper'
 
-describe GroupsHelper, type: :helper do
+describe LinkHelper, type: :helper do
   describe "ext_url" do
     it "adds prefix if missing" do
       expect(helper.ext_url("http://example.com/", "http://example.com/bla")).to eq("http://example.com/bla")
       expect(helper.ext_url("http://example.com/", "bla")).to eq("http://example.com/bla")
-    end
-  end
-  describe "strip_url" do
-    it "removes http(s)://" do
-      expect(helper.strip_url("http://example.com/")).to eq("example.com/")
-      expect(helper.strip_url("https://example.com/")).to eq("example.com/")
-      expect(helper.strip_url("example.com")).to eq("example.com")
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #8917 

Adds a link to the enterprise's website, if any, to the order confirmation page in the form of a button right next to the "Back To Store" button.

![image](https://user-images.githubusercontent.com/65319144/163790748-4ea0b656-7ce3-43d4-820d-d892137cf531.png)


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Scenario 1 - As a loggedin shopper

1. As a hub manager set up a website in the contact page of your enterprise settings
2. Login as a shopper and order something
3. See the button on the order confirmation page, next to "back to store"
4. As a hub manager, remove the website
5. Login as a shopper again and order something
6. See the button is not appearing any longer

Scenario 2 - As a guest shopper

1. Repeat scenario 1 with a guest shopper

#### Release notes

- Adds a "Back To Website" button in Order Confirmation page that will take user to the Enterprise/Distributor website.

Changelog Category: User facing changes
