### PR TITLE
Admin, Create a new product: re-fill the form with fields values if any validation errors occurs when submitting

### DIFF
--- a/app/assets/javascripts/admin/products/controllers/units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/units_controller.js.coffee
@@ -21,6 +21,8 @@ angular.module("admin.products")
         else
           $scope.product.variant_unit = $scope.product.variant_unit_with_scale
           $scope.product.variant_unit_scale = null
+      else if $scope.product.variant_unit && $scope.product.variant_unit_scale
+        $scope.product.variant_unit_with_scale = VariantUnitManager.getUnitWithScale($scope.product.variant_unit, parseFloat($scope.product.variant_unit_scale))
       else
         $scope.product.variant_unit = $scope.product.variant_unit_scale = null
 

--- a/app/assets/javascripts/admin/products/controllers/units_controller.js.coffee
+++ b/app/assets/javascripts/admin/products/controllers/units_controller.js.coffee
@@ -8,7 +8,7 @@ angular.module("admin.products")
       $scope.processVariantUnitWithScale()
       $scope.processUnitValueWithDescription()
       $scope.processUnitPrice()
-      $scope.placeholder_text = new OptionValueNamer($scope.product.master).name()
+      $scope.placeholder_text = new OptionValueNamer($scope.product.master).name() if $scope.product.variant_unit_scale
 
     $scope.variant_unit_options = VariantUnitManager.variantUnitOptions()
 
@@ -34,6 +34,10 @@ angular.module("admin.products")
           $scope.product.master.unit_value  = null if isNaN($scope.product.master.unit_value)
           $scope.product.master.unit_value *= $scope.product.variant_unit_scale if $scope.product.master.unit_value && $scope.product.variant_unit_scale
           $scope.product.master.unit_description = match[3]
+      else
+        value = $scope.product.master.unit_value
+        value /= $scope.product.variant_unit_scale if $scope.product.master.unit_value && $scope.product.variant_unit_scale
+        $scope.product.master.unit_value_with_description = value + " " + $scope.product.master.unit_description
 
     $scope.processUnitPrice = ->
       price = $scope.product.price

--- a/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
+++ b/app/assets/javascripts/admin/products/services/variant_unit_manager.js.coffee
@@ -33,9 +33,12 @@ angular.module("admin.products").factory "VariantUnitManager", (availableUnits) 
       options = for unit_type, _ of @units
         for scale in @unitScales(unit_type, available)
           name = @getUnitName(scale, unit_type)
-          ["#{I18n.t(unit_type)} (#{name})", "#{unit_type}_#{scale}"]
+          ["#{I18n.t(unit_type)} (#{name})", @getUnitWithScale(unit_type, scale)]
       options.push [[I18n.t('items'), 'items']]
       options = [].concat options...
+
+    @getUnitWithScale: (unit_type, scale) ->
+      "#{unit_type}_#{scale}"
 
     @getUnitName: (scale, unitType) ->
       if @units[unitType][scale]

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -36,6 +36,8 @@ module Spree
               redirect_to spree.admin_products_path
             end
           else
+            # Re-fill the form with deleted params on product
+            @on_hand = request.params[:product][:on_hand]
             render :new
           end
         end

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -30,11 +30,7 @@ module Spree
           @object.attributes = permitted_resource_params
           if @object.save
             flash[:success] = flash_message_for(@object, :successfully_created)
-            if params[:button] == "add_another"
-              redirect_to spree.new_admin_product_path
-            else
-              redirect_to spree.admin_products_path
-            end
+            redirect_after_save
           else
             # Re-fill the form with deleted params on product
             @on_hand = request.params[:product][:on_hand]
@@ -142,6 +138,14 @@ module Spree
       end
 
       private
