### PR TITLE
Split Checkout: Sort shipping methods case insensitive

### DIFF
--- a/app/controllers/concerns/checkout_callbacks.rb
+++ b/app/controllers/concerns/checkout_callbacks.rb
@@ -47,7 +47,7 @@ module CheckoutCallbacks
   end
 
   def load_shipping_methods
-    @shipping_methods = available_shipping_methods.sort_by(&:name)
+    @shipping_methods = available_shipping_methods.sort { |a, b| a.name.casecmp(b.name) }
   end
 
   def redirect_to_shop?

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -36,7 +36,7 @@ describe "As a consumer, I want to checkout my order", js: true do
     create(:shipping_method, require_ship_address: true, name: "A Free Shipping with required address")
   }
   let(:free_shipping) {
-    create(:shipping_method, require_ship_address: false, name: "Free Shipping", description: "yellow",
+    create(:shipping_method, require_ship_address: false, name: "free Shipping", description: "yellow",
                              calculator: Calculator::FlatRate.new(preferred_amount: 0.00))
   }
   let(:shipping_tax_rate) { create(:tax_rate, amount: 0.25, zone: zone, included_in_price: true) }
@@ -184,7 +184,7 @@ describe "As a consumer, I want to checkout my order", js: true do
 
       it 'display shipping methods alphabetically' do
         shipping_methods = page.all(:field, "shipping_method_id").map { |field| field.sibling("label") }.map(&:text)
-        expect(shipping_methods).to eq ["A Free Shipping with required address", "Free Shipping", "Local", "Shipping with Fee", "Z Free Shipping without required address"]
+        expect(shipping_methods).to eq ["A Free Shipping with required address", "free Shipping", "Local", "Shipping with Fee", "Z Free Shipping without required address"]
       end
 
       it_behaves_like "when I have an out of stock product in my cart"


### PR DESCRIPTION
#### What? Why?

Follow-up #9138 and comment: https://github.com/openfoodfoundation/openfoodnetwork/pull/9138#issuecomment-1118417237

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?


- Creates multiple shipping methods with different cases (up and down case)
- See that order is well respected in the split checkout

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
