### PR TITLE
spacing between co ordinator dropdown and continue btn

### DIFF
--- a/app/views/admin/order_cycles/set_coordinator.html.haml
+++ b/app/views/admin/order_cycles/set_coordinator.html.haml
@@ -9,7 +9,7 @@
       &nbsp;
     .ten.columns
       = select_tag :coordinator_id, options_for_select(permitted_coordinating_enterprise_options_for(@order_cycle)), { 'required' => true, class: 'select2 fullwidth'}
-    .two.columns.alpha
+    .two.columns
       = f.submit "#{t(:continue)} >"
 
     .two.columns.omega


### PR DESCRIPTION
#### What? Why?

Closes #9233 

Adds spacing between the co-ordinator dropdown and continue button. 
Please see screenshot.

![173a8cd3852d72bb754e8cbca4e9b699](https://user-images.githubusercontent.com/68995267/170821141-350bfa63-dbcf-4f36-ab73-9b29dd8b4cd9.png)

#### What should we test?

- No functionality changes. Only UI change to add spacing.
- Visit page: admin/order_cycles/new

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes | Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

#### Dependencies

- No dependencies

#### Documentation updates

- N / A
