### PR TITLE
Migration to remove addresses with empty phone number.

### DIFF
--- a/db/migrate/20220425102039_remove_bill_addresses_with_null_phone.rb
+++ b/db/migrate/20220425102039_remove_bill_addresses_with_null_phone.rb
@@ -1,6 +1,6 @@
 class RemoveBillAddressesWithNullPhone < ActiveRecord::Migration[6.1]
   class BillAddress < ActiveRecord::Base
-    self.table_name "spree_addresses"
+    self.table_name = "spree_addresses"
 
     scope :invalid, -> { where(phone: nil) }
   end

--- a/db/migrate/20220425102039_remove_bill_addresses_with_null_phone.rb
+++ b/db/migrate/20220425102039_remove_bill_addresses_with_null_phone.rb
@@ -1,0 +1,7 @@
+class RemoveBillAddressesWithNullPhone < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk"
+    add_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk", on_delete: :nullify
+    execute("DELETE from spree_addresses WHERE phone IS NULL AND id IN(SELECT bill_address_id FROM spree_users)")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1300,7 +1300,7 @@ ActiveRecord::Schema.define(version: 2022_06_02_013938) do
   add_foreign_key "spree_tax_rates", "spree_zones", column: "zone_id", name: "spree_tax_rates_zone_id_fk"
   add_foreign_key "spree_taxons", "spree_taxonomies", column: "taxonomy_id", name: "spree_taxons_taxonomy_id_fk"
   add_foreign_key "spree_taxons", "spree_taxons", column: "parent_id", name: "spree_taxons_parent_id_fk"
-  add_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk"
+  add_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk", on_delete: :nullify
   add_foreign_key "spree_users", "spree_addresses", column: "ship_address_id", name: "spree_users_ship_address_id_fk"
   add_foreign_key "spree_variants", "spree_products", column: "product_id", name: "spree_variants_product_id_fk"
   add_foreign_key "spree_zone_members", "spree_zones", column: "zone_id", name: "spree_zone_members_zone_id_fk"


### PR DESCRIPTION
#### What? Why?

Closes #8959 

Removes addresses saved with no phone number to avoid `bill address phone can't be blank` error.

Users who have bill addresses saved without phone will have to re-enter address with phone number the next time they attempt to order.

#### What should we test?

- Query for billing addresses with null `phone`, note down the number.
- Run the migration
- Query again for billing addresses with null `phone`, the returned number must be `0`

#### Release notes
- Removes addresses saved without a phone number so that users dont run into errors.

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
