### PR TITLE
Return if variant is deleted

### DIFF
--- a/engines/order_management/app/services/order_management/subscriptions/validator.rb
+++ b/engines/order_management/app/services/order_management/subscriptions/validator.rb
@@ -103,7 +103,11 @@ module OrderManagement
       end
 
       def requested_variants_available?
-        subscription_line_items.each { |sli| verify_availability_of(sli.variant) }
+        persisting_line_items.each { |sli| verify_availability_of(sli.variant) }
+      end
+
+      def persisting_line_items
+        subscription_line_items.reject(&:marked_for_destruction?)
       end
 
       def verify_availability_of(variant)

--- a/engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb
+++ b/engines/order_management/spec/services/order_management/subscriptions/validator_spec.rb
@@ -507,15 +507,25 @@ module OrderManagement
           end
 
           context "when subscription line items exist" do
-            let(:variant1) { instance_double(Spree::Variant, id: 1) }
+            let(:variant1) { instance_double(Spree::Variant, id: 1, deleted_at: nil) }
             let(:variant2) { instance_double(Spree::Variant, id: 2) }
+            let(:variant3) { instance_double(Spree::Variant, id: 1, deleted_at: Time.zone.now ) }
             let(:subscription_line_item1) {
-              instance_double(SubscriptionLineItem, variant: variant1)
+              instance_double(SubscriptionLineItem,
+                              variant: variant1,
+                              marked_for_destruction?: false)
             }
             let(:subscription_line_item2) {
-              instance_double(SubscriptionLineItem, variant: variant2)
+              instance_double(SubscriptionLineItem,
+                              variant: variant2,
+                              marked_for_destruction?: false)
             }
-            let(:subscription_line_items) { [subscription_line_item1] }
+            let(:subscription_line_item3) {
+              instance_double(SubscriptionLineItem,
+                              variant: variant3,
+                              marked_for_destruction?: true)
+            }
+            let(:subscription_line_items) { [subscription_line_item1, subscription_line_item3] }
 
             context "but some variants are unavailable" do
               let(:product) { instance_double(Spree::Product, name: "some_name") }


### PR DESCRIPTION
#### What? Why?

Closes #9054 
Cannot update subscription after product deleted

#### What should we test?
1. Created a subscription with a live product (almond milk) in a fake shop
2.Deleted product (almond milk) that was in the subscription
3.Tried to delete the deleted product (almond milk) from the subscription and add a new product (beetroot)
4.Refresh page, go back into subscription, deleted product (almond milk) is still there with error, added product (beetroot) is no longer in the subscription

