### PR TITLE
On user confirmation, retrieve and link all orders to the new user that were already placed with the same email

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -41,7 +41,7 @@ module Spree
     accepts_nested_attributes_for :bill_address
     accepts_nested_attributes_for :ship_address
 
-    after_create :associate_customers
+    after_create :associate_customers, :associate_orders
 
     validate :limit_owned_enterprises
 
@@ -111,6 +111,12 @@ module Spree
 
     def associate_customers
       self.customers = Customer.where(email: email)
+    end
+
+    def associate_orders
+      Spree::Order.where(customer: customers).find_each do |order|
+        order.associate_user!(self)
+      end
     end
 
     def can_own_more_enterprises?

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -100,12 +100,17 @@ describe Spree::User do
       let(:enterprise2) { create(:enterprise) }
       let!(:customer1) { create(:customer, user: nil, email: email, enterprise: enterprise1) }
       let!(:customer2) { create(:customer, user: nil, email: email, enterprise: enterprise2) }
+      let!(:order) { create(:order, customer: customer1) }
       let!(:user) { create(:user, email: email) }
 
       it "should associate these customers with the created user" do
         expect(user.customers.reload).to include customer1, customer2
         expect(user.customer_of(enterprise1)).to be_truthy
         expect(user.customer_of(enterprise2)).to be_truthy
+      end
+
+      it "should associate the orders passed by customer linked to the created user" do
+        expect(user.orders.reload).to include order
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes #7905

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
Pretty well explained in the linked issue:
 - As a Hub/Shop, set it your shop to allow guest checkout. (`/admin/enterprises/<shop_permaling>/edit#/shop_preferences`)
 - As a guest customer, place one or more orders (using the same email address) in a Hub
 - Sign up and log in to the account still with the same email address
 - Go to `/account#/orders` -> see that all already placed orders are here
 - Notice that `/account#/transactions` transactions are visible


#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes
<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
