### PR TITLE
Split checkout: Order shipping methods by name

### DIFF
--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -47,7 +47,7 @@ module CheckoutCallbacks
   end
 
   def load_shipping_methods
-    @shipping_methods = available_shipping_methods
+    @shipping_methods = available_shipping_methods.sort_by(&:name)
   end
 
   def redirect_to_shop?

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -182,6 +182,11 @@ describe "As a consumer, I want to checkout my order", js: true do
         expect(page).not_to have_content "Save as default shipping address"
       end
 
+      it 'display shipping methods alphabetically' do
+        shipping_methods = page.all(:field, "shipping_method_id").map { |field| field.sibling("label") }.map(&:text)
+        expect(shipping_methods).to eq ["A Free Shipping with required address", "Free Shipping", "Local", "Shipping with Fee", "Z Free Shipping without required address"]
+      end
+
       it_behaves_like "when I have an out of stock product in my cart"
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #9137

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?

 - Go to a shop with split checkout activated
 - See shipping methods are ordered by alphabetical order

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.
