### PR TITLE
Updating system specs after reports overhaul

### DIFF
--- a/spec/base_spec_helper.rb
+++ b/spec/base_spec_helper.rb
@@ -140,6 +140,7 @@ RSpec.configure do |config|
   config.include ActionView::Helpers::DateHelper
   config.include OpenFoodNetwork::PerformanceHelper
   config.include ActiveJob::TestHelper
+  config.include ReportsHelper
 
   config.include Features::DatepickerHelper, type: :system
   config.include DownloadsHelper, type: :system

--- a/spec/support/downloads_helper.rb
+++ b/spec/support/downloads_helper.rb
@@ -4,7 +4,7 @@ module DownloadsHelper
   TIMEOUT = 10
 
   def self.path
-    Rails.root.join("tmp", "downloads")
+    Rails.root.join("tmp", "capybara")
   end
 
   def downloaded_filename
@@ -17,16 +17,10 @@ module DownloadsHelper
     File.read(downloaded_filename)
   end
 
-  def with_empty_downloads_folder
-    remove_downloaded_files
-    yield
-    remove_downloaded_files
-  end
-
   private
 
   def downloaded_filenames
-    Dir[DownloadsHelper.path.join("*")]
+    Dir[DownloadsHelper.path.join("*")].select { |f| File.file?(f) }
   end
 
   def wait_for_download

--- a/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
@@ -15,13 +15,12 @@ describe "enterprise fee summaries" do
   before do
     login_as current_user
   end
-  
+
   describe "visiting the reports page" do
-        
     before do
       visit admin_reports_path
     end
-  
+
     describe "navigation" do
       context "when accessing the report as an superadmin" do
         let(:current_user) { create(:admin_user) }

--- a/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "system_helper"
 
-feature "enterprise fee summaries", js: true do
+describe "enterprise fee summaries" do
   include AuthenticationHelper
   include WebHelper
 
@@ -15,36 +15,40 @@ feature "enterprise fee summaries", js: true do
   before do
     login_as current_user
   end
-
-  describe "navigation" do
-    context "when accessing the report as an superadmin" do
-      let(:current_user) { create(:admin_user) }
-
-      it "shows link and allows access to the report" do
-        visit spree.admin_reports_path
-        click_on I18n.t("admin.reports.enterprise_fee_summary.name")
-        expect(page).to have_button("Go")
-      end
+  
+  describe "visiting the reports page" do
+        
+    before do
+      visit admin_reports_path
     end
+  
+    describe "navigation" do
+      context "when accessing the report as an superadmin" do
+        let(:current_user) { create(:admin_user) }
 
-    context "when accessing the report as an admin" do
-      let(:current_user) { distributor.owner }
-
-      it "shows link and allows access to the report" do
-        visit spree.admin_reports_path
-        click_on I18n.t("admin.reports.enterprise_fee_summary.name")
-        expect(page).to have_button("Go")
+        it "shows link and allows access to the report" do
+          click_on I18n.t("admin.reports.enterprise_fee_summary.name")
+          expect(page).to have_button("Go")
+        end
       end
-    end
 
-    context "when accessing the report as an enterprise user without sufficient permissions" do
-      let(:current_user) { create(:user) }
+      context "when accessing the report as an admin" do
+        let(:current_user) { distributor.owner }
 
-      it "does not allow access to the report" do
-        visit spree.admin_reports_path
-        expect(page).to have_no_link(I18n.t("admin.reports.enterprise_fee_summary.name"))
-        visit main_app.admin_report_path(report_type: 'enterprise_fee_summary')
-        expect(page).to have_content(I18n.t("unauthorized"))
+        it "shows link and allows access to the report" do
+          click_on I18n.t("admin.reports.enterprise_fee_summary.name")
+          expect(page).to have_button("Go")
+        end
+      end
+
+      context "when accessing the report as an enterprise user without sufficient permissions" do
+        let(:current_user) { create(:user) }
+
+        it "does not allow access to the report" do
+          expect(page).to have_no_link(I18n.t("admin.reports.enterprise_fee_summary.name"))
+          visit main_app.admin_report_path(report_type: 'enterprise_fee_summary')
+          expect(page).to have_content(I18n.t("unauthorized"))
+        end
       end
     end
   end
@@ -91,8 +95,8 @@ feature "enterprise fee summaries", js: true do
                                              distributor: distributor)
         end
         let(:current_user) { create(:admin_user) }
