### PR TITLE
Update orders and delete subscriptions when customer deleted

### DIFF
--- a/app/models/proxy_order.rb
+++ b/app/models/proxy_order.rb
@@ -5,7 +5,7 @@
 # This reduces the need to keep Orders in sync with their parent Subscriptions
 
 class ProxyOrder < ApplicationRecord
-  belongs_to :order, class_name: 'Spree::Order', dependent: :destroy
+  belongs_to :order, class_name: 'Spree::Order'
   belongs_to :subscription
   belongs_to :order_cycle
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -19,7 +19,7 @@ class Subscription < ApplicationRecord
   belongs_to :ship_address, class_name: "Spree::Address"
   has_many :subscription_line_items, inverse_of: :subscription, dependent: :destroy
   has_many :order_cycles, through: :schedule
-  has_many :proxy_orders
+  has_many :proxy_orders, dependent: :destroy
   has_many :orders, through: :proxy_orders
 
   alias_attribute :billing_address, :bill_address

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -17,7 +17,7 @@ class Subscription < ApplicationRecord
   belongs_to :payment_method, class_name: 'Spree::PaymentMethod'
   belongs_to :bill_address, class_name: "Spree::Address"
   belongs_to :ship_address, class_name: "Spree::Address"
-  has_many :subscription_line_items, inverse_of: :subscription
+  has_many :subscription_line_items, inverse_of: :subscription, dependent: :destroy
   has_many :order_cycles, through: :schedule
   has_many :proxy_orders
   has_many :orders, through: :proxy_orders

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -606,7 +606,6 @@ en:
         credit_owed: "Credit Owed"
         balance_due: "Balance Due"
       destroy:
-        has_associated_orders: "Delete failed: customer has associated orders with his shop"
         has_associated_subscriptions: "Delete failed: customer has active associated subscriptions with shops"
     contents:
       edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -606,7 +606,7 @@ en:
         credit_owed: "Credit Owed"
         balance_due: "Balance Due"
       destroy:
-        has_associated_subscriptions: "Delete failed: customer has active associated subscriptions with shops"
+        has_associated_subscriptions: "Delete failed: This customer has active subscriptions. Cancel them first."
     contents:
       edit:
         title: Content

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -607,7 +607,7 @@ en:
         balance_due: "Balance Due"
       destroy:
         has_associated_orders: "Delete failed: customer has associated orders with his shop"
-
+        has_associated_subscriptions: "Delete failed: customer has active associated subscriptions with shops"
     contents:
       edit:
         title: Content

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -81,7 +81,7 @@ describe 'Customers' do
         expect(page).to have_no_content customer1.email
 
         # Deleting
-        create(:order, customer: customer1)
+        create(:subscription, customer: customer1)
         expect{
           within "tr#c_#{customer1.id}" do
             accept_alert do
@@ -89,7 +89,7 @@ describe 'Customers' do
             end
           end
           expect(page).to have_selector "#info-dialog .text",
-                                        text: I18n.t('admin.customers.destroy.has_associated_orders')
+                                        text: I18n.t('admin.customers.destroy.has_associated_subscriptions')
           click_button "OK"
         }.to_not change{ Customer.count }
 


### PR DESCRIPTION
#### What? Why?

Closes #9039 
The current position is to null customer id fields on any orders for the customer when deleting a customer record. If we have an active subscription, we show an error that the subscription needs to be canceled first. We hard delete this once the customer is deleted.  


#### What should we test?
1) Have orders for the customer. Delete the customer record should not show any error
2) Have an active subscription with customer. Error will be shown when you try to delete customer.
     Cancel subscription and delete customer. It will delete both subscription and customer records 

#### Release notes
Changelog Category: Technical changes
Update orders and delete subscriptions when customer deleted
