### PR TITLE
Remove accidental modification of the db schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1300,7 +1300,7 @@ ActiveRecord::Schema.define(version: 2022_06_02_013938) do
   add_foreign_key "spree_tax_rates", "spree_zones", column: "zone_id", name: "spree_tax_rates_zone_id_fk"
   add_foreign_key "spree_taxons", "spree_taxonomies", column: "taxonomy_id", name: "spree_taxons_taxonomy_id_fk"
   add_foreign_key "spree_taxons", "spree_taxons", column: "parent_id", name: "spree_taxons_parent_id_fk"
-  add_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk", on_delete: :nullify
+  add_foreign_key "spree_users", "spree_addresses", column: "bill_address_id", name: "spree_users_bill_address_id_fk"
   add_foreign_key "spree_users", "spree_addresses", column: "ship_address_id", name: "spree_users_ship_address_id_fk"
   add_foreign_key "spree_variants", "spree_products", column: "product_id", name: "spree_variants_product_id_fk"
   add_foreign_key "spree_zone_members", "spree_zones", column: "zone_id", name: "spree_zone_members_zone_id_fk"


### PR DESCRIPTION


#### What? Why?

* https://github.com/openfoodfoundation/openfoodnetwork/pull/9122

fa74dae99c77f1b764a164241970637b5d82cbbb changed the schema file even though the migration doesn't touch the database structure. A previous development version of the migration did this but the finally merged version didn't. So this schema is not valid. Let's hope that nobody set up a new instance with the changed schema and we just fix it to what it was before.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

No test.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


