### PR TITLE
Add disabled_at logic on spree users

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -144,6 +144,32 @@ module Spree
       "#{self.class.name};#{id}"
     end
 
+    def disabled?
+      disabled_at.present?
+    end
+
+    def disable!
+      self.disabled_at = Time.zone.now
+      save!
+    end
+
+    def enable!
+      self.disabled_at = nil
+      save!
+    end
+
+    def toggle_disable
+      disabled?
+    end
+
+    def toggle_disable=(value)
+      if value == '1'
+        disable!
+      else
+        enable!
+      end
+    end
+
     protected
 
     def password_required?

--- a/app/services/permitted_attributes/user.rb
+++ b/app/services/permitted_attributes/user.rb
@@ -15,7 +15,7 @@ module PermittedAttributes
     private
 
     def permitted_attributes
-      [:email, :password, :password_confirmation]
+      [:email, :password, :password_confirmation, :toggle_disable]
     end
   end
 end

--- a/app/views/spree/admin/users/_form.html.haml
+++ b/app/views/spree/admin/users/_form.html.haml
@@ -24,3 +24,10 @@
       = f.label :password_confirmation, t(".confirm_password")
       = f.password_field :password_confirmation, class: "fullwidth"
       = f.error_message_on :password_confirmation
+    = f.field_container :disable do
+      = f.label :disable, t(".disable")
+      =# check_box_tag "user[toggle_disable]", "1", @user.disabled?, id: "user_toggle_disable"
+      = f.check_box :toggle_disable
+      = f.error_message_on :disable
+      - if @user.disabled?
+        = label_tag @user.disabled_at

--- a/db/migrate/20220425230907_add_disabled_at_to_spree_users.rb
+++ b/db/migrate/20220425230907_add_disabled_at_to_spree_users.rb
@@ -1,0 +1,5 @@
+class AddDisabledAtToSpreeUsers < ActiveRecord::Migration[6.1]
+  def up
+    add_column :spree_users, :disabled_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_10_162955) do
+ActiveRecord::Schema.define(version: 2022_04_25_230907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1055,6 +1055,7 @@ ActiveRecord::Schema.define(version: 2022_04_10_162955) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email", limit: 255
+    t.datetime "disabled_at"
     t.index ["confirmation_token"], name: "index_spree_users_on_confirmation_token", unique: true
     t.index ["email"], name: "email_idx_unique", unique: true
     t.index ["persistence_token"], name: "index_users_on_persistence_token"

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -201,4 +201,36 @@ describe Spree::User do
       expect(user.flipper_id).to eq "Spree::User;42"
     end
   end
+
+  describe "#disable!" do
+    it "sets disabled datetime" do
+      user = create(:user)
+      expect(user.disabled_at).to be_nil
+      user.disable!
+      expect(user.disabled_at).not_to be_nil
+    end
+  end
+
+  describe "#enable!" do
+    it "clears disabled datetime" do
+      user = create(:user, disabled_at: Time.zone.now)
+      expect(user.disabled_at).not_to be_nil
+      user.enable!
+      expect(user.disabled_at).to be_nil
+    end
+  end
+
+  describe "#disabled?" do
+    it "returns true with a disabled datetime" do
+      user = create(:user)
+      user.disable!
+      expect(user.disabled?).to be_truthy
+    end
+
+    it "returns false without a disabled datetime" do
+      user = create(:user)
+      user.enable!
+      expect(user.disabled?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
#### What? Why?

Closes #9066.

I decided to add a `disabled_at` field on users in order to handle the state for disability.
We need to:
[ ] Set the field and handle the related logic
[ ] Block the login for disabled users
[ ] Log out users after being disabled


#### What should we test?
- Log as Superadmin
- On a separate session, log in with a basic user
- Visit the basic user page in Admin panel
- Check the 'Disabled' box
- Update the page and control that the 'disabled_at' datetime if shown
- On the separate session, refresh the page and check that the basic user is logged out
- On the separate session, try to log in with the basic user

#### Release notes
- Implement the ability to desactivate an user in Superadmin

Changelog Category: User facing changes
