### PR TITLE
Restore dependency to mime-types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'rails_safe_tasks', '~> 1.0'
 gem "activerecord-import"
 gem "db2fog", github: "openfoodfoundation/db2fog", branch: "rails-6"
 gem "fog-aws", "~> 2.0" # db2fog does not support v3
+gem "mime-types" # required by fog
 
 gem "valid_email2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
@@ -765,6 +768,7 @@ DEPENDENCIES
   knapsack
   letter_opener (>= 1.4.1)
   listen
+  mime-types
   mimemagic (> 0.3.5)
   mini_racer (= 0.4.0)
   monetize (~> 1.11)


### PR DESCRIPTION

#### What? Why?

Our db2fog backups require the mime-types gem but it was removed with
paperclip. Luckily, backups have still been working because the gem was
still available.


#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Production test. We need to check that backups are still working. I tested this in development already.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
