### PR TITLE
Adds optional promo and logo images as traits to the enterprise factory

### DIFF
--- a/spec/factories/enterprise_factory.rb
+++ b/spec/factories/enterprise_factory.rb
@@ -23,6 +23,14 @@ FactoryBot.define do
     end
   end
 
+  trait :with_logo_image do
+    logo { Rack::Test::UploadedFile.new('spec/fixtures/files/logo.png', 'image/png') }
+  end
+
+  trait :with_promo_image do
+    logo { Rack::Test::UploadedFile.new('spec/fixtures/files/promo.png', 'image/png') }
+  end
+
   factory :supplier_enterprise, parent: :enterprise do
     is_primary_producer { true }
     sells { "none" }

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -252,7 +252,6 @@ describe SubscriptionMailer, type: :mailer do
       end
 
       it "renders the shop's logo" do
-        shop.update!(logo: fixture_file_upload("logo.png", "image/png"))
         SubscriptionMailer.placement_summary_email(summary).deliver_now
         expect(SubscriptionMailer.deliveries.last.body).to include "logo.png"
       end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -225,7 +225,7 @@ describe SubscriptionMailer, type: :mailer do
   end
 
   describe "order placement summary" do
-    let!(:shop) { create(:enterprise) }
+    let!(:shop) { create(:enterprise, :with_logo_image) }
     let!(:summary) { double(:summary, shop_id: shop.id) }
     let(:body) { strip_tags(SubscriptionMailer.deliveries.last.body.encoded) }
     let(:scope) { "subscription_mailer" }


### PR DESCRIPTION
#### What? Why?

Relates to #9285

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds traits to the enterprise factory to optionally include promo and logo images.

Does so with a proof-of-concept by:
- changing a spec to red by removing the file attachment
- adding the traits on the factory; adding the trait on the spec file -> should bring the spec to green
 
#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- green build after second commit

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Adds optional promo and logo images as traits to the enterprise factory.

##### Comments

Not sure why but this syntax did not work:
`logo { fixture_file_upload(Rails.root.join('spec', 'fixtures', 'files', 'logo.png'), 'image/png') }`

This way, when running the spec, I got:

```
     Failure/Error: logo { fixture_file_upload(Rails.root.join('spec', 'fixtures', 'files', 'logo.png'), 'image/png') }
     
     NoMethodError:
       undefined method `fixture_file_upload' for #<FactoryBot::SyntaxRunner:0x000055dcc67b30b0>

```

For this reason, this approach was followed instead:
`logo { Rack::Test::UploadedFile.new('spec/fixtures/files/logo.png', 'image/png') }`