### PR TITLE
Split Checkout: Change i18n key on first step from delivery address to shipping info

### DIFF
--- a/app/views/split_checkout/_details.html.haml
+++ b/app/views/split_checkout/_details.html.haml
@@ -69,7 +69,7 @@
   %div.checkout-substep{ "data-controller": "toggle shippingmethod" }
     - selected_shipping_method = @order.shipping_method&.id || params[:shipping_method_id]
     %div.checkout-title
-      = t("split_checkout.step1.delivery_address.title")
+      = t("split_checkout.step1.shipping_info.title")
 
     - display_ship_address = false
     - ship_method_description = nil

--- a/app/views/split_checkout/_summary.html.haml
+++ b/app/views/split_checkout/_summary.html.haml
@@ -43,7 +43,7 @@
 
     %div.summary
       %span.summary-label
-        = t("split_checkout.step1.delivery_address.title")
+        = t("split_checkout.step1.shipping_info.title")
       %span.summary-value
         = @order.shipping_method.name
       %div.summary-description

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1828,8 +1828,8 @@ en:
           placeholder: e.g. SW11 3QN
         country_id:
           label: Country
-      delivery_address:
-          title: Delivery address
+      shipping_info:
+          title: Shipping info
       submit: Next - Payment method
       cancel: Back to Edit basket
     step2:


### PR DESCRIPTION
Delivery address --> shipping info

#### What? Why?

Closes #9172

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

As a customer, with SplitCheckout activated, see that :
- on step 1, section title is "Shipping info"
<img width="680" alt="Capture d’écran 2022-05-11 à 10 13 37" src="https://user-images.githubusercontent.com/296452/167801873-57464d68-aae1-46a7-921e-6fbbe9e7f76a.png">

- on step 3, bold subsection is "Shipping info" as well
<img width="386" alt="Capture d’écran 2022-05-11 à 10 13 09" src="https://user-images.githubusercontent.com/296452/167801860-aa826a2e-f3af-4c87-a958-ee140d114892.png">

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
