### PR TITLE
Correct checksum in Paperclip migration task

### DIFF
--- a/lib/tasks/from_paperclip_to_active_storage.rake
+++ b/lib/tasks/from_paperclip_to_active_storage.rake
@@ -74,7 +74,7 @@ namespace :from_paperclip_to_active_storage do
   # stored on AWS S3. Getting the checksum requires a HEAD request.
   # In my tests, I could process 100 records per minute this way.
   def storage_record_for(name, paperclip)
-    checksum = hex_to_base64_digest(paperclip.s3_object.etag)
+    checksum = hex_to_base64_digest(paperclip.s3_object(:original).etag.delete('"'))
 
     blob = ActiveStorage::Blob.new(
       key: paperclip.path(:original),

--- a/spec/lib/tasks/from_paperclip_to_active_storage_rake_spec.rb
+++ b/spec/lib/tasks/from_paperclip_to_active_storage_rake_spec.rb
@@ -55,7 +55,7 @@ describe "from_paperclip_to_active_storage.rake" do
       stub_request(:head, /amazonaws/).to_return(
         status: 200, body: "",
         headers: {
-          "ETag" => "md5sum000test000example"
+          "ETag" => "87b0a401e077485a078c0a15ceb7eb39"
         }
       )
       stub_request(:put, /amazonaws/).to_return(status: 200, body: "", headers: {})
@@ -70,7 +70,14 @@ describe "from_paperclip_to_active_storage.rake" do
         image.reload.active_storage_attachment.attached?
       }.to(true)
 
-      expect(image.attachment_blob.checksum).to eq "md5sum000test000example"
+      # The checksum can be computed with Active Storage:
+      #
+      #   ActiveStorage::Blob.build_after_unfurling(
+      #     io: file, identify: false,
+      #     filename: "logo-black.png",
+      #     content_type: "image/png",
+      #   ).checksum
+      expect(image.attachment_blob.checksum).to eq "h7CkAeB3SFoHjAoVzrfrOQ=="
     end
   end
 

--- a/spec/lib/tasks/from_paperclip_to_active_storage_rake_spec.rb
+++ b/spec/lib/tasks/from_paperclip_to_active_storage_rake_spec.rb
@@ -55,7 +55,7 @@ describe "from_paperclip_to_active_storage.rake" do
       stub_request(:head, /amazonaws/).to_return(
         status: 200, body: "",
         headers: {
-          "ETag" => "87b0a401e077485a078c0a15ceb7eb39"
+          "ETag" => '"87b0a401e077485a078c0a15ceb7eb39"'
         }
       )
       stub_request(:put, /amazonaws/).to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
#### What? Why?

- https://github.com/openfoodfoundation/openfoodnetwork/pull/9126#issuecomment-1113188729

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Active Storage needs a checksum for each file and AWS S3 provides this
checksum as "ETag". They are both MD5 but AWS stores it as hexdigest and
Active Storage as base64digest. We need to convert it from on to the
other to get a valid checksum for Active Storage.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

On staging servers with **cloud storage** where the migration task has already run, delete all
Active Storage data first and then run the task again:

```
bundle exec rake db:migrate:down VERSION=20220316055458
bundle exec rake db:migrate

bundle exec rake from_paperclip_to_active_storage:copy_content_config
bundle exec rake from_paperclip_to_active_storage:migrate
```


- Take note of which images are broken and which ones are working currently.
- Deploy https://github.com/openfoodfoundation/openfoodnetwork/pull/9126
- All images should still display as before (we can't fix images that were broken before).

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies

We need to persist the storage directory between deploys with ofn-install. :heavy_check_mark: 