+
+      def redirect_after_save
+        if params[:button] == "add_another"
+          redirect_to spree.new_admin_product_path
+        else
+          redirect_to spree.admin_products_path
+        end
+      end
 
       def product_set_from_params
         collection_hash = Hash[products_bulk_params[:products].each_with_index.map { |p, i|

--- a/app/controllers/spree/admin/products_controller.rb
+++ b/app/controllers/spree/admin/products_controller.rb
@@ -34,6 +34,7 @@ module Spree
           else
             # Re-fill the form with deleted params on product
             @on_hand = request.params[:product][:on_hand]
+            @on_demand = request.params[:product][:on_demand]
             render :new
           end
         end

--- a/app/views/spree/admin/products/_display_as.html.haml
+++ b/app/views/spree/admin/products/_display_as.html.haml
@@ -1,4 +1,4 @@
 .six.columns.omega{ "ng-if" => "product.variant_unit_with_scale != 'items'" }
   = f.field_container :display_as do
     = f.label :product_display_as, t('.display_as')
-    %input#product_display_as.fullwidth{name: "product[display_as]", placeholder: "{{ placeholder_text }}", type: "text"}
+    %input#product_display_as.fullwidth{name: "product[display_as]", placeholder: "{{ placeholder_text }}", type: "text", value: @product.master.display_as}

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -90,7 +90,7 @@
         = f.field_container :description do
           = f.label :product_description, t(".product_description")
           %br/
-          %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', "textangular-links-target-blank" => true, 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]"}
+          %text-angular{'id' => 'product_description', 'name' => 'product[description]', 'class' => 'text-angular', "textangular-links-target-blank" => true, 'ta-toolbar' => "[['bold','italics','underline','clear'],['insertLink']]", "ng-model": "product.description"}
             = sanitize(@product.description)
           = f.error_message_on :description
   .four.columns.omega{ style: "text-align: center" }

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -34,8 +34,8 @@
             = f.label :unit_value_with_description, t(".value"), 'ng-disabled' => "!hasUnit(product)"
             %span.required *
             %input.fullwidth{ id: 'product_unit_value_with_description', 'ng-model' => 'product.master.unit_value_with_description', :type => 'text', placeholder: "eg. 2", 'ng-disabled' => "!hasUnit(product)" }
-            %input{ type: 'hidden', 'ng-value' => 'product.master.unit_value', name: 'product[unit_value]' }
-            %input{ type: 'hidden', 'ng-value' => 'product.master.unit_description', name: 'product[unit_description]' }
+            %input{ type: 'hidden', 'ng-value': 'product.master.unit_value', "ng-init": "product.master.unit_value='#{@product.master.unit_value}'", name: 'product[unit_value]' }
+            %input{ type: 'hidden', 'ng-value': 'product.master.unit_description', "ng-init": "product.master.unit_description='#{@product.master.unit_description}'", name: 'product[unit_description]' }
         = render 'display_as', f: f
         .six.columns.omega{ 'ng-show' => "product.variant_unit_with_scale == 'items'" }
           = f.field_container :unit_name do

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -77,7 +77,7 @@
           = f.field_container :on_hand do
             = f.label :on_hand, t(".on_hand")
             %br/
-            = f.text_field :on_hand, class: 'fullwidth'
+            = f.text_field :on_hand, class: 'fullwidth', value: @on_hand
             = f.error_message_on :on_hand
         .three.columns.omega
           = f.field_container :on_demand do

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -50,7 +50,7 @@
             = f.label :price, t(".price")
             %span.required *
             %br/
-            = f.text_field :price, { "class" => "fullwidth", "ng-model" => "product.price" }
+            = f.text_field :price, { "class": "fullwidth", "ng-model": "product.price", "ng-value": "'#{@product.price}'" }
             = f.error_message_on :price
         .four.columns{ ng: { app: 'ofn.admin'}}
           = f.field_container :unit_price do

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -83,7 +83,7 @@
           = f.field_container :on_demand do
             = f.label :on_demand, t(".on_demand")
             %br/
-            = f.check_box :on_demand
+            = f.check_box :on_demand, value: '1', checked: @on_demand == '1'
             = f.error_message_on :on_demand
 
       .sixteen.columns.alpha

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -25,10 +25,10 @@
           = f.field_container :units do
             = f.label :variant_unit_with_scale, t(".units")
             %span.required *
-            %select.select2.fullwidth{ id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options' }
+            %select{id: 'product_variant_unit_with_scale', 'ng-model' => 'product.variant_unit_with_scale', 'ng-options' => 'unit[1] as unit[0] for unit in variant_unit_options',"data-controller": "tom-select", class: "primary"}
               %option{'value' => '', 'ng-hide' => "hasUnit(product)"}
-            %input{ type: 'hidden', 'ng-value' => 'product.variant_unit', name: 'product[variant_unit]' }
-            %input{ type: 'hidden', 'ng-value' => 'product.variant_unit_scale', name: 'product[variant_unit_scale]' }
+            %input{ type: 'hidden', 'ng-value': 'product.variant_unit', "ng-init": "product.variant_unit='#{@product.variant_unit}'", name: 'product[variant_unit]' }
+            %input{ type: 'hidden', 'ng-value': 'product.variant_unit_scale', "ng-init": "product.variant_unit_scale='#{@product.variant_unit_scale}'", name: 'product[variant_unit_scale]' }
         .two.columns
           = f.field_container :unit_value do
             = f.label :unit_value_with_description, t(".value"), 'ng-disabled' => "!hasUnit(product)"

--- a/app/views/spree/admin/products/new.html.haml
+++ b/app/views/spree/admin/products/new.html.haml
@@ -11,7 +11,7 @@
           = f.field_container :supplier do
             = f.label :supplier_id, t(".supplier")
             %span.required *
-            = f.collection_select(:supplier_id, @producers, :id, :name, {:include_blank => true, :selected => select_only_item(@producers)}, {:class => "select2 fullwidth"})
+            = f.select :supplier_id, options_from_collection_for_select(@producers, :id, :name, @product.supplier_id), {}, { "data-controller": "tom-select", class: "primary" }
             = f.error_message_on :supplier
         .eight.columns.omega
           = f.field_container :name do

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -29,6 +29,41 @@ describe '
   describe "creating a product" do
     let!(:tax_category) { create(:tax_category, name: 'Test Tax Category') }
 
+    it "display all attributes when submitting with error: no name" do
+      login_to_admin_section
+
+      click_link 'Products'
+      click_link 'New Product'
+
+      select @supplier.name, from: 'product_supplier_id'
+      select "Weight (kg)", from: 'product_variant_unit_with_scale'
+      fill_in 'product_unit_value_with_description', with: "5 g"
+      assert_selector(:field, placeholder: "5kg g")
+      fill_in 'product_display_as', with: "Big Box of Chocolates"
+      select taxon.name, from: "product_primary_taxon_id"
+      fill_in 'product_price', with: '19.99'
+      fill_in 'product_on_hand', with: 5
+      check 'product_on_demand'
+      select 'Test Tax Category', from: 'product_tax_category_id'
+      page.find("div[id^='taTextElement']").native.send_keys('A description...')
+
+      click_button 'Create'
+
+      expect(page).to have_content "Name can't be blank"
+      expect(page).to have_field 'product_supplier_id', with: @supplier.id
+      expect(page).to have_field 'product_unit_value_with_description', with: "5 g"
+      expect(page).to have_field 'product_display_as', with: "Big Box of Chocolates"
+      expect(page).to have_field 'product_primary_taxon_id', with: taxon.id
+      expect(page).to have_field 'product_price', with: '19.99'
+      expect(page).to have_field 'product_on_hand', with: 5
+      expect(page).to have_field 'product_on_demand', checked: true
+      expect(page).to have_field 'product_tax_category_id', with: tax_category.id
+      expect(page.find("div[id^='taTextElement']")).to have_content 'A description...'
+      expect(page.find("#product_units_field")).to have_content 'Weight (kg)'
+
+      expect(page).to have_content "Name can't be blank"
+    end
+
     it "assigning important attributes", js: true do
       login_to_admin_section
 

--- a/spec/system/admin/products_spec.rb
+++ b/spec/system/admin/products_spec.rb
@@ -137,6 +137,7 @@ describe '
       fill_in 'product_name', with: 'Hot Cakes'
       select 'New supplier', from: 'product_supplier_id'
       select "Weight (kg)", from: 'product_variant_unit_with_scale'
+      fill_in "product_unit_value_with_description", with: ""
       select taxon.name, from: "product_primary_taxon_id"
       fill_in 'product_price', with: '1.99'
       fill_in 'product_on_hand', with: 0


### PR DESCRIPTION
#### What? Why?
Closes #9067

Save and re-display filled input in the `/admin/products/new` form if validation errors does occur. 




#### What should we test?


- As an admin, visit page `/admin/products/new` to create a product
- Fill the form, but not one mandatory field
- Submit the form
- You should see validation error on one empty field, but other fields should be well filled with previous submitted values

Many changes have taken place on this page, we should also check that everything is fine (relations between "unit size", "value", "display as", "price", "unit price", ...)


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
