### PR TITLE
Split checkout: Unless order is complete, /cart could be updated

### DIFF
--- a/app/views/spree/orders/_form.html.haml
+++ b/app/views/spree/orders/_form.html.haml
@@ -19,7 +19,7 @@
       %tbody#line_items{"data-hook" => ""}
         = render partial: 'line_item', collection: order_form.object.line_items, locals: {order_form: order_form}
 
-      = render 'bought' if show_bought_items? && @order.cart?
+      = render 'bought' if show_bought_items? && !@order.complete?
 
       %tfoot#edit-cart
         = render 'spree/orders/form/cart_actions_row' unless @order.complete?

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -887,12 +887,22 @@ describe "As a consumer, I want to checkout my order", js: true do
                order_cycle: order_cycle, distributor: distributor, user_id: order.user_id)
       }
 
-      it "informs about previous orders if distributor allow order changes" do
-        order.distributor.allow_order_changes = true
-        order.distributor.save
-        visit checkout_step_path(:summary)
+      context "when distributor allows order changes" do
+        before do
+          order.distributor.allow_order_changes = true
+          order.distributor.save
+          visit checkout_step_path(:summary)
+        end
 
-        expect(page).to have_content("You have an order for this order cycle already.")
+        it "informs about previous orders" do
+          expect(page).to have_content("You have an order for this order cycle already.")
+        end
+
+        it "show a link to /cart#bought-products page" do
+          expect(page).to have_link("cart", href: "/cart#bought-products")
+          click_on "cart"
+          expect(page).to have_text "#{prev_order.line_items.length} additional items already confirmed for this order cycle"
+        end
       end
 
       it "don't display any message if distributor don't allow order changes" do


### PR DESCRIPTION

#### What? Why?

Closes #9085 

Split_checkout introduced new state for an order, it's not necessary set to `cart`.
Update specs as well
Follow up #8944

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

Well described in the original issue:

- Make sure you are shopping in an order cycle which allows changing and cancelling orders
- Place the first order
- Go back to shop (click 'Shopping @ Shop_xy')
- Begin second order
- Before finishing checkout observe note: You have an order for this order cycle already. Check the cart to see the items you ordered before.
- Click on 'cart' in the note. It redirects to /cart#/bought-products
- Observe that for both split checkout and legacy checkout you have a `additional items already confirmed for this order cycle` section


#### Release notes
Changelog Category: User facing changes