### PR TITLE
Update docker README including docker-compose install

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -28,6 +28,12 @@ $ git clone git@github.com:openfoodfoundation/openfoodnetwork.git
 ```sh
 $ cd openfoodnetwork
 ```
+* If this is your first time using docker, make sure docker-compose is installed:
+
+```sh
+$ sudo apt install docker-compose
+```
+
 * Download the Docker images, build the Docker containers, seed the database with sample data, AND log the screen output from these tasks:
 ```sh
 $ docker/build


### PR DESCRIPTION
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
This pull request updates the Docker README to include a missing piece of installation instructions, `sudo apt install docker-compose`. Contributors need this when running Docker for the first time on a clean install of Ubuntu 20.04, so a user might encounter it if OFN is their first contribution utilizing Docker.

#### What should we test?

You can test the changes to the README and it's markdown by either clicking `View file` on the changed file below, or simply visiting https://github.com/mgrigoriev8109/openfoodnetwork/blob/09239c3c6cdbba61eeb48ee1bda63ff402946b50/docker/README.md 
to make sure that the markdown is styled appropriately. 

#### Release notes

Changelog Category: User facing changes


#### Documentation updates

I'm not too familiar with how the GitHub wiki works, but I don't think so. The current wiki does have a **Docker** link, which seems to simply redirect to https://github.com/openfoodfoundation/openfoodnetwork/blob/master/docker/README.md . So if I'm understanding things correctly, it shouldn't need any updating as it will simply redirect to the updated README. 