### PR TITLE
Add landmark field for addresses

### DIFF
--- a/app/services/permitted_attributes/address.rb
+++ b/app/services/permitted_attributes/address.rb
@@ -7,7 +7,7 @@ module PermittedAttributes
         :firstname, :lastname, :address1, :address2,
         :city, :country_id, :state_id, :zipcode,
         :phone, :state_name, :alternative_phone, :company,
-        :latitude, :longitude
+        :latitude, :longitude, :landmark
       ]
     end
   end

--- a/app/services/permitted_attributes/business_address.rb
+++ b/app/services/permitted_attributes/business_address.rb
@@ -6,7 +6,7 @@ module PermittedAttributes
       [
         :company, :address1, :address2,
         :city, :country_id, :state_id, :zipcode,
-        :phone, :_destroy, :id
+        :phone, :_destroy, :id, :landmark
       ]
     end
   end

--- a/app/views/admin/enterprises/_new_form.html.haml
+++ b/app/views/admin/enterprises/_new_form.html.haml
@@ -78,6 +78,11 @@
     .nine.columns.omega
       = af.text_field :address2
   .row
+    .alpha.three.columns
+      = af.label :landmark, t(:landmark)
+    .nine.columns.omega
+      = af.text_field :landmark
+  .row
     .three.columns.alpha
       = af.label :city, t(:city)
       \/

--- a/app/views/admin/enterprises/form/_address.html.haml
+++ b/app/views/admin/enterprises/form/_address.html.haml
@@ -16,6 +16,11 @@
   .eight.columns.omega
     = af.text_field :address2
 .row
+  .alpha.three.columns
+    = af.label :landmark, t(:landmark)
+  .eight.columns.omega
+    = af.text_field :landmark
+.row
   .three.columns.alpha
     = af.label :city, t(:city)
     \/

--- a/app/views/admin/enterprises/form/_business_address.html.haml
+++ b/app/views/admin/enterprises/form/_business_address.html.haml
@@ -16,6 +16,11 @@
   .eight.columns.omega
     = bf.text_field :address2
 .row
+  .alpha.three.columns
+    = bf.label :landmark, t(".landmark")
+  .eight.columns.omega
+    = bf.text_field :landmark
+.row
   .three.columns.alpha
     = bf.label :city, t(:city)
     \/

--- a/app/views/registration/steps/_details.html.haml
+++ b/app/views/registration/steps/_details.html.haml
@@ -28,6 +28,9 @@
           .field
             %label{ for: 'enterprise_address2' }= t(".address2_field")
             %input.chunky{ id: 'enterprise_address2', name: 'address2', required: false, placeholder: "", required: false, ng: { model: 'enterprise.address.address2' } }
+          .field
+            %label{ for: 'enterprise_landmark' }= t(".landmark_field")
+            %input.chunky{ id: 'enterprise_landmark', name: 'landmark', required: false, placeholder: "", ng: { model: 'enterprise.address.landmark' } }
 
         .small-12.medium-9.large-6.columns.end
           .row

--- a/app/views/shopping_shared/tabs/_contact.html.haml
+++ b/app/views/shopping_shared/tabs/_contact.html.haml
@@ -12,6 +12,9 @@
               - unless current_distributor.address.address2.blank?
                 %br
                 = current_distributor.address.address2
+              - unless current_distributor.address.landmark.blank?
+                %br
+                = current_distributor.address.landmark
               %br
               = current_distributor.address.city
               = current_distributor.address.state

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2319,6 +2319,7 @@ See the %{link} to find out more about %{sitename}'s features and to start using
         state_field_error: "State required"
         country_field: "Country:"
         country_field_error: "Please select a country"
+        landmark_field: "Landmark"
         map_location: "Map Location"
         locate_address: "Locate address on map"
         drag_pin: "Drag and drop the pin to the correct location if not accurate."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -876,6 +876,7 @@ en:
           address1: Legal address
           address1_placeholder: 123 High St.
           address2: Address (contd.)
+          landmark: Landmark
           legal_phone_number: Legal phone number
           phone_placeholder: "98 123 4565"
         contact:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1611,6 +1611,7 @@ en:
   address: Address
   address_placeholder: eg. 123 High Street
   address2: Address (contd.)
+  landmark: Landmark
   city: City
   city_placeholder: eg. Northcote
   latitude: Latitude

--- a/db/migrate/20220608183724_add_landmark_to_address.rb
+++ b/db/migrate/20220608183724_add_landmark_to_address.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLandmarkToAddress < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_addresses, :landmark, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_02_013938) do
+ActiveRecord::Schema.define(version: 2022_06_08_183724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -402,6 +402,7 @@ ActiveRecord::Schema.define(version: 2022_06_02_013938) do
     t.string "company", limit: 255
     t.float "latitude"
     t.float "longitude"
+    t.string "landmark", limit: 255
     t.index ["firstname"], name: "index_addresses_on_firstname"
     t.index ["lastname"], name: "index_addresses_on_lastname"
   end


### PR DESCRIPTION
#### What? Why?

Closes #9275

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->


- See a "Landmark" optional field in the address when registering an enterprise
- Fill that field with a value
- See the value displayed in the other pages that also display an enterprise's address


#### Release notes

Changelog Category: User facing changes

The title of the pull request will be included in the release notes.
