### PR TITLE
Redirect to homepage with flash error when disabled user trying to access any page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,8 +165,9 @@ class ApplicationController < ActionController::Base
     return unless current_spree_user.disabled
 
     flash[:success] = nil
-    flash.now[:error] = I18n.t("devise.failure.disabled")
+    flash[:error] = I18n.t("devise.failure.disabled")
     sign_out current_spree_user
+    redirect_to main_app.root_path
   end
 end
 

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -16,6 +16,7 @@ module Spree
     prepend_before_action :handle_unconfirmed_email
     before_action :set_checkout_redirect, only: :create
     after_action :ensure_valid_locale_persisted, only: :create
+    skip_before_action :check_disabled_user
 
     def create
       authenticate_spree_user!


### PR DESCRIPTION
#### What? Why?

Closes #9338 

Add a redirect to the homepage with a flash message, when a disabled user tries to access any page.

#### What should we test?

- As a customer, log in.
- As a super admin, deactivate that user (in a separate session e.g. private mode of the browser).
- As a customer, try to access your any page (/admin).
- See that you're redirected to homepage with the flash message `Your account has been disabled. Please contact an administrator to solve this issue.`

@jibees edit:

> test every login/logout/user action: like connection, deconnection, bad password, subscription, forget password, ...
> I'm wondering if this one does not close this #9336 too. 

#### Release notes

Redirect to homepage with flash error when disabled user trying to access any page.

Changelog Category: User facing changes