### PR TITLE
Admin, Order creation: Change steps ordering

### DIFF
--- a/app/controllers/spree/admin/orders_controller.rb
+++ b/app/controllers/spree/admin/orders_controller.rb
@@ -42,6 +42,10 @@ module Spree
           @order.update_order!
         end
 
+        if params[:set_distribution_step] && @order.update(order_params)
+          return redirect_to spree.admin_order_customer_path(@order)
+        end
+
         unless order_params.present? && @order.update(order_params) && @order.line_items.present?
           if @order.line_items.empty? && !params[:suppress_error_msg]
             @order.errors.add(:line_items, Spree.t('errors.messages.blank'))
@@ -55,7 +59,7 @@ module Spree
           redirect_to spree.edit_admin_order_path(@order)
         else
           # Jump to next step if order is not complete
-          redirect_to spree.admin_order_customer_path(@order)
+          redirect_to spree.admin_order_payments_path(@order)
         end
       end
 

--- a/app/views/spree/admin/orders/set_distribution.html.haml
+++ b/app/views/spree/admin/orders/set_distribution.html.haml
@@ -21,6 +21,7 @@
     = render 'spree/admin/orders/_form/distribution_fields'
     -# This param passed to stop validation error in next page due to no line items in order yet:
     = hidden_field_tag 'suppress_error_msg', "true"
+    = hidden_field_tag "set_distribution_step", "true"
     = button_tag :class => 'secondary radius expand small', :id => 'update-button' do
       %i.icon-arrow-right
       = t(:next)

--- a/app/views/spree/admin/orders/set_distribution.html.haml
+++ b/app/views/spree/admin/orders/set_distribution.html.haml
@@ -9,7 +9,7 @@
   \#
   = @order.number
 
-= render 'spree/admin/shared/order_tabs', :current => 'Order Details'
+= render 'spree/admin/shared/order_tabs', :current => 'Customer Details'
 
 = csrf_meta_tags
 

--- a/app/views/spree/admin/shared/_order_tabs.html.haml
+++ b/app/views/spree/admin/shared/_order_tabs.html.haml
@@ -44,21 +44,21 @@
 
   %nav.menu
     %ul
-      - order_details_classes = "active" if current == "Order Details"
-      %li{ class: order_details_classes }
-        = link_to_with_icon 'icon-edit', t(:order_details), spree.edit_admin_order_url(@order)
-
       - customer_details_classes = "active" if current == "Customer Details"
       %li{ class: customer_details_classes }
         = link_to_with_icon 'icon-user', t(:customer_details), spree.admin_order_customer_url(@order)
 
-      - adjustments_classes = "active" if current == "Adjustments"
-      %li{ class: adjustments_classes }
-        = link_to_with_icon 'icon-cogs', t(:adjustments), spree.admin_order_adjustments_url(@order)
+      - order_details_classes = "active" if current == "Order Details"
+      %li{ class: order_details_classes }
+        = link_to_with_icon 'icon-edit', t(:order_details), spree.edit_admin_order_url(@order)
 
       - payments_classes = "active" if current == "Payments"
       %li{ class: payments_classes }
         = link_to_with_icon 'icon-credit-card', t(:payments), spree.admin_order_payments_url(@order)
+
+      - adjustments_classes = "active" if current == "Adjustments"
+      %li{ class: adjustments_classes }
+        = link_to_with_icon 'icon-cogs', t(:adjustments), spree.admin_order_adjustments_url(@order)
 
       - if @order.completed?
         - authorizations_classes = "active" if current == "Return Authorizations"

--- a/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -239,12 +239,12 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         context "and no errors" do
-          it "updates distribution charges and redirects to customer details page" do
+          it "updates distribution charges and redirects to payments  page" do
             expect_any_instance_of(Spree::Order).to receive(:recreate_all_fees!)
 
             spree_put :update, params
 
-            expect(response).to redirect_to spree.admin_order_customer_path(order)
+            expect(response).to redirect_to spree.admin_order_payments_path(order)
           end
         end
 

