### PR TITLE
Remove closed associated adjustments button

### DIFF
--- a/app/assets/javascripts/admin/spree/orders/shipments.js.erb
+++ b/app/assets/javascripts/admin/spree/orders/shipments.js.erb
@@ -25,13 +25,12 @@ $(document).ready(function() {
     var link = $(this);
     var shipment_number = link.data('shipment-number');
     var selected_shipping_rate_id = link.parents('tbody').find("select#selected_shipping_rate_id[data-shipment-number='" + shipment_number + "']").val();
-    var unlock = link.parents('tbody').find("input[name='open_adjustment'][data-shipment-number='" + shipment_number + "']:checked").val();
     var url = Spree.url( Spree.routes.orders_api + "/" + order_number + "/shipments/" + shipment_number + ".json");
 
     $.ajax({
       type: "PUT",
       url: url,
-      data: { shipment: { selected_shipping_rate_id: selected_shipping_rate_id, unlock: unlock  } }
+      data: { shipment: { selected_shipping_rate_id: selected_shipping_rate_id  } }
     }).done(function( msg ) {
       window.location.reload();
     }).error(function( msg ) {

--- a/app/controllers/api/v0/shipments_controller.rb
+++ b/app/controllers/api/v0/shipments_controller.rb
@@ -28,19 +28,14 @@ module Api
         authorize! :read, Spree::Shipment
         @shipment = @order.shipments.find_by!(number: params[:id])
         params[:shipment] ||= []
-        unlock = params[:shipment].delete(:unlock)
 
-        if unlock == 'yes'
-          @shipment.fee_adjustment.fire_events(:open)
-        end
+        @shipment.fee_adjustment.fire_events(:open)
 
         if @shipment.update(shipment_params)
           @order.updater.update_totals_and_states
         end
 
-        if unlock == 'yes'
-          @shipment.fee_adjustment.close
-        end
+        @shipment.fee_adjustment.close
 
         render json: @shipment.reload, serializer: Api::ShipmentSerializer, status: :ok
       end

--- a/app/views/spree/admin/orders/_shipment.html.haml
+++ b/app/views/spree/admin/orders/_shipment.html.haml
@@ -40,18 +40,6 @@
               = label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method)
               = select_tag :selected_shipping_rate_id, options_for_select(shipment.shipping_rates.backend.map { |sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id), { :class => 'select2 fullwidth', :data => { 'shipment-number' => shipment.number } }
 
-            - if shipment.fee_adjustment&.closed?
-              %div.field.omega.four.columns
-                %label
-                  = Spree.t(:associated_adjustment_closed)
-                %ul
-                  %li
-                    = radio_button_tag :open_adjustment, 'yes', false, :data => { 'shipment-number' => shipment.number }
-                    = "Yes"
-                  %li
-                    = radio_button_tag :open_adjustment, 'no', true, :data => {'shipment-number' => shipment.number }
-                    = "No"
-
           %td.actions
             - if can? :update, shipment
               = link_to '', '', :class => 'save-method icon_link icon-ok no-text with-tip', :data => { 'shipment-number' => shipment.number, :action => 'save' }, title: I18n.t('actions.save')

--- a/spec/controllers/api/v0/shipments_controller_spec.rb
+++ b/spec/controllers/api/v0/shipments_controller_spec.rb
@@ -273,28 +273,11 @@ describe Api::V0::ShipmentsController, type: :controller do
             expect(order.payment_state).to eq "balance_due" # total changed, payment is due
           end
 
-          context "using the 'unlock' parameter with closed adjustments" do
-            before do
-              order.shipment_adjustments.each(&:close)
-            end
-
-            it "does not update closed adjustments without unlock option" do
-              params[:shipment][:unlock] = "no"
-
-              expect {
-                api_put :update, params
-                expect(response.status).to eq 200
-              }.to_not change { order.reload.shipment.fee_adjustment.amount }
-            end
-
-            it "updates closed adjustments with unlock option selected" do
-              params[:shipment][:unlock] = "yes"
-
-              expect {
-                api_put :update, params
-                expect(response.status).to eq 200
-              }.to change { order.reload.shipment.fee_adjustment.amount }
-            end
+          it "updates closed adjustments" do
+            expect {
+              api_put :update, params
+              expect(response.status).to eq 200
+            }.to change { order.reload.shipment.fee_adjustment.amount }
           end
         end
       end

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -62,7 +62,7 @@ describe "spree/admin/orders/edit.html.haml" do
 
     it "doesn't display closed associated adjustments" do
       render
-      
+
       expect(rendered).to_not have_content "Associated adjustment closed"
     end
   end
@@ -102,7 +102,7 @@ describe "spree/admin/orders/edit.html.haml" do
 
     it "doesn't display closed associated adjustments" do
       render
-      
+
       expect(rendered).to_not have_content "Associated adjustment closed"
     end
   end

--- a/spec/views/spree/admin/orders/edit.html.haml_spec.rb
+++ b/spec/views/spree/admin/orders/edit.html.haml_spec.rb
@@ -59,6 +59,12 @@ describe "spree/admin/orders/edit.html.haml" do
                                               text: out_of_stock_line_item.variant.display_name
       end
     end
+
+    it "doesn't display closed associated adjustments" do
+      render
+      
+      expect(rendered).to_not have_content "Associated adjustment closed"
+    end
   end
 
   context "when order is incomplete" do
@@ -92,6 +98,12 @@ describe "spree/admin/orders/edit.html.haml" do
 
         expect(rendered).to_not have_content "Out of Stock"
       end
+    end
+
+    it "doesn't display closed associated adjustments" do
+      render
+      
+      expect(rendered).to_not have_content "Associated adjustment closed"
     end
   end
 end


### PR DESCRIPTION
Removes the 'Associated Adjustment Closed' options from the order edit
page (/admin/orders/XXXXX/edit).

#### What? Why?

- Closes #9027
- This button is a leftover from Spree that should be removed.

#### What should we test?

- Log in as enterprise user
- Go to an edit order page
- Edit the shipping method
- See the radio buttons do not appear anymore
- Update the shipping and see that fees are updated, too.

#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.
