### PR TITLE
Handle `items` in bulk order management

### DIFF
--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -185,6 +185,8 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
   $scope.getScale = (unitsProduct, unitsVariant) ->
     if unitsProduct.hasOwnProperty("variant_unit") && (unitsProduct.variant_unit == "weight" || unitsProduct.variant_unit == "volume")
       unitsProduct.variant_unit_scale
+    else if unitsProduct.hasOwnProperty("variant_unit") && unitsProduct.variant_unit == "items"
+      1
     else
       null
 

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -211,11 +211,11 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.fulfilled = (sumOfUnitValues) ->
     # A Units Variant is an API object which holds unit properies of a variant
-    if $scope.selectedUnitsProduct.hasOwnProperty("group_buy_unit_size") && $scope.selectedUnitsProduct.group_buy_unit_size > 0 &&
-      $scope.selectedUnitsProduct.hasOwnProperty("variant_unit") &&
-      ( $scope.selectedUnitsProduct.variant_unit == "weight" || $scope.selectedUnitsProduct.variant_unit == "volume" )
-        scale = $scope.selectedUnitsProduct.variant_unit_scale
-        sumOfUnitValues = sumOfUnitValues * scale unless scale == 28.35 || scale == 453.6
+    if $scope.selectedUnitsProduct.hasOwnProperty("group_buy_unit_size")&& $scope.selectedUnitsProduct.group_buy_unit_size > 0 &&
+      $scope.selectedUnitsProduct.hasOwnProperty("variant_unit")
+        if $scope.selectedUnitsProduct.variant_unit == "weight" || $scope.selectedUnitsProduct.variant_unit == "volume"
+          scale = $scope.selectedUnitsProduct.variant_unit_scale
+          sumOfUnitValues = sumOfUnitValues * scale unless scale == 28.35 || scale == 453.6
         $scope.roundToThreeDecimals(sumOfUnitValues / $scope.selectedUnitsProduct.group_buy_unit_size)
     else
       ''

