### PR TITLE
Add order date range to packing reports

### DIFF
--- a/lib/reporting/reports/packing/base.rb
+++ b/lib/reporting/reports/packing/base.rb
@@ -38,7 +38,9 @@ module Reporting
 
         def default_params
           # Prevent breaking change in this report by hidding new columns by default
-          { fields_to_hide: ["phone", "price"] }
+          { fields_to_hide: ["phone", "price"],
+            q: {  order_completed_at_gt: 1.month.ago.beginning_of_day,
+                  order_completed_at_lt: 1.day.from_now.beginning_of_day } }
         end
 
         private


### PR DESCRIPTION
#### What? Why?

Closes #9218
<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Visit `/admin/reports/packing`
- Date range should be preselected: 
<img width="796" alt="Capture d’écran 2022-05-25 à 10 29 46" src="https://user-images.githubusercontent.com/296452/170217819-350cdff5-6aee-43a2-aa49-4f149ac61716.png">


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
