### PR TITLE
Add boolean to specify if enterprise  number (ABN, GST, SIRET, ...) is mandatory or not to generate invoices

### DIFF
--- a/app/controllers/admin/invoice_settings_controller.rb
+++ b/app/controllers/admin/invoice_settings_controller.rb
@@ -19,6 +19,7 @@ module Admin
         :enable_invoices?,
         :invoice_style2?,
         :enable_receipt_printing?,
+        :enterprise_number_required_on_invoices?,
       )
     end
   end

--- a/app/helpers/spree/admin/orders_helper.rb
+++ b/app/helpers/spree/admin/orders_helper.rb
@@ -44,6 +44,14 @@ module Spree
         end
       end
 
+      def print_invoice_link
+        if @order.distributor.can_invoice?
+          print_invoice_link_with_url
+        else
+          notify_about_required_enterprise_number
+        end
+      end
+
       def ticket_links
         return [] unless Spree::Config[:enable_receipt_printing?]
 
@@ -78,11 +86,18 @@ module Spree
           confirm: t(:must_have_valid_business_number, enterprise_name: @order.distributor.name) }
       end
 
-      def print_invoice_link
+      def print_invoice_link_with_url
         { name: t(:print_invoice),
           url: spree.print_admin_order_path(@order),
           icon: 'icon-print',
           target: "_blank" }
+      end
+
+      def notify_about_required_enterprise_number
+        { name: t(:print_invoice),
+          url: "#",
+          icon: 'icon-print',
+          confirm: t(:must_have_valid_business_number, enterprise_name: @order.distributor.name) }
       end
 
       def print_ticket_link

--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -408,6 +408,8 @@ class Enterprise < ApplicationRecord
   end
 
   def can_invoice?
+    return true unless Spree::Config.enterprise_number_required_on_invoices?
+
     abn.present?
   end
 

--- a/app/models/spree/app_configuration.rb
+++ b/app/models/spree/app_configuration.rb
@@ -129,6 +129,7 @@ module Spree
     preference :enable_invoices?, :boolean, default: true
     preference :invoice_style2?, :boolean, default: false
     preference :enable_receipt_printing?, :boolean, default: false
+    preference :enterprise_number_required_on_invoices?, :boolean, default: true
 
     # Stripe payments
     preference :stripe_connect_enabled, :boolean, default: false

--- a/app/views/admin/invoice_settings/edit.html.haml
+++ b/app/views/admin/invoice_settings/edit.html.haml
@@ -20,5 +20,10 @@
     = check_box_tag 'preferences[enable_receipt_printing?]', '1',  Spree::Config[:enable_receipt_printing?]
     = label_tag nil, t('.enable_receipt_printing?')
 
+  .field.align-center
+    = hidden_field_tag 'preferences[enterprise_number_required_on_invoices?]', '0'
+    = check_box_tag 'preferences[enterprise_number_required_on_invoices?]', '1',  Spree::Config[:enterprise_number_required_on_invoices?]
+    = label_tag nil, t('.enterprise_number_required_on_invoices?')
+
   .form-buttons{"data-hook" => "buttons"}
     = button t(:update), 'icon-refresh'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -552,6 +552,7 @@ en:
         enable_invoices?: "Enable Invoices?"
         invoice_style2?: "Use the alternative invoice model that includes total tax breakdown per rate and tax rate info per item (not yet suitable for countries displaying prices excluding tax)"
         enable_receipt_printing?: "Show options for printing receipts using thermal printers in order dropdown?"
+        enterprise_number_required_on_invoices?: "Require an ABN to generate an invoice?"
 
     stripe_connect_settings:
       edit:


### PR DESCRIPTION
#### What? Why?

Closes #9315

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->



#### What should we test?
 - Visit `/admin/invoice_settings/edit`
 - `REQUIRE AN ABN NUMBER TO GENERATE AN INVOICE?` should be checked
<img width="331" alt="Capture d’écran 2022-06-23 à 16 39 38" src="https://user-images.githubusercontent.com/296452/175326180-fd408a42-7ca2-4c08-b8f1-01b4cfa72c74.png">
 - For an enterprise without any ABN number,
<img width="920" alt="Capture d’écran 2022-06-23 à 16 39 55" src="https://user-images.githubusercontent.com/296452/175326320-9baec3e7-cc67-47d4-94c6-69c9bcd32076.png">
 - ... it must be impossible to print/send invoice (blocked with a js alert): 
<img width="493" alt="Capture d’écran 2022-06-23 à 16 41 42" src="https://user-images.githubusercontent.com/296452/175326578-2a773ae8-5dc0-4d51-ac47-50c33f15976f.png">
 
- then, add a ABN number
- you should be able to generate (print/send) invoice

 - then, remove ABN number
 - uncheck `REQUIRE AN ABN NUMBER TO GENERATE AN INVOICE?` under `/admin/invoice_settings/edit`
 - you should be able to generate (print/send) invoice

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: User facing changes

<!-- Choose a pull request title above which explains your change to a
     a user of the Open Food Network app. -->

The title of the pull request will be included in the release notes.


#### Dependencies
<!-- Does this PR depend on another one?
     Add the link or remove this section. -->



#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this PR?
     List them here or remove this section. -->
