### PR TITLE
Fix shipped email tracking information font size

### DIFF
--- a/app/views/spree/shipment_mailer/shipped_email.html.haml
+++ b/app/views/spree/shipment_mailer/shipped_email.html.haml
@@ -15,11 +15,11 @@
     %br
 
 - if @shipment.tracking
-  %p
+  %p.lead
     = t('.track_information', tracking: @shipment.tracking)
 
 - if @shipment.tracking_url
-  %p
+  %p.lead
     = t('.track_link', url: @shipment.tracking_url)
 
 %p.lead

--- a/spec/mailers/previews/shipment_preview.rb
+++ b/spec/mailers/previews/shipment_preview.rb
@@ -5,7 +5,10 @@ require 'open_food_network/scope_variant_to_hub'
 module Spree
   class ShipmentPreview < ActionMailer::Preview
     def shipped
-      ShipmentMailer.shipped_email(Shipment.last)
+      shipment =
+        Shipment.where.not(tracking: [nil, ""]).last ||
+        Shipment.last
+      ShipmentMailer.shipped_email(shipment)
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #8698 

The tracking information in a shipped email looked different from the rest of the email body, and is now updated to be identical by increasing the font size to 17, since it's already the same font family. 

#### What should we test?
An email sent from a staging server including the tracking information .

My understanding is that the shipped email currently has far too many different fonts, and the aim is to decrease the total amount. 

#### Release notes

Changelog Category: User facing changes
