### PR TITLE
Updating order cycle will ensure any $NaN subscription item prices to be recalculated

### DIFF
--- a/app/controllers/admin/order_cycles_controller.rb
+++ b/app/controllers/admin/order_cycles_controller.rb
@@ -96,14 +96,15 @@ module Admin
 
     def update_nil_subscription_line_items_price_estimate(order_cycle)
       order_cycle.schedules.each do |schedule|
-        subscription = Subscription.find_by(schedule_id: schedule.id)
-        shop = Enterprise.managed_by(spree_current_user).find_by(id: subscription.shop_id)
-        subscription.subscription_line_items.nil_price_estimate.each do |line_item|
-          variant = OrderManagement::Subscriptions::VariantsList
-            .eligible_variants(shop).find_by(id: line_item.variant_id)
-          fee_calculator = OpenFoodNetwork::EnterpriseFeeCalculator.new(shop, order_cycle)
-          price = variant.price + fee_calculator.indexed_fees_for(variant)
-          line_item.update_column(:price_estimate, price)
+        Subscription.where(schedule_id: schedule.id).each do |subscription|
+          shop = Enterprise.managed_by(spree_current_user).find_by(id: subscription.shop_id)
+          subscription.subscription_line_items.nil_price_estimate.each do |line_item|
+            variant = OrderManagement::Subscriptions::
+                VariantsList.eligible_variants(shop).find_by(id: line_item.variant_id)
+            fee_calculator = OpenFoodNetwork::EnterpriseFeeCalculator.new(shop, order_cycle)
+            price = variant.price + fee_calculator.indexed_fees_for(variant)
+            line_item.update_column(:price_estimate, price)
+          end
         end
       end
     end

--- a/app/models/subscription_line_item.rb
+++ b/app/models/subscription_line_item.rb
@@ -9,6 +9,7 @@ class SubscriptionLineItem < ApplicationRecord
   validates :quantity, presence: true, numericality: { only_integer: true }
 
   default_scope { order('id ASC') }
+  scope :nil_price_estimate, -> { where(price_estimate: nil) }
 
   def total_estimate
     (price_estimate || 0) * (quantity || 0)


### PR DESCRIPTION
#### What? Why?

Closes #9100 

When an order cycle is expired or inactive and we try to add an item to a subscription, we see that the total for the item is $NaN and the total for the order gets corrupted and also displays $NaN. This is expected since we don't have an order cycle to calculate the fees. Update the order cycle to be upcoming, it will display the estimated price now. Previously, this still displayed as $NaN

#### What should we test?
The ticket has a good instruction from Filipe [here](https://github.com/openfoodfoundation/openfoodnetwork/issues/9100#issuecomment-1114997365)


#### Release notes
Changelog Category: Technical changes
The title of the pull request will be included in the release notes.


#### Dependencies

#### Documentation updates
