### PR TITLE
[Draft] Restore previous functionality for grouping product totals in Orders and Fulfilment reports

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/base.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/base.rb
@@ -21,12 +21,6 @@ module Reporting
           report_line_items.orders
         end
 
-        def query_result
-          report_line_items.list(line_item_includes).group_by { |e|
-            [e.variant_id, e.price, e.order_id]
-          }.values
-        end
-
         private
 
         def order_permissions

--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
@@ -95,6 +95,12 @@ module Reporting
                      :user, :distributor, :shipments] }]
         end
 
+        def query_result
+          report_line_items.list(line_item_includes).group_by { |e|
+            [e.variant_id, e.price, e.order_id]
+          }.values
+        end
+
         private
 
         def row_header(row)

--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier.rb
@@ -44,6 +44,12 @@ module Reporting
             variant: [{ option_values: :option_type }, { product: :supplier }]
           }]
         end
+
+        def query_result
+          report_line_items.list(line_item_includes).group_by { |e|
+            [e.variant_id, e.price]
+          }.values
+        end
       end
     end
   end

--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals.rb
@@ -35,6 +35,12 @@ module Reporting
         def line_item_includes
           [{ variant: [{ option_values: :option_type }, { product: :supplier }] }]
         end
+
+        def query_result
+          report_line_items.list(line_item_includes).group_by { |e|
+            [e.variant_id, e.price]
+          }.values
+        end
       end
     end
   end

--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals_by_distributor.rb
@@ -42,6 +42,12 @@ module Reporting
           [{ order: :distributor,
              variant: [{ option_values: :option_type }, { product: :supplier }] }]
         end
+
+        def query_result
+          report_line_items.list(line_item_includes).group_by { |e|
+            [e.variant_id, e.price]
+          }.values
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #9226 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

After the Reports S1s today we know that Orders and Fulfilments reports have two different grouping functions. This PR moves the grouping down to the report level rather than the base level.

I haven't tested this at all on my local machine... I havent gone through the faff of setting up a local dev environment. But hopefully this speeds up the work of @mkllnk or the next dev that can take a look. 


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Orders and Fulfilments Reports should now:
Split out rows of the report per order in Cust Totals
Group rows in the other 3 reports over all orders.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Additional fix to Orders and Distributors reports to restore previous functionality for grouping product totals except in the Customer Totals report.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
