### PR TITLE
Restarts checkout flow, when emptying the cart

### DIFF
--- a/app/models/spree/order.rb
+++ b/app/models/spree/order.rb
@@ -433,7 +433,7 @@ module Spree
       all_adjustments.destroy_all
       payments.clear
       shipments.destroy_all
-      restart_checkout_flow if state == "payment"
+      restart_checkout_flow if state.in?(["payment", "confirmation"])
     end
 
     def state_changed(name)

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -884,7 +884,6 @@ describe "As a consumer, I want to checkout my order", js: true do
         end
 
         it "emptying the cart changes the order state back to address" do
-          pending "fixing issue #9299"
           visit main_app.cart_path
           expect {
             find('#clear_cart_link').click

--- a/spec/system/consumer/split_checkout_spec.rb
+++ b/spec/system/consumer/split_checkout_spec.rb
@@ -877,6 +877,21 @@ describe "As a consumer, I want to checkout my order", js: true do
           expect(page).to have_current_path checkout_step_path(:payment)
         end
       end
+
+      describe "order state" do
+        before do
+          visit checkout_step_path(:summary)
+        end
+
+        it "emptying the cart changes the order state back to address" do
+          pending "fixing issue #9299"
+          visit main_app.cart_path
+          expect {
+            find('#clear_cart_link').click
+            expect(page).to have_current_path enterprise_shop_path(distributor)
+          }.to change { order.reload.state }.from("confirmation").to("address")
+        end
+      end
     end
 
     context "with previous open orders" do


### PR DESCRIPTION
#### What? Why?

Closes #9299.
Partially addresses  https://github.com/openfoodfoundation/openfoodnetwork/issues/9131: it does not prevent the bug but adds a workaround.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

It follows a similar approach as #9190, but for the order `state = confirmation`;
By clicking "Empty cart" the state of the order should no longer be `confirmation`, and as such, redirection to `/summary` page should not occur.

The PR adds:
- a system spec, which expects the order state to change when the user clicks "Empty Cart", on the `/cart` page => spec fails
- adds the code change, which should allow "Empty Cart" to take effect when the state of the order is `confirmation` => should make the spec pass

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Follow the steps to reproduce on the issue: the bug should not be reproducible (step 7)
- After going through the steps above it should be possible to place an order, as usual

`Worth checking` before and after the PR
- visit shop, add items and proceed to the `/summary` step - don't complete the order
- go back to the `/shop` page and select another shop
- place an order on this second shop

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Restarts checkout flow, when, when emptying the cart