-
         it "generates file with data for all enterprises" do
+          pending "reports overhaul spec update"
           check I18n.t("filters.report_format_csv", scope: i18n_scope)
           click_on "Go"
 
@@ -113,6 +117,7 @@ feature "enterprise fee summaries", js: true do
         let(:current_user) { distributor.owner }
 
         it "generates file with data for the enterprise" do
+          pending "reports overhaul spec update"
           check I18n.t("filters.report_format_csv", scope: i18n_scope)
           click_on "Go"
 
@@ -144,6 +149,7 @@ feature "enterprise fee summaries", js: true do
       end
 
       it "generates file with data for selected order cycle" do
+        pending "reports overhaul spec update"
         select order_cycle.name, from: "report_order_cycle_ids"
         check I18n.t("filters.report_format_csv", scope: i18n_scope)
         click_on "Go"

--- a/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
+++ b/spec/system/admin/reports/enterprise_fee_summaries_spec.rb
@@ -79,26 +79,21 @@ describe "enterprise fee summaries" do
   end
 
   describe "csv downloads" do
-    around do |example|
-      with_empty_downloads_folder { example.run }
-    end
-
     describe "smoke test for generation of report based on permissions" do
-      before do
-        visit main_app.admin_report_path(report_type: 'enterprise_fee_summary')
-      end
-
       context "when logged in as admin" do
         let!(:order) do
           create(:completed_order_with_fees, order_cycle: order_cycle,
                                              distributor: distributor)
         end
         let(:current_user) { create(:admin_user) }
-        it "generates file with data for all enterprises" do
-          pending "reports overhaul spec update"
-          check I18n.t("filters.report_format_csv", scope: i18n_scope)
-          click_on "Go"
 
+        before do
+          visit main_app.admin_report_path(report_type: 'enterprise_fee_summary')
+        end
+
+        it "generates file with data for all enterprises" do
+          select "CSV"
+          click_on "Go"
           expect(downloaded_filename).to include ".csv"
           expect(downloaded_content).to have_content(distributor.name)
         end
@@ -115,15 +110,17 @@ describe "enterprise fee summaries" do
         end
         let(:current_user) { distributor.owner }
 
+        before do
+          visit main_app.admin_report_path(report_type: 'enterprise_fee_summary')
+        end
+
         it "generates file with data for the enterprise" do
-          pending "reports overhaul spec update"
-          check I18n.t("filters.report_format_csv", scope: i18n_scope)
+          select "CSV"
           click_on "Go"
 
           expect(downloaded_filename).to include ".csv"
-          csv_content = downloaded_content
-          expect(csv_content).to have_content(distributor.name)
-          expect(csv_content).not_to have_content(other_distributor.name)
+          expect(downloaded_content).to have_content(distributor.name)
+          expect(downloaded_content).not_to have_content(other_distributor.name)
         end
       end
     end
@@ -148,15 +145,16 @@ describe "enterprise fee summaries" do
       end
 
       it "generates file with data for selected order cycle" do
-        pending "reports overhaul spec update"
-        select order_cycle.name, from: "report_order_cycle_ids"
-        check I18n.t("filters.report_format_csv", scope: i18n_scope)
+        find("#s2id_q_order_cycle_ids").click
+        select order_cycle.name
+
+        find("#report_format").click
+        select "CSV"
         click_on "Go"
 
         expect(downloaded_filename).to include ".csv"
-        csv_content = downloaded_content
-        expect(csv_content).to have_content(distributor.name)
-        expect(csv_content).not_to have_content(second_distributor.name)
+        expect(downloaded_content).to have_content(distributor.name)
+        expect(downloaded_content).not_to have_content(second_distributor.name)
       end
     end
   end

--- a/spec/system/admin/reports/packing_report_spec.rb
+++ b/spec/system/admin/reports/packing_report_spec.rb
@@ -2,14 +2,14 @@
 
 require "system_helper"
 
-describe "Packing Reports", js: true do
+describe "Packing Reports" do
   include AuthenticationHelper
   include WebHelper
 
   describe "Packing reports" do
     before do
       login_as_admin
-      visit spree.admin_reports_path
+      visit admin_reports_path
     end
 
     let(:bill_address1) { create(:address, lastname: "MULLER") }
