### PR TITLE
Fix admin taxonomies interface

### DIFF
--- a/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
+++ b/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
@@ -9,12 +9,17 @@ handle_move = (e, data) ->
   new_parent = data.rslt.np
 
   url = new URL(base_url)
-  url.pathname = url.pathname + '/' + node.attr("id")
+  url.pathname = url.pathname + '/' + node.attr("id") 
+  data = {
+    _method: "put",
+    "taxon[position]": position,
+    "taxon[parent_id]": if !isNaN(new_parent.attr("id")) then new_parent.attr("id") else undefined
+  }
   $.ajax
     type: "POST",
     dataType: "json",
     url: url.toString(),
-    data: ({_method: "put", "taxon[parent_id]": new_parent.attr("id"), "taxon[position]": position }),
+    data: data,
     error: handle_ajax_error
 
   true
@@ -26,11 +31,16 @@ handle_create = (e, data) ->
   position = data.rslt.position
   new_parent = data.rslt.parent
 
+  data = {
+    "taxon[name]": name,
+    "taxon[position]": position
+    "taxon[parent_id]": if !isNaN(new_parent.attr("id")) then new_parent.attr("id") else undefined
+  }
   $.ajax
     type: "POST",
     dataType: "json",
     url: base_url.toString(),
-    data: ({"taxon[name]": name, "taxon[parent_id]": new_parent.attr("id"), "taxon[position]": position }),
+    data: data,
     error: handle_ajax_error,
     success: (data,result) ->
       node.attr('id', data.id)

--- a/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
+++ b/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
@@ -8,7 +8,7 @@ handle_move = (e, data) ->
   node = data.rslt.o
   new_parent = data.rslt.np
 
-  url = Spree.url(base_url).clone()
+  url = new URL(base_url)
   url.pathname = url.pathname + '/' + node.attr("id")
   $.ajax
     type: "POST",
@@ -40,7 +40,7 @@ handle_rename = (e, data) ->
   node = data.rslt.obj
   name = data.rslt.new_name
 
-  url = Spree.url(base_url).clone()
+  url = new URL(base_url)
   url.pathname = url.pathname + '/' + node.attr("id")
 
   $.ajax
@@ -53,8 +53,8 @@ handle_rename = (e, data) ->
 handle_delete = (e, data) ->
   last_rollback = data.rlbk
   node = data.rslt.obj
-  delete_url = base_url.clone()
-  delete_url.setPath delete_url.path() + '/' + node.attr("id")
+  delete_url = new URL(base_url)
+  delete_url.pathname = delete_url.pathname + '/' + node.attr("id")
   if confirm(Spree.translations.are_you_sure_delete)
     $.ajax
       type: "POST",

--- a/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
+++ b/app/assets/javascripts/admin/spree/taxons/taxonomy.js.coffee
@@ -49,6 +49,8 @@ handle_rename = (e, data) ->
   last_rollback = data.rlbk
   node = data.rslt.obj
   name = data.rslt.new_name
+  # change the name inside the main input field as well if taxon is the root one
+  document.getElementById("taxonomy_name").value = name if node.parents("[id]").attr("id") == "taxonomy_tree"
 
   url = new URL(base_url)
   url.pathname = url.pathname + '/' + node.attr("id")

--- a/app/controllers/api/v0/taxons_controller.rb
+++ b/app/controllers/api/v0/taxons_controller.rb
@@ -73,7 +73,7 @@ module Api
       def taxon_params
         return if params[:taxon].blank?
 
-        params.require(:taxon).permit([:name, :parent_id])
+        params.require(:taxon).permit([:name, :parent_id, :position])
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #9031, #9113

The interface was broken, this PR is here to restore, move, delete and rename functionnalities.

Solution for the rename of the first/root taxon is to update the main input field as well:
<img width="696" alt="Capture d’écran 2022-06-02 à 16 10 56" src="https://user-images.githubusercontent.com/296452/171648882-6fb388bb-858f-4a20-b0ef-2bedb79c2543.png">
<img width="685" alt="Capture d’écran 2022-06-02 à 16 11 05" src="https://user-images.githubusercontent.com/296452/171648901-a7f50af1-cb57-4f8e-80ba-7f1ee74274f8.png">
<img width="682" alt="Capture d’écran 2022-06-02 à 16 11 09" src="https://user-images.githubusercontent.com/296452/171648918-c18048f6-d686-4128-af02-50dc8b8b8579.png">


#### What should we test?

see the Steps to reproduce section in the linked issue: #9113

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
