### PR TITLE
Styled text colour of admin order dropdown menu #9296

### DIFF
--- a/app/webpacker/css/admin/orders.scss
+++ b/app/webpacker/css/admin/orders.scss
@@ -82,6 +82,12 @@ div#group_buy_calculation {
 	}
 }
 
+// Changing placeholder text colour
+.items-placeholder::placeholder {
+  color: $white;
+  opacity: 1;
+}
+
 th.actions {
   white-space: nowrap;
 }


### PR DESCRIPTION
### What? Why?

Changes the font colour of a back-order drop down menu placeholder.

Closes #9296

![image](https://user-images.githubusercontent.com/74575106/174514998-256e6109-1569-42e6-b09e-f52ad49b1e81.png)

![Screen Shot 2022-06-20 at 12 33 09 pm](https://user-images.githubusercontent.com/74575106/174515145-11e985a4-521c-4980-bd46-404008317102.png)




### What should we test?

- No functionality changes, just stylistic.
- Visit page: admin/orders/[order number]/customer

#### Release notes

Changelog Category: User facing changes

#### Dependencies
- No dependencies.

#### Documentation updates
- N/A
