### PR TITLE
Fix sending subscription summary emails for shops with logo

### DIFF
--- a/app/views/subscription_mailer/placement_summary_email.html.haml
+++ b/app/views/subscription_mailer/placement_summary_email.html.haml
@@ -12,7 +12,7 @@
         %tr
           %td{:align => "right"}
             - if @shop.logo.variable?
-              = image_tag @shop.logo_variant(:medium), class: "float-right"
+              = image_tag @shop.logo_url(:medium), class: "float-right"
       %span.clear
 
 = render 'summary_overview', summary: @summary

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -240,14 +240,21 @@ describe SubscriptionMailer, type: :mailer do
         allow(summary).to receive(:order_count) { 37 }
         allow(summary).to receive(:issue_count) { 0 }
         allow(summary).to receive(:issues) { {} }
-        SubscriptionMailer.placement_summary_email(summary).deliver_now
       end
 
       it "sends the email, which notifies the enterprise that all orders were successfully processed" do
+        SubscriptionMailer.placement_summary_email(summary).deliver_now
+
         expect(body).to include I18n.t("#{scope}.placement_summary_email.intro", shop: shop.name)
         expect(body).to include I18n.t("#{scope}.summary_overview.total", count: 37)
         expect(body).to include I18n.t("#{scope}.summary_overview.success_all")
         expect(body).to_not include I18n.t("#{scope}.summary_overview.issues")
+      end
+
+      it "renders the shop's logo" do
+        shop.update!(logo: fixture_file_upload("logo.png", "image/png"))
+        SubscriptionMailer.placement_summary_email(summary).deliver_now
+        expect(SubscriptionMailer.deliveries.last.body).to include "logo.png"
       end
     end
 


### PR DESCRIPTION
#### What? Why?

Closes #9277 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

1. Set up an enterprise with logo and subscriptions.
2. Let an order cycle open.
3. The SubscriptionsPlacementJob should send a summary email.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
