### PR TITLE
Admin, print an invoice with alternative mode: fix an issue when enterprise has a logo

### DIFF
--- a/app/views/spree/admin/orders/invoice2.html.haml
+++ b/app/views/spree/admin/orders/invoice2.html.haml
@@ -8,7 +8,7 @@
           = t :tax_invoice
       - if @order.distributor.display_invoice_logo? && @order.distributor.logo.variable?
         %td{ :align => "right", rowspan: 2 }
-          = wicked_pdf_image_tag @order.distributor.logo.variant(resize_to_limit: [150, 150])
+          = wicked_pdf_image_tag @order.distributor.logo_url(:small)
     %tr{ valign: "top" }
       %td{ :align => "left" }
         - if @order.distributor.business_address.blank?


### PR DESCRIPTION
#### What? Why?
With `wicked_pdf_image_tag`, use the method `logo_url`
Closes #9281

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Print an invoice that use alternative model for an order of an enterprise that has a logo, and DISPLAY LOGO IN INVOICES
 - You should have an invoice with a logo

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
