### PR TITLE
Show order and admin page despite broken image

### DIFF
--- a/app/views/spree/shared/_variant_thumbnail.html.haml
+++ b/app/views/spree/shared/_variant_thumbnail.html.haml
@@ -1,6 +1,1 @@
-- if variant.product.images.length == 0
-  = image_tag("/noimage/mini.png")
-- else
-  - # A Rails bug makes it necessary to call `main_app.url_for` here.
-  - # https://github.com/rails/rails/issues/31325
-  = image_tag(main_app.url_for(variant.product.images.first.variant(:mini)))
+= image_tag(variant.product.images.first&.url(:mini) || "/noimage/mini.png")

--- a/spec/views/spree/orders/show.html.haml_spec.rb
+++ b/spec/views/spree/orders/show.html.haml_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "spree/orders/show.html.haml" do
+  helper InjectionHelper
+  helper ShopHelper
+  helper ApplicationHelper
+  helper CheckoutHelper
+  helper SharedHelper
+  helper FooterLinksHelper
+  helper MarkdownHelper
+  helper TermsAndConditionsHelper
+
+  let(:order) {
+    create(
+      :completed_order_with_fees,
+      number: "R123456789",
+    )
+  }
+
+  before do
+    assign(:order, order)
+    allow(view).to receive_messages(
+      current_order: order,
+      last_payment_method: nil,
+    )
+  end
+
+  it "shows the order number" do
+    render
+    expect(rendered).to have_content("R123456789")
+  end
+
+  it "shows product images" do
+    order.line_items.first.variant.product.images << Spree::Image.new(
+      attachment: fixture_file_upload("logo.png", "image/png")
+    )
+
+    render
+
+    expect(rendered).to have_css("img[src*='logo.png']")
+  end
+
+  it "handles broken images" do
+    pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/9279"
+
+    image, = order.line_items.first.variant.product.images << Spree::Image.new(
+      attachment: fixture_file_upload("logo.png", "image/png")
+    )
+    # This image is not "variable" and can't be resized:
+    image.attachment.blob.update!(content_type: "application/octet-stream")
+
+    render
+
+    expect(rendered).to have_no_css("img[src*='logo.png']")
+    expect(rendered).to have_content("R123456789")
+  end
+end

--- a/spec/views/spree/orders/show.html.haml_spec.rb
+++ b/spec/views/spree/orders/show.html.haml_spec.rb
@@ -43,8 +43,6 @@ describe "spree/orders/show.html.haml" do
   end
 
   it "handles broken images" do
-    pending "https://github.com/openfoodfoundation/openfoodnetwork/issues/9279"
-
     image, = order.line_items.first.variant.product.images << Spree::Image.new(
       attachment: fixture_file_upload("logo.png", "image/png")
     )


### PR DESCRIPTION
#### What? Why?

Closes #9279 <!-- Insert issue number here. -->

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

None of our staging servers has images that are broken in this way. We can't test it there. It has to be a production test.

au-prod has plenty of affected orders:

```
Spree::Order.complete.joins(line_items: {variant: {product:{ master: {images: :attachment_blob}}}}).where("content_type = 'application/octet-stream'").distinct.count(:number)
=> 1980

Spree::Order.complete.joins(line_items: {variant: {product:{ master: {images: :attachment_blob}}}}).where("content_type = 'application/octet-stream'").limit(5).pluck(:number)
=> ["R185253078", "R072143542", "R312886220", "R236017021", "R312886220"]
```

- Log in as super admin.
- Visit `/orders/R185253078` or one of the other affected orders.

I just did that after applying the patch manually. :heavy_check_mark: 

So this can be merged after a successful review without staging.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.

