### PR TITLE
Replace 'docker-compose' V1 with 'docker compose' V2

### DIFF
--- a/docker/build-log
+++ b/docker/build-log
@@ -1,12 +1,12 @@
 #!/bin/bash
 set +e
 
-docker-compose down -v --remove-orphans
+docker compose down -v --remove-orphans
 wait
 echo '###########################'
-echo 'BEGIN: docker-compose build'
+echo 'BEGIN: docker compose build'
 echo '###########################'
-docker-compose build # Set up the Docker containers
+docker compose build # Set up the Docker containers
 echo '##############################'
-echo 'FINISHED: docker-compose build'
+echo 'FINISHED: docker compose build'
 echo '##############################'

--- a/docker/cop
+++ b/docker/cop
@@ -3,9 +3,9 @@
 # This script runs RuboCop.
 
 echo '-------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rubocop'
+echo 'BEGIN: docker compose run web bundle exec rubocop'
 echo '-------------------------------------------------'
-docker-compose run web bundle exec rubocop
+docker compose run web bundle exec rubocop
 echo '-----------------------------------------------'
-echo 'END: docker-compose run web bundle exec rubocop'
+echo 'END: docker compose run web bundle exec rubocop'
 echo '-----------------------------------------------'

--- a/docker/qtest-log
+++ b/docker/qtest-log
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo 'BEGIN: docker compose run web bundle exec rake db:test:prepare'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake db:test:prepare
+docker compose run web bundle exec rake db:test:prepare
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo 'END: docker compose run web bundle exec rake db:test:prepare'
 echo '------------------------------------------------------------'
 
 echo '--------------------------------------'
 echo 'BEGIN: running test suite (quiet mode)'
 echo '--------------------------------------'
-docker-compose run web bundle exec rspec spec | grep -v 'DEPRECATION WARNING' | grep -v 'Post.includes(:comments)' | grep -v 'Currently, Active Record recognizes the table in the string' | grep -v "If you don't rely on implicit join references"
+docker compose run web bundle exec rspec spec | grep -v 'DEPRECATION WARNING' | grep -v 'Post.includes(:comments)' | grep -v 'Currently, Active Record recognizes the table in the string' | grep -v "If you don't rely on implicit join references"
 echo '------------------------------------'
 echo 'END: running test suite (quiet mode)'
 echo '------------------------------------'

--- a/docker/run
+++ b/docker/run
@@ -12,11 +12,11 @@ function cleanup {
 
   # ignore errors
   set +e
-  docker-compose down
+  docker compose down
 
   exit $code
 }
 
 trap cleanup EXIT
 
-docker-compose run web $@
+docker compose run web $@

--- a/docker/seed
+++ b/docker/seed
@@ -3,25 +3,25 @@
 # This is the data seeding script.
 
 echo '-------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:reset'
+echo 'BEGIN: docker compose run web bundle exec rake db:reset'
 echo '-------------------------------------------------------'
-docker-compose run web bundle exec rake db:reset
+docker compose run web bundle exec rake db:reset
 echo '-----------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:reset'
+echo 'END: docker compose run web bundle exec rake db:reset'
 echo '-----------------------------------------------------'
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo 'BEGIN: docker compose run web bundle exec rake db:test:prepare'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake db:test:prepare
+docker compose run web bundle exec rake db:test:prepare
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo 'END: docker compose run web bundle exec rake db:test:prepare'
 echo '------------------------------------------------------------'
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake ofn:sample_data'
+echo 'BEGIN: docker compose run web bundle exec rake ofn:sample_data'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake ofn:sample_data
+docker compose run web bundle exec rake ofn:sample_data
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake ofn:sample_data'
+echo 'END: docker compose run web bundle exec rake ofn:sample_data'
 echo '------------------------------------------------------------'

--- a/docker/server-log
+++ b/docker/server-log
@@ -2,8 +2,8 @@
 set +e
 
 echo '########################'
-echo 'BEGIN: docker-compose up'
+echo 'BEGIN: docker compose up'
 echo '########################'
 echo 'View this app in your web browser at'
 echo 'http://localhost:3000/'
-docker-compose up
+docker compose up

--- a/docker/test-log
+++ b/docker/test-log
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 echo '--------------------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rake db:test:prepare'
+echo 'BEGIN: docker compose run web bundle exec rake db:test:prepare'
 echo '--------------------------------------------------------------'
-docker-compose run web bundle exec rake db:test:prepare
+docker compose run web bundle exec rake db:test:prepare
 echo '------------------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rake db:test:prepare'
+echo 'END: docker compose run web bundle exec rake db:test:prepare'
 echo '------------------------------------------------------------'
 
 echo '----------------------------------------------------'
-echo 'BEGIN: docker-compose run web bundle exec rspec spec'
+echo 'BEGIN: docker compose run web bundle exec rspec spec'
 echo '----------------------------------------------------'
-docker-compose run web bundle exec rspec spec
+docker compose run web bundle exec rspec spec
 echo '--------------------------------------------------'
-echo 'END: docker-compose run web bundle exec rspec spec'
+echo 'END: docker compose run web bundle exec rspec spec'
 echo '--------------------------------------------------'


### PR DESCRIPTION
#### What? Why?

Triggered by [this conversation](https://openfoodnetwork.slack.com/archives/C2GQ45KNU/p1653590917345179) on Slack and PR #9238, I found out that our Docker scripts will fail with newer versions of Docker installations, because there is a Docker Compose V2 now, which requires `docker compose` commands instead of `docker-compose` (note the '-').

This PR converts all docker-compose commands to the new version and this seems to fix the scripts on my system.

BUT: I don't know if these scripts will work on older Docker installations. If they don't, this will cause frustration for other users and should be avoided.

A workaround/better solution could be to ask users to install the old docker-compose manually, to make our scripts work without changes.

This is a draft still, because the readme file needs updating too.

#### What should we test?
- Test the updated docker scripts with latest Docker installation
- Test the updated docker scripts with older Docker installation (Docker Compose V1)

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
