### PR TITLE
Select all text upon focus on map search input for Google Maps

### DIFF
--- a/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
+++ b/app/assets/javascripts/darkswarm/directives/map_search.js.coffee
@@ -3,7 +3,7 @@ angular.module('Darkswarm').directive 'mapSearch', ($timeout, Search) ->
   restrict: 'E'
   require: ['^uiGmapGoogleMap', 'ngModel']
   replace: true
-  template: '<input id="pac-input" ng-model="query" placeholder="' + t('location_placeholder') + '"></input>'
+  template: '<input id="pac-input" ng-model="query" placeholder="' + t('location_placeholder') + '" onfocus="this.select()"></input>'
   scope: {}
 
   controller: ($scope) ->


### PR DESCRIPTION
#### What? Why?

Closes #8755 

On the map page, when we search a location and than want to search for
another, we would have to delete letter by letter of the previous search
text.

Now, when we click on the search input to type another search text, the
previous text will be all selected and we can remove everything with
just hitting the backspace once

#### What should we test?

Search input behavior on the map page using Google Maps. See gif below.

![search-input](https://user-images.githubusercontent.com/1068750/169591627-be6d881f-3ad7-4b08-b840-c1028c31b6b5.gif)

#### Release notes

Changelog Category: User facing changes