--- a/spec/system/admin/order_spec.rb
+++ b/spec/system/admin/order_spec.rb
@@ -64,6 +64,12 @@ describe '
     expect(page).not_to have_selector '.flash.error'
     expect(page).not_to have_content "Line items can't be blank"
 
+    expect(page).to have_selector 'h1', text: 'Customer Details'
+    o = Spree::Order.last
+    expect(o.distributor).to eq(distributor)
+    expect(o.order_cycle).to eq(order_cycle)
+
+    click_link "Order Details"
     click_button "Update And Recalculate Fees"
     expect(page).to have_selector '.flash.error'
     expect(page).to have_content "Line items can't be blank"
@@ -77,11 +83,6 @@ describe '
     expect(page).to have_selector 'td', text: product.name
 
     click_button 'Update'
-
-    expect(page).to have_selector 'h1', text: 'Customer Details'
-    o = Spree::Order.last
-    expect(o.distributor).to eq(distributor)
-    expect(o.order_cycle).to eq(order_cycle)
   end
 
   it "can add a product to an existing order" do
@@ -372,12 +373,6 @@ describe '
     # When I create a new order
     login_as user
     new_order_with_distribution(distributor, order_cycle)
-    select2_select product.name, from: 'add_variant_id', search: true
-    find('button.add_variant').click
-    page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr" # Wait for JS
-    click_button 'Update'
-
-    expect(page).to have_selector 'h1.js-admin-page-title', text: "Customer Details"
 
     # The customer selection partial should be visible
     expect(page).to have_selector '#select-customer'
@@ -385,7 +380,6 @@ describe '
     # And I select that customer's email address and save the order
     tomselect_search_and_select customer.email, from: 'customer_search_override'
     click_button 'Update'
-    expect(page).to have_selector "h1.js-admin-page-title", text: "Customer Details"
 
     # Then their addresses should be associated with the order
     order = Spree::Order.last
@@ -395,6 +389,12 @@ describe '
     expect(order.bill_address.zipcode).to eq customer.bill_address.zipcode
     expect(order.ship_address.city).to eq customer.ship_address.city
     expect(order.bill_address.city).to eq customer.bill_address.city
+
+    click_link "Order Details"
+
+    select2_select product.name, from: 'add_variant_id', search: true
+    find('button.add_variant').click
+    page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr" # Wait for JS
   end
 
   context "as an enterprise manager" do
@@ -686,6 +686,8 @@ describe '
 
     it "creating an order with distributor and order cycle" do
       new_order_with_distribution(distributor1, order_cycle1)
+      expect(page).to have_selector 'h1', text: 'Customer Details'
+      click_link "Order Details"
 
       expect(page).to have_content 'ADD PRODUCT'
       select2_select product.name, from: 'add_variant_id', search: true
@@ -704,7 +706,6 @@ describe '
 
       click_button 'Update'
 
-      expect(page).to have_selector 'h1', text: 'Customer Details'
       o = Spree::Order.last
       expect(o.distributor).to eq distributor1
       expect(o.order_cycle).to eq order_cycle1

--- a/spec/system/admin/variant_overrides_spec.rb
+++ b/spec/system/admin/variant_overrides_spec.rb
@@ -449,6 +449,7 @@ describe "
         select2_select distributor.name, from: 'order_distributor_id'
         select2_select order_cycle.name, from: 'order_order_cycle_id'
         click_button 'Next'
+        click_link "Order Details"
       end
 
       # Reproducing a bug, issue #1446


### PR DESCRIPTION
#### What? Why?

Closes #8912

After Set distribution step, we are redirected to Customer Details step.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, visit `/admin/orders/new` to create an order
- See that the first step is `Set distribution`:
<img width="854" alt="Capture d’écran 2022-05-19 à 17 23 10" src="https://user-images.githubusercontent.com/296452/169334879-c2dca573-65de-4398-89f8-5a362e04b22b.png">

- After form filled, click on `Next` and see that you're redirected to `/admin/orders/R[ORDER_ID]/customer`


See Acceptance Criteria of the linked issue.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