@@ -43,6 +43,7 @@ describe "Packing Reports", js: true do
 
     describe "Pack By Customer" do
       it "displays the report" do
+        pending "reports overhaul spec update"
         click_link "Pack By Customer"
         fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
         fill_in 'q_completed_at_lt', with: '2013-04-25 16:00:00'
@@ -58,6 +59,7 @@ describe "Packing Reports", js: true do
       end
 
       it "sorts alphabetically" do
+        pending "reports overhaul spec update"
         click_link "Pack By Customer"
         click_button 'Go'
 
@@ -76,6 +78,7 @@ describe "Packing Reports", js: true do
 
     describe "Pack By Supplier" do
       it "displays the report" do
+        pending "reports overhaul spec update"
         click_link "Pack By Supplier"
         fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
         fill_in 'q_completed_at_lt', with: '2013-04-25 16:00:00'
@@ -112,9 +115,10 @@ describe "Packing Reports", js: true do
     describe "viewing a report" do
       context "when an associated variant has been soft-deleted" do
         it "shows line items" do
+          pending "reports overhaul spec update"
           li1.variant.delete
 
-          visit spree.admin_reports_path
+          visit admin_reports_path
 
           click_on I18n.t("admin.reports.packing.name")
           select oc.name, from: "q_order_cycle_id_in"

--- a/spec/system/admin/reports/packing_report_spec.rb
+++ b/spec/system/admin/reports/packing_report_spec.rb
@@ -12,8 +12,8 @@ describe "Packing Reports" do
       visit admin_reports_path
     end
 
-    let(:bill_address1) { create(:address, lastname: "MULLER") }
-    let(:bill_address2) { create(:address, lastname: "Mistery") }
+    let(:bill_address1) { create(:address, lastname: "ABRA") }
+    let(:bill_address2) { create(:address, lastname: "KADABRA") }
     let(:distributor_address) {
       create(:address, address1: "distributor address", city: 'The Shire', zipcode: "1234")
     }
@@ -33,8 +33,8 @@ describe "Packing Reports" do
     let(:product2) { create(:simple_product, name: "Product 2", supplier: supplier) }
 
     before do
-      Timecop.travel(Time.zone.local(2013, 4, 25, 14, 0, 0)) { order1.finalize! }
-      Timecop.travel(Time.zone.local(2013, 4, 25, 15, 0, 0)) { order2.finalize! }
+      Timecop.travel(Time.zone.local(2022, 4, 25, 14, 0, 0)) { order1.finalize! }
+      Timecop.travel(Time.zone.local(2022, 4, 25, 15, 0, 0)) { order2.finalize! }
 
       create(:line_item_with_shipment, variant: variant1, quantity: 1, order: order1)
       create(:line_item_with_shipment, variant: variant2, quantity: 3, order: order1)
@@ -43,34 +43,42 @@ describe "Packing Reports" do
 
     describe "Pack By Customer" do
       it "displays the report" do
-        pending "reports overhaul spec update"
         click_link "Pack By Customer"
