### PR TITLE
Adds price breakdown assertion

### DIFF
--- a/spec/system/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/system/consumer/shopping/variant_overrides_spec.rb
@@ -102,6 +102,23 @@ describe "shopping with variant overrides defined", js: true do
       expect(page).to have_price with_currency(61.11)
     end
 
+    context "clicking the pie-chart icon" do
+      before do
+        visit shop_path
+        within "#variant-#{product1_variant1.id}" do
+          page.find(".graph-button").click
+        end
+      end
+      it "shows the price breakdown modal" do
+        within(:xpath, '//body') do
+          within(".price_breakdown") do
+            expect(page).to have_content("Price breakdown")
+            expect(page).to have_content("Packing fee")
+          end
+        end
+      end
+    end
+
     # The two specs below reveal an unrelated issue with fee calculation. See:
     # https://github.com/openfoodfoundation/openfoodnetwork/issues/312
 

--- a/spec/system/consumer/shopping/variant_overrides_spec.rb
+++ b/spec/system/consumer/shopping/variant_overrides_spec.rb
@@ -109,11 +109,12 @@ describe "shopping with variant overrides defined", js: true do
           page.find(".graph-button").click
         end
       end
+
       it "shows the price breakdown modal" do
         within(:xpath, '//body') do
           within(".price_breakdown") do
             expect(page).to have_content("Price breakdown")
-            expect(page).to have_content("Packing fee")
+            expect(page).to have_content(enterprise_fee.name.to_s)
           end
         end
       end


### PR DESCRIPTION
#### What? Why?

Relates to #9325.

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Adds assertions on the price breakdown element.

- first commit: adds an `id` tag, to that element
- second commit: adds the assertion on the modal considering #9325 

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Green build.

#### Release notes

<!-- Please select one for your PR and delete the other. -->

Changelog Category: Technical changes
