### PR TITLE
Reports: Remove JSON as a download option

### DIFF
--- a/app/views/admin/reports/_rendering_options.html.haml
+++ b/app/views/admin/reports/_rendering_options.html.haml
@@ -30,7 +30,7 @@
   .omega.fourteen.columns
     = select_tag :report_format, grouped_options_for_select({ |
       t('.formatted_data') => { t('.on_screen') => '', "PDF" => 'pdf', t('.spreadsheet') => 'xlsx' }, |
-      t('.raw_data') => { "CSV" => 'csv', "JSON" => 'json'}, |
+      t('.raw_data') => { "CSV" => 'csv' }, |
     })
 
 


### PR DESCRIPTION
#### What? Why?

Closes #9184 

Remove JSON option from selector
<img width="485" alt="Capture d’écran 2022-05-17 à 10 56 07" src="https://user-images.githubusercontent.com/296452/168772031-ec7763de-66cb-433e-9934-82ec63453230.png">


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, visit any report page, such as `/admin/reports/orders_and_distributors`
- Check that you should not be able to download report as `json` file

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
