### PR TITLE
Reports, Order Cycle Customer Totals: Format date in summary row as it's formatted in a row

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_customer_totals.rb
@@ -126,7 +126,7 @@ module Reporting
             order_cycle: order.order_cycle&.name,
             payment_method: order.payments.first&.payment_method&.name,
             order_number: order.number,
-            date: order.completed_at,
+            date: order.completed_at.strftime("%F %T"),
           }
         end
 

--- a/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
+++ b/spec/lib/reports/orders_and_fulfillment/order_cycle_customer_totals_report_spec.rb
@@ -38,6 +38,11 @@ module Reporting
             expect(report.rows.first.order_number).to eq order.number
             expect(report.rows.first.date).to eq order.completed_at.strftime("%F %T")
           end
+
+          it 'includes the summary row' do
+            expect(report.rows.second.quantity).to eq "TOTAL"
+            expect(report.rows.second.date).to eq order.completed_at.strftime("%F %T")
+          end
         end
 
         context "loading shipping methods" do


### PR DESCRIPTION
#### What? Why?

Closes #9257

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?


- Generate the Order Cycle Customer Totals report in spreadsheet
- Date should be formatted with the same format, ie. with seconds

###### Before
<img width="430" alt="Capture d’écran 2022-06-03 à 08 34 53" src="https://user-images.githubusercontent.com/296452/171813612-ced1b36e-c3d5-41ee-85da-239ac8c3e14c.png">

###### After
<img width="401" alt="Capture d’écran 2022-06-03 à 08 35 20" src="https://user-images.githubusercontent.com/296452/171800771-3c07a81c-68b8-40d6-854d-92fa7aca6f66.png">

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
