### PR TITLE
Splits results per supplier on OC Distributor Totals by Supplier report

### DIFF
--- a/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals.rb
+++ b/lib/reporting/reports/orders_and_fulfillment/order_cycle_supplier_totals.rb
@@ -35,6 +35,12 @@ module Reporting
         def line_item_includes
           [{ variant: [{ option_values: :option_type }, { product: :supplier }] }]
         end
+
+        def query_result
+          report_line_items.list(line_item_includes).group_by { |e|
+            [e.variant_id, e.price]
+          }.values
+        end
       end
     end
   end


### PR DESCRIPTION
#### What? Why?

Closes  #9310.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

- Adds the deleted code on #9310 for Total by suppliers report.
~~- WIP - adds a spec to cover this regression~~ Not in this PR. Existing specs on reports were updated on #9313.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

- Go to admin/reports and select "orders & fulfillment reports'
- Select the Order Cycle Distributor Totals by Supplier
- In the hub filter select 2 hubs which work with the same producer
- Observe that the report does not merge lines -> before staging this PR
- The report should now merge lines -> after staging this PR

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Splits results per supplier on OC Distributor Totals by Supplier report
