### PR TITLE
For all `orders_and_fulfillment` reports, distinct product by `variant`, `price` & `order_id`

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/base.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/base.rb
@@ -22,7 +22,7 @@ module Reporting
         end
 
         def query_result
-          report_line_items.list(line_item_includes).group_by(&:variant_id).values
+          report_line_items.list(line_item_includes).group_by { |e| [e.variant_id, e.price] }.values
         end
 
         private

--- a/lib/reporting/reports/orders_and_fulfillment/base.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/base.rb
@@ -22,7 +22,9 @@ module Reporting
         end
 
         def query_result
-          report_line_items.list(line_item_includes).group_by { |e| [e.variant_id, e.price] }.values
+          report_line_items.list(line_item_includes).group_by { |e|
+            [e.variant_id, e.price, e.order_id]
+          }.values
         end
 
         private


### PR DESCRIPTION


#### What? Why?

Closes #9127

Distinct each line items by `variant_id` and `price`, and then use the `group_by { |e| [e.variant_id, e.price] }` syntax.

#### What should we test?
- As an admin (or not actually), generate 3 orders:
  - 2 with Product_1 with price_1
  - Change the price of Product_1 to price_2
  - 1 with Product_1 with new price_2
- As an admin, visit `/admin/reports/orders_and_fulfillment` generate any reports 
- You should see one row per product having different price and many rows with product with the same price

<img width="1397" alt="Capture d’écran 2022-05-19 à 10 51 02" src="https://user-images.githubusercontent.com/296452/169253987-f80a3728-5060-48ce-8c00-dfdc81b35a84.png">


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
