### PR TITLE
Do not include shipping method in the summary row for the Order Cycle Distributer Totals by Supplier report

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_distributor_totals_by_supplier.rb
@@ -26,8 +26,7 @@ module Reporting
               summary_row: proc do |_key, line_items, rows|
                 {
                   total_cost: rows.sum(&:total_cost),
-                  total_shipping_cost: line_items.map(&:first).map(&:order).uniq.sum(&:ship_total),
-                  shipping_method: rows.first.shipping_method
+                  total_shipping_cost: line_items.map(&:first).map(&:order).uniq.sum(&:ship_total)
                 }
               end
             }


### PR DESCRIPTION
#### What? Why?
This also includes a columns re-order to put `` and `` at the end of the table (as they both are in the summary row)
Closes #9228 
###### Before
<img width="671" alt="Capture d’écran 2022-05-30 à 11 12 56" src="https://user-images.githubusercontent.com/296452/170959582-5ec20113-ed5d-4124-9cb4-7211f7a58e22.png">

###### After, without re-ordering
<img width="806" alt="Capture d’écran 2022-05-30 à 11 13 29" src="https://user-images.githubusercontent.com/296452/170959603-fbb07159-67c2-441f-9fac-db0353b427c8.png">

~##### Finally, with re-ordering~
_Finally, we decided to not re-order columns_
<img width="823" alt="Capture d’écran 2022-05-30 à 11 16 49" src="https://user-images.githubusercontent.com/296452/170960200-ce5fe9cc-288f-4c8b-9900-c1f191647fe9.png">


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- As an admin, generate the Order Cycle Distributer Totals by Supplier report with summary row activated
- See that Shipping Method is not in the summary row section

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
