### PR TITLE
Run Mayhem4API CI check only within organisation

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,7 +1,8 @@
 name: 'Mayhem for API'
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
+    if: ${{ github.repository_owner == "openfoodfoundation" }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true


### PR DESCRIPTION

#### What? Why?

This came up in https://github.com/openfoodfoundation/openfoodnetwork/pull/9044#issuecomment-1116187635.
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

The API key is not accessible in pull requests from forks. Contributor PRs started failing the API test because the secret token for the Mayhem API is not available.

It's also a commercial service allowing us only 50 free builds per month. We can't afford running builds for all contributor PRs which aren't even changing the API. Instead, we only run it on branches of our repository, mostly master now.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- The GH checks below should all pass. The Mayhem4API check should not be in there.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