--- a/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
+++ b/app/assets/javascripts/admin/line_items/controllers/line_items_controller.js.coffee
@@ -166,12 +166,18 @@ angular.module("admin.lineItems").controller 'LineItemsCtrl', ($scope, $timeout,
 
   $scope.sumUnitValues = ->
     sum = $scope.filteredLineItems?.reduce (sum, lineItem) ->
-      sum + $scope.roundToThreeDecimals(lineItem.final_weight_volume / $scope.getLineItemScale(lineItem))
+      if lineItem.units_product.variant_unit == "items"
+        sum + lineItem.quantity
+      else
+        sum + $scope.roundToThreeDecimals(lineItem.final_weight_volume / $scope.getLineItemScale(lineItem))
     , 0
 
   $scope.sumMaxUnitValues = ->
     sum = $scope.filteredLineItems?.reduce (sum,lineItem) ->
-      sum + lineItem.max_quantity * $scope.roundToThreeDecimals(lineItem.units_variant.unit_value / $scope.getLineItemScale(lineItem))
+      if lineItem.units_product.variant_unit == "items"
+        sum + lineItem.max_quantity
+      else
+        sum + lineItem.max_quantity * $scope.roundToThreeDecimals(lineItem.units_variant.unit_value / $scope.getLineItemScale(lineItem))
     , 0
 
   $scope.roundToThreeDecimals = (value) ->

--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -27,6 +27,9 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
         1000.0:
           name: 'kL'
           system: 'metric'
+      'items':
+        1:
+          name: 'items'
 
     @variantUnitOptions: ->
       available = availableUnits.split(",")

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -265,11 +265,19 @@ describe "LineItemsCtrl", ->
           expect(scope.allFinalWeightVolumesPresent()).toEqual true
 
       describe "sumUnitValues()", ->
-        it "returns the sum of the final_weight_volumes line_items", ->
+        it "returns the sum of the final_weight_volumes line_items if volume", ->
           scope.filteredLineItems = [
-            { final_weight_volume: 2 }
-            { final_weight_volume: 7 }
-            { final_weight_volume: 21 }
+            { final_weight_volume: 2, units_product: { variant_unit: "volume" } }
+            { final_weight_volume: 7, units_product: { variant_unit: "volume" } }
+            { final_weight_volume: 21, units_product: { variant_unit: "volume" } }
+          ]
+          expect(scope.sumUnitValues()).toEqual 30
+
+        it "returns the sum of the quantity line_items if items", ->
+          scope.filteredLineItems = [
+            { quantity: 2, units_product: { variant_unit: "items" } }
+            { quantity: 7, units_product: { variant_unit: "items" } }
+            { quantity: 21, units_product: { variant_unit: "items" } }
           ]
           expect(scope.sumUnitValues()).toEqual 30
 
@@ -285,12 +293,21 @@ describe "LineItemsCtrl", ->
       describe "sumMaxUnitValues()", ->
         it "returns the sum of the product of unit_value and maxOf(max_quantity, pristine quantity) for specified line_items", ->
           scope.filteredLineItems = [
-            { id: 1, units_variant: { unit_value: 1 }, max_quantity: 5 }
-            { id: 2, units_variant: { unit_value: 2 }, max_quantity: 1 }
-            { id: 3, units_variant: { unit_value: 3 }, max_quantity: 10 }
+            { id: 1, units_variant: { unit_value: 1 }, max_quantity: 5, units_product: { variant_unit: "volume", variant_unit_scale: 1 } }
+            { id: 2, units_variant: { unit_value: 2 }, max_quantity: 1, units_product: { variant_unit: "volume", variant_unit_scale: 1 } }
+            { id: 3, units_variant: { unit_value: 3 }, max_quantity: 10, units_product: { variant_unit: "volume", variant_unit_scale: 1 } }
           ]
 
           expect(scope.sumMaxUnitValues()).toEqual 37
+
+        it "returns the sum of the product of max_quantity for specified line_items if variant_unit is `items`", ->
+          scope.filteredLineItems = [
+            { id: 1, units_variant: { unit_value: 1 }, max_quantity: 5, units_product: { variant_unit: "items" } }
+            { id: 2, units_variant: { unit_value: 2 }, max_quantity: 1, units_product: { variant_unit: "items" } }
+            { id: 3, units_variant: { unit_value: 3 }, max_quantity: 10, units_product: { variant_unit: "items" } }
+          ]
+
+          expect(scope.sumMaxUnitValues()).toEqual 16
 
       describe "formatting a value based upon the properties of a specified Units Variant", ->
         # A Units Variant is an API object which holds unit properies of a variant

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -305,10 +305,9 @@ describe "LineItemsCtrl", ->
         it "returns '' if selectedUnitsVariant has no property 'variant_unit'", ->
           expect(scope.formattedValueWithUnitName(1,{})).toEqual ''
 
-        it "returns '', and does not call Math.round if variant_unit is 'items'", ->
+        it "returns the value, and does not call Math.round if variant_unit is 'items'", ->
           unitsProduct = { variant_unit: "items" }
-          expect(scope.formattedValueWithUnitName(1,unitsProduct,unitsVariant)).toEqual ''
-          expect(Math.round).not.toHaveBeenCalled()
+          expect(scope.formattedValueWithUnitName(1, unitsProduct, unitsVariant)).toEqual "1 items"
 
         it "calls Math.round() if variant_unit is 'weight' or 'volume'", ->
           unitsProduct = { variant_unit: "weight", variant_unit_scale: 1 }

--- a/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
+++ b/spec/javascripts/unit/admin/line_items/controllers/line_items_controller_spec.js.coffee
@@ -207,18 +207,15 @@ describe "LineItemsCtrl", ->
           scope.selectedUnitsProduct = { variant_unit: "weight" }
           expect(scope.fulfilled()).toEqual ''
 
-        it "returns '', and does not call Math.round if variant_unit is 'items'", ->
-          spyOn(Math,"round")
-          scope.selectedUnitsProduct = { variant_unit: "items", group_buy_unit_size: 10 }
-          expect(scope.fulfilled()).toEqual ''
-          expect(Math.round).not.toHaveBeenCalled()
-
-        it "calls Math.round() if variant_unit is 'weight' or 'volume'", ->
+        it "calls Math.round() if variant_unit is 'weight', 'volume', or items", ->
           spyOn(Math,"round")
           scope.selectedUnitsProduct = { variant_unit: "weight", group_buy_unit_size: 10 }
           scope.fulfilled()
           expect(Math.round).toHaveBeenCalled()
           scope.selectedUnitsProduct = { variant_unit: "volume", group_buy_unit_size: 10 }
+          scope.fulfilled()
+          expect(Math.round).toHaveBeenCalled()
+          scope.selectedUnitsProduct = { variant_unit: "items", group_buy_unit_size: 10 }
           scope.fulfilled()
           expect(Math.round).toHaveBeenCalled()
 


### PR DESCRIPTION
#### What? Why?

Closes #8540

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

- Create product that is set to `items` quantity (_sachets_ means bags, pouch in french) and is available for bulk mode
<img width="563" alt="Capture d’écran 2022-04-25 à 16 11 44" src="https://user-images.githubusercontent.com/296452/165311148-30e077ce-18a7-4d08-9ba2-a8e95d80dc01.png">

- Set a Group By value
<img width="537" alt="Capture d’écran 2022-04-26 à 15 32 06" src="https://user-images.githubusercontent.com/296452/165311450-c27b34b4-aaf3-419c-a526-721074cc6f69.png">

- Checkout that product, and see the Bulk Order Management interface
<img width="1446" alt="Capture d’écran 2022-04-26 à 15 33 13" src="https://user-images.githubusercontent.com/296452/165312694-d8f3fdfa-24b9-43b9-b033-1a39e3526e73.png">


It should not affect the interface in metric and imperial system, but I'd think it worth a check (before and after the PR) ; see previous PR maybe for help (https://github.com/openfoodfoundation/openfoodnetwork/pull/8565)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
