### PR TITLE
Add `order_token` params to the redirect URL after checkout

### DIFF
--- a/app/controllers/split_checkout_controller.rb
+++ b/app/controllers/split_checkout_controller.rb
@@ -132,7 +132,7 @@ class SplitCheckoutController < ::BaseController
     when "confirmation"
       redirect_to checkout_step_path(:summary)
     else
-      redirect_to order_path(@order)
+      redirect_to order_path(@order, order_token: @order.token)
     end
   end
 

--- a/spec/controllers/split_checkout_controller_spec.rb
+++ b/spec/controllers/split_checkout_controller_spec.rb
@@ -227,7 +227,7 @@ describe SplitCheckoutController, type: :controller do
         it "completes the order and redirects to order confirmation" do
           put :update, params: params
 
-          expect(response).to redirect_to order_path(order)
+          expect(response).to redirect_to order_path(order, order_token: order.token)
           expect(order.reload.state).to eq "complete"
         end
       end
@@ -255,7 +255,7 @@ describe SplitCheckoutController, type: :controller do
           it "completes the order and redirects to order confirmation" do
             put :update, params: params
 
-            expect(response).to redirect_to order_path(order)
+            expect(response).to redirect_to order_path(order, order_token: order.token)
             expect(order.reload.state).to eq "complete"
           end
         end


### PR DESCRIPTION
#### What? Why?

Closes #9143

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Proceed to split checkout, and finalize the order
- See that you are redirect to `/orders/R[ORDER_ID]?order_token=[ORDER_TOKEN]`
<img width="920" alt="Capture d’écran 2022-05-09 à 17 33 16" src="https://user-images.githubusercontent.com/296452/167447634-7bb6951d-35af-4fb2-8a0c-d3a119448242.png">
- This URL should be _anonymous available_

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