-        fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
-        fill_in 'q_completed_at_lt', with: '2013-04-25 16:00:00'
+
+        find('#q_order_completed_at_gt').click
+        select_date_from_datepicker Time.zone.at(order1.completed_at - 1.day)
+
+        find('#q_order_completed_at_lt').click
+        select_date_from_datepicker Time.zone.at(order1.completed_at + 1.day)
+
         click_button 'Go'
 
         rows = find("table.report__table").all("thead tr")
         table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
         expect(table).to eq([
-                              ["Hub", "Code", "First Name", "Last Name", "Supplier",
+                              ["Hub", "Customer Code", "First Name", "Last Name", "Supplier",
                                "Product", "Variant", "Quantity", "TempControlled?"].map(&:upcase)
                             ])
         expect(page).to have_selector 'table.report__table tbody tr', count: 5 # Totals row per order
       end
 
       it "sorts alphabetically" do
-        pending "reports overhaul spec update"
         click_link "Pack By Customer"
-        click_button 'Go'
 
+        find('#q_order_completed_at_gt').click
+        select_date_from_datepicker Time.zone.at(order1.completed_at - 1.day)
+
+        find('#q_order_completed_at_lt').click
+        select_date_from_datepicker Time.zone.at(order1.completed_at + 1.day)
+        click_button 'Go'
         rows = find("table.report__table").all("tr")
         table = rows.map { |r| r.all("th,td").map { |c| c.text.strip }[3] }
         expect(table).to eq([
                               "LAST NAME",
-                              order2.bill_address.lastname,
+                              order1.bill_address.lastname,
+                              order1.bill_address.lastname,
                               "",
-                              order1.bill_address.lastname,
-                              order1.bill_address.lastname,
+                              order2.bill_address.lastname,
                               ""
                             ])
       end
@@ -78,19 +86,25 @@ describe "Packing Reports" do
 
     describe "Pack By Supplier" do
       it "displays the report" do
-        pending "reports overhaul spec update"
         click_link "Pack By Supplier"
-        fill_in 'q_completed_at_gt', with: '2013-04-25 13:00:00'
-        fill_in 'q_completed_at_lt', with: '2013-04-25 16:00:00'
+        find('#q_order_completed_at_gt').click
+        select_date_from_datepicker Time.zone.at(order1.completed_at - 1.day)
+
+        find('#q_order_completed_at_lt').click
+        select_date_from_datepicker Time.zone.at(order1.completed_at + 1.day)
+
+        find(:css, "#display_summary_row").set(false) # does not include summary rows
+
         click_button 'Go'
 
         rows = find("table.report__table").all("thead tr")
         table = rows.map { |r| r.all("th").map { |c| c.text.strip } }
         expect(table).to eq([
-                              ["Hub", "Supplier", "Code", "First Name", "Last Name",
+                              ["Hub", "Supplier", "Customer Code", "First Name", "Last Name",
                                "Product", "Variant", "Quantity", "TempControlled?"].map(&:upcase)
                             ])
-        expect(all('table.report__table tbody tr').count).to eq(4) # Totals row per supplier
+
+        expect(all('table.report__table tbody tr').count).to eq(3) # Totals row per supplier
       end
     end
   end
@@ -99,7 +113,7 @@ describe "Packing Reports" do
     let(:distributor) { create(:distributor_enterprise) }
     let(:oc) { create(:simple_order_cycle) }
     let(:order) {
-      create(:completed_order_with_totals, line_items_count: 0, completed_at: 1.day.ago,
+      create(:completed_order_with_totals, line_items_count: 0,
                                            order_cycle: oc, distributor: distributor)
     }
     let(:li1) { build(:line_item_with_shipment) }
@@ -108,14 +122,13 @@ describe "Packing Reports" do
     before do
       order.line_items << li1
       order.line_items << li2
-      order.finalize!
+      Timecop.travel(Time.zone.local(2022, 4, 25, 14, 0, 0)) { order.finalize! }
       login_as_admin
     end
 
     describe "viewing a report" do
       context "when an associated variant has been soft-deleted" do
         it "shows line items" do
-          pending "reports overhaul spec update"
           li1.variant.delete
 
           visit admin_reports_path
@@ -123,11 +136,11 @@ describe "Packing Reports" do
           click_on I18n.t("admin.reports.packing.name")
           select oc.name, from: "q_order_cycle_id_in"
 
-          find('#q_completed_at_gt').click
-          select_date(Time.zone.today - 1.day)
+          find('#q_order_completed_at_gt').click
+          select_date_from_datepicker Time.zone.at(order.completed_at - 1.day)
 
-          find('#q_completed_at_lt').click
-          select_date(Time.zone.today)
+          find('#q_order_completed_at_lt').click
+          select_date_from_datepicker Time.zone.at(order.completed_at + 1.day)
 
           find("button[type='submit']").click
 

--- a/spec/system/admin/reports/payments_report_spec.rb
+++ b/spec/system/admin/reports/payments_report_spec.rb
@@ -31,11 +31,12 @@ describe "Payments Reports" do
     create(:line_item_with_shipment, order: other_order, product: product)
 
     login_as_admin
+    visit main_app.admin_report_path(report_type: 'payments')
   end
 
   context "when choosing itemised payments report type" do
     it "shows orders with payment state, their balance and totals" do
-      visit spree.payments_admin_reports_path
+      pending "reports overhaul spec update"
 
       select I18n.t(:report_itemised_payment), from: "report_subtype"
       find("[type='submit']").click
@@ -72,7 +73,7 @@ describe "Payments Reports" do
     }
 
     it 'shows orders with payment state, their balance and and payment totals' do
-      visit spree.payments_admin_reports_path
+      pending "reports overhaul spec update"
 
       select I18n.t(:report_payment_totals), from: "report_subtype"
       find("[type='submit']").click

--- a/spec/system/admin/reports/payments_report_spec.rb
+++ b/spec/system/admin/reports/payments_report_spec.rb
@@ -36,8 +36,6 @@ describe "Payments Reports" do
 
   context "when choosing itemised payments report type" do
     it "shows orders with payment state, their balance and totals" do
-      pending "reports overhaul spec update"
-
       select I18n.t(:report_itemised_payment), from: "report_subtype"
       find("[type='submit']").click
 
@@ -53,10 +51,10 @@ describe "Payments Reports" do
       expect(page.find("table.report__table tbody tr").text).to have_content([
         order.payment_state,
         order.distributor.name,
-        order.item_total.to_f + other_order.item_total.to_f,
-        order.ship_total.to_f + other_order.ship_total.to_f,
-        order.outstanding_balance.to_f + other_order.outstanding_balance.to_f,
-        order.total.to_f + other_order.total.to_f
+        with_currency(order.item_total.to_f + other_order.item_total.to_f),
+        with_currency(order.ship_total.to_f + other_order.ship_total.to_f),
+        with_currency(order.outstanding_balance.to_f + other_order.outstanding_balance.to_f),
+        with_currency(order.total.to_f + other_order.total.to_f)
       ].compact.join(" "))
     end
   end
@@ -73,8 +71,6 @@ describe "Payments Reports" do
     }
 
     it 'shows orders with payment state, their balance and and payment totals' do
-      pending "reports overhaul spec update"
-
       select I18n.t(:report_payment_totals), from: "report_subtype"
       find("[type='submit']").click
 
@@ -89,6 +85,7 @@ describe "Payments Reports" do
         I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol),
       ].join(" ").upcase)
 
