### PR TITLE
Add translation for order-cycle-status on new order creation from admin

### DIFF
--- a/app/assets/javascripts/admin/orders/controllers/order_controller.js.coffee
+++ b/app/assets/javascripts/admin/orders/controllers/order_controller.js.coffee
@@ -20,7 +20,7 @@ angular.module("admin.orders").controller "orderCtrl", ($scope, shops, orderCycl
     $scope.distributor_id && $scope.order_cycle_id
 
   for oc in $scope.orderCycles
-    oc.name_and_status = "#{oc.name} (#{oc.status})"
+    oc.name_and_status = "#{oc.name} (#{t("admin.order_cycles.status.#{oc.status}")})"
 
   for shop in $scope.shops
     shop.disabled = !$scope.distributorHasOrderCycles(shop)

--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -38,13 +38,13 @@ module OrderCyclesHelper
 
   def order_cycle_status_class(order_cycle)
     if order_cycle.undated?
-      'undated'
+      I18n.t('admin.order_cycles.status.undated')
     elsif order_cycle.upcoming?
-      'upcoming'
+      I18n.t('admin.order_cycles.status.upcoming')
     elsif order_cycle.open?
-      'open'
+      I18n.t('admin.order_cycles.status.open')
     elsif order_cycle.closed?
-      'closed'
+      I18n.t('admin.order_cycles.status.closed')
     end
   end
 

--- a/app/helpers/order_cycles_helper.rb
+++ b/app/helpers/order_cycles_helper.rb
@@ -38,13 +38,13 @@ module OrderCyclesHelper
 
   def order_cycle_status_class(order_cycle)
     if order_cycle.undated?
-      I18n.t('admin.order_cycles.status.undated')
+      'undated'
     elsif order_cycle.upcoming?
-      I18n.t('admin.order_cycles.status.upcoming')
+      'upcoming'
     elsif order_cycle.open?
-      I18n.t('admin.order_cycles.status.open')
+      'open'
     elsif order_cycle.closed?
-      I18n.t('admin.order_cycles.status.closed')
+      'closed'
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1226,6 +1226,11 @@ en:
         msg: This order cycle is linked to %{n} open subscription orders. Changing this date now will not affect any orders which have already been placed, but should be avoided if possible. Are you sure you want to proceed?
         cancel: Cancel
         proceed: Proceed
+      status:
+          undated: undated
+          upcoming: upcoming
+          open: open
+          closed: closed
     producer_properties:
       index:
         title: Producer Properties


### PR DESCRIPTION
#### What? Why?

Closes #9210

Currently, the order cycle status were hardcoded in the app. On changing the language other than English, the order cycle statuses still remained in the English language.
In this PR we have added translation for order cycle statuses, so now when we change the language to some other language, the order cycle statuses(open/closed) also gets translated to that language.




#### What should we test?
- Create new order in the back office: /admin/orders/new
- Select a distributor
- Select an order cycle and observe the state (open/closed)
- Switch the language of the app other than English and check if `state (open/closed)` also gets translated

![order_cycle_status](https://user-images.githubusercontent.com/62114687/174137941-5ca2d5f9-69f2-4837-ab06-fa9f32590dff.png)


#### Release notes


Changelog Category: User facing changes | Technical changes



#### Dependencies
No dependencies.



