### PR TITLE
Disabled_at logic: redirect to login path if user is disabled

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -78,7 +78,7 @@ module Spree
 
     def load_object
       @user ||= spree_current_user
-      if @user
+      if @user && !@user.disabled
         authorize! params[:action].to_sym, @user
       else
         redirect_to main_app.login_path

--- a/spec/system/consumer/account_spec.rb
+++ b/spec/system/consumer/account_spec.rb
@@ -111,5 +111,16 @@ describe '
         expect(page).to have_content I18n.t(:you_have_no_orders_yet)
       end
     end
+
+    context "as a disabled user" do
+      before do
+        user.disabled = '1'
+      end
+
+      it "redirects to the login page" do
+        visit "/account"
+        expect(page).to have_current_path("/")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What? Why?

Closes #9336

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
 - As a customer, log in.
 - As a super admin, deactivate that user (in a separate session e.g. private mode of the browser).
 - As a customer, try to access your account (/account page).
 - See that you're redirected to `/#/login`

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes 

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