+      pending "PR #9229 which will remove currency from the figures below"
       expect(page.find("table.report__table tbody tr").text).to have_content([
         order.payment_state,
         order.distributor.name,
@@ -97,7 +94,7 @@ describe "Payments Reports" do
         order.total.to_f + other_order.total.to_f,
         eft_payment.amount.to_f,
         paypal_payment.amount.to_f,
-        order.outstanding_balance.to_f + other_order.outstanding_balance.to_f,
+        with_currency(order.outstanding_balance + other_order.outstanding_balance),
       ].join(" "))
     end
   end

--- a/spec/system/admin/reports/payments_report_spec.rb
+++ b/spec/system/admin/reports/payments_report_spec.rb
@@ -85,7 +85,6 @@ describe "Payments Reports" do
         I18n.t(:report_header_outstanding_balance_price, currency: currency_symbol),
       ].join(" ").upcase)
 
-      pending "PR #9229 which will remove currency from the figures below"
       expect(page.find("table.report__table tbody tr").text).to have_content([
         order.payment_state,
         order.distributor.name,
@@ -94,7 +93,7 @@ describe "Payments Reports" do
         order.total.to_f + other_order.total.to_f,
         eft_payment.amount.to_f,
         paypal_payment.amount.to_f,
-        with_currency(order.outstanding_balance + other_order.outstanding_balance),
+        order.outstanding_balance + other_order.outstanding_balance,
       ].join(" "))
     end
   end

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -38,5 +38,6 @@ RSpec.configure do |config|
       "#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"
     example.run
     Rails.application.default_url_options[:host] = original_host
+    remove_downloaded_files
   end
 end


### PR DESCRIPTION
#### What? Why?

Related to #9032.
Related to #7088.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Updates existing report specs after reports changes introduced in https://github.com/openfoodfoundation/openfoodnetwork/pull/9032:

- For some reason - I think it is related to failures in routing (?) - report specs were not running, which means any failing example would not be flagged by our build.

- Also, the spec was throwing a `Failure/Error: sleep 0.1 until downloaded?` error, when using the `downloads` folder.

This PR addresses these points and aims only to make existing specs pass.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

Updating specs after reports overhaul

#### Dependencies

Depends on #9229 to uncomment this bit:
https://github.com/openfoodfoundation/openfoodnetwork/pull/9313/commits/88bf3d1adda174b11fc89241c5118ec504fad0dd#diff-6968dad89e7acfe0ae1b2cbc1014ccae35d8d4a7e417383b15833e48bf1ce462R88

